### PR TITLE
Do not assume variable is uninit with only annotations

### DIFF
--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -418,7 +418,7 @@ impl<'a> BindingsBuilder<'a> {
                             _ => Initialized::Yes,
                         },
                     );
-                    let cannonical_ann_idx = match value {
+                    let canonical_ann_idx = match value {
                         Some(value) => self.bind_single_name_assign(
                             &name,
                             value,
@@ -435,14 +435,19 @@ impl<'a> BindingsBuilder<'a> {
                                     initial_value: maybe_ellipses,
                                 }
                             } else {
-                                FlowStyle::Uninitialized
+                                // A flow style might be already set for the
+                                // name, e.g. if it was defined previously.
+                                // If so, we use that style; otherwise, the flow
+                                // style lookup would return an uninitialized
+                                // flow style, which is what we want here.
+                                self.scopes.get_flow_style(&name.id, false).clone()
                             },
                         ),
                     };
                     // This assignment gets checked with the provided annotation. But if there exists a prior
                     // annotation, we might be invalidating it unless the annotations are the same. Insert a
                     // check that in that case the annotations match.
-                    if let Some(ann) = cannonical_ann_idx {
+                    if let Some(ann) = canonical_ann_idx {
                         self.insert_binding(
                             KeyExpect(name.range),
                             BindingExpect::Redefinition {

--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -447,3 +447,19 @@ def foo():
 y = 42
 "#,
 );
+
+// https://github.com/facebook/pyrefly/issues/246
+testcase!(
+    test_declare_after_write_no_error,
+    r#"
+def foo():
+    x = 42
+    x: int
+    y = x
+
+def bar():
+    x = 42
+    x: int = -x
+    y = x
+"#,
+);


### PR DESCRIPTION
Closes #246.

When we encounter an annotated statement without assignment, e.g. `x: int`, we assume that the variable is uninitialised if it's not occuring in a class. This is not universally true, as pointed out by the example reported in the issue.

Instead, this commit proposes to check for the current flow style of the variable being annotated using `get_flow_style` function. The function is able to check for initial use and give the correct uninit flow style, but otherwise returns the existing flow style (e.g. if the variable has already been written to).

Also fixes a small typo nearby.