### PR TITLE
fix emit unused parameter #955

### DIFF
--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -61,6 +61,19 @@ use crate::types::quantified::Quantified;
 use crate::types::types::Type;
 use crate::types::types::Var;
 
+/// The parameter type an argument was matched against.
+#[derive(Clone)]
+pub struct ExpectedArgument {
+    pub ty: Type,
+    pub param_index: Option<usize>,
+}
+
+impl ExpectedArgument {
+    fn new(ty: Type, param_index: Option<usize>) -> Self {
+        Self { ty, param_index }
+    }
+}
+
 /// Structure to turn TypeOrExprs into Types.
 /// This is used to avoid re-inferring types for arguments multiple types.
 ///
@@ -632,17 +645,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         call_context: &CallContext,
         // If Some, records parameter-name → argument-type bindings (for meta-shape inference).
         bound_args: &mut Option<HashMap<String, Type>>,
-    ) -> HashMap<TextRange, Type> {
+    ) -> HashMap<TextRange, ExpectedArgument> {
         let record = |bound: &mut Option<HashMap<String, Type>>, name: &Name, ty: Type| {
             if let Some(map) = bound.as_mut() {
                 map.insert(name.to_string(), self.canonicalize_shape_dsl_type(ty));
             }
         };
-        let mut expected_types: HashMap<TextRange, Type> = HashMap::new();
+        let mut expected_types: HashMap<TextRange, ExpectedArgument> = HashMap::new();
         // We want to work mostly with references, but some things are taken from elsewhere,
         // so have some owners to capture them.
         let param_list_owner = Owner::new();
         let name_owner = Owner::new();
+        let required_owner = Owner::new();
         let type_owner = Owner::new();
 
         let error = |errors, range, kind, msg: String| {
@@ -666,10 +680,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
         // Creates a reversed copy of the parameters that we iterate through from back to front,
         // so that we can easily peek at and pop from the end.
-        let mut rparams: Vec<&Param> = params.items().iter().rev().collect::<Vec<_>>();
+        let mut rparams: Vec<(usize, &Param)> =
+            params.items().iter().enumerate().rev().collect::<Vec<_>>();
         let mut num_positional_params: usize = 0;
         let mut extra_positional_args: Vec<TextRange> = Vec::new();
-        let mut seen_names: SmallMap<&Name, &Type> = SmallMap::new();
+        let mut seen_names: SmallMap<&Name, (&Type, Option<usize>)> = SmallMap::new();
         let mut extra_arg_pos: Option<TextRange> = None;
         let mut unpacked_vararg: Option<(Option<&Name>, &Type)> = None;
         let mut unpacked_vararg_matched_args: Vec<CallArgPreEval<'_>> = Vec::new();
@@ -680,7 +695,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // Returns `Err(q)` when the Var resolved to a quantified ParamSpec `q`
         // (forwarding case), meaning the caller should validate that the
         // remaining args are `*P.args` / `**P.kwargs` and stop matching.
-        let var_to_rparams = |var| -> Result<Vec<&Param>, Box<Quantified>> {
+        let var_to_rparams = |var| -> Result<Vec<(usize, &Param)>, Box<Quantified>> {
             let ps = match self.solver().force_var(var) {
                 Type::ParamSpecValue(ps) => ps,
                 Type::Any(_) | Type::Ellipsis => ParamList::everything(),
@@ -704,13 +719,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     ParamList::everything()
                 }
             };
-            Ok(param_list_owner.push(ps).items().iter().rev().collect())
+            Ok(param_list_owner
+                .push(ps)
+                .items()
+                .iter()
+                .enumerate()
+                .rev()
+                .collect())
         };
         for arg in self_arg.iter().chain(args.iter()) {
             let mut arg_pre = arg.pre_eval(self, arg_errors);
             while arg_pre.step() {
-                let param = if let Some(p) = rparams.last() {
-                    PosParam::new(p)
+                let param = if let Some((index, p)) = rparams.last() {
+                    PosParam::new(p).map(|param| (*index, param))
                 } else if let Some(var) = paramspec {
                     // We've run out of parameters but haven't finished matching arguments. If we
                     // have a ParamSpec Var, it may contribute more parameters; force it and tack
@@ -740,11 +761,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     None
                 };
                 match param {
-                    Some(PosParam {
-                        ty,
-                        name,
-                        kind: kind @ (PosParamKind::PositionalOnly | PosParamKind::Positional),
-                    }) => {
+                    Some((
+                        param_index,
+                        PosParam {
+                            ty,
+                            name,
+                            kind: kind @ (PosParamKind::PositionalOnly | PosParamKind::Positional),
+                        },
+                    )) => {
                         // For unknown-length star args, stop consuming positional parameters
                         // when we reach a one that has a corresponding keyword argument.
                         // This is unsound, but prevents false positive "multiple values" errors.
@@ -762,9 +786,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         {
                             // Remember names of positional parameters to detect duplicates.
                             // We ignore positional-only parameters because they can't be passed in by name.
-                            seen_names.insert(name, ty);
+                            seen_names.insert(name, (ty, Some(param_index)));
                         }
-                        expected_types.insert(arg.range(), ty.clone());
+                        expected_types.insert(
+                            arg.range(),
+                            ExpectedArgument::new(ty.clone(), Some(param_index)),
+                        );
                         let unhinted_arg_ty = bound_args
                             .as_ref()
                             .map(|_| arg_pre.inferred_type(self, arg_errors));
@@ -786,24 +813,36 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             record(bound_args, name, ty);
                         }
                     }
-                    Some(PosParam {
-                        ty,
-                        name,
-                        kind: PosParamKind::Unpacked,
-                    }) => {
+                    Some((
+                        param_index,
+                        PosParam {
+                            ty,
+                            name,
+                            kind: PosParamKind::Unpacked,
+                        },
+                    )) => {
                         // Store args that get matched to an unpacked *args param
                         // Matched args are typechecked separately later
-                        expected_types.insert(arg.range(), ty.clone());
+                        expected_types.insert(
+                            arg.range(),
+                            ExpectedArgument::new(ty.clone(), Some(param_index)),
+                        );
                         unpacked_vararg = Some((name, ty));
                         unpacked_vararg_matched_args.push(arg_pre.clone());
                         arg_pre.post_skip();
                     }
-                    Some(PosParam {
-                        ty,
-                        name,
-                        kind: PosParamKind::Variadic,
-                    }) => {
-                        expected_types.insert(arg.range(), ty.clone());
+                    Some((
+                        param_index,
+                        PosParam {
+                            ty,
+                            name,
+                            kind: PosParamKind::Variadic,
+                        },
+                    )) => {
+                        expected_types.insert(
+                            arg.range(),
+                            ExpectedArgument::new(ty.clone(), Some(param_index)),
+                        );
                         let unhinted_arg_ty = bound_args
                             .as_ref()
                             .map(|_| arg_pre.inferred_type(self, arg_errors));
@@ -954,15 +993,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // Missing positional-only arguments, split by whether the corresponding parameters
         // in the callable have names. E.g., functions declared with `def` have named posonly
         // parameters and `typing.Callable`s have unnamed ones.
-        let mut missing_unnamed_posonly = 0;
-        let mut missing_named_posonly = SmallSet::new();
-        let mut kwparams = OrderedMap::new();
-        let mut kwargs = None;
-        let mut kwargs_is_unpack = false;
+        let mut missing_unnamed_posonly: usize = 0;
+        let mut missing_named_posonly: SmallSet<&Name> = SmallSet::new();
+        let mut kwparams: OrderedMap<&Name, (&Type, &Required, Option<usize>)> = OrderedMap::new();
+        let mut kwargs: Option<(Option<&Name>, &Type)> = None;
+        let mut kwargs_is_unpack: bool = false;
         // Parameters with default values that are not matched to call args.
         let mut default_check = Vec::new();
         loop {
-            let p = match rparams.pop() {
+            let (param_index, p) = match rparams.pop() {
                 Some(p) => p,
                 None if let Some(var) = paramspec => {
                     // We've reached the end of our regular parameter list. Now check if we have more parameters from a ParamSpec.
@@ -1013,21 +1052,23 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
                 Param::Varargs(..) => {}
                 Param::Pos(name, ty, required) | Param::KwOnly(name, ty, required) => {
-                    kwparams.insert(name, (ty, required));
+                    kwparams.insert(name, (ty, required, Some(param_index)));
                 }
                 Param::Kwargs(name, Type::Unpack(f)) if let Type::TypedDict(typed_dict) = &**f => {
                     self.typed_dict_fields(typed_dict)
                         .into_iter()
                         .for_each(|(name, field)| {
+                            let required = if field.required {
+                                Required::Required
+                            } else {
+                                Required::Optional(None)
+                            };
                             kwparams.insert(
                                 name_owner.push(name),
                                 (
                                     type_owner.push(field.ty),
-                                    if field.required {
-                                        &Required::Required
-                                    } else {
-                                        &Required::Optional(None)
-                                    },
+                                    required_owner.push(required),
+                                    None,
                                 ),
                             );
                         });
@@ -1070,7 +1111,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     if let Type::TypedDict(typed_dict) = ty {
                         for (name, field) in self.typed_dict_fields(&typed_dict).into_iter() {
                             let name = name_owner.push(name);
-                            let mut hint = kwargs.as_ref().map(|(_, ty)| *ty);
+                            let mut hint = kwargs.as_ref().map(|(_, ty)| (*ty, None));
                             if let Some(ty) = seen_names.get(name) {
                                 // For Required fields, the conflict is guaranteed, so report
                                 // BadKeywordArgument. For NotRequired fields, the conflict is
@@ -1091,16 +1132,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                     format!("Multiple values for argument `{name}`"),
                                 );
                                 hint = Some(*ty);
-                            } else if let Some((ty, _)) = kwparams.get(name) {
-                                seen_names.insert(name, *ty);
+                            } else if let Some((ty, _, param_index)) = kwparams.get(name) {
+                                seen_names.insert(name, (*ty, *param_index));
                                 if !field.required {
                                     not_required_td_names.insert(name);
                                 }
-                                hint = Some(*ty)
+                                hint = Some((*ty, *param_index))
                             } else if kwargs.is_none() && !kwargs_is_unpack {
                                 unexpected_keyword_error(name, kw.range);
                             }
-                            if let Some(want) = &hint {
+                            if let Some((want, _)) = &hint {
                                 self.check_type_with_options(
                                     &field.ty,
                                     want,
@@ -1169,7 +1210,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                 }
                 Some(id) => {
-                    let mut hint = kwargs.as_ref().map(|(_, ty)| *ty);
+                    let mut hint = kwargs.as_ref().map(|(_, ty)| (*ty, None));
                     let mut has_matching_param = false;
                     if let Some(ty) = seen_names.get(&id.id) {
                         // Use PotentialBadKeywordArgument when the prior entry came from a
@@ -1187,15 +1228,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         );
                         hint = Some(*ty);
                         has_matching_param = true;
-                    } else if let Some((ty, _)) = kwparams.get(&id.id) {
-                        seen_names.insert(&id.id, *ty);
-                        hint = Some(*ty);
+                    } else if let Some((ty, _, param_index)) = kwparams.get(&id.id) {
+                        seen_names.insert(&id.id, (*ty, *param_index));
+                        hint = Some((*ty, *param_index));
                         has_matching_param = true;
                     } else if kwargs.is_none() {
                         unexpected_keyword_error(&id.id, id.range);
                     }
-                    if let Some(expected) = hint {
-                        expected_types.insert(kw.range, expected.clone());
+                    if let Some((expected, param_index)) = hint {
+                        expected_types.insert(
+                            kw.range,
+                            ExpectedArgument::new(expected.clone(), param_index),
+                        );
                     }
                     let unhinted_arg_ty = bound_args
                         .as_ref()
@@ -1217,7 +1261,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             .expr_with_options(
                                 x,
                                 match hint {
-                                    Some(ty) => ExprOptions::check(
+                                    Some((ty, _)) => ExprOptions::check(
                                         ty,
                                         arg_errors,
                                         call_errors,
@@ -1229,7 +1273,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             )
                             .into_ty(),
                         TypeOrExpr::Type(x, range) => {
-                            if let Some(hint) = &hint
+                            if let Some((hint, _)) = &hint
                                 && !hint.is_any()
                             {
                                 self.check_type_with_options(
@@ -1277,7 +1321,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             extra_posargs_iter.next();
         }
         let mut extra_posargs_matched = 0;
-        for (name, (want, required)) in kwparams.iter() {
+        for (name, (want, required, _)) in kwparams.iter() {
             if !seen_names.contains_key(name) {
                 match required {
                     Required::Required => {
@@ -1447,7 +1491,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> (
         Type,
         Vec<TypeVarSpecializationError>,
-        HashMap<TextRange, Type>,
+        HashMap<TextRange, ExpectedArgument>,
     ) {
         self.callable_infer_with_hint(
             hint,
@@ -1491,7 +1535,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> (
         Type,
         Vec<TypeVarSpecializationError>,
-        HashMap<TextRange, Type>,
+        HashMap<TextRange, ExpectedArgument>,
     ) {
         let call_context = CallContext::outside()
             .with_argument_side(ArgumentSide::Got)

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -14,12 +14,14 @@ use pyrefly_types::callable::ArgCount;
 use pyrefly_types::callable::ArgCounts;
 use pyrefly_types::callable::Param;
 use pyrefly_types::meta_shape_dsl::ShapeTransform;
+use pyrefly_types::callable::ParamList;
 use pyrefly_types::tuple::Tuple;
 use pyrefly_types::types::TArgs;
 use pyrefly_util::gas::Gas;
 use pyrefly_util::owner::Owner;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::prelude::VecExt;
+use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use vec1::Vec1;
@@ -461,9 +463,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         .unwrap_or_else(|| overload.1.signature.clone()),
                     None => overload.1.signature.clone(),
                 };
-                let signature = self
-                    .solver()
-                    .for_display(self.heap.mk_callable_from(signature));
+                let signature =
+                    self.format_overload_signature_for_call(&signature, &args, &keywords);
                 details.push(format!("{signature}{suffix}"));
             }
             // We intentionally discard closest_overload.call_errors. When no overload matches,
@@ -871,5 +872,118 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             specialization_errors,
             expected_types,
         }
+    }
+
+    /// Format an overload signature, showing only the parameters used in the call.
+    fn format_overload_signature_for_call(
+        &self,
+        signature: &Callable,
+        args: &[CallArg],
+        keywords: &[CallKeyword],
+    ) -> String {
+        let full_signature = || {
+            format!(
+                "{}",
+                self.solver()
+                    .for_display(self.heap.mk_callable_from(signature.clone()))
+            )
+        };
+        let Params::List(params) = &signature.params else {
+            return full_signature();
+        };
+
+        let mut positional_remaining = args
+            .iter()
+            .filter(|arg| matches!(arg, CallArg::Arg(_)))
+            .count();
+        let mut star_remaining = args
+            .iter()
+            .filter(|arg| matches!(arg, CallArg::Star(..)))
+            .count();
+        let mut keyword_names: Vec<Name> = keywords
+            .iter()
+            .filter_map(|kw| kw.arg.map(|id| id.id.clone()))
+            .collect();
+        let mut has_kwargs = keywords.iter().any(|kw| kw.arg.is_none());
+
+        let mut used_params = Vec::new();
+        let mut omitted = false;
+        let take_keyword = |name: &Name, names: &mut Vec<Name>| {
+            if let Some(index) = names.iter().position(|candidate| candidate == name) {
+                names.remove(index);
+                true
+            } else {
+                false
+            }
+        };
+
+        for param in params.items() {
+            let include = match param {
+                Param::PosOnly(name, _, _) => {
+                    if positional_remaining > 0 {
+                        positional_remaining -= 1;
+                        true
+                    } else if let Some(name) = name {
+                        take_keyword(name, &mut keyword_names)
+                    } else {
+                        false
+                    }
+                }
+                Param::Pos(name, _, _) => {
+                    if positional_remaining > 0 {
+                        positional_remaining -= 1;
+                        let _ = take_keyword(name, &mut keyword_names);
+                        true
+                    } else {
+                        take_keyword(name, &mut keyword_names)
+                    }
+                }
+                Param::Varargs(..) => {
+                    if positional_remaining > 0 || star_remaining > 0 {
+                        positional_remaining = 0;
+                        star_remaining = 0;
+                        true
+                    } else {
+                        false
+                    }
+                }
+                Param::KwOnly(name, _, _) => take_keyword(name, &mut keyword_names),
+                Param::Kwargs(..) => {
+                    if has_kwargs || !keyword_names.is_empty() {
+                        has_kwargs = false;
+                        keyword_names.clear();
+                        true
+                    } else {
+                        false
+                    }
+                }
+            };
+
+            if include {
+                used_params.push(param.clone());
+            } else {
+                omitted = true;
+            }
+        }
+
+        if positional_remaining > 0 || star_remaining > 0 || has_kwargs || !keyword_names.is_empty()
+        {
+            omitted = true;
+        }
+
+        let has_used_params = !used_params.is_empty();
+        let callable = Callable::list(ParamList::new(used_params), signature.ret.clone());
+        let mut display = format!(
+            "{}",
+            self.solver()
+                .for_display(self.heap.mk_callable_from(callable))
+        );
+        if omitted {
+            if let Some(close_paren) = display.find(") ->") {
+                let insert = if has_used_params { ", ..." } else { "..." };
+                display.insert_str(close_paren, insert);
+            }
+        }
+        display
     }
 }

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -15,7 +15,11 @@ use pyrefly_types::callable::ArgCounts;
 use pyrefly_types::callable::Param;
 use pyrefly_types::meta_shape_dsl::ShapeTransform;
 use pyrefly_types::callable::ParamList;
+use pyrefly_types::callable::ParamList;
+use pyrefly_types::display::TypeDisplayContext;
 use pyrefly_types::tuple::Tuple;
+use pyrefly_types::type_output::OutputWithLocations;
+use pyrefly_types::type_output::TypeOutput;
 use pyrefly_types::types::TArgs;
 use pyrefly_util::gas::Gas;
 use pyrefly_util::owner::Owner;
@@ -906,14 +910,34 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .collect();
         let mut has_kwargs = keywords.iter().any(|kw| kw.arg.is_none());
 
-        let mut used_params = Vec::new();
-        let mut omitted = false;
+        let mut elements = Vec::new();
+        let mut named_posonly = false;
+        let mut kwonly = false;
+        let mut in_omitted = false;
         let take_keyword = |name: &Name, names: &mut Vec<Name>| {
             if let Some(index) = names.iter().position(|candidate| candidate == name) {
                 names.remove(index);
                 true
             } else {
                 false
+            }
+        };
+        let format_param = |param: &Param| -> String {
+            let ctx = TypeDisplayContext::new(&[]);
+            let mut output = OutputWithLocations::new(&ctx);
+            let _ = param.fmt_with_type(&mut output, &|ty, out| {
+                let display_ty = self.solver().for_display(ty.clone());
+                out.write_type(&display_ty)
+            });
+            output
+                .parts()
+                .iter()
+                .map(|(part, _)| part.as_str())
+                .collect::<String>()
+        };
+        let mut push_ellipsis = |parts: &mut Vec<String>| {
+            if parts.last().map(|s| s.as_str()) != Some("...") {
+                parts.push("...".to_owned());
             }
         };
 
@@ -959,31 +983,46 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
             };
 
-            if include {
-                used_params.push(param.clone());
-            } else {
-                omitted = true;
+            if !include {
+                in_omitted = true;
+                continue;
+            }
+
+            if named_posonly && !matches!(param, Param::PosOnly(Some(_), _, _)) {
+                elements.push("/".to_owned());
+                named_posonly = false;
+            }
+            if in_omitted {
+                push_ellipsis(&mut elements);
+                in_omitted = false;
+            }
+            if !kwonly && matches!(param, Param::KwOnly(..)) {
+                elements.push("*".to_owned());
+                kwonly = true;
+            }
+            elements.push(format_param(param));
+
+            if matches!(param, Param::PosOnly(Some(_), _, _)) {
+                named_posonly = true;
             }
         }
 
         if positional_remaining > 0 || star_remaining > 0 || has_kwargs || !keyword_names.is_empty()
         {
-            omitted = true;
+            in_omitted = true;
         }
 
-        let has_used_params = !used_params.is_empty();
-        let callable = Callable::list(ParamList::new(used_params), signature.ret.clone());
-        let mut display = format!(
-            "{}",
-            self.solver()
-                .for_display(self.heap.mk_callable_from(callable))
-        );
-        if omitted {
-            if let Some(close_paren) = display.find(") ->") {
-                let insert = if has_used_params { ", ..." } else { "..." };
-                display.insert_str(close_paren, insert);
-            }
+        if named_posonly {
+            elements.push("/".to_owned());
         }
-        display
+        if in_omitted {
+            push_ellipsis(&mut elements);
+        }
+        if elements.is_empty() {
+            elements.push("...".to_owned());
+        }
+
+        let ret_display = format!("{}", self.solver().for_display(signature.ret.clone()));
+        format!("({}) -> {}", elements.join(", "), ret_display)
     }
 }

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -13,11 +13,9 @@ use itertools::Itertools;
 use pyrefly_types::callable::ArgCount;
 use pyrefly_types::callable::ArgCounts;
 use pyrefly_types::callable::Param;
-use pyrefly_types::meta_shape_dsl::ShapeTransform;
-use pyrefly_types::callable::ParamList;
-use pyrefly_types::callable::ParamList;
 use pyrefly_types::callable::Required;
 use pyrefly_types::display::TypeDisplayContext;
+use pyrefly_types::meta_shape_dsl::ShapeTransform;
 use pyrefly_types::tuple::Tuple;
 use pyrefly_types::type_output::OutputWithLocations;
 use pyrefly_types::type_output::TypeOutput;
@@ -26,7 +24,6 @@ use pyrefly_util::gas::Gas;
 use pyrefly_util::owner::Owner;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::prelude::VecExt;
-use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use vec1::Vec1;
@@ -38,6 +35,7 @@ use crate::alt::call::TargetWithTParams;
 use crate::alt::callable::CallArg;
 use crate::alt::callable::CallKeyword;
 use crate::alt::callable::CallWithTypes;
+use crate::alt::callable::ExpectedArgument;
 use crate::alt::expr::TypeOrExpr;
 use crate::alt::unwrap::HintRef;
 use crate::config::error_kind::ErrorKind;
@@ -58,8 +56,8 @@ struct CalledOverload<'f> {
     ctor_targs: Option<TArgs>,
     call_errors: ErrorCollector,
     specialization_errors: Vec<TypeVarSpecializationError>,
-    /// Maps each argument's source range to the parameter type it was matched against.
-    expected_types: HashMap<TextRange, Type>,
+    /// Maps each argument's source range to the parameter it was matched against.
+    expected_types: HashMap<TextRange, ExpectedArgument>,
 }
 
 impl CalledOverload<'_> {
@@ -453,23 +451,31 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 args_display
             );
             let mut details = vec!["Possible overloads:".to_owned()];
+            let empty_expected_types = HashMap::new();
             for overload in &overloads {
-                let suffix = if overload.1.signature == closest_overload.func.1.signature {
-                    " [closest match]"
-                } else {
-                    ""
-                };
-                let signature = match self_obj {
+                let is_closest = overload.1.signature == closest_overload.func.1.signature;
+                let suffix = if is_closest { " [closest match]" } else { "" };
+                let (signature, param_index_offset) = match self_obj {
                     Some(_) => overload
                         .1
                         .signature
                         .split_first_param(&mut Owner::new())
-                        .map(|(_, signature)| signature)
-                        .unwrap_or_else(|| overload.1.signature.clone()),
-                    None => overload.1.signature.clone(),
+                        .map(|(_, signature)| (signature, 1))
+                        .unwrap_or_else(|| (overload.1.signature.clone(), 0)),
+                    None => (overload.1.signature.clone(), 0),
                 };
-                let signature =
-                    self.format_overload_signature_for_call(&signature, &args, &keywords);
+                let expected_types = if is_closest {
+                    &closest_overload.expected_types
+                } else {
+                    &empty_expected_types
+                };
+                let signature = self.format_overload_signature_for_call(
+                    &signature,
+                    expected_types,
+                    param_index_offset,
+                    &args,
+                    &keywords,
+                );
                 details.push(format!("{signature}{suffix}"));
             }
             // We intentionally discard closest_overload.call_errors. When no overload matches,
@@ -634,7 +640,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                     let mut param_types = matched_overloads
                         .iter()
-                        .filter_map(|o| o.expected_types.get(&arg_range));
+                        .filter_map(|o| o.expected_types.get(&arg_range).map(|e| &e.ty));
                     let Some(first) = param_types.next() else {
                         // If we can't find the expected type, be conservative and assume there may be multiple.
                         return true;
@@ -883,6 +889,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     fn format_overload_signature_for_call(
         &self,
         signature: &Callable,
+        expected_types: &HashMap<TextRange, ExpectedArgument>,
+        param_index_offset: usize,
         args: &[CallArg],
         keywords: &[CallKeyword],
     ) -> String {
@@ -897,33 +905,38 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             return full_signature();
         };
 
-        let mut positional_remaining = args
-            .iter()
-            .filter(|arg| matches!(arg, CallArg::Arg(_)))
-            .count();
-        let mut star_remaining = args
-            .iter()
-            .filter(|arg| matches!(arg, CallArg::Star(..)))
-            .count();
-        let mut keyword_names: Vec<Name> = keywords
-            .iter()
-            .filter_map(|kw| kw.arg.map(|id| id.id.clone()))
-            .collect();
-        let mut has_kwargs = keywords.iter().any(|kw| kw.arg.is_none());
+        let missing_required_by_count = || {
+            let has_unknown_args = args.iter().any(|arg| matches!(arg, CallArg::Star(..)))
+                || keywords.iter().any(|kw| kw.arg.is_none());
+            let provided = args
+                .iter()
+                .filter(|arg| matches!(arg, CallArg::Arg(_)))
+                .count()
+                + keywords.iter().filter(|kw| kw.arg.is_some()).count();
+            !has_unknown_args && signature.arg_counts().overall.min > provided
+        };
 
+        if expected_types.is_empty() {
+            let mut display = full_signature();
+            if missing_required_by_count() {
+                display.push_str(" [missing required arguments]");
+            }
+            return display;
+        }
+
+        let used_param_indices: Vec<_> = expected_types
+            .values()
+            .filter_map(|expected| {
+                expected
+                    .param_index
+                    .and_then(|index| index.checked_sub(param_index_offset))
+            })
+            .collect();
         let mut elements = Vec::new();
         let mut named_posonly = false;
         let mut kwonly = false;
         let mut in_omitted = false;
         let mut missing_required = false;
-        let take_keyword = |name: &Name, names: &mut Vec<Name>| {
-            if let Some(index) = names.iter().position(|candidate| candidate == name) {
-                names.remove(index);
-                true
-            } else {
-                false
-            }
-        };
         let format_param = |param: &Param| -> String {
             let ctx = TypeDisplayContext::new(&[]);
             let mut output = OutputWithLocations::new(&ctx);
@@ -937,64 +950,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 .map(|(part, _)| part.as_str())
                 .collect::<String>()
         };
-        let mut push_ellipsis = |parts: &mut Vec<String>| {
+        let push_ellipsis = |parts: &mut Vec<String>| {
             if parts.last().map(|s| s.as_str()) != Some("...") {
                 parts.push("...".to_owned());
             }
         };
 
-        for param in params.items() {
-            let include = match param {
-                Param::PosOnly(name, _, _) => {
-                    if positional_remaining > 0 {
-                        positional_remaining -= 1;
-                        true
-                    } else if let Some(name) = name {
-                        take_keyword(name, &mut keyword_names)
-                    } else {
-                        false
-                    }
-                }
-                Param::Pos(name, _, _) => {
-                    if positional_remaining > 0 {
-                        positional_remaining -= 1;
-                        let _ = take_keyword(name, &mut keyword_names);
-                        true
-                    } else {
-                        take_keyword(name, &mut keyword_names)
-                    }
-                }
-                Param::Varargs(..) => {
-                    if positional_remaining > 0 || star_remaining > 0 {
-                        positional_remaining = 0;
-                        star_remaining = 0;
-                        true
-                    } else {
-                        false
-                    }
-                }
-                Param::KwOnly(name, _, _) => take_keyword(name, &mut keyword_names),
-                Param::Kwargs(..) => {
-                    if has_kwargs || !keyword_names.is_empty() {
-                        has_kwargs = false;
-                        keyword_names.clear();
-                        true
-                    } else {
-                        false
-                    }
-                }
-            };
+        for (index, param) in params.items().iter().enumerate() {
+            let required = matches!(param, Param::PosOnly(_, _, Required::Required))
+                || matches!(param, Param::Pos(_, _, Required::Required))
+                || matches!(param, Param::KwOnly(_, _, Required::Required));
+            let used = used_param_indices.contains(&index);
+            let include = used || required;
 
             if !include {
-                if matches!(param, Param::PosOnly(_, _, Required::Required))
-                    || matches!(param, Param::Pos(_, _, Required::Required))
-                    || matches!(param, Param::KwOnly(_, _, Required::Required))
-                {
-                    missing_required = true;
-                }
                 in_omitted = true;
                 continue;
             }
+            missing_required |= required && !used;
 
             if named_posonly && !matches!(param, Param::PosOnly(Some(_), _, _)) {
                 elements.push("/".to_owned());
@@ -1013,11 +986,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             if matches!(param, Param::PosOnly(Some(_), _, _)) {
                 named_posonly = true;
             }
-        }
-
-        if positional_remaining > 0 || star_remaining > 0 || has_kwargs || !keyword_names.is_empty()
-        {
-            in_omitted = true;
         }
 
         if named_posonly {

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -16,6 +16,7 @@ use pyrefly_types::callable::Param;
 use pyrefly_types::meta_shape_dsl::ShapeTransform;
 use pyrefly_types::callable::ParamList;
 use pyrefly_types::callable::ParamList;
+use pyrefly_types::callable::Required;
 use pyrefly_types::display::TypeDisplayContext;
 use pyrefly_types::tuple::Tuple;
 use pyrefly_types::type_output::OutputWithLocations;
@@ -914,6 +915,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let mut named_posonly = false;
         let mut kwonly = false;
         let mut in_omitted = false;
+        let mut missing_required = false;
         let take_keyword = |name: &Name, names: &mut Vec<Name>| {
             if let Some(index) = names.iter().position(|candidate| candidate == name) {
                 names.remove(index);
@@ -984,6 +986,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             };
 
             if !include {
+                if matches!(param, Param::PosOnly(_, _, Required::Required))
+                    || matches!(param, Param::Pos(_, _, Required::Required))
+                    || matches!(param, Param::KwOnly(_, _, Required::Required))
+                {
+                    missing_required = true;
+                }
                 in_omitted = true;
                 continue;
             }
@@ -1023,6 +1031,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
 
         let ret_display = format!("{}", self.solver().for_display(signature.ret.clone()));
-        format!("({}) -> {}", elements.join(", "), ret_display)
+        let mut display = format!("({}) -> {}", elements.join(", "), ret_display);
+        if missing_required {
+            display.push_str(" [missing required arguments]");
+        }
+        display
     }
 }

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -1430,10 +1430,18 @@ def f(x: int, y: int, z: int) -> int: ...
 def f(x: str, y: str, z: str, w: str) -> str: ...
 def f(x, y, z=None, w=None): return x
 
-f(1, 2)  # E: (x: int, y: int, ...) -> int [missing required arguments] # !E: z: # !E: w:
-f(y=4)  # E: (..., y: int, ...) -> int [missing required arguments] # !E: x: # !E: z:
-f(y="str")  # E: (..., y: int, ...) -> int [missing required arguments] # !E: x: # !E: z:
-f(x="1", z="3")  # E: (x: int, ..., z: int) -> int [missing required arguments] # !E: y:
+f(1, 2)  # E: (x: int, y: int, z: int) -> int [missing required arguments] [closest match]
+f(y=4)  # E: (x: int, y: int, z: int) -> int [missing required arguments] [closest match]
+f(y="str")  # E: (x: int, y: int, z: int) -> int [missing required arguments] [closest match]
+f(x="1", z="3")  # E: (x: int, y: int, z: int) -> int [missing required arguments] [closest match]
+
+@overload
+def h(x: int, y: int, z: int = ...) -> int: ...
+@overload
+def h(x: str, y: str) -> str: ...
+def h(x, y, z=0): return x
+
+h(1, "bad")  # E: (x: int, y: int, ...) -> int [closest match] # !E: z:
     "#,
 );
 

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -1420,6 +1420,21 @@ g(x=1, y="hello")  # E: No matching overload found for function `g` called with 
 );
 
 testcase!(
+    test_overload_error_shows_truncated_signatures,
+    r#"
+from typing import overload
+
+@overload
+def f(x: int, y: int, z: int) -> int: ...
+@overload
+def f(x: str, y: str, z: str, w: str) -> str: ...
+def f(x, y, z=None, w=None): return x
+
+f(1, 2)  # E: (x: int, y: int, ...) # !E: z: # !E: w:
+    "#,
+);
+
+testcase!(
     test_varargs_materialization,
     r#"
 from typing import Any, assert_type, overload

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -1430,10 +1430,10 @@ def f(x: int, y: int, z: int) -> int: ...
 def f(x: str, y: str, z: str, w: str) -> str: ...
 def f(x, y, z=None, w=None): return x
 
-f(1, 2)  # E: (x: int, y: int, ...) # !E: z: # !E: w:
-f(y=4)  # E: (..., y: int, ...) # !E: x: # !E: z:
-f(y="str")  # E: (..., y: int, ...) # !E: x: # !E: z:
-f(x="1", z="3")  # E: (x: int, ..., z: int) # !E: y:
+f(1, 2)  # E: (x: int, y: int, ...) -> int [missing required arguments] # !E: z: # !E: w:
+f(y=4)  # E: (..., y: int, ...) -> int [missing required arguments] # !E: x: # !E: z:
+f(y="str")  # E: (..., y: int, ...) -> int [missing required arguments] # !E: x: # !E: z:
+f(x="1", z="3")  # E: (x: int, ..., z: int) -> int [missing required arguments] # !E: y:
     "#,
 );
 

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -1431,6 +1431,9 @@ def f(x: str, y: str, z: str, w: str) -> str: ...
 def f(x, y, z=None, w=None): return x
 
 f(1, 2)  # E: (x: int, y: int, ...) # !E: z: # !E: w:
+f(y=4)  # E: (..., y: int, ...) # !E: x: # !E: z:
+f(y="str")  # E: (..., y: int, ...) # !E: x: # !E: z:
+f(x="1", z="3")  # E: (x: int, ..., z: int) # !E: y:
     "#,
 );
 


### PR DESCRIPTION
part of #955

callable_infer now records not only the expected parameter type for each call argument, but also which parameter index the argument matched.

Overload “No matching overload” diagnostics use that real argument-to-parameter mapping instead of reconstructing it from positional counts / keyword names.

If the failure is missing required args, show the full required signature so users can see what to pass, e.g. z / w.
If the failure is wrong argument type, truncate unrelated optional params with ... so the relevant parameters stand out.
