### PR TITLE
Move test directory creation functionality into shared util module

### DIFF
--- a/pyrefly/lib/module/finder.rs
+++ b/pyrefly/lib/module/finder.rs
@@ -108,49 +108,10 @@ pub fn find_module_in_site_package_path(
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
     use super::*;
-
-    // Utility structure to facilitate setting up filesystem structure under test directories.
-    enum TestPathKind {
-        File,
-        Directory(Vec<TestPath>),
-    }
-    struct TestPath {
-        name: String,
-        kind: TestPathKind,
-    }
-
-    impl TestPath {
-        fn file(name: &str) -> Self {
-            Self {
-                name: name.to_owned(),
-                kind: TestPathKind::File,
-            }
-        }
-        fn dir(name: &str, children: Vec<TestPath>) -> Self {
-            Self {
-                name: name.to_owned(),
-                kind: TestPathKind::Directory(children),
-            }
-        }
-    }
-
-    fn setup_test_directory(root: &Path, paths: Vec<TestPath>) {
-        for path in paths {
-            match path.kind {
-                TestPathKind::File => {
-                    std::fs::File::create(root.join(path.name)).unwrap();
-                }
-                TestPathKind::Directory(children) => {
-                    let dir = root.join(path.name);
-                    std::fs::create_dir(&dir).unwrap();
-                    setup_test_directory(&dir, children);
-                }
-            }
-        }
-    }
+    use crate::util::test::TestPath;
+    use crate::util::test::TestPathKind;
+    use crate::util::test::setup_test_directory;
 
     #[test]
     fn test_find_module_simple() {

--- a/pyrefly/lib/util/mod.rs
+++ b/pyrefly/lib/util/mod.rs
@@ -25,6 +25,8 @@ pub mod notify_watcher;
 pub mod prelude;
 pub mod recurser;
 pub mod task_heap;
+#[cfg(test)]
+pub mod test;
 pub mod thread_pool;
 pub mod trace;
 pub mod uniques;

--- a/pyrefly/lib/util/test.rs
+++ b/pyrefly/lib/util/test.rs
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+use std::io::Write;
+use std::path::Path;
+
+// Utility structure to facilitate setting up filesystem structure under test directories.
+pub enum TestPathKind {
+    File,
+    FileWithContents(String),
+    Directory(Vec<TestPath>),
+}
+pub struct TestPath {
+    pub name: String,
+    pub kind: TestPathKind,
+}
+
+impl TestPath {
+    pub fn file(name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+            kind: TestPathKind::File,
+        }
+    }
+
+    pub fn dir(name: &str, children: Vec<TestPath>) -> Self {
+        Self {
+            name: name.to_owned(),
+            kind: TestPathKind::Directory(children),
+        }
+    }
+}
+
+pub fn setup_test_directory(root: &Path, paths: Vec<TestPath>) {
+    for path in paths {
+        match path.kind {
+            TestPathKind::File => {
+                std::fs::File::create(root.join(path.name)).unwrap();
+            }
+            TestPathKind::Directory(children) => {
+                let dir = root.join(path.name);
+                std::fs::create_dir(&dir).unwrap();
+                setup_test_directory(&dir, children);
+            }
+            TestPathKind::FileWithContents(contents) => {
+                let path = root.join(path.name);
+                let mut f = std::fs::File::create(path).unwrap();
+                f.write_all(contents.as_bytes()).unwrap();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Summary: I ended up finding this useful elsewhere, so I think it's probably worth pulling out into a util module so it can be reused when needed.

Differential Revision: D73400446


