### PR TITLE
Store `reveal_type` and other errors separately in `CollectedErrors`

### DIFF
--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -639,14 +639,15 @@ impl Args {
         }
 
         let errors = loads.collect_errors();
+        let shown_errors_and_reveal_types = errors.shown_errors_and_reveal_types();
         if let Some(path) = &self.output.output {
             self.output
                 .output_format
-                .write_errors_to_file(path, &errors.shown)?;
+                .write_errors_to_file(path, &shown_errors_and_reveal_types)?;
         } else {
             self.output
                 .output_format
-                .write_errors_to_console(&errors.shown)?;
+                .write_errors_to_console(&shown_errors_and_reveal_types)?;
         }
         memory_trace.stop();
         if let Some(limit) = self.output.count_errors {

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -53,8 +53,12 @@ impl Errors {
     pub fn check_against_expectations(&self) -> anyhow::Result<()> {
         for (load, config) in &self.loads {
             let error_config = config.get_error_config(load.module_info.path().as_path());
-            Expectation::parse(load.module_info.dupe(), load.module_info.contents())
-                .check(&load.errors.collect(&error_config).shown)?;
+            Expectation::parse(load.module_info.dupe(), load.module_info.contents()).check(
+                &load
+                    .errors
+                    .collect(&error_config)
+                    .shown_errors_and_reveal_types(),
+            )?;
         }
         Ok(())
     }

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -215,7 +215,7 @@ impl TestEnv {
                 .transaction()
                 .get_errors(handles.iter())
                 .collect_errors()
-                .shown,
+                .shown_errors_and_reveal_types(),
         );
         (state, move |module| {
             let name = ModuleName::from_str(module);
@@ -449,7 +449,7 @@ pub fn testcase_for_macro(
             )]);
             t.run(&[(h.dupe(), Require::Everything)]);
             let errors = t.get_errors([&h]);
-            print_errors(&errors.collect_errors().shown);
+            print_errors(&errors.collect_errors().shown_errors_and_reveal_types());
             errors.check_against_expectations()?;
         } else {
             let (state, handle) = env.clone().to_state();


### PR DESCRIPTION
Per suggestion in https://github.com/facebook/pyrefly/issues/506#issuecomment-2980865884

This commit separates errors of kind `RevealType` from all shown errors
in `CollectedErrors`. By doing so, we can separate actual type errors
and pseudo-errors generated by calls to `reveal_type`. In the meantime,
this commit adds a function `shown_errors_and_reveal_types` to obtain
all diagnostics for displaying and reporting.

Closes #506.
