### PR TITLE
Don't crash on identical bindings

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -537,6 +537,14 @@ impl<'a> BindingsBuilder<'a> {
         self.table.insert(key, value)
     }
 
+    /// Like `insert_binding` but will ignore subsequent calls
+    /// Should only be used in exceptional cases.
+    pub fn insert_binding_overwrite(&mut self, key: Key, value: Binding) -> Idx<Key> {
+        let idx = self.table.types.0.insert(key);
+        self.table.types.1.insert(idx, value);
+        idx
+    }
+
     /// Insert a binding into the bindings table, given the `idx` of a key that we obtained previously.
     pub fn insert_binding_idx<K: Keyed>(&mut self, idx: Idx<K>, value: K::Value) -> Idx<K>
     where

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -196,7 +196,7 @@ impl<'a> BindingsBuilder<'a> {
             // We still need to produce a `Key` here just to be safe, because other
             // code may rely on all `Identifier`s having `Usage` keys and we could panic
             // in an IDE setting if we don't ensure this is the case.
-            return self.insert_binding(key, Binding::Type(Type::any_error()));
+            return self.insert_binding_overwrite(key, Binding::Type(Type::any_error()));
         }
         match value {
             Ok(value) => {

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -988,6 +988,14 @@ f"{None for y}" # E: Parse # E: Parse # E: Parse # E: Parse # E: Parse
 );
 
 testcase!(
+    test_empty_if,
+    r#"
+# This parse error results in two identical Identifiers, which previously caused a panic.
+a = True if # E: Parse 
+"#,
+);
+
+testcase!(
     test_mangled_for,
     r#"
 # This has identical Identifiers in the AST, which seems like the right AST.


### PR DESCRIPTION
Summary: In some cases we get the same empty identifier more than once. If that happens we shouldn't crash on inserting. Add a test case and ensure we don't crash. This worked 5 days ago, but in D75158225 we fixed one crash while introducing another.

Differential Revision: D75371832


