### PR TITLE
Create lambda scope with barrier false

### DIFF
--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -325,7 +325,7 @@ impl<'a> BindingsBuilder<'a> {
     }
 
     pub fn bind_lambda(&mut self, lambda: &mut ExprLambda, usage: &mut Usage) {
-        self.scopes.push(Scope::function(lambda.range, false));
+        self.scopes.push(Scope::lambda(lambda.range, false));
         if let Some(parameters) = &lambda.parameters {
             for x in parameters {
                 self.bind_lambda_param(x.name());

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -582,6 +582,16 @@ impl Scope {
             }),
         )
     }
+    pub fn lambda(range: TextRange, is_async: bool) -> Self {
+        Self::new(
+            range,
+            false,
+            ScopeKind::Function(ScopeFunction {
+                yields_and_returns: Default::default(),
+                is_async,
+            }),
+        )
+    }
 
     pub fn method(range: TextRange, name: Identifier, is_async: bool) -> Self {
         Self::new(

--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -612,3 +612,17 @@ def try_except_else_finally():
     e7 # E: `e7` is uninitialized
 "#,
 );
+
+// https://github.com/facebook/pyrefly/issues/959
+testcase!(
+    test_lambda_captures_narrowed_variable,
+    r#"
+class A:
+    shape: int = 0
+
+def check[T](new: T, old: T) -> None:
+    if isinstance(new, A):
+        assert isinstance(old, A)
+        lambda: old.shape
+"#,
+);


### PR DESCRIPTION
# Summary
Resolves #959

Lambda expressions were incorrectly using the same scope creation method as regular functions (Scope::function), which sets barrier = true. This was semantically incorrect because:

 1. Lambdas cannot assign variables - Python syntax prohibits assignments in lambda bodies
 2. No UnboundLocalError risk - The barrier mechanism protects against reading variables before local assignment, but lambdas can't create local assignments


## Test plan

I've added a simple test case `test_lambda_captures_narrowed_variable` to ensure that lambda body has access to outer scope flow (not only static info).