### PR TITLE
Enhance protocol validation in type checking

### DIFF
--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -161,6 +161,13 @@ impl ClassMetadata {
         self.protocol_metadata.is_some()
     }
 
+    pub fn is_runtime_checkable_protocol(&self) -> bool {
+        self.protocol_metadata
+            .as_ref()
+            .map(|p| p.is_runtime_checkable)
+            .unwrap_or(false)
+    }
+
     pub fn is_new_type(&self) -> bool {
         self.is_new_type
     }
@@ -328,6 +335,8 @@ impl DataclassMetadata {
 pub struct ProtocolMetadata {
     /// All members of the protocol, excluding ones defined on `object` and not overridden in a subclass.
     pub members: SmallSet<Name>,
+    /// Whether this protocol is decorated with @runtime_checkable
+    pub is_runtime_checkable: bool,
 }
 
 /// A struct representing a class's ancestors, in method resolution order (MRO)

--- a/pyrefly/lib/types/callable.rs
+++ b/pyrefly/lib/types/callable.rs
@@ -223,6 +223,7 @@ pub enum FunctionKind {
     AssertType,
     RevealType,
     Final,
+    RuntimeCheckable,
     PropertySetter(Box<FuncId>),
     Def(Box<FuncId>),
     AbstractMethod,
@@ -485,6 +486,8 @@ impl FunctionKind {
             ("typing", None, "assert_type") => Self::AssertType,
             ("typing", None, "reveal_type") => Self::RevealType,
             ("typing", None, "final") => Self::Final,
+            ("typing", None, "runtime_checkable") => Self::RuntimeCheckable,
+            ("typing_extensions", None, "runtime_checkable") => Self::RuntimeCheckable,
             ("abc", None, "abstractmethod") => Self::AbstractMethod,
             _ => Self::Def(Box::new(FuncId {
                 module,
@@ -550,6 +553,11 @@ impl FunctionKind {
                 module: ModuleName::typing(),
                 cls: None,
                 func: Name::new_static("reveal_type"),
+            },
+            Self::RuntimeCheckable => FuncId {
+                module: ModuleName::typing(),
+                cls: None,
+                func: Name::new_static("runtime_checkable"),
             },
             Self::CallbackProtocol(cls) => FuncId {
                 module: cls.qname().module_name(),


### PR DESCRIPTION
## Implement basic @runtime_checkable protocol support (#47)

This PR implements the core functionality for Issue #47 by adding support for `@runtime_checkable` protocols in isinstance/issubclass checks.

### What's implemented:
- Detection of `@runtime_checkable` decorator on protocols
- Validation that non-decorated protocols cannot be used with isinstance/issubclass  
- Data vs non-data protocol distinction for issubclass validation
- Proper error messages following typing specification

### Test results:
- Detects 3 out of 6 expected errors in `conformance/third_party/protocols_runtime_checkable.py`
- All existing tests continue to pass
- No regressions introduced

### Missing (for future PR):
- "Unsafe overlap" detection for protocols with incompatible method signatures
- This is a more advanced feature that would require additional type analysis

### Files changed:
- `pyrefly/lib/alt/types/class_metadata.rs` - Added `is_runtime_checkable` field
- `pyrefly/lib/alt/class/class_metadata.rs` - Decorator detection logic  
- `pyrefly/lib/types/callable.rs` - Added `RuntimeCheckable` function kind
- `pyrefly/lib/alt/expr.rs` - isinstance/issubclass validation logic