### PR TITLE
Fix flaky test_notebook_publish_diagnostics by preventing unnecessary RecheckFinished events

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -3088,8 +3088,13 @@ impl Server {
             // After we finished a recheck asynchronously, we immediately send `RecheckFinished` to
             // the main event loop of the server. As a result, the server can do a revalidation of
             // all the in-memory files based on the fresh main State as soon as possible.
-            info!("Invalidated config, prepare to recheck open files.");
-            let _ = lsp_queue.send(LspEvent::RecheckFinished);
+            // Only send RecheckFinished if there are actually open files to revalidate.
+            if !open_files.read().is_empty() {
+                info!("Invalidated config, prepare to recheck open files.");
+                let _ = lsp_queue.send(LspEvent::RecheckFinished);
+            } else {
+                info!("Invalidated config, but no open files to recheck.");
+            }
         }));
     }
 

--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_sync.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_sync.rs
@@ -32,12 +32,6 @@ fn test_notebook_publish_diagnostics() {
         .expect_publish_diagnostics_uri(&cell_uri, 1)
         .unwrap();
 
-    // TODO: Stop sending multiple publishDiagnostics on didOpen
-    interaction
-        .client
-        .expect_publish_diagnostics_uri(&cell_uri, 1)
-        .unwrap();
-
     interaction.close_notebook("notebook.ipynb");
 
     interaction


### PR DESCRIPTION
Summary:
The test_notebook_publish_diagnostics test was flaky due to a race condition
during LSP initialization. When a client responded to the WorkspaceConfiguration request
during initialization, workspace_configuration_response() would trigger
invalidate_config_and_validate_in_memory(), which always queued a RecheckFinished event.
This RecheckFinished event calls validate_in_memory_and_commit_if_possible(), publishing
diagnostics for all currently open files.

The race occurred because:
- If didOpen was processed BEFORE RecheckFinished: The notebook was already in open_files,
  so RecheckFinished published diagnostics for it → 2 publishDiagnostics (test passed)
- If didOpen was processed AFTER RecheckFinished: No files were open yet, so
  RecheckFinished published nothing → 1 publishDiagnostics (test failed)

The fix prevents RecheckFinished from being queued when there are no open files to
revalidate. This makes the server behavior deterministic and eliminates the race
condition. As a side benefit, this also improves performance by avoiding unnecessary
revalidation work during initialization.

Differential Revision: D88116232


