### PR TITLE
Fix overriding named tuple synthesized __new__ and __init__

### DIFF
--- a/pyrefly/lib/alt/class/named_tuple.rs
+++ b/pyrefly/lib/alt/class/named_tuple.rs
@@ -92,12 +92,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     fn get_named_tuple_new(&self, cls: &Class, elements: &SmallSet<Name>) -> ClassSynthesizedField {
         let mut params = vec![Param::Pos(
             Name::new_static("cls"),
-            Type::type_form(self.instantiate(cls)),
+            Type::type_form(Type::SelfType(self.as_class_type_unchecked(cls))),
             Required::Required,
         )];
         params.extend(self.get_named_tuple_field_params(cls, elements));
         let ty = Type::Function(Box::new(Function {
-            signature: Callable::list(ParamList::new(params), self.instantiate(cls)),
+            signature: Callable::list(
+                ParamList::new(params),
+                Type::SelfType(self.as_class_type_unchecked(cls)),
+            ),
             metadata: FuncMetadata::def(self.module().name(), cls.name().clone(), dunder::NEW),
         }));
         ClassSynthesizedField::new(ty)
@@ -111,7 +114,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let mut params = vec![self.class_self_param(cls, false)];
         params.extend(self.get_named_tuple_field_params(cls, elements));
         let ty = Type::Function(Box::new(Function {
-            signature: Callable::list(ParamList::new(params), self.instantiate(cls)),
+            signature: Callable::list(ParamList::new(params), Type::None),
             metadata: FuncMetadata::def(self.module().name(), cls.name().clone(), dunder::INIT),
         }));
         ClassSynthesizedField::new(ty)

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -328,3 +328,21 @@ for y in v:
     print(assert_type(y, Any))
 "#,
 );
+
+testcase!(
+    test_named_tuple_override_self,
+    r#"
+from typing import NamedTuple, Self
+
+class A(NamedTuple):
+    x: int
+    y: str
+
+class B(A):
+    def __new__(cls, x: int, y: str) -> Self:
+        return super().__new__(cls, x, y)
+    
+    def __init__(self, x: int, y: str) -> None:
+        return super().__init__(x, y)
+"#,
+);


### PR DESCRIPTION
Summary:
The synthesiezd field should use Type::SelfType, so we can override the implementation with a function that returns Self.

Also, the synthesized __init__ method was returning the class type, but it should return None.

Fixes https://github.com/facebook/pyrefly/issues/761

Differential Revision: D79042183


