### PR TITLE
fix: prevent hints from poisoning generic function inference in OR expressions

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1073,16 +1073,23 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let mut t_acc = Type::never();
         let last_index = values.len() - 1;
         for (i, value) in values.iter().enumerate() {
-            // If there isn't a hint for the overall expression, use the preceding branches as a "soft" hint
-            // for the next one. Most useful for expressions like `optional_list or []`.
-            let hint = hint.or_else(|| {
-                if t_acc.is_never() {
-                    None
-                } else {
-                    Some(HintRef::soft(&t_acc))
-                }
-            });
-            let mut t = self.expr_infer_with_hint(value, hint, errors);
+            let operand_hint = if matches!(op, BoolOp::Or) && matches!(value, Expr::Call(_)) {
+                // Drop the hint for function calls in 'OR' expressions.
+                // This prevents the expected type (e.g. Optional[str]) from improperly influencing
+                // a generic function's inference (forcing it to return Optional[str]
+                // instead of str), while still preserving hints for literals like [].
+                None
+            } else {
+                // Use external hint, or fall back to previous branches
+                hint.or_else(|| {
+                    if t_acc.is_never() {
+                        None
+                    } else {
+                        Some(HintRef::soft(&t_acc))
+                    }
+                })
+            };
+            let mut t = self.expr_infer_with_hint(value, operand_hint, errors);
             self.expand_vars_mut(&mut t);
             // If this is not the last entry, we have to make a type-dependent decision and also narrow the
             // result; both operations require us to force `Var` first or they become unpredictable.


### PR DESCRIPTION
## Summary
Fixes #1635.

This PR fixes a type inference bug where generic functions (like `os.getenv`) returned incorrectly widened types when used on the right-hand side of an `or` expression.

**The Issue:**
When reassigning a variable like `config: str | None`, the type checker passed the variable's current type (`str | None`) as a "context hint" to the right-hand side of the `or`. Generic functions like `os.getenv(key, default)` accepted this hint, widening their return type to match the hint (inferring `T` as `None`) rather than inferring the specific type from their arguments (`default="string"` -> `T=str`).

This resulted in false positive type errors (e.g., `Argument 'str | None' is not assignable...`) even when a valid default value was provided.

## The Fix
I updated `boolop` in `expr.rs` to adjust how hints are propagated in `OR` expressions:

- **For Function Calls (`Expr::Call`):** The context hint is now dropped. This forces the function to infer its return type strictly from its arguments (Inside-Out inference), preventing "poisoning" from the surrounding context.
- **For Literals/Others:** The context hint is preserved. This ensures that expressions like `x: List[int] = None or []` still correctly infer `List[int]` instead of `List[Any]`.

## Test Plan
Added a regression test `test_or_generic_function_hint_poisoning_fix` in `operators.rs`.

The test simulates the `os.getenv` behavior using a generic `identity` function and verifies that:
1. A variable defined as `str | None` set to `None`.
2. Reassigned via `variable or identity("default")`.
3. Correctly narrows to `str` (proving the hint `str | None` was ignored by the function inference).

**Verification:**
Ran tests locally:
`cargo test -p pyrefly --lib test_or_generic_function_hint_poisoning_fix` (Passed)