### PR TITLE
Add support for checking code snippets

### DIFF
--- a/crates/pyrefly_python/src/module_path.rs
+++ b/crates/pyrefly_python/src/module_path.rs
@@ -100,7 +100,7 @@ impl Display for ModulePath {
                 )
             }
             ModulePathDetails::CommandSnippet => {
-                write!(f, "{}", COMMAND_SNIPPET_DISPLAY_PATH)
+                write!(f, "{COMMAND_SNIPPET_DISPLAY_PATH}")
             }
         }
     }

--- a/crates/pyrefly_python/src/module_path.rs
+++ b/crates/pyrefly_python/src/module_path.rs
@@ -21,6 +21,8 @@ use serde::Serializer;
 use crate::dunder;
 use crate::module_name::ModuleName;
 
+const COMMAND_SNIPPET_DISPLAY_PATH: &str = "<string>";
+
 #[derive(Debug, Clone, Dupe, Copy, PartialEq, Eq, Hash, Default)]
 pub enum ModuleStyle {
     /// .py - executable code.
@@ -98,7 +100,7 @@ impl Display for ModulePath {
                 )
             }
             ModulePathDetails::CommandSnippet => {
-                write!(f, "<string>")
+                write!(f, "{}", COMMAND_SNIPPET_DISPLAY_PATH)
             }
         }
     }
@@ -207,7 +209,7 @@ impl ModulePath {
             | ModulePathDetails::BundledTypeshed(path)
             | ModulePathDetails::Memory(path)
             | ModulePathDetails::Namespace(path) => path,
-            ModulePathDetails::CommandSnippet => Path::new("<string>"),
+            ModulePathDetails::CommandSnippet => Path::new(COMMAND_SNIPPET_DISPLAY_PATH),
         }
     }
 

--- a/crates/pyrefly_python/src/module_path.rs
+++ b/crates/pyrefly_python/src/module_path.rs
@@ -45,6 +45,8 @@ pub enum ModulePathDetails {
     /// The module source comes from typeshed bundled with Pyrefly (which gets stored in-memory).
     /// The path is relative to the root of the typeshed directory.
     BundledTypeshed(PathBuf),
+    /// The module source comes from a command-line snippet (pyrefly check --command).
+    CommandSnippet,
 }
 
 impl PartialOrd for ModulePath {
@@ -95,6 +97,9 @@ impl Display for ModulePath {
                     relative_path.display()
                 )
             }
+            ModulePathDetails::CommandSnippet => {
+                write!(f, "<string>")
+            }
         }
     }
 }
@@ -105,7 +110,9 @@ impl Serialize for ModulePath {
             ModulePathDetails::FileSystem(path)
             | ModulePathDetails::Memory(path)
             | ModulePathDetails::Namespace(path) => path.serialize(serializer),
-            ModulePathDetails::BundledTypeshed(_) => self.to_string().serialize(serializer),
+            ModulePathDetails::BundledTypeshed(_) | ModulePathDetails::CommandSnippet => {
+                self.to_string().serialize(serializer)
+            }
         }
     }
 }
@@ -125,6 +132,10 @@ impl ModulePath {
 
     pub fn memory(path: PathBuf) -> Self {
         Self::new(ModulePathDetails::Memory(path))
+    }
+
+    pub fn command_snippet() -> Self {
+        Self::new(ModulePathDetails::CommandSnippet)
     }
 
     pub fn bundled_typeshed(relative_path: PathBuf) -> Self {
@@ -196,6 +207,7 @@ impl ModulePath {
             | ModulePathDetails::BundledTypeshed(path)
             | ModulePathDetails::Memory(path)
             | ModulePathDetails::Namespace(path) => path,
+            ModulePathDetails::CommandSnippet => Path::new("<string>"),
         }
     }
 

--- a/crates/pyrefly_python/src/module_path.rs
+++ b/crates/pyrefly_python/src/module_path.rs
@@ -45,7 +45,7 @@ pub enum ModulePathDetails {
     /// The module source comes from typeshed bundled with Pyrefly (which gets stored in-memory).
     /// The path is relative to the root of the typeshed directory.
     BundledTypeshed(PathBuf),
-    /// The module source comes from a command-line snippet (pyrefly check --command).
+    /// The module source comes from a command-line snippet.
     CommandSnippet,
 }
 

--- a/pyrefly/bin/main.rs
+++ b/pyrefly/bin/main.rs
@@ -57,7 +57,7 @@ struct Args {
 #[deny(clippy::missing_docs_in_private_items)]
 #[derive(Debug, Clone, Parser)]
 struct FullCheckArgs {
-    /// Type check a string of Python code directly (equivalent to mypy -c)
+    /// Type check a string of Python code directly
     #[arg(long, value_name = "CODE", conflicts_with = "files")]
     command: Option<String>,
     /// Files to check (glob supported).

--- a/pyrefly/bin/main.rs
+++ b/pyrefly/bin/main.rs
@@ -65,7 +65,6 @@ struct FullCheckArgs {
     /// check are determined from the closest configuration file.
     /// When supplied, `project_excludes` in any config files loaded for these files to check
     /// are ignored, and we use the default excludes unless overridden with the `--project-excludes` flag.
-    #[arg(required_unless_present = "command")]
     files: Vec<String>,
     /// Files to exclude when type checking.
     #[arg(long)]

--- a/pyrefly/bin/main.rs
+++ b/pyrefly/bin/main.rs
@@ -126,7 +126,6 @@ async fn run_command_check(
     config: Option<PathBuf>,
     mut args: library::run::CheckArgs,
 ) -> anyhow::Result<CommandExitStatus> {
-    // Use the new run_once_with_snippet method that handles virtual modules properly
     let (files_to_check, config_finder) =
         globs_and_config_getter::get(vec![], None, config, &mut args)?;
 

--- a/pyrefly/bin/main.rs
+++ b/pyrefly/bin/main.rs
@@ -125,10 +125,9 @@ async fn run_command_check(
     config: Option<PathBuf>,
     mut args: library::run::CheckArgs,
 ) -> anyhow::Result<CommandExitStatus> {
-    let (files_to_check, config_finder) =
-        globs_and_config_getter::get(vec![], None, config, &mut args)?;
-
-    match args.run_once_with_snippet(code, files_to_check, config_finder, true) {
+    let (_, config_finder) =
+        globs_and_config_getter::get(vec![], None, config, &mut args.config_override)?;
+    match args.run_once_with_snippet(code, config_finder, true) {
         Ok((status, _)) => Ok(status),
         Err(e) => Err(e),
     }

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -419,7 +419,6 @@ impl CheckArgs {
     pub fn run_once_with_snippet(
         self,
         code: String,
-        _files_to_check: FilteredGlobs,
         config_finder: ConfigFinder,
         allow_forget: bool,
     ) -> anyhow::Result<(CommandExitStatus, usize)> {

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -88,6 +88,39 @@ pub struct CheckArgs {
     pub config_override: ConfigOverrideArgs,
 }
 
+/// Arguments for snippet checking (excludes behavior args that don't apply to snippets)
+#[deny(clippy::missing_docs_in_private_items)]
+#[derive(Debug, Parser, Clone)]
+pub struct SnippetCheckArgs {
+    /// Output related configuration options
+    #[command(flatten, next_help_heading = "Output")]
+    output: OutputArgs,
+    /// Configuration override options
+    #[command(flatten, next_help_heading = "Config Overrides")]
+    pub config_override: ConfigOverrideArgs,
+}
+
+impl SnippetCheckArgs {
+    pub fn run_once_with_snippet(
+        self,
+        code: String,
+        config_finder: ConfigFinder,
+        allow_forget: bool,
+    ) -> anyhow::Result<(CommandExitStatus, Vec<Error>)> {
+        let check_args = CheckArgs {
+            output: self.output,
+            behavior: BehaviorArgs {
+                check_all: false,
+                suppress_errors: false,
+                expectations: false,
+                remove_unused_ignores: false,
+            },
+            config_override: self.config_override,
+        };
+        check_args.run_once_with_snippet(code, config_finder, allow_forget)
+    }
+}
+
 /// how/what should Pyrefly output
 #[deny(clippy::missing_docs_in_private_items)]
 #[derive(Debug, Parser, Clone)]

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -462,9 +462,10 @@ impl CheckArgs {
         );
 
         // Add the snippet source to the transaction's memory
-        transaction
-            .as_mut()
-            .set_memory(vec![(PathBuf::from("<string>"), Some(Arc::new(code)))]);
+        transaction.as_mut().set_memory(vec![(
+            PathBuf::from(module_path.as_path()),
+            Some(Arc::new(code)),
+        )]);
 
         self.run_inner(
             timings,

--- a/pyrefly/lib/commands/config_finder.rs
+++ b/pyrefly/lib/commands/config_finder.rs
@@ -106,6 +106,9 @@ pub fn standard_config_finder(
                     ModulePathDetails::BundledTypeshed(_) => {
                         return BundledTypeshed::config();
                     }
+                    ModulePathDetails::CommandSnippet => {
+                        return empty.dupe();
+                    }
                 };
                 cache_parents
                     .lock()

--- a/pyrefly/lib/commands/run.rs
+++ b/pyrefly/lib/commands/run.rs
@@ -17,6 +17,7 @@ use pyrefly_util::trace::init_tracing;
 pub use crate::commands::autotype::AutotypeArgs;
 pub use crate::commands::buck_check::BuckCheckArgs;
 pub use crate::commands::check::CheckArgs;
+pub use crate::commands::check::SnippetCheckArgs;
 pub use crate::commands::dump_config::dump_config;
 pub use crate::commands::init::InitArgs;
 pub use crate::commands::lsp::LspArgs;

--- a/pyrefly/lib/config/finder.rs
+++ b/pyrefly/lib/config/finder.rs
@@ -217,7 +217,7 @@ impl ConfigFinder {
                 f(absolute.as_ref().and_then(|x| x.parent()))
             }
             ModulePathDetails::Namespace(x) => f(x.absolutize().ok().as_deref()),
-            ModulePathDetails::BundledTypeshed(_) => f(None),
+            ModulePathDetails::BundledTypeshed(_) | ModulePathDetails::CommandSnippet => f(None),
         }
     }
 }

--- a/pyrefly/lib/lsp/module_helpers.rs
+++ b/pyrefly/lib/lsp/module_helpers.rs
@@ -39,6 +39,7 @@ pub fn to_real_path(path: &ModulePath) -> Option<PathBuf> {
             }?;
             Some(typeshed_path.join(path))
         }
+        ModulePathDetails::CommandSnippet => None,
     }
 }
 

--- a/pyrefly/lib/state/load.rs
+++ b/pyrefly/lib/state/load.rs
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::anyhow;
@@ -51,7 +50,7 @@ impl Load {
                     .ok_or_else(|| anyhow!("bundled typeshed problem"))
             }),
             ModulePathDetails::CommandSnippet => memory_lookup
-                .get(Path::new("<string>"))
+                .get(path.as_path())
                 .duped()
                 .ok_or_else(|| anyhow!("command snippet not found in memory lookup")),
         };

--- a/pyrefly/lib/state/load.rs
+++ b/pyrefly/lib/state/load.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::anyhow;
@@ -49,6 +50,10 @@ impl Load {
                 x.load(path)
                     .ok_or_else(|| anyhow!("bundled typeshed problem"))
             }),
+            ModulePathDetails::CommandSnippet => memory_lookup
+                .get(Path::new("<string>"))
+                .duped()
+                .ok_or_else(|| anyhow!("command snippet not found in memory lookup")),
         };
         match res {
             Err(err) => (Arc::new(String::new()), Some(err)),

--- a/test/command_snippet.md
+++ b/test/command_snippet.md
@@ -1,0 +1,118 @@
+# Tests for pyrefly check --command option
+
+## Basic command snippet with type error
+
+```scrut {output_stream: stderr}
+$ $PYREFLY check --command "x: int = 'hello'"
+ INFO * (glob)
+
+ERROR `Literal['hello']` is not assignable to `int` [bad-assignment]
+ --> <string>:1:10
+  |
+1 | x: int = 'hello'
+  |          ^^^^^^^
+  |
+[1]
+```
+
+## Valid command snippet (no errors)
+
+```scrut {output_stream: stderr}
+$ $PYREFLY check --command "x: int = 42"
+ INFO * (glob)
+[0]
+```
+
+## Command snippet with imports
+
+```scrut {output_stream: stderr}
+$ $PYREFLY check --command "import sys; print(sys.version)"
+ INFO * (glob)
+[0]
+```
+
+## Command snippet with typing imports and error
+
+```scrut {output_stream: stderr}
+$ $PYREFLY check --command "from typing import List; x: List[str] = [1, 2, 3]"
+ INFO * (glob)
+
+ERROR `list[int]` is not assignable to `list[str]` [bad-assignment]
+ --> <string>:1:49
+  |
+1 | from typing import List; x: List[str] = [1, 2, 3]
+  |                                         ^^^^^^^^^
+  |
+[1]
+```
+
+## Command snippet with multiple errors
+
+```scrut {output_stream: stderr}
+$ $PYREFLY check --command "def foo(x: str) -> int: return len(x); y: str = foo(42)"
+ INFO * (glob)
+
+ERROR Function declared to return `int`, but one or more paths are missing an explicit `return` [bad-return]
+ --> <string>:1:20
+  |
+1 | def foo(x: str) -> int: return len(x); y: str = foo(42)
+  |                    ^^^
+  |
+
+ERROR `int` is not assignable to `str` [bad-assignment]
+ --> <string>:1:49
+  |
+1 | def foo(x: str) -> int: return len(x); y: str = foo(42)
+  |                                                 ^^^^^^^
+  |
+
+ERROR Argument `Literal[42]` is not assignable to parameter `x` with type `str` in function `foo` [bad-argument-type]
+ --> <string>:1:53
+  |
+1 | def foo(x: str) -> int: return len(x); y: str = foo(42)
+  |                                                     ^^
+  |
+[1]
+```
+
+## Command option conflicts with files
+
+```scrut {output_stream: stderr}
+$ echo "x: int = 42" > $TMPDIR/test.py && $PYREFLY check --command "x: int = 42" $TMPDIR/test.py
+error: the argument '--command <CODE>' cannot be used with '[FILES]...'
+
+Usage: pyrefly check --command <CODE> [FILES]...
+
+For more information, try '--help'
+[2]
+```
+
+## Command snippet with JSON output format
+
+```scrut
+$ $PYREFLY check --command "x: int = 'hello'" --output-format=json
+[
+  {
+    "path": "<string>",
+    "line": 1,
+    "column": 10,
+    "stop_line": 1,
+    "stop_column": 17,
+    "code": "bad-assignment",
+    "message": "`Literal['hello']` is not assignable to `int`",
+    "concise_description": "`Literal['hello']` is not assignable to `int`",
+    "inference": {},
+    "name": "bad-assignment"
+  }
+]
+[1]
+```
+
+## Help text shows command option
+
+```scrut
+$ $PYREFLY check --help | grep -A 1 "command"
+      --command <CODE>
+          Type check a string of Python code directly (equivalent to mypy -c)
+[0]
+```

--- a/test/command_snippet.md
+++ b/test/command_snippet.md
@@ -22,12 +22,25 @@ $ $PYREFLY check --command "x: int = 42"
 [0]
 ```
 
-## Command snippet with imports
+## Command snippet with built-in module import
 
 ```scrut {output_stream: stderr}
 $ $PYREFLY check --command "import sys; print(sys.version)"
  INFO Checking current directory with default configuration
  INFO errors shown: 0* (glob)
+[0]
+```
+
+## Command snippet with local file import
+
+```scrut
+$ echo "x: int = 5" > $TEST_PY && $PYREFLY check --command "import test; from typing import reveal_type; reveal_type(test.x)"
+ INFO revealed type: int [reveal-type]
+ --> <string>:1:57
+  |
+1 | import test; from typing import reveal_type; reveal_type(test.x)
+  |                                                         --------
+  |
 [0]
 ```
 

--- a/test/command_snippet.md
+++ b/test/command_snippet.md
@@ -2,10 +2,8 @@
 
 ## Basic command snippet with type error
 
-```scrut {output_stream: stderr}
+```scrut
 $ $PYREFLY check --command "x: int = 'hello'"
- INFO * (glob)
-
 ERROR `Literal['hello']` is not assignable to `int` [bad-assignment]
  --> <string>:1:10
   |
@@ -19,7 +17,8 @@ ERROR `Literal['hello']` is not assignable to `int` [bad-assignment]
 
 ```scrut {output_stream: stderr}
 $ $PYREFLY check --command "x: int = 42"
- INFO * (glob)
+ INFO Checking current directory with default configuration
+ INFO errors shown: 0* (glob)
 [0]
 ```
 
@@ -27,18 +26,17 @@ $ $PYREFLY check --command "x: int = 42"
 
 ```scrut {output_stream: stderr}
 $ $PYREFLY check --command "import sys; print(sys.version)"
- INFO * (glob)
+ INFO Checking current directory with default configuration
+ INFO errors shown: 0* (glob)
 [0]
 ```
 
 ## Command snippet with typing imports and error
 
-```scrut {output_stream: stderr}
+```scrut
 $ $PYREFLY check --command "from typing import List; x: List[str] = [1, 2, 3]"
- INFO * (glob)
-
 ERROR `list[int]` is not assignable to `list[str]` [bad-assignment]
- --> <string>:1:49
+ --> <string>:1:41
   |
 1 | from typing import List; x: List[str] = [1, 2, 3]
   |                                         ^^^^^^^^^
@@ -48,24 +46,20 @@ ERROR `list[int]` is not assignable to `list[str]` [bad-assignment]
 
 ## Command snippet with multiple errors
 
-```scrut {output_stream: stderr}
+```scrut
 $ $PYREFLY check --command "def foo(x: str) -> int: return len(x); y: str = foo(42)"
- INFO * (glob)
-
 ERROR Function declared to return `int`, but one or more paths are missing an explicit `return` [bad-return]
  --> <string>:1:20
   |
 1 | def foo(x: str) -> int: return len(x); y: str = foo(42)
   |                    ^^^
   |
-
 ERROR `int` is not assignable to `str` [bad-assignment]
  --> <string>:1:49
   |
 1 | def foo(x: str) -> int: return len(x); y: str = foo(42)
   |                                                 ^^^^^^^
   |
-
 ERROR Argument `Literal[42]` is not assignable to parameter `x` with type `str` in function `foo` [bad-argument-type]
  --> <string>:1:53
   |
@@ -83,7 +77,7 @@ error: the argument '--command <CODE>' cannot be used with '[FILES]...'
 
 Usage: pyrefly check --command <CODE> [FILES]...
 
-For more information, try '--help'
+For more information, try '--help'.
 [2]
 ```
 
@@ -91,20 +85,21 @@ For more information, try '--help'
 
 ```scrut
 $ $PYREFLY check --command "x: int = 'hello'" --output-format=json
-[
-  {
-    "path": "<string>",
-    "line": 1,
-    "column": 10,
-    "stop_line": 1,
-    "stop_column": 17,
-    "code": "bad-assignment",
-    "message": "`Literal['hello']` is not assignable to `int`",
-    "concise_description": "`Literal['hello']` is not assignable to `int`",
-    "inference": {},
-    "name": "bad-assignment"
-  }
-]
+{
+  "errors": [
+    {
+      "line": 1,
+      "column": 10,
+      "stop_line": 1,
+      "stop_column": 17,
+      "path": "<string>",
+      "code": -2,
+      "name": "bad-assignment",
+      "description": "`Literal['hello']` is not assignable to `int`",
+      "concise_description": "`Literal['hello']` is not assignable to `int`"
+    }
+  ]
+} (no-eol)
 [1]
 ```
 

--- a/test/command_snippet.md
+++ b/test/command_snippet.md
@@ -113,6 +113,6 @@ $ $PYREFLY check --command "x: int = 'hello'" --output-format=json
 ```scrut
 $ $PYREFLY check --help | grep -A 1 "command"
       --command <CODE>
-          Type check a string of Python code directly (equivalent to mypy -c)
+          Type check a string of Python code directly
 [0]
 ```


### PR DESCRIPTION
This PR aims to resolve #503. It adds support for checking Python code snippets directly from the command line using the `snippet` command, equivalent to `mypy -c`. This enables quick type checking of code without creating temporary files.

The implementation creates a virtual module system where snippets are treated as <string> files stored in memory. This allows reuse of the entire existing type checking pipeline while maintaining clean separation between file-based and snippet-based workflows. The virtual module approach also ensures snippets integrate seamlessly with import resolution and configuration systems.

# Core Implementation

- CLI Interface: Added `snippet <CODE>` option to accept Python code strings
- Module System: Extended `ModulePathDetails` with `CommandSnippet` variant for virtual modules
- Memory Storage: Implemented in-memory code storage using `<string>` as virtual file path
- Type Checking: Reused existing `run_inner()` infrastructure for consistent behavior

# Key Files Modified

- pyrefly/bin/main.rs: Added command-line argument parsing, a new `SnippetCheckArgs` (to exclude `behavior`), and `run_snippet_check()`
- pyrefly/lib/module/module_path.rs: Added `CommandSnippet` variant and display logic
- pyrefly/lib/commands/check.rs: Added `run_once_with_snippet()` method
- pyrefly/lib/state/load.rs: Added memory lookup for snippet code loading

# Usage Examples

```bash
pyrefly snippet "x: int = 'hello'"
pyrefly snippet  "import requests; r = requests.get('url')"
pyrefly snippet  "def foo(): pass" --config strict.toml
pyrefly snippet  "bad_code" --output-format json
```

Scrut tests have been added to `test/snippet.md`.
