### PR TITLE
Get windows paths working again for configs

### DIFF
--- a/pyre2/lib/config.rs
+++ b/pyre2/lib/config.rs
@@ -186,6 +186,8 @@ impl ConfigFile {
 
 #[cfg(test)]
 mod tests {
+    use std::path;
+
     use toml::Value;
 
     use super::*;
@@ -323,17 +325,22 @@ mod tests {
 
     #[test]
     fn test_rewrite_with_path_to_config() {
+        fn with_sep(s: &str) -> String {
+            s.replace("/", path::MAIN_SEPARATOR_STR)
+        }
         let mut config = ConfigFile::default();
-        let path_str = "path/to/my/config".to_owned();
+        let path_str = with_sep("path/to/my/config");
+        let project_excludes_vec = vec![
+            path_str.clone() + &with_sep("/**/__pycache__/**"),
+            path_str.clone() + &with_sep("/**/.*"),
+        ];
+
         let test_path = PathBuf::from(path_str.clone());
         config.rewrite_with_path_to_config(&test_path);
 
         let expected_config = ConfigFile {
             project_includes: Globs::new(vec![path_str.clone()]),
-            project_excludes: Globs::new(vec![
-                path_str.clone() + "/**/__pycache__/**",
-                path_str.clone() + "/**/.*",
-            ]),
+            project_excludes: Globs::new(project_excludes_vec),
             search_path: vec![test_path.clone(), test_path.clone()],
             ..ConfigFile::default()
         };


### PR DESCRIPTION
Summary:
We do not handle paths well on Windows, especially if a user passes / in their paths through CLI or config (this is due to how path libraries are implemented in rust). To fix this, we need to sanitize all the paths we get from CLI or configs, either by wrapping everything in a `Platform`-prefixed newtype that we can use as a sanity check (and in construction, fix up the newtype ourselves), or by making a new trait that can do the conversion for us, and calling it everywhere we get user data.


For now, to get things working again, let's just sanitize that path when we're working in the config, and assume our users will be nice to us by keeping their configs' paths platform-specific.

Differential Revision: D71589137


