### PR TITLE
Updates Docs page with example typo fix in configuration.mdx

### DIFF
--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -438,7 +438,7 @@ invalid-argument = false
 ...
 
 # Pyrefly header
-[pyrefly]
+[tool.pyrefly]
 
 #### configuring what to type check and where to import from
 project_includes = ["src"]
@@ -461,7 +461,7 @@ ignore_errors_in_generated_code = true
 use_untyped_imports = true
 ignore_missing_source = true
 
-[pyrefly.errors]
+[tool.pyrefly.errors]
 bad-assignment = false
 invalid-argument = false
 


### PR DESCRIPTION
## Context

This PR updates Website Docs page with example typo fix in `configuration.mdx`.

The example provided had referenced `[pyrefly]` where the TOML stanza should be `[tool.pyrefly]` instead. Confirmed that Pyrefly catches that configuration once the prefix is updated. 

**Python Version:** Python 3.11.11
**Poetry Version:** Poetry (version 2.1.1)
**Pyrefly Version**: pyrefly 0.13.0

I couldn't find which PEP lays out the standard for prefixing `tool.` with tooling in `pyproject.toml`, but it is mentioned slightly in here. https://peps.python.org/pep-0621/

