### PR TITLE
update regex crate: 1.11.1 -> 1.12.2

### DIFF
--- a/crates/pyrefly_config/Cargo.toml
+++ b/crates/pyrefly_config/Cargo.toml
@@ -21,7 +21,7 @@ parse-display = "0.8.2"
 pyrefly_build = { path = "../pyrefly_build" }
 pyrefly_python = { path = "../pyrefly_python" }
 pyrefly_util = { path = "../pyrefly_util" }
-regex = "1.11.1"
+regex = "1.12.2"
 regex-syntax = "0.7.5"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }

--- a/crates/pyrefly_python/Cargo.toml
+++ b/crates/pyrefly_python/Cargo.toml
@@ -19,7 +19,7 @@ lsp-types = { git = "https://github.com/astral-sh/lsp-types", rev = "3512a9f33ea
 parse-display = "0.8.2"
 pathdiff = "0.2"
 pyrefly_util = { path = "../pyrefly_util" }
-regex = "1.11.1"
+regex = "1.12.2"
 ruff_notebook = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }
 ruff_python_parser = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }

--- a/pyrefly/Cargo.toml
+++ b/pyrefly/Cargo.toml
@@ -41,7 +41,7 @@ pyrefly_python = { path = "../crates/pyrefly_python" }
 pyrefly_types = { path = "../crates/pyrefly_types" }
 pyrefly_util = { path = "../crates/pyrefly_util" }
 rayon = "1.11.0"
-regex = "1.11.1"
+regex = "1.12.2"
 ruff_annotate_snippets = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }
 ruff_notebook = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511", features = ["serde"] }


### PR DESCRIPTION
Summary:
Primarily updating for https://docs.rs/regex/latest/regex/struct.Captures.html#method.get_match to avoid explicit `unwrap()` in production code

https://github.com/rust-lang/regex/blob/master/CHANGELOG.md

Differential Revision: D87950658


