### PR TITLE
format params same as signature

### DIFF
--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -798,6 +798,27 @@ impl Param {
             _ => false,
         }
     }
+
+    /// Format a parameter for display using the proper type display infrastructure.
+    /// This ensures consistent formatting with default values, position-only markers, etc.
+    ///
+    /// This is similar to the `Display` impl, but allows passing in a `TypeDisplayContext`
+    /// for context-aware formatting (e.g., disambiguating types with the same name).
+    pub fn format_for_signature(&self, type_ctx: &crate::display::TypeDisplayContext) -> String {
+        use pyrefly_util::display::Fmt;
+
+        use crate::type_output::DisplayOutput;
+
+        format!(
+            "{}",
+            Fmt(|f| {
+                let mut output = DisplayOutput::new(type_ctx, f);
+                self.fmt_with_type(&mut output, &|ty, o| {
+                    type_ctx.fmt_helper_generic(ty, false, o)
+                })
+            })
+        )
+    }
 }
 
 impl Display for Param {

--- a/pyrefly/lib/test/lsp/signature_help.rs
+++ b/pyrefly/lib/test/lsp/signature_help.rs
@@ -772,7 +772,7 @@ foo()
 6 | foo()
         ^
 Signature Help Result: active=0
-- def foo(a: KylesInt) -> None: ..., parameters=[a: int | str], active parameter = 0"
+- def foo(a: KylesInt) -> None: ..., parameters=[a: KylesInt], active parameter = 0"
             .trim(),
         report.trim(),
     );


### PR DESCRIPTION
Summary:
per LSP spec:
> a label of type string should be a substring of its containing signature label.

we must format these the same or editors might not display them

Differential Revision: D88863608


