### PR TITLE
mark flow as terminated when calling pytest.fail, pytest.xfail, pytest.skip

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -97,6 +97,7 @@ use crate::error::context::ErrorInfo;
 use crate::error::context::TypeCheckContext;
 use crate::error::context::TypeCheckKind;
 use crate::error::style::ErrorStyle;
+use crate::export::special::SpecialExport;
 use crate::graph::index::Idx;
 use crate::solver::solver::SubsetError;
 use crate::types::annotation::Annotation;
@@ -2518,9 +2519,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     self.expr(e, None, errors)
                 }
             },
-            Binding::StmtExpr(e, is_assert_type) => {
+            Binding::StmtExpr(e, special_export) => {
                 let result = self.expr(e, None, errors);
-                if !is_assert_type
+                if *special_export != Some(SpecialExport::AssertType)
                     && let Type::ClassType(cls) = &result
                     && self.is_coroutine(&result)
                     && !self.extends_any(cls.class_object())

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -60,6 +60,7 @@ use crate::binding::base_class::BaseClassGeneric;
 use crate::binding::bindings::Bindings;
 use crate::binding::narrow::NarrowOp;
 use crate::binding::pydantic::PydanticConfigDict;
+use crate::export::special::SpecialExport;
 use crate::graph::index::Idx;
 use crate::module::module_info::ModuleInfo;
 use crate::types::annotation::Annotation;
@@ -1187,8 +1188,8 @@ pub enum Binding {
     // Unlike the general `Expr` binding above, this separate binding allows us to
     // perform additional checks that are only relevant for expressions in `Stmt::Expr`,
     // such as verifying for unused awaitables.
-    // The boolean is whether the expression is a call to `assert_type()`
-    StmtExpr(Expr, bool),
+    // The boolean is whether the expression is a call to something defined as a `SpecialExport`
+    StmtExpr(Expr, Option<SpecialExport>),
     /// Propagate a type to a new binding. Takes an optional annotation to
     /// check against (which will override the computed type if they disagree).
     MultiTargetAssign(Option<Idx<KeyAnnotation>>, Idx<Key>, TextRange),

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -1031,11 +1031,15 @@ impl<'a> BindingsBuilder<'a> {
             Stmt::Expr(mut x) => {
                 let mut current = self.declare_current_idx(Key::StmtExpr(x.value.range()));
                 self.ensure_expr(&mut x.value, current.usage());
-                let is_assert_type = matches!(&*x.value,
-                    Expr::Call(ExprCall { func, .. })
-                    if self.as_special_export(func) == Some(SpecialExport::AssertType)
-                );
-                self.insert_binding_current(current, Binding::StmtExpr(*x.value, is_assert_type));
+                let special_export = if let Expr::Call(ExprCall { func, .. }) = &*x.value {
+                    self.as_special_export(func)
+                } else {
+                    None
+                };
+                self.insert_binding_current(current, Binding::StmtExpr(*x.value, special_export));
+                if special_export == Some(SpecialExport::PytestNoReturn) {
+                    self.scopes.mark_flow_termination();
+                }
             }
             Stmt::Pass(_) => { /* no-op */ }
             Stmt::Break(x) => {

--- a/pyrefly/lib/export/special.rs
+++ b/pyrefly/lib/export/special.rs
@@ -57,6 +57,7 @@ pub enum SpecialExport {
     TypingList,
     BuiltinsTuple,
     TypingTuple,
+    PytestNoReturn,
 }
 
 impl SpecialExport {
@@ -105,6 +106,7 @@ impl SpecialExport {
             "List" => Some(Self::TypingList),
             "tuple" => Some(Self::BuiltinsTuple),
             "Tuple" => Some(Self::TypingTuple),
+            "fail" | "xfail" | "skip" => Some(Self::PytestNoReturn),
             _ => None,
         }
     }
@@ -158,6 +160,7 @@ impl SpecialExport {
                 m.as_str(),
                 "typing" | "typing_extensions" | "collections.abc"
             ),
+            Self::PytestNoReturn => matches!(m.as_str(), "pytest"),
         }
     }
 }

--- a/pyrefly/lib/test/flow.rs
+++ b/pyrefly/lib/test/flow.rs
@@ -1728,3 +1728,31 @@ else:
     exit(1)
 "#,
 );
+
+fn env_pytest() -> TestEnv {
+    let mut t = TestEnv::new();
+    t.add_with_path(
+        "pytest",
+        "pytest.pyi",
+        r#"
+from typing import NoReturn
+def fail(x: str) -> NoReturn: ...
+"#,
+    );
+    t
+}
+
+testcase!(
+    test_pytest_noreturn,
+    env_pytest(),
+    r#"
+import pytest
+
+def test_oops() -> None:
+    try:
+        val = True
+    except:
+        pytest.fail("execution stops here")
+    assert val, "oops"
+"#,
+);


### PR DESCRIPTION
Summary:
fixes https://github.com/facebook/pyrefly/issues/1337

full resolution needs a general solution to https://github.com/facebook/pyrefly/issues/361 but we can special-case some common APIs for now.

Differential Revision: D85164900


