### PR TITLE
fix Go-to-def fails on unreachable branches #1254

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -19,6 +19,7 @@ use pyrefly_graph::index_map::IndexMap;
 use pyrefly_python::ast::Ast;
 use pyrefly_python::dunder;
 use pyrefly_python::module_name::ModuleName;
+use pyrefly_python::module_path::ModulePathDetails;
 use pyrefly_python::nesting_context::NestingContext;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_python::sys_info::SysInfo;
@@ -294,6 +295,7 @@ pub struct BindingsBuilder<'a> {
     pub analyze_unannotated_for_ide: bool,
     pub infer_return_types: InferReturnTypes,
     pub treat_all_caps_as_final: bool,
+    error_suppression_depth: usize,
     unused_parameters: Vec<UnusedParameter>,
     unused_imports: Vec<UnusedImport>,
     unused_variables: Vec<UnusedVariable>,
@@ -642,6 +644,7 @@ impl Bindings {
             analyze_unannotated_for_ide,
             infer_return_types,
             treat_all_caps_as_final,
+            error_suppression_depth: 0,
             unused_parameters: Vec::new(),
             unused_imports: Vec::new(),
             unused_variables: Vec::new(),
@@ -1225,6 +1228,7 @@ impl<'a> BindingsBuilder<'a> {
     }
 
     pub fn init_static_scope(&mut self, x: &[Stmt], top_level: bool) {
+        let include_unreachable_defs = self.should_bind_unreachable_branches();
         self.scopes.init_current_static(
             x,
             &self.module_info,
@@ -1237,6 +1241,7 @@ impl<'a> BindingsBuilder<'a> {
                     .0
                     .insert(KeyAnnotation::Annotation(x))
             },
+            include_unreachable_defs,
         );
     }
 
@@ -1261,6 +1266,32 @@ impl<'a> BindingsBuilder<'a> {
             self.stmt(x, parent);
             self.adjacent_namedtuple_defaults = None;
         }
+    }
+
+    pub fn with_error_suppression<R>(
+        &mut self,
+        f: impl FnOnce(&mut BindingsBuilder<'a>) -> R,
+    ) -> R {
+        self.error_suppression_depth += 1;
+        let result = f(self);
+        self.error_suppression_depth -= 1;
+        result
+    }
+
+    #[inline]
+    fn errors_suppressed(&self) -> bool {
+        self.error_suppression_depth > 0
+    }
+
+    pub(crate) fn should_bind_unreachable_branches(&self) -> bool {
+        matches!(
+            self.module_info.path().details(),
+            ModulePathDetails::FileSystem(_)
+                | ModulePathDetails::Memory(_)
+                | ModulePathDetails::BundledTypeshedThirdParty(_)
+                | ModulePathDetails::BundledThirdParty(_)
+        ) && self.module_info.name() != ModuleName::builtins()
+            && self.module_info.name() != ModuleName::extra_builtins()
     }
 
     fn inject_globals(&mut self) {
@@ -1453,6 +1484,9 @@ impl<'a> BindingsBuilder<'a> {
     }
 
     pub fn error(&self, range: TextRange, kind: ErrorKind, msg: String) {
+        if self.errors_suppressed() {
+            return;
+        }
         self.errors.error_builder(range, kind, msg).emit();
     }
 
@@ -1463,6 +1497,9 @@ impl<'a> BindingsBuilder<'a> {
         header: String,
         detail: String,
     ) {
+        if self.errors_suppressed() {
+            return;
+        }
         self.errors
             .error_builder(range, kind, header)
             .with_detail(detail)
@@ -1541,7 +1578,9 @@ impl<'a> BindingsBuilder<'a> {
                             .map(FlowStyle::assume_initialized)
                     })
                     .unwrap_or(FlowStyle::Other);
-                self.scopes.define_in_current_flow(hashed_name, idx, style);
+                let _ = self
+                    .scopes
+                    .define_in_current_flow(hashed_name, idx, style, false);
                 if let Some(narrow_idx) = capture_info.narrow_idx
                     && let Some((_, Some(Binding::Narrow(_, _, _)))) =
                         self.get_original_binding(narrow_idx)
@@ -1585,7 +1624,7 @@ impl<'a> BindingsBuilder<'a> {
                         .flow_style_for_name(name.key())
                         .map(FlowStyle::assume_initialized)
                         .unwrap_or(FlowStyle::Other);
-                    self.scopes.define_in_current_flow(name, idx, style);
+                    let _ = self.scopes.define_in_current_flow(name, idx, style, false);
                 }
                 NameLookupResult::Found {
                     idx,
@@ -1611,8 +1650,9 @@ impl<'a> BindingsBuilder<'a> {
                     // When we use a variable, we mark it as initialized
                     // If the variable was uninitialized before, this will
                     // prevent us from emitting errors for every subsequent usage
-                    self.scopes
-                        .define_in_current_flow(name, idx, FlowStyle::Other);
+                    let _ = self
+                        .scopes
+                        .define_in_current_flow(name, idx, FlowStyle::Other, false);
                 }
                 NameLookupResult::Found {
                     idx,
@@ -1930,19 +1970,37 @@ impl<'a> BindingsBuilder<'a> {
         if !type_alias_reported && !imported_final_reported {
             self.check_for_all_caps_final_reassignment(name, idx);
         }
-        let name = Hashed::new(name);
-        let write_info = self
-            .scopes
-            .define_in_current_flow(name, idx, style)
-            .unwrap_or_else(|| {
-                panic!(
-                    "Name `{name}` not found in static scope of module `{}`.",
-                    self.module_info.name(),
-                )
-            });
+        let mut hashed_name = Hashed::new(name);
+        let allow_unreachable_defs = self.should_bind_unreachable_branches();
+        let mut write_info = self.scopes.define_in_current_flow(
+            hashed_name,
+            idx,
+            style.clone(),
+            allow_unreachable_defs,
+        );
+        if write_info.is_none() && allow_unreachable_defs {
+            let key_range = self.table.types.0.idx_to_key(idx).range();
+            self.scopes.add_synthetic_definition(name, key_range);
+            hashed_name = Hashed::new(name);
+            write_info = self.scopes.define_in_current_flow(
+                hashed_name,
+                idx,
+                style.clone(),
+                allow_unreachable_defs,
+            );
+        }
+        let write_info = write_info.unwrap_or_else(|| {
+            panic!(
+                "Name `{name}` not found in static scope of module `{}`.",
+                self.module_info.name(),
+            )
+        });
+        if !write_info.reachability.is_reachable() {
+            debug_assert!(allow_unreachable_defs);
+        }
         if let Some(range) = write_info.anywhere_range {
             self.table
-                .record_bind_in_anywhere(name.into_key().clone(), range, idx);
+                .record_bind_in_anywhere(hashed_name.into_key().clone(), range, idx);
         }
         write_info.annotation
     }

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -73,6 +73,7 @@ use crate::export::definitions::Definition;
 use crate::export::definitions::DefinitionStyle;
 use crate::export::definitions::Definitions;
 use crate::export::definitions::MutableCaptureKind;
+use crate::export::definitions::Reachability;
 use crate::export::exports::LookupExport;
 use crate::export::special::SpecialExport;
 use crate::module::module_info::ModuleInfo;
@@ -157,6 +158,8 @@ pub struct NameWriteInfo {
     /// If this name only has one assignment, we will skip the `Anywhere` as
     /// an optimization, and this field will be `None`.
     pub anywhere_range: Option<TextRange>,
+    /// Whether the definition is reachable for the current sys_info configuration.
+    pub reachability: Reachability,
 }
 
 #[derive(Clone, Debug)]
@@ -229,6 +232,7 @@ struct StaticInfo {
     /// The range of the textually last assignment to this name. Used to check
     /// whether a captured variable is reassigned after a nested function definition.
     last_range: TextRange,
+    reachability: Reachability,
 }
 
 #[derive(Clone, Debug)]
@@ -309,7 +313,7 @@ impl StaticStyle {
 
     fn of_definition(
         name: Hashed<&Name>,
-        definition: Definition,
+        definition: &Definition,
         scopes: Option<&Scopes>,
         lookup: &dyn LookupExport,
         current_module: ModuleName,
@@ -391,6 +395,7 @@ impl StaticInfo {
             } else {
                 None
             },
+            reachability: self.reachability,
         }
     }
 }
@@ -410,6 +415,7 @@ impl Static {
         range: TextRange,
         style: StaticStyle,
         last_range: TextRange,
+        reachability: Reachability,
     ) {
         match self.0.entry_hashed(name) {
             Entry::Vacant(e) => {
@@ -417,6 +423,7 @@ impl Static {
                     range,
                     style,
                     last_range,
+                    reachability,
                 });
             }
             Entry::Occupied(mut e) => {
@@ -458,6 +465,7 @@ impl Static {
                         }
                     }
                 }
+                found.reachability = found.reachability.combine(reachability);
             }
         }
     }
@@ -475,6 +483,7 @@ impl Static {
         sys_info: SysInfo,
         get_annotation_idx: &mut impl FnMut(ShortIdentifier) -> Idx<KeyAnnotation>,
         scopes: Option<&Scopes>,
+        include_unreachable_defs: bool,
     ) -> (
         SmallSet<Name>,
         SmallMap<Name, ModuleName>,
@@ -486,6 +495,7 @@ impl Static {
             module_info.name(),
             module_info.path().is_init(),
             sys_info,
+            include_unreachable_defs,
         );
         if top_level {
             d.inject_implicit_globals();
@@ -519,13 +529,13 @@ impl Static {
             let last_range = definition.last_range;
             let style = StaticStyle::of_definition(
                 name.as_ref(),
-                definition,
+                &definition,
                 scopes,
                 lookup,
                 module_info.name(),
                 get_annotation_idx,
             );
-            self.upsert(name, range, style, last_range);
+            self.upsert(name, range, style, last_range, definition.reachability);
         }
         for (module, range, wildcard) in all_wildcards {
             // Builtins are a fallback, so they should never shadow an existing definition.
@@ -536,7 +546,13 @@ impl Static {
                 if skip_existing && self.0.get_hashed(name).is_some() {
                     continue;
                 }
-                self.upsert(name.cloned(), range, StaticStyle::MergeableImport, range)
+                self.upsert(
+                    name.cloned(),
+                    range,
+                    StaticStyle::MergeableImport,
+                    range,
+                    Reachability::Reachable,
+                )
             }
         }
         let final_names = d.final_names.keys().cloned().collect();
@@ -560,6 +576,7 @@ impl Static {
                 name.range,
                 StaticStyle::SingleDef(None),
                 name.range,
+                Reachability::Reachable,
             )
         };
         Ast::expr_lvalue(x, &mut add);
@@ -1791,6 +1808,7 @@ impl Scopes {
         lookup: &dyn LookupExport,
         sys_info: SysInfo,
         get_annotation_idx: &mut impl FnMut(ShortIdentifier) -> Idx<KeyAnnotation>,
+        include_unreachable_defs: bool,
     ) {
         let mut initialize = |scope: &mut Scope, myself: Option<&Self>| {
             let (implicit_captures, shadowed_implicit_builtins, final_names, final_string_values) =
@@ -1802,6 +1820,7 @@ impl Scopes {
                     sys_info,
                     get_annotation_idx,
                     myself,
+                    include_unreachable_defs,
                 );
             scope.implicit_captures = implicit_captures;
             scope.shadowed_implicit_builtins = shadowed_implicit_builtins;
@@ -2172,6 +2191,7 @@ impl Scopes {
         name: Hashed<&Name>,
         idx: Idx<Key>,
         style: FlowStyle,
+        allow_unreachable: bool,
     ) -> Option<NameWriteInfo> {
         let in_loop = self.loop_depth() != 0;
         match self.current_mut().flow.info.entry_hashed(name.cloned()) {
@@ -2183,6 +2203,9 @@ impl Scopes {
             }
         }
         let static_info = self.current().stat.0.get_hashed(name)?;
+        if !allow_unreachable && !static_info.reachability.is_reachable() {
+            return None;
+        }
         Some(static_info.as_name_write_info())
     }
 
@@ -2204,6 +2227,7 @@ impl Scopes {
             range,
             StaticStyle::ImplicitBuiltinImport(module),
             range,
+            Reachability::Reachable,
         );
         Key::Import(Box::new((name.into_key().clone(), range)))
     }
@@ -2425,6 +2449,7 @@ impl Scopes {
             name.range,
             StaticStyle::SingleDef(ann),
             name.range,
+            Reachability::Reachable,
         )
     }
 
@@ -2581,6 +2606,7 @@ impl Scopes {
             name.range,
             StaticStyle::PossibleLegacyTParam,
             name.range,
+            Reachability::Reachable,
         )
     }
 
@@ -2594,6 +2620,7 @@ impl Scopes {
             name.range,
             StaticStyle::SingleDef(None),
             name.range,
+            Reachability::Reachable,
         );
     }
 
@@ -2608,6 +2635,22 @@ impl Scopes {
     /// the main AST traversal in bindings.
     pub fn add_lvalue_to_current_static(&mut self, x: &Expr) {
         self.current_mut().stat.expr_lvalue(x);
+    }
+
+    /// Synthesize a static definition entry for `name` in the current scope if it
+    /// is missing. Used when we analyze unreachable code for IDE metadata.
+    pub fn add_synthetic_definition(&mut self, name: &Name, range: TextRange) {
+        let hashed_ref = Hashed::new(name);
+        if self.current().stat.0.get_hashed(hashed_ref).is_some() {
+            return;
+        }
+        self.current_mut().stat.upsert(
+            Hashed::new(name.clone()),
+            range,
+            StaticStyle::SingleDef(None),
+            range,
+            Reachability::Reachable,
+        );
     }
 
     /// Add a loop exit point to the current innermost loop with the current flow.
@@ -3217,6 +3260,7 @@ impl Scopes {
                                 range: TextRange::default(),
                                 style: StaticStyle::ImplicitBuiltinImport(module),
                                 last_range: TextRange::default(),
+                                reachability: Reachability::Reachable,
                             }))
                         })
                     },
@@ -3350,6 +3394,9 @@ impl ScopeTrace {
                     Key::Definition(short_identifier)
                         if short_identifier.range().contains_inclusive(position) =>
                     {
+                        definition = Some(key);
+                    }
+                    Key::Anywhere(x) if x.1.contains_inclusive(position) => {
                         definition = Some(key);
                     }
                     _ => {}

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -1295,7 +1295,8 @@ impl<'a> BindingsBuilder<'a> {
                     // always evaluates statically to `false`, so its branch is skipped below,
                     // yet the following `else` branch must still be treated as type-checking-only.
                     following_runtime_only_branch |= later_branches_are_type_checking;
-                    let new_narrow_ops = if this_branch_chosen == Some(false) {
+                    let new_narrow_ops = NarrowOps::from_expr(self, test.as_ref());
+                    if this_branch_chosen == Some(false) {
                         // Skip the body in this case - it typically means a check (e.g. a sys version,
                         // platform, or TYPE_CHECKING check) where the body is not statically analyzable.
                         // However, we still need to check for `yield`/`yield from` in the skipped
@@ -1304,11 +1305,19 @@ impl<'a> BindingsBuilder<'a> {
                         if Ast::body_contains_yield(&body) {
                             self.scopes.mark_has_yield_in_dead_code();
                         }
+                        if self.should_bind_unreachable_branches() {
+                            self.bind_narrow_ops(
+                                &new_narrow_ops,
+                                NarrowUseLocation::Span(range),
+                                &Usage::NonPinningValue(None),
+                            );
+                            self.with_error_suppression(|builder| {
+                                builder.stmts(body, parent);
+                            });
+                        }
                         self.abandon_branch();
                         continue;
-                    } else {
-                        NarrowOps::from_expr(self, test.as_ref())
-                    };
+                    }
                     if let Some(test_expr) = test {
                         // Typecheck the test condition during solving.
                         self.insert_binding(

--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -50,6 +50,27 @@ pub enum MutableCaptureKind {
     Nonlocal,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum Reachability {
+    #[default]
+    Reachable,
+    Unreachable,
+}
+
+impl Reachability {
+    pub fn combine(self, other: Self) -> Self {
+        if matches!(self, Self::Reachable) || matches!(other, Self::Reachable) {
+            Self::Reachable
+        } else {
+            Self::Unreachable
+        }
+    }
+
+    pub fn is_reachable(self) -> bool {
+        matches!(self, Self::Reachable)
+    }
+}
+
 /// How a name is defined. If a name is defined outside of this
 /// module, we additionally store the module we got it from.
 ///
@@ -114,6 +135,8 @@ pub struct Definition {
     /// True while every definition site is inside an `if __name__ == "__main__":` body.
     /// Such names resolve in-module but are not importable, so the export surface excludes them.
     pub main_guard_only: bool,
+    /// Whether this definition can run given the current configuration.
+    pub reachability: Reachability,
 }
 
 impl Definition {
@@ -124,7 +147,13 @@ impl Definition {
         }
     }
 
-    fn merge(&mut self, other: DefinitionStyle, range: TextRange, in_main_guard: bool) {
+    fn merge(
+        &mut self,
+        other: DefinitionStyle,
+        range: TextRange,
+        in_main_guard: bool,
+        reachability: Reachability,
+    ) {
         self.main_guard_only &= in_main_guard;
         // To ensure binding code cannot produce invalid lookups, we ensure that
         // `self.style` and `self.range` always match.
@@ -148,6 +177,7 @@ impl Definition {
             DefinitionStyle::MutableCapture(..) | DefinitionStyle::Delete => false,
             _ => true,
         };
+        self.reachability = self.reachability.combine(reachability);
     }
 }
 
@@ -278,6 +308,8 @@ struct DefinitionsBuilder {
     module_name: ModuleName,
     is_init: bool,
     sys_info: SysInfo,
+    include_unreachable: bool,
+    reachability: Reachability,
     inner: Definitions,
     in_main_guard: bool,
 }
@@ -327,11 +359,19 @@ fn is_overload_decorator(decorator: &Decorator) -> bool {
 }
 
 impl Definitions {
-    pub fn new(x: &[Stmt], module_name: ModuleName, is_init: bool, sys_info: SysInfo) -> Self {
+    pub fn new(
+        x: &[Stmt],
+        module_name: ModuleName,
+        is_init: bool,
+        sys_info: SysInfo,
+        include_unreachable: bool,
+    ) -> Self {
         let mut builder = DefinitionsBuilder {
             module_name,
             sys_info,
             is_init,
+            include_unreachable,
+            reachability: Reachability::Reachable,
             inner: Definitions::default(),
             in_main_guard: false,
         };
@@ -351,6 +391,7 @@ impl Definitions {
                     docstring_range: None,
                     last_range: TextRange::default(),
                     main_guard_only: false,
+                    reachability: Reachability::Reachable,
                 },
             );
         }
@@ -422,6 +463,18 @@ impl Definitions {
 }
 
 impl DefinitionsBuilder {
+    fn with_reachability<R>(
+        &mut self,
+        reachability: Reachability,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let previous = self.reachability;
+        self.reachability = reachability;
+        let result = f(self);
+        self.reachability = previous;
+        result
+    }
+
     fn stmts(&mut self, xs: &[Stmt]) {
         for x in xs {
             self.stmt(x);
@@ -439,9 +492,10 @@ impl DefinitionsBuilder {
             return;
         }
         let in_main_guard = self.in_main_guard;
+        let reachability = self.reachability;
         match self.inner.definitions.entry(x.clone()) {
             Entry::Occupied(mut e) => {
-                e.get_mut().merge(style, range, in_main_guard);
+                e.get_mut().merge(style, range, in_main_guard, reachability);
             }
             Entry::Vacant(e) => {
                 e.insert(Definition {
@@ -451,6 +505,7 @@ impl DefinitionsBuilder {
                     docstring_range: body.and_then(Docstring::range_from_stmts),
                     last_range: range,
                     main_guard_only: in_main_guard,
+                    reachability,
                 });
             }
         }
@@ -907,13 +962,28 @@ impl DefinitionsBuilder {
                 }
             }
             Stmt::If(x) => {
-                self.named_in_expr(&x.test);
-                let sys_info = self.sys_info;
-                for (test, body) in sys_info.pruned_if_branches(x) {
+                for (test, body) in Ast::if_branches(x) {
+                    if let Some(test_expr) = test {
+                        self.named_in_expr(test_expr);
+                    }
+                    let evaluation = test
+                        .map(|expr| self.sys_info.evaluate_bool(expr))
+                        .unwrap_or(Some(true));
+                    if evaluation == Some(false) && !self.include_unreachable {
+                        continue;
+                    }
+                    let branch_reachability = if evaluation == Some(false) {
+                        Reachability::Unreachable
+                    } else {
+                        Reachability::Reachable
+                    };
                     let outer = self.in_main_guard;
                     self.in_main_guard = outer || test.is_some_and(Ast::is_main_guard);
-                    self.stmts(body);
+                    self.with_reachability(branch_reachability, |builder| builder.stmts(body));
                     self.in_main_guard = outer;
+                    if evaluation == Some(true) {
+                        break; // Later branches are not evaluated in this configuration
+                    }
                 }
                 return; // We went through the relevant branches already
             }
@@ -1037,23 +1107,42 @@ mod tests {
         }
     }
 
-    fn calculate_unranged_definitions(
+    fn calculate_unranged_definitions_with_config(
         contents: &str,
         module_name: ModuleName,
         is_init: bool,
+        include_unreachable: bool,
     ) -> Definitions {
         let mut res = Definitions::new(
             &Ast::parse(contents, PySourceType::Python).0.body,
             module_name,
             is_init,
             SysInfo::default(),
+            include_unreachable,
         );
         res.dunder_all.entries.iter_mut().for_each(unrange);
         res
     }
 
+    fn calculate_unranged_definitions(
+        contents: &str,
+        module_name: ModuleName,
+        is_init: bool,
+    ) -> Definitions {
+        calculate_unranged_definitions_with_config(contents, module_name, is_init, false)
+    }
+
     fn calculate_unranged_definitions_with_defaults(contents: &str) -> Definitions {
         calculate_unranged_definitions(contents, ModuleName::from_str("main"), false)
+    }
+
+    fn calculate_unranged_definitions_with_unreachable(contents: &str) -> Definitions {
+        calculate_unranged_definitions_with_config(
+            contents,
+            ModuleName::from_str("main"),
+            false,
+            true,
+        )
     }
 
     fn assert_import_all(defs: &Definitions, expected_import_all: &[&str]) {
@@ -1084,6 +1173,40 @@ mod tests {
                 .map(|x| x.as_str())
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn test_unreachable_if_defs_respected() {
+        let contents = r#"
+if False:
+    foo: TypeIs[int]
+else:
+    bar = 1
+"#;
+        let defs = calculate_unranged_definitions_with_unreachable(contents);
+        let foo = defs.definitions.get(&Name::new("foo")).unwrap();
+        assert!(matches!(foo.reachability, Reachability::Unreachable));
+        let bar = defs.definitions.get(&Name::new("bar")).unwrap();
+        assert!(matches!(bar.reachability, Reachability::Reachable));
+
+        let defs_pruned = calculate_unranged_definitions_with_defaults(contents);
+        assert!(defs_pruned.definitions.get(&Name::new("foo")).is_none());
+        assert!(defs_pruned.definitions.get(&Name::new("bar")).is_some());
+    }
+
+    #[test]
+    fn test_unreachable_if_comparison_defs_respected() {
+        let contents = r#"
+if 1 == 0:
+    foo = 1
+
+bar = 2
+"#;
+        let defs = calculate_unranged_definitions_with_unreachable(contents);
+        assert!(defs.definitions.get(&Name::new("foo")).is_some());
+
+        let defs_pruned = calculate_unranged_definitions_with_defaults(contents);
+        assert!(defs_pruned.definitions.get(&Name::new("foo")).is_none());
     }
 
     #[test]

--- a/pyrefly/lib/export/exports.rs
+++ b/pyrefly/lib/export/exports.rs
@@ -141,6 +141,7 @@ impl Exports {
             module_info.name(),
             module_info.path().is_init(),
             sys_info,
+            false,
         );
         definitions.inject_implicit_globals();
         definitions.ensure_dunder_all(module_info.path().style());

--- a/pyrefly/lib/stubgen/extract.rs
+++ b/pyrefly/lib/stubgen/extract.rs
@@ -1110,6 +1110,7 @@ fn resolve_dunder_all(body: &[Stmt], module_info: &Module) -> Option<HashSet<Nam
         module_info.name(),
         module_info.path().is_init(),
         SysInfo::default(),
+        false,
     );
     if !matches!(defs.dunder_all.kind, DunderAllKind::Specified) {
         return None;

--- a/pyrefly/lib/test/lsp/definition.rs
+++ b/pyrefly/lib/test/lsp/definition.rs
@@ -102,11 +102,15 @@ if not TYPE_CHECKING:
 # main.py
 5 |     x = 1
         ^
-Definition Result: None
+Definition Result:
+5 |     x = 1
+        ^
 
 7 |     y = x
             ^
-Definition Result: None
+Definition Result:
+5 |     x = 1
+        ^
 "#
         .trim(),
         report.trim(),
@@ -2218,7 +2222,9 @@ if False:
 # main.py
 4 |     print(x)
               ^
-Definition Result: None
+Definition Result:
+2 | x = 5
+    ^
 
 "#
         .trim(),

--- a/pyrefly/lib/test/lsp/hover_type.rs
+++ b/pyrefly/lib/test/lsp/hover_type.rs
@@ -315,35 +315,35 @@ if False:
 # main.py
 3 |   def f():
           ^
-Hover Result: None
+Hover Result: `() -> None`
 
 7 |   x = 3
       ^
-Hover Result: None
+Hover Result: `Literal[3]`
 
 9 |   x
       ^
-Hover Result: None
+Hover Result: `Literal[3]`
 
 11 |   f
        ^
-Hover Result: None
+Hover Result: `() -> None`
 
 14 |   def f():
            ^
-Hover Result: None
+Hover Result: `() -> None`
 
 18 |   x = 3
        ^
-Hover Result: None
+Hover Result: `Literal[3]`
 
 20 |   x
        ^
-Hover Result: None
+Hover Result: `Literal[3]`
 
 22 |   f
        ^
-Hover Result: None
+Hover Result: `() -> None`
 "#
         .trim(),
         report.trim(),

--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -1451,7 +1451,6 @@ def test_2(cond: bool):
 
 // https://github.com/facebook/pyrefly/issues/2930
 testcase!(
-    bug = "del in dead code should still make the variable local, hiding the outer binding",
     test_del_in_dead_code_makes_local,
     r#"
 x = 1
@@ -1459,7 +1458,7 @@ x = 1
 def f():
     # Even though the del is in unreachable code, Python's compiler
     # still marks x as local in f's scope.
-    print(x)
+    print(x)  # E: `x` is uninitialized
     if False:
         del x
 "#,

--- a/pyrefly/lib/test/sys_info.rs
+++ b/pyrefly/lib/test/sys_info.rs
@@ -416,7 +416,7 @@ def test_and_three_guards() -> None:
 def test_or_basic() -> None:
     # `or` short-circuits when the left side is *true*. False on the left
     # means the right side IS evaluated — the name is unknown.
-    if False or A:  # E: Could not find name `A`
+    if False or D:  # E: Could not find name `D`
         pass
 
 def test_or_always_true_guard() -> None:
@@ -435,8 +435,8 @@ def test_and_body_unreachable() -> None:
         _ = A
 
 def test_no_guard_produces_error() -> None:
-    # Baseline: without any guard, accessing A must produce an error.
-    A  # E: Could not find name `A`
+    # Baseline: without any guard, accessing an unknown name must produce an error.
+    E  # E: Could not find name `E`
 "#,
 );
 


### PR DESCRIPTION
fix #1254

Added a suppression stack so binding code can execute unreachable branches without emitting type errors and exposed a helper to gate this behavior to filesystem/memory modules only, skipping `builtins/__builtins__`.

Updated the if binding logic to analyze statically false branches only when the new gate allows it, then discard their flow so control-flow facts stay unchanged while IDE features (like go-to-def) gain the needed Keys.

