### PR TITLE
display qualified names from typing module

### DIFF
--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -86,6 +86,7 @@ pub struct TypeDisplayContext<'a> {
     qnames: SmallMap<&'a Name, QNameInfo>,
     /// Should we display for IDE Hover? This makes type names more readable but less precise.
     hover: bool,
+    always_display_module_name: bool,
 }
 
 impl<'a> TypeDisplayContext<'a> {
@@ -121,6 +122,7 @@ impl<'a> TypeDisplayContext<'a> {
         for c in self.qnames.values_mut() {
             c.info.insert(fake_module, None);
         }
+        self.always_display_module_name = true;
     }
 
     /// Always display the module name, except for builtins.
@@ -139,6 +141,7 @@ impl<'a> TypeDisplayContext<'a> {
                 c.info.insert(fake_module, None);
             }
         }
+        self.always_display_module_name = true;
     }
 
     /// Set the context to display for hover. This makes type names more readable but less precise.
@@ -223,6 +226,19 @@ impl<'a> TypeDisplayContext<'a> {
         self.fmt_helper(t, f, true)
     }
 
+    fn maybe_fmt_with_module(
+        &self,
+        module: &str,
+        name: &str,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        if self.always_display_module_name {
+            write!(f, "{module}.{name}")
+        } else {
+            write!(f, "{name}")
+        }
+    }
+
     fn fmt_helper<'b>(
         &self,
         t: &'b Type,
@@ -280,17 +296,18 @@ impl<'a> TypeDisplayContext<'a> {
                 write!(f, "]")
             }
             Type::SelfType(cls) => {
-                write!(f, "Self@")?;
+                self.maybe_fmt_with_module("typing", "Self@", f)?;
                 self.fmt_qname(cls.qname(), f)
             }
 
             // Other things
             Type::Literal(lit) => {
-                write!(f, "Literal[")?;
+                self.maybe_fmt_with_module("typing", "Literal", f)?;
+                write!(f, "[")?;
                 self.fmt_lit(lit, f)?;
                 write!(f, "]")
             }
-            Type::LiteralString => write!(f, "LiteralString"),
+            Type::LiteralString => self.maybe_fmt_with_module("typing", "LiteralString", f),
             Type::Callable(box c) => {
                 if self.hover && is_toplevel {
                     c.fmt_with_type_with_newlines(f, &|t| self.display_internal(t))
@@ -378,9 +395,13 @@ impl<'a> TypeDisplayContext<'a> {
                     )
                 }
             }
-            Type::Never(NeverStyle::NoReturn) => write!(f, "NoReturn"),
-            Type::Never(NeverStyle::Never) => write!(f, "Never"),
-            Type::Union(types) if types.is_empty() => write!(f, "Never"),
+            Type::Never(NeverStyle::NoReturn) => {
+                self.maybe_fmt_with_module("typing", "NoReturn", f)
+            }
+            Type::Never(NeverStyle::Never) => self.maybe_fmt_with_module("typing", "Never", f),
+            Type::Union(types) if types.is_empty() => {
+                self.maybe_fmt_with_module("typing", "Never", f)
+            }
             Type::Union(types) => {
                 // All Literals will be collected into a single Literal at the index of the first Literal.
                 let mut literal_idx = None;
@@ -401,7 +422,12 @@ impl<'a> TypeDisplayContext<'a> {
                     }
                 }
                 if let Some(i) = literal_idx {
-                    display_types.insert(i, format!("Literal[{}]", commas_iter(|| &literals)));
+                    if self.always_display_module_name {
+                        display_types
+                            .insert(i, format!("typing.Literal[{}]", commas_iter(|| &literals)));
+                    } else {
+                        display_types.insert(i, format!("Literal[{}]", commas_iter(|| &literals)));
+                    }
                 }
                 // This is mainly to prettify types for functions with different names but the same signature
                 let display_types_deduped = display_types
@@ -469,17 +495,23 @@ impl<'a> TypeDisplayContext<'a> {
                 }
             }
             Type::Type(ty) => write!(f, "type[{}]", self.display_internal(ty)),
-            Type::TypeGuard(ty) => write!(f, "TypeGuard[{}]", self.display_internal(ty)),
-            Type::TypeIs(ty) => write!(f, "TypeIs[{}]", self.display_internal(ty)),
+            Type::TypeGuard(ty) => {
+                self.maybe_fmt_with_module("typing", "TypeGuard", f)?;
+                write!(f, "[{}]", self.display_internal(ty))
+            }
+            Type::TypeIs(ty) => {
+                self.maybe_fmt_with_module("typing", "TypeIs", f)?;
+                write!(f, "[{}]", self.display_internal(ty))
+            }
             Type::Unpack(box ty @ Type::TypedDict(_)) => {
-                write!(f, "Unpack[{}]", self.display_internal(ty))
+                self.maybe_fmt_with_module("typing", "Unpack", f)?;
+                write!(f, "[{}]", self.display_internal(ty))
             }
             Type::Unpack(ty) => write!(f, "*{}", self.display_internal(ty)),
-            Type::Concatenate(args, pspec) => write!(
-                f,
-                "Concatenate[{}]",
-                commas_iter(|| append(args.iter(), [pspec]))
-            ),
+            Type::Concatenate(args, pspec) => {
+                self.maybe_fmt_with_module("typing", "Concatenate", f)?;
+                write!(f, "[{}]", commas_iter(|| append(args.iter(), [pspec])))
+            }
             Type::Module(m) => write!(f, "Module[{m}]"),
             Type::Var(var) => write!(f, "{var}"),
             Type::Quantified(var) => write!(f, "{var}"),
@@ -499,7 +531,7 @@ impl<'a> TypeDisplayContext<'a> {
             Type::SpecialForm(x) => write!(f, "{x}"),
             Type::Ellipsis => write!(f, "Ellipsis"),
             Type::Any(style) => match style {
-                AnyStyle::Explicit => write!(f, "Any"),
+                AnyStyle::Explicit => self.maybe_fmt_with_module("typing", "Any", f),
                 AnyStyle::Implicit | AnyStyle::Error => write!(f, "Unknown"),
             },
             Type::TypeAlias(ta) => {
@@ -864,9 +896,21 @@ pub mod tests {
         let t = Type::ClassType(ClassType::new(c, TArgs::default()));
         let mut ctx = TypeDisplayContext::new(&[&t]);
         assert_eq!(ctx.display(&t).to_string(), "foo");
+        assert_eq!(
+            ctx.display(&Type::LiteralString).to_string(),
+            "LiteralString"
+        );
+        assert_eq!(ctx.display(&Type::any_explicit()).to_string(), "Any");
+        assert_eq!(ctx.display(&Type::never()).to_string(), "Never");
 
         ctx.always_display_module_name();
         assert_eq!(ctx.display(&t).to_string(), "mod.ule.foo");
+        assert_eq!(
+            ctx.display(&Type::LiteralString).to_string(),
+            "typing.LiteralString"
+        );
+        assert_eq!(ctx.display(&Type::any_explicit()).to_string(), "typing.Any");
+        assert_eq!(ctx.display(&Type::never()).to_string(), "typing.Never");
     }
 
     #[test]

--- a/pyrefly/lib/lsp/features/mod.rs
+++ b/pyrefly/lib/lsp/features/mod.rs
@@ -6,3 +6,4 @@
  */
 
 pub mod hover;
+pub mod provide_type;

--- a/pyrefly/lib/lsp/features/provide_type.rs
+++ b/pyrefly/lib/lsp/features/provide_type.rs
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use lsp_types::MarkupContent;
+use lsp_types::Position;
+use lsp_types::TextDocumentIdentifier;
+use lsp_types::request::Request;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug)]
+pub enum ProvideType {}
+
+impl Request for ProvideType {
+    type Params = ProvideTypeParams;
+    type Result = Option<ProvideTypeResponse>;
+    const METHOD: &'static str = "types/provide-type";
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProvideTypeParams {
+    pub text_document: TextDocumentIdentifier,
+    pub positions: Vec<Position>,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub struct ProvideTypeResponse {
+    pub contents: Vec<MarkupContent>,
+}

--- a/pyrefly/lib/lsp/features/provide_type.rs
+++ b/pyrefly/lib/lsp/features/provide_type.rs
@@ -6,11 +6,16 @@
  */
 
 use lsp_types::MarkupContent;
+use lsp_types::MarkupKind;
 use lsp_types::Position;
 use lsp_types::TextDocumentIdentifier;
 use lsp_types::request::Request;
+use pyrefly_build::handle::Handle;
+use pyrefly_types::display::TypeDisplayContext;
 use serde::Deserialize;
 use serde::Serialize;
+
+use crate::state::state::Transaction;
 
 #[derive(Debug)]
 pub enum ProvideType {}
@@ -31,4 +36,32 @@ pub struct ProvideTypeParams {
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 pub struct ProvideTypeResponse {
     pub contents: Vec<MarkupContent>,
+}
+
+pub fn provide_type(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    positions: Vec<Position>,
+) -> Option<ProvideTypeResponse> {
+    let info = transaction.get_module_info(handle)?;
+    let mut contents = Vec::new();
+
+    for position in positions {
+        let text_size = info.lined_buffer().from_lsp_position(position);
+        if let Some(ty) = transaction.get_type_at(handle, text_size) {
+            let mut c = TypeDisplayContext::new(&[&ty]);
+            c.set_display_mode_to_hover();
+            c.always_display_module_name();
+            contents.push(MarkupContent {
+                kind: MarkupKind::PlainText,
+                value: c.display(&ty).to_string(),
+            });
+        } else {
+            contents.push(MarkupContent {
+                kind: MarkupKind::PlainText,
+                value: String::new(),
+            });
+        }
+    }
+    Some(ProvideTypeResponse { contents })
 }


### PR DESCRIPTION
Summary:
We qualify classes, but not things that have their own variant in the Type enum like Any, Literal, Never, etc.

This affects the query module, so probably needs a review from folks using that to make sure it's OK.

Differential Revision: D84072684


