### PR TITLE
allow completion results from Key::Anywhere

### DIFF
--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -1225,7 +1225,6 @@ Completion Results:
     );
 }
 
-// todo(kylei): completion on redeclaration of variables
 #[test]
 fn redeclaration() {
     let code = r#"
@@ -1242,6 +1241,7 @@ ff
 4 | ff
      ^
 Completion Results:
+- (Variable) fff: int
 "#
         .trim(),
         report.trim(),


### PR DESCRIPTION
Summary: `Key::Anywhere` are also definition sites of variables - they should show up in completions

Differential Revision: D79653243


