### PR TITLE
error on missing __all__ implementation

### DIFF
--- a/pyrefly/lib/error/kind.rs
+++ b/pyrefly/lib/error/kind.rs
@@ -182,6 +182,8 @@ pub enum ErrorKind {
     MissingAttribute,
     /// Accessing an attribute that does not exist on a module.
     MissingModuleAttribute,
+    /// Element present in __all__ but not defined in the module.
+    MissingDunderAllImplementation,
     /// The attribute exists but does not support this access pattern.
     NoAccess,
     /// Attempting to call an overloaded function, but none of the signatures match.

--- a/pyrefly/lib/state/steps.rs
+++ b/pyrefly/lib/state/steps.rs
@@ -159,7 +159,7 @@ impl Step {
         load: Arc<Load>,
         ast: Arc<ModModule>,
     ) -> Exports {
-        Exports::new(&ast.body, &load.module_info, ctx.sys_info)
+        Exports::new(&ast.body, &load.module_info, ctx.sys_info, &load.errors)
     }
 
     #[inline(never)]


### PR DESCRIPTION
Summary:
if an item is present in __all__ but not implemented, pyre should raise an error.

See [this github issue](https://github.com/facebook/pyrefly/issues/204).

Rollback Plan:

Differential Revision: D77612155


