### PR TITLE
Make our github CI run from the root

### DIFF
--- a/.github/workflows/pyrefly.yml
+++ b/.github/workflows/pyrefly.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: pyrefly
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Summary: Now we have a Cargo workspace.

Reviewed By: rchen152

Differential Revision: D75097359


