### PR TITLE
Implement a basic model for `functools.total_ordering`

### DIFF
--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -405,6 +405,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         }
         let mut is_final = false;
+        let mut is_total_ordering = false;
         for decorator in decorators {
             let decorator = self.get_idx(*decorator);
             match decorator.ty().callee_kind() {
@@ -430,6 +431,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             "@runtime_checkable can only be applied to Protocol classes".to_owned(),
                         );
                     }
+                }
+                Some(CalleeKind::Function(FunctionKind::TotalOrdering)) => {
+                    is_total_ordering = true;
                 }
                 _ => {}
             }
@@ -477,6 +481,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             is_new_type,
             is_final,
             has_unknown_tparams,
+            is_total_ordering,
             errors,
         )
     }

--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -49,7 +49,7 @@ use crate::types::types::Type;
 
 /// Private helper type used to share part of the logic needed for the
 /// binding-level work of finding legacy type parameters versus the type-level
-/// work of computing inherticance information and the MRO.
+/// work of computing inheritance information and the MRO.
 #[derive(Debug, Clone)]
 pub enum BaseClass {
     TypedDict,

--- a/pyrefly/lib/alt/class/mod.rs
+++ b/pyrefly/lib/alt/class/mod.rs
@@ -13,5 +13,6 @@ pub mod enums;
 pub mod named_tuple;
 pub mod new_type;
 pub mod targs;
+pub mod total_ordering;
 pub mod typed_dict;
 pub mod variance_inference;

--- a/pyrefly/lib/alt/class/total_ordering.rs
+++ b/pyrefly/lib/alt/class/total_ordering.rs
@@ -1,0 +1,94 @@
+use core::panic;
+
+use ruff_python_ast::name::Name;
+use starlark_map::small_map::SmallMap;
+
+use crate::alt::answers::AnswersSolver;
+use crate::alt::answers::LookupAnswer;
+use crate::alt::types::class_metadata::ClassSynthesizedField;
+use crate::alt::types::class_metadata::ClassSynthesizedFields;
+use crate::dunder;
+use crate::types::callable::Callable;
+use crate::types::callable::FuncMetadata;
+use crate::types::callable::Function;
+use crate::types::callable::Param;
+use crate::types::callable::ParamList;
+use crate::types::callable::Params;
+use crate::types::callable::Required;
+use crate::types::class::Class;
+use crate::types::types::Type;
+
+// https://github.com/python/cpython/blob/a8ec511900d0d84cffbb4ee6419c9a790d131129/Lib/functools.py#L173
+// conversion order of rich comparison methods:
+const LT_CONVERSION_ORDER: &[Name; 3] = &[dunder::GT, dunder::LE, dunder::GE];
+const GT_CONVERSION_ORDER: &[Name; 3] = &[dunder::LT, dunder::GE, dunder::LE];
+const LE_CONVERSION_ORDER: &[Name; 3] = &[dunder::GE, dunder::LT, dunder::GT];
+const GE_CONVERSION_ORDER: &[Name; 3] = &[dunder::LE, dunder::GT, dunder::LT];
+
+impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
+    fn synthesize_rich_cmp(&self, cls: &Class, cmp: &Name) -> ClassSynthesizedField {
+        let conversion_order = if cmp == &dunder::LT {
+            LT_CONVERSION_ORDER
+        } else if cmp == &dunder::GT {
+            GT_CONVERSION_ORDER
+        } else if cmp == &dunder::LE {
+            LE_CONVERSION_ORDER
+        } else if cmp == &dunder::GE {
+            GE_CONVERSION_ORDER
+        } else {
+            unreachable!("Unexpected rich comparison method: {}", cmp);
+        };
+        // The first field in the conversion order is the one that we will use to synthesize the method.
+        for other_cmp in conversion_order {
+            let other_cmp_field = cls.fields().find(|f| **f == *other_cmp);
+            if other_cmp_field.is_some() {
+                // FIXME: We should use the type from `other_cmp_field` instead of `cls_type`.
+                // However, here we use the type of the class itself, which is not always correct.
+                let cls_type = self.instantiate(cls);
+                let self_param = self.class_self_param(cls, false);
+                let other_param =
+                    Param::Pos(Name::new_static("other"), cls_type, Required::Required);
+                return ClassSynthesizedField::new(Type::Function(Box::new(Function {
+                    signature: Callable {
+                        params: Params::List(ParamList::new(vec![self_param, other_param])),
+                        ret: self.stdlib.bool().clone().to_type(),
+                    },
+                    metadata: FuncMetadata::def(
+                        self.module_info().name(),
+                        cls.name().clone(),
+                        cmp.clone(),
+                    ),
+                })));
+            }
+        }
+        unreachable!("Rich comparison method not found in conversion order");
+    }
+
+    pub fn get_total_ordering_synthesized_fields(
+        &self,
+        cls: &Class,
+    ) -> Option<ClassSynthesizedFields> {
+        let metadata = self.get_metadata_for_class(cls);
+        if !metadata.is_total_ordering() {
+            return None;
+        }
+        // The class must have one of the rich comparison dunder methods defined
+        if !cls
+            .fields()
+            .any(|f| *f == dunder::LT || *f == dunder::LE || *f == dunder::GT || *f == dunder::GE)
+        {
+            // TODO: raise an error properly.
+            panic!("Class does not define any rich comparison methods");
+        }
+        let rich_cmps_to_synthesize: Vec<_> = dunder::RICH_CMPS_TOTAL_ORDERING
+            .iter()
+            .filter(|cmp| !cls.contains(cmp))
+            .collect();
+        let mut fields = SmallMap::new();
+        for cmp in rich_cmps_to_synthesize {
+            let synthesized_field = self.synthesize_rich_cmp(cls, cmp);
+            fields.insert(cmp.clone(), synthesized_field);
+        }
+        Some(ClassSynthesizedFields::new(fields))
+    }
+}

--- a/pyrefly/lib/alt/class/total_ordering.rs
+++ b/pyrefly/lib/alt/class/total_ordering.rs
@@ -58,10 +58,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .fields()
             .any(|f| *f == dunder::LT || *f == dunder::LE || *f == dunder::GT || *f == dunder::GE)
         {
+            let total_ordering_metadata = metadata.total_ordering_metadata().unwrap();
             self.error(
                 errors,
-                // FIXME: Should use the range for @total_ordering decorator
-                cls.range(),
+                total_ordering_metadata.location,
                 ErrorKind::MissingAttribute,
                 None,
                 format!(

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -1331,10 +1331,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let fields = match &self.get_idx(fields.0).0 {
             None => ClassSynthesizedFields::default(),
             Some(cls) => self
+                // FIXME: This approach is not compositional, since total
+                // ordering fields need to be generated independently and then
+                // merged with the other synthesized fields.
+                // For example, a dataclass with total ordering fields will not have the
+                // total ordering fields synthesized right now.
                 .get_typed_dict_synthesized_fields(cls)
                 .or_else(|| self.get_dataclass_synthesized_fields(cls))
                 .or_else(|| self.get_named_tuple_synthesized_fields(cls))
                 .or_else(|| self.get_new_type_synthesized_fields(cls))
+                .or_else(|| self.get_total_ordering_synthesized_fields(cls))
                 .unwrap_or_default(),
         };
         Arc::new(fields)

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -1326,6 +1326,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
     pub fn solve_class_synthesized_fields(
         &self,
+        errors: &ErrorCollector,
         fields: &BindingClassSynthesizedFields,
     ) -> Arc<ClassSynthesizedFields> {
         let fields = match &self.get_idx(fields.0).0 {
@@ -1340,7 +1341,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 .or_else(|| self.get_dataclass_synthesized_fields(cls))
                 .or_else(|| self.get_named_tuple_synthesized_fields(cls))
                 .or_else(|| self.get_new_type_synthesized_fields(cls))
-                .or_else(|| self.get_total_ordering_synthesized_fields(cls))
+                .or_else(|| self.get_total_ordering_synthesized_fields(errors, cls))
                 .unwrap_or_default(),
         };
         Arc::new(fields)

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -1331,18 +1331,25 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Arc<ClassSynthesizedFields> {
         let fields = match &self.get_idx(fields.0).0 {
             None => ClassSynthesizedFields::default(),
-            Some(cls) => self
-                // FIXME: This approach is not compositional, since total
-                // ordering fields need to be generated independently and then
-                // merged with the other synthesized fields.
-                // For example, a dataclass with total ordering fields will not have the
-                // total ordering fields synthesized right now.
-                .get_typed_dict_synthesized_fields(cls)
-                .or_else(|| self.get_dataclass_synthesized_fields(cls))
-                .or_else(|| self.get_named_tuple_synthesized_fields(cls))
-                .or_else(|| self.get_new_type_synthesized_fields(cls))
-                .or_else(|| self.get_total_ordering_synthesized_fields(errors, cls))
-                .unwrap_or_default(),
+            Some(cls) => {
+                let mut fields = ClassSynthesizedFields::default();
+                if let Some(new_fields) = self.get_typed_dict_synthesized_fields(cls) {
+                    fields = fields.combine(new_fields);
+                }
+                if let Some(new_fields) = self.get_dataclass_synthesized_fields(cls) {
+                    fields = fields.combine(new_fields);
+                }
+                if let Some(new_fields) = self.get_named_tuple_synthesized_fields(cls) {
+                    fields = fields.combine(new_fields);
+                }
+                if let Some(new_fields) = self.get_new_type_synthesized_fields(cls) {
+                    fields = fields.combine(new_fields);
+                }
+                if let Some(new_fields) = self.get_total_ordering_synthesized_fields(errors, cls) {
+                    fields = fields.combine(new_fields);
+                }
+                fields
+            }
         };
         Arc::new(fields)
     }

--- a/pyrefly/lib/alt/traits.rs
+++ b/pyrefly/lib/alt/traits.rs
@@ -262,9 +262,9 @@ impl<Ans: LookupAnswer> Solve<Ans> for KeyClassSynthesizedFields {
     fn solve(
         answers: &AnswersSolver<Ans>,
         binding: &BindingClassSynthesizedFields,
-        _errors: &ErrorCollector,
+        errors: &ErrorCollector,
     ) -> Arc<ClassSynthesizedFields> {
-        answers.solve_class_synthesized_fields(binding)
+        answers.solve_class_synthesized_fields(errors, binding)
     }
 
     fn create_recursive(_: &AnswersSolver<Ans>, _: &Self::Value) -> Self::Recursive {}

--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -304,6 +304,15 @@ impl ClassSynthesizedFields {
     pub fn get(&self, name: &Name) -> Option<&ClassSynthesizedField> {
         self.0.get(name)
     }
+
+    /// Combines two sets of synthesized fields, with the second set
+    /// overwriting any fields in the first set that have the same name.
+    pub fn combine(mut self, other: Self) -> Self {
+        for (name, field) in other.0 {
+            self.0.insert(name, field);
+        }
+        self
+    }
 }
 
 impl Display for ClassSynthesizedFields {

--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -49,6 +49,7 @@ pub struct ClassMetadata {
     /// Is it possible for this class to have type parameters that we don't know about?
     /// This can happen if, e.g., a class inherits from Any.
     has_unknown_tparams: bool,
+    is_total_ordering: bool,
 }
 
 impl VisitMut<Type> for ClassMetadata {
@@ -80,6 +81,7 @@ impl ClassMetadata {
         is_new_type: bool,
         is_final: bool,
         has_unknown_tparams: bool,
+        is_total_ordering: bool,
         errors: &ErrorCollector,
     ) -> ClassMetadata {
         let mro = Mro::new(cls, &bases_with_metadata, errors);
@@ -103,6 +105,7 @@ impl ClassMetadata {
             is_new_type,
             is_final,
             has_unknown_tparams,
+            is_total_ordering,
         }
     }
 
@@ -166,6 +169,7 @@ impl ClassMetadata {
             is_new_type: false,
             is_final: false,
             has_unknown_tparams: false,
+            is_total_ordering: false,
         }
     }
 
@@ -226,6 +230,10 @@ impl ClassMetadata {
 
     pub fn is_enum(&self) -> bool {
         self.enum_metadata.is_some()
+    }
+
+    pub fn is_total_ordering(&self) -> bool {
+        self.is_total_ordering
     }
 
     pub fn protocol_metadata(&self) -> Option<&ProtocolMetadata> {

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -1539,7 +1539,7 @@ pub struct BindingClassMetadata {
     pub class_idx: Idx<KeyClass>,
     pub bases: Box<[Expr]>,
     pub keywords: Box<[(Name, Expr)]>,
-    pub decorators: Box<[Idx<Key>]>,
+    pub decorators: Box<[(Idx<Key>, TextRange)]>,
     pub is_new_type: bool,
     pub special_base: Option<Box<BaseClass>>,
 }

--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -114,8 +114,10 @@ impl<'a> BindingsBuilder<'a> {
         let mut key_class_fields: SmallSet<Idx<KeyClassField>> = SmallSet::new();
 
         let body = mem::take(&mut x.body);
-        let decorators =
-            self.ensure_and_bind_decorators(mem::take(&mut x.decorator_list), class_object.usage());
+        let decorators_with_ranges = self.ensure_and_bind_decorators_with_ranges(
+            mem::take(&mut x.decorator_list),
+            class_object.usage(),
+        );
 
         self.scopes.push(Scope::annotation(x.range));
 
@@ -180,7 +182,7 @@ impl<'a> BindingsBuilder<'a> {
                 class_idx: class_indices.class_idx,
                 bases: bases.clone().into_boxed_slice(),
                 keywords: keywords.into_boxed_slice(),
-                decorators: decorators.clone().into_boxed_slice(),
+                decorators: decorators_with_ranges.clone().into_boxed_slice(),
                 is_new_type: false,
                 special_base: None,
             },
@@ -290,11 +292,14 @@ impl<'a> BindingsBuilder<'a> {
         }
 
         let legacy_tparams = legacy_tparam_builder.lookup_keys();
+        let decorator_keys = decorators_with_ranges
+            .map(|(idx, _)| *idx)
+            .into_boxed_slice();
 
         self.bind_definition_user(
             &x.name,
             class_object,
-            Binding::ClassDef(class_indices.class_idx, decorators.into_boxed_slice()),
+            Binding::ClassDef(class_indices.class_idx, decorator_keys),
             FlowStyle::Other,
         );
         fields_possibly_defined_by_this_class.reserve(0); // Attempt to shrink to capacity

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -737,4 +737,19 @@ impl<'a> BindingsBuilder<'a> {
         }
         decorator_keys
     }
+
+    pub fn ensure_and_bind_decorators_with_ranges(
+        &mut self,
+        decorators: Vec<Decorator>,
+        usage: &mut Usage,
+    ) -> Vec<(Idx<Key>, TextRange)> {
+        let mut decorator_keys_with_ranges = Vec::with_capacity(decorators.len());
+        for mut x in decorators {
+            self.ensure_expr(&mut x.expression, usage);
+            let range = x.range();
+            let k = self.insert_binding(Key::Anon(x.range), Binding::Decorator(x.expression));
+            decorator_keys_with_ranges.push((k, range));
+        }
+        decorator_keys_with_ranges
+    }
 }

--- a/pyrefly/lib/dunder.rs
+++ b/pyrefly/lib/dunder.rs
@@ -48,6 +48,8 @@ pub const SETITEM: Name = Name::new_static("__setitem__");
 pub const BOOL: Name = Name::new_static("__bool__");
 
 pub const RICH_CMPS: &[Name] = &[LT, LE, EQ, NE, GT, GE];
+/// Rich comparison methods supplied by the `functools.total_ordering` decorator
+pub const RICH_CMPS_TOTAL_ORDERING: &[Name] = &[LT, LE, GT, GE];
 
 /// Returns the associated dunder if `op` corresponds to a "rich comparison method":
 /// https://docs.python.org/3/reference/datamodel.html#object.__lt__.

--- a/pyrefly/lib/module/module_name.rs
+++ b/pyrefly/lib/module/module_name.rs
@@ -134,6 +134,10 @@ impl ModuleName {
         Self::from_str("dataclasses")
     }
 
+    pub fn functools() -> Self {
+        Self::from_str("functools")
+    }
+
     pub fn type_checker_internals() -> Self {
         Self::from_str("_typeshed._type_checker_internals")
     }

--- a/pyrefly/lib/test/decorators.rs
+++ b/pyrefly/lib/test/decorators.rs
@@ -350,3 +350,15 @@ reveal_type(A.__gt__)  # E: revealed type: (self: A, other: A) -> bool
 a <= b
 "#,
 );
+
+testcase!(
+    test_total_ordering_no_rich_cmp,
+    r#"
+from functools import total_ordering
+
+@total_ordering
+class A:  # E: Class `A` must define at least one of the rich comparison methods.
+    def __init__(self, x: int) -> None:
+        self.x = x
+"#,
+);

--- a/pyrefly/lib/test/decorators.rs
+++ b/pyrefly/lib/test/decorators.rs
@@ -362,3 +362,28 @@ class A:  # E: Class `A` must define at least one of the rich comparison methods
         self.x = x
 "#,
 );
+
+testcase!(
+    test_total_ordering_dataclass,
+    r#"
+from dataclasses import dataclass
+from functools import total_ordering
+from typing import reveal_type
+
+@dataclass
+@total_ordering
+class A:
+    x: int
+    def __lt__(self, other: "A") -> bool:
+        return self.x < other.x
+
+a = A(x=1)
+b = A(x=2)
+
+# This should give the correct type for the method `__lt__`
+reveal_type(A.__lt__)  # E: revealed type: (self: Self@A, other: A) -> bool
+# This should give be synthesized via `functools.total_ordering`
+reveal_type(A.__gt__)  # E: revealed type: (self: A, other: A) -> bool
+a <= b
+"#,
+);

--- a/pyrefly/lib/test/decorators.rs
+++ b/pyrefly/lib/test/decorators.rs
@@ -356,8 +356,8 @@ testcase!(
     r#"
 from functools import total_ordering
 
-@total_ordering
-class A:  # E: Class `A` must define at least one of the rich comparison methods.
+@total_ordering  # E: Class `A` must define at least one of the rich comparison methods.
+class A:
     def __init__(self, x: int) -> None:
         self.x = x
 "#,

--- a/pyrefly/lib/types/callable.rs
+++ b/pyrefly/lib/types/callable.rs
@@ -253,6 +253,7 @@ pub enum FunctionKind {
     AbstractMethod,
     /// Instance of a protocol with a `__call__` method. The function has the `__call__` signature.
     CallbackProtocol(Box<ClassType>),
+    TotalOrdering,
 }
 
 /// A map from keywords to boolean values. Useful for storing sets of keyword arguments for various
@@ -530,6 +531,7 @@ impl FunctionKind {
             ("typing", None, "runtime_checkable") => Self::RuntimeCheckable,
             ("typing_extensions", None, "runtime_checkable") => Self::RuntimeCheckable,
             ("abc", None, "abstractmethod") => Self::AbstractMethod,
+            ("functools", None, "total_ordering") => Self::TotalOrdering,
             _ => Self::Def(Box::new(FuncId {
                 module,
                 cls: cls.cloned(),
@@ -611,6 +613,11 @@ impl FunctionKind {
                 func: Name::new_static("abstractmethod"),
             },
             Self::PropertySetter(func_id) | Self::Def(func_id) => (**func_id).clone(),
+            Self::TotalOrdering => FuncId {
+                module: ModuleName::functools(),
+                cls: None,
+                func: Name::new_static("total_ordering"),
+            },
         }
     }
 }


### PR DESCRIPTION
This PR adds modelling of `functools.total_ordering` (closes #491), which allows a class with (at least) one rich comparison method to automatically have all other rich comparison methods.

At a high level, this PR incorporates the following changes:
1. Capture `is_total_ordering` in class metadata if the decorator is present.
2. Synthesize missing rich comparison methods for those decorated classes.
3. Report an error if the decorator is present but no rich comparison method is present.

I have some open issues that can be fixed either in this PR after receiving some code pointers, or in subsequent PRs.
Open issues (marked in FIXMEs):
- [x] Error is currently raised on class declaration, ideally it should be on the decorator
- [x] Type information for synthesized rich comparison methods are not following the comparison method they're synthesizing from: e.g. if `__lt__` is synthesized from `__gt__`, then they should have the same type. Currently we model the synthesizing order, but we are not giving the same type.
- [x] Classes that have synthetic methods via multiple pathways will not have all the synthetic methods. For example, it's possible to decorate a class with `@dataclass` and `@total_ordering` at the same time, and they should have synthesized methods from both decorators.