### PR TITLE
Detect redundant cast usage and emit warning

### DIFF
--- a/pyrefly/lib/alt/special_calls.rs
+++ b/pyrefly/lib/alt/special_calls.rs
@@ -234,6 +234,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 "`typing.cast` missing required argument `val`".to_owned(),
             );
         }
+        if let Some(val_expr) = val {
+            let val_type = self.expr_infer(val_expr, errors);
+        
+            if self.subtype(&val_type, &ret) {
+                self.error(
+                    errors,
+                    range,
+                    ErrorKind::RedundantCast,
+                    None,
+                    "`typing.cast` is unnecessary because the value already has the target type".to_owned(),
+                );
+            }
+        }        
         ret
     }
 

--- a/pyrefly/lib/error/kind.rs
+++ b/pyrefly/lib/error/kind.rs
@@ -172,6 +172,7 @@ pub enum ErrorKind {
     /// The attribute exists but cannot be modified.
     ReadOnly,
     /// Raised when a cast is unnecessary because the value already has the target type.
+    /// It is always a warning.
     RedundantCast,
     /// Raised by a call to reveal_type().
     RevealType,
@@ -228,6 +229,7 @@ impl ErrorKind {
         match self {
             ErrorKind::RevealType => Severity::Info,
             ErrorKind::Deprecated => Severity::Warn,
+            ErrorKind::RedundantCast => Severity::Warn,
             _ => Severity::Error,
         }
     }

--- a/pyrefly/lib/error/kind.rs
+++ b/pyrefly/lib/error/kind.rs
@@ -171,6 +171,8 @@ pub enum ErrorKind {
     ParseError,
     /// The attribute exists but cannot be modified.
     ReadOnly,
+    /// Raised when a cast is unnecessary because the value already has the target type.
+    RedundantCast,
     /// Raised by a call to reveal_type().
     RevealType,
     /// An error related to type alias usage or definition.

--- a/pyrefly/lib/test/redundant_cast.rs
+++ b/pyrefly/lib/test/redundant_cast.rs
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ use crate::testcase;
+
+
+testcase!(
+    test_redundant_cast_simple,
+    r#"
+from typing import cast
+
+x = cast(int, 5)  # E: Redundant cast: expression already has type `int`
+y = cast(str, "hello")  # E: Redundant cast: expression already has type `str`
+"#,
+);
+
+testcase!(
+    test_redundant_cast_with_annotation,
+    r#"
+from typing import cast
+
+x: int = cast(int, 42)  # E: Redundant cast: expression already has type `int`
+"#,
+);
+
+testcase!(
+    test_non_redundant_cast,
+    r#"
+from typing import Any, cast
+
+def deserialize(data: Any) -> int:
+    return cast(int, data)
+"#,
+);


### PR DESCRIPTION
## Summary

This PR adds detection for redundant usage of `typing.cast` where the value being cast already matches the target type. In such cases, a warning is now emitted to inform users of unnecessary casting.

## Implementation Details

- A check was added before applying the cast to compare the inferred type of the value against the target type.
- If both types match, an `ErrorKind::RedundantCast` warning is emitted instead of applying the cast.
- The cast still proceeds (non-fatal) to maintain soundness.
- Includes tests under `redundant_cast.rs`.

## Example

```python
from typing import cast

def f(x: int) -> int:
    return cast(int, x)  # warning: Redundant cast
```
## Testing

- Added test case: `test_redundant_cast_simple`
- Added test case: `test_redundant_cast_with_annotation`
- Added test case: `test_non_redundant_cast`

Closes #593