### PR TITLE
Fixes signature help active parameter highlighting ,issue num 1417

### DIFF
--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -906,7 +906,7 @@ impl<'a> Transaction<'a> {
             |(callables, chosen_overload_index, arg_index)| SignatureHelp {
                 signatures: callables
                     .into_iter()
-                    .map(|t| Self::create_signature_information(t, arg_index))
+                    .map(|t| Self::create_signature_information(t)) // Remove arg_index parameter
                     .collect_vec(),
                 active_signature: Some(chosen_overload_index as u32),
                 active_parameter: Some(arg_index as u32),
@@ -914,31 +914,23 @@ impl<'a> Transaction<'a> {
         )
     }
 
-    fn create_signature_information(type_: Type, arg_index: usize) -> SignatureInformation {
+    fn create_signature_information(type_: Type) -> SignatureInformation {
         let type_ = type_.deterministic_printing();
         let label = type_.as_hover_string();
-        let (parameters, active_parameter) =
+        let parameters =
             if let Some(params) = Self::normalize_singleton_function_type_into_params(type_) {
-                let active_parameter = if arg_index < params.len() {
-                    Some(arg_index as u32)
-                } else {
-                    None
-                };
-                (
-                    Some(params.map(|param| ParameterInformation {
-                        label: ParameterLabel::Simple(format!("{param}")),
-                        documentation: None,
-                    })),
-                    active_parameter,
-                )
+                Some(params.map(|param| ParameterInformation {
+                    label: ParameterLabel::Simple(format!("{param}")),
+                    documentation: None,
+                }))
             } else {
-                (None, None)
+                None
             };
         SignatureInformation {
             label,
             documentation: None,
             parameters,
-            active_parameter,
+            active_parameter: None, // Don't set this per-signature
         }
     }
 

--- a/pyrefly/lib/test/lsp/signature_help.rs
+++ b/pyrefly/lib/test/lsp/signature_help.rs
@@ -20,11 +20,16 @@ fn get_test_report(state: &State, handle: &Handle, position: TextSize) -> String
     if let Some(SignatureHelp {
         signatures,
         active_signature,
-        active_parameter: _,
+        active_parameter,
     }) = state.transaction().get_signature_help_at(handle, position)
     {
         let active_signature_result = if let Some(active) = active_signature {
             format!(" active={active}")
+        } else {
+            "".to_owned()
+        };
+        let active_parameter_result = if let Some(active) = active_parameter {
+            format!(", active parameter={active}")
         } else {
             "".to_owned()
         };
@@ -63,7 +68,10 @@ fn get_test_report(state: &State, handle: &Handle, position: TextSize) -> String
                 },
             )
             .join("\n");
-        format!("Signature Help Result:{active_signature_result}\n{signatures_result}")
+        // format!("Signature Help Result:{active_signature_result}\n{signatures_result}")
+        format!(
+            "Signature Help Result:{active_signature_result}{active_parameter_result}\n{signatures_result}"
+        )
     } else {
         "Signature Help: None".to_owned()
     }
@@ -89,39 +97,39 @@ f("",3,True)
 # main.py
 4 | f()
       ^
-Signature Help Result: active=0
+Signature Help Result: active=0, active parameter=0
 - def f(
     a: str,
     b: int,
     c: bool
-) -> None, parameters=[a: str, b: int, c: bool], active parameter = 0
+) -> None, parameters=[a: str, b: int, c: bool]
 
 6 | f("", )
          ^
-Signature Help Result: active=0
+Signature Help Result: active=0, active parameter=1
 - def f(
     a: str,
     b: int,
     c: bool
-) -> None, parameters=[a: str, b: int, c: bool], active parameter = 1
+) -> None, parameters=[a: str, b: int, c: bool]
 
 8 | f("",3, )
            ^
-Signature Help Result: active=0
+Signature Help Result: active=0, active parameter=2
 - def f(
     a: str,
     b: int,
     c: bool
-) -> None, parameters=[a: str, b: int, c: bool], active parameter = 2
+) -> None, parameters=[a: str, b: int, c: bool]
 
 10 | f("",3,True)
             ^
-Signature Help Result: active=0
+Signature Help Result: active=0, active parameter=2
 - def f(
     a: str,
     b: int,
     c: bool
-) -> None, parameters=[a: str, b: int, c: bool], active parameter = 2
+) -> None, parameters=[a: str, b: int, c: bool]
 "#
         .trim(),
         report.trim(),
@@ -142,8 +150,8 @@ f(
 # main.py
 4 | f(
       ^
-Signature Help Result: active=0
-- def f(a: str) -> None, parameters=[a: str], active parameter = 0
+Signature Help Result: active=0, active parameter=0
+- def f(a: str) -> None, parameters=[a: str]
 "#
         .trim(),
         report.trim(),
@@ -167,13 +175,13 @@ f(g())
 # main.py
 5 | f()
       ^
-Signature Help Result: active=0
-- def f(a: str) -> None, parameters=[a: str], active parameter = 0
+Signature Help Result: active=0, active parameter=0
+- def f(a: str) -> None, parameters=[a: str]
 
 7 | f(g())
         ^
-Signature Help Result: active=0
-- def g(b: int) -> None, parameters=[b: int], active parameter = 0
+Signature Help Result: active=0, active parameter=0
+- def g(b: int) -> None, parameters=[b: int]
 "#
         .trim(),
         report.trim(),
@@ -202,43 +210,43 @@ foo.f("",3,True)
 # main.py
 6 | foo.f()
           ^
-Signature Help Result: active=0
+Signature Help Result: active=0, active parameter=0
 - def f(
     self: Foo,
     a: str,
     b: int,
     c: bool
-) -> None, parameters=[a: str, b: int, c: bool], active parameter = 0
+) -> None, parameters=[a: str, b: int, c: bool]
 
 8 | foo.f("", )
              ^
-Signature Help Result: active=0
+Signature Help Result: active=0, active parameter=1
 - def f(
     self: Foo,
     a: str,
     b: int,
     c: bool
-) -> None, parameters=[a: str, b: int, c: bool], active parameter = 1
+) -> None, parameters=[a: str, b: int, c: bool]
 
 10 | foo.f("",3, )
                 ^
-Signature Help Result: active=0
+Signature Help Result: active=0, active parameter=2
 - def f(
     self: Foo,
     a: str,
     b: int,
     c: bool
-) -> None, parameters=[a: str, b: int, c: bool], active parameter = 2
+) -> None, parameters=[a: str, b: int, c: bool]
 
 12 | foo.f("",3,True)
                 ^
-Signature Help Result: active=0
+Signature Help Result: active=0, active parameter=2
 - def f(
     self: Foo,
     a: str,
     b: int,
     c: bool
-) -> None, parameters=[a: str, b: int, c: bool], active parameter = 2
+) -> None, parameters=[a: str, b: int, c: bool]
 "#
         .trim(),
         report.trim(),
@@ -272,30 +280,30 @@ overloaded_func(1, T)
 # main.py
 13 | overloaded_func()
                      ^
-Signature Help Result: active=0
-- (a: str) -> bool, parameters=[a: str], active parameter = 0
+Signature Help Result: active=0, active parameter=0
+- (a: str) -> bool, parameters=[a: str]
 - (
     a: int,
     b: bool
-) -> str, parameters=[a: int, b: bool], active parameter = 0
+) -> str, parameters=[a: int, b: bool]
 
 15 | overloaded_func(1, )
                        ^
-Signature Help Result: active=0
+Signature Help Result: active=0, active parameter=1
 - (a: str) -> bool, parameters=[a: str]
 - (
     a: int,
     b: bool
-) -> str, parameters=[a: int, b: bool], active parameter = 1
+) -> str, parameters=[a: int, b: bool]
 
 17 | overloaded_func(1, T)
                         ^
-Signature Help Result: active=1
+Signature Help Result: active=1, active parameter=1
 - (a: str) -> bool, parameters=[a: str]
 - (
     a: int,
     b: bool
-) -> str, parameters=[a: int, b: bool], active parameter = 1
+) -> str, parameters=[a: int, b: bool]
 "#
         .trim(),
         report.trim(),
@@ -331,20 +339,20 @@ foo.overloaded_meth(1, F)
 # main.py
 15 | foo.overloaded_meth()
                          ^
-Signature Help Result: active=0
+Signature Help Result: active=0, active parameter=0
 - (
     self: Foo,
     a: str
-) -> bool, parameters=[a: str], active parameter = 0
+) -> bool, parameters=[a: str]
 - (
     self: Foo,
     a: int,
     b: bool
-) -> str, parameters=[a: int, b: bool], active parameter = 0
+) -> str, parameters=[a: int, b: bool]
 
 17 | foo.overloaded_meth(1, )
                             ^
-Signature Help Result: active=0
+Signature Help Result: active=0, active parameter=1
 - (
     self: Foo,
     a: str
@@ -353,11 +361,11 @@ Signature Help Result: active=0
     self: Foo,
     a: int,
     b: bool
-) -> str, parameters=[a: int, b: bool], active parameter = 1
+) -> str, parameters=[a: int, b: bool]
 
 19 | foo.overloaded_meth(1, F)
                             ^
-Signature Help Result: active=1
+Signature Help Result: active=1, active parameter=1
 - (
     self: Foo,
     a: str
@@ -366,7 +374,7 @@ Signature Help Result: active=1
     self: Foo,
     a: int,
     b: bool
-) -> str, parameters=[a: int, b: bool], active parameter = 1
+) -> str, parameters=[a: int, b: bool]
 "#
         .trim(),
         report.trim(),


### PR DESCRIPTION
## Summary
Fixes signature help active parameter highlighting issue where the wrong parameter was being highlighted during function call completion.

## Problem
When typing inside a function parameter (e.g., `np.array([1], dtype=`), the signature help incorrectly highlighted the next parameter (`copy`) instead of the current one being typed (`dtype`).

## Root Cause
The bug was caused by setting the `active_parameter` field at both:
1. The `SignatureHelp` level (correct - indicates which parameter globally)
2. The individual `SignatureInformation` level (incorrect - should be None)

According to the LSP specification, `active_parameter` should only be set at the `SignatureHelp` level to indicate which parameter is currently active across all signature overloads.

## Changes Made
- Removed the `active_parameter` calculation from `create_signature_information` function in `lsp.rs`
- Removed unused `arg_index` parameter from `create_signature_information`
- Updated the call site in `get_signature_help_at` to not pass `arg_index`
- Updated test expectations in `signature_help.rs` to check `active_parameter` at the correct level

## Testing
- [x] Code compiles successfully
- [x] All existing tests pass (including 6 updated signature help tests)
- [x] Code follows the LSP specification for signature help

Fixes #1417