### PR TITLE
Automatically add site_package_path entries as project_excludes

### DIFF
--- a/pyrefly_util/src/globs.rs
+++ b/pyrefly_util/src/globs.rs
@@ -277,6 +277,10 @@ impl Globs {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    pub fn append(&mut self, patterns: &[Glob]) {
+        self.0.extend_from_slice(patterns);
+    }
 }
 
 impl Display for Globs {


### PR DESCRIPTION
Summary:
This diff auto-adds `site_package_path` entries to `project_excludes`, which should help in cases where users don't have a `.gitignore` (which will also be fixed in https://github.com/facebook/pyrefly/issues/319). It seems like there should never be a situation where we're performing type checks on the site package path.

I'm not fully set on adding this, since I can see cases where users might expect to run Pyrefly on something in their site package path as a test, but I don't think that's going to be a common problem. They can also get around it by setting `site-package-path = []`.

Differential Revision: D76149500


