### PR TITLE
populate display name when untyping a type alias

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -15,8 +15,8 @@
     {
       "code": -2,
       "column": 9,
-      "concise_description": "`TypeAlias[GoodTypeAlias3, type[list[int | None]]]` is not subscriptable",
-      "description": "`TypeAlias[GoodTypeAlias3, type[list[int | None]]]` is not subscriptable",
+      "concise_description": "`TypeAlias[GoodTypeAlias3, type[list[GoodTypeAlias2]]]` is not subscriptable",
+      "description": "`TypeAlias[GoodTypeAlias3, type[list[GoodTypeAlias2]]]` is not subscriptable",
       "line": 68,
       "name": "unsupported-operation",
       "severity": "error",
@@ -270,8 +270,8 @@
     {
       "code": -2,
       "column": 9,
-      "concise_description": "`type[list[int | None]]` is not subscriptable",
-      "description": "`type[list[int | None]]` is not subscriptable",
+      "concise_description": "`type[list[GoodTypeAlias2]]` is not subscriptable",
+      "description": "`type[list[GoodTypeAlias2]]` is not subscriptable",
       "line": 77,
       "name": "unsupported-operation",
       "severity": "error",

--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -449,11 +449,8 @@ impl<'a> TypeDisplayContext<'a> {
             Type::Union(box Union {
                 display_name: Some(name),
                 ..
-            }) => output.write_str(name),
-            Type::Union(box Union {
-                members,
-                display_name: None,
-            }) => {
+            }) if !is_toplevel => output.write_str(name),
+            Type::Union(box Union { members, .. }) => {
                 let mut literal_idx = None;
                 let mut literals = Vec::new();
                 let mut union_members: Vec<&Type> = Vec::new();
@@ -1175,8 +1172,12 @@ pub mod tests {
             "None | Literal[True, 'test'] | LiteralString"
         );
         assert_eq!(
-            Type::union(vec![nonlit1, nonlit2]).to_string(),
-            "None | LiteralString"
+            Type::type_form(Type::Union(Box::new(Union {
+                members: vec![nonlit1, nonlit2],
+                display_name: Some("MyUnion".to_owned())
+            })))
+            .to_string(),
+            "type[MyUnion]"
         );
     }
 

--- a/crates/pyrefly_types/src/type_output.rs
+++ b/crates/pyrefly_types/src/type_output.rs
@@ -402,7 +402,7 @@ mod tests {
 
         let int_type = Type::ClassType(ClassType::new(int_class, TArgs::default()));
         let str_type = Type::ClassType(ClassType::new(str_class, TArgs::default()));
-        let union_type = Type::Union(vec![int_type, str_type, Type::None]);
+        let union_type = Type::union(vec![int_type, str_type, Type::None]);
 
         let ctx = TypeDisplayContext::new(&[&union_type]);
         let mut output = OutputWithLocations::new(&ctx);

--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -1472,10 +1472,15 @@ impl Type {
         })
     }
 
-    pub fn sort_unions(self) -> Self {
+    pub fn sort_unions_and_drop_names(self) -> Self {
         self.transform(&mut |ty| {
-            if let Type::Union(box Union { members: ts, .. }) = ty {
+            if let Type::Union(box Union {
+                members: ts,
+                display_name,
+            }) = ty
+            {
                 ts.sort();
+                *display_name = None;
             }
         })
     }

--- a/pyrefly/lib/alt/answers_solver.rs
+++ b/pyrefly/lib/alt/answers_solver.rs
@@ -17,6 +17,7 @@ use dupe::IterDupedExt;
 use itertools::Either;
 use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::module_path::ModulePath;
+use pyrefly_types::types::Union;
 use pyrefly_util::display::DisplayWithCtx;
 use pyrefly_util::display::commas_iter;
 use pyrefly_util::recurser::Guard;
@@ -797,12 +798,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             fn go(&mut self, ty: &Type, in_type: bool) {
                 match ty {
                     Type::Never(_) if !in_type => (),
-                    Type::Union(tys) => {
+                    Type::Union(box Union { members, .. }) => {
                         self.seen_union = true;
-                        tys.iter().for_each(|ty| self.go(ty, in_type))
+                        members.iter().for_each(|ty| self.go(ty, in_type))
                     }
-                    Type::Type(box Type::Union(tys)) if !in_type => {
-                        tys.iter().for_each(|ty| self.go(ty, true))
+                    Type::Type(box Type::Union(box Union { members, .. })) if !in_type => {
+                        members.iter().for_each(|ty| self.go(ty, true))
                     }
                     Type::Var(v) if let Some(_guard) = self.me.recurse(*v) => {
                         self.go(&self.me.solver().force_var(*v), in_type)

--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -16,6 +16,7 @@ use pyrefly_types::special_form::SpecialForm;
 use pyrefly_types::types::Forall;
 use pyrefly_types::types::Forallable;
 use pyrefly_types::types::TArgs;
+use pyrefly_types::types::Union;
 use pyrefly_types::types::Var;
 use ruff_python_ast::helpers::is_dunder;
 use ruff_python_ast::name::Name;
@@ -1795,12 +1796,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::SuperInstance(box (cls, obj)) => {
                 acc.push(AttributeBase1::SuperInstance(cls, obj))
             }
-            Type::Union(members) => {
+            Type::Union(box Union { members, .. }) => {
                 for ty in members {
                     self.as_attribute_base1(ty, acc)
                 }
             }
-            Type::Type(box Type::Union(members)) => {
+            Type::Type(box Type::Union(box Union { members, .. })) => {
                 for ty in members {
                     self.as_attribute_base1(Type::type_form(ty), acc)
                 }

--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -14,6 +14,7 @@ use pyrefly_types::quantified::Quantified;
 use pyrefly_types::types::CalleeKind;
 use pyrefly_types::types::TArgs;
 use pyrefly_types::types::TParams;
+use pyrefly_types::types::Union;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::prelude::VecExt;
 use ruff_python_ast::Arguments;
@@ -260,7 +261,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::Var(v) if let Some(_guard) = self.recurse(v) => {
                 self.as_call_target_impl(self.solver().force_var(v), quantified, dunder_call)
             }
-            Type::Union(xs) => {
+            Type::Union(box Union { members: xs, .. }) => {
                 let xs_length = xs.len();
                 let targets = xs
                     .into_iter()
@@ -315,7 +316,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::Quantified(q) if q.is_type_var() => match q.restriction() {
                 Restriction::Unrestricted => CallTargetLookup::Error(vec![]),
                 Restriction::Bound(bound) => match bound {
-                    Type::Union(members) => {
+                    Type::Union(box Union { members, .. }) => {
                         let mut targets = Vec::new();
                         for member in members {
                             if let CallTargetLookup::Ok(target) = self.as_call_target_impl(

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -22,6 +22,7 @@ use pyrefly_types::callable::Params;
 use pyrefly_types::simplify::unions;
 use pyrefly_types::type_var::Restriction;
 use pyrefly_types::types::TParams;
+use pyrefly_types::types::Union;
 use pyrefly_util::owner::Owner;
 use pyrefly_util::prelude::ResultExt;
 use pyrefly_util::visit::Visit;
@@ -944,7 +945,9 @@ fn make_bound_method_helper(
         Type::Overload(overload) if should_bind2(&overload.metadata) => {
             BoundMethodType::Overload(overload)
         }
-        Type::Union(ref ts) => {
+        Type::Union(box Union {
+            members: ref ts, ..
+        }) => {
             let mut bound_methods = Vec::with_capacity(ts.len());
             for t in ts {
                 match make_bound_method_helper(obj.clone(), t.clone(), should_bind) {

--- a/pyrefly/lib/alt/class/classdef.rs
+++ b/pyrefly/lib/alt/class/classdef.rs
@@ -11,6 +11,7 @@ use dupe::Dupe;
 use pyrefly_python::nesting_context::NestingContext;
 use pyrefly_types::callable::Callable;
 use pyrefly_types::special_form::SpecialForm;
+use pyrefly_types::types::Union;
 use ruff_python_ast::Identifier;
 use ruff_python_ast::StmtClassDef;
 use ruff_python_ast::name::Name;
@@ -51,7 +52,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::SelfType(ty_cls) | Type::ClassType(ty_cls) => {
                 self.has_superclass(ty_cls.class_object(), class)
             }
-            Type::Union(xs) => xs
+            Type::Union(box Union { members: xs, .. }) => xs
                 .iter()
                 .all(|x| self.is_compatible_constructor_return(x, class)),
             _ => false,

--- a/pyrefly/lib/alt/class/django.rs
+++ b/pyrefly/lib/alt/class/django.rs
@@ -15,6 +15,7 @@ use pyrefly_types::class::Class;
 use pyrefly_types::literal::Lit;
 use pyrefly_types::tuple::Tuple;
 use pyrefly_types::types::Type;
+use pyrefly_types::types::Union;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprCall;
 use ruff_python_ast::name::Name;
@@ -67,7 +68,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::ClassDef(cls) => {
                 self.get_django_field_type_from_class(cls, class, field_name, initial_value_expr)
             }
-            Type::Union(union) => {
+            Type::Union(box Union { members: union, .. }) => {
                 let transformed: Vec<_> = union
                     .iter()
                     .map(|variant| {
@@ -365,7 +366,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // Get the related model type from the field
         let ty = class_field.ty();
         let (related_cls, is_foreign_key_nullable) = match ty {
-            Type::Union(union) => {
+            Type::Union(box Union { members: union, .. }) => {
                 // Nullable foreign key: extract the class type from the union
                 let cls = union.iter().find_map(|variant| match variant {
                     Type::ClassType(cls) => Some(cls.clone()),

--- a/pyrefly/lib/alt/class/pydantic.rs
+++ b/pyrefly/lib/alt/class/pydantic.rs
@@ -21,6 +21,7 @@ use pyrefly_types::callable::Required;
 use pyrefly_types::keywords::DataclassFieldKeywords;
 use pyrefly_types::lit_int::LitInt;
 use pyrefly_types::literal::Lit;
+use pyrefly_types::types::Union;
 use ruff_python_ast::name::Name;
 use ruff_text_size::TextRange;
 
@@ -143,7 +144,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     /// Recursively expands nested RootModels (e.g., RootModel[RootModel[int]] expands to RootModel[int] | int).
     pub fn extract_root_model_inner_type(&self, ty: &Type) -> Option<Type> {
         match ty {
-            Type::Union(types) => {
+            Type::Union(box Union { members: types, .. }) => {
                 let root_types: Vec<Type> = types
                     .iter()
                     .filter_map(|t| self.extract_root_model_inner_type(t))

--- a/pyrefly/lib/alt/class/variance_inference.rs
+++ b/pyrefly/lib/alt/class/variance_inference.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use dupe::Dupe;
 use pyrefly_derive::TypeEq;
 use pyrefly_python::dunder;
+use pyrefly_types::types::Union;
 use pyrefly_util::visit::VisitMut;
 use ruff_python_ast::name::Name;
 use starlark_map::small_map::SmallMap;
@@ -172,8 +173,8 @@ fn on_class(
             Type::Quantified(q) => {
                 on_var(q.name(), variance, inj);
             }
-            Type::Union(t) => {
-                for ty in t {
+            Type::Union(box Union { members: tys, .. }) => {
+                for ty in tys {
                     on_type(variance, inj, ty, on_edge, on_var);
                 }
             }

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -21,6 +21,7 @@ use pyrefly_types::types::BoundMethod;
 use pyrefly_types::types::TParam;
 use pyrefly_types::types::TParams;
 use pyrefly_types::types::TParamsSource;
+use pyrefly_types::types::Union;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::visit::Visit;
 use ruff_python_ast::Expr;
@@ -903,7 +904,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> (Arc<TParams>, Callable) {
         let returns_callable = match &signature.ret {
             Type::Callable(_) => true,
-            Type::Union(ts) => ts.iter().any(|t| matches!(t, Type::Callable(_))),
+            Type::Union(box Union { members: ts, .. }) => {
+                ts.iter().any(|t| matches!(t, Type::Callable(_)))
+            }
             _ => false,
         };
         if !returns_callable {

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -14,6 +14,7 @@ use pyrefly_types::callable::ArgCounts;
 use pyrefly_types::callable::Param;
 use pyrefly_types::tuple::Tuple;
 use pyrefly_types::types::TArgs;
+use pyrefly_types::types::Union;
 use pyrefly_util::gas::Gas;
 use pyrefly_util::owner::Owner;
 use pyrefly_util::prelude::SliceExt;
@@ -149,7 +150,7 @@ impl<'a> ArgsExpander<'a> {
     /// Expands a type according to https://typing.python.org/en/latest/spec/overload.html#argument-type-expansion.
     fn expand_type<Ans: LookupAnswer>(ty: Type, solver: &AnswersSolver<Ans>) -> Vec<Type> {
         match ty {
-            Type::Union(ts) => ts,
+            Type::Union(box Union { members: ts, .. }) => ts,
             Type::ClassType(cls) if cls.is_builtin("bool") => vec![
                 Type::Literal(Lit::Bool(true)),
                 Type::Literal(Lit::Bool(false)),
@@ -161,7 +162,9 @@ impl<'a> ArgsExpander<'a> {
                     .map(Type::Literal)
                     .collect()
             }
-            Type::Type(box Type::Union(ts)) => ts.into_map(Type::type_form),
+            Type::Type(box Type::Union(box Union { members: ts, .. })) => {
+                ts.into_map(Type::type_form)
+            }
             Type::Tuple(Tuple::Concrete(elements)) => {
                 let mut count = 1;
                 let mut changed = false;

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -3800,7 +3800,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::None => Some(Type::None), // Both a value and a type
             Type::Ellipsis => Some(Type::Ellipsis), // A bit weird because of tuples, so just promote it
             Type::Any(style) => Some(style.propagate()),
-            Type::TypeAlias(ta) => self.untype_opt(ta.as_type(), range, errors),
+            Type::TypeAlias(ta) => {
+                let mut aliased_type = self.untype_opt(ta.as_type(), range, errors)?;
+                if let Type::Union(box Union { display_name, .. }) = &mut aliased_type {
+                    *display_name = Some(ta.name.to_string());
+                }
+                Some(aliased_type)
+            }
             t @ Type::Unpack(
                 box Type::Tuple(_) | box Type::TypeVarTuple(_) | box Type::Quantified(_),
             ) => Some(t),

--- a/pyrefly/lib/alt/special_calls.rs
+++ b/pyrefly/lib/alt/special_calls.rs
@@ -12,6 +12,7 @@
  */
 
 use pyrefly_types::callable::FuncMetadata;
+use pyrefly_types::types::Union;
 use pyrefly_util::visit::Visit;
 use pyrefly_util::visit::VisitMut;
 use ruff_python_ast::Expr;
@@ -476,7 +477,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     // Could be anything inside here, so add in Any.
                     res.push(Type::Any(AnyStyle::Implicit));
                 }
-                Type::Tuple(Tuple::Concrete(ts)) | Type::Union(ts) => {
+                Type::Tuple(Tuple::Concrete(ts)) | Type::Union(box Union { members: ts, .. }) => {
                     for t in ts {
                         f(me, t, res)
                     }
@@ -491,7 +492,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         f(me, t, res)
                     }
                 }
-                Type::Type(box Type::Union(ts)) => {
+                Type::Type(box Type::Union(box Union { members: ts, .. })) => {
                     for t in ts {
                         f(me, Type::type_form(t), res)
                     }

--- a/pyrefly/lib/alt/special_calls.rs
+++ b/pyrefly/lib/alt/special_calls.rs
@@ -70,8 +70,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     .distribute_type_over_union();
                 // Make assert_type(Self@SomeClass, typing.Self) work.
                 ty.subst_self_type_mut(&self_form);
-                // Re-sort unions. Make sure to keep this as the final step before comparison.
-                ty.sort_unions()
+                // Re-sort unions & drop any display names.
+                // Make sure to keep this as the final step before comparison.
+                ty.sort_unions_and_drop_names()
             };
             let a = normalize_type(a, expr_a);
             let b = normalize_type(b, expr_b);

--- a/pyrefly/lib/alt/specials.rs
+++ b/pyrefly/lib/alt/specials.rs
@@ -7,6 +7,7 @@
 
 use std::slice;
 
+use pyrefly_types::types::Union;
 use pyrefly_util::display::DisplayWithCtx;
 use pyrefly_util::prelude::SliceExt;
 use ruff_python_ast::Expr;
@@ -200,7 +201,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 fn is_valid_literal(x: &Type) -> bool {
                     match x {
                         Type::None | Type::Literal(_) | Type::Any(AnyStyle::Error) => true,
-                        Type::Union(xs) => xs.iter().all(is_valid_literal),
+                        Type::Union(box Union { members: xs, .. }) => {
+                            xs.iter().all(is_valid_literal)
+                        }
                         _ => false,
                     }
                 }

--- a/pyrefly/lib/commands/infer.rs
+++ b/pyrefly/lib/commands/infer.rs
@@ -11,6 +11,7 @@ use clap::Parser;
 use dupe::Dupe;
 use pyrefly_config::args::ConfigOverrideArgs;
 use pyrefly_config::finder::ConfigFinder;
+use pyrefly_types::types::Union;
 use pyrefly_util::forgetter::Forgetter;
 use pyrefly_util::fs_anyhow;
 use pyrefly_util::includes::Includes;
@@ -197,7 +198,9 @@ fn hint_to_string(
     let hint = hint.promote_literals(stdlib);
     let hint = hint.explicit_any().clean_var();
     let hint = match hint {
-        Type::Union(types) => unions_with_literals(types, stdlib, enum_members),
+        Type::Union(box Union { members: types, .. }) => {
+            unions_with_literals(types, stdlib, enum_members)
+        }
         _ => hint,
     };
     hint.to_string()

--- a/pyrefly/lib/lsp/wasm/inlay_hints.rs
+++ b/pyrefly/lib/lsp/wasm/inlay_hints.rs
@@ -442,7 +442,7 @@ impl<'a> Transaction<'a> {
                             arg.ty = Some(ty[0].clone());
                         } else {
                             let ty = ty.into_iter().filter(|x| !x.is_any()).collect();
-                            arg.ty = Some(Type::Union(ty));
+                            arg.ty = Some(Type::union(ty));
                         }
                         arg
                     })

--- a/pyrefly/lib/report/pysa/function.rs
+++ b/pyrefly/lib/report/pysa/function.rs
@@ -22,6 +22,7 @@ use pyrefly_types::class::Class;
 use pyrefly_types::types::BoundMethodType;
 use pyrefly_types::types::Overload;
 use pyrefly_types::types::Type;
+use pyrefly_types::types::Union;
 use pyrefly_util::thread_pool::ThreadPool;
 use rayon::prelude::*;
 use ruff_python_ast::AnyNodeRef;
@@ -499,7 +500,7 @@ fn export_signatures_from_type(ty: &Type, context: &ModuleContext) -> Vec<Functi
             BoundMethodType::Overload(overload) => export_overload_signatures(overload, context),
         },
         Type::Overload(overload) => export_overload_signatures(overload, context),
-        Type::Union(union) => union
+        Type::Union(box Union { members: union, .. }) => union
             .iter()
             .flat_map(|ty| export_signatures_from_type(ty, context))
             .collect::<Vec<_>>(),

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -457,8 +457,17 @@ impl Solver {
     /// Simplify a type as much as we can.
     fn simplify_mut(&self, t: &mut Type) {
         t.transform_mut(&mut |x| {
-            if let Type::Union(box Union { members: xs, .. }) = x {
-                *x = unions(mem::take(xs));
+            if let Type::Union(box Union {
+                members: xs,
+                display_name: original_name,
+            }) = x
+            {
+                let mut merged = unions(mem::take(xs));
+                // Preserve union display names during simplification
+                if let Type::Union(box Union { display_name, .. }) = &mut merged {
+                    *display_name = original_name.clone();
+                }
+                *x = merged;
             }
             if let Type::Intersect(y) = x {
                 *x = intersect(mem::take(&mut y.0), y.1.clone());

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -32,6 +32,7 @@ use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_python::symbol_kind::SymbolKind;
 use pyrefly_python::sys_info::SysInfo;
 use pyrefly_types::facet::FacetKind;
+use pyrefly_types::types::Union;
 use pyrefly_util::gas::Gas;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::prelude::VecExt;
@@ -1175,7 +1176,7 @@ impl<'a> Transaction<'a> {
             let completions = |ty| solver.completions(ty, Some(name), false);
 
             match base_type {
-                Type::Union(tys) | Type::Intersect(box (tys, _)) => tys
+                Type::Union(box Union { members: tys, .. }) | Type::Intersect(box (tys, _)) => tys
                     .into_iter()
                     .filter_map(|ty_| {
                         self.find_definition_for_base_type(
@@ -2387,9 +2388,9 @@ impl<'a> Transaction<'a> {
                     ..Default::default()
                 });
             }
-            Type::Union(types) => {
-                for union_type in types {
-                    Self::add_literal_completions_from_type(union_type, completions);
+            Type::Union(box Union { members, .. }) => {
+                for member in members {
+                    Self::add_literal_completions_from_type(member, completions);
                 }
             }
             _ => {}
@@ -2483,8 +2484,8 @@ impl<'a> Transaction<'a> {
                                 .or_insert_with(|| field.ty.clone());
                         }
                     }
-                    Type::Union(types) => {
-                        stack.extend(types.into_iter());
+                    Type::Union(box Union { members, .. }) => {
+                        stack.extend(members.into_iter());
                     }
                     _ => {}
                 }

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -577,7 +577,7 @@ class A:
     def f(self, x: TA1):
         pass
 class B(A):
-    def f(self, x: TA2):  # E: `B.f` has type `BoundMethod[B, (self: B, x: float | int) -> None]`, which is not assignable to `BoundMethod[B, (self: B, x: float | int | None) -> None]`, the type of `A.f`
+    def f(self, x: TA2):  # E: `B.f` has type `BoundMethod[B, (self: B, x: TA2) -> None]`, which is not assignable to `BoundMethod[B, (self: B, x: TA1) -> None]`, the type of `A.f`
         pass
     "#,
 );


### PR DESCRIPTION
Summary:
- populate display name when untyping a union
- keep name when simplifying
- display the expanded type when the top level type being printed is the alias (only use the display name for nested types)

Differential Revision: D87558543
