### PR TITLE
feat(cached_property): added support for cached_propery.cached_propery

### DIFF
--- a/pyrefly/lib/types/class.rs
+++ b/pyrefly/lib/types/class.rs
@@ -258,6 +258,7 @@ impl ClassKind {
             ("builtins", "classmethod") => Self::ClassMethod,
             ("builtins", "property") => Self::Property,
             ("functools", "cached_property") => Self::Property,
+            ("cached_property", "cached_property") => Self::Property,
             ("cinder", "cached_property") => Self::Property,
             ("cinder", "async_cached_property") => Self::Property,
             ("enum", "member") => Self::EnumMember,


### PR DESCRIPTION
Hi, our code base is quite large and our code currently isn't executed with python 3.12 interpreter. Because of that we chose not using the builtin [fucntools.cached_property](https://docs.python.org/3/library/functools.html#functools.cached_property), because as noted in the python docs: 
"Prior to Python 3.12, cached_property included an undocumented lock to ensure that in multi-threaded usage the getter function was guaranteed to run only once per instance. However, the lock was per-property, not per-instance, which could result in unacceptably high lock contention. In Python 3.12+ this locking is removed."
So instead we are using the third party framework [cached_property](https://github.com/pydanny/cached-property), until we migrate our code to be fully python 3.12 compatible (that could take time). I wanted to migrate from mypy to pyrefly because it looks awesome but everywhere I used cached_property pyrefly failed to understand that the return object of the property is the value annotated in the return type of the property and not a cached_property.

Example:
```python
from cached_property import cached_property

class A:
    b: int = 5

class B:
    @cached_property
    def a(self) -> A:
        return A()

    @property
    def b(self) -> int:
        return self.a.b
```
pyrefly check output:
Object of class `cached_property` has no attribute `b` [missing-attribute]



