### PR TITLE
Fix missing comma in website docs for nvim

### DIFF
--- a/website/docs/IDE.mdx
+++ b/website/docs/IDE.mdx
@@ -124,7 +124,7 @@ require("mason-lspconfig").setup()
             ```lua
             vim.lsp.config('pyrefly', {
                 -- example of how to run `uv` installed Pyrefly without adding to your path
-                cmd = { 'uvx', 'pyrefly', 'lsp' }
+                cmd = { 'uvx', 'pyrefly', 'lsp' },
 
                 -- only enable for markdown files (probably a bad idea, but it's an example :) )
                 filetypes = { 'markdown' }


### PR DESCRIPTION
Hey team,

Noticed a tiny missing comma in the docs for nvim (website).😅
Just a small cleanup to keep things neat and clear.

Thanks for the awesome work you’re doing here!