### PR TITLE
Fix `key lacking binding panic` when two and more names defined by walrus operators in generator

### DIFF
--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -548,7 +548,11 @@ impl<'a> DefinitionsBuilder<'a> {
             Expr::Named(expr_named) => {
                 self.expr_lvalue(&expr_named.target);
             }
-            Expr::Lambda(..) | Expr::SetComp(..) | Expr::DictComp(..) | Expr::ListComp(..) => {
+            Expr::Lambda(..)
+            | Expr::SetComp(..)
+            | Expr::DictComp(..)
+            | Expr::ListComp(..)
+            | Expr::Generator(..) => {
                 // These expressions define a scope, so walrus operators only define a name
                 // within that scope, not in the surrounding statement's scope.
             }
@@ -712,7 +716,10 @@ assert (x9 := 42), (x10 := "oops")
 type y = (x11 := int)
 # Named expressions inside expression-level scopes should not appear in definitions.
 lambda x: (z := 42)
+{z := "str" for _ in [1]}
+{(z := "str"):1 for _ in [1]}
 [z for x in [1, 2, 3] if z := x > 2]
+(z := "str" for _ in [1])
 "#,
         );
         assert_definition_names(


### PR DESCRIPTION
# Summary 
Resolves #848

The fix added `Expr::Generator` to the list of expressions that must be skipped during accumulation of names defined by walrus operators in an expression.

Added test coverage for expressions that define scope and may contain walrus operators.

# Explanation

Definition of two names by walrus operators in generators like
```python
x1 = (w:=1 for _ in [1])
x2 = (w:="str" for _ in [1])
```
or even
```python
x1 = (w:=1 for _ in [w:="str"])
```
causes a panic due to an index Anywhere("w") being created, but no binding exists.
