### PR TITLE
feat(narrow): Special-case truthiness of known builtins

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -619,32 +619,34 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
                 ty.clone()
             }
-            AtomicNarrowOp::IsTruthy | AtomicNarrowOp::IsFalsy => self.distribute_over_union(ty, |t| {
-                let boolval = matches!(op, AtomicNarrowOp::IsTruthy);
-                // Do not emit errors here: the narrowed range doesn't always correspond to a valid expression
-                // For example, narrowing generated for implicit else branches.
-                if self.as_bool(
-                    t,
-                    range,
-                    &ErrorCollector::new(errors.module().clone(), ErrorStyle::Never),
-                ) == Some(!boolval)
-                {
-                    return Type::never();
-                } else if let Type::ClassType(cls) = t {
-                    if cls.is_builtin("bool") {
-                        return Type::Literal(Lit::Bool(boolval));
-                    }
-                    if !boolval {
-                        if cls.is_builtin("int") {
-                            return Type::Literal(Lit::Int(LitInt::new(0)));
-                        } else if cls.is_builtin("str") {
-                            return Type::Literal(Lit::Str("".into()));
+            AtomicNarrowOp::IsTruthy | AtomicNarrowOp::IsFalsy => {
+                self.distribute_over_union(ty, |t| {
+                    let boolval = matches!(op, AtomicNarrowOp::IsTruthy);
+                    // Do not emit errors here: the narrowed range doesn't always correspond to a valid expression
+                    // For example, narrowing generated for implicit else branches.
+                    if self.as_bool(
+                        t,
+                        range,
+                        &ErrorCollector::new(errors.module().clone(), ErrorStyle::Never),
+                    ) == Some(!boolval)
+                    {
+                        return Type::never();
+                    } else if let Type::ClassType(cls) = t {
+                        if cls.is_builtin("bool") {
+                            return Type::Literal(Lit::Bool(boolval));
+                        }
+                        if !boolval {
+                            if cls.is_builtin("int") {
+                                return Type::Literal(Lit::Int(LitInt::new(0)));
+                            } else if cls.is_builtin("str") {
+                                return Type::Literal(Lit::Str("".into()));
+                            }
                         }
                     }
-                }
 
-                t.clone()
-            }),
+                    t.clone()
+                })
+            }
             AtomicNarrowOp::Eq(v) => {
                 let right = self.expr_infer(v, errors);
                 if matches!(right, Type::Literal(_) | Type::None) {

--- a/pyrefly/lib/test/attribute_narrow.rs
+++ b/pyrefly/lib/test/attribute_narrow.rs
@@ -275,7 +275,7 @@ def f(foo: object):
 testcase!(
     test_join_empty_facets_vs_nonempty,
     r#"
-from typing import reveal_type
+from typing import reveal_type, Literal
 class A:
     x: int | None
 def test(y: A | None) -> None:
@@ -283,7 +283,7 @@ def test(y: A | None) -> None:
         if y.x:
             reveal_type(y)  # E: revealed type: A (_.x: int)
         else:
-            reveal_type(y)  # E: revealed type: A (_.x: int | None)
+            reveal_type(y)  # E: revealed type: A (_.x: Literal[0] | None)
     else:
         reveal_type(y)  # E: revealed type: None
     reveal_type(y)  # E: revealed type: A | None

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -262,14 +262,14 @@ def f(x: str | None, y: int | None):
 testcase!(
     test_not,
     r#"
-from typing import assert_type
+from typing import assert_type, Literal
 def f(x: str | None):
     if not x is None:
         assert_type(x, str)
     else:
         assert_type(x, None)
     if not x:
-        assert_type(x, str | None)
+        assert_type(x, None | Literal[""])
     else:
         assert_type(x, str)
     "#,
@@ -1753,5 +1753,33 @@ def test4(x: int | None) -> None:
     if x is not None and foo():
         return
     assert_type(x, int | None) 
+    "#,
+);
+
+
+testcase!(
+    test_truthy_falsy_builtins,
+    r#"
+from typing import assert_type, Literal
+def test(a: int, b: str):
+    if not a:
+        assert_type(a, Literal[0])
+    else:
+        assert_type(a, int)
+
+    if not b:
+        assert_type(b, Literal[""])
+    else:
+        assert_type(b, str)
+
+    if a:
+        assert_type(a, int)
+    else:
+        assert_type(a, Literal[0])
+
+    if b:
+        assert_type(b, str)
+    else:
+        assert_type(b, Literal[""])
     "#,
 );

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -1756,7 +1756,6 @@ def test4(x: int | None) -> None:
     "#,
 );
 
-
 testcase!(
     test_truthy_falsy_builtins,
     r#"


### PR DESCRIPTION
Improves type narrowing for truthiness checks on built-in types like `int` and `str`.

When a variable of type `int` is used in a context where it is known to be falsy (e.g., `if not var:`), its type is now narrowed to `Literal[0]`. Similarly, a `str` type is narrowed to `Literal[""]`.

This provides more precise type inference in common scenarios involving truthiness checks.

Fixes: #1141

---

## Evidence.

<img width="724" height="362" alt="Screenshot_2025-10-04_18-17-29" src="https://github.com/user-attachments/assets/848d1781-780f-4740-8956-c0cb46a4a209" />
<img width="759" height="343" alt="Screenshot_2025-10-04_18-17-48" src="https://github.com/user-attachments/assets/d14a51d1-c689-4053-8005-4a3d3a59a41f" />
<img width="756" height="356" alt="Screenshot_2025-10-04_18-18-03" src="https://github.com/user-attachments/assets/1e6b4cce-6353-4e50-bb4d-98085ee0de37" />
<img width="739" height="318" alt="Screenshot_2025-10-04_18-18-15" src="https://github.com/user-attachments/assets/2fd6af4b-be40-4f9d-8df3-220bcbc708af" />
