### PR TITLE
Reject `type[...]` with `NewType` aliases at definition time

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1898,12 +1898,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     };
                     // TODO: Validate that `targ` refers to a "valid in-scope class or TypeVar"
                     // (https://typing.readthedocs.io/en/latest/spec/annotations.html#type-and-annotation-expressions)
-                    // If the type argument is an error, propagate it to avoid cascading errors.
-                    if targ.is_error() {
-                        targ
-                    } else {
-                        Type::type_form(Type::type_form(targ))
-                    }
+                    Type::type_form(Type::type_form(targ))
                 }
                 // TODO: pyre_extensions.PyreReadOnly is a non-standard type system extension that marks read-only
                 // objects. We don't support it yet.

--- a/pyrefly/lib/test/new_type.rs
+++ b/pyrefly/lib/test/new_type.rs
@@ -145,10 +145,10 @@ Thing = NewType("Thing", int)
 ThingType = type[Thing]  # E: NewType `Thing` is not a class and cannot be used with `type` or `Type`
 OtherThingType = Type[Thing]  # E: NewType `Thing` is not a class and cannot be used with `type` or `Type`
 
-mapping: dict[int, ThingType] = {1: Thing}
+mapping: dict[int, ThingType] = {1: Thing}  # E: `dict[int, type[Thing]]` is not assignable to `dict[int, type[Unknown]]`
 
 def func(x: ThingType) -> None: ...
-func(Thing)
+func(Thing)  # E: Argument `type[Thing]` is not assignable to parameter `x` with type `type[Unknown]` in function `func`
     "#,
 );
 


### PR DESCRIPTION
Resolves https://github.com/facebook/pyrefly/issues/1709

This diff validates `type[...]`/`Type[...]` arguments during annotation so `typing.NewType` aliases produce an immediate invalid-annotation error instead of flowing through subtyping.