### PR TITLE
binding: treat `assert False` as terminating control flow

### DIFF
--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -765,6 +765,9 @@ impl<'a> BindingsBuilder<'a> {
             Stmt::Assert(mut x) => {
                 self.ensure_expr(&mut x.test, &mut Usage::Narrowing);
                 self.bind_narrow_ops(&NarrowOps::from_expr(self, Some(&x.test)), x.range);
+                if let Some(false) = self.sys_info.evaluate_bool(&x.test) {
+                    self.scopes.mark_flow_termination();
+                }
                 self.insert_binding(Key::Anon(x.test.range()), Binding::Expr(None, *x.test));
                 if let Some(mut msg_expr) = x.msg {
                     let mut msg_user = self.declare_user(Key::UsageLink(msg_expr.range()));

--- a/pyrefly/lib/test/flow.rs
+++ b/pyrefly/lib/test/flow.rs
@@ -1134,6 +1134,36 @@ assert_type(vari, Literal["test"])
 );
 
 testcase!(
+    test_assert_false_terminates_flow,
+    r#"
+from typing import assert_type, Literal
+
+def test_unreachable_code_after_assert_false() -> None:
+    # This test verifies that code immediately following 'assert False'
+    # is considered unreachable by Pyrefly's type checker.
+
+    x = 10
+    assert False, "This assertion should cause control flow to terminate in this branch."
+    # This line should be unreachable.
+    raise Exception("Something unexpected happened here!")
+    "#,
+);
+testcase!(
+    test_assert_true_does_not_terminate_flow,
+    r#"
+from typing import assert_type, Literal, reveal_type
+
+def test_assert_true_normal_flow():
+    x = 10
+
+    assert True, "This assertion always passes"
+    # This line should be reachable and its operations should be evaluated
+    y = x + 5
+    assert_type(y, int)
+    "#,
+);
+
+testcase!(
     bug = "Merge flow is lax about possibly-undefined locals, so we don't catch that `z` may be uninitialized.",
     test_named_inside_boolean_op,
     r#"


### PR DESCRIPTION
This change makes Pyrefly recognize `assert False` as a control flow terminator, similar to `raise`. It adds a call to `mark_flow_termination` when the assert condition is statically known to be `False`.

closes https://github.com/facebook/pyrefly/issues/599