### PR TITLE
Fix #1699: Install python-dateutil in sandbox using micropip

### DIFF
--- a/website/src/sandbox/pythonWorker.ts
+++ b/website/src/sandbox/pythonWorker.ts
@@ -82,6 +82,18 @@ const initPyodide = async () => {
         },
     });
 
+    // Load python-dateutil package for sandbox use
+    // See: https://github.com/facebook/pyrefly/issues/1699
+    try {
+        await py.loadPackage('micropip');
+        await py.runPythonAsync(`
+import micropip
+await micropip.install('python-dateutil')
+        `);
+    } catch (error) {
+        console.error('[Pyodide] Failed to install python-dateutil:', error);
+    }
+
     return py;
 };
 


### PR DESCRIPTION
# Summary
Load python-dateutil when initializing Pyodide using micropip.install()This PR enables users to import and use `python dateutil` in the Pyrefly sandbox by automatically installing the package during Pyodide initialization.

**Changes:**
- Modified `pythonWorker.ts` to load micropip and install python-dateutil during Pyodide init
- Added error handling to prevent initialization failures if package loading fails

<!-- Describe the change in this PR -->

Fixes #1699 

# Test Plan

**Local Testing:**
- ⚠️ Unable to fully verify locally due to SRI (Subresource Integrity) check failures on Pyodide packages in dev environment

**Verification needed:**
- Maintainers should verify this works in production/CI where SRI checks pass correctly

