### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/pyrefly/lib/alt/answers.rs
+++ b/pyrefly/lib/alt/answers.rs
@@ -686,7 +686,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             f: F,
             /// Arguments we have already used for the function.
             /// If we see the same element twice in a union (perhaps due to nested Var expansion),
-            /// we only need to process it once. Aviods O(n^2) for certain flow patterns.
+            /// we only need to process it once. Avoids O(n^2) for certain flow patterns.
             done: SmallSet<Type>,
             /// Have we seen a union node? If not, we can skip the cache
             /// as there will only be exactly one call to `f` (the common case).

--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -501,7 +501,7 @@ impl Linearization {
         // Merge the base class ancestors into a single Vec, in MRO order.
         //
         // The merge rule says we take the first available "head" of a chain (which are represented
-        // as revered vecs) that is not in the "tail" of any chain, then strip it from all chains.
+        // as reversed vecs) that is not in the "tail" of any chain, then strip it from all chains.
         let mut ancestors = Vec::new();
         while !ancestor_chains.is_empty() {
             // Identify a candidate for the next MRO entry: it must be the next ancestor in some chain,

--- a/pyrefly/lib/commands/config_finder.rs
+++ b/pyrefly/lib/commands/config_finder.rs
@@ -20,7 +20,7 @@ use crate::util::arc_id::ArcId;
 use crate::util::lock::Mutex;
 
 /// Create a standard `ConfigFinder`. The `configure` function is expected to set any additional options,
-/// then call `configure` and `valiate`.
+/// then call `configure` and `validate`.
 /// The `path` to `configure` is a directory, either to the python file or the config file.
 #[allow(clippy::field_reassign_with_default)] // ConfigFile default is dubious
 pub fn standard_config_finder(

--- a/pyrefly/lib/commands/lsp.rs
+++ b/pyrefly/lib/commands/lsp.rs
@@ -145,7 +145,7 @@ impl<'a> IDETransactionManager<'a> {
         if let Some(transaction) = state.try_new_committable_transaction(Require::Exports, None) {
             // If we can commit in-memory changes, then there is no point of holding the
             // non-commitable transaction with a possibly outdated view of the `ReadableState`
-            // so we can destory the saved state.
+            // so we can destroy the saved state.
             self.saved_state = None;
             Ok(transaction)
         } else {
@@ -159,7 +159,7 @@ impl<'a> IDETransactionManager<'a> {
 
     /// Produce a `Transaction` to power readonly IDE services.
     /// This transaction will never be able to be committed.
-    /// After using it, the state should be saved by caling the `save` method.
+    /// After using it, the state should be saved by calling the `save` method.
     ///
     /// The `Transaction` will always contain the handles of all open files with the latest content.
     /// It might be created fresh from state, or reused from previously saved state.
@@ -677,7 +677,7 @@ impl Server {
     }
 
     /// Perform an invalidation of elements on `State` and commit them.
-    /// Runs asyncronously. Returns immediately and may wait a while for a commitable transaction.
+    /// Runs asynchronously. Returns immediately and may wait a while for a committable transaction.
     fn invalidate(&self, f: impl FnOnce(&mut Transaction) + Send + 'static) {
         let state = self.state.dupe();
         let immediately_handled_events = self.immediately_handled_events.dupe();

--- a/pyrefly/lib/config/config.rs
+++ b/pyrefly/lib/config/config.rs
@@ -796,9 +796,9 @@ mod tests {
             "project_includes",
             "project_excludes",
             "python_interpreter",
-            // values we won't be geting
+            // values we won't be getting
             "extras",
-            // values that must be Some (if flattend, their contents will be checked)
+            // values that must be Some (if flattened, their contents will be checked)
             "python_environment",
         ]
         .into_iter()

--- a/pyrefly/lib/module/module_name.rs
+++ b/pyrefly/lib/module/module_name.rs
@@ -110,7 +110,7 @@ impl ModuleName {
     }
 
     /// The "unknown" module name, which corresponds to `__unknown__`.
-    /// Used for files directly openned or passed on the command line which aren't on the search path.
+    /// Used for files directly opened or passed on the command line which aren't on the search path.
     pub fn unknown() -> Self {
         Self::from_str("__unknown__")
     }

--- a/pyrefly/lib/test/attribute_narrow.rs
+++ b/pyrefly/lib/test/attribute_narrow.rs
@@ -178,7 +178,7 @@ class C:
     def x(self, value: int) -> None: ...
 def f(c: C):
     assert_type(c.x, int | None)
-    # No narrowing occurs on assignment to a descriptor. This is debateable, although
+    # No narrowing occurs on assignment to a descriptor. This is debatable, although
     # in the case where the set type is mismatched vs get it would be absurd to narrow,
     # and it could be very difficult in the presence of overloads.
     c.x = 42
@@ -191,7 +191,7 @@ def f(c: C):
 );
 
 testcase!(
-    bug = "PyTorch TODO: Implement gettitem narrowing",
+    bug = "PyTorch TODO: Implement getitem narrowing",
     test_attr_arg,
     r#"
 from typing import Any, Optional, reveal_type

--- a/pyrefly/lib/types/simplify.rs
+++ b/pyrefly/lib/types/simplify.rs
@@ -51,7 +51,7 @@ fn unions_internal(xs: Vec<Type>, stdlib: Option<&Stdlib>) -> Type {
         if let Some(stdlib) = stdlib {
             collapse_literals(&mut res, stdlib);
         }
-        // `res` is collapsable again if `flatten_and_dedup` drops `xs` to 0 or 1 elements
+        // `res` is collapsible again if `flatten_and_dedup` drops `xs` to 0 or 1 elements
         try_collapse(res).unwrap_or_else(Type::Union)
     })
 }

--- a/pyrefly/lib/types/type_info.rs
+++ b/pyrefly/lib/types/type_info.rs
@@ -113,7 +113,7 @@ impl TypeInfo {
     }
 
     /// Add a narrow to the TypeInfo. This is used for narrowing conditions, not assignment - it
-    /// only adds a new narrow (possibly overwriting any prexisting narrow), without changing subtrees.
+    /// only adds a new narrow (possibly overwriting any preexisting narrow), without changing subtrees.
     fn add_narrow(&mut self, names: &Vec1<Name>, ty: Type) {
         if let Some((name, more_names)) = names.split_first() {
             if let Some(attrs) = &mut self.attrs {

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -62,7 +62,7 @@ the start location is the directory containing each file to be type checked, and
 we find the config for each file matched by the pattern provided. No
 config flag can be passed into Pyrefly in single file checking mode, since the behavior
 is very ambiguous (would we apply the given config to each file? should the config
-override all settings, or jsut some of them?, ...).
+override all settings, or just some of them?, ...).
 
 If a `pyrefly.toml` is found, it is parsed and used for type checking, and will
 return an error to the user on invalid types, syntax, values, or unknown config options.

--- a/website/docs/import-resolution.mdx
+++ b/website/docs/import-resolution.mdx
@@ -60,7 +60,7 @@ You can control the above behavior with the following two configs:
   file. Check for `-stubs` first and fall back to non-stubs, regardless of the presence of a `py.typed` with
   `partial\n` or if the non-stubs packages contain a `py.typed`.
 - [`ignore_missing_source`](./configuration.mdx#ignore_missing_source): don't try to check for a backing non-stubs
-  package when we find a `-stubs` pacakge. Immediately return the `-stubs` package when found.
+  package when we find a `-stubs` package. Immediately return the `-stubs` package when found.
 
 ## Stub Files vs Source Files
 

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -60,6 +60,6 @@ pyrefly check --suppress-errors
 # step 3
 pyrefly check --remove-unused-ignores
 ```
-Repeat the steps above until you get a clean fomatting run and a clean type check.
+Repeat the steps above until you get a clean formatting run and a clean type check.
 
 This will add ` # pyrefly: ignore` comments to your code that will enable you to silence errors, and come back and fix them at a later date. This can make the process of upgrading a large codebase much more manageable.

--- a/website/docs/python-typing-for-beginners.mdx
+++ b/website/docs/python-typing-for-beginners.mdx
@@ -63,7 +63,7 @@ class Rectangle:
 
 rect = Rectangle(width=100, height=50)
 
-area = rect.width * rect.hieght
+area = rect.width * rect.height
 
 print(area)
 ```
@@ -85,7 +85,7 @@ class Rectangle:
 
 rect = Rectangle(width=100, height=50)
 
-area = rect.width * rect.hieght
+area = rect.width * rect.height
 `}
   />
 </pre>


### PR DESCRIPTION
https://pypi.org/project/codespell
```bash
codespell --ignore-words-list=ans,classe,defaulty,deriver,notin \
          --skip="*.lock,./pyrefly/third_party/typeshed/*" \
          --write-changes
```