### PR TITLE
Attempt directory matching with excludes

### DIFF
--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -58,10 +58,11 @@ The following is the order in which configuration options are selected:
   - Equivalent configs: `exclude` in Pyright and MyPy
   - Notes: we match on these patterns, unlike `project_includes`, where we
     enumerate all (Python) files under the directory. Becaues of this,
-    `project_excludes` does not do directory matching. `**/__pycache__/` and
-    `**/__pycache__` will only match a file path that ends in `__pycache__`, not
-    anything nested under it like `__pycache__/file.pyc`. **For your own sanity,
-    add `/**` when trying to match everything under a directory\*\*.
+    `project_excludes` does not do directory matching unless a `/` is added at
+    the end of your glob pattern. `**/__pycache__/` will only match files under
+    a directory named `__pycache__/`, but not a file named `__pycache__`.
+    Likewise, `**/__pycache__` will only match files named `__pycache__`, but
+    not files under a directory named `__pycache__/`.
 - `search_path`: a file path describing a root from which imports should be
   found and imported from (including modules in `project_includes`). This takes
   the highest precedence in import order, before `typeshed` and


### PR DESCRIPTION
Summary:
In an earlier diff, I added the `project_excludes` config item and flag, which is powered by `glob::Pattern::matches_path()`. When doing this, I noticed that we don't match directory prefixes, meaning something like `**/__pycache__` or `**/__pycache__/` will not match `project/__pycache__/some_file.pyc`. You would need to specify `**/__pycache__/**`.

The way we get around this while enumerating files to type check is by iterating through all files in the directory, and recurring through any subdirectories, to get the python files inside. Since we're trying to speed things up by matching instead of walking/enumerating directories, we don't know what directories to check.

oh_my_glob

We then have a few options of heuristics to try:
1. Try to see if the last component of the pattern is a file, and if not, and if the pattern doesn't end in `**`, then append `/**` (or just `**` if the `/` is already there), and perform that as the check. Fail if whatever pattern we end up with can't compile.
    1. This doesn't work super well, since we can't check if the end of a pattern is a file if we have any wildcards in the pattern (i.e. if the pattern is anything but a relative/absolute path to a directory/file to check)
2. Try to match `<pattern>` and `<pattern>/**` (if the last path component is not `**`), and only return error if the first one fails.
    1. This might be wrong in cases like `path/to/my_dir/*`, where we would end up checking `path/to/my/dir/*/**`, which ends up being `path/to/my/dir/**`.
    2. This still might be a reasonable solution, but it still feels off, and I think we can do better.
3. See if the last component of the path has a `.` in it not at the start of the path (i.e. probably a file suffix and not hidden file/directory). If so, add `**`.
    1. The issue with this approach is that we might not match individual files that have no `.py` suffix that our users want us to check.
    2. This might be fine though, since right now, we only type find files that end in `.py` and `.pyi`, so files must have a `.` in them.
    3. We will also not end up checking `.<filename>.py`, but I don't think that will be common or reasonable for us to really expect to do.
4. See if the end of the pattern is a `/`, and if so, always append `**`.
    1. `/` will always denote a directory, so this should be a safe assumption to make.
    2. The issue with this one is that users still may end directories without a `/`, expecting it to match everything in that directory.

Given these approaches, I implemented **option 4** below, since that one is easy to do, and I think reasonable enough. Also, if we end up allowing files without a `.py` suffix to be checked (e.g. `./my_python_binary_with_shebang`), we will be backward compatible.

Totally open to changing approaches on this one, so let me know your thoughts.

Reviewed By: grievejia

Differential Revision: D71570912


