### PR TITLE
Fix: Detect type errors for bare return statements (#1508)

### DIFF
--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -1046,6 +1046,7 @@ pub struct ReturnExplicit {
     pub expr: Option<Box<Expr>>,
     pub is_generator: bool,
     pub is_async: bool,
+    pub range: TextRange,
 }
 
 #[derive(Clone, Debug)]

--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -357,6 +357,7 @@ impl<'a> BindingsBuilder<'a> {
                         expr: x.value,
                         is_generator,
                         is_async,
+                        range: x.range,
                     }),
                 )
             })

--- a/pyrefly/lib/test/returns.rs
+++ b/pyrefly/lib/test/returns.rs
@@ -286,3 +286,30 @@ def f(x: str): pass
 return f(1) # E: Invalid `return` outside of a function # E: `Literal[1]` is not assignable to parameter `x` with type `str`
 "#,
 );
+
+testcase!(
+    test_bare_return_with_non_none_type,
+    r#"
+def test() -> int:
+    return  # E: Returned type `None` is not assignable to declared return type `int`
+"#,
+);
+
+testcase!(
+    test_bare_return_with_none_type,
+    r#"
+def test() -> None:
+    return  # Should work - None is assignable to None
+"#,
+);
+
+testcase!(
+    test_bare_return_in_generator,
+    r#"
+from typing import Generator
+
+def gen() -> Generator[int, None, str]:
+    yield 1
+    return  # E: Returned type `None` is not assignable to declared return type `str`
+"#,
+);


### PR DESCRIPTION
## Changes

1. Added `range` field to `ReturnExplicit` struct to track the return statement location
2. Updated `binding/function.rs` to pass the range when creating `ReturnExplicit`
3. Added type checking in `solve.rs` for bare return

## Testing
  - ✅ Added 3 new test cases in returns.rs

<img width="1738" height="2120" alt="CleanShot 2025-11-07 at 10 29 00@2x" src="https://github.com/user-attachments/assets/baae6d23-befc-42b3-8e87-22727d61a441" />


Fixes #1508