### PR TITLE
Support enums inheriting from multiple classes

### DIFF
--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -742,6 +742,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     )
                 }),
                 is_django,
+                class_iteration_yields: {
+                    Type::ClassType(self.promote_nontypeddict_silently_to_classtype(cls))
+                },
             })
         } else {
             None

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -653,6 +653,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // Use the iterable protocol interfaces to determine the iterable type.
         // Special cases like Tuple should be intercepted first.
         let context = || ErrorContext::Iteration(self.for_display(iterable.clone()));
+
+        if let Type::ClassDef(cls) = iterable {
+            let metadata = self.get_metadata_for_class(cls);
+            if let Some(enum_metadata) = metadata.enum_metadata() {
+                return vec![Iterable::OfType(
+                    enum_metadata.class_iteration_yields.clone(),
+                )];
+            }
+        }
+
         match iterable {
             Type::ClassType(cls) if let Some(Tuple::Concrete(elts)) = self.as_tuple(cls) => {
                 vec![Iterable::FixedLen(elts.clone())]

--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -330,11 +330,14 @@ pub struct TypedDictMetadata {
 
 #[derive(Clone, Debug, TypeEq, PartialEq, Eq)]
 pub struct EnumMetadata {
+    /// The ClassType for this enum
     pub cls: ClassType,
     /// Whether this enum inherits from enum.Flag.
     pub is_flag: bool,
     /// Is there any `_value_` field present.
     pub has_value: bool,
+    /// What type does iterating over this enum class yield?
+    pub class_iteration_yields: Type,
     /// Whether this is a special Django enum.
     pub is_django: bool,
 }

--- a/pyrefly/lib/test/django/enums.rs
+++ b/pyrefly/lib/test/django/enums.rs
@@ -26,7 +26,6 @@ def get_choices_using_property(choices: type[IntegerChoices]) -> list[tuple[int,
 );
 
 testcase!(
-    bug = "We should properly interpret IntegerChoices and propagate the write types through the enum (IntegerChoices is an enum)",
     test_int_choices_enums,
     django_env(),
     r#"
@@ -34,14 +33,13 @@ from django.db.models import IntegerChoices
 from django.utils.translation import gettext_lazy as _
 from typing_extensions import assert_type
 
-
 class Suit(IntegerChoices):
     DIAMOND = 1, _("Diamond")
     SPADE = 2, _("Spade")
     HEART = 3, _("Heart")
     CLUB = 4, _("Club")
 
-assert_type(Suit.CLUB.value, int) # E: assert_type(tuple[Literal[4], _StrPromise], int)
+assert_type(Suit.CLUB.value, int) 
 "#,
 );
 

--- a/pyrefly/lib/test/django/enums.rs
+++ b/pyrefly/lib/test/django/enums.rs
@@ -69,8 +69,8 @@ class Medal(TextChoices):
 
 # Assertions for mixing multiple choices types with consistent base types - only `TextChoices`.
 x1 = (Medal, Gender)
-assert_type([member.label for choices in x1 for member in choices], list[_StrOrPromise]) # E: Type `type[Gender]` is not iterable  # E: Type `type[Medal]` is not iterable 
-assert_type([member.value for choices in x1 for member in choices], list[str]) # E: Type `type[Gender]` is not iterable  # E: Type `type[Medal]` is not iterable 
+assert_type([member.label for choices in x1 for member in choices], list[_StrOrPromise]) 
+assert_type([member.value for choices in x1 for member in choices], list[str]) 
 "#,
 );
 

--- a/pyrefly/lib/test/enums.rs
+++ b/pyrefly/lib/test/enums.rs
@@ -117,7 +117,6 @@ Color = Enum("C", 'RED', 'GREEN', 'BLUE')  # E: Expected string literal "Color"
 );
 
 testcase!(
-    bug = "Enums with multiple inheritance are not iterable. Maybe a MRO / metaclass resolution issue?",
     test_iterate,
     r#"
 from typing import assert_type
@@ -134,9 +133,9 @@ class E3(StrEnum):
 
 for e in E1:
     assert_type(e, E1)
-for e in E2: # E: Type `type[E2]` is not iterable
+for e in E2: 
     assert_type(e, E2)
-for e in E3: # E: Type `type[E3]` is not iterable
+for e in E3: 
     assert_type(e, E3)
 
     "#,


### PR DESCRIPTION
Summary:
This decreases  django's test_enum's false positives.
 52 errors -> 44 errors



I am not familiar with the enum code yet so would love some feedback here. 

Currently, we don't support iterating over an enum when it inherits from multiple classes. This is a bug in normal enums and an important one to address in django enums. 

I have a workaround, which is to store the enum iterable type in the enum metadata and then special case it in the solver.

Can I get some initial thoughts about this as a temporary workaround or if we need to hold off on this and explore other options?

Differential Revision: D83203854


