### PR TITLE
Treat .pyc imports as typing.Any when no stubs can be found

### DIFF
--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -278,6 +278,8 @@ information will still be replaced with `typing.Any`.
 - Notes:
   - `errors = {import-error = false}` (TOML inline table for `errors`) has similar behavior in Pyrefly, but ignores
     *all* import errors instead of import errors from specific modules, and won't replace findable modules with `typing.Any`.
+  - Automatic Handling of `.pyc` Files: When a `.pyc` file is encountered and no source/stub files are available, Pyrefly automatically treats module as `typing.Any`.
+    This behavior ensures that compiled Python files without available source code do not cause import errors and are handled permissively.
 
 ### `ignore-errors-in-generated-code`
 


### PR DESCRIPTION
Fixes https://github.com/facebook/pyrefly/issues/456

Summary:
Updates the module resolution logic to treat .pyc files as typing.Any when no source or stub files are available. Ensures that compiled Python files are handled gracefully without causing import errors due to missing type information.

Adds doc updates and unit test cases to verify the correct identification and handling of .pyc files in the module search process.

Differential Revision: D76854224
