### PR TITLE
Move dotfile exclusion from project_excludes to core globbing logic

### DIFF
--- a/pyrefly/lib/config/config.rs
+++ b/pyrefly/lib/config/config.rs
@@ -345,10 +345,9 @@ impl ConfigFile {
 
     pub fn default_project_excludes() -> Globs {
         Globs::new(vec![
-            // match any hidden file, but don't match `.` or `..` (equivalent to regex: `\.[^/\.]{0,1}.*`)
-            "**/.[!/.]*".to_owned(),
             // match any `.venv` or `venv` directory
             "**/*venv/**".to_owned(),
+            // Note: dot files are now excluded at the Glob::files() level
         ])
     }
 

--- a/pyrefly_util/src/globs.rs
+++ b/pyrefly_util/src/globs.rs
@@ -911,7 +911,9 @@ mod tests {
 
         // Helper function to assert that a glob pattern returns no files
         let assert_empty_glob = |pattern_str: &str, description: &str| {
-            let found_files = Glob::new_with_root(root, pattern_str.to_owned()).files().unwrap_or_else(|_| Vec::new());
+            let found_files = Glob::new_with_root(root, pattern_str.to_owned())
+                .files()
+                .unwrap_or_else(|_| Vec::new());
             assert!(
                 found_files.is_empty(),
                 "{} should be excluded, found: {:?}",

--- a/pyrefly_util/src/globs.rs
+++ b/pyrefly_util/src/globs.rs
@@ -32,6 +32,12 @@ use crate::prelude::SliceExt;
 use crate::prelude::VecExt;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Default)]
+
+/// A glob pattern for matching files.
+///
+/// Only matches Python files (.py, .pyi) and automatically excludes:
+/// - Files that don't have .py or .pyi extensions
+/// - Files whose names start with '.' (dot files)
 pub struct Glob(PathBuf);
 
 impl Glob {
@@ -100,10 +106,28 @@ impl Glob {
         ext.is_some_and(|e| e == "py" || e == "pyi")
     }
 
+    /// Returns true if the given file should be included in results.
+    /// Filters out non-Python files and dot files.
+    fn should_include_file(path: &Path) -> bool {
+        // Check if it's a Python file
+        if !Self::is_python_extension(path.extension()) {
+            return false;
+        }
+        
+        // Check if it's a dot file
+        if let Some(file_name) = path.file_name().and_then(OsStr::to_str) {
+            if file_name.starts_with('.') {
+                return false;
+            }
+        }
+        
+        true
+    }
+
     fn resolve_path(path: PathBuf, results: &mut Vec<PathBuf>) -> anyhow::Result<()> {
         if path.is_dir() {
             Self::resolve_dir(&path, results)?;
-        } else if Self::is_python_extension(path.extension()) {
+        } else if Self::should_include_file(&path) {
             results.push(path);
         }
         Ok(())
@@ -748,7 +772,6 @@ mod tests {
             "a/b.py",
             "a/c/d.py",
             "a/c/e.pyi",
-            "a/.dotfile.py",
             "a/__pycache__/g.py",
             "a/__pycache__/h.pyi",
             "c/j/k.py",
@@ -766,7 +789,6 @@ mod tests {
             &[
                 "a/b.py",
                 "a/c/d.py",
-                "a/.dotfile.py",
                 "a/__pycache__/g.py",
                 "c/j/k.py",
                 "l.py",
@@ -782,7 +804,6 @@ mod tests {
                 "a/b.py",
                 "a/c/d.py",
                 "a/c/e.pyi",
-                "a/.dotfile.py",
                 "a/__pycache__/g.py",
                 "a/__pycache__/h.pyi",
                 "c/j/k.py",
@@ -805,7 +826,6 @@ mod tests {
                 "a/b.py",
                 "a/c/d.py",
                 "a/c/e.pyi",
-                "a/.dotfile.py",
                 "a/__pycache__/g.py",
                 "a/__pycache__/h.pyi",
             ],
@@ -817,7 +837,6 @@ mod tests {
                 "a/b.py",
                 "a/c/d.py",
                 "a/c/e.pyi",
-                "a/.dotfile.py",
                 "a/__pycache__/g.py",
                 "a/__pycache__/h.pyi",
             ],
@@ -829,7 +848,6 @@ mod tests {
                 "a/b.py",
                 "a/c/d.py",
                 "a/c/e.pyi",
-                "a/.dotfile.py",
                 "a/__pycache__/g.py",
                 "a/__pycache__/h.pyi",
             ],
@@ -843,7 +861,6 @@ mod tests {
                 "a/c/e.pyi",
                 "a/__pycache__/g.py",
                 "a/__pycache__/h.pyi",
-                "a/.dotfile.py",
             ],
         )
         .unwrap();
@@ -862,12 +879,82 @@ mod tests {
                 "a/b.py",
                 "a/c/d.py",
                 "a/c/e.pyi",
-                "a/.dotfile.py",
                 "a/__pycache__/g.py",
                 "a/__pycache__/h.pyi",
                 "c/j/k.py",
             ],
         )
         .unwrap();
+
+    }
+
+    #[test]
+    fn test_dot_file_exclusion() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        TestPath::setup_test_directory(
+            root,
+            vec![
+                TestPath::dir(
+                    "a",
+                    vec![
+                        TestPath::file("b.py"),
+                        TestPath::file(".dotfile.py"),
+                        TestPath::dir(
+                            "c",
+                            vec![
+                                TestPath::file("d.py"),
+                                TestPath::file(".hidden.py"),
+                            ],
+                        ),
+                    ],
+                ),
+                TestPath::file(".top_level_dot.py"),
+            ],
+        );
+
+        // Test explicit dot file exclusion
+        let dotfile_direct = Glob::new_with_root(root, "a/.dotfile.py".to_owned()).files();
+        match dotfile_direct {
+            Err(_) => {}, // Expected: no files found
+            Ok(files) => assert!(files.is_empty(), "Direct dot file path should be excluded, found: {:?}", files),
+        }
+        
+        let dotfile_recursive = Glob::new_with_root(root, "**/.dotfile.py".to_owned()).files();
+        match dotfile_recursive {
+            Err(_) => {}, // Expected: no files found  
+            Ok(files) => assert!(files.is_empty(), "Recursive dot file pattern should be excluded, found: {:?}", files),
+        }
+        
+        let dotfile_wildcard = Glob::new_with_root(root, "**/.*.py".to_owned()).files();
+        match dotfile_wildcard {
+            Err(_) => {}, // Expected: no files found
+            Ok(files) => assert!(files.is_empty(), "Dot file wildcard should be excluded, found: {:?}", files),
+        }
+
+        // Test that top-level dot files are also excluded
+        let top_level_dot = Glob::new_with_root(root, ".top_level_dot.py".to_owned()).files();
+        match top_level_dot {
+            Err(_) => {}, // Expected: no files found
+            Ok(files) => assert!(files.is_empty(), "Top-level dot file should be excluded, found: {:?}", files),
+        }
+
+        // Test that nested dot files are excluded
+        let nested_dot = Glob::new_with_root(root, "a/c/.hidden.py".to_owned()).files();
+        match nested_dot {
+            Err(_) => {}, // Expected: no files found
+            Ok(files) => assert!(files.is_empty(), "Nested dot file should be excluded, found: {:?}", files),
+        }
+
+        // Verify that normal files are still found
+        let normal_files = Glob::new_with_root(root, "**/*.py".to_owned()).files().unwrap();
+        assert!(!normal_files.is_empty(), "Normal Python files should still be found");
+        
+        // Ensure no dot files are in the results
+        for file in &normal_files {
+            if let Some(file_name) = file.file_name().and_then(|n| n.to_str()) {
+                assert!(!file_name.starts_with('.'), "Found dot file in results: {:?}", file);
+            }
+        }
     }
 }

--- a/pyrefly_util/src/globs.rs
+++ b/pyrefly_util/src/globs.rs
@@ -909,58 +909,23 @@ mod tests {
             ],
         );
 
+        // Helper function to assert that a glob pattern returns no files
+        let assert_empty_glob = |pattern_str: &str, description: &str| {
+            let found_files = Glob::new_with_root(root, pattern_str.to_owned()).files().unwrap_or_else(|_| Vec::new());
+            assert!(
+                found_files.is_empty(),
+                "{} should be excluded, found: {:?}",
+                description,
+                found_files
+            );
+        };
+
         // Test explicit dot file exclusion
-        let dotfile_direct = Glob::new_with_root(root, "a/.dotfile.py".to_owned()).files();
-        match dotfile_direct {
-            Err(_) => {} // Expected: no files found
-            Ok(files) => assert!(
-                files.is_empty(),
-                "Direct dot file path should be excluded, found: {:?}",
-                files
-            ),
-        }
-
-        let dotfile_recursive = Glob::new_with_root(root, "**/.dotfile.py".to_owned()).files();
-        match dotfile_recursive {
-            Err(_) => {} // Expected: no files found
-            Ok(files) => assert!(
-                files.is_empty(),
-                "Recursive dot file pattern should be excluded, found: {:?}",
-                files
-            ),
-        }
-
-        let dotfile_wildcard = Glob::new_with_root(root, "**/.*.py".to_owned()).files();
-        match dotfile_wildcard {
-            Err(_) => {} // Expected: no files found
-            Ok(files) => assert!(
-                files.is_empty(),
-                "Dot file wildcard should be excluded, found: {:?}",
-                files
-            ),
-        }
-
-        // Test that top-level dot files are also excluded
-        let top_level_dot = Glob::new_with_root(root, ".top_level_dot.py".to_owned()).files();
-        match top_level_dot {
-            Err(_) => {} // Expected: no files found
-            Ok(files) => assert!(
-                files.is_empty(),
-                "Top-level dot file should be excluded, found: {:?}",
-                files
-            ),
-        }
-
-        // Test that nested dot files are excluded
-        let nested_dot = Glob::new_with_root(root, "a/c/.hidden.py".to_owned()).files();
-        match nested_dot {
-            Err(_) => {} // Expected: no files found
-            Ok(files) => assert!(
-                files.is_empty(),
-                "Nested dot file should be excluded, found: {:?}",
-                files
-            ),
-        }
+        assert_empty_glob("a/.dotfile.py", "Direct dot file path");
+        assert_empty_glob("**/.dotfile.py", "Recursive dot file pattern");
+        assert_empty_glob("**/.*.py", "Dot file wildcard");
+        assert_empty_glob(".top_level_dot.py", "Top-level dot file");
+        assert_empty_glob("a/c/.hidden.py", "Nested dot file");
 
         // Verify that normal files are still found
         let normal_files = Glob::new_with_root(root, "**/*.py".to_owned())

--- a/pyrefly_util/src/globs.rs
+++ b/pyrefly_util/src/globs.rs
@@ -113,14 +113,14 @@ impl Glob {
         if !Self::is_python_extension(path.extension()) {
             return false;
         }
-        
+
         // Check if it's a dot file
         if let Some(file_name) = path.file_name().and_then(OsStr::to_str) {
             if file_name.starts_with('.') {
                 return false;
             }
         }
-        
+
         true
     }
 
@@ -885,7 +885,6 @@ mod tests {
             ],
         )
         .unwrap();
-
     }
 
     #[test]
@@ -902,10 +901,7 @@ mod tests {
                         TestPath::file(".dotfile.py"),
                         TestPath::dir(
                             "c",
-                            vec![
-                                TestPath::file("d.py"),
-                                TestPath::file(".hidden.py"),
-                            ],
+                            vec![TestPath::file("d.py"), TestPath::file(".hidden.py")],
                         ),
                     ],
                 ),
@@ -916,44 +912,73 @@ mod tests {
         // Test explicit dot file exclusion
         let dotfile_direct = Glob::new_with_root(root, "a/.dotfile.py".to_owned()).files();
         match dotfile_direct {
-            Err(_) => {}, // Expected: no files found
-            Ok(files) => assert!(files.is_empty(), "Direct dot file path should be excluded, found: {:?}", files),
+            Err(_) => {} // Expected: no files found
+            Ok(files) => assert!(
+                files.is_empty(),
+                "Direct dot file path should be excluded, found: {:?}",
+                files
+            ),
         }
-        
+
         let dotfile_recursive = Glob::new_with_root(root, "**/.dotfile.py".to_owned()).files();
         match dotfile_recursive {
-            Err(_) => {}, // Expected: no files found  
-            Ok(files) => assert!(files.is_empty(), "Recursive dot file pattern should be excluded, found: {:?}", files),
+            Err(_) => {} // Expected: no files found
+            Ok(files) => assert!(
+                files.is_empty(),
+                "Recursive dot file pattern should be excluded, found: {:?}",
+                files
+            ),
         }
-        
+
         let dotfile_wildcard = Glob::new_with_root(root, "**/.*.py".to_owned()).files();
         match dotfile_wildcard {
-            Err(_) => {}, // Expected: no files found
-            Ok(files) => assert!(files.is_empty(), "Dot file wildcard should be excluded, found: {:?}", files),
+            Err(_) => {} // Expected: no files found
+            Ok(files) => assert!(
+                files.is_empty(),
+                "Dot file wildcard should be excluded, found: {:?}",
+                files
+            ),
         }
 
         // Test that top-level dot files are also excluded
         let top_level_dot = Glob::new_with_root(root, ".top_level_dot.py".to_owned()).files();
         match top_level_dot {
-            Err(_) => {}, // Expected: no files found
-            Ok(files) => assert!(files.is_empty(), "Top-level dot file should be excluded, found: {:?}", files),
+            Err(_) => {} // Expected: no files found
+            Ok(files) => assert!(
+                files.is_empty(),
+                "Top-level dot file should be excluded, found: {:?}",
+                files
+            ),
         }
 
         // Test that nested dot files are excluded
         let nested_dot = Glob::new_with_root(root, "a/c/.hidden.py".to_owned()).files();
         match nested_dot {
-            Err(_) => {}, // Expected: no files found
-            Ok(files) => assert!(files.is_empty(), "Nested dot file should be excluded, found: {:?}", files),
+            Err(_) => {} // Expected: no files found
+            Ok(files) => assert!(
+                files.is_empty(),
+                "Nested dot file should be excluded, found: {:?}",
+                files
+            ),
         }
 
         // Verify that normal files are still found
-        let normal_files = Glob::new_with_root(root, "**/*.py".to_owned()).files().unwrap();
-        assert!(!normal_files.is_empty(), "Normal Python files should still be found");
-        
+        let normal_files = Glob::new_with_root(root, "**/*.py".to_owned())
+            .files()
+            .unwrap();
+        assert!(
+            !normal_files.is_empty(),
+            "Normal Python files should still be found"
+        );
+
         // Ensure no dot files are in the results
         for file in &normal_files {
             if let Some(file_name) = file.file_name().and_then(|n| n.to_str()) {
-                assert!(!file_name.starts_with('.'), "Found dot file in results: {:?}", file);
+                assert!(
+                    !file_name.starts_with('.'),
+                    "Found dot file in results: {:?}",
+                    file
+                );
             }
         }
     }


### PR DESCRIPTION
Move dotfile exclusion from `project_excludes` to `Glob::files()`

Files starting with '.' can never be importable by Python, so this
exclusion should be built into the core globbing logic rather than
relying on configuration. This ensures dotfiles are always excluded
even when project_excludes is overridden.

Resolves #321 