### PR TITLE
update the documentSelector to apply to `inmemory` python documents

### DIFF
--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -264,6 +264,8 @@ export async function activate(context: ExtensionContext) {
       {scheme: 'untitled', language: 'python'},
       // Support for notebook cells
       {scheme: 'vscode-notebook-cell', language: 'python'},
+      // Support for in-memory documents like the Positron Console
+      {scheme: 'inmemory', language: 'python'},
     ],
     // Support for notebooks
     // @ts-ignore


### PR DESCRIPTION
Hi! 👋 This PR adds an entry to the language client `documentSelector` so that Pyrefly LSP features apply to Python documents with the schema [`inmemory`](https://github.com/microsoft/vscode/blob/137bc408a840e323fb9f462ddf255d9a944e715a/src/vs/base/common/network.ts#L18).

I work on the Code - OSS fork [Positron](https://github.com/posit-dev/positron). We've been impressed by the features and maturity of this project, and since Positron is intended to be a batteries-included IDE, we are going to bundle the Pyrefly extension with new releases, instead of relying fully on our bespoke Jedi LSP like in the past.

One of the features of Positron is its [Console](https://positron.posit.co/migrate-rstudio.html#positrons-user-interface), which is where users can run interactive temporary code. We intend to have the same LSP experience in the Console as in document editing. The text in our Console uses the `inmemory` schema, which is similar to how other in-memory text editor models in extensions work. This is important so we don't trigger file-saving behavior or other things that are associated with files on disk. 

I think it would make sense for Pyrefly to work in these in-memory Python situations, both for the Positron Console and otherwise.