### PR TITLE
Add tests validating behavior of glob matching

### DIFF
--- a/pyrefly/lib/module/finder.rs
+++ b/pyrefly/lib/module/finder.rs
@@ -153,55 +153,14 @@ pub fn find_module_in_site_package_path(
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
     use super::*;
-
-    // Utility structure to facilitate setting up filesystem structure under test directories.
-    enum TestPathKind {
-        File,
-        Directory(Vec<TestPath>),
-    }
-    struct TestPath {
-        name: String,
-        kind: TestPathKind,
-    }
-
-    impl TestPath {
-        fn file(name: &str) -> Self {
-            Self {
-                name: name.to_owned(),
-                kind: TestPathKind::File,
-            }
-        }
-        fn dir(name: &str, children: Vec<TestPath>) -> Self {
-            Self {
-                name: name.to_owned(),
-                kind: TestPathKind::Directory(children),
-            }
-        }
-    }
-
-    fn setup_test_directory(root: &Path, paths: Vec<TestPath>) {
-        for path in paths {
-            match path.kind {
-                TestPathKind::File => {
-                    std::fs::File::create(root.join(path.name)).unwrap();
-                }
-                TestPathKind::Directory(children) => {
-                    let dir = root.join(path.name);
-                    std::fs::create_dir(&dir).unwrap();
-                    setup_test_directory(&dir, children);
-                }
-            }
-        }
-    }
+    use crate::test::util::TestPath;
 
     #[test]
     fn test_find_module_simple() {
         let tempdir = tempfile::tempdir().unwrap();
         let root = tempdir.path();
-        setup_test_directory(
+        TestPath::setup_test_directory(
             root,
             vec![TestPath::dir(
                 "foo",
@@ -230,7 +189,7 @@ mod tests {
     fn test_find_module_init() {
         let tempdir = tempfile::tempdir().unwrap();
         let root = tempdir.path();
-        setup_test_directory(
+        TestPath::setup_test_directory(
             root,
             vec![TestPath::dir(
                 "foo",
@@ -255,7 +214,7 @@ mod tests {
     fn test_find_pyi_takes_precedence() {
         let tempdir = tempfile::tempdir().unwrap();
         let root = tempdir.path();
-        setup_test_directory(
+        TestPath::setup_test_directory(
             root,
             vec![TestPath::dir(
                 "foo",
@@ -276,7 +235,7 @@ mod tests {
     fn test_find_init_takes_precedence() {
         let tempdir = tempfile::tempdir().unwrap();
         let root = tempdir.path();
-        setup_test_directory(
+        TestPath::setup_test_directory(
             root,
             vec![TestPath::dir(
                 "foo",
@@ -297,7 +256,7 @@ mod tests {
     fn test_basic_namespace_package() {
         let tempdir = tempfile::tempdir().unwrap();
         let root = tempdir.path();
-        setup_test_directory(
+        TestPath::setup_test_directory(
             root,
             vec![
                 TestPath::dir("a", vec![]),
@@ -328,7 +287,7 @@ mod tests {
     fn test_find_regular_package_early_return() {
         let tempdir = tempfile::tempdir().unwrap();
         let root = tempdir.path();
-        setup_test_directory(
+        TestPath::setup_test_directory(
             root,
             vec![
                 TestPath::dir(
@@ -363,7 +322,7 @@ mod tests {
     fn test_find_namespace_package_no_early_return() {
         let tempdir = tempfile::tempdir().unwrap();
         let root = tempdir.path();
-        setup_test_directory(
+        TestPath::setup_test_directory(
             root,
             vec![
                 TestPath::dir(
@@ -391,7 +350,7 @@ mod tests {
     fn test_find_stubs_module_takes_precedence() {
         let tempdir = tempfile::tempdir().unwrap();
         let root = tempdir.path();
-        setup_test_directory(
+        TestPath::setup_test_directory(
             root,
             vec![
                 TestPath::dir(

--- a/pyrefly/lib/test/mod.rs
+++ b/pyrefly/lib/test/mod.rs
@@ -48,7 +48,7 @@ mod type_alias;
 mod type_var_tuple;
 mod typed_dict;
 mod typing_self;
-mod util;
+pub mod util;
 mod variance_inference;
 mod with;
 mod yields;

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -6,7 +6,9 @@
  */
 
 use std::collections::HashMap;
+use std::io::Write as _;
 use std::num::NonZeroUsize;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread::sleep;
@@ -411,5 +413,53 @@ pub fn get_class(name: &str, handle: &Handle, state: &State) -> Option<Class> {
     match solutions.get(&KeyExport(Name::new(name))).map(|x| &**x) {
         Some(Type::ClassDef(cls)) => Some(cls.dupe()),
         _ => None,
+    }
+}
+
+// Utility structure to facilitate setting up non-memory filesystem structure under test directories.
+pub enum TestPathKind {
+    File,
+    #[expect(dead_code)]
+    FileWithContents(String),
+    Directory(Vec<TestPath>),
+}
+pub struct TestPath {
+    pub name: String,
+    pub kind: TestPathKind,
+}
+
+impl TestPath {
+    pub fn file(name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+            kind: TestPathKind::File,
+        }
+    }
+
+    pub fn dir(name: &str, children: Vec<TestPath>) -> Self {
+        Self {
+            name: name.to_owned(),
+            kind: TestPathKind::Directory(children),
+        }
+    }
+
+    pub fn setup_test_directory(root: &Path, paths: Vec<TestPath>) {
+        for path in paths {
+            match path.kind {
+                TestPathKind::File => {
+                    std::fs::File::create(root.join(path.name)).unwrap();
+                }
+                TestPathKind::Directory(children) => {
+                    let dir = root.join(path.name);
+                    std::fs::create_dir(&dir).unwrap();
+                    Self::setup_test_directory(&dir, children);
+                }
+                TestPathKind::FileWithContents(contents) => {
+                    let path = root.join(path.name);
+                    let mut f = std::fs::File::create(path).unwrap();
+                    f.write_all(contents.as_bytes()).unwrap();
+                }
+            }
+        }
     }
 }

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -70,6 +70,8 @@ the config is invalid.
       well.
     - When a `project_includes` pattern does not match any files, we will return
       an error.
+    - If you get an error about no matches for a directory when passing a glob as a CLI
+      argument, try wrapping the glob in quotes to prevent eager shell glob expansion.
 - `project_excludes`: the glob patterns used to describe which files to avoid
   type checking, usually as a more fine-grained way of controlling the files you
   get type errors on.
@@ -90,6 +92,8 @@ the config is invalid.
     - When passing in `FILES...`, we also do not consult the config file for
       what to use for `project_excludes`. If `project_excludes` should not use
       the default value, override it with a flag as well.
+    - If you get an error about no matches for a directory when passing a glob as a CLI
+      argument, try wrapping the glob in quotes to prevent eager shell glob expansion.
 - `search_path`: a file path describing a root from which imports should be
   found and imported from (including modules in `project_includes`). This takes
   the highest precedence in import order, before `typeshed` and


### PR DESCRIPTION
Summary:
This diff makes no functional changes. It only fixes a few lines in documentation (which I plan to expand on during the docathon) and adds tests for existing functionality, some of which has bugs.

Over the next few diffs, I'll uncomment all of the tests below as I get things working, but the tests below show the state of how I think globs should be working.

We also don't have a way to verify that filesystem matching is working as expected, so these tests cover that as well.

Differential Revision: D73378283


