### PR TITLE
Disable mypy_primer_comment more cleanly

### DIFF
--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -1,12 +1,11 @@
 name: Comment with mypy_primer diff
 
-# Disabled for now, because it generates a lot of spurious errors.
-# on:  # zizmor: ignore[dangerous-triggers]
-#   workflow_run:
-#     workflows:
-#       - Run mypy_primer
-#     types:
-#       - completed
+on:  # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows:
+      - Run mypy_primer
+    types:
+      - completed
 
 permissions: {}
 
@@ -17,7 +16,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Temporarily disabled because it is often not that helpful
+    if: false
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download diffs
         uses: actions/github-script@v7


### PR DESCRIPTION
Summary: Github complains this job has no `on` section. Instead use `if false` which stack overflow suggests is the right way to do it.

Reviewed By: rchen152

Differential Revision: D79520518
