### PR TITLE
feat(code-action): add ignore comment to suppress error

### DIFF
--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -25,12 +25,44 @@ fn apply_patch(info: &ModuleInfo, range: TextRange, patch: String) -> (String, S
     (before, after)
 }
 
-fn get_test_report(state: &State, handle: &Handle, position: TextSize) -> String {
+fn get_test_report_insert_import(state: &State, handle: &Handle, position: TextSize) -> String {
     let mut report = "Code Actions Results:\n".to_owned();
     let transaction = state.transaction();
     for (title, info, range, patch) in transaction
         .local_quickfix_code_actions(handle, TextRange::new(position, position))
-        .unwrap_or_default()
+        .into_iter()
+        .flatten()
+        // NOTE: We do NOT patch buffer with ignore comment code action that is
+        // tested separately
+        .filter(|(title, _, _, _)| !title.contains("ignore"))
+    {
+        let (before, after) = apply_patch(&info, range, patch);
+        report.push_str("# Title: ");
+        report.push_str(&title);
+        report.push('\n');
+        report.push_str("\n## Before:\n");
+        report.push_str(&before);
+        report.push_str("\n## After:\n");
+        report.push_str(&after);
+        report.push('\n');
+    }
+    report
+}
+
+fn get_test_report_ignore_code_action(
+    state: &State,
+    handle: &Handle,
+    position: TextSize,
+) -> String {
+    let mut report = "Code Actions Results:\n".to_owned();
+    let transaction = state.transaction();
+    for (title, info, range, patch) in transaction
+        .local_quickfix_code_actions(handle, TextRange::new(position, position))
+        .into_iter()
+        .flatten()
+        // NOTE: We ONLY patch buffer with ignore comment code action so
+        // we can test it separately
+        .filter(|(title, _, _, _)| title.contains("ignore"))
     {
         let (before, after) = apply_patch(&info, range, patch);
         report.push_str("# Title: ");
@@ -46,6 +78,100 @@ fn get_test_report(state: &State, handle: &Handle, position: TextSize) -> String
 }
 
 #[test]
+fn add_ignore_comment() {
+    let report = get_batched_lsp_operations_report_allow_error(
+        &[
+            ("a", "my_export = 3\nanother_thing = 4"),
+            ("b", "from a import another_thing\nmy_export\n# ^"),
+            (
+                "c",
+                r#"
+def func(x: int) -> int:
+    pass
+func(y)
+#    ^"#,
+            ),
+            (
+                "d",
+                r#"
+def func(x: int) -> int:
+#                    ^
+    pass
+func(y)"#,
+            ),
+        ],
+        get_test_report_ignore_code_action,
+    );
+    assert_eq!(
+        r#"
+# a.py
+
+# b.py
+2 | my_export
+      ^
+Code Actions Results:
+# Title: Suppress UnknownName with ignore comment
+
+## Before:
+from a import another_thing
+my_export
+# ^
+## After:
+from a import another_thing
+# pyrefly: ignore[unknown-name]
+my_export
+# ^
+
+
+
+# c.py
+4 | func(y)
+         ^
+Code Actions Results:
+# Title: Suppress UnknownName with ignore comment
+
+## Before:
+
+def func(x: int) -> int:
+    pass
+func(y)
+#    ^
+## After:
+
+def func(x: int) -> int:
+    pass
+# pyrefly: ignore[unknown-name]
+func(y)
+#    ^
+
+
+
+# d.py
+2 | def func(x: int) -> int:
+                         ^
+Code Actions Results:
+# Title: Suppress BadReturn with ignore comment
+
+## Before:
+
+def func(x: int) -> int:
+#                    ^
+    pass
+func(y)
+## After:
+
+# pyrefly: ignore[bad-return]
+def func(x: int) -> int:
+#                    ^
+    pass
+func(y)
+"#
+        .trim(),
+        report.trim()
+    );
+}
+
+#[test]
 fn basic_test() {
     let report = get_batched_lsp_operations_report_allow_error(
         &[
@@ -54,7 +180,7 @@ fn basic_test() {
             ("c", "my_export\n# ^"),
             ("d", "my_export = 3\n"),
         ],
-        get_test_report,
+        get_test_report_insert_import,
     );
     // We should suggest imports from both a and d, but not b.
     assert_eq!(
@@ -102,7 +228,7 @@ fn insertion_test_comments() {
             ("a", "my_export = 3\n"),
             ("b", "# i am a comment\nmy_export\n# ^"),
         ],
-        get_test_report,
+        get_test_report_insert_import,
     );
     // We will insert the import after a comment, which might not be the intended target of the
     // comment. This is not ideal, but we cannot do much better without sophisticated comment
@@ -139,7 +265,7 @@ fn insertion_test_existing_imports() {
             ("a", "my_export = 3\n"),
             ("b", "from typing import List\nmy_export\n# ^"),
         ],
-        get_test_report,
+        get_test_report_insert_import,
     );
     // Insert before all imports. This might not adhere to existing import sorting code style.
     assert_eq!(
@@ -174,7 +300,7 @@ fn insertion_test_duplicate_imports() {
             ("a", "my_export = 3\nanother_thing = 4"),
             ("b", "from a import another_thing\nmy_export\n# ^"),
         ],
-        get_test_report,
+        get_test_report_insert_import,
     );
     // The insertion won't attempt to merge imports from the same module.
     // It's not illegal, but it would be nice if we do merge.


### PR DESCRIPTION
This PR address #675.

It works by
1. By gathering all the errors whose range contains the current cursor.
2. Finding the column position of the first non-whitespace character of the line the cursor is on. Let us call this `column offset`.
3. Inserting an ignore comment on the line above the cursor; the comment is preceded by `column offset` single-spaces to match the prior indentation.

In my tests I have found this simple scheme to be surprisingly robust. My first attempt used the ast exclusively, but the ast does not contain comments, nor a way to insert _comments_ into the tree, meaning, just for this one use case of programmatically adding ignore comments, I cannot update the document using the ast, and I found myself having to calculate whitespace offsets in my first ast only attempt.

It is also worth pointing out that some LSPs might not _want_ to provide this kind of code action--they want to encourage the user to address the underlying cause, not ignore it. But because Pyrefly is new, there are many false positives and so I think this will be a welcome addition. Plus, the suppression comments in this code action reference specific error codes, so the user in the future can address the lints precisely.

Future work is needed to address different types of ignore comments and a code action to

- Add all ignore comments to a module
- Add a top-level ignore comment to a module

Both should be relatively straightforward to do by using the utility functions I added in `pyrefly/lib/state/ide.rs`

Let me know your thoughts on this.

Thanks!