### PR TITLE
collect type params at bindings phase for legacy explicit type alias

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -4980,8 +4980,8 @@
     {
       "code": -2,
       "column": 18,
-      "concise_description": "`ParamSpec[P]` is not allowed in this context",
-      "description": "`ParamSpec[P]` is not allowed in this context",
+      "concise_description": "`ParamSpec` is not allowed in this context",
+      "description": "`ParamSpec` is not allowed in this context",
       "line": 15,
       "name": "invalid-annotation",
       "stop_column": 19,

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -6,6 +6,7 @@
  */
 
 use std::iter;
+use std::ops::Deref;
 use std::sync::Arc;
 
 use dupe::Dupe;
@@ -73,6 +74,7 @@ use crate::binding::binding::FunctionStubOrImpl;
 use crate::binding::binding::IsAsync;
 use crate::binding::binding::Key;
 use crate::binding::binding::KeyExport;
+use crate::binding::binding::KeyLegacyTypeParam;
 use crate::binding::binding::KeyUndecoratedFunction;
 use crate::binding::binding::LastStmt;
 use crate::binding::binding::LinkedKey;
@@ -92,6 +94,7 @@ use crate::error::context::ErrorInfo;
 use crate::error::context::TypeCheckContext;
 use crate::error::context::TypeCheckKind;
 use crate::error::style::ErrorStyle;
+use crate::graph::index::Idx;
 use crate::solver::solver::SubsetError;
 use crate::types::annotation::Annotation;
 use crate::types::annotation::Qualifier;
@@ -1009,6 +1012,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ///
     /// When present, we visit those types first to determine the `TParams` for this alias, and any
     /// type variables when we subsequently visit the aliased type are considered out of scope.
+    ///
+    /// `legacy_tparams` refers to the type parameters collected in the bindings phase. It is only populated if we know for sure
+    /// that this is actually a type alias, like when a variable assignment is annotated with `TypeAlias`
     fn as_type_alias(
         &self,
         name: &Name,
@@ -1016,6 +1022,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         ty: Type,
         expr: &Expr,
         typealiastype_tparams: Option<Vec<Expr>>,
+        legacy_tparams: &Option<Box<[Idx<KeyLegacyTypeParam>]>>,
         errors: &ErrorCollector,
     ) -> Type {
         let range = expr.range();
@@ -1055,13 +1062,20 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             );
             tparams_for_type_alias_type = Some(tparams.len());
         }
-        self.tvars_to_tparams_for_type_alias(
-            &mut ty,
-            &mut seen_type_vars,
-            &mut seen_type_var_tuples,
-            &mut seen_param_specs,
-            &mut tparams,
-        );
+        if let Some(legacy_tparams) = legacy_tparams {
+            tparams = legacy_tparams
+                .iter()
+                .filter_map(|key| self.get_idx(*key).deref().parameter().cloned())
+                .collect();
+        } else {
+            self.tvars_to_tparams_for_type_alias(
+                &mut ty,
+                &mut seen_type_vars,
+                &mut seen_type_var_tuples,
+                &mut seen_param_specs,
+                &mut tparams,
+            );
+        }
         if let Some(n) = tparams_for_type_alias_type {
             for extra_tparam in tparams.iter().skip(n) {
                 errors.add(
@@ -2472,7 +2486,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 self.attr_infer(&binding, &attr.id, attr.range, errors, None)
                     .into_ty()
             }
-            Binding::NameAssign(name, annot_key, expr) => {
+            Binding::NameAssign(name, annot_key, expr, legacy_tparams) => {
                 let (has_type_alias_qualifier, ty) = match annot_key.as_ref() {
                     // First infer the type as a normal value
                     Some((style, k)) => {
@@ -2520,6 +2534,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         ty,
                         expr,
                         None,
+                        legacy_tparams,
                         errors,
                     ),
                     None if Self::may_be_implicit_type_alias(&ty)
@@ -2531,6 +2546,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             ty,
                             expr,
                             None,
+                            legacy_tparams,
                             errors,
                         )
                     }
@@ -3057,7 +3073,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             Binding::ScopedTypeAlias(name, params, expr) => {
                 let ty = self.expr_infer(expr, errors);
-                let ta = self.as_type_alias(name, TypeAliasStyle::Scoped, ty, expr, None, errors);
+                let ta =
+                    self.as_type_alias(name, TypeAliasStyle::Scoped, ty, expr, None, &None, errors);
                 match ta {
                     Type::Forall(..) => self.error(
                         errors,
@@ -3090,6 +3107,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     ty,
                     &expr,
                     Some(type_param_exprs),
+                    &None,
                     errors,
                 );
                 if let Some(k) = ann

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -1004,7 +1004,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
-    /// `type_params` refers specifically to the elements of the tuple literal passed to the `TypeAliasType` constructor
+    /// `typealiastype_tparams` refers specifically to the elements of the tuple literal passed to the `TypeAliasType` constructor
     /// For all other kinds of type aliases, it should be `None`.
     ///
     /// When present, we visit those types first to determine the `TParams` for this alias, and any
@@ -1015,7 +1015,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         style: TypeAliasStyle,
         ty: Type,
         expr: &Expr,
-        type_params: Option<Vec<Expr>>,
+        typealiastype_tparams: Option<Vec<Expr>>,
         errors: &ErrorCollector,
     ) -> Type {
         let range = expr.range();
@@ -1044,7 +1044,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let mut seen_param_specs = SmallMap::new();
         let mut tparams = Vec::new();
         let mut tparams_for_type_alias_type = None;
-        if let Some(type_params) = &type_params {
+        if let Some(type_params) = &typealiastype_tparams {
             self.tvars_to_tparams_for_type_alias_type(
                 type_params,
                 &mut seen_type_vars,

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -1232,6 +1232,7 @@ pub enum Binding {
         Name,
         Option<(AnnotationStyle, Idx<KeyAnnotation>)>,
         Box<Expr>,
+        Option<Box<[Idx<KeyLegacyTypeParam>]>>,
     ),
     /// A type alias declared with the `type` soft keyword
     ScopedTypeAlias(Name, Option<TypeParams>, Box<Expr>),
@@ -1439,10 +1440,10 @@ impl DisplayWith<Bindings> for Binding {
                     op.display_with(ctx.module())
                 )
             }
-            Self::NameAssign(name, None, expr) => {
+            Self::NameAssign(name, None, expr, _) => {
                 write!(f, "NameAssign({name}, None, {})", m.display(expr))
             }
-            Self::NameAssign(name, Some((style, annot)), expr) => {
+            Self::NameAssign(name, Some((style, annot)), expr, _) => {
                 write!(
                     f,
                     "NameAssign({name}, {style:?}, {}, {})",
@@ -1589,10 +1590,10 @@ impl Binding {
             Binding::ScopedTypeAlias(_, _, _) | Binding::TypeAliasType(_, _, _) => {
                 Some(SymbolKind::TypeAlias)
             }
-            Binding::NameAssign(name, _, _) if name.as_str() == name.to_uppercase() => {
+            Binding::NameAssign(name, _, _, _) if name.as_str() == name.to_uppercase() => {
                 Some(SymbolKind::Constant)
             }
-            Binding::NameAssign(name, _, _) => {
+            Binding::NameAssign(name, _, _, _) => {
                 if name.as_str().chars().all(|c| c.is_uppercase() || c == '_') {
                     Some(SymbolKind::Constant)
                 } else {

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2350,7 +2350,7 @@ impl<'a> Transaction<'a> {
                 key @ Key::Definition(_) if containers => {
                     if let Some(ty) = self.get_type(handle, key) {
                         let e = match bindings.get(idx) {
-                            Binding::NameAssign(_, None, e) => match &**e {
+                            Binding::NameAssign(_, None, e, _) => match &**e {
                                 Expr::List(ExprList { elts, .. }) => {
                                     if elts.is_empty() {
                                         Some(&**e)
@@ -2443,7 +2443,7 @@ impl<'a> Transaction<'a> {
                         && let Some(ty) = self.get_type(handle, key) =>
                 {
                     let e = match bindings.get(idx) {
-                        Binding::NameAssign(_, None, e) => Some(&**e),
+                        Binding::NameAssign(_, None, e, _) => Some(&**e),
                         Binding::Expr(None, e) => Some(e),
                         _ => None,
                     };

--- a/pyrefly/lib/test/type_alias.rs
+++ b/pyrefly/lib/test/type_alias.rs
@@ -542,10 +542,10 @@ from typing import *
 Ts = TypeVarTuple('Ts')
 P = ParamSpec('P')
 t1: TypeAlias = Unpack[TypedDict]  # E: `Unpack` is not allowed in this context # E: `TypedDict` is not allowed in this context
-t2: TypeAlias = P  # E: `ParamSpec[P]` is not allowed in this context
+t2: TypeAlias = P  # E: `ParamSpec` is not allowed in this context
 t3: TypeAlias = Unpack[Ts]  # E: `Unpack` is not allowed in this context
 t4: TypeAlias = Literal  # E: Expected a type argument for `Literal`
-t5: TypeAlias = Ts  # E: `TypeVarTuple` is not allowed in this context
+t5: TypeAlias = Ts  # E: `TypeVarTuple` must be unpacked
 t6: TypeAlias = Generic  # E: Expected a type argument for `Generic`
 t7: TypeAlias = Protocol  # E: Expected a type argument for `Protocol`
 t8: TypeAlias = Generic[int]  # E: `Generic` is not allowed in this context
@@ -655,8 +655,8 @@ testcase!(
 from typing import ParamSpec, TypeVarTuple, Unpack
 P = ParamSpec('P')
 Ts = TypeVarTuple('Ts')
-Error1 = type[P]  # E: `ParamSpec[P]` is not allowed
-Error2 = type[Ts]  # E: `TypeVarTuple` is not allowed
+Error1 = type[P]  # E: `ParamSpec` is not allowed
+Error2 = type[Ts]  # E: `TypeVarTuple` must be unpacked
 Error3 = type[Unpack[Ts]]  # E: `Unpack` is not allowed
     "#,
 );
@@ -710,7 +710,7 @@ U = TypeVar('U', bound=str)
 
 X: TypeAlias = list[T]
 Y: TypeAlias = X[S]
-Z: TypeAlias = X[U]  # E: `str` is not assignable to upper bound `int`
+Z: TypeAlias = X[U]  # E: `U` is not assignable to upper bound `int`
     "#,
 );
 
@@ -760,7 +760,6 @@ class A:
 );
 
 testcase!(
-    bug = "there shouldn't be an error here",
     test_generic_typealias_of_typealiastype,
     r#"
 from typing import TypeAlias, TypeAliasType, TypeVar
@@ -772,7 +771,7 @@ Spam1 = TypeAliasType("Spam1", T2 | type[T1], type_params=(T1, T2))
 Spam2: TypeAlias = Spam1[T1, T2]
 
 x1: Spam1[int, str] = int
-x2: Spam2[int, str] = int # E: Type `int` is not assignable to upper bound `bytes | str` of type variable `T2` # E: `type[int]` is not assignable to `int | type[str]`
+x2: Spam2[int, str] = int
     "#,
 );
 
@@ -794,7 +793,6 @@ x2: Spam2[int, str] = int # E: `TypeAlias[Spam2, type[T2 | type[T1]]]` is not su
 );
 
 testcase!(
-    bug = "there shouldn't be an error here",
     test_generic_typealias_of_explicit_typealias,
     r#"
 from typing import TypeAlias, TypeAliasType, TypeVar
@@ -803,9 +801,9 @@ T1 = TypeVar("T1")
 T2 = TypeVar("T2", bound=str | bytes)
 
 Spam1: TypeAlias = type[T1] | T2
-Spam2: TypeAlias = Spam1[T1, T2] # E: Type `object` is not assignable to upper bound `bytes | str` of type variable `T2`
+Spam2: TypeAlias = Spam1[T1, T2]
 
-x1: Spam1[int, str] = int  # E: Type `int` is not assignable to upper bound `bytes | str` of type variable `T2`  # E: `type[int]` is not assignable to `int | type[str]`
-x2: Spam2[int, str] = int  # E: `type[int]` is not assignable to `int | type[str]`
+x1: Spam1[int, str] = int
+x2: Spam2[int, str] = int
     "#,
 );


### PR DESCRIPTION
Summary:
fixes https://github.com/facebook/pyrefly/issues/1162

This is related to our (problematic) handling of legacy type aliases as well as our internal representation of type aliases.

For generic legacy type aliases, we traverse the resolved type of the RHS to determine the type parameters. However, when the RHS is a specialization of another type alias, the type we see is the aliased type because `untype()` eagerly resolves aliases. The order of the type arguments during specialization may not match the order that they appear in the aliased type, resulting in this bug.

https://github.com/facebook/pyrefly/issues/1162#issuecomment-3353329339 explains a bit more.

The solution in this diff is to use the legacy type parameter collector (also used in function and class definitions) to collect type parameters at the bindings phase when we know for sure we're dealing with a type alias (the assignment is annotated with TypeAlias or the RHS is a UnionType, for example). If we're not sure, then we fall back to the previous behavior of collecting type params from the resolved type.

One long term fix is to have a type that represents a specialized type alias, like we do for classes using`ClassType`.

Differential Revision: D83597568


