### PR TITLE
Disallow TypedDict special form outside of base class context

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -10657,6 +10657,16 @@
       "name": "invalid-argument",
       "stop_column": 27,
       "stop_line": 35
+    },
+    {
+      "code": -2,
+      "column": 24,
+      "concise_description": "Expected a type argument for `TypedDict`",
+      "description": "Expected a type argument for `TypedDict`",
+      "line": 40,
+      "name": "invalid-annotation",
+      "stop_column": 33,
+      "stop_line": 40
     }
   ]
 }

--- a/conformance/third_party/conformance.result
+++ b/conformance/third_party/conformance.result
@@ -589,7 +589,5 @@
   "typeddicts_type_consistency.py": [
     "Line 151: Unexpected errors [\"`dict[str, int]` is not assignable to TypedDict key `z` with type `Literal[''] | TypedDict[Inner3]`\"]"
   ],
-  "typeddicts_usage.py": [
-    "Line 40: Expected 1 errors"
-  ]
+  "typeddicts_usage.py": []
 }

--- a/conformance/third_party/results.json
+++ b/conformance/third_party/results.json
@@ -1,9 +1,9 @@
 {
   "total": 136,
-  "pass": 58,
-  "fail": 78,
+  "pass": 59,
+  "fail": 77,
   "pass_rate": 0.43,
-  "differences": 378,
+  "differences": 377,
   "passing": [
     "aliases_explicit.py",
     "aliases_newtype.py",
@@ -62,7 +62,8 @@
     "typeddicts_final.py",
     "typeddicts_operations.py",
     "typeddicts_readonly.py",
-    "typeddicts_readonly_kwargs.py"
+    "typeddicts_readonly_kwargs.py",
+    "typeddicts_usage.py"
   ],
   "failing": {
     "aliases_implicit.py": 6,
@@ -141,8 +142,7 @@
     "typeddicts_readonly_inheritance.py": 7,
     "typeddicts_readonly_update.py": 2,
     "typeddicts_required.py": 2,
-    "typeddicts_type_consistency.py": 1,
-    "typeddicts_usage.py": 1
+    "typeddicts_type_consistency.py": 1
   },
   "comment": "@generated"
 }

--- a/pyrefly/lib/test/type_alias.rs
+++ b/pyrefly/lib/test/type_alias.rs
@@ -487,7 +487,7 @@ testcase!(
 from typing import *
 Ts = TypeVarTuple('Ts')
 P = ParamSpec('P')
-t1: TypeAlias = Unpack[TypedDict]  # E: Unpack is not allowed in this context
+t1: TypeAlias = Unpack[TypedDict]  # E: Unpack is not allowed in this context # E: Expected a type argument for `TypedDict`
 t2: TypeAlias = P  # E: ParamSpec[P] is not allowed in this context
 t3: TypeAlias = Unpack[Ts]  # E: Unpack is not allowed in this context
 t4: TypeAlias = Literal  # E: Expected a type argument for `Literal`
@@ -508,7 +508,7 @@ testcase!(
     r#"
 from typing import Callable, Any
 def foo(x: Callable[[str], Any]) -> None:
-    pass 
+    pass
 
 foo(str)
     "#,
@@ -536,7 +536,7 @@ testcase!(
 from typing import TypeAlias
 
 class B: ...
-R: TypeAlias = B  
+R: TypeAlias = B
 class C: ...
 class F:
     T: TypeAlias = C

--- a/pyrefly/lib/test/typed_dict.rs
+++ b/pyrefly/lib/test/typed_dict.rs
@@ -627,7 +627,7 @@ class TD(TypedDict):
 testcase!(
     test_typed_dict_isinstance_issubclass_not_allowed,
     r#"
-from typing import *
+from typing import TypedDict
 
 class D(TypedDict):
     x: int
@@ -636,4 +636,29 @@ x = int
 isinstance(x, D)  # E: TypedDict `D` not allowed as second argument to isinstance()
 issubclass(x, D)  # E: TypedDict `D` not allowed as second argument to issubclass()
 "#,
+);
+
+testcase!(
+    test_typeddict_valid_base_class,
+    r#"
+from typing import TypedDict
+
+class Person(TypedDict):
+    name: str
+    age: int
+    "#,
+);
+
+testcase!(
+    test_typeddict_invalid_annotations,
+    r#"
+from typing import TypedDict, TypeVar
+
+T = TypeVar("T", bound=TypedDict)  # E: Expected a type argument for `TypedDict`
+
+def test(x: TypedDict):  # E: Expected a type argument for `TypedDict`
+    pass
+
+x: TypedDict  # E: Expected a type argument for `TypedDict`
+    "#,
 );

--- a/pyrefly/lib/types/special_form.rs
+++ b/pyrefly/lib/types/special_form.rs
@@ -74,7 +74,9 @@ impl SpecialForm {
     /// Is this special form valid as an un-parameterized annotation anywhere?
     pub fn is_valid_unparameterized_annotation(self, type_form_context: TypeFormContext) -> bool {
         match self {
-            SpecialForm::Protocol => matches!(type_form_context, TypeFormContext::BaseClassList),
+            SpecialForm::Protocol | SpecialForm::TypedDict => {
+                matches!(type_form_context, TypeFormContext::BaseClassList)
+            }
             SpecialForm::TypeAlias => matches!(
                 type_form_context,
                 TypeFormContext::TypeAlias | TypeFormContext::VarAnnotation(Initialized::Yes)
@@ -87,7 +89,6 @@ impl SpecialForm {
             SpecialForm::LiteralString
             | SpecialForm::Never
             | SpecialForm::NoReturn
-            | SpecialForm::TypedDict
             | SpecialForm::Type
             | SpecialForm::SelfType => true,
             _ => false,


### PR DESCRIPTION
## Description

This PR disallows TypedDicts from being used outside of the list of base classes, generating invalid annotation errors if this is the case.

## Relevant Issue
Closes https://github.com/facebook/pyrefly/issues/468.

## Testing Instructions

To test this PR manually, create a Python script like
```
from typing import TypedDict, TypeVar

T = TypeVar("T", bound=TypedDict)

def test(x: TypedDict):
    pass

x: TypedDict

```
and run `pyrefly check`. Verify that errors are generated.