### PR TITLE
Fix __future__ imports being flagged as unused

### DIFF
--- a/crates/pyrefly_python/src/module_name.rs
+++ b/crates/pyrefly_python/src/module_name.rs
@@ -116,6 +116,10 @@ impl ModuleName {
         Self::from_str("typing_extensions")
     }
 
+    pub fn future() -> Self {
+        Self::from_str("__future__")
+    }
+
     pub fn types() -> Self {
         Self::from_str("types")
     }

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -1054,14 +1054,11 @@ impl<'a> BindingsBuilder<'a> {
                     };
                     let key = self.insert_binding(key, val);
                     // Register the imported name from wildcard imports
-                    self.scopes.register_import_with_star(
-                        &Identifier {
-                            node_index: AtomicNodeIndex::default(),
-                            id: name.into_key().clone(),
-                            range: x.range,
-                        },
-                        true,
-                    );
+                    self.scopes.register_import_with_star(&Identifier {
+                        node_index: AtomicNodeIndex::default(),
+                        id: name.into_key().clone(),
+                        range: x.range,
+                    });
                     self.bind_name(
                         name.key(),
                         key,
@@ -1116,7 +1113,13 @@ impl<'a> BindingsBuilder<'a> {
                         Binding::Type(Type::any_explicit())
                     }
                 };
-                self.scopes.register_import(&asname);
+                // __future__ imports have side effects even if not explicitly used,
+                // so we skip the unused import check for them.
+                if m == ModuleName::future() {
+                    self.scopes.register_future_import(&asname);
+                } else {
+                    self.scopes.register_import(&asname);
+                }
                 self.bind_definition(&asname, val, FlowStyle::Import(m, x.name.id));
             }
         }

--- a/pyrefly/lib/test/lsp/diagnostic.rs
+++ b/pyrefly/lib/test/lsp/diagnostic.rs
@@ -150,6 +150,34 @@ def foo() -> str:
 }
 
 #[test]
+fn test_future_import_not_reported_as_unused() {
+    let code = r#"
+from __future__ import annotations
+
+def foo() -> str:
+    return "hello"
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::indexing(), true);
+    let handle = handles.get("main").unwrap();
+    let report = get_unused_import_diagnostics(&state, handle);
+    assert_eq!(report, "No unused imports");
+}
+
+#[test]
+fn test_future_import_with_alias_not_reported_as_unused() {
+    let code = r#"
+from __future__ import annotations as _annotations
+
+def foo() -> str:
+    return "hello"
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::indexing(), true);
+    let handle = handles.get("main").unwrap();
+    let report = get_unused_import_diagnostics(&state, handle);
+    assert_eq!(report, "No unused imports");
+}
+
+#[test]
 fn test_generator_with_send() {
     let code = r#"
 from typing import Generator


### PR DESCRIPTION
Fixes #1809

# Summary
`__future__` imports have side effects at module level even if the imported name is never referenced, so they should not
be reported as unused.

Renamed `is_star_import` to `skip_unused_check` because the field describes *why* it exists (skip unused checking) not *what* sets it. This makes the code clearer when both star imports and `__future__` imports need the same behavior.

# Test Plan
- Added two new unit tests:
    - `test_future_import_not_reported_as_unused`
    - `test_future_import_with_alias_not_reported_as_unused`
- All existing tests pass (`cargo test`)