### PR TITLE
Fix non-determinism in autocomplete integration test

### DIFF
--- a/pyrefly/lib/test/lsp/test_files/tests_requiring_config/autoimport_provider.py
+++ b/pyrefly/lib/test/lsp/test_files/tests_requiring_config/autoimport_provider.py
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+def this_is_a_very_long_function_name_so_we_can_deterministically_test_autoimport_with_fuzzy_search() -> (
+    None
+):
+    return


### PR DESCRIPTION
Summary:
The non-determinism is likely coming from that there are multiple matches, and one match is on the edge of being either matched or not matched.

This diff addresses the issue by running the test on an extremely long name instead, so that the fuzzy matcher will always match it with high confidence.

Differential Revision: D77039902


