### PR TITLE
Don't enumerate files and directories that are excluded by a FilteredGlob

### DIFF
--- a/test/errors.md
+++ b/test/errors.md
@@ -27,13 +27,11 @@ $ echo "x: str = 12" > $TMPDIR/shown1.py && \
 [1]
 ```
 
-## We return an error when all files are filtered by project_excludes
+## We return an error when an entire project_includes pattern is matched by project_excludes
 
 ```scrut {output_stream: stderr}
-$ echo "x: str = 12" > $TMPDIR/excluded.py && \
-> $PYREFLY check --python-version 3.13.0 $TMPDIR/excluded.py --project-excludes="$TMPDIR/*"
-All found `project_includes` files were filtered by `project_excludes` patterns.
-`project_includes`:* (glob)
-`project_excludes`:* (glob)
+$ $PYREFLY check --python-version 3.13.0 "$TMPDIR/*" --project-excludes="$TMPDIR/*"
+Pattern * is matched by `project-excludes`. (glob)
+`project-excludes`: * (glob)
 [1]
 ```

--- a/test/find.md
+++ b/test/find.md
@@ -42,7 +42,7 @@ $ mkdir -p $TMPDIR/src_project/src/foo && echo "x: int = 0" > $TMPDIR/src_projec
 ## Relative --project-excludes
 
 ```scrut {output_stream: stderr}
-$ mkdir $TMPDIR/foo && touch $TMPDIR/foo/bar.py && echo "x: str = 0" > $TMPDIR/foo/problem.py && cd $TMPDIR/foo && $PYREFLY check *.py --project-excludes=problem.py
+$ mkdir $TMPDIR/foo && touch $TMPDIR/foo/bar.py && echo "x: str = 0" > $TMPDIR/foo/problem.py && cd $TMPDIR/foo && $PYREFLY check "*.py" --project-excludes=problem.py
  INFO errors shown: 0* (glob)
 [0]
 ```


### PR DESCRIPTION
Summary:
[An issue was reported](https://github.com/facebook/pyrefly/issues/360) that mentioned installing many dependencies slows down Pyrefly by a lot.

While we have [a task](https://github.com/facebook/pyrefly/issues/319) to address that by adding `.gitignore` entries into `project-excludes`, I realized that the way I implemented `FilteredGlobs` won't handle this well. We'll be ignoring them, but **we still have to enumerate everything first**, which means the `.gitignore` task will only help with reducing errors, not speeding up type checking.

This diff addresses that problem by threading our `project-excludes` as a `Globs` filter through our enumeration logic, and checking if a given glob or path matches, before iterating through the glob or path (if it's a directory).

This does cause us to lose messaging around "all found files were filtered by project excludes", but I think this is worth the trade. We can always add something back later if no files are returned that performs the same logic at the cost of slowing down the runtime massively.

---

Test on [Pyp](https://github.com/hauntsaninja/pyp) with [these dependencies](https://github.com/facebook/pyrefly/issues/360#issuecomment-2946645042):

Before
```
INFO ... transitive dependencies: 498, ... time: 20.89s (listing 19.01s; checking 1.49s) ...
```
(I've also seen durations up to as long as 50s!)

After
```
INFO ... transitive dependencies: 498, ... time: 1.26s ...
```

Differential Revision: D76149499


