### PR TITLE
Handle scoping correctly for class fields in body (reland)

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -788,9 +788,32 @@ impl<'a> BindingsBuilder<'a> {
     ) -> Result<(Idx<Key>, Option<Idx<Key>>), LookupError> {
         let mut barrier = false;
         let ok_no_usage = |idx| Ok((idx, None));
+        let is_current_scope_class = matches!(self.scopes.current().kind, ScopeKind::Class(_));
+        let is_current_scope_annotation =
+            matches!(self.scopes.current().kind, ScopeKind::Annotation);
+        // FIXME: Temporarily allow comprehensions to see all class fields, but
+        // class fields should be only allowed be used in the place of iterator,
+        // i.e. in `[expr1 for x in expr2]`, `expr2` can see class fields, but not `expr1`.
+        // See https://github.com/facebook/pyrefly/issues/264#issuecomment-3282180275 for details.
+        let is_current_scope_comprehension =
+            matches!(self.scopes.current().kind, ScopeKind::Comprehension);
+        let mut is_current_scope = true;
         for scope in self.scopes.iter_rev() {
             if let Some(flow) = scope.flow.info.get_hashed(name)
                 && !barrier
+                // Handles the special case of class fields:
+                // From https://docs.python.org/3/reference/executionmodel.html#resolution-of-names:
+                // """The scope of names defined in a class block is limited to the
+                // class block; it does not extend to the code blocks of
+                // methods. This includes comprehensions and generator
+                // expressions, but it does not include annotation scopes, which
+                // have access to their enclosing class scopes."""
+                && (
+                    (is_current_scope_class && is_current_scope) // The class body can see class fields in the current scope
+                    || is_current_scope_annotation // Annotations can see class fields in enclosing scopes
+                    || is_current_scope_comprehension // Comprehensions can see class fields in the current scope, but only in the place of iterators
+                    || !matches!(flow.style, FlowStyle::ClassField { .. }) // Other scopes cannot see class fields
+                )
             {
                 let (idx, maybe_pinned_idx) = self.detect_possible_first_use(flow.key, usage);
                 if let Some(pinned_idx) = maybe_pinned_idx {
@@ -814,6 +837,7 @@ impl<'a> BindingsBuilder<'a> {
                     }
                 }
             }
+            is_current_scope = false;
             barrier = barrier || scope.barrier;
         }
         Err(LookupError::NotFound)

--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -636,7 +636,7 @@ __all__ += []  # E: Could not find name `__all__`
 
 // https://github.com/facebook/pyrefly/issues/264
 testcase!(
-    bug = "This was implemented but we backed it out due to subtleties - see D82224938. All these should show `Literal['string']`",
+    bug = "All these should show `Literal['string']`. The issue with comprehension persists, see also the next test case.",
     test_class_scope_lookups_when_skip,
     r#"
 from typing import reveal_type
@@ -650,9 +650,9 @@ class A:
     x = 42
     def f():
         reveal_type(x) # E: revealed type: Literal['string']
-    lambda_f = lambda: reveal_type(x) # E: revealed type: Literal[42]
+    lambda_f = lambda: reveal_type(x) # E: revealed type: Literal['string']
     class B:
-        reveal_type(x) # E: revealed type: Literal[42]
+        reveal_type(x) # E: revealed type: Literal['string']
     [reveal_type(x) for _ in range(1)] # E: revealed type: Literal[42]
 "#,
 );


### PR DESCRIPTION
This is a reland of PR #1024 / D81681451 for addressing #264

The original change was reverted in
2747227a88409096d68d0a07223105024227d4f9 / D82227101 due to regression (#1073 and #1074).

This reland addresses the regression:
- allows annotation scope to access class fields (instead of static type information which was incorrect)
- allows comprehension scopre to access class fields (this leaves the test still broken --- since comprehension scoping is incorrect for iterator expressions in a comprehension)