### PR TITLE
Return Result for all absolutize calls

### DIFF
--- a/crates/pyrefly_config/src/args.rs
+++ b/crates/pyrefly_config/src/args.rs
@@ -44,6 +44,13 @@ pub struct ConfigOverrideArgs {
     #[arg(long, value_parser = absolute_path_parser)]
     search_path: Option<Vec<PathBuf>>,
 
+    /// Disable Pyrefly default heuristics, specifically those around
+    /// constructing a modified search path. Setting this flag will instruct
+    /// Pyrefly to use the exact `search_path` you give it through your config
+    /// file and CLI args.
+    #[arg(long)]
+    disable_search_path_heuristics: Option<bool>,
+
     /// The Python version any `sys.version` checks should evaluate against.
     #[arg(long)]
     python_version: Option<PythonVersion>,
@@ -156,6 +163,9 @@ impl ConfigOverrideArgs {
         }
         if let Some(x) = &self.search_path {
             config.search_path_from_args = x.clone();
+        }
+        if let Some(x) = &self.disable_search_path_heuristics {
+            config.disable_search_path_heuristics = *x;
         }
         if let Some(x) = &self.site_package_path {
             config.python_environment.site_package_path = Some(x.clone());

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -1104,19 +1104,30 @@ mod tests {
             typeshed_path: None,
         };
 
+        let current_dir = std::env::current_dir().unwrap();
         let path_str = with_sep("path/to/my/config");
-        let test_path = PathBuf::from(path_str.clone());
+        let test_path = current_dir.join(&path_str);
 
         let project_includes_vec = vec![
-            path_str.clone() + &with_sep("/path1/**"),
-            path_str.clone() + &with_sep("/path2/path3"),
+            test_path.join("path1/**").to_string_lossy().into_owned(),
+            test_path.join("path2/path3").to_string_lossy().into_owned(),
         ];
-        let project_excludes_vec = vec![path_str.clone() + &with_sep("/tests/untyped/**")];
+        let project_excludes_vec = vec![
+            test_path
+                .join("tests/untyped/**")
+                .to_string_lossy()
+                .into_owned(),
+        ];
         let search_path = vec![test_path.join("../..")];
         python_environment.site_package_path =
             Some(vec![test_path.join("venv/lib/python1.2.3/site-packages")]);
 
-        let sub_config_matches = Glob::new(path_str.clone() + &with_sep("/sub/project/**"));
+        let sub_config_matches = Glob::new(
+            test_path
+                .join("sub/project/**")
+                .to_string_lossy()
+                .into_owned(),
+        );
 
         config.rewrite_with_path_to_config(&test_path);
 

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -67,7 +67,7 @@ pub enum ConfigSource {
 }
 
 impl ConfigSource {
-    pub fn root<'a>(&'a self) -> Option<&'a Path> {
+    pub fn root(&self) -> Option<&Path> {
         match &self {
             Self::File(path) | Self::Marker(path) => path.parent(),
             Self::Synthetic => None,
@@ -224,6 +224,13 @@ pub struct ConfigFile {
          )]
     pub fallback_search_path: Vec<PathBuf>,
 
+    /// Disable Pyrefly default heuristics, specifically those around
+    /// constructing a modified search path. Setting this flag will instruct
+    /// Pyrefly to use the exact `search_path` you give it through your config
+    /// file and CLI args.
+    #[serde(default, skip_serializing_if = "crate::util::skip_default_false")]
+    pub disable_search_path_heuristics: bool,
+
     /// Override the bundled typeshed with a custom path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub typeshed_path: Option<PathBuf>,
@@ -295,6 +302,7 @@ impl Default for ConfigFile {
             },
             search_path_from_args: Vec::new(),
             search_path_from_file: Vec::new(),
+            disable_search_path_heuristics: false,
             import_root: None,
             fallback_search_path: Vec::new(),
             python_environment: Default::default(),
@@ -814,6 +822,7 @@ mod tests {
                 project_excludes: Globs::new(vec!["tests/untyped/**".to_owned()]),
                 search_path_from_args: Vec::new(),
                 search_path_from_file: vec![PathBuf::from("../..")],
+                disable_search_path_heuristics: false,
                 import_root: None,
                 fallback_search_path: Vec::new(),
                 python_environment: PythonEnvironment {
@@ -1066,6 +1075,7 @@ mod tests {
             project_excludes: Globs::new(vec!["tests/untyped/**".to_owned()]),
             search_path_from_args: Vec::new(),
             search_path_from_file: vec![PathBuf::from("../..")],
+            disable_search_path_heuristics: false,
             import_root: None,
             fallback_search_path: Vec::new(),
             python_environment: python_environment.clone(),
@@ -1112,6 +1122,7 @@ mod tests {
             },
             search_path_from_args: Vec::new(),
             search_path_from_file: search_path,
+            disable_search_path_heuristics: false,
             import_root: None,
             fallback_search_path: Vec::new(),
             python_environment,

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -399,7 +399,11 @@ impl ConfigFile {
         self.search_path_from_args
             .iter()
             .chain(self.search_path_from_file.iter())
-            .chain(self.import_root.iter())
+            .chain(if self.disable_search_path_heuristics {
+                None.iter()
+            } else {
+                self.import_root.iter()
+            })
     }
 
     pub fn site_package_path<'a>(&'a self) -> impl Iterator<Item = &'a PathBuf> + Clone {
@@ -415,18 +419,23 @@ impl ConfigFile {
 
     /// Gets the full, ordered path used for import lookup. Used for pretty-printing.
     pub fn structured_import_lookup_path(&self) -> Vec<ImportLookupPathPart> {
-        vec![
+        let mut result = vec![
             ImportLookupPathPart::SearchPathFromArgs(&self.search_path_from_args),
             ImportLookupPathPart::SearchPathFromFile(&self.search_path_from_file),
-            ImportLookupPathPart::ImportRoot(self.import_root.as_ref()),
-            ImportLookupPathPart::FallbackSearchPath(&self.fallback_search_path),
-            ImportLookupPathPart::SitePackagePath(
-                self.python_environment.site_package_path.as_ref().unwrap(),
-            ),
-            ImportLookupPathPart::InterpreterSitePackagePath(
-                &self.python_environment.interpreter_site_package_path,
-            ),
-        ]
+        ];
+        if !self.disable_search_path_heuristics {
+            result.push(ImportLookupPathPart::ImportRoot(self.import_root.as_ref()));
+            result.push(ImportLookupPathPart::FallbackSearchPath(
+                &self.fallback_search_path,
+            ));
+        }
+        result.push(ImportLookupPathPart::SitePackagePath(
+            self.python_environment.site_package_path.as_ref().unwrap(),
+        ));
+        result.push(ImportLookupPathPart::InterpreterSitePackagePath(
+            &self.python_environment.interpreter_site_package_path,
+        ));
+        result
     }
 
     pub fn get_sys_info(&self) -> SysInfo {

--- a/pyrefly/lib/commands/config_finder.rs
+++ b/pyrefly/lib/commands/config_finder.rs
@@ -81,10 +81,12 @@ pub fn standard_config_finder(
                 .lock()
                 .entry(path.clone())
                 .or_insert_with(|| {
-                    let (config, errors) = configure2(
-                        path.parent(),
-                        ConfigFile::init_at_root(&path, &ProjectLayout::Flat),
-                    );
+                    let (default_config, default_error) =
+                        ConfigFile::init_at_root(&path, &ProjectLayout::Flat);
+                    if let Err(error) = default_error {
+                        debug_log(vec![ConfigError::error(error)]);
+                    }
+                    let (config, errors) = configure2(path.parent(), default_config);
                     // Since this is a config we generated, these are likely internal errors.
                     debug_log(errors);
                     config

--- a/pyrefly/lib/module/finder.rs
+++ b/pyrefly/lib/module/finder.rs
@@ -431,8 +431,8 @@ pub fn find_import(
         .find(module)
     {
         Ok(path)
-    } else if let Some(path) =
-        find_module_in_search_path(module, config.fallback_search_path.iter())?
+    } else if !config.disable_search_path_heuristics
+        && let Some(path) = find_module_in_search_path(module, config.fallback_search_path.iter())?
     {
         Ok(path)
     } else if let Some(path) = find_module_in_site_package_path(


### PR DESCRIPTION
Summary:
This diff rewrites some of our logic to return a `Result` instead of just calling `unwrap()` on a `Path::absolutize()` call. `Path::absolutize()` and `absolutize_from()` have signatures returning `Result`, but in practice, don't ever actually return one (`Absolutize::absolutize_virtually()` does return real results though).

We should probably handle them properly, just in case an update ever comes out or something changes.

Differential Revision: D78754538


