### PR TITLE
Add option to specify error type with suppression comment

### DIFF
--- a/pyrefly/lib/error/error.rs
+++ b/pyrefly/lib/error/error.rs
@@ -178,7 +178,7 @@ impl Error {
         error_kind: ErrorKind,
     ) -> Self {
         let display_range = module_info.display_range(range);
-        let is_ignored = module_info.is_ignored(&display_range);
+        let is_ignored = module_info.is_ignored(&display_range, error_kind);
         let msg_has_details = msg.len() > 1;
         let mut msg = msg.into_iter();
         let msg_header = msg.next().unwrap().into_boxed_str();

--- a/pyrefly/lib/error/kind.rs
+++ b/pyrefly/lib/error/kind.rs
@@ -189,6 +189,19 @@ pub enum ErrorKind {
     UnsupportedOperand,
 }
 
+impl std::str::FromStr for ErrorKind {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        ERROR_KIND_CACHE
+            .iter()
+            .zip(enum_iterator::all::<ErrorKind>())
+            .find(|(cached, _)| cached == &s)
+            .map(|(_, kind)| kind)
+            .ok_or(())
+    }
+}
+
 /// Computing the error kinds is disturbingly expensive, so cache the results.
 /// Also means we can grab error code names without allocation, which is nice.
 static ERROR_KIND_CACHE: LazyLock<Vec<String>> = LazyLock::new(ErrorKind::cache);

--- a/pyrefly/lib/error/kind.rs
+++ b/pyrefly/lib/error/kind.rs
@@ -14,6 +14,7 @@ use enum_iterator::Sequence;
 use parse_display::Display;
 use serde::Deserialize;
 use serde::Serialize;
+use starlark_map::small_map::SmallMap;
 use yansi::Paint;
 use yansi::Painted;
 
@@ -193,28 +194,32 @@ impl std::str::FromStr for ErrorKind {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ERROR_KIND_CACHE
-            .iter()
-            .zip(enum_iterator::all::<ErrorKind>())
-            .find(|(cached, _)| cached == &s)
-            .map(|(_, kind)| kind)
-            .ok_or(())
+        ERROR_KIND_CACHE.get(s).copied().ok_or(())
     }
 }
 
 /// Computing the error kinds is disturbingly expensive, so cache the results.
 /// Also means we can grab error code names without allocation, which is nice.
-static ERROR_KIND_CACHE: LazyLock<Vec<String>> = LazyLock::new(ErrorKind::cache);
+static ERROR_KIND_CACHE: LazyLock<SmallMap<String, ErrorKind>> = LazyLock::new(ErrorKind::cache);
 
 impl ErrorKind {
-    fn cache() -> Vec<String> {
-        enum_iterator::all::<ErrorKind>()
-            .map(|x| x.to_string().to_case(Case::Kebab))
-            .collect()
+    fn cache() -> SmallMap<String, ErrorKind> {
+        let mut map = SmallMap::new();
+
+        for kind in enum_iterator::all::<ErrorKind>() {
+            let key = kind.to_string().to_case(Case::Kebab);
+            map.insert(key, kind);
+        }
+
+        map
     }
 
     pub fn to_name(self) -> &'static str {
-        ERROR_KIND_CACHE[self as usize].as_str()
+        ERROR_KIND_CACHE
+            .get_index(self as usize)
+            .unwrap()
+            .0
+            .as_str()
     }
 
     pub fn severity(self) -> Severity {

--- a/pyrefly/lib/module/ignore.rs
+++ b/pyrefly/lib/module/ignore.rs
@@ -154,6 +154,15 @@ mod tests {
         assert!(Ignore::get_suppression_kind("# ignore: pyrefly").is_none());
         assert!(Ignore::get_suppression_kind(" pyrefly: ignore").is_none());
         assert!(Ignore::get_suppression_kind("normal line").is_none());
+        assert!(
+            Ignore::get_suppression_kind("# pyrefly: ignore") == Some(SuppressionKind::Pyrefly)
+        );
+        assert!(
+            Ignore::get_suppression_kind("# pyrefly: ignore[bad-return]")
+                == Some(SuppressionKind::TypedPyrefly(ErrorKind::BadReturn))
+        );
+        assert!(Ignore::get_suppression_kind("# pyrefly: ignore[]").is_none());
+        assert!(Ignore::get_suppression_kind("# pyrefly: ignore[bad-]").is_none());
     }
 
     #[test]

--- a/pyrefly/lib/module/ignore.rs
+++ b/pyrefly/lib/module/ignore.rs
@@ -5,17 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::str::FromStr;
+
 use dupe::Dupe;
 use itertools::Itertools;
 use pyrefly_util::lined_buffer::LineNumber;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 
+use crate::error::kind::ErrorKind;
+
 #[derive(PartialEq, Debug, Clone, Hash, Eq, Dupe, Copy)]
 pub enum SuppressionKind {
     Ignore,
     Pyre,
     Pyrefly,
+    TypedPyrefly(ErrorKind),
 }
 
 /// Record the position of `# type: ignore[valid-type]` statements.
@@ -71,20 +76,29 @@ impl Ignore {
     }
 
     pub fn get_suppression_kind(line: &str) -> Option<SuppressionKind> {
-        fn match_pyrefly_ignore(line: &str) -> bool {
+        fn match_pyrefly_ignore(line: &str) -> Option<SuppressionKind> {
             let mut words = line.split_whitespace();
             if let Some("pyrefly:") = words.next() {
-                words.next() == Some("ignore")
-            } else {
-                false
+                if let Some(word) = words.next() {
+                    if word == "ignore" {
+                        return Some(SuppressionKind::Pyrefly);
+                    }
+
+                    if word.starts_with("ignore[") && word.ends_with(']') {
+                        if let Ok(kind) = ErrorKind::from_str(&word[7..word.len() - 1]) {
+                            return Some(SuppressionKind::TypedPyrefly(kind));
+                        }
+                    }
+                }
             }
+            None
         }
 
         for l in line.split("# ").skip(1) {
             if l.starts_with("type: ignore") {
                 return Some(SuppressionKind::Ignore);
-            } else if match_pyrefly_ignore(l) {
-                return Some(SuppressionKind::Pyrefly);
+            } else if let Some(value) = match_pyrefly_ignore(l) {
+                return Some(value);
             } else if l.starts_with("pyre-ignore") || l.starts_with("pyre-fixme") {
                 return Some(SuppressionKind::Pyre);
             }
@@ -92,15 +106,31 @@ impl Ignore {
         None
     }
 
-    pub fn is_ignored(&self, start_line: LineNumber, end_line: LineNumber) -> bool {
+    pub fn is_ignored(
+        &self,
+        start_line: LineNumber,
+        end_line: LineNumber,
+        kind: ErrorKind,
+    ) -> bool {
         if self.ignore_all {
-            true
-        } else {
-            // We allow an ignore the line before the range, or on any line within the range.
-            // We convert to/from zero-indexed because OneIndexed does not implement Step.
-            (start_line.to_zero_indexed().saturating_sub(1)..=end_line.to_zero_indexed())
-                .any(|x| self.ignores.contains_key(&LineNumber::from_zero_indexed(x)))
+            return true;
         }
+
+        // We allow an ignore the line before the range, or on any line within the range.
+        // We convert to/from zero-indexed because LineNumber does not implement Step.
+        for line in start_line.to_zero_indexed().saturating_sub(1)..=end_line.to_zero_indexed() {
+            if let Some(suppressions) = self.ignores.get(&LineNumber::from_zero_indexed(line)) {
+                if suppressions.iter().any(|supp| match supp {
+                    SuppressionKind::Ignore | SuppressionKind::Pyrefly => true,
+                    SuppressionKind::TypedPyrefly(supp_kind) => supp_kind == &kind,
+                    _ => false,
+                }) {
+                    return true;
+                }
+            }
+        }
+
+        false
     }
 
     /// Get all the ignores of a given kind.

--- a/pyrefly/lib/module/ignore.rs
+++ b/pyrefly/lib/module/ignore.rs
@@ -84,8 +84,10 @@ impl Ignore {
                         return Some(SuppressionKind::Pyrefly);
                     }
 
-                    if word.starts_with("ignore[") && word.ends_with(']') {
-                        if let Ok(kind) = ErrorKind::from_str(&word[7..word.len() - 1]) {
+                    if let Some(word) = word.strip_prefix("ignore[")
+                        && let Some(word) = word.strip_suffix(']')
+                    {
+                        if let Ok(kind) = ErrorKind::from_str(word) {
                             return Some(SuppressionKind::TypedPyrefly(kind));
                         }
                     }

--- a/pyrefly/lib/module/module_info.rs
+++ b/pyrefly/lib/module/module_info.rs
@@ -15,6 +15,7 @@ use pyrefly_util::lined_buffer::LinedBuffer;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
 
+use crate::error::kind::ErrorKind;
 use crate::module::ignore::Ignore;
 use crate::module::module_name::ModuleName;
 use crate::module::module_path::ModulePath;
@@ -99,7 +100,7 @@ impl ModuleInfo {
         self.0.name
     }
 
-    pub fn is_ignored(&self, source_range: &DisplayRange) -> bool {
+    pub fn is_ignored(&self, source_range: &DisplayRange, error_kind: ErrorKind) -> bool {
         // Extend the range of the error to include comment lines before it.
         // This makes it so that the preceding ignore could "see through" comments.
         let start_line = {
@@ -119,7 +120,9 @@ impl ModuleInfo {
             }
             start_line
         };
-        self.0.ignore.is_ignored(start_line, source_range.end.line)
+        self.0
+            .ignore
+            .is_ignored(start_line, source_range.end.line, error_kind)
     }
 
     pub fn ignore(&self) -> &Ignore {

--- a/pyrefly/lib/test/suppression.rs
+++ b/pyrefly/lib/test/suppression.rs
@@ -62,3 +62,73 @@ testcase!(
 3 + "3" # E:
 "#,
 );
+
+testcase!(
+    test_pyrefly_suppression_typed,
+    r#"
+def foo() -> str:
+  # pyrefly: ignore[bad-return]
+  return 1
+"#,
+);
+
+testcase!(
+    test_pyrefly_suppression_typed_inline,
+    r#"
+def foo() -> str:
+  return 1  # pyrefly: ignore[bad-return]
+"#,
+);
+
+testcase!(
+    test_pyrefly_suppression_typed_wrong_type,
+    r#"
+def foo() -> str:
+  # pyrefly: ignore[bad-assignment]
+  return 1 # E:
+"#,
+);
+
+testcase!(
+    test_pyrefly_suppression_typed_inline_wrong_type,
+    r#"
+def foo() -> str:
+  return 1  # pyrefly: ignore[bad-assignment]  # E:
+"#,
+);
+
+testcase!(
+    test_pyrefly_suppression_typed_bad_type,
+    r#"
+def foo() -> str:
+  # pyrefly: ignore[bad-]
+  return 1 # E:
+"#,
+);
+
+testcase!(
+    test_pyrefly_suppression_typed_empty,
+    r#"
+def foo() -> str:
+  # pyrefly: ignore[]
+  return 1 # E:
+"#,
+);
+
+testcase!(
+    test_pyrefly_suppression_typed_whitespace_variation,
+    r#"
+def foo() -> str:
+  #   pyrefly:    ignore   [  bad-return  ]
+  return 1
+"#,
+);
+
+testcase!(
+    test_pyrefly_suppression_typed_multiple_codes,
+    r#"
+def foo() -> str:
+  # pyrefly: ignore[bad-return, bad-assignment]
+  return 1  # E:
+"#,
+);

--- a/pyrefly/lib/test/suppression.rs
+++ b/pyrefly/lib/test/suppression.rs
@@ -85,7 +85,7 @@ testcase!(
     r#"
 def foo() -> str:
   # pyrefly: ignore[bad-assignment]
-  return 1 # E:
+  return 1 # E: Returned type `Literal[1]` is not assignable to declared return type `str`
 "#,
 );
 
@@ -93,7 +93,7 @@ testcase!(
     test_pyrefly_suppression_typed_inline_wrong_type,
     r#"
 def foo() -> str:
-  return 1  # pyrefly: ignore[bad-assignment]  # E:
+  return 1  # pyrefly: ignore[bad-assignment]  # E: Returned type `Literal[1]` is not assignable to declared return type `str`
 "#,
 );
 
@@ -102,7 +102,7 @@ testcase!(
     r#"
 def foo() -> str:
   # pyrefly: ignore[bad-]
-  return 1 # E:
+  return 1 # E: Returned type `Literal[1]` is not assignable to declared return type `str`
 "#,
 );
 
@@ -111,7 +111,7 @@ testcase!(
     r#"
 def foo() -> str:
   # pyrefly: ignore[]
-  return 1 # E:
+  return 1 # E: Returned type `Literal[1]` is not assignable to declared return type `str`
 "#,
 );
 
@@ -129,6 +129,16 @@ testcase!(
     r#"
 def foo() -> str:
   # pyrefly: ignore[bad-return, bad-assignment]
-  return 1  # E:
+  return 1  # E: Returned type `Literal[1]` is not assignable to declared return type `str`
+"#,
+);
+
+testcase!(
+    test_pyrefly_suppression_typed_multiple_valid_codes,
+    r#"
+def foo() -> str:
+  # pyrefly: ignore[bad-return]
+  # pyrefly: ignore[bad-argument-type]
+  return len(1) # E: Returned type `int` is not assignable to declared return type `str`
 "#,
 );

--- a/website/docs/error-suppressions.mdx
+++ b/website/docs/error-suppressions.mdx
@@ -22,6 +22,13 @@ def foo() -> int:
   return "this is a type error" # pyrefly: ignore
 ```
 
+You can also target specific error types:
+
+```python
+def foo() -> int:
+  return "this is a type error" # pyrefly: ignore[bad-return]
+```
+
 We respect the specification and allow `type: ignore` to be used:
 
 ```python

--- a/website/docs/migrating-from-mypy.mdx
+++ b/website/docs/migrating-from-mypy.mdx
@@ -84,10 +84,17 @@ However, they support significantly fewer options, and only `disable_error_code`
 
 Like mypy, pyrefly has ways to silence specific error codes. Full details can be found in the [Error Suppression docs](error-suppressions.mdx)
 
-To silence an error on a specific line, add a disable comment above that line:
+To silence an error on a specific line, add a disable comment above that line. You can either suppress all errors on that line:
 
 ```
 # pyrefly: ignore
+x: str = 1
+```
+
+Or target a specific error type:
+
+```
+# pyrefly: ignore[bad-assignment]
 x: str = 1
 ```
 

--- a/website/docs/migrating-from-pyright.mdx
+++ b/website/docs/migrating-from-pyright.mdx
@@ -66,10 +66,17 @@ Diagnostic settings are carried over to the equivalent subconfig, using the mapp
 
 Like pyright, pyrefly has ways to silence specific error codes. Full details can be found in the [Error Suppression docs](error-suppressions.mdx).
 
-To silence an error on a specific line, add a disable comment above that line:
+To silence an error on a specific line, add a disable comment above that line. You can either suppress all errors on that line:
 
 ```
 # pyrefly: ignore
+x: str = 1
+```
+
+Or target a specific error type:
+
+```
+# pyrefly: ignore[bad-assignment]
 x: str = 1
 ```
 


### PR DESCRIPTION
Summary:

* Added support for error type with suppression comment such as `# pyrefly: ignore[error-type]`
* Tests for the new suppression type
* Modified mdx files to include information about the new suppression option

Resolves #538 