### PR TITLE
test VSCode extention import auto complete suggestions include hidden dot .directories

### DIFF
--- a/pyrefly/lib/module/finder.rs
+++ b/pyrefly/lib/module/finder.rs
@@ -213,12 +213,6 @@ fn find_one_part_prefix<'a>(
                 let file_name = path.file_name().and_then(|n| n.to_str());
 
                 if let Some(name) = file_name {
-                    // Skip hidden filesystem entries (e.g. `.venv`, `.git`) so they don't
-                    // surface in import completion lists. These entries are not valid module
-                    // names in user code and previously cluttered suggestions.
-                    if name.starts_with('.') {
-                        continue;
-                    }
                     // Check if the name starts with the prefix
                     if name.starts_with(prefix.as_str()) {
                         // Check if it's a regular package


### PR DESCRIPTION
check #1173 is fixed.

~~Filtered hidden filesystem entries when gathering module prefixes so .venv-style folders no longer surface in import completions~~ fixed by other commit.

Added an LSP regression test