### PR TITLE
Fix minor typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ for information on how to contribute to Pyrefly.
 
 ## Choices
 
-There are a number of choices when writing a Python type checker. We are take
+There are a number of choices when writing a Python type checker. We are taking
 inspiration from [Pyre1](https://pyre-check.org/),
 [Pyright](https://github.com/microsoft/pyright) and
 [MyPy](https://mypy.readthedocs.io/en/stable/). Some notable choices:


### PR DESCRIPTION
I found a minor typo issue in the README.md file.

Nothing too fancy, but in the part of the inspiration, I've found that it's currently written as **_We are take inspiration_**, and I suppose that you're thinking of writing **We are taking inspiration**