### PR TITLE
Migrate `--no-summary` to `--summary=none` in init command

### DIFF
--- a/pyrefly/lib/commands/init.rs
+++ b/pyrefly/lib/commands/init.rs
@@ -139,7 +139,7 @@ impl InitArgs {
                 "--suppress-errors",
                 "--output-format",
                 "omit-errors",
-                "--no-summary",
+                "--summary=none",
             ]);
 
             // Use get to get the filtered globs and config finder
@@ -296,7 +296,7 @@ impl InitArgs {
             "--suppress-errors",
             "--output-format",
             "omit-errors",
-            "--no-summary",
+            "--summary=none",
         ]);
 
         // Collect file paths from errors in selected directories


### PR DESCRIPTION
As noted in #730, the deprecated flag is used in the `init` command for suppressing errors. This is an easy change to migrate the flag to `--summary=none`.

Tested `pyrefly init` on a library manually and saw no regression