### PR TITLE
Add CLI flag for `use-untyped-imports`

### DIFF
--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -173,6 +173,9 @@ struct ConfigOverrideArgs {
     /// `python_platform`, or `site_package_path` if any of the values are missing.
     #[arg(long, env = clap_env("PYTHON_INTERPRETER"), value_name = "EXE_PATH")]
     python_interpreter: Option<PathBuf>,
+    /// Whether to search imports in `site-package-path` that do not have a `py.typed` file unconditionally.
+    #[arg(long, env = clap_env("USE_UNTYPED_IMPORTS"))]
+    use_untyped_imports: Option<bool>,
 }
 
 impl OutputFormat {
@@ -537,6 +540,9 @@ impl Args {
         }
         if let Some(x) = &self.config_override.python_interpreter {
             config.python_interpreter = Some(x.clone());
+        }
+        if let Some(x) = &self.config_override.use_untyped_imports {
+            config.use_untyped_imports = *x;
         }
         config.configure();
         let errors = config.validate();

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -302,8 +302,8 @@ more information on when a `site-package-path` cannot be used for typing informa
 
 - Type: bool
 - Default: true
-- Flag equivalent: none
-- ENV equivalent: none
+- Flag equivalent: `--use-untyped-imports`
+- ENV equivalent: `PYREFLY_USE_UNTYPED_IMPORTS`
 - Equivalent configs: `useLibraryCodeForTypes` in Pyright, `follow_untyped_imports` in mypy
 
 ### `ignore-missing-source`


### PR DESCRIPTION
Summary:
A new CLI flag `use-untyped-imports` to override the value from the config. Resolves #459 

Please let me know if any changes are required. Thank you