### PR TITLE
Pypi -> PyPI

### DIFF
--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -3,7 +3,7 @@ title: Installation
 description: How to install Pyrefly
 ---
 
-Pyrefly is available on [Pypi](https://pypi.org/project/pyrefly/) with a new release every Monday. We often release more frequently when shipping new features and bug fixes.
+Pyrefly is available on [PyPI](https://pypi.org/project/pyrefly/) with a new release every Monday. We often release more frequently when shipping new features and bug fixes.
 
 ## Install
 


### PR DESCRIPTION
That's how PyPI styles themselves (eg https://docs.pypi.org/)

> PyPI is the official repository of packages for Python