### PR TITLE
Fix diagnostic race condition when switching Python interpreters

### DIFF
--- a/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
@@ -325,11 +325,10 @@ fi
             }
         ]));
 
-    // BUG (for diff 1): Expecting 1 error demonstrates the cache not being cleared.
-    // After switching to good interpreter, the error should be resolved to 0.
+    // After switching to good interpreter with site-packages, the import error should be resolved
     interaction.client.expect_publish_diagnostics_error_count(
         test_files_root.path().join("custom_interpreter/src/foo.py"),
-        1,
+        0,
     );
 
     interaction.shutdown();


### PR DESCRIPTION
Summary:
When switching Python interpreters via workspace/didChangeConfiguration, the LSP
would sometimes show stale diagnostics because of a race condition in how config
invalidation and diagnostic publishing interacted.

The issue was that invalidate_config_and_validate_in_memory() would:
1. Invalidate configs and mark modules as dirty
2. Commit the transaction with updated configs
3. Send RecheckFinished event to trigger diagnostic publishing

However, the RecheckFinished event handler could run and publish diagnostics
before modules had actually re-run with the new config, resulting in diagnostics
that still showed errors from the old interpreter's site-packages.

The fix is to publish diagnostics immediately after committing the config
invalidation transaction, using a fresh transaction that reflects the newly
committed state. This ensures diagnostics always use the updated configs.

Additionally, extracted the diagnostic publishing logic into a reusable
publish_diagnostics_for_handles() method to avoid code duplication.

This likely helps with https://github.com/facebook/pyrefly/issues/1667

Differential Revision: D87848835


