### PR TITLE
Flag unreachable `return` and `yield` statements

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -249,6 +249,10 @@ pub enum ErrorKind {
     /// Identity comparison (`is` or `is not`) between types that are provably disjoint
     /// or between literals whose comparison result is statically known.
     UnnecessaryComparison,
+    /// A return or yield statement that can never be reached.
+    /// This occurs when a return/yield follows a statement that always exits,
+    /// such as return, raise, break, or continue.
+    UnreachableStatement,
     /// Attempting to use a feature that is not yet supported.
     Unsupported,
     /// Attempting to `del` something that cannot be deleted

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -482,6 +482,14 @@ impl<'a> BindingsBuilder<'a> {
     }
 
     fn record_yield(&mut self, mut x: ExprYield) {
+        // Check if this yield is unreachable (comes after a terminating statement)
+        if self.scopes.has_flow_terminated() {
+            self.error(
+                x.range,
+                ErrorInfo::Kind(ErrorKind::UnreachableStatement),
+                "This `yield` expression is unreachable".to_owned(),
+            );
+        }
         let mut yield_link = self.declare_current_idx(Key::YieldLink(x.range));
         let idx = self.idx_for_promise(KeyYield(x.range));
         self.ensure_expr_opt(x.value.as_deref_mut(), yield_link.usage());
@@ -492,6 +500,14 @@ impl<'a> BindingsBuilder<'a> {
     }
 
     fn record_yield_from(&mut self, mut x: ExprYieldFrom) {
+        // Check if this yield from is unreachable (comes after a terminating statement)
+        if self.scopes.has_flow_terminated() {
+            self.error(
+                x.range,
+                ErrorInfo::Kind(ErrorKind::UnreachableStatement),
+                "This `yield from` expression is unreachable".to_owned(),
+            );
+        }
         let mut yield_from_link = self.declare_current_idx(Key::YieldLink(x.range));
         let idx = self.idx_for_promise(KeyYieldFrom(x.range));
         self.ensure_expr(&mut x.value, yield_from_link.usage());

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -1849,6 +1849,11 @@ impl Scopes {
         self.current_mut().flow.has_terminated = true;
     }
 
+    /// Check if the current flow has terminated (e.g., after a return, raise, break, or continue).
+    pub fn has_flow_terminated(&self) -> bool {
+        self.current().flow.has_terminated
+    }
+
     /// Whenever we enter the scope of a method *and* we see a matching
     /// parameter, we record the name of it so that we can detect `self` assignments
     /// that might define class fields.

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -272,6 +272,14 @@ impl<'a> BindingsBuilder<'a> {
     /// If this is the top level, report a type error about the invalid return
     /// and also create a binding to ensure we type check the expression.
     fn record_return(&mut self, mut x: StmtReturn) {
+        // Check if this return is unreachable (comes after a terminating statement)
+        if self.scopes.has_flow_terminated() {
+            self.error(
+                x.range(),
+                ErrorInfo::Kind(ErrorKind::UnreachableStatement),
+                "This `return` statement is unreachable".to_owned(),
+            );
+        }
         // PEP 765: Disallow return in finally block (Python 3.14+)
         if self.sys_info.version().at_least(3, 14) && self.scopes.in_finally() {
             self.error(

--- a/pyrefly/lib/test/returns.rs
+++ b/pyrefly/lib/test/returns.rs
@@ -313,3 +313,68 @@ def gen() -> Generator[int, None, str]:
     return  # E: Returned type `None` is not assignable to declared return type `str`
 "#,
 );
+
+testcase!(
+    test_unreachable_return_after_return,
+    r#"
+def test():
+    return 1
+    return 2 # E: This `return` statement is unreachable
+"#,
+);
+
+testcase!(
+    test_unreachable_return_after_raise,
+    r#"
+def test():
+    raise Exception()
+    return 1 # E: This `return` statement is unreachable
+"#,
+);
+
+testcase!(
+    test_unreachable_yield_after_return,
+    r#"
+def test():
+    return 1
+    yield 2 # E: This `yield` expression is unreachable
+"#,
+);
+
+testcase!(
+    test_unreachable_return_after_break,
+    r#"
+def test():
+    while True:
+        break
+        return 1 # E: This `return` statement is unreachable
+"#,
+);
+
+testcase!(
+    test_unreachable_return_after_continue,
+    r#"
+def test():
+    while True:
+        continue
+        return 1 # E: This `return` statement is unreachable
+"#,
+);
+
+testcase!(
+    test_yield_after_yield_is_ok,
+    r#"
+def test():
+    yield 1
+    yield 2  # No error - yields can follow other yields
+"#,
+);
+
+testcase!(
+    test_unreachable_yield_from_after_return,
+    r#"
+def test():
+    return 1
+    yield from [2, 3] # E: This `yield from` expression is unreachable
+"#,
+);

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -1088,6 +1088,35 @@ def test1(x: object) -> None:
 
 This check is relatively conservative and only warn on limited cases where the comparison is highly likely to be redundant.
 
+## unreachable-statement
+
+This error is raised when a `return` or `yield` statement can never be reached because it comes
+after a statement that always exits the current flow, such as `return`, `raise`, `break`, or `continue`.
+
+```python
+def example():
+    return 1
+    return 2  # This `return` statement is unreachable [unreachable-statement]
+
+def generator():
+    return
+    yield 1  # This `yield` expression is unreachable [unreachable-statement]
+
+def loop_example():
+    while True:
+        break
+        return 1  # This `return` statement is unreachable [unreachable-statement]
+```
+
+Note that `yield` statements can follow other `yield` statements without error, since generators
+can produce multiple values:
+
+```python
+def valid_generator():
+    yield 1
+    yield 2  # This is valid
+```
+
 ## unsupported
 
 This error indicates that pyrefly does not currently support a typing feature.


### PR DESCRIPTION
Resolves https://github.com/facebook/pyrefly/issues/1812

This diff adds detection for return and yield statements that can never be reached because they follow a statement that always terminates flow, such as return, raise, break, or continue. We now have a new `unreachable-statement` error kind.