### PR TITLE
Fix comment and docstring typos

### DIFF
--- a/crates/pyrefly_python/src/ast.rs
+++ b/crates/pyrefly_python/src/ast.rs
@@ -130,8 +130,8 @@ impl Ast {
             s = &buffer;
             add += TextSize::new(1); // 3 for the quotes, minus 1 for the bracket, minus 1 for the raw quote
         }
-        // Make sure the range is precise, so that we get the right UTF8 indicies.
-        // We might have a problem with \ escapes moving indicies, but if necessary we can ban those.
+        // Make sure the range is precise, so that we get the right UTF8 indices.
+        // We might have a problem with \ escapes moving indices, but if necessary we can ban those.
         Ast::parse_expr(s, x.range.start() + add)
     }
 

--- a/crates/pyrefly_python/src/ignore.rs
+++ b/crates/pyrefly_python/src/ignore.rs
@@ -17,7 +17,7 @@
 //! Note that Pyright will only honor such codes after `# pyright: ignore[code]`.
 //!
 //! You can also use `# mypy: ignore-errors`, `# pyrefly: ignore-errors`
-//! or `# type: ignore` at the beginning of a file to surpress all errors.
+//! or `# type: ignore` at the beginning of a file to suppress all errors.
 //!
 //! For Pyre compatibility we also allow `# pyre-ignore` and `# pyre-fixme`
 //! as equivalents to `pyre: ignore`, and `# pyre-ignore-all-errors` as

--- a/crates/pyrefly_util/src/globs.rs
+++ b/crates/pyrefly_util/src/globs.rs
@@ -470,7 +470,7 @@ impl Globs {
 /// A struct which allows filtering by matching a high-priority [`Globs`] of excludes
 /// and several ignore files. The first positive (ignore) or negative (allowlist)
 /// match that's found from the following order is what's used.
-/// 1. `excludes`: user-provied paths, either from a config or CLI.
+/// 1. `excludes`: user-provided paths, either from a config or CLI.
 /// 2. `.gitignore`: if one exists from an upward search from `root`, the first
 ///    positive or negative match (`!`) is used
 /// 3. `.ignore`: if it exists, behaves similar to `.gitignore`

--- a/pyrefly/lib/alt/answers_solver.rs
+++ b/pyrefly/lib/alt/answers_solver.rs
@@ -251,7 +251,7 @@ impl Cycle {
         cycle
     }
 
-    /// Do a pre-calculation check, to handle progress recurively traversing
+    /// Do a pre-calculation check, to handle progress recursively traversing
     /// the cycle until we reach the second instance of `break_at`.
     ///
     /// For each cycle participant we encounter, we move it from the
@@ -548,16 +548,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let answer = K::solve(self, binding, self.base_errors);
         let (v, rec) = calculation.record_value(answer);
         // If this was the first write to a Calculation that had a recursive placeholder,
-        // we need to record the placeholder => final answer correspondance.
+        // we need to record the placeholder => final answer correspondence.
         if let Some(r) = rec {
             let k = self.bindings().idx_to_key(idx).range();
             // Always force recursive Vars as soon as we produce the final answer. This limits
             // nondeterminism by ensuring that nothing downstream of the cycle can pin the type
             // once the cycle has finished (although there can still be data races where the
-            // Var excapes the cycle in another thread before it has finished computing).
+            // Var escapes the cycle in another thread before it has finished computing).
             //
             // `Var::ZERO` is just a dummy value used by a few of the `K: Solve`
-            // implementations that doen't actually use the Var, so we have to skip it.
+            // implementations that doesn't actually use the Var, so we have to skip it.
             K::record_recursive(self, k, &v, r, self.base_errors);
             if r != Var::ZERO {
                 self.solver().force_var(r);

--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -746,7 +746,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         ctor_targs: Option<&mut TArgs>,
     ) -> (Type, Callable) {
         // There may be Expr values in args and keywords.
-        // If we infer them for each overload, we may end up infering them multiple times.
+        // If we infer them for each overload, we may end up inferring them multiple times.
         // If those overloads contain nested overloads, then we can easily end up with O(2^n) perf.
         // Therefore, flatten all TypeOrExpr's into Type before we start
         let call = CallWithTypes::new();

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -48,7 +48,7 @@ use crate::types::types::Type;
 use crate::types::types::Var;
 
 /// Structure to turn TypeOrExprs into Types.
-/// This is used to avoid re-infering types for arguments multiple types.
+/// This is used to avoid re-inferring types for arguments multiple types.
 ///
 /// Implemented by keeping an `Owner` to hand out references to `Type`.
 pub struct CallWithTypes(Owner<Type>);

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -731,7 +731,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> ClassField {
         // TODO(stroxler): Clean this up, as we convert more of the class field logic to using enums.
         //
-        // It's a mess becasue we are relying on refs to fields that don't make sense for some cases,
+        // It's a mess because we are relying on refs to fields that don't make sense for some cases,
         // which requires us having a place to store synthesized dummy values until we've refactored more.
         let value_storage = Owner::new();
         let initial_value_storage = Owner::new();

--- a/pyrefly/lib/alt/debugging.rs
+++ b/pyrefly/lib/alt/debugging.rs
@@ -23,7 +23,7 @@ use crate::graph::index::Idx;
 /// Debugging helpers for the AnswersSolver.
 ///
 /// These are all string-returning functions, which make them potentially less efficient
-/// but more convienient than `Display` implementations because they are easy to use
+/// but more convenient than `Display` implementations because they are easy to use
 /// for string-based comparisons for filtered debugging.
 ///
 /// For example, one useful snippet in unit tests is:

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -2005,7 +2005,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
             }
             Binding::Pin(unpinned_idx, first_use) => {
-                // Calclulate the first use for its side-effects (it might pin `Var`s)
+                // Calculate the first use for its side-effects (it might pin `Var`s)
                 match first_use {
                     FirstUse::UsedBy(idx) => {
                         self.get_idx(*idx);

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -929,7 +929,7 @@ impl<'a> BindingsBuilder<'a> {
     /// binding. The loop follows `Forward` nodes backward, and returns:
     /// - Some(...) if we find either a legacy type variable or an import (in which case it *might*
     ///   be a legacy type variable, so we'll let the solve stage decide)
-    /// - None if we find somethign that is definitely not a legacy type variable.
+    /// - None if we find something that is definitely not a legacy type variable.
     fn lookup_legacy_tparam_from_idx(
         &mut self,
         name: &Identifier,

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -222,7 +222,7 @@ impl<'a> BindingsBuilder<'a> {
     /// - Information about what binding it is being used in, which is used both
     ///   - to track first-use to get deterministic inference of placeholder
     ///     types like empty list
-    ///   - to determin when we are in a static typing usage
+    ///   - to determine when we are in a static typing usage
     /// - The lookup kind, which is used to distinguish between normal lookups,
     ///   which allow uses of nonlocals, versus mutable lookups that do not
     ///   (unless the nonlocal was explicitly mutably captured by a `global`

--- a/pyrefly/lib/binding/flow_ops.rs
+++ b/pyrefly/lib/binding/flow_ops.rs
@@ -59,7 +59,7 @@ impl MergeItem {
         // We are promising to bind this key at the end of the merge (see `merged_flow_info`).
         //
         // Note that in loops, the speculative phi logic may have already inserted this key,
-        // in which case `idx_for_promise` will just give us back the idx we aready created.
+        // in which case `idx_for_promise` will just give us back the idx we already created.
         let phi_idx = idx_for_promise(Key::Phi(name, range));
         let mut myself = Self {
             phi_idx,

--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -287,7 +287,7 @@ impl<'a> BindingsBuilder<'a> {
             .push_function_scope(range, func_name, class_key.is_some());
         self.parameters(parameters, class_key);
         self.scopes.pop();
-        // If we are in a class, use a simple visiter to find `self.<attr>` assignments.
+        // If we are in a class, use a simple visitor to find `self.<attr>` assignments.
         if class_key.is_some() {
             SelfAttrNames::find(func_name, parameters, body)
         } else {

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -1080,7 +1080,7 @@ impl Scopes {
         }
     }
 
-    /// Insert an annotation pulled from some ancester scope for a name
+    /// Insert an annotation pulled from some ancestor scope for a name
     /// defined by a `global` or `nonlocal` declaration.
     pub fn set_annotation_for_mutable_capture(
         &mut self,

--- a/pyrefly/lib/graph/calculation.rs
+++ b/pyrefly/lib/graph/calculation.rs
@@ -48,7 +48,7 @@ pub enum ProposalResult<T, R> {
     CycleDetected,
     /// The current thread has encountered a cycle, this is the recursive placeholder.
     CycleBroken(R),
-    /// A final reasult is already available.
+    /// A final result is already available.
     Calculated(T),
 }
 

--- a/pyrefly/lib/playground.rs
+++ b/pyrefly/lib/playground.rs
@@ -54,7 +54,7 @@ impl Position {
         }
     }
 
-    // This should always succeed, but we are being convervative
+    // This should always succeed, but we are being conservative
     fn to_display_pos(&self) -> Option<DisplayPos> {
         Some(DisplayPos {
             line: LineNumber::new(u32::try_from(self.line).ok()?)?,

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -54,7 +54,7 @@ const INITIAL_GAS: Gas = Gas::new(25);
 enum Variable {
     /// A variable in a container with an unspecified element type, e.g. `[]: list[V]`
     Contained,
-    /// A variable due to generic instantitation, `def f[T](x: T): T` with `f(1)`
+    /// A variable due to generic instantiation, `def f[T](x: T): T` with `f(1)`
     Quantified(Quantified),
     /// A variable caused by recursion, e.g. `x = f(); def f(): return x`.
     /// The second value is the default value of the Var, if one exists.

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -670,42 +670,42 @@ impl<'a> Transaction<'a> {
                 identifier: _,
                 context: IdentifierContext::FunctionDef { docstring_range: _ },
             }) => {
-                // TODO(grievejia): Handle defintions of functions
+                // TODO(grievejia): Handle definitions of functions
                 None
             }
             Some(IdentifierWithContext {
                 identifier: _,
                 context: IdentifierContext::ClassDef { docstring_range: _ },
             }) => {
-                // TODO(grievejia): Handle defintions of classes
+                // TODO(grievejia): Handle definitions of classes
                 None
             }
             Some(IdentifierWithContext {
                 identifier: _,
                 context: IdentifierContext::Parameter,
             }) => {
-                // TODO(grievejia): Handle defintions of params
+                // TODO(grievejia): Handle definitions of params
                 None
             }
             Some(IdentifierWithContext {
                 identifier: _,
                 context: IdentifierContext::TypeParameter,
             }) => {
-                // TODO(grievejia): Handle defintions of type params
+                // TODO(grievejia): Handle definitions of type params
                 None
             }
             Some(IdentifierWithContext {
                 identifier: _,
                 context: IdentifierContext::ExceptionHandler,
             }) => {
-                // TODO(grievejia): Handle defintions of exception names
+                // TODO(grievejia): Handle definitions of exception names
                 None
             }
             Some(IdentifierWithContext {
                 identifier: _,
                 context: IdentifierContext::PatternMatch(_),
             }) => {
-                // TODO(grievejia): Handle defintions of pattern-introduced names
+                // TODO(grievejia): Handle definitions of pattern-introduced names
                 None
             }
             Some(IdentifierWithContext {

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -427,7 +427,7 @@ assert_type(C().f(None, 1), int)
 // because the default value can be overridden by instance assignment.
 //
 // Our behavior is compatible, but the underlying implementation is not, we are
-// behaving this way based on how we treate the Callable type rather than based
+// behaving this way based on how we treat the Callable type rather than based
 // on the absence of `ClassVar`.
 //
 // See https://discuss.python.org/t/when-should-we-assume-callable-types-are-method-descriptors/92938


### PR DESCRIPTION
# Summary

This PR fixes **only** typos in comments and docstings. The [typos-cli](https://docs.rs/crate/typos-cli/latest) used for this purpose.

# Proposals

1. Should I correct typos in variables/methods/structs, etc.? Examples
```
commitable -> committable
Overriden ->  Overridden
further -> further
```
2.  Add a typos check to the CI pipeline. If this seems like a good idea to you, I can implement it.