### PR TITLE
Move precedence of configuration of LSP/IDE provided interpreters be higher

### DIFF
--- a/crates/pyrefly_config/src/environment/interpreters.rs
+++ b/crates/pyrefly_config/src/environment/interpreters.rs
@@ -87,9 +87,9 @@ impl Interpreters {
     ///
     /// The priorities are:
     /// 1. Check for an overridden `--python-interpreter` or `--conda-environment`
-    /// 2. Check for an active venv or Conda environment
-    /// 3. Check for a configured `python-interpreter`
-    /// 4. Check for a configured `conda-environment`
+    /// 2. Check for a configured `python-interpreter`
+    /// 3. Check for a configured `conda-environment`
+    /// 4. Check for an active venv or Conda environment
     /// 5. Check for a `venv` in the current project
     /// 6. Use an interpreter we can find on the `$PATH`
     /// 7. Give up and return an error
@@ -108,10 +108,6 @@ impl Interpreters {
                 .transpose_err();
         }
 
-        if let Some(active_env) = ActiveEnvironment::find() {
-            return Ok(ConfigOrigin::auto(active_env));
-        }
-
         if let Some(interpreter) = &self.python_interpreter {
             return Ok(interpreter.clone());
         }
@@ -121,6 +117,13 @@ impl Interpreters {
                 .as_deref()
                 .map(conda::find_interpreter_from_env)
                 .transpose_err();
+        }
+
+        // Configuration options should take precedence over environment variables, otherwise
+        // overriding project interpreter settings becomes much harder, espcially when used in
+        // IDEs.
+        if let Some(active_env) = ActiveEnvironment::find() {
+            return Ok(ConfigOrigin::auto(active_env));
         }
 
         if let Some(start_path) = path

--- a/crates/pyrefly_config/src/util.rs
+++ b/crates/pyrefly_config/src/util.rs
@@ -45,6 +45,10 @@ pub(crate) enum ConfigOrigin<T> {
     #[serde(skip)]
     Auto(T),
 
+    /// This value was explicitly provided by the IDE using "workspace.configuration" using LSP protocol.
+    #[serde(skip)]
+    Lsp(T),
+
     /// This value was provided by a [`ConfigFile`], either explicitly or implicitly.
     ConfigFile(T),
 }
@@ -81,7 +85,10 @@ impl<T> Deref for ConfigOrigin<T> {
 
     fn deref(&self) -> &Self::Target {
         match self {
-            Self::CommandLine(value) | Self::ConfigFile(value) | Self::Auto(value) => value,
+            Self::CommandLine(value)
+            | Self::ConfigFile(value)
+            | Self::Auto(value)
+            | Self::Lsp(value) => value,
         }
     }
 }
@@ -89,7 +96,10 @@ impl<T> Deref for ConfigOrigin<T> {
 impl<T> DerefMut for ConfigOrigin<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
-            Self::CommandLine(value) | Self::ConfigFile(value) | Self::Auto(value) => value,
+            Self::CommandLine(value)
+            | Self::ConfigFile(value)
+            | Self::Auto(value)
+            | Self::Lsp(value) => value,
         }
     }
 }
@@ -116,6 +126,11 @@ impl<T> ConfigOrigin<T> {
         Self::Auto(value)
     }
 
+    /// Construct a new [`ConfigOrigin::Lsp`] with the given value.
+    pub(crate) fn lsp(value: T) -> Self {
+        Self::Lsp(value)
+    }
+
     /// Consume the [`ConfigOrigin`], mapping the internal value with the
     /// given function, and inserting it into a new [`ConfigOrigin`] of the same
     /// variant.
@@ -127,6 +142,7 @@ impl<T> ConfigOrigin<T> {
             ConfigOrigin::ConfigFile(value) => ConfigOrigin::ConfigFile(f(value)),
             ConfigOrigin::CommandLine(value) => ConfigOrigin::CommandLine(f(value)),
             ConfigOrigin::Auto(value) => ConfigOrigin::Auto(f(value)),
+            ConfigOrigin::Lsp(value) => ConfigOrigin::Lsp(f(value)),
         }
     }
 
@@ -135,6 +151,7 @@ impl<T> ConfigOrigin<T> {
             ConfigOrigin::ConfigFile(ref value) => ConfigOrigin::ConfigFile(value),
             ConfigOrigin::CommandLine(ref value) => ConfigOrigin::CommandLine(value),
             ConfigOrigin::Auto(ref value) => ConfigOrigin::Auto(value),
+            ConfigOrigin::Lsp(ref value) => ConfigOrigin::Lsp(value),
         }
     }
 
@@ -154,9 +171,11 @@ impl<T, E> ConfigOrigin<Result<T, E>> {
             ConfigOrigin::ConfigFile(Ok(value)) => Ok(ConfigOrigin::ConfigFile(value)),
             ConfigOrigin::CommandLine(Ok(value)) => Ok(ConfigOrigin::CommandLine(value)),
             ConfigOrigin::Auto(Ok(value)) => Ok(ConfigOrigin::Auto(value)),
+            ConfigOrigin::Lsp(Ok(value)) => Ok(ConfigOrigin::Lsp(value)),
             ConfigOrigin::ConfigFile(Err(err))
             | ConfigOrigin::CommandLine(Err(err))
-            | ConfigOrigin::Auto(Err(err)) => Err(err),
+            | ConfigOrigin::Auto(Err(err))
+            | ConfigOrigin::Lsp(Err(err)) => Err(err),
         }
     }
 }

--- a/pyrefly/lib/lsp/workspace.rs
+++ b/pyrefly/lib/lsp/workspace.rs
@@ -195,9 +195,10 @@ impl Workspaces {
                         mut env,
                     }) = w.python_info.clone()
                     {
-                        let site_package_path = config.python_environment.site_package_path.take();
+                        let site_package_path: Option<Vec<PathBuf>> =
+                            config.python_environment.site_package_path.take();
                         env.site_package_path = site_package_path;
-                        config.interpreters.set_python_interpreter(interpreter);
+                        config.interpreters.set_lsp_python_interpreter(interpreter);
                         config.python_environment = env;
                     }
                 })


### PR DESCRIPTION
Relates to 
- #784

When running pyrefly as an IDE plugin for VSCode, the `CONDA_ENV` environment variable set, however it points to the wrong environment. I'm not exactly sure why it points to the wrong environment, so I want to override the interpreter path. However it is not possible to override the python interpreter path for `pyrefly`, because configuration values in `pyrefly.toml` has less precedence than environment variables.

I believe IDE / LSP configuration should take precedence over environment variables, otherwise VSCode extension chooses the wrong environment.