### PR TITLE
Fix up test_find_module_prefixes

### DIFF
--- a/pyrefly/lib/module/finder.rs
+++ b/pyrefly/lib/module/finder.rs
@@ -975,8 +975,10 @@ mod tests {
                 TestPath::dir("foo2", Vec::new()),
             ],
         );
+        let mut res = find_module_prefixes(ModuleName::from_str("fo"), [root.to_path_buf()].iter());
+        res.sort();
         assert_eq!(
-            find_module_prefixes(ModuleName::from_str("fo"), [root.to_path_buf()].iter(),),
+            res,
             vec![ModuleName::from_str("foo"), ModuleName::from_str("foo2")]
         );
     }
@@ -992,8 +994,10 @@ mod tests {
                 TestPath::dir("foo2", Vec::new()),
             ],
         );
+        let mut res = find_module_prefixes(ModuleName::from_str("fo"), [root.to_path_buf()].iter());
+        res.sort();
         assert_eq!(
-            find_module_prefixes(ModuleName::from_str("fo"), [root.to_path_buf()].iter(),),
+            res,
             vec![ModuleName::from_str("foo"), ModuleName::from_str("foo2")]
         );
     }


### PR DESCRIPTION
Summary:
This code finds module prefixes in the order they appear on disk. Often files written in one order will read in that order, but there is no guarantee, and it's file system dependent. To make sure these tests are deterministic on all file systems, sort the result.

Note that before the result is used in LSP we sort it anyway, so it doesn't need sorting in the real method.

Differential Revision: D77373942


