### PR TITLE
refresh tokens on invalidations

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -145,6 +145,7 @@ use lsp_types::request::Rename;
 use lsp_types::request::Request as _;
 use lsp_types::request::SemanticTokensFullRequest;
 use lsp_types::request::SemanticTokensRangeRequest;
+use lsp_types::request::SemanticTokensRefresh;
 use lsp_types::request::SignatureHelpRequest;
 use lsp_types::request::UnregisterCapability;
 use lsp_types::request::WillRenameFiles;
@@ -1220,6 +1221,17 @@ impl Server {
                 Self::append_unreachable_diagnostics(transaction, &handle, diagnostics);
             }
             self.connection.publish_diagnostics(diags);
+            if self
+                .initialize_params
+                .capabilities
+                .workspace
+                .as_ref()
+                .and_then(|w| w.semantic_tokens.as_ref())
+                .and_then(|st| st.refresh_support)
+                .unwrap_or(false)
+            {
+                self.send_request::<SemanticTokensRefresh>(());
+            }
         };
 
         match possibly_committable_transaction {


### PR DESCRIPTION
Summary:
There have been reports of semantic tokens not appearing sometimes. I have trouble reproducing this entirely, but I do notice the following:
- open file
- semantic tokens appear
- interpreter change takes effect
- imports that now are found do not have tokens until i switch windows and return

this is because we invalidated the file from a config change, but clients have no idea the content is different. we must tell the editor that the content has changed with [this message](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokens_refreshRequest). If a client supports it, we send it. it takes no parameters and will only re-query the minimum it needs.

to fix other parts of semantic tokens not appearing, it might be necessary to do something like this (D85099658). but I haven't been able to reproduce this issue so I'm not sure it's needed.

Reviewed By: yangdanny97

Differential Revision: D85100320


