### PR TITLE
select workspace folder uris correctly

### DIFF
--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -134,7 +134,7 @@ async function overridePythonPath(
     }
     let scopeUri = configurationItems[index].scopeUri;
     return await pythonExtension.environments.getActiveEnvironmentPath(
-      scopeUri === undefined ? undefined : vscode.Uri.file(scopeUri),
+      scopeUri === undefined ? undefined : vscode.Uri.parse(scopeUri),
     ).path;
   };
   const newResult = await Promise.all(
@@ -153,7 +153,9 @@ async function overridePythonPath(
 export async function activate(context: ExtensionContext) {
   // Initialize the output channel if it doesn't exist
   if (!outputChannel) {
-    outputChannel = vscode.window.createOutputChannel('Pyrefly language server');
+    outputChannel = vscode.window.createOutputChannel(
+      'Pyrefly language server',
+    );
   }
 
   const path: string = requireSetting('pyrefly.lspPath');


### PR DESCRIPTION
Summary:
fixes https://github.com/facebook/pyrefly/issues/1253

I think this fixes it because a file at test/test2 would be under the test/ workspace folder. but the folder test/test2 would be under test/test2.

Differential Revision: D84197665


