### PR TITLE
Attempt to build jemalloc with the right page size

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -144,6 +144,10 @@ jobs:
           manylinux: auto
           args: --release --out dist
           working-directory: pyrefly
+          env:
+            # aarch64-linux builds need JEMALLOC_SYS_WITH_LG_PAGE=16, or they segfault.
+            # See https://github.com/facebook/pyrefly/issues/380
+            JEMALLOC_SYS_WITH_LG_PAGE: ${{ startsWith(matrix.target, 'aarch64') && '16' || '' }}
       - name: Test wheel
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |


### PR DESCRIPTION
Summary: In https://github.com/facebook/pyrefly/issues/380 a user reported that jemalloc segfaults on startup. https://github.com/facebook/buck2/pull/693 seems to be the corresponding fix in Buck2. Attempt to port that over.

Differential Revision: D75512738


