### PR TITLE
use lazy blocking mode for completion test that requires indexing

### DIFF
--- a/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
@@ -326,8 +326,6 @@ fn test_completion_with_autoimport_in_defined_module() {
     interaction.shutdown().unwrap();
 }
 
-// TODO: figure out why this test fails on Windows.
-#[cfg(unix)]
 #[test]
 fn test_completion_with_autoimport_duplicates() {
     let root = get_test_files_root();
@@ -345,6 +343,11 @@ fn test_completion_with_autoimport_duplicates() {
 
     interaction.client.did_open("foo.py");
 
+    // Wait for publishDiagnostics to ensure file is fully validated
+    interaction
+        .client
+        .expect_publish_diagnostics_error_count(root_path.join("foo.py"), 1)
+        .unwrap();
     interaction
         .client
         .completion("foo.py", 5, 14)


### PR DESCRIPTION
Summary:
test is flaky: https://github.com/facebook/pyrefly/actions/runs/19869027949/job/56939483229

looks like it's sometimes not fully indexed when it needs completions. we should make it sequential

Differential Revision: D88194472


