### PR TITLE
Show Argument types in Overload Message Errors

### DIFF
--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -216,31 +216,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let args = call.vec_call_arg(args, self, errors);
         let keywords = call.vec_call_keyword(keywords, self, errors);
 
-        // Build a string showing the argument types for error messages
-        let mut arg_type_strs = Vec::new();
-        for arg in &args {
-            let (ty, prefix) = match arg {
-                CallArg::Arg(value) => (value.infer(self, errors), ""),
-                CallArg::Star(value, _) => (value.infer(self, errors), "*"),
-            };
-            let ty_display = self.solver().for_display(ty);
-            arg_type_strs.push(format!("{}{}", prefix, ty_display));
-        }
-        for kw in &keywords {
-            let ty = kw.value.infer(self, errors);
-            let ty_display = self.solver().for_display(ty);
-            if let Some(arg_name) = kw.arg {
-                arg_type_strs.push(format!("{}={}", arg_name.as_str(), ty_display));
-            } else {
-                arg_type_strs.push(format!("**{}", ty_display));
-            }
-        }
-        let args_display = if arg_type_strs.is_empty() {
-            "()".to_owned()
-        } else {
-            format!("({})", arg_type_strs.join(", "))
-        };
-
         // Evaluate the call following https://typing.python.org/en/latest/spec/overload.html#overload-call-evaluation.
 
         // Step 1: eliminate overloads that accept an incompatible number of arguments.
@@ -286,7 +261,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 );
 
                 // Step 3: perform argument type expansion.
-                let mut args_expander = ArgsExpander::new(args, keywords);
+                let mut args_expander = ArgsExpander::new(args.clone(), keywords.clone());
                 let owner = Owner::new();
                 'outer: while !matched
                     && let Some(arg_lists) = args_expander.expand(self, errors, &owner)
@@ -363,12 +338,37 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             (closest_overload.res, closest_overload.func.1.signature)
         } else {
+            // Build a string showing the argument types for error messages
+            let mut arg_type_strs = Vec::new();
+            for arg in &args {
+                let (ty, prefix) = match arg {
+                    CallArg::Arg(value) => (value.infer(self, errors), ""),
+                    CallArg::Star(value, _) => (value.infer(self, errors), "*"),
+                };
+                let ty_display = self.for_display(ty);
+                arg_type_strs.push(format!("{}{}", prefix, ty_display));
+            }
+            for kw in &keywords {
+                let ty = kw.value.infer(self, errors);
+                let ty_display = self.for_display(ty);
+                if let Some(arg_name) = kw.arg {
+                    arg_type_strs.push(format!("{}={}", arg_name.as_str(), ty_display));
+                } else {
+                    arg_type_strs.push(format!("**{}", ty_display));
+                }
+            }
+            let args_display = if arg_type_strs.is_empty() {
+                "()".to_owned()
+            } else {
+                format!("({})", arg_type_strs.join(", "))
+            };
+
             let mut msg = vec1![
                 format!(
-                    "No matching overload found for function `{}`",
-                    metadata.kind.as_func_id().format(self.module().name())
+                    "No matching overload found for function `{}` called with arguments: {}",
+                    metadata.kind.as_func_id().format(self.module().name()),
+                    args_display
                 ),
-                format!("Called with arguments: {}", args_display),
                 "Possible overloads:".to_owned(),
             ];
             for overload in overloads {

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -1154,10 +1154,10 @@ def f(x: str) -> str: ...
 def f(x): return x
 
 # Test with wrong type - should show argument type in error
-f(3.14)  # E: No matching overload found for function `f`\n  Called with arguments: (float)
+f(3.14)  # E: No matching overload found for function `f` called with arguments: (float)
 
 # Test with keyword argument
-f(x=3.14)  # E: No matching overload found for function `f`\n  Called with arguments: (x=float)
+f(x=3.14)  # E: No matching overload found for function `f` called with arguments: (x=float)
 
 # Test with multiple arguments (Pyrefly infers literal types for constants)
 @overload
@@ -1166,7 +1166,7 @@ def g(x: int, y: int) -> int: ...
 def g(x: str, y: str) -> str: ...
 def g(x, y): return x
 
-g(1, "hello")  # E: No matching overload found for function `g`\n  Called with arguments: (Literal[1], Literal['hello'])
-g(x=1, y="hello")  # E: No matching overload found for function `g`\n  Called with arguments: (x=Literal[1], y=Literal['hello'])
+g(1, "hello")  # E: No matching overload found for function `g` called with arguments: (Literal[1], Literal['hello'])
+g(x=1, y="hello")  # E: No matching overload found for function `g` called with arguments: (x=Literal[1], y=Literal['hello'])
     "#,
 );


### PR DESCRIPTION
Resolves #1302. With these changes, it's clearer to the user why the overload error was thrown. When no overload matches a function call, Pyrefly now displays the actual argument types that were provided. This eliminates the need to hover over each argument to understand why the call failed.

From Sandbox link:
https://pyrefly.org/sandbox/?project=N4IgZglgNgpgziAXKOBDAdgEwEYHsAeAdAA4CeS4ATrgLYAEALqcROgOZ0Q3G6UN0AqADroRmGGEbwGACgCUdALQA%2BTun4AfOgDlc6GIhF1jdSjAYBXSujoBWEQ-So6AXjWyG0%2BXJEgANCBkZmBQpIQMtFAUAMR0AAqkwaF0aFh4%2BHQAxnqQbFaoDBB6hCKxAMowMHQAFgwMxHCIAPRNQRKhhLxsTTDoTZi4mXBN2ei5%2BYV6TXRgvHSoAG6o0KjYsFk5EHmUBUU2uMST6HAl6GQM1XqKCzCUcHuudEIgAMyEAIwATM%2B%2BAL4BqEyhRuADFoDAKKkcAQSORfkA

Before:
  ERROR No matching overload found for function `int.__new__`
    Possible overloads:
    (cls: type[int], x: Buffer | SupportsIndex | ..., /) -> int

  After:
  ERROR No matching overload found for function `int.__new__`
    Called with arguments: (type[int], int | None)
    Possible overloads:
    (cls: type[int], x: Buffer | SupportsIndex | ..., /) -> int