### PR TITLE
sort before deduping

### DIFF
--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -1578,7 +1578,13 @@ impl<'a> Transaction<'a> {
             .to_owned();
             item.sort_text = Some(sort_text);
         }
-        results.sort_by(|item1, item2| item1.sort_text.cmp(&item2.sort_text));
+        results.sort_by(|item1, item2| {
+            item1
+                .sort_text
+                .cmp(&item2.sort_text)
+                .then_with(|| item1.label.cmp(&item2.label))
+                .then_with(|| item1.detail.cmp(&item2.detail))
+        });
         results.dedup_by(|item1, item2| item1.label == item2.label && item1.detail == item2.detail);
         results
     }

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -69,8 +69,8 @@ Completion Results:
 10 | bar.
          ^
 Completion Results:
-- (Field) y: int
 - (Field) x: int
+- (Field) y: int
 "#
         .trim(),
         report.trim(),
@@ -98,10 +98,10 @@ foo.
 10 | foo.
          ^
 Completion Results:
-- (Field) x: int
+- (Method) class_method: BoundMethod[type[Foo], (cls: type[Self@Foo]) -> None]
 - (Method) method: BoundMethod[Foo, (self: Self@Foo) -> None]
 - (Function) static_method: () -> None
-- (Method) class_method: BoundMethod[type[Foo], (cls: type[Self@Foo]) -> None]
+- (Field) x: int
 "#
         .trim(),
         report.trim(),
@@ -128,8 +128,8 @@ foo.
 9 | foo.
         ^
 Completion Results:
-- (Field) y: int
 - (Field) x: int
+- (Field) y: int
 - (Field) _private: bool
 - (Field) __special__: str
 "#
@@ -158,16 +158,16 @@ def foo():
       ^
 Completion Results:
 - (Function) bar: () -> None
-- (Variable) xxxx: Literal[3]
 - (Function) foo: () -> None
+- (Variable) xxxx: Literal[3]
 
 8 |     y
         ^
 Completion Results:
-- (Variable) yyyy: Literal[4]
-- (Variable) xxxx: Literal[3]
 - (Function) bar: () -> None
 - (Function) foo: () -> None
+- (Variable) xxxx: Literal[3]
+- (Variable) yyyy: Literal[4]
 "#
         .trim(),
         report.trim(),
@@ -246,13 +246,13 @@ Completion Results:
 - (Variable) __cached__
 - (Variable) __debug__
 - (Variable) __dict__
+- (Variable) __doc__
 - (Variable) __file__
 - (Variable) __loader__
 - (Variable) __name__
 - (Variable) __package__
 - (Variable) __path__
 - (Variable) __spec__
-- (Variable) __doc__
 
 
 # foo.py
@@ -319,13 +319,13 @@ Completion Results:
 - (Variable) __cached__
 - (Variable) __debug__
 - (Variable) __dict__
+- (Variable) __doc__
 - (Variable) __file__
 - (Variable) __loader__
 - (Variable) __name__
 - (Variable) __package__
 - (Variable) __path__
 - (Variable) __spec__
-- (Variable) __doc__
 
 
 # foo.py
@@ -360,13 +360,13 @@ Completion Results:
 - (Variable) __cached__
 - (Variable) __debug__
 - (Variable) __dict__
+- (Variable) __doc__
 - (Variable) __file__
 - (Variable) __loader__
 - (Variable) __name__
 - (Variable) __package__
 - (Variable) __path__
 - (Variable) __spec__
-- (Variable) __doc__
 
 
 # foo.py
@@ -599,17 +599,17 @@ isins
          ^
 Completion Results:
 - (Function) isinstance
-- (Function) timerfd_settime_ns: from os import timerfd_settime_ns
-
-- (Function) distributions: from importlib.metadata import distributions
-
-- (Function) packages_distributions: from importlib.metadata import packages_distributions
+- (Class) FirstHeaderLineIsContinuationDefect: from email.errors import FirstHeaderLineIsContinuationDefect
 
 - (Class) MissingHeaderBodySeparatorDefect: from email.errors import MissingHeaderBodySeparatorDefect
 
+- (Function) distributions: from importlib.metadata import distributions
+
 - (Function) fix_missing_locations: from ast import fix_missing_locations
 
-- (Class) FirstHeaderLineIsContinuationDefect: from email.errors import FirstHeaderLineIsContinuationDefect
+- (Function) packages_distributions: from importlib.metadata import packages_distributions
+
+- (Function) timerfd_settime_ns: from os import timerfd_settime_ns
 "#
         .trim(),
         report.trim(),

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/duplicate_export_test/foo.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/duplicate_export_test/foo.py
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+MutableMapping  # noqa: F821

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/duplicate_export_test/pyrefly.toml
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/duplicate_export_test/pyrefly.toml
@@ -1,0 +1,1 @@
+search_path = ["./"]

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/duplicate_export_test/typing.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/duplicate_export_test/typing.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+class MutableMappingUnrelatedBefore: ...
+
+
+class MutableMapping: ...
+
+
+class MutableMappingUnrelatedAfter: ...


### PR DESCRIPTION
Summary:
In the IDE, I almost always see duplicate completions for stdlib functions. This is because we add all search paths and only dedup results by neighbors. We end up finding the builtin in-memory typeshed, the one in the interpreter, and any others. instead, we should sort before deduping to remove all duplicates. Since VSCode ranks our results anyway, this should have no side effects in the IDE.

Note: the test added in this diff fails before this diff (there are duplicate MutableMapping), but i'm unable to commit it without this change because auto-import is not deterministic in which module it adds first. This sorting also helps us write similar tests in the future.

Reviewed By: ndmitchell

Differential Revision: D78700243


