### PR TITLE
Fix `key-already-exists panic` when checking nested comprehensions that are incomplete

### DIFF
--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -211,7 +211,7 @@ impl<'a> BindingsBuilder<'a> {
     /// the type if we found that name in scope; if we do not find the name we
     /// record an error and fall back to `Any`.
     ///
-    /// This function is the the core scope lookup logic for binding creation.
+    /// This function is the core scope lookup logic for binding creation.
     pub fn ensure_name(
         &mut self,
         name: &Identifier,
@@ -268,7 +268,10 @@ impl<'a> BindingsBuilder<'a> {
             // This is necessary so that, e.g. `[x for x in x]` correctly uses the outer scope for
             // the `in x` lookup.
             self.ensure_expr(&mut comp.iter, usage);
-            let iterable_value_idx = self.insert_binding(
+            // Incomplete nested comprehensions can have identical iterators
+            // for inner and outer loops. It is safe to overwrite it because it literally the same.
+            println!("{:?}", comp.iter);
+            let iterable_value_idx = self.insert_binding_overwrite(
                 Key::Anon(comp.iter.range()),
                 Binding::IterableValue(None, comp.iter.clone(), IsAsync::new(comp.is_async)),
             );

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -1658,3 +1658,18 @@ def f(x:float, y:bool) -> float:
     return x * y 
 "#,
 );
+
+testcase!(
+    test_nested_list_comp,
+    r#"from typing import assert_type
+assert_type([a for a in [b for b in ["a", "b"]]], list[str])
+"#,
+);
+
+testcase!(
+    test_incomplete_nested_list_comp,
+    r#"# Issue https://github.com/facebook/pyrefly/issues/455
+[a for [a for # E: Could # E: Parse # E: Could # E: Parse # E: Parse
+"#,
+);
+


### PR DESCRIPTION
# Summary

Resolves #455 
An incomplete nested list comprehension `[a for [a for` is parsed into two `ListComp` expressions with the same `iter`, which is empty. I assume this is correct because there are no objects to iter over. It is a syntax error. The panic occurred due to inserting `comp.iter` binding twice. If two iters have the same range, then it might be safe to consider them as the same expression. Therefore, it is safe to overwrite the binding.

But I am not sure if this is the best option. Alternatives might be:
- check existing bindings before inserting and ignore them 
- or produce some error for the user.

# Test Plan

Added two tests to pyrefly/lib/test/simple.rs
1. test_nested_list_comp - checks nested list comp type inference
2. test_incomplete_nested_list_comp - checks no panic for incomplete nested list comp