### PR TITLE
Add django metadata to enum metadata

### DIFF
--- a/crates/pyrefly_python/src/module_name.rs
+++ b/crates/pyrefly_python/src/module_name.rs
@@ -156,6 +156,10 @@ impl ModuleName {
         Self::from_str("pydantic.root_model")
     }
 
+    pub fn django_models_enums() -> Self {
+        Self::from_str("django.db.models.enums")
+    }
+
     /// The "unknown" module name, which corresponds to `__unknown__`.
     /// Used for files directly opened or passed on the command line which aren't on the search path.
     pub fn unknown() -> Self {

--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -706,6 +706,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         bases_with_metadata: &[(Class, Arc<ClassMetadata>)],
         errors: &ErrorCollector,
     ) -> Option<EnumMetadata> {
+        let is_django = bases_with_metadata.iter().any(|(base, base_meta)| {
+            base.has_toplevel_qname(ModuleName::django_models_enums().as_str(), "Choices")
+                || base_meta
+                    .enum_metadata()
+                    .as_ref()
+                    .is_some_and(|meta| meta.is_django)
+        });
+
         if let Some(metaclass) = metaclass
             && self
                 .as_superclass(metaclass, self.stdlib.enum_meta().class_object())
@@ -733,6 +741,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         &Type::ClassType(self.stdlib.enum_flag().clone()),
                     )
                 }),
+                is_django,
             })
         } else {
             None

--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -335,6 +335,8 @@ pub struct EnumMetadata {
     pub is_flag: bool,
     /// Is there any `_value_` field present.
     pub has_value: bool,
+    /// Whether this is a special Django enum.
+    pub is_django: bool,
 }
 
 #[derive(Clone, Debug, TypeEq, PartialEq, Eq)]


### PR DESCRIPTION
Summary:
Enums are responsible for the majority of false positives in the django stubs' assert_type testsuite.

Out of 71  total false positives, 59 are coming from enums and 41 of them are assert type failures.

In this diff, we start by adding a flag to identify IntegerChoices, which is an enum class defined in django stubs.

Reviewed By: rchen152

Differential Revision: D83096242


