### PR TITLE
Fix broken link

### DIFF
--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -1,0 +1,7 @@
+---
+title: Getting Started
+
+description: Quick start guide for Pyrefly
+---
+
+Pyrefly isn't ready just yet,  but you can see our roadmap [here](https://github.com/facebook/pyrefly/milestone/1). We will be populating this section soon!

--- a/website/docs/python-typing-5-minutes.mdx
+++ b/website/docs/python-typing-5-minutes.mdx
@@ -304,4 +304,4 @@ reveal_type(f("")) # revealed type: str
 - **Advanced Types:** The guide covers advanced concepts like composing types, using unions and optionals, generics, protocols, and structural types like dataclasses and TypedDict.
 - **Practical Examples:** The guide includes examples of functions, generic classes, structural typing with protocols, and more, demonstrating how to apply these concepts in real-world scenarios.
 
-## Next: [Getting Started With Pyrefly](../fb/getting-started/)
+## Next: [Getting Started With Pyrefly](../getting-started/)


### PR DESCRIPTION
Summary:
The getting started page isn't filled out yet, but it does have a link to the milestones
which is 100% fine to be public.

So we should make it visible; as it is, Github CI is broken because the open-source
docusaurus build is failing on a missing linke.

Differential Revision: D73536895
