### PR TITLE
InitVar Fields are not instance attributes in dataclasses

### DIFF
--- a/pyrefly/lib/test/dataclasses.rs
+++ b/pyrefly/lib/test/dataclasses.rs
@@ -597,3 +597,26 @@ class D:
     y: InitVar[int]  # OK
     "#,
 );
+
+testcase!(
+    test_initvar_not_stored_as_attributes,
+    r#"
+from dataclasses import dataclass, field, InitVar
+@dataclass
+class InitVarTest:
+    value: int = field(init=False)
+    mode: InitVar[str]
+    count: InitVar[int]
+    def __post_init__(self, mode: str, count: int):
+        if mode == "number":
+            self.value = count * 10
+        else:
+            self.value = 0
+instance = InitVarTest("number", 5)
+# InitVar fields should not be accessible as instance attributes
+instance.mode  # E: Object of class `InitVarTest` has no attribute `mode`
+instance.count  # E: Object of class `InitVarTest` has no attribute `count`
+# Regular fields should be accessible
+instance.value  # OK
+    "#,
+);

--- a/pyrefly/lib/types/annotation.rs
+++ b/pyrefly/lib/types/annotation.rs
@@ -62,6 +62,10 @@ impl Annotation {
         self.has_qualifier(&Qualifier::Final)
     }
 
+    pub fn is_init_var(&self) -> bool {
+        self.has_qualifier(&Qualifier::InitVar)
+    }
+
     pub fn has_qualifier(&self, qualifier: &Qualifier) -> bool {
         self.qualifiers.iter().any(|q| q == qualifier)
     }


### PR DESCRIPTION
### Summary

This PR addresses Issue #409 by ensuring that `InitVar` fields are **not treated as instance attributes** in dataclasses.

### Changes

- Introduced a new method `is_init_var` in both `ClassField` and `Annotation` to determine whether a field is an `InitVar`.
- Updated `get_instance_attribute` to prevent access to `InitVar` fields as instance attributes.
- Added a test case to verify that `InitVar` fields are correctly excluded from instance attribute access.
