### PR TITLE
Skip return type checks for abstract methods

### DIFF
--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -58,6 +58,7 @@ use crate::types::types::Type;
 struct Decorators {
     has_no_type_check: bool,
     is_overload: bool,
+    is_abstract_method: bool,
     decorators: Box<[Idx<Key>]>,
 }
 
@@ -416,9 +417,12 @@ impl<'a> BindingsBuilder<'a> {
     fn decorators(&mut self, decorator_list: Vec<Decorator>, usage: &mut Usage) -> Decorators {
         let mut is_overload = false;
         let mut has_no_type_check = false;
+        let mut is_abstract_method = false;
         for d in &decorator_list {
             let special_export = self.as_special_export(&d.expression);
             is_overload = is_overload || matches!(special_export, Some(SpecialExport::Overload));
+            is_abstract_method =
+                is_abstract_method || matches!(special_export, Some(SpecialExport::AbstractMethod));
             has_no_type_check =
                 has_no_type_check || matches!(special_export, Some(SpecialExport::NoTypeCheck));
         }
@@ -428,6 +432,7 @@ impl<'a> BindingsBuilder<'a> {
         Decorators {
             has_no_type_check,
             is_overload,
+            is_abstract_method,
             decorators,
         }
     }
@@ -443,7 +448,9 @@ impl<'a> BindingsBuilder<'a> {
         func_name: &Identifier,
         class_key: Option<Idx<KeyClass>>,
     ) -> (FunctionStubOrImpl, Option<SelfAssignments>) {
-        let stub_or_impl = if is_ellipse(&body)
+        let stub_or_impl = if (body.first().is_some_and(is_docstring)
+            && decorators.is_abstract_method)
+            || is_ellipse(&body)
             || (body.first().is_some_and(is_docstring) && decorators.is_overload)
         {
             FunctionStubOrImpl::Stub

--- a/pyrefly/lib/export/special.rs
+++ b/pyrefly/lib/export/special.rs
@@ -40,6 +40,7 @@ pub enum SpecialExport {
     Type,
     NoTypeCheck,
     Overload,
+    AbstractMethod,
 }
 
 impl SpecialExport {
@@ -71,6 +72,7 @@ impl SpecialExport {
             "type" => Some(Self::Type),
             "no_type_check" => Some(Self::NoTypeCheck),
             "overload" => Some(Self::Overload),
+            "abstractmethod" => Some(Self::AbstractMethod),
             _ => None,
         }
     }
@@ -101,6 +103,7 @@ impl SpecialExport {
             }
             Self::Exit => matches!(m.as_str(), "sys" | "builtins"),
             Self::OsExit => matches!(m.as_str(), "os"),
+            Self::AbstractMethod => matches!(m.as_str(), "abc"),
         }
     }
 }

--- a/pyrefly/lib/test/decorators.rs
+++ b/pyrefly/lib/test/decorators.rs
@@ -418,3 +418,61 @@ reveal_type(A.__le__)  # E: revealed type: (self: Self@A, other: object) -> bool
 reveal_type(A.__ge__)  # E: revealed type: (self: Self@A, other: object) -> bool
 "#,
 );
+
+testcase!(
+    test_overload_with_docstring,
+    r#"
+from typing import overload, Any
+@overload
+def foo(a: int) -> int: ...  
+@overload
+def foo(a: str) -> str:
+    """Docstring"""
+def foo(*args, **kwargs) -> Any:
+    pass
+    
+    "#,
+);
+
+testcase!(
+    test_overload_with_docstring2,
+    r#"
+from typing import overload, Any
+@overload
+def foo(a: int) -> int: ...  
+@overload
+def foo(a: str) -> str: 
+    """Docstring"""
+    return 123             # E: Returned type `Literal[123]` is not assignable to declared return type `str`
+def foo(*args, **kwargs) -> Any:
+    pass
+    
+    "#,
+);
+
+testcase!(
+    test_abstract_method_skip_return,
+    r#"
+from abc import abstractmethod
+
+class C:
+        @abstractmethod
+        def m1(self) -> int:
+            return NotImplemented
+
+        @abstractmethod
+        def m2(self) -> int:
+            pass
+
+        @abstractmethod
+        def m3(self) -> int:
+            """some docstring"""
+
+        @abstractmethod
+        def m4(self) -> int: ...
+
+        @abstractmethod
+        def method5(self) -> int:
+            return "sub" # E: Returned type `Literal['sub']` is not assignable to declared return type `int`
+    "#,
+);


### PR DESCRIPTION
closes #515. Did the same thing I did for #368. I might have missed something let me know if I did.