### PR TITLE
fix Enum should be subscriptable #916

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -2031,6 +2031,26 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         )
                     }
                 }
+                Type::Type(inner) if self.is_enum_class_type(inner.as_ref()) => {
+                    let base_display_ty = Type::Type(inner.clone());
+                    let enum_value_ty = *inner;
+                    if self.is_subset_eq(
+                        &self.expr(slice, None, errors),
+                        &self.stdlib.str().clone().to_type(),
+                    ) {
+                        enum_value_ty
+                    } else {
+                        self.error(
+                            errors,
+                            slice.range(),
+                            ErrorInfo::Kind(ErrorKind::BadIndex),
+                            format!(
+                                "Enum type `{}` can only be indexed by strings",
+                                self.for_display(base_display_ty)
+                            ),
+                        )
+                    }
+                }
                 Type::Type(box Type::SpecialForm(special)) => {
                     self.apply_special_form(special, slice, range, errors)
                 }

--- a/pyrefly/lib/test/enums.rs
+++ b/pyrefly/lib/test/enums.rs
@@ -587,6 +587,32 @@ def get_labels(enum_cls: type[T_Enum]) -> list[str]:
 );
 
 testcase!(
+    test_enum_type_getitem,
+    r#"
+from enum import Enum
+from typing import TypeVar, assert_type
+
+class Color(Enum):
+    RED = "red"
+    BLUE = "blue"
+
+def accepts_base(cls: type[Enum], key: str) -> None:
+    assert_type(cls[key], Enum)
+
+def accepts_specific(cls: type[Color], key: str) -> None:
+    assert_type(cls[key], Color)
+
+T_Enum = TypeVar("T_Enum", bound=Enum)
+
+def accepts_generic(cls: type[T_Enum], key: str) -> None:
+    assert_type(cls[key], T_Enum)
+
+def bad_key(cls: type[Enum]) -> None:
+    cls[0]  # E: Enum type `type[Enum]` can only be indexed by strings
+"#,
+);
+
+testcase!(
     test_mixin_datatype,
     r#"
 from enum import Enum


### PR DESCRIPTION
fix #916

class objects typed as type[Enum] (or any enum subclass) support string subscripting just like concrete Enum

Added an is_enum_class_type guard that returns the underlying enum instance type when indexing a Type[...] value with a str, and emits the existing “Enum type … can only be indexed by strings” error for non-string keys to keep diagnostics consistent.
