### PR TITLE
Fix namespace package finding

### DIFF
--- a/crates/pyrefly_config/src/environment/mod.rs
+++ b/crates/pyrefly_config/src/environment/mod.rs
@@ -9,5 +9,5 @@ pub(crate) mod active_environment;
 pub(crate) mod conda;
 pub mod environment;
 pub(crate) mod finder;
-pub(crate) mod interpreters;
+pub mod interpreters;
 pub(crate) mod venv;

--- a/pyrefly/lib/module/finder.rs
+++ b/pyrefly/lib/module/finder.rs
@@ -52,6 +52,14 @@ impl FindResult {
         }
     }
 
+    fn style(&self) -> Option<ModuleStyle> {
+        match self {
+            Self::SingleFilePyiModule(_) => Some(ModuleStyle::Interface),
+            Self::SingleFilePyModule(_) => Some(ModuleStyle::Executable),
+            _ => None,
+        }
+    }
+
     /// Compares the given `FindResult`s, taking the variant with the highest priority,
     /// and preferring variant `a` (the 'earlier' variant). The contents of the variants
     /// are not compared.
@@ -110,8 +118,8 @@ fn find_one_part_in_root(
         if candidate_path.exists() {
             let result = FindResult::single_file(candidate_path.clone(), candidate_file_suffix);
             if let Some(filter) = style_filter {
-                if let Ok(module_path) = result.clone().module_path()
-                    && module_path.style() == filter
+                if let Some(style) = result.style()
+                    && style == filter
                 {
                     return Some(result);
                 }


### PR DESCRIPTION
Summary:
This diff mostly includes updates to an interface and the affected tests.

This diff stores found namespace results, and returns them  yfrom the end of `find_import_filtered` if no higher-priority `FindResult` is found sooner. This is because results in `search-path`, `typeshed`, and `site-package-path` can override a previously found namespace package if they contain a file or regular package match, and we shouldn't just early return from a single find component if we find a namespace result.

Differential Revision: D83847654


