### PR TITLE
doc: update GitHub developers setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ of 2025.
 
 ### GitHub developers
 
-`cd pyrefly` then use the normal `cargo` commands (e.g. `cargo build`,
-`cargo test`).
+- Install or update Rust nightly `rustup install nightly`
+- `cd pyrefly` then use the normal `cargo +nightly` commands (e.g. `cargo +nightly build`,
+  `cargo +nightly test`).
 
 ### Meta internal developers
 


### PR DESCRIPTION
## What is in this PR?

- Update GitHub developers setup guide to resolve error
```sh
error: the 'cargo' binary, normally provided by the 'cargo' component, is not applicable to the 'nightly-2025-02-16-aarch64-apple-darwin' toolchain
```

