### PR TITLE
Add a Linux ARM build

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -121,6 +121,7 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - i686-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Summary: A user found this didn't work in their Linux container on a Mac. This probably makes it work.

Differential Revision: D75082013


