### PR TITLE
test(#1732): Add test for await in async generator

### DIFF
--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -736,3 +736,8 @@ class C:
             pass
     "#,
 );
+
+testcase!(test_await_in_async_generator, r#"
+async def a_gen():
+    yield await test2()
+"#,);


### PR DESCRIPTION
## Summary

Adds a test case for issue #1732 - false positive syntax error when using `await` inside async generator functions.

The test demonstrates that `await` should be allowed inside async generator definitions, as the await expression executes inside the async function that consumes the generator.

## Test Plan

Added `test_await_in_async_generator` test case that verifies `async def a_gen(): yield await test2()` does not produce a false positive error.

Fixes #1732