### PR TITLE
Unify docs on `displayTypeErrors`

### DIFF
--- a/lsp/README.md
+++ b/lsp/README.md
@@ -24,10 +24,8 @@ to ensure your project is set up properly, see
 The following configuration options are IDE-specific and exposed as VSCode
 settings:
 
-- `python.pyrefly.disableTypeErrors` [enum: default, force-on, force-off]: by
-  default, Pyrefly will only provide type errors in your project if a
-  `pyrefly.toml` is present. Modify this setting to override the IDE
-  diagnostics.
+- `python.pyrefly.displayTypeErrors` [enum: default, force-on, force-off]: by
+  default, If `'default'`, Pyrefly will only provide type check squiggles in the IDE if a `pyrefly.toml` is present. If `'force-off'`, Pyrefly will never provide type check squiggles in the IDE. If `'force-on'`, Pyrefly will always provide type check squiggles in the IDE.
 - `python.pyrefly.disableLanguageServices` [boolean: false]: by default, Pyrefly
   will provide both type errors and other language features like go-to
   definition, intellisense, hover, etc. Enable this option to keep type errors

--- a/website/docs/IDE.mdx
+++ b/website/docs/IDE.mdx
@@ -31,7 +31,7 @@ The following configuration options are IDE-specific and exposed as VSCode setti
 - Disable certain language services
   - `python.pyrefly.disabledLanguageServices` [json: {}]: a config to disable certain lsp methods from pyrefly. For example, if you want go-to definition but not find-references.
 - Disable type errors
-  - `python.pyrefly.displayTypeErrors` [string: 'default']: If `'default'`, Pyrefly will only provide type check squiggles in the IDE if your file is covered by a [Pyrefly configuration](../configuration). If `'force-off'`, Pyrefly will never provide type check squiggles in the IDE. If `'force-on'`, Pyrefly will always provide type check squiggles in the IDE.
+  - `python.pyrefly.displayTypeErrors` [enum: default, force-on, force-off]: If `'default'`, Pyrefly will only provide type check squiggles in the IDE if your file is covered by a [Pyrefly configuration](../configuration). If `'force-off'`, Pyrefly will never provide type check squiggles in the IDE. If `'force-on'`, Pyrefly will always provide type check squiggles in the IDE.
 - Specify a custom Pyrefly Binary (lspPath)
   - `pyrefly.lspPath` [string: '']: If your platform is not supported, you can build pyrefly from source and specify the binary path with the `lspPath` config.
 - Use a specific interpreter


### PR DESCRIPTION
Currently there are consistencies between the website doc and the extension doc (I think the website doc is more "correct", as the setting is now `displayTypeErrors` not `disableTypeErrors`). This PR fix these inconsistencies.