### PR TITLE
fix multiple inheritance check for properties

### DIFF
--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -497,13 +497,9 @@ assert_type(x, int)
     "#,
 );
 
-// We currently treat `Callable` as not having method binding behavior. This is
-// not compatible with Pyright and mypy, both of which assume in the face of
-// ambiguity that the callable is probably a function or lambda.
-//
+// To align with mypy & pyright, ClassVar[Callable] attributes should have method binding behavior
 // See https://discuss.python.org/t/when-should-we-assume-callable-types-are-method-descriptors/92938
 testcase!(
-    bug = "We probably need to treat `f` as a method here.",
     test_callable_as_class_var,
     r#"
 from typing import assert_type, Callable, ClassVar
@@ -511,8 +507,7 @@ def get_callback() -> Callable[[object, int], int]: ...
 class C:
     f: ClassVar[Callable[[object, int], int]] = get_callback()
 assert_type(C.f(None, 1), int)
-# We probably should to be treating f as a bound method here.
-assert_type(C().f(None, 1), int)
+assert_type(C().f(1), int)
 "#,
 );
 

--- a/pyrefly/lib/test/class_subtyping.rs
+++ b/pyrefly/lib/test/class_subtyping.rs
@@ -287,8 +287,8 @@ class C(A, B): # E: Field `x` has inconsistent types inherited from multiple bas
 class D:
     x: int
 
-# Here we repeat the error on E, despite the error already being reported in C.
-class E(C, D): # E: Field `x` has inconsistent types inherited from multiple base classes
+# We do not report the error for E, since it has already been reported on C
+class E(C, D):
     pass
 "#,
 );
@@ -305,8 +305,8 @@ class C(A, B):
 class D:
     x: int
 
-# Here we still report the error on E, despite the field being overridden in C.
-class E(C, D): # E: Field `x` has inconsistent types inherited from multiple base classes
+# We do not report the error on E, since we already reported an error on C
+class E(C, D):
     pass
 "#,
 );
@@ -367,5 +367,32 @@ class Bar:
 # For read-write fields, the inherited type from each parent should be assignable to the intersection
 class Both(Foo, Bar):  # E: Field `x` is declared `float`
     ...
+"#,
+);
+
+testcase!(
+    test_multiple_inheritance_property,
+    r#"
+from typing import overload
+
+class A:
+    @property
+    def x(self, /) -> int: ...
+    @x.setter
+    def x(self, x: int, /) -> None: ...
+
+class B:
+    @property
+    def x(self, /) -> int: ...
+
+class C(A, B): ...
+
+class D:
+    @property
+    def x(self, /) -> str: ...
+    @x.setter
+    def x(self, x: str, /) -> None: ...
+
+class E(D, B): ...  # E: Field `x` has inconsistent types inherited from multiple base classes
 "#,
 );


### PR DESCRIPTION
Summary:
We can't ever use the field type directly, for read-write properties it's the setter type and read-only properties it's the getter type. We need to call the getter and check that type instead.

fixes https://github.com/facebook/pyrefly/issues/1530

Differential Revision: D86828464


