### PR TITLE
add support & tests for negative index into bytearrays

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1615,7 +1615,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Expr::NumberLiteral(ExprNumberLiteral { value, .. }) => {
                 if let Number::Int(int_value) = value {
                     if let Some(byte) = bytes.get(int_value.as_usize().unwrap_or_default()) {
-                        Type::Literal(Lit::Bytes(Box::new([*byte])))
+                        Type::Literal(Lit::Int(LitInt::new((*byte).into())))
+                        // Type::Literal(Lit::Bytes(Box::new([*byte])))
                     } else {
                         self.error(
                             errors,
@@ -1629,7 +1630,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         )
                     }
                 } else {
-                    self.stdlib.bytes().clone().to_type()
+                    self.error(
+                        errors,
+                        range,
+                        ErrorKind::IndexError,
+                        None,
+                        format!("Index {value:?} into bytearray is not an int"),
+                    )
                 }
             }
             _ => self.stdlib.bytes().clone().to_type(),

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -59,6 +59,7 @@ use crate::types::type_var_tuple::TypeVarTuple;
 use crate::types::types::AnyStyle;
 use crate::types::types::CalleeKind;
 use crate::types::types::Type;
+use crate::util::display::DisplayWithCtx;
 use crate::util::prelude::SliceExt;
 use crate::util::prelude::VecExt;
 use crate::util::visit::Visit;
@@ -1623,7 +1624,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             ErrorKind::IndexError,
                             None,
                             format!(
-                                "Index {int_value} out of range bytes with {} elements",
+                                "Index `{int_value}` out of range bytes with {} elements",
                                 bytes.len()
                             ),
                         )
@@ -1634,7 +1635,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         range,
                         ErrorKind::IndexError,
                         None,
-                        format!("Index {value:?} into bytearray is not an int"),
+                        format!(
+                            "Index `{}` into bytearray is not an int",
+                            index_expr.display_with(self.module_info())
+                        ),
                     )
                 }
             }

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1612,7 +1612,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         range: TextRange,
     ) -> Type {
         match index_expr {
-            // TODO: add support for negative indices case which should match `Expr::UnaryOp(...)`
             Expr::NumberLiteral(ExprNumberLiteral { value, .. }) => {
                 if let Number::Int(int_value) = value {
                     if let Some(byte) = bytes.get(int_value.as_usize().unwrap_or_default()) {
@@ -1625,6 +1624,42 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             None,
                             format!(
                                 "Index `{int_value}` out of range bytes with {} elements",
+                                bytes.len()
+                            ),
+                        )
+                    }
+                } else {
+                    self.error(
+                        errors,
+                        range,
+                        ErrorKind::IndexError,
+                        None,
+                        format!(
+                            "Index `{}` into bytearray is not an int",
+                            index_expr.display_with(self.module_info())
+                        ),
+                    )
+                }
+            }
+            // Support for negative indexes, e.g. x[-1]
+            Expr::UnaryOp(ruff_python_ast::ExprUnaryOp {
+                op: ruff_python_ast::UnaryOp::USub,
+                operand: box Expr::NumberLiteral(ExprNumberLiteral { value, .. }),
+                ..
+            }) => {
+                if let Number::Int(int_value) = value {
+                    if let Some(byte) =
+                        bytes.get(bytes.len() - int_value.as_usize().unwrap_or_default())
+                    {
+                        Type::Literal(Lit::Int(LitInt::new((*byte).into())))
+                    } else {
+                        self.error(
+                            errors,
+                            range,
+                            ErrorKind::IndexError,
+                            None,
+                            format!(
+                                "Index `-{int_value}` out of range bytes with {} elements",
                                 bytes.len()
                             ),
                         )

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1616,7 +1616,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if let Number::Int(int_value) = value {
                     if let Some(byte) = bytes.get(int_value.as_usize().unwrap_or_default()) {
                         Type::Literal(Lit::Int(LitInt::new((*byte).into())))
-                        // Type::Literal(Lit::Bytes(Box::new([*byte])))
                     } else {
                         self.error(
                             errors,

--- a/pyrefly/lib/test/literal.rs
+++ b/pyrefly/lib/test/literal.rs
@@ -181,7 +181,7 @@ testcase!(
     r#"
 from typing import assert_type, Literal
 x = b"far"
-assert_type(x[0], int)
+assert_type(x[0], Literal[102])
 
 # TODO: add support for negative indices case which should match `Expr::UnaryOp(...)`
 assert_type(x[-1], bytes)

--- a/pyrefly/lib/test/literal.rs
+++ b/pyrefly/lib/test/literal.rs
@@ -181,8 +181,9 @@ testcase!(
     r#"
 from typing import assert_type, Literal
 x = b"far"
+
 assert_type(x[0], Literal[102])
-x[3.14]  # E: Index Float(3.14) into bytearray is not an int
+x[3.14]  # E: Index `3.14` into bytearray is not an int
 
 # TODO: add support for negative indices case which should match `Expr::UnaryOp(...)`
 assert_type(x[-1], bytes)

--- a/pyrefly/lib/test/literal.rs
+++ b/pyrefly/lib/test/literal.rs
@@ -186,7 +186,8 @@ assert_type(x[0], Literal[102])
 x[3.14]  # E: Index `3.14` into bytearray is not an int
 
 # TODO: add support for negative indices case which should match `Expr::UnaryOp(...)`
-assert_type(x[-1], bytes)
+assert_type(x[-1], Literal[114])
+x[-6.28]  # E: Index `-6.28` into bytearray is not an int
 
 assert_type(x[0:1], bytes)
 "#,

--- a/pyrefly/lib/test/literal.rs
+++ b/pyrefly/lib/test/literal.rs
@@ -181,7 +181,7 @@ testcase!(
     r#"
 from typing import assert_type, Literal
 x = b"far"
-assert_type(x[0], Literal[b"f"])
+assert_type(x[0], int)
 
 # TODO: add support for negative indices case which should match `Expr::UnaryOp(...)`
 assert_type(x[-1], bytes)

--- a/pyrefly/lib/test/literal.rs
+++ b/pyrefly/lib/test/literal.rs
@@ -182,6 +182,7 @@ testcase!(
 from typing import assert_type, Literal
 x = b"far"
 assert_type(x[0], Literal[102])
+x[3.14]  # E: Index Float(3.14) into bytearray is not an int
 
 # TODO: add support for negative indices case which should match `Expr::UnaryOp(...)`
 assert_type(x[-1], bytes)


### PR DESCRIPTION
completing the work started at #305, #303.

* adds support for negative indices for bytestrings, e.g. `x[-1]` (where `x` is a bytestring). 
* also, adds tests for both cases.