### PR TITLE
Make placeholder doc pages public

### DIFF
--- a/website/docs/IDE.mdx
+++ b/website/docs/IDE.mdx
@@ -1,0 +1,36 @@
+---
+title: IDE
+
+description: Pyrefly in the IDE
+---
+
+# Pyrefly in the IDE
+Pyrefly seamlessly integrates into IDEs with our [VSCode](https://marketplace.visualstudio.com/items?itemName=meta.pyrefly) and [OpenVSX](https://open-vsx.org/extension/meta/pyrefly) extensions. For other editors like vim/emacs, see [other editors](#other-editors).
+
+## Quick start
+1. Install the Pyrefly extension from the [VSCode marketplace](https://marketplace.visualstudio.com/items?itemName=meta.pyrefly) or [OpenVSX](https://open-vsx.org/extension/meta/pyrefly)
+2. Open a python file and the extension will activate
+
+## Features
+The Pyrefly extension provides:
+- Inline type errors matching the Pyrefly command-line
+- Types shown inline and on hover
+- Go-to definition
+- Autocomplete / intellisense
+
+## Customization
+By default, Pyrefly should work in the IDE with no configuration necessary. But to ensure your project is set up properly, see [configurations](../../configuration).
+
+The following configuration options are IDE-specific:
+- `python.pyrefly.disableLanguageServices` [boolean: false]: by default, Pyrefly will provide both type errors and other language features like go-to definition, intellisense, hover, etc. Enable this option to keep type errors from Pyrefly but use VSCode's Python extension for everything else.
+
+If the project configuration does not specify the Python interpreter, Pyrefly will use the [interpreter selected in VSCode](https://code.visualstudio.com/docs/python/environments).
+
+## Issues?
+If you experience issues with the Pyrefly extension, please create an [issue](https://github.com/facebook/pyrefly/issues) on github.
+
+## Other Editors
+Support for other editors is community-driven. If you would like to set this up, please contribute.
+
+- An unofficial Jetbrains extension has been developed [here](https://plugins.jetbrains.com/plugin/26829-pyrefly)
+- For Neovim support, see the issue [here](https://github.com/facebook/pyrefly/issues/55)

--- a/website/docs/error-suppresions.mdx
+++ b/website/docs/error-suppresions.mdx
@@ -1,0 +1,7 @@
+---
+title: Error Suppressions
+
+description: How to suppress errors in Pyrefly
+---
+
+INFO TO BE ADDED

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -1,0 +1,7 @@
+---
+title: Getting Started
+
+description: Quick start guide for Pyrefly
+---
+
+Pyrefly isn't ready just yet,  but you can see our roadmap [here](https://github.com/facebook/pyrefly/milestone/1). We will be populating this section soon!

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -48,14 +48,14 @@ Ready to get started with Pyrefly? Check out these resources:
 
 - [Installation Guide](../installation) - Install and set up Pyrefly for your project
 - [IDE Integration](../IDE) - Use Pyrefly in your favorite editor
-- [Python Typing for Beginners](../../python-typing-for-beginners) - Master the basics of Python's type system
-- [Frequently Asked Questions](../../pyrefly-faq) - Common questions about Pyrefly
+- [Python Typing for Beginners](../python-typing-for-beginners) - Master the basics of Python's type system
+- [Frequently Asked Questions](../pyrefly-faq) - Common questions about Pyrefly
 
 ## Configuration
 
 Once you've installed Pyrefly, you can customize its behavior:
 
-- [Configuration Guide](../../configuration) - Configure Pyrefly for your project's specific needs
+- [Configuration Guide](../configuration) - Configure Pyrefly for your project's specific needs
 
 ## Migrating from Other Typecheckers
 
@@ -67,11 +67,11 @@ If you're currently using a different Python typechecker, we have guides to help
 
 Pyrefly provides detailed explanations for all the errors it can detect:
 
-- [Error Kinds](../../error-kinds) - A comprehensive list of all Pyrefly errors with their explanations
+- [Error Kinds](../error-kinds) - A comprehensive list of all Pyrefly errors with their explanations
 
 ## Advanced Topics
 
 As you become more familiar with Pyrefly, explore these advanced topics:
 
 - [Error Suppressions](../error-suppresions) - Learn how to suppress specific errors that show up in Pyrefly
-- [Import Resolution](../../import-resolution) - Learn how Pyrefly resolves imports in your code
+- [Import Resolution](../import-resolution) - Learn how Pyrefly resolves imports in your code

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -1,0 +1,65 @@
+---
+title: Installation
+
+description: How to install Pyrefly
+---
+
+
+Pyrefly isn't ready just yet,  but you can see our roadmap [here](https://github.com/facebook/pyrefly/milestone/1). We will be populating this section soon!
+
+----
+
+If you want to experiment with our tool, the easiest way to install Pyrefly is via `pip`.
+
+```
+pip install pyrefly
+```
+
+Then, `cd` into the directory or project you would like to type check and run
+
+```
+pyrefly check
+```
+
+You'll want to set up a basic configuration file to type check your project. You can add configuration options to a `pyproject.toml` file, or create a `pyrefly.toml` file in your project directory.
+
+```
+[tool.pyrefly]
+search_path = [
+    "example_directory/..."
+]
+```
+
+Then, simply run `pyrefly check`, this time the tool will use your configuration options.
+
+It's likely the tool will return a list of type errors, this is perfectly normal. At this point you have a few options:
+
+1. Silence the errors using `# pyrefly: ignore` comments. This will get your project to a clean type checking state and you can drive down the number of errors as you go. We've included a script that can do this for you:
+
+```
+pyrefly check --suppress-errors
+```
+2. Use extra configuration options to silence specific categories of errors, or exclude files with more errors than average.
+
+----
+# Upgrading Pyrefly
+
+Upgrading the version of Pyrefly you're using, or a third party library you depend on can surface new type errors in your code. Fixing them all at once is often not realistic. We've written scripts to help you temporarily silence them.
+
+```
+# step 1
+pyrefly check --suppress-errors
+```
+
+```
+# step 2
+<run your formatter of choice>
+```
+
+```
+# step 3
+pyrefly check --remove-unused-ignores
+```
+Repeat the steps above until you get a clean fomatting run and a clean type check.
+
+This will add ` # pyrefly: ignore` comments to your code that will enable you to silence errors, and come back and fix them at a later date. This can make the process of upgrading a large codebase much more manageable.

--- a/website/docs/migrating-from-mypy.mdx
+++ b/website/docs/migrating-from-mypy.mdx
@@ -1,0 +1,80 @@
+---
+title: Migrating from Mypy
+
+description: How to switch from Mypy to Pyrefly
+---
+
+# Running Pyrefly
+
+Like mypy, pyrefly can be given a list of files to check:
+
+```sh
+$ pyrefly check file1.py file2.py
+```
+
+The easiest way to run pyrefly on all files in a project is to run it from the project root:
+
+```sh
+$ cd your/project
+$ pyrefly check
+```
+
+Pyrefly is designed to have sensible defaults, and you may not need to configure it at all.
+However, projects with existing mypy configs may want to configure pyrefly to suit their own needs.
+
+# Mypy Config Migration
+
+To make it as easy as possible to get started with pyrefly, we've provided a script for automatically migrating a mypy config to pyrefly.
+
+```sh
+$ pyrefly config-migration path/to/your/mypy.ini
+```
+
+This will load your existing `mypy.ini` and transform it into a `pyrefly.toml` while preserving as many options as possible. See `config-migration --help` for more options.
+
+We do recommend checking the resulting config for errors. While there is some overlap between mypy's config options and pyrefly's config options, it's not always possible to cleanly translate one config option to another.
+
+If you'd rather start fresh with a hand-written config, please see the [pyrefly configuration docs](../configuration.mdx). If you run into any issues with config migration, please [let us know](https://github.com/facebook/pyrefly/issues)!
+
+## Config Migration Details
+
+`files`, `modules`, and `packages` are combined into `project_includes`. This should work exactly the same for `files` and `packages`. Mypy doesn't recurse into `modules`, but pyrefly will.
+
+Pyrefly makes an effort to transform the `exclude` regex into a list of filepath globs for `project_excludes`. This should excel on simple regexes, such as `some/file.py|exclude_dir/`, which becomes `["**/some/file.py", "**/exclude_dir/"]`.
+
+The `ignore_missing_imports` per-module config option is turned into a list of modules. For example:
+
+```ini
+[mypy-some.*.module]
+ignore_missing_imports = True
+```
+
+Becomes:
+
+```toml
+replace_imports_with_any = ["some.*.module"]
+```
+
+Pyrefly does support mypy's [module name pattern syntax](https://mypy.readthedocs.io/en/stable/config_file.html#config-file-format).
+
+Mypy's `follow_untyped_imports` option is allowed to be global or per-module. The pyrefly equivalent, `use_untyped_imports`, is only global. If any per-module section in the mypy config has `follow_untyped_imports = True`, then `use_untyped_imports` will be `true` in the pyrefly config.
+
+# Silencing Errors
+
+Like mypy, pyrefly has ways to silence specific error codes. Full details can be found in the [Error Suppression docs](error-suppresions.mdx).
+
+To silence an error on a specific line, add a disable comment above that line:
+
+```
+# pyrefly: ignore
+x: str = 1
+```
+
+To suppress all instances of an error, disable that error in the config:
+
+```
+[errors]
+import-error = false
+```
+
+This is equivalent to mypy's `disable_error_code`, though of course the [error codes](../error-kinds.mdx) are different!

--- a/website/docs/migrating-from-pyright.mdx
+++ b/website/docs/migrating-from-pyright.mdx
@@ -1,0 +1,63 @@
+---
+title: Migrating from Pyright
+
+description: How to switch from Pyright to Pyrefly
+---
+
+# Running Pyrefly
+
+Like pyright, pyrefly can be given a list of files to check:
+
+```sh
+$ pyrefly check file1.py file2.py
+```
+
+The easiest way to run pyrefly on all files in a project is to run it from the project root:
+
+```sh
+$ cd your/project
+$ pyrefly check
+```
+
+Pyrefly doesn't need a config file to start checking your code. Its sensible defaults are designed to work well for most projects.
+However, projects with existing pyright configs may want to configure pyrefly to suit their own needs.
+
+# Pyright Config Migration
+
+To make it as easy as possible to get started with pyrefly, we've provided a script for automatically migrating a pyright config to pyrefly.
+
+```sh
+$ pyrefly config-migration path/to/your/pyrightconfig.json
+```
+
+This will load your existing `pyrightconfig.json` and transform it into a `pyrefly.toml` while preserving as many options as possible. See `config-migration --help` for more options.
+
+There is a significant overlap between pyright's and pyrefly's configuration options, so migration is pretty straightforward. However, it may be worth checking the generated config for errors, just in case.
+
+If you'd rather start fresh with a hand-written config, please see the [pyrefly configuration docs](../configuration). If you run into any issues with config migration, please [let us know](https://github.com/facebook/pyrefly/issues)!
+
+## Config Migration Details
+
+When it comes to listing files, pyright uses just paths, while pyrefly supports glob patterns. Thankfully, paths are a subset of glob patterns, so pyrefly can just use the paths as-is. You could consider manually simplifying the paths into glob patterns, but it's not necessary.
+
+Pyright supports four platforms: Windows, Linux, Darwin (macOS), and All. Since pyrefly only supports Python's [supported platforms](https://docs.python.org/3/library/sys.html#sys.platform), we choose to treat "All" as "linux".
+
+# Silencing Errors
+
+Like pyright, pyrefly has ways to silence specific error codes. Full details can be found in the [Error Suppression docs](../error-suppresions).
+
+To silence an error on a specific line, add a disable comment above that line:
+
+```
+# pyrefly: ignore
+x: str = 1
+```
+
+To suppress all instances of an error, disable that error in the config:
+
+```
+[errors]
+import-error = false
+```
+
+This is similar to pyright's [type check rule overrides](https://microsoft.github.io/pyright/#/configuration?id=type-check-rule-overrides), though of course the [error codes](../error-kinds) are different!

--- a/website/docs/migrating-to-pyrefly.mdx
+++ b/website/docs/migrating-to-pyrefly.mdx
@@ -1,0 +1,15 @@
+---
+title: Migrating to Pyrefly
+description: How to switch from another typechecker to Pyrefly
+---
+
+# Migrating to Pyrefly
+
+Welcome to the Pyrefly migration guide. This section provides resources to help you transition from other type checkers to Pyrefly.
+
+## Migration Guides
+
+- [Migrating from Mypy](migrating-from-mypy.mdx) - Guide for transitioning from Mypy to Pyrefly
+- [Migrating from Pyright](migrating-from-pyright.mdx) - Guide for transitioning from Pyright to Pyrefly
+
+Choose the appropriate guide based on your current type checker to get started with your migration to Pyrefly.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -35,14 +35,12 @@ function getNavBarItems() {
             label: 'Sandbox',
             position: 'left' as const,
         },
-        // TODO (T221099224) remove this check when we are ready to publish Installation doc to public
-        process.env.INTERNAL_STATIC_DOCS === '1' ?
         {
-            to: 'en/docs/fb/installation/',
-            activeBasePath: 'en/docs/fb/installation',
+            to: 'en/docs/installation/',
+            activeBasePath: 'en/docs/installation',
             label: 'Install',
             position: 'left' as const,
-        } : null,
+        },
         // Please keep GitHub link to the right for consistency.
         {
             href: 'https://github.com/facebook/pyrefly',

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -35,41 +35,33 @@ const docsSidebar = [
         label: 'Getting Started',
         description: "Never used a type system before or just new to Pyrefly? Start here!",
         collapsed: false,
-        items: [...fbInternalOnly(['fb/installation']), 'configuration'],
+        items: ['installation', 'configuration'],
     },
-    ...fbInternalOnly(
-        [
-            {
-                type: 'category' as const,
-                label: 'Migrating to Pyrefly',
-                link: {
-                    type: 'doc' as const,
-                    id: 'fb/migrating-to-pyrefly',
-                },
-                description: "Never used a type system before or just new to Pyrefly? Start here!",
-                items: ['fb/migrating-from-mypy',  'fb/migrating-from-pyright']
-            },
-        ]
-    ),
+    {
+        type: 'category' as const,
+        label: 'Migrating to Pyrefly',
+        link: {
+            type: 'doc' as const,
+            id: 'migrating-to-pyrefly',
+        },
+        description: "Never used a type system before or just new to Pyrefly? Start here!",
+        items: ['migrating-from-mypy',  'migrating-from-pyright']
+    },
     {
         type: 'doc' as const,
         id: 'pyrefly-faq',
         label: 'FAQ',
     },
-    ...fbInternalOnly(
-        [
-            {
-                type: 'doc' as const,
-                id: 'fb/IDE',
-                label: 'IDE',
-            },
-            {
-                type: 'doc' as const,
-                id: 'fb/error-suppresions',
-                label: 'Error Suppressions',
-            },
-        ]
-    ),
+    {
+        type: 'doc' as const,
+        id: 'IDE',
+        label: 'IDE',
+    },
+    {
+        type: 'doc' as const,
+        id: 'error-suppresions',
+        label: 'Error Suppressions',
+    },
     {
         type: 'doc' as const,
         id: 'error-kinds',


### PR DESCRIPTION
Summary:
We have a lot of issues with broken links; it's tricky to handle moving pages,
especially because if we try to hide placeholder pages, then the internal and
external builds are different and some of the broken link warnings will only
show up on github.

Let's just make all pages public, even if they are still placeholders (the
only remaining placeholders are error-suppressions and getting-started, we
could probably prioritize these soon).

Differential Revision: D73594605
