### PR TITLE
Disallow TypedDict in isinstance/issubclass checks

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -10536,6 +10536,16 @@
       "name": "typed-dict-key-error",
       "stop_column": 25,
       "stop_line": 28
+    },
+    {
+      "code": -2,
+      "column": 22,
+      "concise_description": "TypedDict `Movie` not allowed as second argument to isinstance()",
+      "description": "TypedDict `Movie` not allowed as second argument to isinstance()",
+      "line": 35,
+      "name": "invalid-argument",
+      "stop_column": 27,
+      "stop_line": 35
     }
   ]
 }

--- a/conformance/third_party/conformance.result
+++ b/conformance/third_party/conformance.result
@@ -603,7 +603,6 @@
     "Line 151: Unexpected errors [\"`dict[str, int]` is not assignable to TypedDict key `z` with type `Literal[''] | TypedDict[Inner3]`\"]"
   ],
   "typeddicts_usage.py": [
-    "Line 35: Expected 1 errors",
     "Line 40: Expected 1 errors"
   ]
 }

--- a/conformance/third_party/results.json
+++ b/conformance/third_party/results.json
@@ -3,7 +3,7 @@
   "pass": 56,
   "fail": 80,
   "pass_rate": 0.41,
-  "differences": 390,
+  "differences": 389,
   "passing": [
     "aliases_explicit.py",
     "aliases_newtype.py",
@@ -142,7 +142,7 @@
     "typeddicts_readonly_update.py": 2,
     "typeddicts_required.py": 2,
     "typeddicts_type_consistency.py": 2,
-    "typeddicts_usage.py": 2
+    "typeddicts_usage.py": 1
   },
   "comment": "@generated"
 }

--- a/pyrefly/lib/alt/special_calls.rs
+++ b/pyrefly/lib/alt/special_calls.rs
@@ -302,6 +302,20 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     format!("NewType `{}` not allowed in {}", cls.name(), func_display(),),
                 );
             }
+            // Check if this is a TypedDict
+            if metadata.is_typed_dict() {
+                self.error(
+                    errors,
+                    range,
+                    ErrorKind::InvalidArgument,
+                    None,
+                    format!(
+                        "TypedDict `{}` not allowed as second argument to {}",
+                        cls.name(),
+                        func_display()
+                    ),
+                );
+            }
             // Check if this is a protocol that needs @runtime_checkable
             if metadata.is_protocol() && !metadata.is_runtime_checkable_protocol() {
                 self.error(

--- a/pyrefly/lib/test/typed_dict.rs
+++ b/pyrefly/lib/test/typed_dict.rs
@@ -122,7 +122,7 @@ def test():
     s['data'] = []
     s['data'] = [42]
     s['data'] = [42, 'hello']
-    s['data'] = ['hello']  
+    s['data'] = ['hello']
     "#,
 );
 
@@ -583,5 +583,19 @@ from typing import TypedDict, Required, NotRequired
 class TD(TypedDict):
     x: Required[NotRequired[int]]  # E: Cannot combine `Required` and `NotRequired` for a TypedDict field
     y: NotRequired[Required[int]]  # E: Cannot combine `Required` and `NotRequired` for a TypedDict field
+"#,
+);
+
+testcase!(
+    test_typed_dict_isinstance_issubclass_not_allowed,
+    r#"
+from typing import *
+
+class D(TypedDict):
+    x: int
+
+x = int
+isinstance(x, D)  # E: TypedDict `D` not allowed as second argument to isinstance()
+issubclass(x, D)  # E: TypedDict `D` not allowed as second argument to issubclass()
 "#,
 );


### PR DESCRIPTION
## Description

This PR disallows TypedDicts as the second argument to `is instance` and `issubclass` checks.

## Relevant Issue
Closes https://github.com/facebook/pyrefly/issues/469.

## Testing Instructions

To test this PR manually, create a Python script like
```
from typing import *

class D(TypedDict):
    x: int

x = int
isinstance(x, D)
issubclass(x, D)
```
and run `pyrefly check`. Verify that errors are generated.