### PR TITLE
Support subscripts into 'bytes'

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -957,6 +957,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     Some(&|| ErrorContext::Index(self.for_display(base.clone()))),
                 ),
                 Type::Any(style) => style.propagate(),
+                Type::Literal(Lit::Bytes(_)) => self.stdlib.bytes().clone().to_type(),
                 Type::LiteralString | Type::Literal(Lit::Str(_)) if xs.len() <= 3 => {
                     // We could have a more precise type here, but this matches Pyright.
                     self.stdlib.str().clone().to_type()

--- a/pyrefly/lib/test/literal.rs
+++ b/pyrefly/lib/test/literal.rs
@@ -175,3 +175,16 @@ bad1: Literal # E: Expected a type argument for `Literal`
 bad2: list[Literal]  # E: Expected a type argument for `Literal`
 "#,
 );
+
+testcase!(
+    test_literal_with_byte,
+    r#"
+from typing import assert_type, Literal
+x = b"foo"
+assert_type(x[0], bytes)
+assert_type(x[0:1], bytes)
+
+# TODO: assert type for literal
+# assert_type(x[0], Literal[b"f"])
+"#,
+);


### PR DESCRIPTION
Summary:
issue:
https://github.com/facebook/pyrefly/issues/255


the current codebase doesn't infer typecheck for byte type.

Differential Revision: D74999274


