### PR TITLE
Run scrut tests on open source builds

### DIFF
--- a/.github/workflows/pyrefly.yml
+++ b/.github/workflows/pyrefly.yml
@@ -28,7 +28,7 @@ jobs:
       if: ${{ matrix.os == 'windows-latest' }}
       run: echo "CARGO_HOME=C:\\cargo" >> ${{ matrix.github_env }}
     - name: install Scrut
-      run: curl --proto '=https' --tlsv1.2 -sSf https://facebookincubator.github.io/scrut/install.sh | sh
+      run: curl --proto '=https' --tlsv1.2 -sSf https://facebookincubator.github.io/scrut/install.sh | bash
     - name: set up rust cache
       uses: Swatinem/rust-cache@v2
       with:

--- a/.github/workflows/pyrefly.yml
+++ b/.github/workflows/pyrefly.yml
@@ -29,6 +29,8 @@ jobs:
       run: echo "CARGO_HOME=C:\\cargo" >> ${{ matrix.github_env }}
     - name: install Scrut
       run: curl --proto '=https' --tlsv1.2 -sSf https://facebookincubator.github.io/scrut/install.sh | bash
+      # Scrut doesn't support Windows yet
+      if: ${{ matrix.os != 'windows-latest' }}
     - name: set up rust cache
       uses: Swatinem/rust-cache@v2
       with:
@@ -41,10 +43,11 @@ jobs:
     - run: cargo clippy --release
     - run: cargo build --release
     - run: cargo test --release
-    - name: Scrut tests
+    - name: Run Scrut tests
       env:
         PYREFLY: ${{ github.workspace }}/target/release/pyrefly
         TYPESHED_ROOT: ${{ github.workspace }}/crates/pyrefly_bundled/third_party
         JQ: jq
         TEST_PY: ${{ github.workspace }}/test.py
       run: scrut test test
+      if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/pyrefly.yml
+++ b/.github/workflows/pyrefly.yml
@@ -27,6 +27,8 @@ jobs:
       # by Cargo have long paths and will cause builds/tests to fail
       if: ${{ matrix.os == 'windows-latest' }}
       run: echo "CARGO_HOME=C:\\cargo" >> ${{ matrix.github_env }}
+    - name: install Scrut
+      run: curl --proto '=https' --tlsv1.2 -sSf https://facebookincubator.github.io/scrut/install.sh | sh
     - name: set up rust cache
       uses: Swatinem/rust-cache@v2
       with:
@@ -39,3 +41,10 @@ jobs:
     - run: cargo clippy --release
     - run: cargo build --release
     - run: cargo test --release
+    - name: Scrut tests
+      env:
+        PYREFLY: ${{ github.workspace }}/target/release/pyrefly
+        TYPESHED_ROOT: ${{ github.workspace }}/crates/pyrefly_bundled/third_party
+        JQ: jq
+        TEST_PY: ${{ github.workspace }}/test.py
+      run: scrut test test


### PR DESCRIPTION
This PR adds functionality to run scrut tests in `test` directory on open source builds:
- If `scrut` is installed, run it in the open source version of `test.py`
- Install `scrut` on Ubuntu/macos CI workflow, and run the scrut tests during CI.