### PR TITLE
Build aarch64-unknown-linux-gnu wheels

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -121,6 +121,7 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - i686-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Build wheels for aarch64 (ie. arm64) linux.