### PR TITLE
make magic_dunder_attr lookup use get_possible_attribute_bases

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -545,8 +545,23 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Option<Type> {
         let mut not_found = false;
         let mut attr_tys = Vec::new();
-        self.map_over_union(base, |base| {
-            match self.lookup_magic_dunder_attr_no_union(base, attr_name) {
+        let attr_bases = self.get_possible_attribute_bases(base);
+        for attr_base in attr_bases {
+            let lookup_result = match attr_base {
+                None => {
+                    LookupResult::InternalError(InternalError::AttributeBaseUndefined(base.clone()))
+                }
+                Some(base) => {
+                    let direct_lookup_result =
+                        self.lookup_magic_dunder_attr(base.clone(), attr_name);
+                    self.lookup_attr_from_base_getattr_fallback(
+                        base,
+                        attr_name,
+                        direct_lookup_result,
+                    )
+                }
+            };
+            match lookup_result {
                 LookupResult::Found(attr) => attr_tys.push(
                     self.resolve_get_access(attr, range, errors, context)
                         .unwrap_or_else(|e| {
@@ -570,7 +585,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     not_found = true;
                 }
             }
-        });
+        }
         if not_found {
             return None;
         }
@@ -1447,20 +1462,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> LookupResult {
         let direct_lookup_result = self.lookup_attr_from_attribute_base(base.clone(), attr_name);
         self.lookup_attr_from_base_getattr_fallback(base, attr_name, direct_lookup_result)
-    }
-
-    // This function is intended as a low-level building block
-    // Unions or intersections should be handled by callers
-    fn lookup_magic_dunder_attr_no_union(&self, base: &Type, attr_name: &Name) -> LookupResult {
-        match self.as_attribute_base_no_union(base.clone()) {
-            None => {
-                LookupResult::InternalError(InternalError::AttributeBaseUndefined(base.clone()))
-            }
-            Some(base) => {
-                let direct_lookup_result = self.lookup_magic_dunder_attr(base.clone(), attr_name);
-                self.lookup_attr_from_base_getattr_fallback(base, attr_name, direct_lookup_result)
-            }
-        }
     }
 
     // This function is intended as a low-level building block

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -20,6 +20,14 @@ def f(a: int, b: int) -> None:
 );
 
 testcase!(
+    test_bounded_type_var_comparison,
+    r#"
+def compare[T: int](x: T, y: T) -> bool:
+    return x > y
+"#,
+);
+
+testcase!(
     test_negative_literals,
     r#"
 from typing import Literal


### PR DESCRIPTION
Summary:
fixes https://github.com/facebook/pyrefly/issues/554

This diff changes the magic dunder attr lookup to work the same as other attribute lookups, allowing it to handle bounded type vars

Differential Revision: D77377201


