### PR TITLE
Escape strings when auto-completing literals

### DIFF
--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -1935,9 +1935,10 @@ impl<'a> Transaction<'a> {
         match param_type {
             Type::Literal(lit) => {
                 completions.push(CompletionItem {
-                    label: lit.to_string(),
+                    // TODO: Pass the flag correctly for whether literal string is single quoted or double quoted
+                    label: lit.to_string_escaped(true),
                     kind: Some(CompletionItemKind::VALUE),
-                    detail: Some(format!("{}", param_type)),
+                    detail: Some(format!("{param_type}")),
                     ..Default::default()
                 });
             }

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -858,6 +858,39 @@ Completion Results:
 }
 
 #[test]
+fn completion_literal_with_escape_chars() {
+    let code = r#"
+from typing import Literal
+def foo(x: Literal['\a', '\b', '\f', '\n', '\r', '\t', '\v', '\\', '"', "'"]): ...
+foo(
+#   ^
+"#;
+    let report =
+        get_batched_lsp_operations_report_allow_error(&[("main", code)], get_default_test_report());
+    assert_eq!(
+        r#"
+# main.py
+4 | foo(
+        ^
+Completion Results:
+- (Value) '"': Literal['"']
+- (Value) '\'': Literal['\'']
+- (Value) '\\': Literal['\\']
+- (Value) '\a': Literal['\a']
+- (Value) '\b': Literal['\b']
+- (Value) '\f': Literal['\f']
+- (Value) '\n': Literal['\n']
+- (Value) '\r': Literal['\r']
+- (Value) '\t': Literal['\t']
+- (Value) '\v': Literal['\v']
+- (Variable) x=: Literal['\a', '\b', '\t', '\n', '\v', '\f', '\r', '"', '\'', '\\']
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn completion_literal_union() {
     let code = r#"
 from typing import Literal, Union


### PR DESCRIPTION
Implementing escaping for single quotes to address #1095.

For a more proper fix, we should detect whether the string being completed is using single/double quotes (depends on fix for #1086), and auto-complete accordingly. Maybe, also a user-preference setting to allow the user to choose as well?