### PR TITLE
Separate lines of source code & lines of dependencies checked in summary

### DIFF
--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -717,7 +717,7 @@ impl CheckArgs {
             };
         }
         if self.output.summary == Summary::Full {
-            let user_handles: HashSet<Handle> = handles.iter().map(|(h, _)| h.clone()).collect();
+            let user_handles: HashSet<&Handle> = handles.iter().map(|(h, _)| h).collect();
             let (user_lines, dep_lines) = transaction.split_line_count(&user_handles);
             info!(
                 "{} ({}); {} ({} in your project, {} in dependencies); \

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -6,6 +6,7 @@
  */
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt;
 use std::fmt::Display;
 use std::fs::File;
@@ -716,14 +717,19 @@ impl CheckArgs {
             };
         }
         if self.output.summary == Summary::Full {
+            let user_handles: HashSet<Handle> = handles.iter().map(|(h, _)| h.clone()).collect();
+            let (user_lines, dep_lines) = transaction.split_line_count(&user_handles);
             info!(
-                "{} ({}, {}); took {timings}; memory ({})",
+                "{} ({}); {} ({} in your project, {} in dependencies); \
+                took {timings}; memory ({})",
                 count(handles.len(), "module"),
                 count(
                     transaction.module_count() - handles.len(),
                     "dependent module"
                 ),
-                count(transaction.line_count(), "line"),
+                count(user_lines + dep_lines, "line"),
+                count(user_lines, "line"),
+                count(dep_lines, "line"),
                 memory_trace.peak()
             );
         }

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -516,32 +516,9 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    pub fn line_count(&self) -> usize {
-        if self.data.updated_modules.is_empty() {
-            return self
-                .readable
-                .modules
-                .values()
-                .map(|x| x.state.steps.line_count())
-                .sum();
-        }
-        let mut res = self
-            .data
-            .updated_modules
-            .iter_unordered()
-            .map(|x| x.1.state.read().steps.line_count())
-            .sum();
-        for (k, v) in self.readable.modules.iter() {
-            if self.data.updated_modules.get(k).is_none() {
-                res += v.state.steps.line_count();
-            }
-        }
-        res
-    }
-
     /// Computes line count split between user-owned and dependency modules.
     /// Returns (user_lines, dependency_lines).
-    pub fn split_line_count(&self, user_handles: &HashSet<Handle>) -> (usize, usize) {
+    pub fn split_line_count(&self, user_handles: &HashSet<&Handle>) -> (usize, usize) {
         let mut user_lines = 0;
         let mut dep_lines = 0;
 


### PR DESCRIPTION
Resolves facebook/pyrefly#241

Adds a new method split_line_count that updates the info line in the cli's full summary to include both user and dependency line counts.

Example: `INFO 4 modules (269 dependent modules); 82,204 lines (17 lines in your project, 82,187 lines in dependencies); took 1.98s; memory (physical 169.6 MiB)`

A warning is now thrown during build (warning: method `line_count` is never used) but didn't want to modify or remove this method to avoid breaking any external usage.

Let me know if you'd like any changes to the formatting, output wording, or implementation approach.