### PR TITLE
Create SubConfig

### DIFF
--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -243,8 +243,8 @@ impl Handles {
         self.module_to_error_config.insert(
             ModulePath::filesystem(path.clone()),
             ErrorConfig::new(
-                config.errors.clone(),
-                config.ignore_errors_in_generated_code,
+                config.errors().clone(),
+                config.ignore_errors_in_generated_code(),
             ),
         );
         let loader = self.get_or_register_loader(&config);
@@ -258,7 +258,7 @@ impl Handles {
         let key = LoaderInputs {
             search_path: config.search_path.clone(),
             site_package_path: config.site_package_path().to_owned(),
-            replace_imports_with_any: config.replace_imports_with_any.clone(),
+            replace_imports_with_any: config.replace_imports_with_any().to_vec(),
         };
         if let Some(loader) = self.loader_factory.get_mut(&key) {
             loader.dupe()
@@ -422,7 +422,7 @@ impl Args {
             &mut config.python_interpreter,
             self.python_interpreter.as_ref(),
         );
-        set_if_some(
+        set_option_if_some(
             &mut config.ignore_errors_in_generated_code,
             self.ignore_errors_in_generated_code.as_ref(),
         );

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -423,7 +423,7 @@ impl Args {
             self.python_interpreter.as_ref(),
         );
         set_option_if_some(
-            &mut config.ignore_errors_in_generated_code,
+            &mut config.root.ignore_errors_in_generated_code,
             self.ignore_errors_in_generated_code.as_ref(),
         );
         config.configure();

--- a/pyrefly/lib/commands/lsp.rs
+++ b/pyrefly/lib/commands/lsp.rs
@@ -883,7 +883,8 @@ impl Server {
             let new_config = Config::new(
                 search_path,
                 site_package_path,
-                env.get_runtime_metadata(),
+                // this is okay, since `get_interpreter_env()` must return an environment with all values as `Some()`
+                RuntimeMetadata::new(env.python_version.unwrap(), env.python_platform.unwrap()),
                 config.open_files.lock().clone(),
             );
             configs.insert(config_path, new_config);

--- a/pyrefly/lib/config/base.rs
+++ b/pyrefly/lib/config/base.rs
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::config::error::ErrorDisplayConfig;
+use crate::config::util::ExtraConfigs;
+use crate::module::wildcard::ModuleWildcard;
+
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Default)]
+pub struct ConfigBase {
+    /// Errors to silence (or not) when printing errors.
+    #[serde(default)]
+    pub errors: Option<ErrorDisplayConfig>,
+
+    /// String-prefix-matched names of modules from which import errors should be ignored
+    /// and the module should always be replaced with `typing.Any`
+    #[serde(default)]
+    pub replace_imports_with_any: Option<Vec<ModuleWildcard>>,
+
+    /// analyze function body and infer return type
+    #[serde(default)]
+    pub skip_untyped_functions: Option<bool>,
+
+    /// Whether to ignore type errors in generated code. By default this is disabled.
+    /// Generated code is defined as code that contains the marker string `@` immediately followed by `generated`.
+    #[serde(default)]
+    pub ignore_errors_in_generated_code: Option<bool>,
+
+    /// Any unknown config items
+    #[serde(default, flatten)]
+    pub extras: ExtraConfigs,
+}

--- a/pyrefly/lib/config/mod.rs
+++ b/pyrefly/lib/config/mod.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+pub mod base;
 pub mod config;
 pub mod environment;
 pub mod error;

--- a/pyrefly/lib/config/util.rs
+++ b/pyrefly/lib/config/util.rs
@@ -21,7 +21,7 @@ pub fn set_option_if_some<T: Clone>(config_field: &mut Option<T>, value: Option<
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 #[serde(transparent)]
 pub struct ExtraConfigs(pub Table);
 

--- a/pyrefly/lib/lib.rs
+++ b/pyrefly/lib/lib.rs
@@ -52,6 +52,7 @@ mod util;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use crate::commands::run;
+pub use crate::config::base::ConfigBase;
 pub use crate::config::config::ConfigFile;
 pub use crate::config::environment::PythonEnvironment;
 pub use crate::config::finder;


### PR DESCRIPTION
Summary:
# This Feature...
Over the next few diffs, we'll be implementing the functionality for sub-configs. This involves selecting configuration values from a sub-config for a matched file path, overriding the value used in the root config (if present). It will allow users with multiple projects in the same repository that should use different settings to work under the same config, type checking everything at once, and could make LSP configuration easier if we choose to emulate Pyright's approach.

## High Level Approach

1. Make all config values `Option` types. This will let us know that we need to fall back to the next sub-config or the root config, instead of taking whatever default value we find.
2. Make a `BaseConfig` type, which will be flattened into the main `ConfigFile` type.
3. Make a `Glob` type (pull some of the logic from `Globs`).
4. Create `SubConfigs` and add them to `ConfigFile`, which are `BaseConfigs` paired with a `Glob`.
5. Implement configuration resolution, which will figure out which `SubConfig` to use (or the default), and grab the given config value from it.

# This Diff...

This diff creates the `SubConfig` struct, which allows us to store `SubConfig`s in a `ConfigFile`. The main changes involve adding the field to the `ConfigFile` struct, updating `from_file()` and `validate()` to operate on sub configs in addition to the root, and adding the field to struct construction when required.

The rest of the changes add tests to validate the behavior works as expected.

Differential Revision: D73000284


