### PR TITLE
Update python interpreter in config to make verbose logging clearer

### DIFF
--- a/pyrefly/lib/config/config.rs
+++ b/pyrefly/lib/config/config.rs
@@ -518,6 +518,7 @@ impl ConfigFile {
             {
                 let system_env = PythonEnvironment::get_interpreter_env(&interpreter);
                 self.python_environment.override_empty(system_env);
+                self.python_interpreter = Some(interpreter);
             } else {
                 self.python_environment.set_empty_to_default();
                 warn!(


### PR DESCRIPTION
Summary:
It's confusing that we say `python_interpreter: None` in the `DEBUG Config is:` output during verbose logging. It's confused me and several users, so let's fix that bug here so that we can stop being confusing.

p.s. I think I made this change a while ago and just forgot to write the found interpreter :(

Differential Revision: D76307599


