### PR TITLE
Handle scoping correctly for class fields in body

### DIFF
--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -633,3 +633,25 @@ testcase!(
 __all__ += []  # E: Could not find name `__all__`
 "#,
 );
+
+// https://github.com/facebook/pyrefly/issues/264
+testcase!(
+    test_class_var_scope,
+    r#"
+from typing import reveal_type
+
+x = 'string'
+
+class A:
+    x = 42
+    def f():
+        reveal_type(x) # E: revealed type: Literal['string']
+
+    lambda_f = lambda: reveal_type(x) # E: revealed type: Literal['string']
+
+    class B:
+        reveal_type(x) # E: revealed type: Literal['string']
+
+    [reveal_type(x) for _ in range(1)] # E: revealed type: Literal['string']
+"#,
+);


### PR DESCRIPTION
Fixes #264.

This diff addresses the scoping issues of class fields in nested scopes.

When a class field is defined in a class body, the scope of the field should only be available in the immediate class block, unless for annotations. This is described in the Python doc at https://docs.python.org/3/reference/executionmodel.html#resolution-of-names

To address this issue, we check the flow style when looking up a variable. If the variable is defined as a class field, we apply appropriate checks to avoid the incorrect scoping rule from being applied.