### PR TITLE
fix Highlighting does not support Chinese. #1686

### DIFF
--- a/pyrefly/lib/state/semantic_tokens.rs
+++ b/pyrefly/lib/state/semantic_tokens.rs
@@ -114,6 +114,10 @@ impl SemanticTokensLegends {
             let length = if start_pos.line == end_pos.line {
                 end_pos.character.saturating_sub(start_pos.character)
             } else {
+                // LSP semantic tokens must be expressed within a single line; we currently
+                // generate only single-line ranges, so treat any multi-line span as invalid
+                // and skip it. (Today this effectively never happens, but the guard keeps us
+                // from emitting malformed data if it does.)
                 0
             };
             if length == 0 {

--- a/pyrefly/lib/test/lsp/semantic_tokens.rs
+++ b/pyrefly/lib/test/lsp/semantic_tokens.rs
@@ -56,7 +56,7 @@ fn assert_full_semantic_tokens(files: &[(&'static str, &str)], expected: &str) {
             let end_utf16 = start_col + token_length;
             let line_utf16_len = line.encode_utf16().count();
             let text = if end_utf16 <= line_utf16_len {
-                let start_byte = utf16_to_byte_index(line, start_col.min(line_utf16_len));
+                let start_byte = utf16_to_byte_index(line, start_col);
                 let end_byte = utf16_to_byte_index(line, end_utf16);
                 line[start_byte..end_byte].to_owned()
             } else {


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1686

Re-encoded semantic token offsets to use UTF-16/position-encoding distances everywhere, so both delta_start and length now come from LSP positions rather than raw byte ranges; this keeps multi-byte identifiers aligned with the editor’s expectations

Extended the semantic-token test harness with a UTF-16 aware slicing helper so expected token strings can be reconstructed even when source lines contain multi-byte characters.

# Test Plan

<!-- Describe how you tested this PR -->

Added a regression test that covers a Chinese identifier assignment/use, proving the encoder stays accurate on non-ASCII text in the future.

<!-- Run test.py and commit any changes to generated files -->
