### PR TITLE
fix: handle Type::Type(box Type::None) for attribute access

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -1672,6 +1672,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             },
             Type::Type(box Type::Any(style)) => acc.push(AttributeBase1::TypeAny(style)),
             Type::Type(box Type::Never(_)) => acc.push(AttributeBase1::TypeNever),
+            Type::Type(box Type::None) => acc.push(AttributeBase1::ClassObject(
+                ClassBase::ClassType(self.stdlib.none_type().clone()),
+            )),
             // At runtime, these special forms are classes. This has been tested with Python
             // versions 3.11-3.13. Note that other special forms are classes in some versions, but
             // their representations aren't stable across versions.

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -1217,13 +1217,12 @@ def f[T: Foo | Bar](y: T, z: Foo | Bar) -> T:
 );
 
 testcase!(
-    bug = "type[None] should be types.NoneType",
     test_attribute_access_on_type_none,
     r#"
 # handy hack to get a type[X] for any X
 def ty[T](x: T) -> type[T]: ...
 
-ty(None).__bool__(None) # E: Expr::attr_infer_for_type attribute base undefined
+ty(None).__bool__(None)
 "#,
 );
 


### PR DESCRIPTION

  ## Summary

  Fixes #1625.

  This PR fixes a type checking bug where accessing attributes on `type[None]` would fail with "Expr::attr_infer_for_type attribute base undefined". The type checker now correctly 
  treats `type[None]` as `types.NoneType`, allowing proper attribute access.

  ## The Issue

  When attempting to access attributes on `type[None]`, Pyrefly failed to resolve the attribute base. For example:

  ```python
  def ty[T](x: T) -> type[T]: ...
```
result 
```
  ty(None).__bool__(None)  # ERROR: Expr::attr_infer_for_type attribute base undefined
```
  At runtime, type[None] is types.NoneType, which is a real Python class with methods like __bool__. However, Pyrefly's attribute resolution in as_attribute_base1 didn't handle the
  Type::Type(box Type::None) case, causing it to fail when trying to resolve attributes.

  The Fix

  I added a case to handle Type::Type(box Type::None) in the as_attribute_base1 function in pyrefly/lib/alt/attr.rs:1675:
```
  Type::Type(box Type::None) => acc.push(AttributeBase1::ClassObject(
      ClassBase::ClassType(self.stdlib.none_type().clone()),
  )),
```
  This treats type[None] as a class object of type types.NoneType, which allows the type checker to properly resolve attributes on it.

  Test Plan

  Updated the existing test case test_attribute_access_on_type_none in pyrefly/lib/test/attributes.rs:
  - Removed the bug = "type[None] should be types.NoneType" marker
  - Removed the error expectation comment # E: Expr::attr_infer_for_type attribute base undefined

  The test now verifies that ty(None).__bool__(None) type checks without errors.

  Verification:
  Ran test locally:
  cargo test test_attribute_access_on_type_none -- --nocapture
result ( passes ) 
