### PR TITLE
rank re-exports beneath other exports in module completions

### DIFF
--- a/pyrefly/lib/alt/answers.rs
+++ b/pyrefly/lib/alt/answers.rs
@@ -680,6 +680,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 is_deprecated: _,
                 definition,
                 docstring_range: _,
+                is_reexport: _,
             } in self.completions(base.clone(), Some(attribute_name), false)
             {
                 match definition {

--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -1845,6 +1845,8 @@ pub struct AttrInfo {
     pub is_deprecated: bool,
     pub definition: Option<AttrDefinition>,
     pub docstring_range: Option<TextRange>,
+    /// is this defined in another module (true) or in this module (false)?
+    pub is_reexport: bool,
 }
 
 impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
@@ -1872,6 +1874,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                     TextRangeWithModule::new(c.module().dupe(), range),
                                 )),
                                 docstring_range: c.field_docstring_range(fld),
+                                is_reexport: false,
                             });
                         }
                     }
@@ -1886,6 +1889,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 TextRangeWithModule::new(c.module().dupe(), range),
                             )),
                             docstring_range: c.field_docstring_range(expected_attribute_name),
+                            is_reexport: false,
                         });
                     }
                 }
@@ -1966,6 +1970,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                     }) => *docstring_range,
                                     _ => None,
                                 },
+                                is_reexport: matches!(
+                                    export_location,
+                                    ExportLocation::OtherModule(..)
+                                ),
                             }),
                     );
                 }
@@ -1994,6 +2002,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 }) => *docstring_range,
                                 _ => None,
                             },
+                            is_reexport: matches!(export_location, ExportLocation::OtherModule(..)),
                         });
                     }
                 }

--- a/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
@@ -371,7 +371,7 @@ fn test_completion_with_autoimport() {
                         label: "this_is_a_very_long_function_name_so_we_can_deterministically_test_autoimport_with_fuzzy_search".to_owned(),
                         detail: Some("from autoimport_provider import this_is_a_very_long_function_name_so_we_can_deterministically_test_autoimport_with_fuzzy_search\n".to_owned()),
                         kind: Some(CompletionItemKind::FUNCTION),
-                        sort_text: Some("3".to_owned()),
+                        sort_text: Some("4".to_owned()),
                         additional_text_edits: Some(vec![lsp_types::TextEdit {
                             range: lsp_types::Range {
                                 start: lsp_types::Position {
@@ -412,7 +412,7 @@ fn test_completion_with_autoimport() {
                         label: "this_is_a_very_long_function_name_so_we_can_deterministically_test_autoimport_with_fuzzy_search".to_owned(),
                         detail: Some("from autoimport_provider import this_is_a_very_long_function_name_so_we_can_deterministically_test_autoimport_with_fuzzy_search\n".to_owned()),
                         kind: Some(CompletionItemKind::FUNCTION),
-                        sort_text: Some("3".to_owned()),
+                        sort_text: Some("4".to_owned()),
                         additional_text_edits: Some(vec![lsp_types::TextEdit {
                             range: lsp_types::Range {
                                 start: lsp_types::Position {


### PR DESCRIPTION
Summary:
https://github.com/facebook/pyrefly/issues/1149 reports type stubs appearing in the completions of a stdlib module.

it turns out these are legitimate completions for os.pyi, but not os.py. the real fix is in https://github.com/facebook/pyrefly/issues/1090.
but in the meantime, i'll derank re-exports beneath items defined in the module.

Differential Revision: D84645691


