### PR TITLE
Bug Fix 708 - Union Iterability Checker

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -560,6 +560,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
+    fn is_iterable(&self, ty: &Type) -> bool {
+        self.unwrap_iterable(ty).is_some()
+            || matches!(ty, Type::Tuple(_))
+            || matches!(ty, Type::ClassType(cls) if self.as_tuple(cls).is_some())
+    }
+
     /// Given an `iterable` type, determine the iteration type; this is the type
     /// of `x` if we were to loop using `for x in iterable`.
     ///
@@ -585,11 +591,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::Union(ts) => ts
                 .iter()
                 .filter_map(|t| {
-                    let is_iterable = self.unwrap_iterable(t).is_some()
-                        || matches!(t, Type::Tuple(_))
-                        || matches!(t, Type::ClassType(cls) if self.as_tuple(cls).is_some());
-
-                    if is_iterable {
+                    if self.is_iterable(t) {
                         Some(self.iterate(t, range, errors))
                     } else {
                         None

--- a/pyrefly/lib/test/pattern_match.rs
+++ b/pyrefly/lib/test/pattern_match.rs
@@ -60,3 +60,22 @@ def my_func(x: dict[MyEnumType, int]) -> int:
             return 0
 "#,
 );
+
+testcase!(
+    test_union_pattern_match_sequence,
+    r#"
+from typing import *
+
+class T: ...
+
+def my_func(x: T | tuple[T, T]):
+    match x:
+        case T(), T():  # Should not error: Type `T` is not iterable
+            print("Two T")
+        case T():
+            print("One T")
+
+my_func(T())
+my_func((T(), T()))
+"#,
+);


### PR DESCRIPTION
This PR tries to solve bug #708. The problem with the current implementation was that given a union type, solve.rs would iterate over each of the two types without considering whether both types were iterable. The fix tries to check if each option in the union is iterable, checking for explicit `__iter__` or seeing if it behaves like a tuple or is a tuple. The original bug was added as a test to pattern_match.rs.