### PR TITLE
Allow using dict expressions for Pydantic config

### DIFF
--- a/pyrefly/lib/binding/pydantic.rs
+++ b/pyrefly/lib/binding/pydantic.rs
@@ -6,6 +6,7 @@
  */
 
 use pyrefly_derive::TypeEq;
+use ruff_python_ast::DictItem;
 use ruff_python_ast::Expr;
 use ruff_python_ast::Keyword;
 use ruff_python_ast::name::Name;
@@ -26,6 +27,65 @@ pub const ROOT: Name = Name::new_static("root");
 pub const STRICT: Name = Name::new_static("strict");
 const FROZEN: Name = Name::new_static("frozen");
 const EXTRA: Name = Name::new_static("extra");
+
+// An abstraction to iterate over configuration values, whether `ConfigDict()` or a dict display
+// is used.
+enum PydanticConfigExpr<'a> {
+    ExprCall(&'a ruff_python_ast::ExprCall),
+    ExprDict(&'a ruff_python_ast::ExprDict),
+}
+
+impl<'a> PydanticConfigExpr<'a> {
+    fn iter(&self) -> PydanticConfigExprIter<'_> {
+        match *self {
+            Self::ExprCall(expr_call) => {
+                PydanticConfigExprIter::ExprCall(expr_call.arguments.keywords.iter())
+            }
+            Self::ExprDict(expr_dict) => PydanticConfigExprIter::ExprDict(expr_dict.items.iter()),
+        }
+    }
+}
+
+enum PydanticConfigExprIter<'a> {
+    ExprCall(std::slice::Iter<'a, Keyword>),
+    ExprDict(std::slice::Iter<'a, DictItem>),
+}
+
+impl<'a> Iterator for PydanticConfigExprIter<'a> {
+    type Item = (&'a str, &'a Expr);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::ExprCall(kw_iter) => {
+                let nxt = kw_iter.find(|&kw| kw.arg.is_some());
+                match nxt {
+                    Some(kw) => Some((kw.arg.as_ref().unwrap().as_str(), &kw.value)),
+                    None => None,
+                }
+            }
+            Self::ExprDict(items_iter) => {
+                let nxt = items_iter.find(|&i| {
+                    i.key
+                        .as_ref()
+                        .is_some_and(|key| key.is_string_literal_expr())
+                });
+                match nxt {
+                    Some(item) => Some((
+                        item.key
+                            .as_ref()
+                            .unwrap()
+                            .as_string_literal_expr()
+                            .unwrap()
+                            .value
+                            .to_str(),
+                        &item.value,
+                    )),
+                    None => None,
+                }
+            }
+        }
+    }
+}
 
 /// If a class body contains a `model_config` attribute assigned to a `pydantic.ConfigDict`, the
 /// configuration options from the `ConfigDict`. In the answers phase, this will be merged with
@@ -56,6 +116,24 @@ impl Default for PydanticValidationFlags {
 }
 
 impl<'a> BindingsBuilder<'a> {
+    fn get_pydantic_config_expr<'b>(&self, e: &'b Expr) -> Option<PydanticConfigExpr<'b>> {
+        if let Some(call) = e.as_call_expr()
+            && (matches!(
+                self.as_special_export(&call.func),
+                Some(SpecialExport::PydanticConfigDict)
+            ) || call
+                .func
+                .as_name_expr()
+                .is_some_and(|name| name.id == "dict"))
+        {
+            return Some(PydanticConfigExpr::ExprCall(call));
+        } else if let Some(expr_dict) = e.as_dict_expr() {
+            return Some(PydanticConfigExpr::ExprDict(expr_dict));
+        }
+
+        None
+    }
+
     // The goal of this function is to extract pydantic metadata (https://docs.pydantic.dev/latest/concepts/models/) from expressions.
     // TODO: Consider propagating the entire expression instead of the value
     // in case it is aliased.
@@ -66,57 +144,38 @@ impl<'a> BindingsBuilder<'a> {
         pydantic_config_dict: &mut PydanticConfigDict,
     ) {
         if name.as_str() == "model_config"
-            && let Some(call) = e.as_call_expr()
-            && let Some(special) = self.as_special_export(&call.func)
-            && special == SpecialExport::PydanticConfigDict
+            && let Some(pydantic_config_expr) = self.get_pydantic_config_expr(e)
         {
-            for kw in &call.arguments.keywords {
-                if let Some(v) = self.extract_bool_keyword(kw, &FROZEN) {
-                    pydantic_config_dict.frozen = Some(v);
-                }
-
-                if let Some(arg_name) = &kw.arg
-                    && arg_name.id == EXTRA
+            for (name, value) in pydantic_config_expr.iter() {
+                if name == FROZEN
+                    && let Expr::BooleanLiteral(bl) = value
                 {
-                    let config_dict_extra = kw.value.clone().string_literal_expr();
-                    pydantic_config_dict.extra = match config_dict_extra {
-                        Some(extra) => {
-                            let val = extra.value.to_str();
-
-                            if val == "allow" || val == "ignore" {
-                                Some(true)
-                            } else if val == "forbid" {
-                                Some(false)
-                            } else {
-                                None
-                            }
-                        }
-                        None => None,
-                    };
-                }
-
-                if let Some(v) = self.extract_bool_keyword(kw, &STRICT) {
-                    pydantic_config_dict.strict = Some(v);
-                }
-
-                if let Some(v) = self.extract_bool_keyword(kw, &VALIDATE_BY_NAME) {
-                    pydantic_config_dict.validation_flags.validate_by_name = v;
-                }
-                if let Some(v) = self.extract_bool_keyword(kw, &VALIDATE_BY_ALIAS) {
-                    pydantic_config_dict.validation_flags.validate_by_alias = v;
+                    pydantic_config_dict.frozen = Some(bl.value);
+                } else if name == EXTRA
+                    && let Some(extra) = value.as_string_literal_expr()
+                {
+                    let extra_value = extra.value.to_str();
+                    pydantic_config_dict.extra = if matches!(extra_value, "allow" | "ignore") {
+                        Some(true)
+                    } else if extra_value == "forbid" {
+                        Some(false)
+                    } else {
+                        None
+                    }
+                } else if name == STRICT
+                    && let Expr::BooleanLiteral(bl) = value
+                {
+                    pydantic_config_dict.strict = Some(bl.value);
+                } else if name == VALIDATE_BY_NAME
+                    && let Expr::BooleanLiteral(bl) = value
+                {
+                    pydantic_config_dict.validation_flags.validate_by_name = bl.value;
+                } else if name == VALIDATE_BY_ALIAS
+                    && let Expr::BooleanLiteral(bl) = value
+                {
+                    pydantic_config_dict.validation_flags.validate_by_alias = bl.value;
                 }
             }
-        }
-    }
-
-    fn extract_bool_keyword(&self, kw: &Keyword, target_kw: &Name) -> Option<bool> {
-        if let Some(arg_name) = &kw.arg
-            && arg_name.id == *target_kw
-            && let Expr::BooleanLiteral(bl) = &kw.value
-        {
-            Some(bl.value)
-        } else {
-            None
         }
     }
 }

--- a/pyrefly/lib/test/pydantic/config.rs
+++ b/pyrefly/lib/test/pydantic/config.rs
@@ -37,6 +37,36 @@ m.x = 10 # E: Cannot set field `x`
 );
 
 pydantic_testcase!(
+    test_model_config_dict_func,
+    r#"
+from pydantic import BaseModel
+
+class Model(BaseModel):
+    model_config = dict(frozen=True)
+
+    x: int = 42
+
+m = Model()
+m.x = 10 # E: Cannot set field `x`
+"#,
+);
+
+pydantic_testcase!(
+    test_model_config_dict_display,
+    r#"
+from pydantic import BaseModel
+
+class Model(BaseModel):
+    model_config = {'frozen': True}
+
+    x: int = 42
+
+m = Model()
+m.x = 10 # E: Cannot set field `x`
+"#,
+);
+
+pydantic_testcase!(
     test_not_a_pydantic_model,
     r#"
 from pydantic import ConfigDict

--- a/pyrefly/lib/test/pydantic/config.rs
+++ b/pyrefly/lib/test/pydantic/config.rs
@@ -42,7 +42,7 @@ pydantic_testcase!(
 from pydantic import BaseModel
 
 class Model(BaseModel):
-    model_config = dict(frozen=True)
+    model_config = dict(frozen=True) # E: `dict[str, bool]` is not assignable to attribute `model_config` with type `TypedDict[ConfigDict]`
 
     x: int = 42
 


### PR DESCRIPTION
Fixes https://github.com/facebook/pyrefly/issues/1227.

To avoid duplicating logic, I abstracted the logic away, which simplifies the configuration extraction logic.

cc @rchen152, ~~I just need to fix conflicts with https://github.com/facebook/pyrefly/commit/7f376a689f30f0760310bc2c26aafb65be6357d2~~ done.