### PR TITLE
Implementing feature #593, warn on redundant cast

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -200,6 +200,8 @@ pub enum ErrorKind {
     ParseError,
     /// The attribute exists but cannot be modified.
     ReadOnly,
+    /// Warning when casting a value to a type it is already compatible with.
+    RedundantCast,
     /// Attempting to use value that is equivalent to True or always False in boolean context.
     RedundantCondition,
     /// Raised by a call to reveal_type().
@@ -261,6 +263,7 @@ impl ErrorKind {
         match self {
             ErrorKind::RevealType => Severity::Info,
             ErrorKind::Deprecated => Severity::Warn,
+            ErrorKind::RedundantCast => Severity::Warn,
             _ => Severity::Error,
         }
     }

--- a/pyrefly/lib/alt/special_calls.rs
+++ b/pyrefly/lib/alt/special_calls.rs
@@ -252,6 +252,21 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 "`typing.cast` missing required argument `val`".to_owned(),
             );
         }
+        if let Some(val_expr) = val {
+            let val_type = self.expr_infer(val_expr, errors);
+            if !val_type.is_any() && self.is_subset_eq(&val_type, &ret) {
+                self.error(
+                    errors,
+                    range,
+                    ErrorInfo::Kind(ErrorKind::RedundantCast),
+                    format!(
+                        "Redundant cast: `{}` is already assignable to type `{}`",
+                        val_type.deterministic_printing(),
+                        ret.clone().deterministic_printing()
+                    ),
+                );
+            }
+        }
         ret
     }
 

--- a/pyrefly/lib/test/mod.rs
+++ b/pyrefly/lib/test/mod.rs
@@ -44,6 +44,7 @@ mod pattern_match;
 mod perf;
 mod protocol;
 mod pydantic;
+mod redundant_cast;
 mod returns;
 mod scope;
 mod simple;

--- a/pyrefly/lib/test/redundant_cast.rs
+++ b/pyrefly/lib/test/redundant_cast.rs
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::testcase;
+
+testcase!(
+    test_redundant_cast_literals,
+    r#"
+from typing import cast
+x = cast(int, 5)  # E: Redundant cast: `Literal[5]` is already assignable to type `int`
+y = cast(str, "hello")  # E: Redundant cast: `Literal['hello']` is already assignable to type `str`
+"#,
+);
+
+testcase!(
+    test_redundant_cast_variables,
+    r#"
+from typing import cast
+x: int = 42
+y = cast(int, x)  # E: Redundant cast: `int` is already assignable to type `int`
+"#,
+);
+
+testcase!(
+    test_valid_casts_no_warning,
+    r#"
+from typing import Any, cast
+def deserialize(data: Any) -> int:
+    return cast(int, data)  # No warning - valid cast from Any
+
+obj: object = "hello"
+s = cast(str, obj)  # No warning - valid cast from object to str
+"#,
+);

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -746,6 +746,24 @@ x = Ex()
 x.meaning = 0
 ```
 
+## redundant-cast
+
+This warning is raised when `typing.cast()` is used to cast a value to a type it is already compatible with. Such casts are unnecessary and can be removed to improve code clarity.
+
+```python
+import typing
+
+x: int = 42
+# This cast is redundant since x is already an int
+y = typing.cast(int, x)  # redundant-cast
+
+# This is a valid cast since we're casting from a more general type
+obj: object = "hello"
+s = typing.cast(str, obj)  # No warning - this is a valid cast
+```
+
+The redundant cast warning helps identify unnecessary type casts that don't provide any additional type safety benefits.
+
 ## redundant-condition
 
 This error is used to indicate a type that's equivalent to True or False is used as a boolean condition (e.g. an uncalled function)


### PR DESCRIPTION
Summary
This PR adds detection for redundant usage of typing.cast where the value being cast already matches the target type. In such cases, a warning is now emitted to inform users of unnecessary casting.

Implementation Details
A check was added before applying the cast to compare the inferred type of the value against the target type.
If both types match, an ErrorKind::RedundantCast warning is emitted instead of applying the cast.
Includes tests under redundant_cast.rs.

Closes #593