### PR TITLE
fix Types from the typing module are currently not clickable in type hints #1681

### DIFF
--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -2404,8 +2404,8 @@ def overloaded_func[T](
 
     #[test]
     fn test_get_types_with_location_typevar() {
-        let tvar = fake_tyvar("T", "test.module", 15);
         let heap = TypeHeap::new();
+        let tvar = fake_tyvar("T", "test.module", 15);
         let t = tvar.to_type(&heap);
         let parts = get_parts(&t);
 

--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -369,11 +369,12 @@ impl<'a> TypeDisplayContext<'a> {
         name: &str,
         output: &mut impl TypeOutput,
     ) -> fmt::Result {
-        if self.always_display_module_name {
-            output.write_str(module)?;
-            output.write_str(".")?;
-        }
-        output.write_str(name)
+        let module_name = ModuleName::from_str(module);
+        output.write_symbol(
+            module_name,
+            std::borrow::Cow::Borrowed(name),
+            self.always_display_module_name,
+        )
     }
 
     /// Helper function to format a sequence of types with a separator.
@@ -1348,10 +1349,7 @@ impl Type {
         rendered
     }
 
-    pub fn get_types_with_locations(
-        &self,
-        stdlib: Option<&Stdlib>,
-    ) -> Vec<TypeLabelPart> {
+    pub fn get_types_with_locations(&self, stdlib: Option<&Stdlib>) -> Vec<TypeLabelPart> {
         let mut ctx = TypeDisplayContext::new(&[self]);
         if let Some(s) = stdlib {
             ctx.set_stdlib(s);

--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -2409,10 +2409,11 @@ def overloaded_func[T](
         let t = tvar.to_type(&heap);
         let parts = get_parts(&t);
 
-        assert_eq!(parts[0].text, "TypeVar[");
+        let typevar_part = parts.iter().find(|part| part.text == "TypeVar");
+        assert!(typevar_part.is_some(), "Should have TypeVar in parts");
         assert!(
-            parts[0].location.is_none(),
-            "TypeVar[ should not have location"
+            typevar_part.unwrap().location.is_none(),
+            "TypeVar should not have location"
         );
         assert_part_has_location(&parts, "T", "test.module", 15);
     }
@@ -2453,9 +2454,9 @@ def overloaded_func[T](
         assert_output_contains(&parts, "True");
         let literal_part = parts.iter().find(|part| part.text == "Literal");
         assert!(literal_part.is_some());
-        let symbol = literal_part.unwrap().symbol.as_ref().unwrap();
-        assert_eq!(symbol.module.as_str(), "typing");
-        assert_eq!(symbol.name, "Literal");
+        let literal_part = literal_part.unwrap();
+        assert!(literal_part.location.is_none());
+        assert!(literal_part.symbol.is_none());
     }
 
     #[test]

--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -1153,7 +1153,11 @@ impl<'a> TypeDisplayContext<'a> {
                 self.fmt_helper_generic(ty, false, output)
             }
             Type::Concatenate(args, pspec) => {
-                self.maybe_fmt_with_module("typing", "Concatenate", output)?;
+                if self.always_display_module_name {
+                    output.write_str("typing.")?;
+                }
+                let qname = self.get_special_form_qname("Concatenate");
+                output.write_builtin("Concatenate", qname)?;
                 output.write_str("[")?;
                 write!(
                     output,
@@ -1194,7 +1198,13 @@ impl<'a> TypeDisplayContext<'a> {
             Type::SpecialForm(x) => write!(output, "{x}"),
             Type::Ellipsis => output.write_str("Ellipsis"),
             Type::Any(style) => match style {
-                AnyStyle::Explicit => self.maybe_fmt_with_module("typing", "Any", output),
+                AnyStyle::Explicit => {
+                    if self.always_display_module_name {
+                        output.write_str("typing.")?;
+                    }
+                    let qname = self.get_special_form_qname("Any");
+                    output.write_builtin("Any", qname)
+                }
                 AnyStyle::Implicit | AnyStyle::Error => output.write_str("Unknown"),
             },
             Type::TypeAlias(ta) => match &**ta {
@@ -1387,6 +1397,7 @@ pub mod tests {
     use pyrefly_python::module_name::ModuleName;
     use pyrefly_python::module_path::ModulePath;
     use pyrefly_python::nesting_context::NestingContext;
+    use pyrefly_python::sys_info::PythonVersion;
     use ruff_python_ast::Identifier;
     use ruff_text_size::TextSize;
     use starlark_map::smallset;
@@ -1400,6 +1411,7 @@ pub mod tests {
     use crate::callable::Param;
     use crate::callable::ParamList;
     use crate::callable::Params;
+    use crate::callable::PrefixParam;
     use crate::callable::Required;
     use crate::class::Class;
     use crate::class::ClassDefIndex;
@@ -1415,6 +1427,7 @@ pub mod tests {
     use crate::quantified::QuantifiedOrigin;
     use crate::shaped_array::ShapedArrayShape;
     use crate::shaped_array::ShapedArrayType;
+    use crate::stdlib::Stdlib;
     use crate::tuple::Tuple;
     use crate::type_alias::TypeAlias;
     use crate::type_alias::TypeAliasData;
@@ -1478,6 +1491,30 @@ pub mod tests {
             None,
             PreInferenceVariance::Invariant,
         )
+    }
+
+    fn fake_module(name: &str) -> Module {
+        Module::new(
+            ModuleName::from_str(name),
+            ModulePath::filesystem(PathBuf::from(name)),
+            Arc::new("1234567890".to_owned()),
+        )
+    }
+
+    fn fake_special_form_stdlib(special_forms: &[(&'static str, u32)]) -> Stdlib {
+        Stdlib::new(PythonVersion::default(), &|_, _| None, &|module, name| {
+            special_forms
+                .iter()
+                .find(|(special_form, _)| {
+                    module == ModuleName::typing() && name.as_str() == *special_form
+                })
+                .map(|(_, range)| {
+                    (
+                        fake_module("typing"),
+                        TextRange::empty(TextSize::new(*range)),
+                    )
+                })
+        })
     }
 
     fn fake_bound_method(method_name: &str, class_name: &str, module_name_str: &str) -> Type {
@@ -2349,6 +2386,10 @@ def overloaded_func[T](
         output.parts().to_vec()
     }
 
+    fn get_parts_with_stdlib(t: &Type, stdlib: &Stdlib) -> Vec<TypeLabelPart> {
+        t.get_types_with_locations(Some(stdlib))
+    }
+
     fn parts_to_string(parts: &[TypeLabelPart]) -> String {
         parts
             .iter()
@@ -2657,6 +2698,37 @@ def overloaded_func[T](
 
         assert_output_contains(&parts, "ParamSpec");
         assert_part_has_location(&parts, "P", "test.module", 75);
+    }
+
+    #[test]
+    fn test_get_types_with_location_explicit_any_special_form() {
+        let stdlib = fake_special_form_stdlib(&[("Any", 101)]);
+        let parts = get_parts_with_stdlib(&Type::any_explicit(), &stdlib);
+
+        assert_part_has_location(&parts, "Any", "typing", 101);
+    }
+
+    #[test]
+    fn test_get_types_with_location_annotated_special_form() {
+        let stdlib = fake_special_form_stdlib(&[("Annotated", 102)]);
+        let parts = get_parts_with_stdlib(
+            &Type::Annotated(Box::new(Type::None), Box::new([])),
+            &stdlib,
+        );
+
+        assert_part_has_location(&parts, "Annotated", "typing", 102);
+    }
+
+    #[test]
+    fn test_get_types_with_location_concatenate_special_form() {
+        let stdlib = fake_special_form_stdlib(&[("Concatenate", 103)]);
+        let t = Type::Concatenate(
+            vec![PrefixParam::new(Type::None, Required::Required)].into_boxed_slice(),
+            Box::new(Type::Ellipsis),
+        );
+        let parts = get_parts_with_stdlib(&t, &stdlib);
+
+        assert_part_has_location(&parts, "Concatenate", "typing", 103);
     }
 
     #[test]

--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -11,7 +11,6 @@ use std::cell::RefCell;
 use std::fmt;
 use std::fmt::Display;
 
-use pyrefly_python::module::TextRangeWithModule;
 use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::qname::QName;
 use pyrefly_util::display::Fmt;
@@ -39,6 +38,7 @@ use crate::type_alias::TypeAliasRef;
 use crate::type_alias::TypeAliasStyle;
 use crate::type_output::DisplayOutput;
 use crate::type_output::OutputWithLocations;
+use crate::type_output::TypeLabelPart;
 use crate::type_output::TypeOutput;
 use crate::type_var::Restriction;
 use crate::typed_dict::AnonymousTypedDictInner;
@@ -1351,7 +1351,7 @@ impl Type {
     pub fn get_types_with_locations(
         &self,
         stdlib: Option<&Stdlib>,
-    ) -> Vec<(String, Option<TextRangeWithModule>)> {
+    ) -> Vec<TypeLabelPart> {
         let mut ctx = TypeDisplayContext::new(&[self]);
         if let Some(s) = stdlib {
             ctx.set_stdlib(s);
@@ -2345,32 +2345,30 @@ def overloaded_func[T](
     }
 
     // Helper functions for testing get_types_with_location
-    fn get_parts(t: &Type) -> Vec<(String, Option<TextRangeWithModule>)> {
+    fn get_parts(t: &Type) -> Vec<TypeLabelPart> {
         let ctx = TypeDisplayContext::new(&[t]);
         let output = ctx.get_types_with_location(t, false);
         output.parts().to_vec()
     }
 
-    fn parts_to_string(parts: &[(String, Option<TextRangeWithModule>)]) -> String {
-        parts.iter().map(|(s, _)| s.as_str()).collect::<String>()
+    fn parts_to_string(parts: &[TypeLabelPart]) -> String {
+        parts
+            .iter()
+            .map(|part| part.text.as_str())
+            .collect::<String>()
     }
 
-    fn assert_part_has_location(
-        parts: &[(String, Option<TextRangeWithModule>)],
-        name: &str,
-        module: &str,
-        position: u32,
-    ) {
-        let part = parts.iter().find(|(s, _)| s == name);
+    fn assert_part_has_location(parts: &[TypeLabelPart], name: &str, module: &str, position: u32) {
+        let part = parts.iter().find(|part| part.text == name);
         assert!(part.is_some(), "Should have {} in parts", name);
-        let (_, location) = part.unwrap();
-        assert!(location.is_some(), "{} should have location", name);
-        let loc = location.as_ref().unwrap();
+        let loc = part.unwrap().location.as_ref();
+        assert!(loc.is_some(), "{} should have location", name);
+        let loc = loc.unwrap();
         assert_eq!(loc.module.name().as_str(), module);
         assert_eq!(loc.range.start().to_u32(), position);
     }
 
-    fn assert_output_contains(parts: &[(String, Option<TextRangeWithModule>)], needle: &str) {
+    fn assert_output_contains(parts: &[TypeLabelPart], needle: &str) {
         let full_str = parts_to_string(parts);
         assert!(
             full_str.contains(needle),
@@ -2398,9 +2396,27 @@ def overloaded_func[T](
         let t = Type::ClassType(ClassType::new(foo, TArgs::new(tparams, vec![inner_type])));
         let parts = get_parts(&t);
 
-        assert_eq!(parts[0].0, "Foo");
+        assert_eq!(parts[0].text, "Foo");
         assert_part_has_location(&parts, "Foo", "test.module", 10);
-        assert!(parts.iter().any(|(s, _)| s == "Bar"), "Should have Bar");
+        assert!(
+            parts.iter().any(|part| part.text == "Bar"),
+            "Should have Bar"
+        );
+    }
+
+    #[test]
+    fn test_get_types_with_location_typevar() {
+        let tvar = fake_tyvar("T", "test.module", 15);
+        let heap = TypeHeap::new();
+        let t = tvar.to_type(&heap);
+        let parts = get_parts(&t);
+
+        assert_eq!(parts[0].text, "TypeVar[");
+        assert!(
+            parts[0].location.is_none(),
+            "TypeVar[ should not have location"
+        );
+        assert_part_has_location(&parts, "T", "test.module", 15);
     }
 
     #[test]
@@ -2415,8 +2431,14 @@ def overloaded_func[T](
         let parts1 = ctx.get_types_with_location(&t1, false).parts().to_vec();
         let parts2 = ctx.get_types_with_location(&t2, false).parts().to_vec();
 
-        let loc1 = parts1.iter().find_map(|(_, loc)| loc.as_ref()).unwrap();
-        let loc2 = parts2.iter().find_map(|(_, loc)| loc.as_ref()).unwrap();
+        let loc1 = parts1
+            .iter()
+            .find_map(|part| part.location.as_ref())
+            .unwrap();
+        let loc2 = parts2
+            .iter()
+            .find_map(|part| part.location.as_ref())
+            .unwrap();
         assert_ne!(
             loc1.range.start().to_u32(),
             loc2.range.start().to_u32(),
@@ -2431,6 +2453,11 @@ def overloaded_func[T](
 
         assert_output_contains(&parts, "Literal");
         assert_output_contains(&parts, "True");
+        let literal_part = parts.iter().find(|part| part.text == "Literal");
+        assert!(literal_part.is_some());
+        let symbol = literal_part.unwrap().symbol.as_ref().unwrap();
+        assert_eq!(symbol.module.as_str(), "typing");
+        assert_eq!(symbol.name, "Literal");
     }
 
     #[test]
@@ -2454,8 +2481,8 @@ def overloaded_func[T](
         let parts = get_parts(&t);
 
         assert_eq!(parts.len(), 1);
-        assert_eq!(parts[0].0, "None");
-        assert!(parts[0].1.is_none(), "None should not have location");
+        assert_eq!(parts[0].text, "None");
+        assert!(parts[0].location.is_none(), "None should not have location");
     }
 
     #[test]
@@ -2480,7 +2507,11 @@ def overloaded_func[T](
         for param in &["T", "U", "Ts"] {
             assert_output_contains(&parts, param);
         }
-        assert!(parts.iter().any(|(s, loc)| s == "[" && loc.is_none()));
+        assert!(
+            parts
+                .iter()
+                .any(|part| part.text == "[" && part.location.is_none())
+        );
         assert!(parts_to_string(&parts).starts_with('['));
         assert_output_contains(&parts, "](");
     }
@@ -2510,7 +2541,7 @@ def overloaded_func[T](
         for expected in &["Literal", "Color", "RED"] {
             assert_output_contains(&parts, expected);
         }
-        assert!(parts.iter().any(|(_, loc)| loc.is_some()));
+        assert!(parts.iter().any(|part| part.location.is_some()));
     }
 
     #[test]

--- a/crates/pyrefly_types/src/stdlib.rs
+++ b/crates/pyrefly_types/src/stdlib.rs
@@ -29,6 +29,9 @@ use crate::types::Type;
 /// These are defined as annotated assignments in typing.pyi (e.g., `Literal: _SpecialForm`)
 /// rather than as classes, so they require special handling.
 const SPECIAL_FORM_NAMES: &[&str] = &[
+    "Annotated",
+    "Any",
+    "Concatenate",
     "Literal",
     "LiteralString",
     "Never",

--- a/crates/pyrefly_types/src/type_output.rs
+++ b/crates/pyrefly_types/src/type_output.rs
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::borrow::Cow;
 use std::fmt;
 
 use pyrefly_python::module::TextRangeWithModule;
+use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::qname::QName;
 
 use crate::display::TypeDisplayContext;
@@ -28,6 +30,12 @@ pub trait TypeOutput {
     fn write_targs(&mut self, targs: &TArgs) -> fmt::Result;
     fn write_type(&mut self, ty: &Type) -> fmt::Result;
     fn write_builtin(&mut self, name: &str, qname: Option<&QName>) -> fmt::Result;
+    fn write_symbol(
+        &mut self,
+        module: ModuleName,
+        name: Cow<'_, str>,
+        display_module: bool,
+    ) -> fmt::Result;
 }
 
 /// Implementation of `TypeOutput` that writes formatted types to plain text.
@@ -74,6 +82,22 @@ impl<'a, 'b, 'f> TypeOutput for DisplayOutput<'a, 'b, 'f> {
     fn write_builtin(&mut self, name: &str, _qname: Option<&QName>) -> fmt::Result {
         self.formatter.write_str(name)
     }
+
+    fn write_symbol(
+        &mut self,
+        module: ModuleName,
+        name: Cow<'_, str>,
+        display_module: bool,
+    ) -> fmt::Result {
+        if display_module {
+            write!(self.formatter, "{}.{}", module, name)
+        } else {
+            match name {
+                Cow::Borrowed(s) => self.formatter.write_str(s),
+                Cow::Owned(s) => self.formatter.write_str(&s),
+            }
+        }
+    }
 }
 
 /// This struct is used to collect the type to be displayed as a vector. Each element
@@ -82,8 +106,21 @@ impl<'a, 'b, 'f> TypeOutput for DisplayOutput<'a, 'b, 'f> {
 /// each of these will be concatenated to create the final type.
 /// The second element of the vector is an optional location. For any part that do have
 /// a location this will be included. For separators like '|', '[', etc. this will be None.
+#[derive(Clone, Debug)]
+pub struct TypeSymbolReference {
+    pub module: ModuleName,
+    pub name: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct TypeLabelPart {
+    pub text: String,
+    pub location: Option<TextRangeWithModule>,
+    pub symbol: Option<TypeSymbolReference>,
+}
+
 pub struct OutputWithLocations<'a> {
-    parts: Vec<(String, Option<TextRangeWithModule>)>,
+    parts: Vec<TypeLabelPart>,
     context: &'a TypeDisplayContext<'a>,
 }
 
@@ -95,14 +132,18 @@ impl<'a> OutputWithLocations<'a> {
         }
     }
 
-    pub fn parts(&self) -> &[(String, Option<TextRangeWithModule>)] {
+    pub fn parts(&self) -> &[TypeLabelPart] {
         &self.parts
     }
 }
 
 impl TypeOutput for OutputWithLocations<'_> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.parts.push((s.to_owned(), None));
+        self.parts.push(TypeLabelPart {
+            text: s.to_owned(),
+            location: None,
+            symbol: None,
+        });
         Ok(())
     }
 
@@ -110,13 +151,21 @@ impl TypeOutput for OutputWithLocations<'_> {
         use std::fmt::Write;
         let mut s = String::new();
         s.write_fmt(args)?;
-        self.parts.push((s, None));
+        self.parts.push(TypeLabelPart {
+            text: s,
+            location: None,
+            symbol: None,
+        });
         Ok(())
     }
 
     fn write_qname(&mut self, qname: &QName) -> fmt::Result {
         let location = TextRangeWithModule::new(qname.module().clone(), qname.range());
-        self.parts.push((qname.id().to_string(), Some(location)));
+        self.parts.push(TypeLabelPart {
+            text: qname.id().to_string(),
+            location: Some(location),
+            symbol: None,
+        });
         Ok(())
     }
 
@@ -134,7 +183,11 @@ impl TypeOutput for OutputWithLocations<'_> {
             }
             _ => None,
         };
-        self.parts.push((formatted, location));
+        self.parts.push(TypeLabelPart {
+            text: formatted,
+            location,
+            symbol: None,
+        });
         Ok(())
     }
 
@@ -151,15 +204,36 @@ impl TypeOutput for OutputWithLocations<'_> {
     }
 
     fn write_builtin(&mut self, name: &str, qname: Option<&QName>) -> fmt::Result {
-        match qname {
-            Some(q) => {
-                let location = TextRangeWithModule::new(q.module().clone(), q.range());
-                self.parts.push((name.to_owned(), Some(location)));
+        let location = qname.map(|q| TextRangeWithModule::new(q.module().clone(), q.range()));
+        self.parts.push(TypeLabelPart {
+            text: name.to_owned(),
+            location,
+            symbol: None,
+        });
+        Ok(())
+    }
+    fn write_symbol(
+        &mut self,
+        module: ModuleName,
+        name: Cow<'_, str>,
+        display_module: bool,
+    ) -> fmt::Result {
+        let text = if display_module {
+            format!("{}.{}", module, name)
+        } else {
+            match &name {
+                Cow::Borrowed(s) => (*s).to_owned(),
+                Cow::Owned(s) => s.clone(),
             }
-            None => {
-                self.parts.push((name.to_owned(), None));
-            }
-        }
+        };
+        self.parts.push(TypeLabelPart {
+            text,
+            location: None,
+            symbol: Some(TypeSymbolReference {
+                module,
+                name: name.into_owned(),
+            }),
+        });
         Ok(())
     }
 }
@@ -183,6 +257,7 @@ mod tests {
     use crate::class::Class;
     use crate::class::ClassDefIndex;
     use crate::class::ClassType;
+    use crate::lit_int::LitInt;
     use crate::literal::LitEnum;
     use crate::literal::LitStyle;
     use crate::quantified::AnchorIndex;
@@ -221,17 +296,17 @@ mod tests {
 
         output.write_str("hello").unwrap();
         assert_eq!(output.parts().len(), 1);
-        assert_eq!(output.parts()[0].0, "hello");
-        assert!(output.parts()[0].1.is_none());
+        assert_eq!(output.parts()[0].text, "hello");
+        assert!(output.parts()[0].location.is_none());
 
         output.write_str(" world").unwrap();
         assert_eq!(output.parts().len(), 2);
-        assert_eq!(output.parts()[1].0, " world");
-        assert!(output.parts()[1].1.is_none());
+        assert_eq!(output.parts()[1].text, " world");
+        assert!(output.parts()[1].location.is_none());
 
         let parts = output.parts();
-        assert_eq!(parts[0].0, "hello");
-        assert_eq!(parts[1].0, " world");
+        assert_eq!(parts[0].text, "hello");
+        assert_eq!(parts[1].text, " world");
     }
 
     #[test]
@@ -254,11 +329,11 @@ mod tests {
         output.write_qname(&qname).unwrap();
 
         assert_eq!(output.parts().len(), 1);
-        let (name_str, location) = &output.parts()[0];
-        assert_eq!(name_str, "MyClass");
+        let part = &output.parts()[0];
+        assert_eq!(part.text, "MyClass");
 
-        assert!(location.is_some());
-        let loc = location.as_ref().unwrap();
+        assert!(part.location.is_some());
+        let loc = part.location.as_ref().unwrap();
         assert_eq!(
             loc.range,
             TextRange::new(TextSize::new(4), TextSize::new(11))
@@ -276,8 +351,8 @@ mod tests {
         output.write_lit(&str_lit).unwrap();
 
         assert_eq!(output.parts().len(), 1);
-        assert_eq!(output.parts()[0].0, "'hello'");
-        assert!(output.parts()[0].1.is_none());
+        assert_eq!(output.parts()[0].text, "'hello'");
+        assert!(output.parts()[0].location.is_none());
     }
 
     #[test]
@@ -297,13 +372,13 @@ mod tests {
         output.write_lit(&enum_lit).unwrap();
 
         assert_eq!(output.parts().len(), 1);
-        let (formatted, location) = &output.parts()[0];
+        let part = &output.parts()[0];
 
-        assert_eq!(formatted, "Color.RED");
+        assert_eq!(part.text, "Color.RED");
 
         // Verify the location was captured from the enum's class qname
-        assert!(location.is_some());
-        let loc = location.as_ref().unwrap();
+        assert!(part.location.is_some());
+        let loc = part.location.as_ref().unwrap();
         assert_eq!(loc.range, TextRange::empty(TextSize::new(10)));
         assert_eq!(loc.module.name(), ModuleName::from_str("colors"));
     }
@@ -366,26 +441,26 @@ mod tests {
         // Now that write_type is implemented, it actually writes the types
         // Should have: "[", "None", ", ", "LiteralString", ", ", "Any", "]"
         assert_eq!(output.parts().len(), 7);
-        assert_eq!(output.parts()[0].0, "[");
-        assert!(output.parts()[0].1.is_none());
+        assert_eq!(output.parts()[0].text, "[");
+        assert!(output.parts()[0].location.is_none());
 
-        assert_eq!(output.parts()[1].0, "None");
-        assert!(output.parts()[1].1.is_none());
+        assert_eq!(output.parts()[1].text, "None");
+        assert!(output.parts()[1].location.is_none());
 
-        assert_eq!(output.parts()[2].0, ", ");
-        assert!(output.parts()[2].1.is_none());
+        assert_eq!(output.parts()[2].text, ", ");
+        assert!(output.parts()[2].location.is_none());
 
-        assert_eq!(output.parts()[3].0, "LiteralString");
-        assert!(output.parts()[3].1.is_none());
+        assert_eq!(output.parts()[3].text, "LiteralString");
+        assert!(output.parts()[3].location.is_none());
 
-        assert_eq!(output.parts()[4].0, ", ");
-        assert!(output.parts()[4].1.is_none());
+        assert_eq!(output.parts()[4].text, ", ");
+        assert!(output.parts()[4].location.is_none());
 
-        assert_eq!(output.parts()[5].0, "Any");
-        assert!(output.parts()[5].1.is_none());
+        assert_eq!(output.parts()[5].text, "Any");
+        assert!(output.parts()[5].location.is_none());
 
-        assert_eq!(output.parts()[6].0, "]");
-        assert!(output.parts()[6].1.is_none());
+        assert_eq!(output.parts()[6].text, "]");
+        assert!(output.parts()[6].location.is_none());
     }
 
     #[test]
@@ -396,15 +471,15 @@ mod tests {
         // Test simple types that don't have locations
         output.write_type(&Type::None).unwrap();
         assert_eq!(output.parts().len(), 1);
-        assert_eq!(output.parts()[0].0, "None");
-        assert!(output.parts()[0].1.is_none());
+        assert_eq!(output.parts()[0].text, "None");
+        assert!(output.parts()[0].location.is_none());
 
         output
             .write_type(&Type::LiteralString(LitStyle::Implicit))
             .unwrap();
         assert_eq!(output.parts().len(), 2);
-        assert_eq!(output.parts()[1].0, "LiteralString");
-        assert!(output.parts()[1].1.is_none());
+        assert_eq!(output.parts()[1].text, "LiteralString");
+        assert!(output.parts()[1].location.is_none());
     }
 
     #[test]
@@ -424,13 +499,13 @@ mod tests {
         assert!(!output.parts().is_empty());
 
         // Find the int and str parts and verify they have locations
-        let int_part = output.parts().iter().find(|p| p.0 == "int");
+        let int_part = output.parts().iter().find(|p| p.text == "int");
         assert!(int_part.is_some());
-        assert!(int_part.unwrap().1.is_some());
+        assert!(int_part.unwrap().location.is_some());
 
-        let str_part = output.parts().iter().find(|p| p.0 == "str");
+        let str_part = output.parts().iter().find(|p| p.text == "str");
         assert!(str_part.is_some());
-        assert!(str_part.unwrap().1.is_some());
+        assert!(str_part.unwrap().location.is_some());
     }
 
     #[test]
@@ -449,7 +524,11 @@ mod tests {
         ctx.fmt_helper_generic(&union_type, false, &mut output)
             .unwrap();
 
-        let parts_str: String = output.parts().iter().map(|(s, _)| s.as_str()).collect();
+        let parts_str: String = output
+            .parts()
+            .iter()
+            .map(|part| part.text.as_str())
+            .collect();
         assert_eq!(parts_str, "int | str | None");
 
         // New behavior: Union types are split into separate parts
@@ -458,20 +537,26 @@ mod tests {
         assert_eq!(parts.len(), 5, "Union should be split into 5 parts");
 
         // Verify each part
-        assert_eq!(parts[0].0, "int");
-        assert!(parts[0].1.is_some(), "int should have location");
+        assert_eq!(parts[0].text, "int");
+        assert!(parts[0].location.is_some(), "int should have location");
 
-        assert_eq!(parts[1].0, " | ");
-        assert!(parts[1].1.is_none(), "separator should not have location");
+        assert_eq!(parts[1].text, " | ");
+        assert!(
+            parts[1].location.is_none(),
+            "separator should not have location"
+        );
 
-        assert_eq!(parts[2].0, "str");
-        assert!(parts[2].1.is_some(), "str should have location");
+        assert_eq!(parts[2].text, "str");
+        assert!(parts[2].location.is_some(), "str should have location");
 
-        assert_eq!(parts[3].0, " | ");
-        assert!(parts[3].1.is_none(), "separator should not have location");
+        assert_eq!(parts[3].text, " | ");
+        assert!(
+            parts[3].location.is_none(),
+            "separator should not have location"
+        );
 
-        assert_eq!(parts[4].0, "None");
-        assert!(parts[4].1.is_none(), "None should not have location");
+        assert_eq!(parts[4].text, "None");
+        assert!(parts[4].location.is_none(), "None should not have location");
     }
 
     #[test]
@@ -496,7 +581,11 @@ mod tests {
             .unwrap();
 
         // Check the concatenated result
-        let parts_str: String = output.parts().iter().map(|(s, _)| s.as_str()).collect();
+        let parts_str: String = output
+            .parts()
+            .iter()
+            .map(|part| part.text.as_str())
+            .collect();
         assert_eq!(parts_str, "int & str");
 
         // New behavior: Intersection types are split into separate parts
@@ -505,14 +594,17 @@ mod tests {
         assert_eq!(parts.len(), 3, "Intersection should be split into 3 parts");
 
         // Verify each part
-        assert_eq!(parts[0].0, "int");
-        assert!(parts[0].1.is_some(), "int should have location");
+        assert_eq!(parts[0].text, "int");
+        assert!(parts[0].location.is_some(), "int should have location");
 
-        assert_eq!(parts[1].0, " & ");
-        assert!(parts[1].1.is_none(), "separator should not have location");
+        assert_eq!(parts[1].text, " & ");
+        assert!(
+            parts[1].location.is_none(),
+            "separator should not have location"
+        );
 
-        assert_eq!(parts[2].0, "str");
-        assert!(parts[2].1.is_some(), "str should have location");
+        assert_eq!(parts[2].text, "str");
+        assert!(parts[2].location.is_some(), "str should have location");
     }
 
     #[test]
@@ -532,7 +624,11 @@ mod tests {
         ctx.fmt_helper_generic(&tuple_type, false, &mut output)
             .unwrap();
 
-        let parts_str: String = output.parts().iter().map(|(s, _)| s.as_str()).collect();
+        let parts_str: String = output
+            .parts()
+            .iter()
+            .map(|part| part.text.as_str())
+            .collect();
         assert_eq!(parts_str, "tuple[int]");
 
         // Without stdlib: The "tuple" part is NOT clickable
@@ -541,19 +637,66 @@ mod tests {
         assert_eq!(parts.len(), 4, "Should have 4 parts");
 
         // Verify each part
-        assert_eq!(parts[0].0, "tuple");
+        assert_eq!(parts[0].text, "tuple");
         assert!(
-            parts[0].1.is_none(),
+            parts[0].location.is_none(),
             "tuple should not have location without stdlib"
         );
 
-        assert_eq!(parts[1].0, "[");
-        assert!(parts[1].1.is_none(), "[ should not have location");
+        assert_eq!(parts[1].text, "[");
+        assert!(parts[1].location.is_none(), "[ should not have location");
 
-        assert_eq!(parts[2].0, "int");
-        assert!(parts[2].1.is_some(), "int should have location (clickable)");
+        assert_eq!(parts[2].text, "int");
+        assert!(
+            parts[2].location.is_some(),
+            "int should have location (clickable)"
+        );
 
-        assert_eq!(parts[3].0, "]");
-        assert!(parts[3].1.is_none(), "] should not have location");
+        assert_eq!(parts[3].text, "]");
+        assert!(parts[3].location.is_none(), "] should not have location");
+    }
+
+    #[test]
+    fn test_output_with_locations_literal_base_not_clickable() {
+        // TODO(jvansch): When implementing clickable support for the base type in special forms like Literal[1],
+        // update this test to verify that "Literal" has a location and is clickable.
+        // Expected future behavior: [("Literal", Some(location)), ("[", None), ("1", None), ("]", None)]
+
+        // Create Literal[1] type
+        let literal_type = Lit::Int(LitInt::new(1)).to_implicit_type();
+
+        let ctx = TypeDisplayContext::new(&[&literal_type]);
+        let mut output = OutputWithLocations::new(&ctx);
+
+        ctx.fmt_helper_generic(&literal_type, false, &mut output)
+            .unwrap();
+
+        let parts_str: String = output
+            .parts()
+            .iter()
+            .map(|part| part.text.as_str())
+            .collect();
+        assert_eq!(parts_str, "Literal[1]");
+
+        // Current behavior: The "Literal" part is NOT clickable
+        // Expected parts: [("Literal", None), ("[", None), ("1", None), ("]", None)]
+        let parts = output.parts();
+        assert_eq!(parts.len(), 4, "Should have 4 parts");
+
+        // Verify each part
+        assert_eq!(parts[0].text, "Literal");
+        assert!(
+            parts[0].location.is_none(),
+            "Literal should not have location (not clickable)"
+        );
+
+        assert_eq!(parts[1].text, "[");
+        assert!(parts[1].location.is_none(), "[ should not have location");
+
+        assert_eq!(parts[2].text, "1");
+        assert!(parts[2].location.is_none(), "1 should not have location");
+
+        assert_eq!(parts[3].text, "]");
+        assert!(parts[3].location.is_none(), "] should not have location");
     }
 }

--- a/crates/pyrefly_types/src/type_output.rs
+++ b/crates/pyrefly_types/src/type_output.rs
@@ -663,13 +663,7 @@ mod tests {
         // Expected future behavior: [("Literal", Some(location)), ("[", None), ("1", None), ("]", None)]
 
         // Create Literal[1] type
-<<<<<<< HEAD
         let literal_type = Lit::Int(LitInt::new(1)).to_implicit_type();
-||||||| parent of a0412b19d (fmt)
-        let literal_type = Type::Literal(Lit::Int(LitInt::new(1)));
-=======
-        let literal_type = Lit::Int(crate::lit_int::LitInt::new(1)).to_implicit_type();
->>>>>>> a0412b19d (fmt)
 
         let ctx = TypeDisplayContext::new(&[&literal_type]);
         let mut output = OutputWithLocations::new(&ctx);

--- a/crates/pyrefly_types/src/type_output.rs
+++ b/crates/pyrefly_types/src/type_output.rs
@@ -663,7 +663,13 @@ mod tests {
         // Expected future behavior: [("Literal", Some(location)), ("[", None), ("1", None), ("]", None)]
 
         // Create Literal[1] type
+<<<<<<< HEAD
         let literal_type = Lit::Int(LitInt::new(1)).to_implicit_type();
+||||||| parent of a0412b19d (fmt)
+        let literal_type = Type::Literal(Lit::Int(LitInt::new(1)));
+=======
+        let literal_type = Lit::Int(crate::lit_int::LitInt::new(1)).to_implicit_type();
+>>>>>>> a0412b19d (fmt)
 
         let ctx = TypeDisplayContext::new(&[&literal_type]);
         let mut output = OutputWithLocations::new(&ctx);

--- a/pyrefly/lib/lsp/wasm/inlay_hints.rs
+++ b/pyrefly/lib/lsp/wasm/inlay_hints.rs
@@ -179,9 +179,9 @@ impl<'a> Transaction<'a> {
                 let label_parts = once((prefix.to_owned(), None))
                     .chain(type_parts.iter().map(|part| {
                         let location = part.location.clone().or_else(|| {
-                            part.symbol
-                                .as_ref()
-                                .and_then(|symbol| self.resolve_type_symbol_reference(handle, symbol))
+                            part.symbol.as_ref().and_then(|symbol| {
+                                self.resolve_type_symbol_reference(handle, symbol)
+                            })
                         });
                         (part.text.clone(), location)
                     }))

--- a/pyrefly/lib/lsp/wasm/inlay_hints.rs
+++ b/pyrefly/lib/lsp/wasm/inlay_hints.rs
@@ -13,6 +13,7 @@ use pyrefly_graph::index::Idx;
 use pyrefly_python::ast::Ast;
 use pyrefly_python::module::TextRangeWithModule;
 use pyrefly_types::literal::Lit;
+use pyrefly_types::type_output::TypeSymbolReference;
 use pyrefly_util::visit::Visit;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprAttribute;
@@ -33,6 +34,7 @@ use crate::binding::binding::Key;
 use crate::binding::binding::KeyClassField;
 use crate::binding::binding::UnpackedPosition;
 use crate::binding::bindings::Bindings;
+use crate::export::exports::ExportLocation;
 use crate::state::lsp::AllOffPartial;
 use crate::state::lsp::AnnotationKind;
 use crate::state::lsp::DefinitionMetadata;
@@ -92,6 +94,38 @@ pub fn normalize_singleton_function_type_into_params(type_: Type) -> Option<Vec<
 }
 
 impl<'a> Transaction<'a> {
+    fn resolve_type_symbol_reference(
+        &self,
+        handle: &Handle,
+        symbol: &TypeSymbolReference,
+    ) -> Option<TextRangeWithModule> {
+        const MAX_LOOKUP_DEPTH: usize = 8;
+        let mut current_handle = handle.clone();
+        let mut current_module = symbol.module;
+        let mut current_name = ruff_python_ast::name::Name::new(symbol.name.clone());
+        for _ in 0..MAX_LOOKUP_DEPTH {
+            let module_handle = self
+                .import_handle(&current_handle, current_module, None)
+                .finding()?;
+            let module_info = self.get_module_info(&module_handle)?;
+            let exports = self.get_exports(&module_handle);
+            match exports.get(&current_name) {
+                Some(ExportLocation::ThisModule(export)) => {
+                    return Some(TextRangeWithModule::new(module_info, export.location));
+                }
+                Some(ExportLocation::OtherModule(next_module, alias)) => {
+                    current_handle = module_handle;
+                    current_module = *next_module;
+                    if let Some(alias_name) = alias {
+                        current_name = alias_name.clone();
+                    }
+                }
+                None => return None,
+            }
+        }
+        None
+    }
+
     pub fn inlay_hints(
         &self,
         handle: &Handle,
@@ -143,11 +177,14 @@ impl<'a> Transaction<'a> {
             |prefix: &str, position: TextSize, ty: &Type, insertable: bool| -> InlayHintData {
                 let type_parts = ty.get_types_with_locations(Some(&stdlib));
                 let label_parts = once((prefix.to_owned(), None))
-                    .chain(
-                        type_parts
-                            .iter()
-                            .map(|(text, loc)| (text.clone(), loc.clone())),
-                    )
+                    .chain(type_parts.iter().map(|part| {
+                        let location = part.location.clone().or_else(|| {
+                            part.symbol
+                                .as_ref()
+                                .and_then(|symbol| self.resolve_type_symbol_reference(handle, symbol))
+                        });
+                        (part.text.clone(), location)
+                    }))
                     .collect();
                 InlayHintData {
                     position,

--- a/pyrefly/lib/state/lsp/quick_fixes/extract_shared.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/extract_shared.rs
@@ -379,7 +379,7 @@ pub(super) fn type_to_annotation(ty: Type, stdlib: &Stdlib) -> Option<String> {
         return None;
     }
     let parts = ty.get_types_with_locations(Some(stdlib));
-    Some(parts.into_iter().map(|(part, _)| part).collect())
+    Some(parts.into_iter().map(|part| part.text).collect())
 }
 
 pub(super) fn has_existing_from_import(ast: &ModModule, module_name: &str, name: &str) -> bool {

--- a/pyrefly/lib/state/lsp/quick_fixes/generate_code.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/generate_code.rs
@@ -173,7 +173,7 @@ pub(crate) fn generate_code_actions(
         } else {
             let ty = Type::optional(ty);
             let parts = ty.get_types_with_locations(Some(&stdlib));
-            Some(parts.into_iter().map(|(part, _)| part).collect::<String>())
+            Some(parts.into_iter().map(|part| part.text).collect::<String>())
         }
     }) {
         Some(Some(annotation)) => format!("{statement_indent}{name}: {annotation} = None\n"),

--- a/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
@@ -896,3 +896,43 @@ fn test_inlay_hint_unpack_has_location() {
 
     interaction.shutdown().unwrap();
 }
+
+#[test]
+fn test_inlay_hint_typing_literals_have_locations() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(None),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open("inlay_hint_test.py");
+
+    interaction
+        .client
+        .inlay_hint("inlay_hint_test.py", 0, 0, 100, 0)
+        .expect_response_with(|result| {
+            let hints = match result {
+                Some(hints) => hints,
+                None => return false,
+            };
+
+            hints.iter().any(|hint| match &hint.label {
+                lsp_types::InlayHintLabel::LabelParts(parts) => parts.iter().any(|part| {
+                    part.value == "Literal"
+                        && part
+                            .location
+                            .as_ref()
+                            .map(|loc| loc.uri.path().contains("typing.pyi"))
+                            .unwrap_or(false)
+                }),
+                _ => false,
+            })
+        })
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}

--- a/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
@@ -7,33 +7,13 @@
 
 use serde_json::json;
 
-<<<<<<< HEAD
 use crate::object_model::InitializeSettings;
 use crate::object_model::LspInteraction;
+use crate::util::ExpectedInlayHint;
+use crate::util::ExpectedTextEdit;
 use crate::util::check_inlay_hint_label_values;
 use crate::util::get_test_files_root;
 use crate::util::inlay_hints_match_expected;
-use crate::util::ExpectedInlayHint;
-use crate::util::ExpectedTextEdit;
-||||||| parent of 394f30f3a (fmt)
-use crate::test::lsp::lsp_interaction::object_model::InitializeSettings;
-use crate::test::lsp::lsp_interaction::object_model::LspInteraction;
-use crate::test::lsp::lsp_interaction::util::check_inlay_hint_label_values;
-use crate::test::lsp::lsp_interaction::util::get_test_files_root;
-use crate::test::lsp::lsp_interaction::util::inlay_hints_match_expected;
-use crate::test::lsp::lsp_interaction::util::ExpectedInlayHint;
-use crate::test::lsp::lsp_interaction::util::ExpectedTextEdit;
-=======
-use crate::test::lsp::lsp_interaction::object_model::InitializeSettings;
-use crate::test::lsp::lsp_interaction::object_model::LspInteraction;
-use crate::test::lsp::lsp_interaction::util::check_inlay_hint_label_values;
-use crate::test::lsp::lsp_interaction::util::get_test_files_root;
-use crate::test::lsp::lsp_interaction::util::inlay_hints_match_expected;
-use crate::test::lsp::lsp_interaction::util::ExpectedInlayHint;
-use crate::test::lsp::lsp_interaction::util::ExpectedTextEdit;
-use crate::test::lsp::lsp_interaction::util::get_test_files_root;
-use crate::test::lsp::lsp_interaction::util::inlay_hints_match_expected;
->>>>>>> 394f30f3a (fmt)
 
 #[test]
 fn test_inlay_hint_default_config() {
@@ -50,40 +30,6 @@ fn test_inlay_hint_default_config() {
         .unwrap();
 
     interaction.client.did_open("inlay_hint_test.py");
-
-    let expected = [
-        ExpectedInlayHint {
-            labels: &[
-                " -> ", "tuple", "[", "Literal", "[", "1", "]", ", ", "Literal", "[", "2", "]", "]",
-            ],
-            position: (6, 21),
-            text_edit: ExpectedTextEdit {
-                new_text: " -> tuple[Literal[1], Literal[2]]",
-                range_start: (6, 21),
-                range_end: (6, 21),
-            },
-        },
-        ExpectedInlayHint {
-            labels: &[
-                ": ", "tuple", "[", "Literal", "[", "1", "]", ", ", "Literal", "[", "2", "]", "]",
-            ],
-            position: (11, 6),
-            text_edit: ExpectedTextEdit {
-                new_text: ": tuple[Literal[1], Literal[2]]",
-                range_start: (11, 6),
-                range_end: (11, 6),
-            },
-        },
-        ExpectedInlayHint {
-            labels: &[" -> ", "Literal", "[", "0", "]"],
-            position: (14, 15),
-            text_edit: ExpectedTextEdit {
-                new_text: " -> Literal[0]",
-                range_start: (14, 15),
-                range_end: (14, 15),
-            },
-        },
-    ];
 
     interaction
         .client

--- a/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
@@ -9,11 +9,8 @@ use serde_json::json;
 
 use crate::object_model::InitializeSettings;
 use crate::object_model::LspInteraction;
-use crate::util::ExpectedInlayHint;
-use crate::util::ExpectedTextEdit;
 use crate::util::check_inlay_hint_label_values;
 use crate::util::get_test_files_root;
-use crate::util::inlay_hints_match_expected;
 
 #[test]
 fn test_inlay_hint_default_config() {
@@ -907,7 +904,9 @@ fn test_inlay_hint_typing_literals_have_locations() {
     interaction.set_root(root.path().to_path_buf());
     interaction
         .initialize(InitializeSettings {
-            configuration: Some(None),
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
             ..Default::default()
         })
         .unwrap();

--- a/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
@@ -11,6 +11,9 @@ use crate::object_model::InitializeSettings;
 use crate::object_model::LspInteraction;
 use crate::util::check_inlay_hint_label_values;
 use crate::util::get_test_files_root;
+use crate::util::inlay_hints_match_expected;
+use crate::util::ExpectedInlayHint;
+use crate::util::ExpectedTextEdit;
 
 #[test]
 fn test_inlay_hint_default_config() {
@@ -27,6 +30,64 @@ fn test_inlay_hint_default_config() {
         .unwrap();
 
     interaction.client.did_open("inlay_hint_test.py");
+
+    let expected = [
+        ExpectedInlayHint {
+            labels: &[
+                " -> ",
+                "tuple",
+                "[",
+                "Literal",
+                "[",
+                "1",
+                "]",
+                ", ",
+                "Literal",
+                "[",
+                "2",
+                "]",
+                "]",
+            ],
+            position: (6, 21),
+            text_edit: ExpectedTextEdit {
+                new_text: " -> tuple[Literal[1], Literal[2]]",
+                range_start: (6, 21),
+                range_end: (6, 21),
+            },
+        },
+        ExpectedInlayHint {
+            labels: &[
+                ": ",
+                "tuple",
+                "[",
+                "Literal",
+                "[",
+                "1",
+                "]",
+                ", ",
+                "Literal",
+                "[",
+                "2",
+                "]",
+                "]",
+            ],
+            position: (11, 6),
+            text_edit: ExpectedTextEdit {
+                new_text: ": tuple[Literal[1], Literal[2]]",
+                range_start: (11, 6),
+                range_end: (11, 6),
+            },
+        },
+        ExpectedInlayHint {
+            labels: &[" -> ", "Literal", "[", "0", "]"],
+            position: (14, 15),
+            text_edit: ExpectedTextEdit {
+                new_text: " -> Literal[0]",
+                range_start: (14, 15),
+                range_end: (14, 15),
+            },
+        },
+    ];
 
     interaction
         .client

--- a/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
@@ -7,6 +7,7 @@
 
 use serde_json::json;
 
+<<<<<<< HEAD
 use crate::object_model::InitializeSettings;
 use crate::object_model::LspInteraction;
 use crate::util::check_inlay_hint_label_values;
@@ -14,6 +15,25 @@ use crate::util::get_test_files_root;
 use crate::util::inlay_hints_match_expected;
 use crate::util::ExpectedInlayHint;
 use crate::util::ExpectedTextEdit;
+||||||| parent of 394f30f3a (fmt)
+use crate::test::lsp::lsp_interaction::object_model::InitializeSettings;
+use crate::test::lsp::lsp_interaction::object_model::LspInteraction;
+use crate::test::lsp::lsp_interaction::util::check_inlay_hint_label_values;
+use crate::test::lsp::lsp_interaction::util::get_test_files_root;
+use crate::test::lsp::lsp_interaction::util::inlay_hints_match_expected;
+use crate::test::lsp::lsp_interaction::util::ExpectedInlayHint;
+use crate::test::lsp::lsp_interaction::util::ExpectedTextEdit;
+=======
+use crate::test::lsp::lsp_interaction::object_model::InitializeSettings;
+use crate::test::lsp::lsp_interaction::object_model::LspInteraction;
+use crate::test::lsp::lsp_interaction::util::check_inlay_hint_label_values;
+use crate::test::lsp::lsp_interaction::util::get_test_files_root;
+use crate::test::lsp::lsp_interaction::util::inlay_hints_match_expected;
+use crate::test::lsp::lsp_interaction::util::ExpectedInlayHint;
+use crate::test::lsp::lsp_interaction::util::ExpectedTextEdit;
+use crate::test::lsp::lsp_interaction::util::get_test_files_root;
+use crate::test::lsp::lsp_interaction::util::inlay_hints_match_expected;
+>>>>>>> 394f30f3a (fmt)
 
 #[test]
 fn test_inlay_hint_default_config() {
@@ -34,19 +54,7 @@ fn test_inlay_hint_default_config() {
     let expected = [
         ExpectedInlayHint {
             labels: &[
-                " -> ",
-                "tuple",
-                "[",
-                "Literal",
-                "[",
-                "1",
-                "]",
-                ", ",
-                "Literal",
-                "[",
-                "2",
-                "]",
-                "]",
+                " -> ", "tuple", "[", "Literal", "[", "1", "]", ", ", "Literal", "[", "2", "]", "]",
             ],
             position: (6, 21),
             text_edit: ExpectedTextEdit {
@@ -57,19 +65,7 @@ fn test_inlay_hint_default_config() {
         },
         ExpectedInlayHint {
             labels: &[
-                ": ",
-                "tuple",
-                "[",
-                "Literal",
-                "[",
-                "1",
-                "]",
-                ", ",
-                "Literal",
-                "[",
-                "2",
-                "]",
-                "]",
+                ": ", "tuple", "[", "Literal", "[", "1", "]", ", ", "Literal", "[", "2", "]", "]",
             ],
             position: (11, 6),
             text_edit: ExpectedTextEdit {

--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_inlay_hint.rs
@@ -9,11 +9,11 @@ use serde_json::json;
 
 use crate::object_model::InitializeSettings;
 use crate::object_model::LspInteraction;
+use crate::util::ExpectedInlayHint;
+use crate::util::ExpectedTextEdit;
 use crate::util::check_inlay_hint_label_values;
 use crate::util::get_test_files_root;
 use crate::util::inlay_hints_match_expected;
-use crate::util::ExpectedInlayHint;
-use crate::util::ExpectedTextEdit;
 
 #[test]
 fn test_inlay_hints() {
@@ -40,70 +40,38 @@ fn test_inlay_hints() {
     interaction
         .inlay_hint_cell("notebook.ipynb", "cell1", 0, 0, 100, 0)
         .expect_response_with(|result| {
-            let hints = match result {
-                Some(hints) => hints,
-                None => return false,
-            };
-            if hints.len() != 1 {
-                return false;
-            }
-            let hint = &hints[0];
-            if hint.position.line != 0 || hint.position.character != 21 {
-                return false;
-            }
-            check_inlay_hint_label_values(
-                hint,
-                &[
-                    (" -> ", false),
-                    ("tuple", true),
-                    ("[", false),
-                    ("Literal", true),
-                    ("[", false),
-                    ("1", false),
-                    ("]", false),
-                    (", ", false),
-                    ("Literal", true),
-                    ("[", false),
-                    ("2", false),
-                    ("]", false),
-                    ("]", false),
+            let expected = [ExpectedInlayHint {
+                labels: &[
+                    " -> ", "tuple", "[", "Literal", "[", "1", "]", ", ", "Literal", "[", "2", "]",
+                    "]",
                 ],
-            )
+                position: (0, 21),
+                text_edit: ExpectedTextEdit {
+                    new_text: " -> tuple[Literal[1], Literal[2]]",
+                    range_start: (0, 21),
+                    range_end: (0, 21),
+                },
+            }];
+            inlay_hints_match_expected(result, &expected)
         })
         .unwrap();
 
     interaction
         .inlay_hint_cell("notebook.ipynb", "cell2", 0, 0, 100, 0)
         .expect_response_with(|result| {
-            let hints = match result {
-                Some(hints) => hints,
-                None => return false,
-            };
-            if hints.len() != 1 {
-                return false;
-            }
-            let hint = &hints[0];
-            if hint.position.line != 0 || hint.position.character != 6 {
-                return false;
-            }
-            check_inlay_hint_label_values(
-                hint,
-                &[
-                    (": ", false),
-                    ("tuple", true),
-                    ("[", false),
-                    ("Literal", true),
-                    ("[", false),
-                    ("1", false),
-                    ("]", false),
-                    (", ", false),
-                    ("Literal", true),
-                    ("[", false),
-                    ("2", false),
-                    ("]", false),
-                    ("]", false),
+            let expected = [ExpectedInlayHint {
+                labels: &[
+                    ": ", "tuple", "[", "Literal", "[", "1", "]", ", ", "Literal", "[", "2", "]",
+                    "]",
                 ],
-            )
+                position: (0, 6),
+                text_edit: ExpectedTextEdit {
+                    new_text: ": tuple[Literal[1], Literal[2]]",
+                    range_start: (0, 6),
+                    range_end: (0, 6),
+                },
+            }];
+            inlay_hints_match_expected(result, &expected)
         })
         .unwrap();
 

--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_inlay_hint.rs
@@ -78,27 +78,16 @@ fn test_inlay_hints() {
     interaction
         .inlay_hint_cell("notebook.ipynb", "cell3", 0, 0, 100, 0)
         .expect_response_with(|result| {
-            let hints = match result {
-                Some(hints) => hints,
-                None => return false,
-            };
-            if hints.len() != 1 {
-                return false;
-            }
-            let hint = &hints[0];
-            if hint.position.line != 0 || hint.position.character != 15 {
-                return false;
-            }
-            check_inlay_hint_label_values(
-                hint,
-                &[
-                    (" -> ", false),
-                    ("Literal", true),
-                    ("[", false),
-                    ("0", false),
-                    ("]", false),
-                ],
-            )
+            let expected = [ExpectedInlayHint {
+                labels: &[" -> ", "Literal", "[", "0", "]"],
+                position: (0, 15),
+                text_edit: ExpectedTextEdit {
+                    new_text: " -> Literal[0]",
+                    range_start: (0, 15),
+                    range_end: (0, 15),
+                },
+            }];
+            inlay_hints_match_expected(result, &expected)
         })
         .unwrap();
 

--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_inlay_hint.rs
@@ -9,11 +9,8 @@ use serde_json::json;
 
 use crate::object_model::InitializeSettings;
 use crate::object_model::LspInteraction;
-use crate::util::ExpectedInlayHint;
-use crate::util::ExpectedTextEdit;
 use crate::util::check_inlay_hint_label_values;
 use crate::util::get_test_files_root;
-use crate::util::inlay_hints_match_expected;
 
 #[test]
 fn test_inlay_hints() {
@@ -40,54 +37,130 @@ fn test_inlay_hints() {
     interaction
         .inlay_hint_cell("notebook.ipynb", "cell1", 0, 0, 100, 0)
         .expect_response_with(|result| {
-            let expected = [ExpectedInlayHint {
-                labels: &[
-                    " -> ", "tuple", "[", "Literal", "[", "1", "]", ", ", "Literal", "[", "2", "]",
-                    "]",
+            let hints = match result {
+                Some(hints) => hints,
+                None => return false,
+            };
+            if hints.len() != 1 {
+                return false;
+            }
+            let hint = &hints[0];
+            if hint.position.line != 0 || hint.position.character != 21 {
+                return false;
+            }
+            if !check_inlay_hint_label_values(
+                hint,
+                &[
+                    (" -> ", false),
+                    ("tuple", true),
+                    ("[", false),
+                    ("Literal", true),
+                    ("[", false),
+                    ("1", false),
+                    ("]", false),
+                    (", ", false),
+                    ("Literal", true),
+                    ("[", false),
+                    ("2", false),
+                    ("]", false),
+                    ("]", false),
                 ],
-                position: (0, 21),
-                text_edit: ExpectedTextEdit {
-                    new_text: " -> tuple[Literal[1], Literal[2]]",
-                    range_start: (0, 21),
-                    range_end: (0, 21),
-                },
-            }];
-            inlay_hints_match_expected(result, &expected)
+            ) {
+                return false;
+            }
+            let text_edits = match &hint.text_edits {
+                Some(edits) if edits.len() == 1 => &edits[0],
+                _ => return false,
+            };
+            text_edits.new_text == " -> tuple[Literal[1], Literal[2]]"
+                && text_edits.range.start.line == 0
+                && text_edits.range.start.character == 21
+                && text_edits.range.end.line == 0
+                && text_edits.range.end.character == 21
         })
         .unwrap();
 
     interaction
         .inlay_hint_cell("notebook.ipynb", "cell2", 0, 0, 100, 0)
         .expect_response_with(|result| {
-            let expected = [ExpectedInlayHint {
-                labels: &[
-                    ": ", "tuple", "[", "Literal", "[", "1", "]", ", ", "Literal", "[", "2", "]",
-                    "]",
+            let hints = match result {
+                Some(hints) => hints,
+                None => return false,
+            };
+            if hints.len() != 1 {
+                return false;
+            }
+            let hint = &hints[0];
+            if hint.position.line != 0 || hint.position.character != 6 {
+                return false;
+            }
+            if !check_inlay_hint_label_values(
+                hint,
+                &[
+                    (": ", false),
+                    ("tuple", true),
+                    ("[", false),
+                    ("Literal", true),
+                    ("[", false),
+                    ("1", false),
+                    ("]", false),
+                    (", ", false),
+                    ("Literal", true),
+                    ("[", false),
+                    ("2", false),
+                    ("]", false),
+                    ("]", false),
                 ],
-                position: (0, 6),
-                text_edit: ExpectedTextEdit {
-                    new_text: ": tuple[Literal[1], Literal[2]]",
-                    range_start: (0, 6),
-                    range_end: (0, 6),
-                },
-            }];
-            inlay_hints_match_expected(result, &expected)
+            ) {
+                return false;
+            }
+            let text_edits = match &hint.text_edits {
+                Some(edits) if edits.len() == 1 => &edits[0],
+                _ => return false,
+            };
+            text_edits.new_text == ": tuple[Literal[1], Literal[2]]"
+                && text_edits.range.start.line == 0
+                && text_edits.range.start.character == 6
+                && text_edits.range.end.line == 0
+                && text_edits.range.end.character == 6
         })
         .unwrap();
 
     interaction
         .inlay_hint_cell("notebook.ipynb", "cell3", 0, 0, 100, 0)
         .expect_response_with(|result| {
-            let expected = [ExpectedInlayHint {
-                labels: &[" -> ", "Literal", "[", "0", "]"],
-                position: (0, 15),
-                text_edit: ExpectedTextEdit {
-                    new_text: " -> Literal[0]",
-                    range_start: (0, 15),
-                    range_end: (0, 15),
-                },
-            }];
-            inlay_hints_match_expected(result, &expected)
+            let hints = match result {
+                Some(hints) => hints,
+                None => return false,
+            };
+            if hints.len() != 1 {
+                return false;
+            }
+            let hint = &hints[0];
+            if hint.position.line != 0 || hint.position.character != 15 {
+                return false;
+            }
+            if !check_inlay_hint_label_values(
+                hint,
+                &[
+                    (" -> ", false),
+                    ("Literal", true),
+                    ("[", false),
+                    ("0", false),
+                    ("]", false),
+                ],
+            ) {
+                return false;
+            }
+            let text_edits = match &hint.text_edits {
+                Some(edits) if edits.len() == 1 => &edits[0],
+                _ => return false,
+            };
+            text_edits.new_text == " -> Literal[0]"
+                && text_edits.range.start.line == 0
+                && text_edits.range.start.character == 15
+                && text_edits.range.end.line == 0
+                && text_edits.range.end.character == 15
         })
         .unwrap();
 

--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_inlay_hint.rs
@@ -11,6 +11,9 @@ use crate::object_model::InitializeSettings;
 use crate::object_model::LspInteraction;
 use crate::util::check_inlay_hint_label_values;
 use crate::util::get_test_files_root;
+use crate::util::inlay_hints_match_expected;
+use crate::util::ExpectedInlayHint;
+use crate::util::ExpectedTextEdit;
 
 #[test]
 fn test_inlay_hints() {

--- a/pyrefly/lib/test/lsp/lsp_interaction/util.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/util.rs
@@ -10,8 +10,6 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use lsp_types::GotoDefinitionResponse;
-use lsp_types::InlayHint;
-use lsp_types::InlayHintLabel;
 use lsp_types::Location;
 use pyrefly::module::bundled::BundledStub;
 use pyrefly::module::typeshed::typeshed;
@@ -37,74 +35,6 @@ pub fn bundled_typeshed_path() -> PathBuf {
     let mut path = std::env::temp_dir();
     path.push(typeshed().unwrap().get_path_name());
     path
-}
-
-pub struct ExpectedTextEdit<'a> {
-    pub new_text: &'a str,
-    pub range_start: (u32, u32),
-    pub range_end: (u32, u32),
-}
-
-pub struct ExpectedInlayHint<'a> {
-    pub labels: &'a [&'a str],
-    pub position: (u32, u32),
-    pub text_edit: ExpectedTextEdit<'a>,
-}
-
-pub fn inlay_hints_match_expected(
-    result: Option<Vec<InlayHint>>,
-    expected: &[ExpectedInlayHint<'_>],
-) -> bool {
-    let hints = match result {
-        Some(hints) => hints,
-        None => return false,
-    };
-    if hints.len() != expected.len() {
-        return false;
-    }
-
-    for (hint, expected_hint) in hints.iter().zip(expected.iter()) {
-        let position = hint.position;
-        if position.line != expected_hint.position.0
-            || position.character != expected_hint.position.1
-        {
-            return false;
-        }
-
-        let parts = match &hint.label {
-            InlayHintLabel::LabelParts(parts) => parts,
-            _ => return false,
-        };
-        if parts.len() != expected_hint.labels.len() {
-            return false;
-        }
-        for (part, expected_value) in parts.iter().zip(expected_hint.labels.iter()) {
-            if part.value != *expected_value {
-                return false;
-            }
-            if *expected_value == "Literal" && part.location.is_none() {
-                return false;
-            }
-        }
-
-        let text_edits = match &hint.text_edits {
-            Some(edits) if edits.len() == 1 => &edits[0],
-            _ => return false,
-        };
-        if text_edits.new_text != expected_hint.text_edit.new_text {
-            return false;
-        }
-        let start = &expected_hint.text_edit.range_start;
-        let end = &expected_hint.text_edit.range_end;
-        if text_edits.range.start.line != start.0
-            || text_edits.range.start.character != start.1
-            || text_edits.range.end.line != end.0
-            || text_edits.range.end.character != end.1
-        {
-            return false;
-        }
-    }
-    true
 }
 
 fn copy_dir_recursively(src: &Path, dst: &Path) {

--- a/pyrefly/lib/test/lsp/lsp_interaction/util.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/util.rs
@@ -10,6 +10,8 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use lsp_types::GotoDefinitionResponse;
+use lsp_types::InlayHint;
+use lsp_types::InlayHintLabel;
 use lsp_types::Location;
 use pyrefly::module::bundled::BundledStub;
 use pyrefly::module::typeshed::typeshed;
@@ -35,6 +37,74 @@ pub fn bundled_typeshed_path() -> PathBuf {
     let mut path = std::env::temp_dir();
     path.push(typeshed().unwrap().get_path_name());
     path
+}
+
+pub struct ExpectedTextEdit<'a> {
+    pub new_text: &'a str,
+    pub range_start: (u32, u32),
+    pub range_end: (u32, u32),
+}
+
+pub struct ExpectedInlayHint<'a> {
+    pub labels: &'a [&'a str],
+    pub position: (u32, u32),
+    pub text_edit: ExpectedTextEdit<'a>,
+}
+
+pub fn inlay_hints_match_expected(
+    result: Option<Vec<InlayHint>>,
+    expected: &[ExpectedInlayHint<'_>],
+) -> bool {
+    let hints = match result {
+        Some(hints) => hints,
+        None => return false,
+    };
+    if hints.len() != expected.len() {
+        return false;
+    }
+
+    for (hint, expected_hint) in hints.iter().zip(expected.iter()) {
+        let position = hint.position;
+        if position.line != expected_hint.position.0
+            || position.character != expected_hint.position.1
+        {
+            return false;
+        }
+
+        let parts = match &hint.label {
+            InlayHintLabel::LabelParts(parts) => parts,
+            _ => return false,
+        };
+        if parts.len() != expected_hint.labels.len() {
+            return false;
+        }
+        for (part, expected_value) in parts.iter().zip(expected_hint.labels.iter()) {
+            if part.value != *expected_value {
+                return false;
+            }
+            if *expected_value == "Literal" && part.location.is_none() {
+                return false;
+            }
+        }
+
+        let text_edits = match &hint.text_edits {
+            Some(edits) if edits.len() == 1 => &edits[0],
+            _ => return false,
+        };
+        if text_edits.new_text != expected_hint.text_edit.new_text {
+            return false;
+        }
+        let start = &expected_hint.text_edit.range_start;
+        let end = &expected_hint.text_edit.range_end;
+        if text_edits.range.start.line != start.0
+            || text_edits.range.start.character != start.1
+            || text_edits.range.end.line != end.0
+            || text_edits.range.end.character != end.1
+        {
+            return false;
+        }
+    }
+    true
 }
 
 fn copy_dir_recursively(src: &Path, dst: &Path) {


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1681

Reworked the type-label plumbing so OutputWithLocations now emits TypeLabelPart records that carry both the rendered text and optional TypeSymbolReference metadata (module/name) whenever we render known symbols (e.g., via maybe_fmt_with_module). This involved extending the TypeOutput trait with write_symbol and updating all implementations/tests accordingly.

In the LSP transaction, added resolve_type_symbol_reference to import typing/typing_extensions modules on demand and attach their source locations to inlay-hint label parts when the original type string lacked a location. Both return-type and variable-type hint builders now fall back to this resolver before emitting each label part.

# Test Plan

Strengthened coverage with a new end-to-end LSP test that asserts Literal label parts point into typing.pyi, alongside the existing goto-type-definition test. The display-layer tests were also updated to exercise the richer label parts and verify Literal parts carry typing metadata.

<!-- Run test.py and commit any changes to generated files -->
