### PR TITLE
Attach deprecated flags during auto complete

### DIFF
--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -27,6 +27,7 @@ use starlark_map::small_set::SmallSet;
 use vec1::Vec1;
 
 use crate::callable::Callable;
+use crate::callable::FuncId;
 use crate::callable::FuncMetadata;
 use crate::callable::Function;
 use crate::callable::FunctionKind;
@@ -1420,6 +1421,16 @@ impl Type {
                 BoundMethodType::Forall(forall) => Some(forall.body.signature),
                 BoundMethodType::Overload(_) => None,
             },
+            _ => None,
+        }
+    }
+
+    /// Return the FuncId if this type corresponds to a function or method.
+    pub fn to_funcid(&self) -> Option<FuncId> {
+        match &self {
+            Type::Function(f) => Some(f.metadata.kind.as_func_id()),
+            Type::BoundMethod(m) => Some(m.func.metadata().kind.as_func_id()),
+            Type::Overload(o) => Some(o.metadata.kind.as_func_id()),
             _ => None,
         }
     }

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -217,28 +217,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
     /// Check whether a type corresponds to a deprecated function or method, and if so, log a deprecation warning.
     pub fn check_for_deprecated_call(&self, ty: &Type, range: TextRange, errors: &ErrorCollector) {
-        let deprecated_function = match ty {
-            Type::Function(f) if f.metadata.flags.is_deprecated => {
-                Some(f.metadata.kind.as_func_id().format(self.module().name()))
-            }
-            Type::BoundMethod(m) if m.func.metadata().flags.is_deprecated => Some(
-                m.func
-                    .metadata()
-                    .kind
-                    .as_func_id()
-                    .format(self.module().name()),
-            ),
-            Type::Overload(o) if o.metadata.flags.is_deprecated => {
-                Some(o.metadata.kind.as_func_id().format(self.module().name()))
-            }
-            _ => None,
-        };
+        if !ty.is_deprecated() {
+            return;
+        }
+        let deprecated_function = ty
+            .to_funcid()
+            .map(|func_id| func_id.format(self.module().name()));
         if let Some(deprecated_function) = deprecated_function {
             self.error(
                 errors,
                 range,
                 ErrorInfo::Kind(ErrorKind::Deprecated),
-                format!("`{}` is deprecated", deprecated_function),
+                format!("`{deprecated_function}` is deprecated"),
             );
         }
     }

--- a/pyrefly/lib/export/exports.rs
+++ b/pyrefly/lib/export/exports.rs
@@ -47,7 +47,7 @@ pub struct Export {
 pub enum ExportLocation {
     // This export is defined in this module.
     ThisModule(Export),
-    // Export from another module ModuleName. If it's alised, the old name (before the alias) is provided.
+    // Export from another module ModuleName. If it's aliased, the old name (before the alias) is provided.
     OtherModule(ModuleName, Option<Name>),
 }
 

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -13,6 +13,7 @@ use fuzzy_matcher::skim::SkimMatcherV2;
 use itertools::Itertools;
 use lsp_types::CompletionItem;
 use lsp_types::CompletionItemKind;
+use lsp_types::CompletionItemTag;
 use lsp_types::DocumentSymbol;
 use lsp_types::ParameterInformation;
 use lsp_types::ParameterLabel;
@@ -2005,11 +2006,17 @@ impl<'a> Transaction<'a> {
                         })
                     }
                     let exports = self.get_exports(&handle);
-                    for name in exports.keys() {
+                    for (name, export) in exports.iter() {
+                        let is_deprecated = matches!(export, ExportLocation::ThisModule(export) if export.is_deprecated);
                         result.push(CompletionItem {
                             label: name.to_string(),
                             // todo(kylei): completion kind for exports
                             kind: Some(CompletionItemKind::VARIABLE),
+                            tags: if is_deprecated {
+                                Some(vec![CompletionItemTag::DEPRECATED])
+                            } else {
+                                None
+                            },
                             ..Default::default()
                         })
                     }

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2071,10 +2071,19 @@ impl<'a> Transaction<'a> {
                                     Some(Type::Function(_)) => Some(CompletionItemKind::FUNCTION),
                                     _ => Some(CompletionItemKind::FIELD),
                                 };
+                                let ty = &x.ty;
+                                let is_deprecated =
+                                    ty.as_ref().map(|ty| ty.is_deprecated()).unwrap_or(false);
+                                let detail = ty.clone().map(|t| t.as_hover_string());
                                 result.push(CompletionItem {
                                     label: x.name.as_str().to_owned(),
-                                    detail: x.ty.clone().map(|t| t.as_hover_string()),
+                                    detail,
                                     kind,
+                                    tags: if is_deprecated {
+                                        Some(vec![CompletionItemTag::DEPRECATED])
+                                    } else {
+                                        None
+                                    },
                                     ..Default::default()
                                 });
                             });

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -1852,6 +1852,11 @@ impl<'a> Transaction<'a> {
                             Some(k.to_lsp_completion_item_kind())
                         }),
                     additional_text_edits,
+                    tags: if export.is_deprecated {
+                        Some(vec![CompletionItemTag::DEPRECATED])
+                    } else {
+                        None
+                    },
                     ..Default::default()
                 });
             }

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -1305,6 +1305,39 @@ Completion Results:
 }
 
 #[test]
+fn autoimport_relative_on_deprecated() {
+    let code = r#"
+T = foooooo
+#       ^
+"#;
+    let bar_code = r#"
+from warnings import deprecated
+@deprecated("this is not ok")
+def foooooo():
+    ...
+"#;
+    let report = get_batched_lsp_operations_report_allow_error(
+        &[("main", code), ("bar", bar_code)],
+        get_test_report(Default::default(), ImportFormat::Relative),
+    );
+    assert_eq!(
+        r#"
+# main.py
+2 | T = foooooo
+            ^
+Completion Results:
+- (Function) [DEPRECATED] foooooo: from .bar import foooooo
+
+
+
+# bar.py
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn autoimport_completions_on_builtins() {
     let code = r#"
 T = Literal

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -393,6 +393,59 @@ Completion Results:
 }
 
 #[test]
+fn from_import_deprecated() {
+    let foo_code = r#"
+from warnings import deprecated
+
+def func_ok():
+    ...
+@deprecated("this is not ok")
+def func_not_ok():
+    ...
+"#;
+    let main_code = r#"
+from foo import func
+#          ^        ^
+"#;
+    let report = get_batched_lsp_operations_report_allow_error(
+        &[("main", main_code), ("foo", foo_code)],
+        get_default_test_report(),
+    );
+    assert_eq!(
+        r#"
+# main.py
+2 | from foo import func
+               ^
+Completion Results:
+
+2 | from foo import func
+                        ^
+Completion Results:
+- (Variable) deprecated
+- (Variable) [DEPRECATED] func_not_ok
+- (Variable) func_ok
+- (Variable) __annotations__
+- (Variable) __builtins__
+- (Variable) __cached__
+- (Variable) __debug__
+- (Variable) __dict__
+- (Variable) __doc__
+- (Variable) __file__
+- (Variable) __loader__
+- (Variable) __name__
+- (Variable) __package__
+- (Variable) __path__
+- (Variable) __spec__
+
+
+# foo.py
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn from_import_basic() {
     let foo_code = r#"
 imperial_guard = "cool"

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -109,6 +109,39 @@ Completion Results:
     );
 }
 
+// TODO: Mark deprecated properties as deprecated
+#[test]
+fn dot_complete_with_deprecated() {
+    let code = r#"
+from warnings import deprecated
+class Foo:
+    x: int
+    @deprecated("this is not ok")
+    def not_ok(self): ...
+    @deprecated("this is also not ok")
+    @property
+    def also_not_ok(self) -> int: ...
+foo = Foo()
+foo. 
+#   ^
+"#;
+    let report =
+        get_batched_lsp_operations_report_allow_error(&[("main", code)], get_default_test_report());
+    assert_eq!(
+        r#"
+# main.py
+11 | foo. 
+         ^
+Completion Results:
+- (Field) also_not_ok: int
+- (Method) [DEPRECATED] not_ok: (self: Foo) -> None
+- (Field) x: int
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
 #[test]
 fn dot_complete_types_test() {
     let code = r#"

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -246,6 +246,31 @@ Completion Results:
 }
 
 #[test]
+fn variable_complete_with_deprecation() {
+    let code = r#"
+from warnings import deprecated
+@deprecated("this is not ok")
+def not_ok(): ...
+def foo():
+  n
+# ^
+"#;
+    let report =
+        get_batched_lsp_operations_report_allow_error(&[("main", code)], get_default_test_report());
+    assert_eq!(
+        r#"
+# main.py
+6 |   n
+      ^
+Completion Results:
+- (Function) [DEPRECATED] not_ok: () -> None
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn variable_with_globals_complete_test() {
     let code = r#"
 FileExistsOrNot = 1

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -38,17 +38,26 @@ fn get_test_report(
             kind,
             insert_text,
             data,
+            tags,
             ..
         } in state
             .transaction()
             .completion(handle, position, import_format)
         {
+            let is_deprecated = if let Some(tags) = tags {
+                tags.contains(&lsp_types::CompletionItemTag::DEPRECATED)
+            } else {
+                false
+            };
             if (filter.include_keywords || kind != Some(CompletionItemKind::KEYWORD))
                 && (filter.include_builtins || data != Some(serde_json::json!("builtin")))
             {
                 report.push_str("\n- (");
                 report.push_str(&format!("{:?}", kind.unwrap()));
                 report.push_str(") ");
+                if is_deprecated {
+                    report.push_str("[DEPRECATED] ");
+                }
                 report.push_str(&label);
                 if let Some(detail) = detail {
                     report.push_str(": ");


### PR DESCRIPTION
We know whether a method or a function is deprecated in Pyrefly, but the information is not propagated to LSP autocomplete (#1038). This diff passes along the deprecated tags in LSP auto completion. 

Caveat: deprecated properties in classes are currently not tagged with deprecated tag correctly.