### PR TITLE
Handle ReadOnly TypedDict subtyping

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -10258,6 +10258,16 @@
     {
       "code": -2,
       "column": 14,
+      "concise_description": "`TypedDict[C1]` is not assignable to `TypedDict[B1]`",
+      "description": "`TypedDict[C1]` is not assignable to `TypedDict[B1]`",
+      "line": 38,
+      "name": "bad-assignment",
+      "stop_column": 15,
+      "stop_line": 38
+    },
+    {
+      "code": -2,
+      "column": 14,
       "concise_description": "`TypedDict[A1]` is not assignable to `TypedDict[C1]`",
       "description": "`TypedDict[A1]` is not assignable to `TypedDict[C1]`",
       "line": 40,
@@ -10274,6 +10284,16 @@
       "name": "bad-assignment",
       "stop_column": 15,
       "stop_line": 79
+    },
+    {
+      "code": -2,
+      "column": 14,
+      "concise_description": "`TypedDict[A2]` is not assignable to `TypedDict[B2]`",
+      "description": "`TypedDict[A2]` is not assignable to `TypedDict[B2]`",
+      "line": 81,
+      "name": "bad-assignment",
+      "stop_column": 15,
+      "stop_line": 81
     },
     {
       "code": -2,
@@ -10465,6 +10485,16 @@
     }
   ],
   "typeddicts_type_consistency.py": [
+    {
+      "code": -2,
+      "column": 10,
+      "concise_description": "`TypedDict[B1]` is not assignable to `TypedDict[A1]`",
+      "description": "`TypedDict[B1]` is not assignable to `TypedDict[A1]`",
+      "line": 21,
+      "name": "bad-assignment",
+      "stop_column": 12,
+      "stop_line": 21
+    },
     {
       "code": -2,
       "column": 10,

--- a/conformance/third_party/conformance.result
+++ b/conformance/third_party/conformance.result
@@ -568,8 +568,6 @@
   "typeddicts_operations.py": [],
   "typeddicts_readonly.py": [],
   "typeddicts_readonly_consistency.py": [
-    "Line 38: Expected 1 errors",
-    "Line 81: Expected 1 errors",
     "Line 79: Unexpected errors ['`TypedDict[C2]` is not assignable to `TypedDict[A2]`']"
   ],
   "typeddicts_readonly_inheritance.py": [
@@ -591,7 +589,6 @@
     "Line 74: Unexpected errors [\"Expected a type form, got instance of `Literal['RecursiveMovie']`\"]"
   ],
   "typeddicts_type_consistency.py": [
-    "Line 21: Expected 1 errors",
     "Line 151: Unexpected errors [\"`dict[str, int]` is not assignable to TypedDict key `z` with type `Literal[''] | TypedDict[Inner3]`\"]"
   ],
   "typeddicts_usage.py": [

--- a/conformance/third_party/results.json
+++ b/conformance/third_party/results.json
@@ -3,7 +3,7 @@
   "pass": 58,
   "fail": 78,
   "pass_rate": 0.43,
-  "differences": 384,
+  "differences": 381,
   "passing": [
     "aliases_explicit.py",
     "aliases_newtype.py",
@@ -137,11 +137,11 @@
     "tuples_type_compat.py": 8,
     "typeddicts_class_syntax.py": 5,
     "typeddicts_inheritance.py": 1,
-    "typeddicts_readonly_consistency.py": 3,
+    "typeddicts_readonly_consistency.py": 1,
     "typeddicts_readonly_inheritance.py": 7,
     "typeddicts_readonly_update.py": 2,
     "typeddicts_required.py": 2,
-    "typeddicts_type_consistency.py": 2,
+    "typeddicts_type_consistency.py": 1,
     "typeddicts_usage.py": 2
   },
   "comment": "@generated"

--- a/pyrefly/lib/test/typed_dict.rs
+++ b/pyrefly/lib/test/typed_dict.rs
@@ -238,9 +238,27 @@ def foo(a: Coord, b: Coord3D, c: Pair):
     coord: Coord = b
     coord2: Coord3D = a  # E: `TypedDict[Coord]` is not assignable to `TypedDict[Coord3D]`
     coord3: Coord = c  # E: `TypedDict[Pair]` is not assignable to `TypedDict[Coord]`
-    coord4: Pair = a
+    coord4: Pair = a  # E: `TypedDict[Coord]` is not assignable to `TypedDict[Pair]`
     "#,
 );
+
+testcase!(
+    test_typed_dict_readonly_subtype,
+    r#"
+from typing import ReadOnly, TypedDict
+
+class TD(TypedDict):
+    a: ReadOnly[int]
+
+class TD2(TypedDict):
+    a: ReadOnly[object]
+
+def foo(td: TD, td2: TD2) -> None:
+    td: TD = td2  # E: `TypedDict[TD2]` is not assignable to `TypedDict[TD]`
+    td2: TD2 = td
+    "#,
+);
+
 
 testcase!(
     test_typed_dict_not_required,
@@ -366,6 +384,26 @@ f(x=1, y=2)
 f(x=1, y=2, z=3)
 f(x=1, y=2, z=3, a=4)  # E: Unexpected keyword argument `a`
 f(x="", y=2)  # E: Argument `Literal['']` is not assignable to parameter `x` with type `int` in function `f`
+    "#,
+);
+
+testcase!(
+    test_typed_dict_incompatible_types,
+    r#"
+from typing import ReadOnly, TypedDict
+
+class TD(TypedDict):
+    a: int
+
+class TD2(TypedDict):
+    a: ReadOnly[int]
+
+class TD3(TypedDict):
+    a: bool
+
+def foo(td2: TD2, td3: TD3) -> None:
+    td2: TD = td2  # E: `TypedDict[TD2]` is not assignable to `TypedDict[TD]`
+    td3: TD = td3  # E: `TypedDict[TD3]` is not assignable to `TypedDict[TD]`
     "#,
 );
 
@@ -583,5 +621,5 @@ from typing import TypedDict, Required, NotRequired
 class TD(TypedDict):
     x: Required[NotRequired[int]]  # E: Cannot combine `Required` and `NotRequired` for a TypedDict field
     y: NotRequired[Required[int]]  # E: Cannot combine `Required` and `NotRequired` for a TypedDict field
-"#,
+    "#,
 );

--- a/pyrefly/lib/test/typed_dict.rs
+++ b/pyrefly/lib/test/typed_dict.rs
@@ -259,7 +259,6 @@ def foo(td: TD, td2: TD2) -> None:
     "#,
 );
 
-
 testcase!(
     test_typed_dict_not_required,
     r#"
@@ -402,8 +401,8 @@ class TD3(TypedDict):
     a: bool
 
 def foo(td2: TD2, td3: TD3) -> None:
-    td2: TD = td2  # E: `TypedDict[TD2]` is not assignable to `TypedDict[TD]`
-    td3: TD = td3  # E: `TypedDict[TD3]` is not assignable to `TypedDict[TD]`
+    bar: TD = td2  # E: `TypedDict[TD2]` is not assignable to `TypedDict[TD]`
+    baz: TD = td3  # E: `TypedDict[TD3]` is not assignable to `TypedDict[TD]`
     "#,
 );
 


### PR DESCRIPTION
Fixes #333 and handles:
* ReadOnly[X] assigned to equivalent X key
* non-ReadOnly items treated as invariants

I also referenced
> Read-only items behave covariantly, as they cannot be mutated. This is similar to container types such as Sequence, and different from non-read-only items, which behave invariantly.

from https://typing.python.org/en/latest/spec/typeddict.html#id4