### PR TITLE
await language server stop

### DIFF
--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -179,9 +179,9 @@ async function triggerMsPythonRefreshLanguageServers() {
     await config.update(setting, previousSetting, vscode.ConfigurationTarget.Global);
 }
 
-export function deactivate(): Thenable<void> | undefined {
+export async function deactivate(): Promise<void> | undefined {
     if (!client) {
         return undefined;
     }
-    return client.stop();
+    return await client.stop();
 }


### PR DESCRIPTION
Summary:
my fix for https://github.com/facebook/pyrefly/issues/853 (D79814747):
- fixes the issue for local builds of the oss extension
- does not fix the issue for remote builds of the oss extension (github actions)
- always fixes the issue on the internal extension

I tried two .vsixes built off github actions:
https://github.com/facebook/pyrefly/actions/runs/16818863625/job/47641707986
https://github.com/facebook/pyrefly/actions/runs/16836394658/job/47696837101
and both of them end up with duplicate pyrefly processes on window reload. but local builds of the same extension on the same machine work (only up to one pyrefly process)

the only difference in the build that I know of is:
- remote builds: cargo build --release --all-features --artifact-dir lsp/bin --manifest-path pyrefly/Cargo.toml -Z unstable-options (from ./pyrefly)
- local builds: cargo build --release --artifact-dir ../lsp/bin -Z unstable-options (from ./pyrefly/pyrefly)

I can't figure out what the difference is. So in the meantime, I'm putting up this fix

Differential Revision: D79913429


