### PR TITLE
Fix --remove-unused-ignores leaving blank lines

### DIFF
--- a/pyrefly/lib/error/suppress.rs
+++ b/pyrefly/lib/error/suppress.rs
@@ -372,8 +372,9 @@ pub fn remove_unused_ignores(loads: &Errors, all: bool) -> usize {
                         let new_string = regex.replace_all(line, "");
                         if !new_string.trim().is_empty() {
                             buf.push_str(new_string.trim_end());
+                            buf.push('\n');
                         }
-                        buf.push('\n');
+                        // Skip writing newline if the line becomes empty after removing the ignore
                         continue;
                     }
                     buf.push_str(line);
@@ -613,7 +614,6 @@ def f() -> int:
 "#;
         let want = r#"
 def f() -> int:
-
     return 1
 "#;
         assert_remove_ignores(input, want, false, 1);
@@ -628,7 +628,6 @@ def g() -> str:
 "#;
         let want = r#"
 def g() -> str:
-
     return "hello"
 "#;
         assert_remove_ignores(input, want, false, 1);
@@ -660,7 +659,6 @@ def f() -> int:
 def g() -> str:
     return "hello"
 def f() -> int:
-
     return 1
 "##;
         assert_remove_ignores(input, output, false, 2);


### PR DESCRIPTION
# Summary
When removing unused ignore comments, standalone comment lines were leaving blank lines behind. This fix ensures that when a line becomes empty after removing the ignore comment, the entire line (including the newline) is removed.

Fixes #1768

## Changes
- Updated the logic in `remove_unused_ignores` to conditionally write newlines

# Test Plan
  - ✅ All 20 tests in `error::suppress::tests` pass
  - ✅ Manually tested the exact workflow from the issue:
