### PR TITLE
Fix singular and plural in summary

### DIFF
--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -575,7 +575,7 @@ impl Args {
 
         if !self.no_summary {
             info!(
-                "{} errors shown, {} errors ignored, {} modules, {} transitive dependencies, {} lines, took {timings}, peak memory {}",
+                "errors shown: {}, errors ignored: {}, modules: {}, transitive dependencies: {}, lines: {}, took {timings}, peak memory {}",
                 number_thousands(shown_errors_count),
                 number_thousands(errors.disabled.len() + errors.suppressed.len()),
                 number_thousands(handles.len()),


### PR DESCRIPTION
Computers are really bad at some things, but one thing they're really good at is counting :)

So let's replace:

```
 INFO 0 errors shown, 0 errors ignored, 1 modules, 65 transitive dependencies, 18,208 lines, took 0.10s, peak memory physical 76 MiB
```

With:

```
 INFO 0 errors shown, 0 errors ignored, 1 module, 65 transitive dependencies, 18,208 lines, took 0.57s, peak memory physical 89.3 MiB
```


