### PR TITLE
fix(tests): dont hardcode /bin/bash in mock python interpreter

### DIFF
--- a/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
@@ -55,7 +55,7 @@ fn setup_dummy_interpreter(custom_interpreter_path: &Path) -> PathBuf {
     // Create a mock Python interpreter script that returns the environment info
     // This simulates what a real Python interpreter would return when queried with the env script
     let python_script = format!(
-        r#"#!/bin/bash
+        r#"#!/usr/bin/env bash
 if [[ "$1" == "-c" && "$2" == *"import json, sys"* ]]; then
     cat << 'EOF'
 {{"python_platform": "linux", "python_version": "3.12.0", "site_package_path": ["{site_packages}"]}}


### PR DESCRIPTION
# Summary

Hardcoding `/bin/bash` in the mock interpreter script causes the tests to fail in environments without bash installed at that location.

Using `/usr/bin/env bash` is the most portable way to locate the bash interpreter across different systems. Currently this issue causes failures on NixOS which does *not* have bash at `/bin/bash`.

# Test Plan

Ran tests on NixOS to confirm they pass, also tested on mac with bash at `/bin/bash` to confirm still worked

<!-- Run test.py and commit any changes to generated files -->
