### PR TITLE
Fix: Incorrect return path identification with try/finally #1091

### DIFF
--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -699,7 +699,13 @@ fn function_last_expressions<'a>(
                 }
             }
             Stmt::Try(x) => {
-                if !x.finalbody.is_empty() {
+                // If final body is not empty, _and_ contains a return statement,
+                // process it.
+                if !x.finalbody.is_empty()
+                    && x.finalbody
+                        .iter()
+                        .any(|stmt| matches!(stmt, Stmt::Return(_)))
+                {
                     f(sys_info, &x.finalbody, res)?;
                 } else {
                     if x.orelse.is_empty() {

--- a/pyrefly/lib/test/flow.rs
+++ b/pyrefly/lib/test/flow.rs
@@ -1450,3 +1450,14 @@ def f(v):
         print(value)
     "#,
 );
+
+testcase!(
+    test_trycatch_implicit_return,
+    r#"
+def f() -> int:
+    try:
+        return 1
+    finally:
+        pass
+    "#,
+);


### PR DESCRIPTION
This patch fixes an error in incorrect return patch identification with try/finally.
When a finally block is seen:
- Previously: only process the finally block for returns
- Now: check if finally block has a "return" statement. If not, process other blocks.

E.g. failing case:

```python
try:
    return 1
finally:
    pass
```
