### PR TITLE
Add support for TSP snapshot request

### DIFF
--- a/pyrefly/lib/state/epoch.rs
+++ b/pyrefly/lib/state/epoch.rs
@@ -18,6 +18,11 @@ impl Epoch {
     pub fn next(&mut self) {
         self.0 += 1;
     }
+
+    /// Get the epoch value as an integer
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
 }
 
 /// Invariant: checked >= computed >= changed

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -295,6 +295,11 @@ impl<'a> Transaction<'a> {
         self.data.subscriber = subscriber;
     }
 
+    /// Get the current epoch of this transaction
+    pub fn current_epoch(&self) -> Epoch {
+        self.data.now
+    }
+
     pub fn get_solutions(&self, handle: &Handle) -> Option<Arc<Solutions>> {
         self.with_module_inner(handle, |x| x.steps.solutions.dupe())
     }

--- a/pyrefly/lib/test/tsp/tsp_interaction/mod.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/mod.rs
@@ -8,4 +8,5 @@
 //! Tests for TSP (Type Server Protocol) request handlers
 
 pub mod get_supported_protocol_version;
+pub mod get_snapshot;
 pub mod object_model;

--- a/pyrefly/lib/test/tsp/tsp_interaction/object_model.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/object_model.rs
@@ -119,6 +119,15 @@ impl TestTspServer {
         }));
     }
 
+    pub fn get_snapshot(&mut self) {
+        let id = self.next_request_id();
+        self.send_message(Message::Request(Request {
+            id,
+            method: "typeServer/getSnapshot".to_owned(),
+            params: serde_json::json!(null),
+        }));
+    }
+
     pub fn did_open(&self, file: &'static str) {
         let path = self.get_root_or_panic().join(file);
         self.send_message(Message::Notification(Notification {

--- a/pyrefly/lib/tsp/requests/get_snapshot.rs
+++ b/pyrefly/lib/tsp/requests/get_snapshot.rs
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Implementation of the getSnapshot TSP request
+
+use crate::tsp::server::TspServer;
+
+impl TspServer {
+    /// Get the current snapshot version
+    /// 
+    /// The snapshot represents the current epoch of the global state.
+    /// It changes whenever files are modified, configuration changes,
+    /// or any other event that would trigger a recomputation.
+    pub fn get_snapshot(&self) -> i32 {
+        *self.current_snapshot.lock().unwrap_or_else(|poisoned| {
+            // In case of poisoned mutex, recover and return the value
+            eprintln!("TSP: Warning - snapshot mutex was poisoned, recovering");
+            poisoned.into_inner()
+        })
+    }
+}

--- a/pyrefly/lib/tsp/requests/mod.rs
+++ b/pyrefly/lib/tsp/requests/mod.rs
@@ -8,3 +8,4 @@
 //! TSP request implementations
 
 pub mod get_supported_protocol_version;
+pub mod get_snapshot;


### PR DESCRIPTION
This PR adds another request handler for TSP = "typeServer/getSnapshot". The snapshot request is how the client side of a TSP connection indicates which 'state of the world' it's currently querying about. The server side keeps a 'snapshot' to indicate when the state of the world has changed. 

Internally I used the 'epoch' and the 'RecheckFinished' event to indicate what the snapshot is and when it's changed.