### PR TITLE
Fix class override check with contravariant Self

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1809,8 +1809,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // keys but not regular fields.
                 continue;
             }
-            let want_attribute =
-                self.as_instance_attribute(&want_class_field, &Instance::of_class(parent));
+            // Substitute `Self` with derived class to support contravariant occurrences of `Self`
+            let want_attribute = self.as_instance_attribute(
+                &want_class_field,
+                &Instance::of_protocol(parent, self.instantiate(cls)),
+            );
             if got_attribute.is_none() {
                 // Optimisation: Only compute the `got_attr` once, and only if we actually need it.
                 got_attribute = Some(self.as_instance_attribute(

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -446,3 +446,29 @@ class Derived(Base):
     method = staticmethod(a_method)
     "#,
 );
+
+testcase!(
+    test_override_self,
+    r#"
+from typing import Self
+class Base:
+    def covariant(self) -> Self:
+        return self
+
+    def contravariant(self, other: Self) -> None:
+        pass
+
+    def invariant(self) -> list[Self]:
+        return []
+
+class Derived(Base):
+    def covariant(self) -> Self:
+        return self
+
+    def contravariant(self, other: Self) -> None:
+        pass
+
+    def invariant(self) -> list[Self]:
+        return []
+    "#,
+);


### PR DESCRIPTION
Summary:
When we check class consistency, we use the same technique as protocol matching: we substitute Self using the derived class.

Fixes https://github.com/facebook/pyrefly/issues/1052

Differential Revision: D81885918


