### PR TITLE
fix panic: attempt to subtract with overflow in validate_type_guard_positional_argument_count #1715

### DIFF
--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -1191,7 +1191,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .iter()
             .filter(|p| matches!(p, Param::Pos(..) | Param::PosOnly(..)))
             .count()
-            - (if defining_cls.is_some() && !is_staticmethod {
+            .saturating_sub(if defining_cls.is_some() && !is_staticmethod {
                 1 // Subtract the "self" or "cls" parameter
             } else {
                 0

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -1592,6 +1592,10 @@ class C:
     @staticmethod
     def guard_kw_arg_static(*, x) -> TypeGuard[int]: # E: Type guard functions must accept at least one positional argument
         return True
+
+class D:
+    def guard_missing_self() -> TypeGuard[int]: # E: Type guard functions must accept at least one positional argument
+        return True
 "#,
 );
 
@@ -1655,6 +1659,10 @@ class C:
 
     @staticmethod
     def guard_kw_arg_static(*, x) -> TypeIs[int]: # E: Type guard functions must accept at least one positional argument
+        return True
+
+class D:
+    def guard_missing_self() -> TypeIs[int]: # E: Type guard functions must accept at least one positional argument
         return True
 "#,
 );


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1715

Now uses saturating_sub when discounting the implicit self/cls parameter, so malformed methods that omit that parameter trigger the expected diagnostic instead of underflowing a usize.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Introduce regression cases where a class method returning TypeGuard/TypeIs lacks any positional parameters;