### PR TITLE
Add a test to keep error-kinds.mdx in sync with the ErrorKind enum

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [env]
-TEST_FILES_PATH = "lib/test/lsp/test_files"
+ERROR_KINDS_DOC_PATH = { value = "website/docs/error-kinds.mdx", relative = true }
+TEST_FILES_PATH = { value = "pyrefly/lib/test/lsp/test_files", relative = true }

--- a/pyrefly/Cargo.toml
+++ b/pyrefly/Cargo.toml
@@ -66,6 +66,7 @@ yansi = { version = "1.0.0-rc.1", features = ["hyperlink"] }
 
 [dev-dependencies]
 pretty_assertions = { version = "1.2", features = ["alloc"], default-features = false }
+pulldown-cmark = "0.9.1"
 tempfile = "3.15"
 
 [build-dependencies]

--- a/pyrefly/lib/error/context.rs
+++ b/pyrefly/lib/error/context.rs
@@ -69,12 +69,6 @@ impl TypeCheckContext {
             context: None,
         }
     }
-
-    /// Temporary helper to label errors as Unknown before we properly classify them.
-    #[expect(dead_code)]
-    pub fn unknown() -> Self {
-        Self::of_kind(TypeCheckKind::Unknown)
-    }
 }
 
 #[derive(Debug)]
@@ -126,9 +120,6 @@ pub enum TypeCheckKind {
     YieldFrom,
     /// Bare yield when the return annotation expects an actual value.
     UnexpectedBareYield,
-    // TODO: categorize all type checks and remove Unknown and Test designations
-    #[allow(dead_code)]
-    Unknown,
 }
 
 impl TypeCheckKind {
@@ -166,7 +157,6 @@ impl TypeCheckKind {
             Self::YieldValue => ErrorKind::InvalidYield,
             Self::YieldFrom => ErrorKind::InvalidYield,
             Self::UnexpectedBareYield => ErrorKind::InvalidYield,
-            Self::Unknown => ErrorKind::Unknown,
         }
     }
 }

--- a/pyrefly/lib/error/context.rs
+++ b/pyrefly/lib/error/context.rs
@@ -71,6 +71,7 @@ impl TypeCheckContext {
     }
 
     /// Temporary helper to label errors as Unknown before we properly classify them.
+    #[expect(dead_code)]
     pub fn unknown() -> Self {
         Self::of_kind(TypeCheckKind::Unknown)
     }
@@ -126,15 +127,16 @@ pub enum TypeCheckKind {
     /// Bare yield when the return annotation expects an actual value.
     UnexpectedBareYield,
     // TODO: categorize all type checks and remove Unknown and Test designations
+    #[allow(dead_code)]
     Unknown,
 }
 
 impl TypeCheckKind {
     pub fn from_annotation_target(target: &AnnotationTarget) -> Self {
         match target {
-            AnnotationTarget::Param(_)
-            | AnnotationTarget::ArgsParam(_)
-            | AnnotationTarget::KwargsParam(_) => Self::Unknown,
+            AnnotationTarget::Param(name)
+            | AnnotationTarget::ArgsParam(name)
+            | AnnotationTarget::KwargsParam(name) => Self::CallArgument(Some(name.clone()), None),
             AnnotationTarget::Return(_func) => Self::ExplicitFunctionReturn,
             AnnotationTarget::Assign(name, _is_initialized) => Self::AnnotatedName(name.clone()),
             AnnotationTarget::ClassMember(member) => Self::Attribute(member.clone()),
@@ -160,7 +162,7 @@ impl TypeCheckKind {
             Self::IterationVariableMismatch(..) => ErrorKind::BadAssignment,
             Self::AnnAssign => ErrorKind::BadAssignment,
             Self::UnpackedAssign => ErrorKind::BadAssignment,
-            Self::ExceptionClass => ErrorKind::Unknown,
+            Self::ExceptionClass => ErrorKind::InvalidInheritance,
             Self::YieldValue => ErrorKind::InvalidYield,
             Self::YieldFrom => ErrorKind::InvalidYield,
             Self::UnexpectedBareYield => ErrorKind::InvalidYield,

--- a/pyrefly/lib/error/display.rs
+++ b/pyrefly/lib/error/display.rs
@@ -221,9 +221,6 @@ impl TypeCheckKind {
                 "Expected to yield a value of type `{}`, but a bare `yield` gives `None` instead",
                 ctx.display(want),
             ),
-            Self::Unknown => {
-                format!("EXPECTED {} <: {}", ctx.display(got), ctx.display(want))
-            }
         }
     }
 }

--- a/pyrefly/lib/error/kind.rs
+++ b/pyrefly/lib/error/kind.rs
@@ -181,8 +181,6 @@ pub enum ErrorKind {
     UnsupportedOperand,
     /// Attempting to use a feature that is not yet supported.
     Unsupported,
-    /// Unknown or not-yet-defined error.
-    Unknown,
 }
 
 /// Computing the error kinds is disturbingly expensive, so cache the results.
@@ -213,7 +211,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_error_kind_name() {
-        assert_eq!(ErrorKind::Unknown.to_name(), "unknown");
+        assert_eq!(ErrorKind::Unsupported.to_name(), "unsupported");
         assert_eq!(ErrorKind::ParseError.to_name(), "parse-error");
     }
 }

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -24,6 +24,7 @@ use vec1::vec1;
 use crate::alt::answers::LookupAnswer;
 use crate::error::collector::ErrorCollector;
 use crate::error::context::TypeCheckContext;
+use crate::error::context::TypeCheckKind;
 use crate::solver::type_order::TypeOrder;
 use crate::types::callable::Callable;
 use crate::types::callable::Function;
@@ -504,7 +505,9 @@ impl Solver {
                 // is more restrictive (so the `forced` is an over-approximation).
                 if !self.is_subset_eq(&t, &forced, type_order) {
                     // Poor error message, but overall, this is a terrible experience for users.
-                    self.error(&forced, &t, errors, loc, &|| TypeCheckContext::unknown());
+                    self.error(&forced, &t, errors, loc, &|| {
+                        TypeCheckContext::of_kind(TypeCheckKind::AnnAssign)
+                    });
                 }
             }
             _ => {

--- a/pyrefly/lib/test/flow.rs
+++ b/pyrefly/lib/test/flow.rs
@@ -75,7 +75,7 @@ testcase!(
 from typing import assert_type, Any, Literal
 def f(condition) -> None:
     x = 1
-    while condition():  # E: EXPECTED Literal[1] | list[int] <: int
+    while condition():  # E: `Literal[1] | list[int]` is not assignable to `int`
         assert_type(x, Literal[1] | list[int])
         x = [x]
         assert_type(x, list[int])

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -324,7 +324,7 @@ testcase!(
 from typing import assert_type, Literal
 def f() -> str | None: ...
 x = f()
-while x is None:  # E: EXPECTED Literal[42] | str <: str | None
+while x is None:  # E: `Literal[42] | str` is not assignable to `str | None`
     if f():
         x = 42
         break

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -158,6 +158,10 @@ However, it is best practice to use the class syntax if possible, which doesn't 
 Like `bad-class-definition`, this error kind is uncommon because other error kinds are used for more specific issues.
 For example, argument order is enforced by the parser, so `def f(x: int = 1, y: str)` is a `parse-error`.
 
+## bad-instantiation
+
+<!-- TODO(rechen): fill this in -->
+
 ## bad-keyword-argument
 
 bad-keyword-argument pops up when a keyword argument is given multiple values:
@@ -274,6 +278,14 @@ This error occurs when attempting to `del` something that cannot be deleted.
 
 Besides obvious things like built-in values (you can't `del True`!), some object attributes are protected from deletion.
 For example, read-only and required `TypedDict` fields cannot be deleted.
+
+## deprecated
+
+<!-- TODO(rechen): fill this in -->
+
+## implicitly-defined-attribute
+
+<!-- TODO(rechen): fill this in -->
 
 ## import-error
 
@@ -715,6 +727,10 @@ def where() -> None:
   global spoon
 ```
 
+## unsupported
+
+This error indicates that pyrefly does not currently support a typing feature.
+
 ## unsupported-operand
 
 This error arises when attempting to perform an operation between values of two incompatible types.
@@ -726,7 +742,3 @@ An exception is the `in` operator, which fails when looking for a value in somet
 if "hello" in 1:  # int doesn't support `in`!
   ...
 ```
-
-## unsupported
-
-This error indicates that pyrefly does not currently support a typing feature.


### PR DESCRIPTION
Summary: It's much too easy for to add a new ErrorKind variant and forget to update the docs. Add a test to catch this.

Differential Revision: D76565757
