### PR TITLE
docs: add Helix docs for IDE

### DIFF
--- a/website/docs/IDE.mdx
+++ b/website/docs/IDE.mdx
@@ -85,3 +85,15 @@ let g:ale_linters = {
     ...
   \ }
 ```
+
+### Helix
+Ensure that pyrefly is on `$PATH`. Add this snippet to your `languages.toml` file
+```toml
+[language-server.pyrefly]
+command = "pyrefly"
+args = ["lsp"]
+
+[[language]]
+name = "python"
+language-servers = ["pyrefly"]
+```


### PR DESCRIPTION
Add [Helix Editor](https://github.com/helix-editor/helix) to the IDE installation docs