### PR TITLE
Disable completions in comments

### DIFF
--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2635,6 +2635,7 @@ impl<'a> Transaction<'a> {
         results.dedup_by(|item1, item2| item1.label == item2.label && item1.detail == item2.detail);
         (results, is_incomplete)
     }
+
     fn completion_disabled_ranges_for_module(module: &ModuleInfo) -> Vec<TextRange> {
         let mut ranges = Vec::new();
         let source = module.lined_buffer().contents();

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -2420,3 +2420,33 @@ Completion Results:
         report.trim(),
     );
 }
+
+#[test]
+fn test_no_completion_in_comments() {
+    let code = r#"
+# This is a comment
+#      ^
+import sys
+x = sys.version
+#       ^
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::indexing(), true);
+    let handle = handles.get("main").unwrap();
+    let positions = extract_cursors_for_test(code);
+    let txn = state.transaction();
+
+    // Position 0: inside comment - should return empty
+    let comment_completions = txn.completion(&handle, positions[0], ImportFormat::Absolute, true);
+    assert!(
+        comment_completions.is_empty(),
+        "Expected no completions in comment, but got {} completions",
+        comment_completions.len()
+    );
+
+    // Position 1: normal code - should return completions
+    let normal_completions = txn.completion(&handle, positions[1], ImportFormat::Absolute, true);
+    assert!(
+        !normal_completions.is_empty(),
+        "Expected completions in normal code but got none"
+    );
+}


### PR DESCRIPTION
fixes #1371
The disabled_ranges_for_module function now detects three types of ranges where completions should be disabled:

Unreachable code (existing) - code after return, break, etc.
Comments (new) - lines starting with #
String literals (new) - text inside quotes

Implementation

Extended disabled_ranges_for_module() to accept a Module parameter for accessing source text
Added collect_comment_ranges() - scans source line-by-line using existing find_comment_start_in_line() utility
Added collect_string_literal_ranges() - walks AST to find StringLiteral nodes
Updated all call sites to pass the module_info parameter
@yangdanny97 
