### PR TITLE
fix: ensure await check recurses into generator conditions

### DIFF
--- a/crates/pyrefly_python/src/ast.rs
+++ b/crates/pyrefly_python/src/ast.rs
@@ -330,12 +330,16 @@ impl Ast {
     }
 
     pub fn contains_await(expr: &Expr) -> bool {
-        let mut found = false;
-        expr.visit(&mut |node: &Expr| {
+        // Iterative DFS to safely visit all nodes, including the root and nested children.
+        let mut stack = vec![expr];
+
+        while let Some(node) = stack.pop() {
             if matches!(node, Expr::Await(_)) {
-                found = true;
+                return true;
             }
-        });
-        found
+            node.recurse(&mut |child| stack.push(child));
+        }
+
+        false
     }
 }

--- a/pyrefly/lib/test/yields.rs
+++ b/pyrefly/lib/test/yields.rs
@@ -483,3 +483,19 @@ def f(start, iterable: Iterable[_T], step) ->  Iterator[_T]:
 
     "#,
 );
+
+testcase!(
+    test_async_generator_nested_await_in_condition,
+    r#"
+from typing import AsyncGenerator, assert_type
+
+async def some_async_func(x: int) -> bool:
+    return True
+
+async def main() -> None:
+    # Regression test for Issue #1611
+    # Previously inferred as Generator (sync) because await was nested in comparison
+    generator = (x for x in [1, 2, 3] if await some_async_func(x) == True)
+    assert_type(generator, AsyncGenerator[int, None])
+"#,
+);


### PR DESCRIPTION
## Summary
Fixes #1611.

Previously, comprehensions were incorrectly inferred as synchronous `Generator` instead of `AsyncGenerator` when the `await` keyword was nested inside a binary expression or comparison (e.g., `if await foo() == True`). The previous AST visitor did not fully recurse into the condition's children in all cases.

## The Fix
I updated the `contains_await` logic in `ast.rs` to use a **manual iterative Depth-First Search (DFS)** using a stack.

- **Correctness:** This ensures we scan the entire expression tree, identifying `await` nodes even when deeply nested inside other expressions.
- **Robustness:** By using an iterative stack instead of recursion, we avoid potential stack overflow issues on deeply nested inputs.

## Test Plan
Added a regression test `test_async_generator_nested_await_in_condition` in `yields.rs`.

**Verification:**
- Verified that `if await foo() == True` correctly results in `AsyncGenerator`.
- Ran tests locally: `cargo test -p pyrefly --lib test_async_generator_nested_await_in_condition` (Passed)