### PR TITLE
fix: expect correct response uri

### DIFF
--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_definition.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_definition.rs
@@ -27,12 +27,12 @@ fn test_notebook_definition_import() {
     // Jump to definition of "List"
     interaction.definition_cell("notebook.ipynb", "cell1", 0, 20);
 
-    // Check that the response uri ends with "typing.py"
+    // Check that the response uri ends with "typing.pyi"
     interaction.client.expect_response_with(
         |response| {
             response.result.as_ref().is_some_and(|r| {
                 r.get("uri")
-                    .is_some_and(|uri| uri.as_str().is_some_and(|x| x.ends_with("typing.py")))
+                    .is_some_and(|uri| uri.as_str().is_some_and(|x| x.ends_with("typing.pyi")))
             })
         },
         "expected definition in typing.pyi",


### PR DESCRIPTION
Noticed a little inconsistency:
- `typing.py` in this section and the comment above it: <https://github.com/facebook/pyrefly/blob/bd1ad924/pyrefly/lib/test/lsp/lsp_interaction/notebook_definition.rs#L35>
- `typing.pyi` mentioned in the error message here: <https://github.com/facebook/pyrefly/blob/bd1ad924/pyrefly/lib/test/lsp/lsp_interaction/notebook_definition.rs#L38>

`py` fails the test but `pyi` succeeds, so I'm assuming the error message has the correct filename.

I do notice a `typing.pyi` here, which I assume is what's being expected: <https://github.com/facebook/pyrefly/blob/bd1ad924/crates/pyrefly_bundled/third_party/typeshed/stdlib/typing.pyi>

<details><summary>Failure logs:</summary>

```
failures:

---- test::lsp::lsp_interaction::notebook_definition::test_notebook_definition_import stdout ----
client--->server {"id":1,"method":"initialize","params":{"capabilities":{"textDocument":{"publishDiagnostics":{"codeDescriptionSupport":true,"dataSupport":true,"relatedInformation":true,"tagSupport":{"valueSet":[1,2]},"versionSupport":false}},"workspace":{"configuration":true}},"clientInfo":{"name":"debug"},"processId":24374,"rootPath":"/","trace":"verbose"}}
client<---server {"id":1,"result":{"capabilities":{"codeActionProvider":{"codeActionKinds":["quickfix"]},"completionProvider":{"triggerCharacters":["."]},"declarationProvider":true,"definitionProvider":true,"documentHighlightProvider":true,"documentSymbolProvider":true,"foldingRangeProvider":true,"hoverProvider":true,"implementationProvider":true,"inlayHintProvider":true,"notebookDocumentSync":{"notebookSelector":[{"cells":[{"language":"python"}]}]},"positionEncoding":"utf-16","signatureHelpProvider":{"triggerCharacters":["(",","]},"textDocumentSync":2,"typeDefinitionProvider":true,"workspace":{"fileOperations":{"willRename":{"filters":[{"pattern":{"glob":"**/*.{py,pyi}","matches":"file"},"scheme":"file"}]}},"workspaceFolders":{"changeNotifications":true,"supported":true}},"workspaceSymbolProvider":true},"serverInfo":{"name":"pyrefly-lsp","version":"pyrefly-lsp-test-version"}}}
client--->server {"method":"initialized","params":{}}
 INFO Reading messages
DEBUG Running with 3 threads (5 MiB stack size)
client<---server {"id":1,"method":"workspace/configuration","params":{"items":[{"section":"python"}]}}
client--->server {"id":1}
client--->server {"method":"notebookDocument/didOpen","params":{"cellTextDocuments":[{"languageId":"python","text":"from typing import List","uri":"vscode-notebook-cell:///private/tmp/nix-build-pyrefly-0.42.1.drv-0/pyrefly_lsp_testxydDFn/notebook.ipynb#cell1","version":1}],"notebookDocument":{"cells":[{"document":"vscode-notebook-cell:///private/tmp/nix-build-pyrefly-0.42.1.drv-0/pyrefly_lsp_testxydDFn/notebook.ipynb#cell1","kind":2}],"metadata":{"language_info":{"name":"python"}},"notebookType":"jupyter-notebook","uri":"file:///private/tmp/nix-build-pyrefly-0.42.1.drv-0/pyrefly_lsp_testxydDFn/notebook.ipynb","version":1}}}
 INFO Language server processed event `LspResponse` in 0.00s (0.00s waiting)
 INFO File /private/tmp/nix-build-pyrefly-0.42.1.drv-0/pyrefly_lsp_testxydDFn/notebook.ipynb opened, prepare to validate open files.
 WARN While finding Python interpreter: Python environment (version, platform, or site-package-path) has value unset, but no Python interpreter could be found to query for values. Falling back to Pyrefly defaults for missing values.
DEBUG Running epoch 1 of run 0
client--->server {"id":2,"method":"textDocument/definition","params":{"position":{"character":20,"line":0},"textDocument":{"uri":"vscode-notebook-cell:///private/tmp/nix-build-pyrefly-0.42.1.drv-0/pyrefly_lsp_testxydDFn/notebook.ipynb#cell1"}}}
 WARN While finding Python interpreter: Python environment (version, platform, or site-package-path) has value unset, but no Python interpreter could be found to query for values. Falling back to Pyrefly defaults for missing values.
 INFO Validated open files and saved non-committable transaction.
DEBUG Enqueued task on sourcedb_queue heavy task queue
 INFO Language server processed event `DidOpenNotebookDocument` in 0.06s (0.00s waiting)
DEBUG Dequeued task on sourcedb_queue heavy task queue
 INFO Handling non-canceled request textDocument/definition (2)
client<---server {"method":"textDocument/publishDiagnostics","params":{"diagnostics":[],"uri":"vscode-notebook-cell:///private/tmp/nix-build-pyrefly-0.42.1.drv-0/pyrefly_lsp_testxydDFn/notebook.ipynb#cell1"}}
 INFO Ran task on sourcedb_queue heavy task queue. Queue time: 0.00, task time: 0.00
 INFO Language server processed event `LspRequest(textDocument/definition)` in 0.00s (0.06s waiting)
client<---server {"id":2,"result":{"range":{"end":{"character":4,"line":444},"start":{"character":0,"line":444}},"uri":"file:///private/tmp/nix-build-pyrefly-0.42.1.drv-0/pyrefly_bundled_typeshed/typing.pyi"}}

thread 'test::lsp::lsp_interaction::notebook_definition::test_notebook_definition_import' panicked at pyrefly/lib/test/lsp/lsp_interaction/object_model.rs:555:29:
Message validation failed: expected definition in typing.pyi. Message: Response(Response { id: RequestId(I32(2)), result: Some(Object {"range": Object {"end": Object {"character": Number(4), "line": Number(444)}, "start": Object {"character": Number(0), "line": Number(444)}}, "uri": String("file:///private/tmp/nix-build-pyrefly-0.42.1.drv-0/pyrefly_bundled_typeshed/typing.pyi")}), error: None })
 INFO waiting for connection to close


failures:
    test::lsp::lsp_interaction::notebook_definition::test_notebook_definition_import

test result: FAILED(B. 2783 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 25.78s

error: test failed, to rerun pass `--lib`
error: builder for '/nix/store/w1jy7s5l93m3m5qk20vizz793xmwasfc-pyrefly-0.42.1.drv' failed with exit code 101;
       last 25 log lines:
       >  WARN While finding Python interpreter: Python environment (version, platform, or site-package-path) has value unset, but no Python interpreter could be found to query for values. Falling back to Pyrefly defaults for missing values.
       > DEBUG Running epoch 1 of run 0
       > client--->server {"id":2,"method":"textDocument/definition","params":{"position":{"character":20,"line":0},"textDocument":{"uri":"vscode-notebook-cell:///private/tmp/nix-build-pyrefly-0.42.1.drv-0/pyrefly_lsp_testxydDFn/notebook.ipynb#cell1"}}}
       >  WARN While finding Python interpreter: Python environment (version, platform, or site-package-path) has value unset, but no Python interpreter could be found to query for values. Falling back to Pyrefly defaults for missing values.
       >  INFO Validated open files and saved non-committable transaction.
       > DEBUG Enqueued task on sourcedb_queue heavy task queue
       >  INFO Language server processed event `DidOpenNotebookDocument` in 0.06s (0.00s waiting)
       > DEBUG Dequeued task on sourcedb_queue heavy task queue
       >  INFO Handling non-canceled request textDocument/definition (2)
       > client<---server {"method":"textDocument/publishDiagnostics","params":{"diagnostics":[],"uri":"vscode-notebook-cell:///private/tmp/nix-build-pyrefly-0.42.1.drv-0/pyrefly_lsp_testxydDFn/notebook.ipynb#cell1"}}
       >  INFO Ran task on sourcedb_queue heavy task queue. Queue time: 0.00, task time: 0.00
       >  INFO Language server processed event `LspRequest(textDocument/definition)` in 0.00s (0.06s waiting)
       > client<---server {"id":2,"result":{"range":{"end":{"character":4,"line":444},"start":{"character":0,"line":444}},"uri":"file:///private/tmp/nix-build-pyrefly-0.42.1.drv-0/pyrefly_bundled_typeshed/typing.pyi"}}
       >
       > thread 'test::lsp::lsp_interaction::notebook_definition::test_notebook_definition_import' panicked at pyrefly/lib/test/lsp/lsp_interaction/object_model.rs:555:29:
       > Message validation failed: expected definition in typing.pyi. Message: Response(Response { id: RequestId(I32(2)), result: Some(Object {"range": Object {"end": Object {"character": Number(4), "line": Number(444)}, "start": Object {"character": Number(0), "line": Number(444)}}, "uri": String("file:///private/tmp/nix-build-pyrefly-0.42.1.drv-0/pyrefly_bundled_typeshed/typing.pyi")}), error: None })
       >  INFO waiting for connection to close
       >
       >
       > failures:
       >     test::lsp::lsp_interaction::notebook_definition::test_notebook_definition_import
       >
       > test result: FAILED(B. 2783 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 25.78s
       >
       > error: test failed, to rerun pass `--lib`
```

</details>