### PR TITLE
Allow recursive definition in functional typed dict

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -11442,17 +11442,6 @@
       "severity": "error",
       "stop_column": 34,
       "stop_line": 60
-    },
-    {
-      "code": -2,
-      "column": 75,
-      "concise_description": "Expected a type form, got instance of `Literal['RecursiveMovie']`",
-      "description": "Expected a type form, got instance of `Literal['RecursiveMovie']`",
-      "line": 71,
-      "name": "not-a-type",
-      "severity": "error",
-      "stop_column": 91,
-      "stop_line": 71
     }
   ],
   "typeddicts_type_consistency.py": [

--- a/conformance/third_party/conformance.result
+++ b/conformance/third_party/conformance.result
@@ -325,9 +325,7 @@
   "typeddicts_readonly_inheritance.py": [],
   "typeddicts_readonly_kwargs.py": [],
   "typeddicts_readonly_update.py": [],
-  "typeddicts_required.py": [
-    "Line 71: Unexpected errors [\"Expected a type form, got instance of `Literal['RecursiveMovie']`\"]"
-  ],
+  "typeddicts_required.py": [],
   "typeddicts_type_consistency.py": [],
   "typeddicts_usage.py": []
 }

--- a/conformance/third_party/results.json
+++ b/conformance/third_party/results.json
@@ -1,9 +1,9 @@
 {
   "total": 138,
-  "pass": 100,
-  "fail": 38,
-  "pass_rate": 0.72,
-  "differences": 154,
+  "pass": 101,
+  "fail": 37,
+  "pass_rate": 0.73,
+  "differences": 153,
   "passing": [
     "aliases_explicit.py",
     "aliases_newtype.py",
@@ -103,6 +103,7 @@
     "typeddicts_readonly_inheritance.py",
     "typeddicts_readonly_kwargs.py",
     "typeddicts_readonly_update.py",
+    "typeddicts_required.py",
     "typeddicts_type_consistency.py",
     "typeddicts_usage.py"
   ],
@@ -143,8 +144,7 @@
     "qualifiers_annotated.py": 6,
     "qualifiers_final_annotation.py": 12,
     "specialtypes_never.py": 1,
-    "specialtypes_type.py": 8,
-    "typeddicts_required.py": 1
+    "specialtypes_type.py": 8
   },
   "comment": "@generated"
 }

--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -1017,7 +1017,7 @@ impl<'a> BindingsBuilder<'a> {
                     if let Some(key) = &mut item.key {
                         self.ensure_expr(key, class_object.usage());
                     }
-                    self.ensure_type(&mut item.value.clone(), &mut None);
+                    self.ensure_type(&mut item.value, &mut None);
                     match (&item.key, &item.value) {
                         (Some(Expr::StringLiteral(k)), v) => {
                             Some((k.value.to_string(), k.range(), Some(v.clone()), None))

--- a/pyrefly/lib/test/typed_dict.rs
+++ b/pyrefly/lib/test/typed_dict.rs
@@ -1803,13 +1803,13 @@ testcase!(
     test_unpack_inherited_typeddict,
     r#"
 import typing_extensions as te
-    
+
 class InheritFromMe(te.TypedDict):
     foo: bool
-    
+
 class TestBadUnpackingError(InheritFromMe):
     bar: bool
-    
+
 unpack_this: InheritFromMe = {"foo": True}
 test1: TestBadUnpackingError = {"bar": True, **unpack_this}
 test2: TestBadUnpackingError = {"bar": True, "foo": True}
@@ -1916,4 +1916,15 @@ def f(foo: Foo, k: Literal["bar", "baz"]):
     print(foo[k])
     foo[k] = 2
     "#,
+);
+
+testcase!(
+    test_recursive_functional_typeddict,
+    r#"
+from typing import NamedTuple, TypedDict, Optional
+ListNode = TypedDict('ListNode', {
+    'value': int,
+    'next': Optional['ListNode'],
+})
+"#,
 );


### PR DESCRIPTION
Consider the following snippet

```
from typing import NamedTuple, Optional, TypedDict

X = NamedTuple("X", [("x", Optional["X"])])
Y = TypedDict("Y", {"y": Optional["Y"]})
```

Pyrefly errors on the line for `TypedDict` but not for `NamedTuple`, which is reflected in conformance testsuite `typeddicts_required.py` (L71).

I've examined the code between processing a functional named tuple declaration and a functional typed dict. The only difference seems to be an extra `.clone()` for typed dict. Somehow that was the actual culprit --- removing the extraneous clone causes the error to go away!