### PR TITLE
Fix test on windows

### DIFF
--- a/pyrefly/lib/test/lsp/lsp_interaction.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction.rs
@@ -323,7 +323,7 @@ fn test_completion() {
                         "uri": Url::from_file_path(root.path().join("foo.py")).unwrap().to_string()
                     },
                     "position": {
-                        "line": 7,
+                        "line": 11,
                         "character": 1
                     }
                 }),
@@ -336,7 +336,7 @@ fn test_completion() {
                         "uri": Url::from_file_path(root.path().join("foo.py")).unwrap().to_string()
                     },
                     "position": {
-                        "line": 7,
+                        "line": 11,
                         "character": 2
                     }
                 }),


### PR DESCRIPTION
Summary: D74495716 changes the integrated test and caused line numbers to move around. This test should be updated but somehow it's still passing under linux. However, now I noticed it's failing on windows CI, so this diff properly updates it.

Differential Revision: D74502692


