### PR TITLE
Never add the cwd to the search path if we find a pyproject.toml

### DIFF
--- a/pyrefly/bin/main.rs
+++ b/pyrefly/bin/main.rs
@@ -200,6 +200,7 @@ fn get_globs_and_config(
         ));
     }
     args.absolute_search_path();
+    args.validate()?;
     if files.is_empty() {
         get_globs_and_config_for_project(config, project_excludes, args)
     } else {

--- a/pyrefly/lib/commands/buck_check.rs
+++ b/pyrefly/lib/commands/buck_check.rs
@@ -61,11 +61,10 @@ fn read_input_file(path: &Path) -> anyhow::Result<InputFile> {
 fn compute_errors(sys_info: SysInfo, sourcedb: BuckSourceDatabase) -> Vec<Error> {
     let modules = sourcedb.modules_to_check();
 
-    let mut config = ConfigFile::default();
+    let mut config = ConfigFile::empty();
     config.python_environment.python_platform = Some(sys_info.platform().clone());
     config.python_environment.python_version = Some(sys_info.version());
     config.python_environment.site_package_path = Some(Vec::new());
-    config.search_path = Vec::new();
     config.custom_module_paths = sourcedb.list();
     config.configure();
     let config = ArcId::new(config);

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -33,6 +33,7 @@ use crate::commands::suppress;
 use crate::commands::util::module_from_path;
 use crate::config::config::ConfigFile;
 use crate::config::config::ConfigSource;
+use crate::config::config::validate_path;
 use crate::config::finder::ConfigFinder;
 use crate::error::error::Error;
 use crate::error::error::print_error_counts;
@@ -440,6 +441,20 @@ impl Args {
                 state.config_finder(),
             );
         }
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        fn validate_arg(arg_name: &str, paths: Option<&Vec<PathBuf>>) -> anyhow::Result<()> {
+            if let Some(paths) = paths {
+                for path in paths {
+                    validate_path(path).with_context(|| format!("Invalid {}", arg_name))?;
+                }
+            }
+            Ok(())
+        }
+        validate_arg("--site-package-path", self.site_package_path.as_ref())?;
+        validate_arg("--search-path", self.search_path.as_ref())?;
+        Ok(())
     }
 
     pub fn override_config(&self, mut config: ConfigFile) -> ConfigFile {

--- a/pyrefly/lib/config/config.rs
+++ b/pyrefly/lib/config/config.rs
@@ -10,11 +10,9 @@ use std::fmt;
 use std::fmt::Display;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::LazyLock;
 
 use anyhow::Context;
 use anyhow::anyhow;
-use dupe::Dupe;
 use itertools::Itertools;
 use path_absolutize::Absolutize;
 use serde::Deserialize;
@@ -37,7 +35,6 @@ use crate::state::loader::FindError;
 use crate::sys_info::PythonPlatform;
 use crate::sys_info::PythonVersion;
 use crate::sys_info::SysInfo;
-use crate::util::arc_id::ArcId;
 use crate::util::fs_anyhow;
 use crate::util::globs::Glob;
 use crate::util::globs::Globs;
@@ -210,17 +207,12 @@ impl ConfigFile {
     pub const PYPROJECT_FILE_NAME: &str = "pyproject.toml";
     pub const CONFIG_FILE_NAMES: &[&str] = &[Self::PYREFLY_FILE_NAME, Self::PYPROJECT_FILE_NAME];
 
-    /// An empty `ConfigFile` with no search path at all. Always returns the same `ArcId`.
+    /// An empty `ConfigFile` with no search path at all.
     #[allow(clippy::field_reassign_with_default)] // Default doesn't do what a normal Default does
-    pub fn empty() -> ArcId<Self> {
-        static EMPTY: LazyLock<ArcId<ConfigFile>> = LazyLock::new(|| {
-            let mut config = ConfigFile::default();
-            config.search_path = Vec::new();
-            config.python_environment.site_package_path = Some(Vec::new());
-            config.configure();
-            ArcId::new(config)
-        });
-        EMPTY.dupe()
+    pub fn empty() -> Self {
+        let mut config = ConfigFile::default();
+        config.search_path = Vec::new();
+        config
     }
 
     pub fn default_project_includes() -> Globs {

--- a/pyrefly/lib/config/config.rs
+++ b/pyrefly/lib/config/config.rs
@@ -141,24 +141,11 @@ impl ConfigFile {
     /// Gets a default ConfigFile, with no path rewriting. This should only be used for unit testing,
     /// since it may have strange runtime behavior. Prefer to use `ConfigFile::default()` instead.
     fn default_no_path_rewrite() -> Self {
-        ConfigFile {
-            source: ConfigSource::Synthetic,
-            project_includes: Self::default_project_includes(),
-            project_excludes: Self::default_project_excludes(),
-            python_interpreter: PythonEnvironment::get_default_interpreter(),
-            search_path: Self::default_search_path(),
-            python_environment: PythonEnvironment {
-                python_platform: None,
-                python_version: None,
-                site_package_path: None,
-                site_package_path_from_interpreter: false,
-            },
-            root: Default::default(),
-            sub_configs: Default::default(),
-            custom_module_paths: Default::default(),
-            use_untyped_imports: true,
-            ignore_missing_source: true,
-        }
+        let mut result = Self::empty();
+        result.project_includes = Self::default_project_includes();
+        result.project_excludes = Self::default_project_excludes();
+        result.search_path = Self::default_search_path();
+        result
     }
 
     /// Get the given [`ModuleName`] from this config's search and site package paths.
@@ -208,11 +195,25 @@ impl ConfigFile {
     pub const CONFIG_FILE_NAMES: &[&str] = &[Self::PYREFLY_FILE_NAME, Self::PYPROJECT_FILE_NAME];
 
     /// An empty `ConfigFile` with no search path at all.
-    #[allow(clippy::field_reassign_with_default)] // Default doesn't do what a normal Default does
     pub fn empty() -> Self {
-        let mut config = ConfigFile::default();
-        config.search_path = Vec::new();
-        config
+        ConfigFile {
+            source: ConfigSource::Synthetic,
+            project_includes: Globs::new(Vec::new()),
+            project_excludes: Globs::new(Vec::new()),
+            python_interpreter: PythonEnvironment::get_default_interpreter(),
+            search_path: Vec::new(),
+            python_environment: PythonEnvironment {
+                python_platform: None,
+                python_version: None,
+                site_package_path: None,
+                site_package_path_from_interpreter: false,
+            },
+            root: Default::default(),
+            sub_configs: Default::default(),
+            custom_module_paths: Default::default(),
+            use_untyped_imports: true,
+            ignore_missing_source: true,
+        }
     }
 
     pub fn default_project_includes() -> Globs {

--- a/pyrefly/lib/config/config.rs
+++ b/pyrefly/lib/config/config.rs
@@ -229,8 +229,8 @@ impl ConfigFile {
     }
 
     pub fn default_search_path() -> Vec<PathBuf> {
-        // Note that rewrite_with_path_to_config() always adds the path to the config file to the search path.
-        Vec::new()
+        // Note that rewrite_with_path_to_config() converts this to the config file's containing directory.
+        vec![PathBuf::from("")]
     }
 
     pub fn default_true() -> bool {
@@ -366,9 +366,6 @@ impl ConfigFile {
             base.push(search_root.as_path());
             *search_root = base;
         });
-        // push config to search path to make sure we can fall back to the config directory as an import path
-        // if users forget to add it
-        self.search_path.push(config_root.to_path_buf());
         self.python_environment
             .site_package_path
             .iter_mut()
@@ -442,6 +439,8 @@ impl ConfigFile {
 
             if let Some(config_root) = config_path.parent() {
                 config.rewrite_with_path_to_config(config_root);
+                // push config to search path to make sure we can fall back to the config directory as an import path
+                config.search_path.push(config_root.to_path_buf());
             }
 
             Ok(config)
@@ -744,7 +743,7 @@ mod tests {
             path_str.clone() + &with_sep("/path2/path3"),
         ];
         let project_excludes_vec = vec![path_str.clone() + &with_sep("/tests/untyped/**")];
-        let search_path = vec![test_path.join("../.."), test_path.clone()];
+        let search_path = vec![test_path.join("../..")];
         python_environment.site_package_path =
             Some(vec![test_path.join("venv/lib/python1.2.3/site-packages")]);
 

--- a/pyrefly/lib/config/config.rs
+++ b/pyrefly/lib/config/config.rs
@@ -410,11 +410,6 @@ impl ConfigFile {
                 }
                 _ => (),
             }
-            let p = if p == Path::new("") {
-                Path::new("./")
-            } else {
-                p
-            };
             warn!("Nonexistent `{field}` found: {}", p.display());
         }
         if !self.python_environment.site_package_path_from_interpreter {

--- a/pyrefly/lib/module/bundled.rs
+++ b/pyrefly/lib/module/bundled.rs
@@ -101,7 +101,7 @@ impl BundledTypeshed {
 
     pub fn config() -> ArcId<ConfigFile> {
         static CONFIG: LazyLock<ArcId<ConfigFile>> = LazyLock::new(|| {
-            let mut config_file = ConfigFile::default();
+            let mut config_file = ConfigFile::empty();
             config_file.python_environment.site_package_path = Some(Vec::new());
             config_file.search_path = match stdlib_search_path() {
                 Some(path) => vec![path],

--- a/pyrefly/lib/playground.rs
+++ b/pyrefly/lib/playground.rs
@@ -114,9 +114,8 @@ pub struct Playground {
 
 impl Playground {
     pub fn new() -> Self {
-        let mut config = ConfigFile::default();
+        let mut config = ConfigFile::empty();
         config.python_environment.set_empty_to_default();
-        config.search_path = Vec::new();
         config.configure();
         let config = ArcId::new(config);
 

--- a/pyrefly/lib/test/state.rs
+++ b/pyrefly/lib/test/state.rs
@@ -94,9 +94,8 @@ fn test_multiple_path() {
         ("main", "main.py", MAIN_PY),
     ];
 
-    let mut config = ConfigFile::default();
+    let mut config = ConfigFile::empty();
     config.python_environment.set_empty_to_default();
-    config.search_path = Vec::new();
     for (name, path, _) in FILES.iter().rev() {
         config.custom_module_paths.insert(
             ModuleName::from_str(name),
@@ -144,9 +143,8 @@ impl Incremental {
         init_test();
         let data = IncrementalData::default();
 
-        let mut config = ConfigFile::default();
+        let mut config = ConfigFile::empty();
         config.python_environment.set_empty_to_default();
-        config.search_path = Vec::new();
         for file in ["main", "foo", "bar", "baz"] {
             config.custom_module_paths.insert(
                 ModuleName::from_str(file),

--- a/pyrefly/lib/util/globs.rs
+++ b/pyrefly/lib/util/globs.rs
@@ -192,7 +192,7 @@ impl Glob {
             .with_context(|| format!("When resolving pattern `{pattern_str}`"))?;
         if result.is_empty() {
             return Err(anyhow::anyhow!(
-                "No files matched pattern `{}`",
+                "No Python files matched pattern `{}`",
                 pattern_str
             ));
         }
@@ -317,7 +317,7 @@ impl Globs {
             match self.files_eden() {
                 Ok(files) if files.is_empty() => {
                     return Err(anyhow::anyhow!(
-                        "No files matched pattern(s) {}",
+                        "No Python files matched pattern(s) {}",
                         self.0
                             .map(|p| format!("`{}`", p.0.to_string_lossy()))
                             .join(", "),

--- a/test/basic.md
+++ b/test/basic.md
@@ -99,8 +99,8 @@ All found `project_includes` files were filtered by `project_excludes` patterns.
 ```scrut {output_stream: stderr}
 $ echo "" > $TMPDIR/empty.py && $PYREFLY check --python-version 3.13.0 $TMPDIR/empty.py \
 > --search-path $TMPDIR/abcd --site-package-path $TMPDIR/abcd
-*WARN Nonexistent `site_package_path` found:* (glob)
-*WARN Nonexistent `search_path` found:* (glob)
+*WARN Invalid site_package_path: * does not exist (glob)
+*WARN Invalid search_path: * does not exist (glob)
 * INFO * errors* (glob)
 [0]
 ```

--- a/test/basic.md
+++ b/test/basic.md
@@ -20,7 +20,7 @@ $ $PYREFLY check $TEST_PY -a
 
 ```scrut {output_stream: stderr}
 $ $PYREFLY check $TMPDIR/does_not_exist --python-version 3.13.0
-No files matched pattern `*/does_not_exist` (glob)
+No Python files matched pattern `*/does_not_exist` (glob)
 [1]
 ```
 

--- a/test/basic.md
+++ b/test/basic.md
@@ -19,8 +19,16 @@ $ $PYREFLY check $TEST_PY -a
 ## Error on a non-existent file
 
 ```scrut {output_stream: stderr}
-$ $PYREFLY check $TMPDIR/does_not_exist --python-version 3.13.0 --search-path $TMPDIR/does_not_exist
+$ $PYREFLY check $TMPDIR/does_not_exist --python-version 3.13.0
 No files matched pattern `*/does_not_exist` (glob)
+[1]
+```
+
+## Error on a non-existent search path
+
+```scrut {output_stream: stderr}
+$ echo "" > $TMPDIR/empty.py && $PYREFLY check $TMPDIR/empty.py --search-path $TMPDIR/does_not_exist
+Invalid --search-path: `*/does_not_exist` does not exist (glob)
 [1]
 ```
 
@@ -97,10 +105,10 @@ All found `project_includes` files were filtered by `project_excludes` patterns.
 ## Error on a non-existent search-path/site-package-path
 
 ```scrut {output_stream: stderr}
-$ echo "" > $TMPDIR/empty.py && $PYREFLY check --python-version 3.13.0 $TMPDIR/empty.py \
-> --search-path $TMPDIR/abcd --site-package-path $TMPDIR/abcd
+$ echo "" > $TMPDIR/empty.py && echo -e "project_includes = [\"$TMPDIR/empty.py\"]\nsite_package_path = [\"$TMPDIR/abcd\"]\nsearch_path = [\"$TMPDIR/abcd\"]" > $TMPDIR/pyrefly.toml && $PYREFLY check -c $TMPDIR/pyrefly.toml --python-version 3.13.0 && rm $TMPDIR/pyrefly.toml
 *WARN Invalid site_package_path: * does not exist (glob)
 *WARN Invalid search_path: * does not exist (glob)
+* INFO * (glob)
 * INFO * errors* (glob)
 [0]
 ```


### PR DESCRIPTION
Summary:
Previously, if we saw a pyproject.toml without a [tool.pyrefly] section, we'd first create a default ConfigFile rooted at the cwd, then add the path to the config root to the search path. But if the pyrefly section was present, we'd only add the config root. Now we add only the config root in both cases.

This also fixes a minor bug where we previously added the config root twice when the pyrefly section was present.

Differential Revision: D74159947


