### PR TITLE
move disabledLanguageServices out of pyrefly.analysis

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -107,7 +107,7 @@
                         "verbose"
                     ]
                 },
-                "python.pyrefly.analysis.disabledLanguageServices": {
+                "python.pyrefly.disabledLanguageServices": {
                     "type": "object",
                     "default": {},
                     "description": "Disable specific language services. Set individual services to true to disable them.",

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -1971,8 +1971,7 @@ impl Server {
             }
 
             // Check if the specific service is disabled
-            if let Some(lsp_config) = workspace.lsp_analysis_config
-                && let Some(disabled_services) = lsp_config.disabled_language_services
+            if let Some(disabled_services) = workspace.disabled_language_services
                 && let Some(method) = method
                 && disabled_services.is_disabled(method)
             {

--- a/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
@@ -426,7 +426,7 @@ fn test_disable_specific_language_services_via_analysis_config() {
         error: None,
     });
 
-    // Change configuration to disable only hover (mimicking pyrefly.analysis.disabledLanguageServices)
+    // Change configuration to disable only hover (using pyrefly.disabledLanguageServices)
     interaction.server.did_change_configuration();
     interaction
         .client
@@ -436,19 +436,15 @@ fn test_disable_specific_language_services_via_analysis_config() {
         serde_json::json!([
             {
                 "pyrefly": {
-                    "analysis": {
-                        "disabledLanguageServices": {
-                            "hover": true,
-                        }
+                    "disabledLanguageServices": {
+                        "hover": true,
                     }
                 }
             },
             {
                 "pyrefly": {
-                    "analysis": {
-                        "disabledLanguageServices": {
-                            "hover": true,
-                        }
+                    "disabledLanguageServices": {
+                        "hover": true,
                     }
                 }
             }

--- a/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
@@ -60,7 +60,6 @@ fn test_inlay_hint_default_config() {
     interaction.shutdown();
 }
 
-// todo(kylei): we should honor the inlay hints analysis being disabled
 #[test]
 fn test_inlay_hint_default_and_pyrefly_analysis() {
     let root = get_test_files_root();
@@ -88,32 +87,7 @@ fn test_inlay_hint_default_and_pyrefly_analysis() {
 
     interaction.client.expect_response(Response {
         id: interaction.server.current_request_id(),
-        result: Some(serde_json::json!([
-            {
-                "label":" -> tuple[Literal[1], Literal[2]]",
-                "position":{"character":21,"line":6},
-                "textEdits":[{
-                    "newText":" -> tuple[Literal[1], Literal[2]]",
-                    "range":{"end":{"character":21,"line":6},"start":{"character":21,"line":6}}
-                }]
-            },
-            {
-                "label":": tuple[Literal[1], Literal[2]]",
-                "position":{"character":6,"line":11},
-                "textEdits":[{
-                    "newText":": tuple[Literal[1], Literal[2]]",
-                    "range":{"end":{"character":6,"line":11},"start":{"character":6,"line":11}}
-                }]
-            },
-            {
-                "label":" -> Literal[0]",
-                "position":{"character":15,"line":14},
-                "textEdits":[{
-                    "newText":" -> Literal[0]",
-                    "range":{"end":{"character":15,"line":14},"start":{"character":15,"line":14}}
-                }]
-            }
-        ])),
+        result: Some(serde_json::json!([])),
         error: None,
     });
 


### PR DESCRIPTION
Summary: disabledLanguageServices should live in pyrefly root, not pyrefly analysis. there shouldn't be a pyrefly analysis in addition to the default analysis, otherwise we have conflicting settings.

Differential Revision: D86734423


