### PR TITLE
Use Pyrefly config finding default logic before langauge client provides expected python environment

### DIFF
--- a/pyrefly/lib/config/environment/environment.rs
+++ b/pyrefly/lib/config/environment/environment.rs
@@ -102,7 +102,7 @@ pub struct PythonEnvironment {
 impl PythonEnvironment {
     const DEFAULT_INTERPRETERS: &[&str] = &["python3", "python"];
 
-    fn pyrefly_default() -> Self {
+    pub fn pyrefly_default() -> Self {
         let mut env = Self::default();
         env.set_empty_to_default();
         env


### PR DESCRIPTION
Summary:
vscode-python is only used in VSCode, so our logic around getting the interpreter from the IDE only really works there. This was reported as part of the problem in [this issue](https://github.com/facebook/pyrefly/issues/356), where Helix is used but Pyrefly isn't finding a local .venv interpreter.

To fix that, we should just not set a default interpreter in the IDE until one is provided to us. We should instead use the directory the `standard_config_finder` gives us and try to find an interpreter at that location. 

If a language client later gives us an interpreter to use, this will be fine since we should clear out any cached configs and start using the newly provided interpreter in the workspace it was configured in.

Differential Revision: D76306932


