### PR TITLE
Add CLI flag for `ignore-errors-in-generated-code` (#464)

### DIFF
--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -187,6 +187,9 @@ struct ConfigOverrideArgs {
     /// Ignore missing source packages when only type stubs are available, allowing imports to proceed without source validation.
     #[arg(long, env = clap_env("IGNORE_MISSING_SOURCE"))]
     ignore_missing_source: Option<bool>,
+    // Whether to ignore type errors in generated code.
+    #[arg(long, env = clap_env("IGNORE_ERRORS_IN_GENERATED_CODE"))]
+    ignore_errors_in_generated_code: Option<bool>,
 }
 
 impl OutputFormat {
@@ -571,6 +574,9 @@ impl Args {
                     .filter_map(|x| ModuleWildcard::new(x).ok())
                     .collect(),
             );
+        }
+        if let Some(x) = &self.config_override.ignore_errors_in_generated_code {
+            config.root.ignore_errors_in_generated_code = Some(*x);
         }
         config.configure();
         let errors = config.validate();

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -290,7 +290,7 @@ the substring '<span>&#64;</span>generated'.
 - Default: false
 - Flag equivalent: `--ignore-errors-in-generated-code`
 - ENV equivalent: `IGNORE_ERRORS_IN_GENERATED_CODE`
-- Equivalent configs: none
+- Equivalent configs: `PYREFLY_IGNORE_ERRORS_IN_GENERATED_CODE`
 
 ### `use-untyped-imports`
 


### PR DESCRIPTION
Add a CLI flag `ignore-errors-in-generated-code` to override the value from the config.

Resolves: #464