### PR TITLE
Add unix only tag for unix-only import in LSP test

### DIFF
--- a/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
@@ -6,6 +6,7 @@
  */
 
 use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
 use lsp_server::Message;


### PR DESCRIPTION
This diff fixes open source windows build.

In L78-L83 of the file, the code block accessing unix permissions are already tagged `#[cfg(unix)]`. This diff adds the same config tag on the import so that windows build can be fixed.