### PR TITLE
Don't remove the lock when building wasm

### DIFF
--- a/pyrefly_wasm/build.sh
+++ b/pyrefly_wasm/build.sh
@@ -15,9 +15,6 @@ else
   TARGET="web"
 fi
 
-# Temporary hack: currently fails with our lock file
-rm ../Cargo.lock || true
-
 # Make sure Rust is on the PATH
 export PATH="$HOME/.cargo/bin:$PATH"
   # If you are running into issues with compiling zstd on your mac, you'll need to install


### PR DESCRIPTION
Summary: We used to have to do this. But now the Cargo.lock is much more accurate so we don't have to.

Differential Revision: D76601808
