### PR TITLE
Verify overloaded method name displays in hover trace

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -471,8 +471,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             && !self.is_compatible_constructor_return(&ret, cls.class_object())
         {
             if let Some(metaclass_dunder_call) = self.get_metaclass_dunder_call(&cls) {
-                // Not quite an overload, but close enough
-                self.record_overload_trace_from_type(range, metaclass_dunder_call);
+                self.record_resolved_trace(range, metaclass_dunder_call);
             }
             // Got something other than an instance of the class under construction.
             return ret;
@@ -503,8 +502,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 );
                 let has_errors = !dunder_new_errors.is_empty();
                 errors.extend(dunder_new_errors);
-                // Not quite an overload, but close enough
-                self.record_overload_trace_from_type(range, new_method);
+                self.record_resolved_trace(range, new_method);
                 if self.is_compatible_constructor_return(&ret, cls.class_object()) {
                     dunder_new_ret = Some(ret);
                 } else if !matches!(ret, Type::Any(AnyStyle::Error | AnyStyle::Implicit)) {
@@ -546,8 +544,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             if !dunder_new_has_errors {
                 errors.extend(dunder_init_errors);
             }
-            // Not quite an overload, but close enough
-            self.record_overload_trace_from_type(range, init_method);
+            self.record_resolved_trace(range, init_method);
         }
         self.solver()
             .finish_class_targs(cls.targs_mut(), self.uniques);

--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -46,7 +46,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         opname: &Name,
         call_arg_type: &Type,
     ) -> Type {
-        self.record_overload_trace_from_type(range, method_type.clone());
+        self.record_resolved_trace(range, method_type.clone());
         let callable = self.as_call_target_or_error(
             method_type,
             CallStyle::Method(opname),

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -168,6 +168,41 @@ x: int = 5  # pyrefly: ignore[bad-return]
 }
 
 #[test]
+fn hover_over_overloaded_binary_operator_shows_dunder_name() {
+    let code = r#"
+from typing import overload
+
+class Matrix:
+    @overload
+    def __matmul__(self, other: Matrix) -> Matrix: ...
+    @overload
+    def __matmul__(self, other: int) -> Matrix: ...
+    def __matmul__(self, other) -> Matrix: ...
+
+lhs = Matrix()
+rhs = Matrix()
+lhs @ rhs
+#   ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert_eq!(
+        r#"
+# main.py
+13 | lhs @ rhs
+         ^
+```python
+(attribute) __matmul__: (
+    self: Matrix,
+    other: Matrix
+) -> Matrix
+```
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn hover_over_code_with_ignore_shows_type() {
     let code = r#"
 a: int = "test"  # pyrefly: ignore


### PR DESCRIPTION
Close #1416.

Apparently, the issue of the method name not displaying has been fixed. I added a test case to verify this, and also refactored `OverloadedCallee` to an enum to better distinguish between resolved (show one) vs candidate (show all) traces.

<img width="696" height="264" alt="Screenshot 2025-11-10 at 7 04 03 PM" src="https://github.com/user-attachments/assets/360a4420-9701-4eb8-b0b6-4f2ee4167fa5" />
