### PR TITLE
clear interpreter cache on changes

### DIFF
--- a/pyrefly/lib/commands/config_finder.rs
+++ b/pyrefly/lib/commands/config_finder.rs
@@ -15,6 +15,7 @@ use pyrefly_config::args::ConfigOverrideArgs;
 use pyrefly_config::base::ConfigBase;
 use pyrefly_config::config::DirectoryRelativeFallbackSearchPathCache;
 use pyrefly_config::config::FallbackSearchPath;
+use pyrefly_config::environment::environment::PythonEnvironment;
 use pyrefly_python::module_path::ModulePathDetails;
 use pyrefly_util::arc_id::ArcId;
 use pyrefly_util::lock::Mutex;
@@ -150,6 +151,7 @@ pub fn standard_config_finder(configure: Arc<dyn ConfigConfigurer>) -> ConfigFin
             cache_one.lock().clear();
             cache_parents.lock().clear();
             cache_ancestors.clear();
+            PythonEnvironment::clear_interpreter_cache();
         })
     };
 


### PR DESCRIPTION
Summary:
[bug report](https://github.com/facebook/pyrefly/issues/1632#issuecomment-3560579415)

  Root Cause:
  1. PythonEnvironment::get_interpreter_env() caches interpreter environments in a global static registry (INTERPRETER_ENV_REGISTRY at environment.rs:30-32)
  2. When invalidate_config() is called (state.rs:1317), it clears the ConfigFinder cache
  3. ConfigFinder::clear() (finder.rs:195-199) calls clear_extra_caches()
  4. But clear_extra_caches (config_finder.rs:145-154) does NOT clear INTERPRETER_ENV_REGISTRY
  5. Result: When you switch interpreters, the cached PythonEnvironment from the old interpreter persists

  This explains the LSP trace perfectly:
  - First switch .venv → miniforge3: Works (no cache yet)
  - Second switch miniforge3 → .venv: Broken - diagnostics show miniforge3's site-packages even though .venv interpreter is selected

  The Fix

  Add a public function to clear the interpreter cache and call it from clear_extra_caches:

  When the interpreter changes:
  1. Extension sends DidChangeConfigurationNotification
  2. Server calls request_settings_for_all_workspaces() → gets new pythonPath
  3. workspace_configuration_response() sets modified = true
  4. invalidate_config_and_validate_in_memory() is called
  5. config_finder.clear() now clears the interpreter cache
  6. Next config load re-queries the interpreter for site-packages
  7. Diagnostics show correct site-packages for the new interpreter

  This ensures that switching interpreters immediately invalidates all cached environment data, forcing a fresh query of the new interpreter's site-packages.

Differential Revision: D87643729


