### PR TITLE
Disable project excludes heuristics when explicit config is given

### DIFF
--- a/crates/pyrefly_config/src/args.rs
+++ b/crates/pyrefly_config/src/args.rs
@@ -363,7 +363,7 @@ impl ConfigOverrideArgs {
         (ArcId::new(config), errors)
     }
 
-    pub fn excludes_heuristics_disabled(&self) -> bool {
-        self.disable_project_excludes_heuristics.unwrap_or(false)
+    pub fn disable_project_excludes_heuristics(&self) -> Option<bool> {
+        self.disable_project_excludes_heuristics
     }
 }

--- a/test/config.md
+++ b/test/config.md
@@ -346,3 +346,14 @@ $ mkdir -p $TMPDIR/disable_excludes_heuristics/.src && \
 ERROR *main.py* ?bad-assignment? (glob)
 [1]
 ```
+
+## We can still find hard-coded `project-excludes` when overridden in configs
+
+<!-- Uss the same test setup from "We can still find hard-coded `project-excludes` when overridden -->
+
+```scrut {output_stream: stdout}
+$ echo "disable-project-excludes-heuristics = true" > $TMPDIR/disable_excludes_heuristics/pyrefly.toml && \
+> $PYREFLY check $TMPDIR/disable_excludes_heuristics/.src/main.py -c $TMPDIR/disable_excludes_heuristics/pyrefly.toml --output-format=min-text
+ERROR *main.py* ?bad-assignment? (glob)
+[1]
+```


### PR DESCRIPTION
Summary: We should be able to disable project excludes when passing in `-c` with files

Differential Revision: D86925739


