### PR TITLE
Allow blank github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: false
+blank_issues_enabled: true


### PR DESCRIPTION
Summary:
I get annoyed having to fill out the bug form and clean it up after creating an issue when it's something unrelated to a bug.

We should add non-bug issues back. I don't think we need much more structure than just a blank issue for things other than bugs.

Reviewed By: ndmitchell

Differential Revision: D76603522

Resolves #475 
