### PR TITLE
Fix False-Positive when trying to access a `@property` of a generic parameter with union type bound

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -1496,7 +1496,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             },
             AttributeBase1::Quantified(q, bound) => {
                 if let Some(upper_bound) = bound {
-                    match self.get_bounded_quantified_attribute(q.clone(), upper_bound, attr_name) {
+                    let specific_q = match q.restriction() {
+                        Restriction::Constraints(_) => {
+                            q.clone().with_restriction(Restriction::Constraints(vec![
+                                upper_bound.clone().to_type(),
+                            ]))
+                        }
+                        Restriction::Bound(_) => q
+                            .clone()
+                            .with_restriction(Restriction::Bound(upper_bound.clone().to_type())),
+                        Restriction::Unrestricted => q.clone(),
+                    };
+                    match self.get_bounded_quantified_attribute(specific_q, upper_bound, attr_name)
+                    {
                         Some(attr) => acc.found(attr, base),
                         None => acc.not_found(NotFoundOn::ClassInstance(
                             upper_bound.class_object().dupe(),

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -658,15 +658,8 @@ fn bind_instance_attribute(
 ) -> Attribute {
     // Decorated objects are methods, so they can't be ClassVars
     if attr.is_property_getter() {
-        // For property getters on TypeVar instances, use the bound type instead of the TypeVar
-        let obj_type = match &instance.kind {
-            InstanceKind::TypeVar(_) => {
-                ClassType::new(instance.class.dupe(), instance.targs.clone()).to_type()
-            }
-            _ => instance.to_type(),
-        };
         Attribute::property(
-            make_bound_method(obj_type, attr).into_inner(),
+            make_bound_method(instance.to_type(), attr).into_inner(),
             None,
             instance.class.dupe(),
         )

--- a/pyrefly/lib/test/generic_restrictions.rs
+++ b/pyrefly/lib/test/generic_restrictions.rs
@@ -391,9 +391,11 @@ class Foo[T: (A, B)]:
 );
 
 testcase!(
-    test_generic_union_constraint_with_property_access,
+    test_union_bounded_typevar_with_property_get,
     r#"
+# https://github.com/facebook/pyrefly/issues/869
 from collections import defaultdict
+from typing import assert_type
 
 class A:
 
@@ -401,15 +403,86 @@ class A:
     def attr(self) -> str:
         return "A"
 
+
 class B:
 
     @property
     def attr(self) -> str:
         return "B"
 
+
 def foo[T: A | B](items: list[T]) -> None:
     results: defaultdict[str, list[T]] = defaultdict(list)
     for item in items:
+        assert_type(item.attr, str)
         results[item.attr].append(item)
+    "#,
+);
+
+testcase!(
+    test_union_bounded_typevar_property_return_self,
+    r#"
+from typing import Self
+class A:
+    @property
+    def attr(self) -> Self: ...
+
+class B:
+    @property
+    def attr(self) -> Self: ...
+
+def foo[T: A | B](x: T) -> T:
+    return x.attr
+    "#,
+);
+
+testcase!(
+    test_constrained_typevar_property_return_self,
+    r#"
+from typing import Self
+class A:
+    @property
+    def attr(self) -> Self: ...
+
+class B:
+    @property
+    def attr(self) -> Self: ...
+
+def foo[T: (A, B)](x: T) -> T:
+    return x.attr
+    "#,
+);
+
+testcase!(
+    test_union_bounded_typevar_instance_method_return_self,
+    r#"
+from typing import Self
+class A:
+
+    def method(self) -> Self: ...
+
+class B:
+
+    def method(self) -> Self: ...
+
+def foo[T: A | B](x: T) -> T:
+    return x.method()
+    "#,
+);
+
+testcase!(
+    test_constrained_typevar_instance_method_return_self,
+    r#"
+from typing import Self
+class A:
+
+    def method(self) -> Self: ...
+
+class B:
+
+    def method(self) -> Self: ...
+
+def foo[T: (A, B)](x: T) -> T:
+    return x.method()
     "#,
 );


### PR DESCRIPTION
# Summary

Resolves #869

This fix ensures that when accessing properties on generic type parameters with union constraints (e.g., T: A | B), the type checker correctly resolves the property return type instead of treating it as the TypeVar itself.

## Explanation

To access TypeVar methods with union bounds, we must ensure that each union member type has the specified method. Currently, Pyrefly bound union types to self when accessing methods, rather than to concrete types. This fix should resolve that issue.

## Test Plan

- Added several test cases to ensure correctness of method calling on TypeVar with union bound and restrictions.

