### PR TITLE
impl "go to definition" on inlay hints / location

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -2640,7 +2640,7 @@ impl Server {
         )?;
         let res = t
             .into_iter()
-            .filter_map(|(text_size, label_parts)| {
+            .filter_map(|(text_size, label)| {
                 // If the url is a notebook cell, filter out inlay hints for other cells
                 if info.to_cell_for_lsp(text_size) != maybe_cell_idx {
                     return None;
@@ -2648,36 +2648,20 @@ impl Server {
                 let position = info.to_lsp_position(text_size);
                 // The range is half-open, so the end position is exclusive according to the spec.
                 if position >= range.start && position < range.end {
-                    let label = InlayHintLabel::LabelParts(
-                        label_parts
-                            .iter()
-                            .map(|(text, location_opt)| {
-                                let location = location_opt
-                                    .as_ref()
-                                    .and_then(|loc| self.to_lsp_location(loc));
-
-                                InlayHintLabelPart {
-                                    value: text.clone(),
-                                    tooltip: None,
-                                    location,
-                                    command: None,
-                                }
-                            })
-                            .collect(),
-                    );
+                    let label_text = label.text();
                     Some(InlayHint {
-                    position,
-                    label,
-                    kind: None,
-                    text_edits: Some(vec![TextEdit {
-                        range: Range::new(position, position),
-                        new_text: label_parts.iter().map(|(text, _)| text.as_str()).collect(),
-                    }]),
-                    tooltip: None,
-                    padding_left: None,
-                    padding_right: None,
-                    data: None,
-                })
+                        position,
+                        label: self.label_segments_to_lsp(&label, &label_text),
+                        kind: None,
+                        text_edits: Some(vec![TextEdit {
+                            range: Range::new(position, position),
+                            new_text: label_text,
+                        }]),
+                        tooltip: None,
+                        padding_left: None,
+                        padding_right: None,
+                        data: None,
+                    })
                 } else {
                     None
                 }

--- a/pyrefly/lib/playground.rs
+++ b/pyrefly/lib/playground.rs
@@ -618,14 +618,10 @@ impl Playground {
             .get_module_info(handle)
             .zip(transaction.inlay_hints(handle, Default::default()))
             .map(|(info, hints)| {
-                hints.into_map(|(position, label_parts)| {
+                hints.into_map(|(position, label)| {
                     let position = Position::from_display_pos(info.display_pos(position));
-                    // Concatenate all label parts into a single string for the playground
-                    let label: String = label_parts.iter().map(|(text, _)| text.as_str()).collect();
-                    InlayHint {
-                        label: label.text(),
-                        position,
-                    }
+                    let label = label.text();
+                    InlayHint { label, position }
                 })
             })
             .unwrap_or_default()

--- a/pyrefly/lib/test/lsp/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/inlay_hint.rs
@@ -22,15 +22,13 @@ fn generate_inlay_hint_report(code: &str, hint_config: InlayHintConfig) -> Strin
         report.push_str(name);
         report.push_str(".py\n");
         let handle = handles.get(name).unwrap();
-        for (pos, label_parts) in state
+        for (pos, label) in state
             .transaction()
             .inlay_hints(handle, hint_config)
             .unwrap()
         {
             report.push_str(&code_frame_of_source_at_position(code, pos));
             report.push_str(" inlay-hint: `");
-            // Concatenate label parts into a single string
-            let hint: String = label_parts.iter().map(|(text, _)| text.as_str()).collect();
             report.push_str(&label.text());
             report.push_str("`\n\n");
         }

--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_inlay_hint.rs
@@ -5,11 +5,44 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use serde_json::json;
+use lsp_types::InlayHint;
+use lsp_types::InlayHintLabel;
 
 use crate::test::lsp::lsp_interaction::object_model::InitializeSettings;
 use crate::test::lsp::lsp_interaction::object_model::LspInteraction;
 use crate::test::lsp::lsp_interaction::util::get_test_files_root;
+
+fn expect_inlay_labels(response: Option<Vec<InlayHint>>, expected: &[(&str, u32, u32)]) -> bool {
+    match response {
+        Some(hints) => {
+            if hints.len() != expected.len() {
+                return false;
+            }
+            hints
+                .iter()
+                .zip(expected.iter())
+                .all(|(hint, (label, line, character))| {
+                    if hint.position.line != *line || hint.position.character != *character {
+                        return false;
+                    }
+                    let rendered: String = match &hint.label {
+                        InlayHintLabel::String(text) => text.clone(),
+                        InlayHintLabel::LabelParts(parts) => {
+                            parts.iter().map(|part| part.value.as_str()).collect()
+                        }
+                    };
+                    if rendered != *label {
+                        return false;
+                    }
+                    match &hint.text_edits {
+                        Some(edits) => edits.iter().any(|edit| edit.new_text.as_str() == *label),
+                        None => false,
+                    }
+                })
+        }
+        None => expected.is_empty(),
+    }
+}
 
 #[test]
 fn test_inlay_hints() {
@@ -31,69 +64,20 @@ fn test_inlay_hints() {
 
     interaction
         .inlay_hint_cell("notebook.ipynb", "cell1", 0, 0, 100, 0)
-        .expect_response(json!([{
-            "label": [
-                {"value": " -> "},
-                {"value": "tuple"},
-                {"value": "["},
-                {"value": "Literal"},
-                {"value": "["},
-                {"value": "1"},
-                {"value": "]"},
-                {"value": ", "},
-                {"value": "Literal"},
-                {"value": "["},
-                {"value": "2"},
-                {"value": "]"},
-                {"value": "]"}
-            ],
-            "position": {"character": 21, "line": 0},
-            "textEdits": [{
-                "newText": " -> tuple[Literal[1], Literal[2]]",
-                "range": {"end": {"character": 21, "line": 0}, "start": {"character": 21, "line": 0}}
-            }]
-        }]));
+        .expect_response_with(|response| {
+            expect_inlay_labels(response, &[(" -> tuple[Literal[1], Literal[2]]", 0, 21)])
+        });
 
     interaction
         .inlay_hint_cell("notebook.ipynb", "cell2", 0, 0, 100, 0)
-        .expect_response(json!([{
-            "label": [
-                {"value": ": "},
-                {"value": "tuple"},
-                {"value": "["},
-                {"value": "Literal"},
-                {"value": "["},
-                {"value": "1"},
-                {"value": "]"},
-                {"value": ", "},
-                {"value": "Literal"},
-                {"value": "["},
-                {"value": "2"},
-                {"value": "]"},
-                {"value": "]"}
-            ],
-            "position": {"character": 6, "line": 0},
-            "textEdits": [{
-                "newText": ": tuple[Literal[1], Literal[2]]",
-                "range": {"end": {"character": 6, "line": 0}, "start": {"character": 6, "line": 0}}
-            }]
-        }]));
+        .expect_response_with(|response| {
+            expect_inlay_labels(response, &[(": tuple[Literal[1], Literal[2]]", 0, 6)])
+        });
 
     interaction
         .inlay_hint_cell("notebook.ipynb", "cell3", 0, 0, 100, 0)
-        .expect_response(json!([{
-            "label": [
-                {"value": " -> "},
-                {"value": "Literal"},
-                {"value": "["},
-                {"value": "0"},
-                {"value": "]"}
-            ],
-            "position": {"character": 15, "line": 0},
-            "textEdits": [{
-                "newText": " -> Literal[0]",
-                "range": {"end": {"character": 15, "line": 0}, "start": {"character": 15, "line": 0}}
-            }]
-        }]));
+        .expect_response_with(|response| {
+            expect_inlay_labels(response, &[(" -> Literal[0]", 0, 15)])
+        });
     interaction.shutdown();
 }


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

impl https://github.com/DetachHead/basedpyright/issues/651

part of #1589 

Introduced InlayHintLabelSegments/InlayHintLabelSegment to capture each rendered fragment plus its optional TextRangeWithModule, and taught Transaction::inlay_hints to emit these richer labels instead of raw strings so we can preserve click targets coming from the type formatter. The non-type hints still use the helper from_text, so downstream code only needs to call .text() when a plain string is required.

Updated the LSP server to convert those segments into InlayHintLabelParts (falling back to strings when no locations exist) so
 VS Code and others now support clickable inlay hints; text edits still use concatenated text, so formatting behavior remains unchanged.

# Test Plan

Added an explicit regression that asserts label parts carry the document URI/range for MyClass, proving that go-to-definition on inlay hints now works as requested in basedpyright#651.

Existing notebook and CLI tests read the assembled text, so no user-facing breakage.

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
