### PR TITLE
fix: assert_type test for indexing into byte literal

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1615,7 +1615,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Expr::NumberLiteral(ExprNumberLiteral { value, .. }) => {
                 if let Number::Int(int_value) = value {
                     if let Some(byte) = bytes.get(int_value.as_usize().unwrap_or_default()) {
-                        Type::Literal(Lit::Bytes(Box::new([*byte])))
+                        Type::Literal(Lit::Int(LitInt::new((*byte).into())))
+                        // Type::Literal(Lit::Bytes(Box::new([*byte])))
                     } else {
                         self.error(
                             errors,
@@ -1629,7 +1630,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         )
                     }
                 } else {
-                    self.stdlib.bytes().clone().to_type()
+                    self.error(
+                        errors,
+                        range,
+                        ErrorKind::IndexError,
+                        None,
+                        format!("Index {value:?} into bytearray is not an int"),
+                    )
                 }
             }
             _ => self.stdlib.bytes().clone().to_type(),

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1616,7 +1616,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if let Number::Int(int_value) = value {
                     if let Some(byte) = bytes.get(int_value.as_usize().unwrap_or_default()) {
                         Type::Literal(Lit::Int(LitInt::new((*byte).into())))
-                        // Type::Literal(Lit::Bytes(Box::new([*byte])))
                     } else {
                         self.error(
                             errors,

--- a/pyrefly/lib/test/literal.rs
+++ b/pyrefly/lib/test/literal.rs
@@ -181,7 +181,7 @@ testcase!(
     r#"
 from typing import assert_type, Literal
 x = b"far"
-assert_type(x[0], int)
+assert_type(x[0], Literal[102])
 
 # TODO: add support for negative indices case which should match `Expr::UnaryOp(...)`
 assert_type(x[-1], bytes)

--- a/pyrefly/lib/test/literal.rs
+++ b/pyrefly/lib/test/literal.rs
@@ -181,7 +181,7 @@ testcase!(
     r#"
 from typing import assert_type, Literal
 x = b"far"
-assert_type(x[0], Literal[b"f"])
+assert_type(x[0], int)
 
 # TODO: add support for negative indices case which should match `Expr::UnaryOp(...)`
 assert_type(x[-1], bytes)

--- a/pyrefly/lib/test/literal.rs
+++ b/pyrefly/lib/test/literal.rs
@@ -182,6 +182,7 @@ testcase!(
 from typing import assert_type, Literal
 x = b"far"
 assert_type(x[0], Literal[102])
+x[3.14]  # E: Index Float(3.14) into bytearray is not an int
 
 # TODO: add support for negative indices case which should match `Expr::UnaryOp(...)`
 assert_type(x[-1], bytes)


### PR DESCRIPTION
continuing the work from https://github.com/facebook/pyrefly/commit/03084134d88ae15f5e1943850e39a473fb19316c

fixing the test case when indexing into a bytestring: if `x: bytes`, then `x[0]: int`.
see [PEP 358](https://peps.python.org/pep-0358/#specification) for more info!