### PR TITLE
fix Hover does not show docstring for nested class #1327

### DIFF
--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -378,6 +378,10 @@ impl<'a> BindingsBuilder<'a> {
                 if let Some(docstring_range) = Docstring::range_from_stmts(&func_def.body) {
                     field_docstrings.insert(func_def.name.range, docstring_range);
                 }
+            } else if let Stmt::ClassDef(class_def) = stmt {
+                if let Some(docstring_range) = Docstring::range_from_stmts(&class_def.body) {
+                    field_docstrings.insert(class_def.name.range, docstring_range);
+                }
             } else if is_field
                 && let Some(next_stmt) = body.get(i + 1)
                 && let Stmt::Expr(expr_stmt) = next_stmt

--- a/pyrefly/lib/test/lsp/hover_docstring.rs
+++ b/pyrefly/lib/test/lsp/hover_docstring.rs
@@ -211,6 +211,28 @@ Docstring Result: `Test docstring`
 }
 
 #[test]
+fn nested_class_test() {
+    let code = r#"
+class Foo:
+    class Bar:
+        """Test docstring"""
+print(Foo.Bar)
+#           ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], test_report_factory(code));
+    assert_eq!(
+        r#"
+# main.py
+5 | print(Foo.Bar)
+                ^
+Docstring Result: `Test docstring`
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn cross_module_function_test() {
     let lib = r#"
 def f():


### PR DESCRIPTION
fix #1327

Ensure nested classes contribute their docstrings to attribute metadata by collecting docstrings from Stmt::ClassDef bodies during class binding.
