### PR TITLE
Try turning on rust-cache for the `pyrefly` workflow

### DIFF
--- a/.github/workflows/pyrefly.yml
+++ b/.github/workflows/pyrefly.yml
@@ -27,6 +27,10 @@ jobs:
       # by Cargo have long paths and will cause builds/tests to fail
       if: ${{ matrix.os == 'windows-latest' }}
       run: echo "CARGO_HOME=C:\\cargo" >> ${{ matrix.github_env }}
+    - name: set up rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: pyrefly
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: nightly-2025-05-09


### PR DESCRIPTION
Summary:
I'm not totally satisfied that I understand perfectly how this works, it's
at least possible that our override of `CARGO_HOME` will impact it on
windows.

But it's worth trying. The exact config snippet I pulled from a buck
example.

I think the pyrefly workflow accounts for the majority of our rust build
time, so I think that if this works, we should see some actual results
in both turnaround time and compute use.

Differential Revision: D78710986
