### PR TITLE
fix Feature Request: support show on hover for operator overload #994

### DIFF
--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -46,6 +46,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         opname: &Name,
         call_arg_type: &Type,
     ) -> Type {
+        self.record_overload_trace_from_type(range, method_type.clone());
         let callable = self.as_call_target_or_error(
             method_type,
             CallStyle::Method(opname),

--- a/pyrefly/lib/test/lsp/hover_type.rs
+++ b/pyrefly/lib/test/lsp/hover_type.rs
@@ -175,6 +175,31 @@ Hover Result: `dict[int, ((x: int) -> int)]`
 }
 
 #[test]
+fn operator_overload_hover() {
+    let code = r#"
+class My:
+    def __eq__(self, other: object) -> bool:
+        return True
+
+a = My()
+b = My()
+result = a == b
+#           ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert_eq!(
+        r#"
+# main.py
+8 | result = a == b
+                ^
+Hover Result: `(self: My, other: object) -> bool`
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn import_test() {
     let code = r#"
 import typing


### PR DESCRIPTION
fix #994

Added self.record_overload_trace_from_type in so binary operators record the callable they dispatch to, enabling us to recover the underlying overload signature.

Extended Transaction::get_type_at with type_from_expression_at and wired it into the fallback path, allowing hover requests on expression nodes (including operators) to surface either the chosen overload or the inferred expression type.

Introduced a regression test that asserts hovering == now yields the overload’s signature.
