### PR TITLE
Fix: Correctly detect await in nested generator expressions

### DIFF
--- a/crates/pyrefly_python/src/ast.rs
+++ b/crates/pyrefly_python/src/ast.rs
@@ -331,11 +331,14 @@ impl Ast {
 
     pub fn contains_await(expr: &Expr) -> bool {
         let mut found = false;
-        expr.visit(&mut |node: &Expr| {
-            if matches!(node, Expr::Await(_)) {
-                found = true;
+        // Recursive function that checks this node and recurses to children
+        fn check(expr: &Expr, found: &mut bool) {
+            if matches!(expr, Expr::Await(_)) {
+                *found = true;
             }
-        });
+            expr.recurse(&mut |child: &Expr| check(child, found));
+        }
+        expr.visit(&mut |node: &Expr| check(node, &mut found));
         found
     }
 }

--- a/pyrefly/lib/test/yields.rs
+++ b/pyrefly/lib/test/yields.rs
@@ -446,6 +446,21 @@ async def test_implicit_generators() -> None:
 );
 
 testcase!(
+    test_async_generator_comprehension_with_nested_await,
+    r#"
+from typing import AsyncGenerator, assert_type
+
+async def some_async_func(x: int) -> bool:
+    return x % 2 == 0
+
+async def main() -> None:
+    # await is nested inside a comparison expression in the condition
+    generator = (x for x in [1, 2, 3] if await some_async_func(x) == True)
+    assert_type(generator, AsyncGenerator[int, None])
+"#,
+);
+
+testcase!(
     bug = "We don't understand yield in lambda, and misattribute the yield to the surrounding function",
     test_lambda_yield,
     r#"


### PR DESCRIPTION
Fix #1611: Correctly detect await in nested generator expressions

Description:
The contains_await() function was not recursing into child expressions, causing generator comprehensions with await nested inside comparisons (e.g., `if await func() == True`) to be incorrectly typed as Generator instead of AsyncGenerator.
Fixed by rewriting contains_await() to follow the visitor pattern correctly, ensuring it recursively checks all child expressions for await keywords.

Added test case that reproduces the exact bug from issue #1611