### PR TITLE
Fix: Python version dropdown options visibility in Chromium browsers #1034

### DIFF
--- a/website/src/sandbox/PythonVersionSelector.tsx
+++ b/website/src/sandbox/PythonVersionSelector.tsx
@@ -33,7 +33,7 @@ export default function PythonVersionSelector({
                 aria-label="Select Python version"
             >
                 {SUPPORTED_VERSIONS.map((version) => (
-                    <option key={version} value={version}>
+                    <option key={version} value={version} {...stylex.props(styles.option)}>
                         Python {version}
                     </option>
                 ))}
@@ -75,5 +75,9 @@ const styles = stylex.create({
         paddingRight: '8px',
         boxSizing: 'border-box',
         display: 'block'
+    },
+    option: {
+        color: 'var(--color-text)',
+        backgroundColor: 'var(--color-background)',
     },
 });


### PR DESCRIPTION
  ## Summary
  Fixes #1034 : Python version dropdown menu visibility issue in browsers where dropdown options
  appeared as white text on white background, making them unreadable.
  
**Browsers affected:** Mostly chromium based (Chrome, Arc, Brave)
  ## Changes
  - Added explicit `color` and `backgroundColor` styles to `<option>` elements in PythonVersionSelector
  component
  - Applied `var(--color-text)` and `var(--color-background)` to match sandbox theme colors

  ## Testing
  - [x] Ran Jest tests - all passed
  - [x] Ran main test suite - all passed
  - [x] Manual testing performed
  - [x] Browser compatibility verified (Firefox, Brave)