### PR TITLE
fix [deprecated] error should show the deprecation message #1582

### DIFF
--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -327,6 +327,8 @@ pub struct FuncFlags {
     pub is_classmethod: bool,
     /// A function decorated with `@deprecated`
     pub is_deprecated: bool,
+    /// Optional explanation attached to `@deprecated`
+    pub deprecated_message: Option<String>,
     /// A function decorated with `@property`
     pub is_property_getter: bool,
     /// A function decorated with `functools.cached_property` or equivalent.

--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -1103,6 +1103,10 @@ impl Type {
         self.check_toplevel_func_metadata(&|meta| meta.flags.is_deprecated)
     }
 
+    pub fn deprecated_message(&self) -> Option<String> {
+        self.check_toplevel_func_metadata(&|meta| meta.flags.deprecated_message.clone())
+    }
+
     pub fn has_final_decoration(&self) -> bool {
         self.check_toplevel_func_metadata(&|meta| meta.flags.has_final_decoration)
     }

--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -35,6 +35,7 @@ use crate::alt::class::class_field::DescriptorBase;
 use crate::alt::unwrap::HintRef;
 use crate::binding::binding::Key;
 use crate::config::error_kind::ErrorKind;
+use crate::deprecation::format_deprecated_message;
 use crate::error::collector::ErrorCollector;
 use crate::error::context::ErrorContext;
 use crate::error::context::ErrorInfo;
@@ -339,7 +340,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     // We manually construct an error using the message from the context but a
                     // Deprecated error kind so that the error is shown at the Deprecated severity
                     // (default: WARN) rather than the severity of the context's error kind.
-                    let msg = format!("`{}` is deprecated", m.kind.format(self.module().name()));
+                    let msg = format_deprecated_message(
+                        format!("`{}` is deprecated", m.kind.format(self.module().name())),
+                        m.flags.deprecated_message.as_deref(),
+                    );
                     let full_msg = if let Some(ctx) = context {
                         vec1![ctx().format(), msg]
                     } else {

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -56,6 +56,7 @@ use crate::binding::binding::Key;
 use crate::binding::binding::KeyYield;
 use crate::binding::binding::KeyYieldFrom;
 use crate::config::error_kind::ErrorKind;
+use crate::deprecation::format_deprecated_message;
 use crate::error::collector::ErrorCollector;
 use crate::error::context::ErrorContext;
 use crate::error::context::ErrorInfo;
@@ -247,7 +248,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 errors,
                 range,
                 ErrorInfo::Kind(ErrorKind::Deprecated),
-                format!("`{deprecated_function}` is deprecated"),
+                format_deprecated_message(
+                    format!("`{deprecated_function}` is deprecated"),
+                    ty.deprecated_message().as_deref(),
+                ),
             );
         }
     }

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -32,6 +32,7 @@ use crate::alt::callable::CallWithTypes;
 use crate::alt::expr::TypeOrExpr;
 use crate::alt::unwrap::HintRef;
 use crate::config::error_kind::ErrorKind;
+use crate::deprecation::format_deprecated_message;
 use crate::error::collector::ErrorCollector;
 use crate::error::context::ErrorContext;
 use crate::error::context::ErrorInfo;
@@ -320,10 +321,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if matched {
             // If the selected overload is deprecated, we log a deprecation error.
             if closest_overload.func.1.metadata.flags.is_deprecated {
-                self.error(
-                    errors,
-                    range,
-                    ErrorInfo::new(ErrorKind::Deprecated, context),
+                let msg = format_deprecated_message(
                     format!(
                         "Call to deprecated overload `{}`",
                         closest_overload
@@ -333,6 +331,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             .kind
                             .format(self.module().name())
                     ),
+                    closest_overload
+                        .func
+                        .1
+                        .metadata
+                        .flags
+                        .deprecated_message
+                        .as_deref(),
+                );
+                self.error(
+                    errors,
+                    range,
+                    ErrorInfo::new(ErrorKind::Deprecated, context),
+                    msg,
                 );
             }
             (closest_overload.res, closest_overload.func.1.signature)

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -285,6 +285,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             is_new_type,
             pydantic_config_dict,
             django_primary_key_field,
+            deprecated,
         } = binding;
         let metadata = match &self.get_idx(*k).0 {
             None => ClassMetadata::recursive(),
@@ -296,6 +297,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 *is_new_type,
                 pydantic_config_dict,
                 django_primary_key_field.as_ref(),
+                deprecated.as_ref(),
                 errors,
             ),
         };
@@ -3494,6 +3496,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             &x.decorators,
             &x.legacy_tparams,
             x.module_style,
+            x.deprecated.as_ref(),
             errors,
         )
     }

--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -54,6 +54,7 @@ pub struct ClassMetadata {
     is_new_type: bool,
     is_final: bool,
     is_deprecated: bool,
+    deprecated_message: Option<String>,
     is_disjoint_base: bool,
     total_ordering_metadata: Option<TotalOrderingMetadata>,
     /// If this class is decorated with `typing.dataclass_transform(...)`, the keyword arguments
@@ -97,6 +98,7 @@ impl ClassMetadata {
         dataclass_transform_metadata: Option<DataclassTransformKeywords>,
         pydantic_model_kind: Option<PydanticModelKind>,
         django_model_metadata: Option<DjangoModelMetadata>,
+        deprecated_message: Option<String>,
     ) -> ClassMetadata {
         ClassMetadata {
             metaclass,
@@ -113,6 +115,7 @@ impl ClassMetadata {
             is_new_type,
             is_final,
             is_deprecated,
+            deprecated_message,
             is_disjoint_base,
             total_ordering_metadata,
             dataclass_transform_metadata,
@@ -137,6 +140,7 @@ impl ClassMetadata {
             is_new_type: false,
             is_final: false,
             is_deprecated: false,
+            deprecated_message: None,
             is_disjoint_base: false,
             total_ordering_metadata: None,
             dataclass_transform_metadata: None,
@@ -208,6 +212,10 @@ impl ClassMetadata {
 
     pub fn is_deprecated(&self) -> bool {
         self.is_deprecated
+    }
+
+    pub fn deprecated_message(&self) -> Option<&str> {
+        self.deprecated_message.as_deref()
     }
 
     pub fn is_disjoint_base(&self) -> bool {

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -61,6 +61,7 @@ use crate::binding::base_class::BaseClassGeneric;
 use crate::binding::bindings::Bindings;
 use crate::binding::narrow::NarrowOp;
 use crate::binding::pydantic::PydanticConfigDict;
+use crate::deprecation::DeprecatedDecoration;
 use crate::export::special::SpecialExport;
 use crate::graph::index::Idx;
 use crate::module::module_info::ModuleInfo;
@@ -103,7 +104,7 @@ assert_words!(BindingAnnotation, 15);
 assert_words!(BindingClass, 23);
 assert_words!(BindingTParams, 10);
 assert_words!(BindingClassBaseType, 3);
-assert_words!(BindingClassMetadata, 11);
+assert_words!(BindingClassMetadata, 14);
 assert_bytes!(BindingClassMro, 4);
 assert_bytes!(BindingAbstractClassCheck, 4);
 assert_words!(BindingClassField, 21);
@@ -112,7 +113,7 @@ assert_bytes!(BindingLegacyTypeParam, 16);
 assert_words!(BindingYield, 4);
 assert_words!(BindingYieldFrom, 4);
 assert_bytes!(BindingDecoratedFunction, 20);
-assert_words!(BindingUndecoratedFunction, 21);
+assert_words!(BindingUndecoratedFunction, 24);
 
 #[derive(Clone, Dupe, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AnyIdx {
@@ -1044,6 +1045,7 @@ pub struct BindingUndecoratedFunction {
     pub legacy_tparams: Box<[Idx<KeyLegacyTypeParam>]>,
     pub decorators: Box<[(Idx<Key>, TextRange)]>,
     pub module_style: ModuleStyle,
+    pub deprecated: Option<DeprecatedDecoration>,
 }
 
 impl DisplayWith<Bindings> for BindingUndecoratedFunction {
@@ -2085,6 +2087,7 @@ pub struct BindingClassMetadata {
     /// The name of the field that has primary_key=True, if any (for Django models).
     /// Note that we calculate this field for all classes, but it is ignored unless the class is a django model.
     pub django_primary_key_field: Option<Name>,
+    pub deprecated: Option<DeprecatedDecoration>,
 }
 
 impl DisplayWith<Bindings> for BindingClassMetadata {

--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -61,6 +61,8 @@ use crate::binding::scope::Scope;
 use crate::binding::scope::UnusedParameter;
 use crate::binding::scope::YieldsAndReturns;
 use crate::config::base::UntypedDefBehavior;
+use crate::deprecation::DeprecatedDecoration;
+use crate::deprecation::parse_deprecated_decorator;
 use crate::export::special::SpecialExport;
 use crate::graph::index::Idx;
 use crate::types::types::Type;
@@ -72,6 +74,7 @@ struct Decorators {
     is_override: bool,
     is_classmethod: bool,
     decorators: Box<[(Idx<Key>, TextRange)]>,
+    deprecated: Option<DeprecatedDecoration>,
 }
 
 pub struct SelfAssignments {
@@ -459,6 +462,7 @@ impl<'a> BindingsBuilder<'a> {
         let mut has_no_type_check = false;
         let mut is_abstract_method = false;
         let mut is_classmethod = false;
+        let mut deprecated = None;
         for d in &decorator_list {
             let special_export = self.as_special_export(&d.expression);
             is_overload = is_overload || matches!(special_export, Some(SpecialExport::Overload));
@@ -475,6 +479,9 @@ impl<'a> BindingsBuilder<'a> {
                     special_export,
                     Some(SpecialExport::ClassMethod | SpecialExport::AbstractClassMethod)
                 );
+            if deprecated.is_none() {
+                deprecated = parse_deprecated_decorator(d);
+            }
         }
         let decorators = self
             .ensure_and_bind_decorators(decorator_list, usage)
@@ -486,6 +493,7 @@ impl<'a> BindingsBuilder<'a> {
             is_override,
             is_classmethod,
             decorators,
+            deprecated,
         }
     }
 
@@ -705,6 +713,7 @@ impl<'a> BindingsBuilder<'a> {
                 decorators: decorators.decorators,
                 legacy_tparams: legacy_tparams.into_boxed_slice(),
                 module_style: self.module_info.path().style(),
+                deprecated: decorators.deprecated,
             },
         );
 

--- a/pyrefly/lib/deprecation.rs
+++ b/pyrefly/lib/deprecation.rs
@@ -1,0 +1,99 @@
+use ruff_python_ast::Decorator;
+use ruff_python_ast::Expr;
+use ruff_python_ast::ExprAttribute;
+use ruff_python_ast::ExprCall;
+use ruff_python_ast::ExprName;
+use ruff_python_ast::ExprStringLiteral;
+
+/// Metadata extracted from a `@deprecated` decorator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeprecatedDecoration {
+    pub message: Option<String>,
+}
+
+impl DeprecatedDecoration {
+    pub fn new(message: Option<String>) -> Self {
+        Self { message }
+    }
+}
+
+fn attribute_to_name(expr: &ExprAttribute) -> Option<String> {
+    let mut parts = Vec::new();
+    let mut current = expr;
+    loop {
+        parts.push(current.attr.to_string());
+        match &*current.value {
+            Expr::Name(ExprName { id, .. }) => {
+                parts.push(id.to_string());
+                break;
+            }
+            Expr::Attribute(inner) => {
+                current = inner;
+            }
+            _ => return None,
+        }
+    }
+    parts.reverse();
+    Some(parts.join("."))
+}
+
+fn decorator_name(expr: &Expr) -> Option<String> {
+    if let Some(name) = expr.as_name_expr() {
+        Some(name.id.to_string())
+    } else if let Some(attr) = expr.as_attribute_expr() {
+        attribute_to_name(attr)
+    } else {
+        None
+    }
+}
+
+fn is_deprecated_target(name: &str) -> bool {
+    matches!(
+        name,
+        "deprecated" | "warnings.deprecated" | "typing_extensions.deprecated"
+    )
+}
+
+fn extract_message(call: &ExprCall) -> Option<String> {
+    if let Some(arg) = call.arguments.args.first() {
+        if let Expr::StringLiteral(ExprStringLiteral { value, .. }) = arg {
+            return Some(value.to_string());
+        }
+    }
+    for kw in &call.arguments.keywords {
+        if let Some(keyword) = &kw.arg
+            && keyword == "msg"
+            && let Expr::StringLiteral(ExprStringLiteral { value, .. }) = &kw.value
+        {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+/// Parse a decorator and return its deprecation metadata if it represents `@deprecated`.
+pub fn parse_deprecated_decorator(decorator: &Decorator) -> Option<DeprecatedDecoration> {
+    let call = decorator.expression.as_call_expr()?;
+    let func_name = decorator_name(&call.func)?;
+    if !is_deprecated_target(&func_name) {
+        return None;
+    }
+    Some(DeprecatedDecoration::new(extract_message(call)))
+}
+
+/// Format a base description (`"`foo` is deprecated"`) with an optional detail message.
+pub fn format_deprecated_message(base: impl Into<String>, message: Option<&str>) -> String {
+    let base = base.into();
+    match message.map(str::trim).filter(|msg| !msg.is_empty()) {
+        Some(msg) => format!("{base}: {msg}"),
+        None => base,
+    }
+}
+
+/// Format a base description using metadata from a parsed decorator.
+pub fn format_deprecated_with_decoration(
+    base: impl Into<String>,
+    decoration: Option<&DeprecatedDecoration>,
+) -> String {
+    format_deprecated_message(base, decoration.and_then(|d| d.message.as_deref()))
+}

--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -33,6 +33,8 @@ use starlark_map::small_map::Entry;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 
+use crate::deprecation::DeprecatedDecoration;
+use crate::deprecation::parse_deprecated_decorator;
 use crate::export::special::SpecialExport;
 use crate::types::globals::ImplicitGlobal;
 
@@ -136,7 +138,7 @@ pub struct Definitions {
     /// files.
     pub implicitly_imported_submodules: SmallSet<Name>,
     /// Deprecated names that are defined in this module.
-    pub deprecated: SmallSet<Name>,
+    pub deprecated: SmallMap<Name, DeprecatedDecoration>,
     /// Special exports defined in this module
     pub special_exports: SmallMap<Name, SpecialExport>,
 }
@@ -201,16 +203,6 @@ fn implicitly_imported_submodule(
         .strip_prefix(importing_module_name.components().as_slice())
         .and_then(|components| components.first())
         .cloned()
-}
-
-fn is_deprecated_decorator(decorator: &Decorator) -> bool {
-    decorator.expression.as_call_expr().is_some_and(|x| {
-        x.func.as_name_expr().is_some_and(|x| {
-            x.id == "deprecated"
-                || x.id == "warnings.deprecated"
-                || x.id == "typing_extensions.deprecated"
-        })
-    })
 }
 
 fn is_overload_decorator(decorator: &Decorator) -> bool {
@@ -440,13 +432,9 @@ impl<'a> DefinitionsBuilder<'a> {
                 decorator_list,
                 ..
             }) => {
-                // If the class is decorated with `@deprecated`, we mark it as deprecated.
-                let mut is_deprecated = false;
-                for d in decorator_list {
-                    is_deprecated = is_deprecated || is_deprecated_decorator(d);
-                }
-                if is_deprecated {
-                    self.inner.deprecated.insert(name.id.clone());
+                if let Some(decoration) = decorator_list.iter().find_map(parse_deprecated_decorator)
+                {
+                    self.inner.deprecated.insert(name.id.clone(), decoration);
                 }
                 self.add_identifier_with_body(
                     name,
@@ -576,15 +564,19 @@ impl<'a> DefinitionsBuilder<'a> {
                 ..
             }) => {
                 let mut is_overload = false;
-                let mut is_deprecated = false;
+                let mut deprecated_decoration = None;
                 for d in decorator_list {
                     is_overload = is_overload || is_overload_decorator(d);
-                    is_deprecated = is_deprecated || is_deprecated_decorator(d);
+                    if deprecated_decoration.is_none() {
+                        deprecated_decoration = parse_deprecated_decorator(d);
+                    }
                 }
                 // If the function is not an overload and decorated with
                 // `@deprecated`, we mark it as deprecated.
-                if is_deprecated && !is_overload {
-                    self.inner.deprecated.insert(name.id.clone());
+                if deprecated_decoration.is_some() && !is_overload {
+                    self.inner
+                        .deprecated
+                        .insert(name.id.clone(), deprecated_decoration.unwrap());
                 }
                 self.add_identifier_with_body(
                     name,

--- a/pyrefly/lib/lib.rs
+++ b/pyrefly/lib/lib.rs
@@ -33,6 +33,7 @@ mod binding;
 #[cfg(not(target_arch = "wasm32"))]
 mod commands;
 mod compat;
+mod deprecation;
 mod error;
 mod export;
 mod graph;

--- a/pyrefly/lib/report/binding_memory.rs
+++ b/pyrefly/lib/report/binding_memory.rs
@@ -166,6 +166,7 @@ mod tests {
             is_new_type: false,
             pydantic_config_dict: PydanticConfigDict::default(),
             django_primary_key_field: None,
+            deprecated: None,
         };
         assert_eq!(
             ReportKey::new(module, &v),

--- a/pyrefly/lib/state/ide.rs
+++ b/pyrefly/lib/state/ide.rs
@@ -155,6 +155,7 @@ fn create_intermediate_definition_from(
                     symbol_kind: Some(symbol_kind),
                     docstring_range: func.docstring_range,
                     is_deprecated: false,
+                    deprecation: None,
                     special_export: None,
                 }));
             }
@@ -166,6 +167,7 @@ fn create_intermediate_definition_from(
                             symbol_kind: Some(SymbolKind::Class),
                             docstring_range: None,
                             is_deprecated: false,
+                            deprecation: None,
                             special_export: None,
                         }))
                     }
@@ -178,6 +180,7 @@ fn create_intermediate_definition_from(
                         symbol_kind: Some(SymbolKind::Class),
                         docstring_range: *docstring_range,
                         is_deprecated: false,
+                        deprecation: None,
                         special_export: None,
                     })),
                 };
@@ -188,6 +191,7 @@ fn create_intermediate_definition_from(
                     symbol_kind: current_binding.symbol_kind(),
                     docstring_range: None,
                     is_deprecated: false,
+                    deprecation: None,
                     special_export: None,
                 }));
             }

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -1172,6 +1172,7 @@ impl<'a> Transaction<'a> {
                         symbol_kind: Some(SymbolKind::Module),
                         docstring_range,
                         is_deprecated: false,
+                        deprecation: None,
                         special_export: None,
                     },
                 ))

--- a/pyrefly/lib/test/calls.rs
+++ b/pyrefly/lib/test/calls.rs
@@ -93,7 +93,7 @@ testcase!(
 from warnings import deprecated
 @deprecated("function is deprecated")
 def old_function() -> None: ...
-old_function()  # E: `old_function` is deprecated
+old_function()  # E: `old_function` is deprecated: function is deprecated
     "#,
 );
 
@@ -112,7 +112,7 @@ testcase!(
 from typing_extensions import deprecated
 @deprecated("function is deprecated")
 def old_function() -> None: ...
-old_function()  # E: `old_function` is deprecated
+old_function()  # E: `old_function` is deprecated: function is deprecated
     "#,
 );
 
@@ -125,7 +125,7 @@ from warnings import deprecated
 def old_function() -> None: ...
 
 def take_callable(f: Callable) -> None: ...
-take_callable(old_function)  # E: `old_function` is deprecated
+take_callable(old_function)  # E: `old_function` is deprecated: function is deprecated
     "#,
 );
 
@@ -138,7 +138,7 @@ class C:
     def old_function(self) -> None: ...
 
 c = C()
-c.old_function()  # E: `C.old_function` is deprecated
+c.old_function()  # E: `C.old_function` is deprecated: function is deprecated
     "#,
 );
 
@@ -156,7 +156,7 @@ def f(x: str) -> str: ...
 def f(x: int | str) -> int | str:
     return x
 
-f(0)  # E: `f` is deprecated
+f(0)  # E: `f` is deprecated: DEPRECATED
     "#,
 );
 
@@ -174,7 +174,7 @@ def f(x: str) -> str: ...
 def f(x: int | str) -> int | str:
     return x
 
-f(0)  # E: Call to deprecated overload `f`
+f(0)  # E: Call to deprecated overload `f`: DEPRECATED
 f("foo") # No error
     "#,
 );
@@ -191,7 +191,7 @@ def f(x: int) -> int: ...  # E: Overloaded function must have an implementation
 @overload
 def f(x: str) -> str: ...
 
-f(0)  # E: Call to deprecated overload `f`
+f(0)  # E: Call to deprecated overload `f`: DEPRECATED
 f("foo") # No error
     "#,
 );

--- a/pyrefly/lib/test/constructors.rs
+++ b/pyrefly/lib/test/constructors.rs
@@ -557,6 +557,6 @@ class A:
         return super().__new__(cls)
     def __init__(self, x: str):
         pass
-A(0) # E: `A.__new__` is deprecated # E: `Literal[0]` is not assignable to parameter `x` with type `str`
+A(0) # E: `A.__new__` is deprecated: old old old # E: `Literal[0]` is not assignable to parameter `x` with type `str`
     "#,
 );

--- a/pyrefly/lib/test/decorators.rs
+++ b/pyrefly/lib/test/decorators.rs
@@ -209,7 +209,7 @@ testcase!(
     test_invalid_top_level_function_decorators,
     r#"
 from typing import *
-from abc import abstractstaticmethod, abstractmethod # E: `abstractstaticmethod` is deprecated
+from abc import abstractstaticmethod, abstractmethod # E: `abstractstaticmethod` is deprecated: Deprecated since Python 3.3. Use `@staticmethod` stacked on top of `@abstractmethod` instead.
 from enum import member, nonmember
 
 @member  # E: can only be used on methods

--- a/pyrefly/lib/test/descriptors.rs
+++ b/pyrefly/lib/test/descriptors.rs
@@ -105,7 +105,7 @@ testcase!(
     test_abstract_property,
     r#"
 from typing import assert_type
-from abc import ABC, abstractproperty # E: `abstractproperty` is deprecated
+from abc import ABC, abstractproperty # E: `abstractproperty` is deprecated: Deprecated since Python 3.3. Use `@property` stacked on top of `@abstractmethod` instead.
 class C(ABC):
     @abstractproperty
     def foo(self) -> int:

--- a/pyrefly/lib/test/imports.rs
+++ b/pyrefly/lib/test/imports.rs
@@ -828,7 +828,7 @@ testcase!(
     test_import_deprecated_class_warn,
     env_class_x_deprecated(),
     r#"
-from foo import X # E: `X` is deprecated
+from foo import X # E: `X` is deprecated: Don't use this
 
 x = X()
 "#,
@@ -838,7 +838,7 @@ testcase!(
     test_import_star_deprecated_class_warn,
     env_class_x_deprecated(),
     r#"
-from foo import * # E: `X` is deprecated
+from foo import * # E: `X` is deprecated: Don't use this
 
 x = X()
 "#,
@@ -859,9 +859,9 @@ testcase!(
     test_import_deprecated_func_warn,
     env_func_x_deprecated(),
     r#"
-from foo import x # E: `x` is deprecated
+from foo import x # E: `x` is deprecated: Don't use this
 
-x()  # E: `foo.x` is deprecated
+x()  # E: `foo.x` is deprecated: Don't use this
 "#,
 );
 
@@ -869,9 +869,9 @@ testcase!(
     test_import_as_deprecated_func_warn,
     env_func_x_deprecated(),
     r#"
-from foo import x as y # E: `x` is deprecated
+from foo import x as y # E: `x` is deprecated: Don't use this
 
-y()  # E: `foo.x` is deprecated
+y()  # E: `foo.x` is deprecated: Don't use this
 "#,
 );
 
@@ -879,9 +879,9 @@ testcase!(
     test_import_star_deprecated_func_warn,
     env_func_x_deprecated(),
     r#"
-from foo import * # E: `x` is deprecated
+from foo import * # E: `x` is deprecated: Don't use this
 
-x()  # E: `foo.x` is deprecated
+x()  # E: `foo.x` is deprecated: Don't use this
 "#,
 );
 
@@ -921,9 +921,9 @@ testcase!(
     test_import_conditionally_deprecated_func_warn,
     env_func_x_deprecated_conditionally(),
     r#"
-from foo import x # E: `x` is deprecated
+from foo import x # E: `x` is deprecated: Don't use this
 
-x()  # E: `foo.x` is deprecated
+x()  # E: `foo.x` is deprecated: Don't use this
 "#,
 );
 

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -604,7 +604,7 @@ class A:
 class B:
     def __radd__(self, other) -> Self:
         return self
-assert_type(A() + B(), A)  # E: `A.__add__` is deprecated
+assert_type(A() + B(), A)  # E: `A.__add__` is deprecated: Super deprecated
     "#,
 );
 

--- a/test/errors.md
+++ b/test/errors.md
@@ -23,12 +23,12 @@ $ echo "x: str = 12" > $TMPDIR/shown1.py && \
 > echo "import shown1; y: int = shown1.x" > $TMPDIR/shown2.py && \
 > $PYREFLY check --python-version 3.13.0 $TMPDIR/shown2.py --check-all --output-format=min-text
 */shown*.py:1:* (glob)
- WARN ast.pyi:1113:10-11: `Constant.n` is deprecated [deprecated]
- WARN ast.pyi:1113:10-18: `Constant.n` is deprecated [deprecated]
- WARN ast.pyi:1123:10-11: `Constant.s` is deprecated [deprecated]
- WARN ast.pyi:1123:10-18: `Constant.s` is deprecated [deprecated]
- WARN importlib/_bootstrap_external.pyi:1:40-41: `WindowsRegistryFinder` is deprecated [deprecated]
- WARN importlib/resources/__init__.pyi:51:9-29: `contents` is deprecated [deprecated]
+ WARN ast.pyi:1113:10-11: `Constant.n` is deprecated: Removed in Python 3.14. Use `value` instead. [deprecated]
+ WARN ast.pyi:1113:10-18: `Constant.n` is deprecated: Removed in Python 3.14. Use `value` instead. [deprecated]
+ WARN ast.pyi:1123:10-11: `Constant.s` is deprecated: Removed in Python 3.14. Use `value` instead. [deprecated]
+ WARN ast.pyi:1123:10-18: `Constant.s` is deprecated: Removed in Python 3.14. Use `value` instead. [deprecated]
+ WARN importlib/_bootstrap_external.pyi:1:40-41: `WindowsRegistryFinder` is deprecated: Deprecated since Python 3.6. Use site configuration instead. Future versions of Python may not enable this finder by default. [deprecated]
+ WARN importlib/resources/__init__.pyi:51:9-29: `contents` is deprecated: Deprecated since Python 3.11. Use `files(anchor).iterdir()`. [deprecated]
 */shown*.py:1:* (glob)
 [1]
 ```


### PR DESCRIPTION
fix #1582

Added a shared helper that parses `@deprecated` decorators (including attribute forms), captures the optional message, and exposes formatting utilities. Wired this through exports, so Export now carries structured.

DeprecatedDecoration data, and all binding/LSP/state code that synthesizes Export instances were updated accordingly.

Function/class metadata now stores deprecation messages, so solver diagnostics, overload checks, attribute completions, etc., emit “foo is deprecated: <reason>” when provided.

Binding structures and type flags were extended so decorated definitions retain the message through compilation phases; BindingClassMetadata also tracks class-level deprecations.

