### PR TITLE
Try setting a cache for node packages

### DIFF
--- a/.github/workflows/build_extension.yml
+++ b/.github/workflows/build_extension.yml
@@ -111,6 +111,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
       - name: save platform name
         run: echo "platform=${{ matrix.platform }}-${{ matrix.arch }}" >> ${{ matrix.github_env }}
       - run: npm ci

--- a/.github/workflows/test_extension.yml
+++ b/.github/workflows/test_extension.yml
@@ -77,6 +77,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
       - run: npm ci
         working-directory: lsp/
       - run: npm run compile


### PR DESCRIPTION
Summary:
According to these two docs, npm package caching works out of the box,
we should be able to save a chunk of time and compute cost pretty easily:
- https://docs.github.com/en/actions/reference/dependency-caching-reference#setup--actions-for-specific-package-managers
- https://github.com/actions/setup-node#caching-global-packages-data

Rust caching does not work out of the box according to any docs I found, so
it may be trickier to implement, I'm still trying to understand what
these docs are saying about how to manually use cache keys.

But since the extension builds and tests are the single biggest capacity use,
this change alone should help save some resources and speed up our CI
turnaround times.

Differential Revision: D78693087
