### PR TITLE
Don't crash when producing completions

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -1533,17 +1533,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 for info in &mut res {
                     if let Some(definition) = &info.definition {
                         match definition {
-                            AttrDefinition::FullyResolved(TextRangeWithModuleInfo {
-                                module_info: _,
-                                range,
-                            }) => {
+                            AttrDefinition::FullyResolved(..) => {
                                 info.ty = match self
                                     .lookup_attr_from_attribute_base(base.clone(), &info.name)
                                 {
+                                    // Important we do not use the resolved TextRange, as it might be in a different module.
+                                    // Whereas the empty TextRange is valid for all modules.
                                     LookupResult::Found(attr) => self
                                         .resolve_get_access(
                                             attr,
-                                            *range,
+                                            TextRange::default(),
                                             &self.error_swallower(),
                                             None,
                                         )
@@ -1551,9 +1550,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                     _ => None,
                                 };
                             }
-                            AttrDefinition::PartiallyResolvedImportedModuleAttribute {
-                                module_name: _,
-                            } => {}
+                            AttrDefinition::PartiallyResolvedImportedModuleAttribute { .. } => {}
                         }
                     }
                 }


### PR DESCRIPTION
Summary:
A many-step reproduce required. We were checking for completions, which then does a type check of the attributes. That type check uses no error collector, the current module, but a location from where the attribute was defined. Mixing modules and ranges from different places goes wrong. In this case it goes wrong only when we add an error into the collector, which only happens if we have an overloaded property, as overload passes a real error collector.

Solution is just use the empty range if we don't want errors, as the empty range is valid for all modules.

Fixes #347

Differential Revision: D75373926


