### PR TITLE
fix Add Support For completionItem/resolve #1689

### DIFF
--- a/crates/pyrefly_python/Cargo.toml
+++ b/crates/pyrefly_python/Cargo.toml
@@ -23,7 +23,7 @@ regex = "1.12.4"
 ruff_notebook = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5" }
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5" }
 ruff_python_parser = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5" }
-ruff_text_size = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 starlark_map = "0.14.2"
 static_interner = { version = "0.1.3", features = ["dupe"] }

--- a/crates/pyrefly_types/Cargo.toml
+++ b/crates/pyrefly_types/Cargo.toml
@@ -19,7 +19,7 @@ pyrefly_derive = { path = "../pyrefly_derive" }
 pyrefly_python = { path = "../pyrefly_python" }
 pyrefly_util = { path = "../pyrefly_util" }
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5" }
-ruff_text_size = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5", features = ["serde"] }
 starlark_map = "0.14.2"
 static_assertions = "1.1.0"
 vec1 = { version = "1.12.1", features = ["serde"] }

--- a/crates/pyrefly_util/Cargo.toml
+++ b/crates/pyrefly_util/Cargo.toml
@@ -34,7 +34,7 @@ rayon = "1.11.0"
 ruff_notebook = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5" }
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5" }
 ruff_source_file = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5" }
-ruff_text_size = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 starlark_map = "0.14.2"

--- a/pyrefly/Cargo.toml
+++ b/pyrefly/Cargo.toml
@@ -61,7 +61,7 @@ ruff_notebook = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5", features = ["serde"] }
 ruff_python_parser = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5" }
 ruff_source_file = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5" }
-ruff_text_size = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff/", rev = "db5aa0a5f1b92cb91d910bf0866a967554dd94f5", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_repr = "0.1.14"

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -2114,14 +2114,6 @@ impl Server {
                         )
                     {
                         self.record_completion_mru(&params);
-                        self.send_response(new_response(x.id, Ok(params)));
-                    }
-                } else if let Some(params) = as_request::<ResolveCompletionItem>(&x) {
-                    if let Some(params) = self
-                        .extract_request_params_or_send_err_response::<ResolveCompletionItem>(
-                            params, &x.id,
-                        )
-                    {
                         self.send_response(new_response(
                             x.id,
                             Ok(transaction.resolve_completion_item(params)),

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -1948,14 +1948,14 @@ impl Server {
 
                 // These are messages where VS Code will use results from previous document versions,
                 // we really don't want to implicitly cancel those.
-                // `TypeErrorDisplayStatusRequest` is in the list because cancelling it leaves the
-                // status-bar item hidden until the next unrelated event; stale data is fine here.
                 const ONLY_ONCE: &[&str] = &[
                     Completion::METHOD,
-                    ResolveCompletionItem::METHOD,
                     SignatureHelpRequest::METHOD,
+                    ResolveCompletionItem::METHOD,
                     GotoDefinition::METHOD,
                     ProvideType::METHOD,
+                    // `TypeErrorDisplayStatusRequest` is in the list because cancelling it leaves the
+                    // status-bar item hidden until the next unrelated event; stale data is fine here.
                     TypeErrorDisplayStatusRequest::METHOD,
                 ];
 
@@ -2115,6 +2115,17 @@ impl Server {
                     {
                         self.record_completion_mru(&params);
                         self.send_response(new_response(x.id, Ok(params)));
+                    }
+                } else if let Some(params) = as_request::<ResolveCompletionItem>(&x) {
+                    if let Some(params) = self
+                        .extract_request_params_or_send_err_response::<ResolveCompletionItem>(
+                            params, &x.id,
+                        )
+                    {
+                        self.send_response(new_response(
+                            x.id,
+                            Ok(transaction.resolve_completion_item(params)),
+                        ));
                     }
                 } else if let Some(params) = as_request::<DocumentHighlightRequest>(&x) {
                     if let Some(params) = self

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -1950,8 +1950,8 @@ impl Server {
                 // we really don't want to implicitly cancel those.
                 const ONLY_ONCE: &[&str] = &[
                     Completion::METHOD,
-                    SignatureHelpRequest::METHOD,
                     ResolveCompletionItem::METHOD,
+                    SignatureHelpRequest::METHOD,
                     GotoDefinition::METHOD,
                     ProvideType::METHOD,
                     // `TypeErrorDisplayStatusRequest` is in the list because cancelling it leaves the

--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -45,11 +45,14 @@ use crate::lsp::wasm::signature_help::CallInfo;
 use crate::state::ide::common_alias_target_module;
 use crate::state::ide::import_regular_import_edit;
 use crate::state::ide::insert_import_edit;
+use crate::state::lsp::CompletionResolveData;
 use crate::state::lsp::FindPreference;
 use crate::state::lsp::IdentifierContext;
 use crate::state::lsp::IdentifierWithContext;
 use crate::state::lsp::ImportFormat;
 use crate::state::lsp::MIN_CHARACTERS_TYPED_AUTOIMPORT;
+use crate::state::lsp::completion_data_doc_range;
+use crate::state::lsp::completion_data_handle_path;
 use crate::state::state::Transaction;
 use crate::types::callable::Param;
 use crate::types::types::Type;
@@ -603,6 +606,7 @@ impl Transaction<'_> {
                     continue;
                 }
                 let module_description = handle_to_import_from.module().as_str().to_owned();
+                let handle_for_data = handle_to_import_from.dupe();
                 let (detail_text, additional_text_edits, imported_module) = {
                     let import_edit = insert_import_edit(
                         &ast,
@@ -629,6 +633,12 @@ impl Transaction<'_> {
                         &imported_module,
                         &name,
                     );
+                let data = CompletionResolveData::export_value(
+                    handle_for_data.module(),
+                    name.clone(),
+                    completion_data_handle_path(&handle_for_data),
+                    completion_data_doc_range(export.docstring_range),
+                );
 
                 completions.push(RankedCompletion {
                     item: CompletionItem {
@@ -646,6 +656,7 @@ impl Transaction<'_> {
                                 description: Some(module_description),
                             },
                         ),
+                        data: Some(data),
                         tags: if is_deprecated {
                             Some(vec![CompletionItemTag::DEPRECATED])
                         } else {
@@ -836,7 +847,7 @@ impl Transaction<'_> {
     ) {
         let exports = self.get_exports(imp_handle);
         for (name, export) in exports.iter() {
-            let (is_deprecated, kind) = match export {
+            let (is_deprecated, kind, data) = match export {
                 ExportLocation::ThisModule(export) => (
                     export.deprecation.is_some(),
                     export
@@ -844,12 +855,19 @@ impl Transaction<'_> {
                         .map_or(CompletionItemKind::VARIABLE, |k| {
                             k.to_lsp_completion_item_kind()
                         }),
+                    Some(CompletionResolveData::export_value(
+                        imp_handle.module(),
+                        name.as_str(),
+                        completion_data_handle_path(imp_handle),
+                        completion_data_doc_range(export.docstring_range),
+                    )),
                 ),
-                ExportLocation::OtherModule(_, _) => (false, CompletionItemKind::VARIABLE),
+                ExportLocation::OtherModule(_, _) => (false, CompletionItemKind::VARIABLE, None),
             };
             result.push(RankedCompletion::new(CompletionItem {
                 label: name.to_string(),
                 kind: Some(kind),
+                data,
                 tags: if is_deprecated {
                     Some(vec![CompletionItemTag::DEPRECATED])
                 } else {

--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -51,7 +51,6 @@ use crate::state::lsp::IdentifierContext;
 use crate::state::lsp::IdentifierWithContext;
 use crate::state::lsp::ImportFormat;
 use crate::state::lsp::MIN_CHARACTERS_TYPED_AUTOIMPORT;
-use crate::state::lsp::completion_data_doc_range;
 use crate::state::lsp::completion_data_handle_path;
 use crate::state::state::Transaction;
 use crate::types::callable::Param;
@@ -412,6 +411,7 @@ impl Transaction<'_> {
             .import_handle(handle, ModuleName::builtins(), None)
             .finding()
         {
+            let builtin_path = completion_data_handle_path(&builtin_handle);
             let builtin_exports = self.get_exports(&builtin_handle);
             for (name, location) in builtin_exports.iter() {
                 if let Some(identifier) = identifier
@@ -422,19 +422,30 @@ impl Transaction<'_> {
                 {
                     continue;
                 }
-                let kind = match location {
+                let (kind, data) = match location {
                     ExportLocation::OtherModule(..) => continue,
-                    ExportLocation::ThisModule(export) => export
-                        .symbol_kind
-                        .map_or(Some(CompletionItemKind::VARIABLE), |k| {
-                            Some(k.to_lsp_completion_item_kind())
-                        }),
+                    ExportLocation::ThisModule(export) => {
+                        let data = CompletionResolveData::export_value(
+                            ModuleName::builtins(),
+                            name.as_str(),
+                            export.docstring_range.and(builtin_path.clone()),
+                            export.docstring_range,
+                        );
+                        (
+                            export
+                                .symbol_kind
+                                .map_or(Some(CompletionItemKind::VARIABLE), |k| {
+                                    Some(k.to_lsp_completion_item_kind())
+                                }),
+                            Some(data),
+                        )
+                    }
                 };
                 completions.push(RankedCompletion::new(CompletionItem {
                     label: name.as_str().to_owned(),
                     detail: None,
                     kind,
-                    data: Some(serde_json::json!("builtin")),
+                    data,
                     ..Default::default()
                 }));
             }
@@ -637,7 +648,7 @@ impl Transaction<'_> {
                     handle_for_data.module(),
                     name.clone(),
                     completion_data_handle_path(&handle_for_data),
-                    completion_data_doc_range(export.docstring_range),
+                    export.docstring_range,
                 );
 
                 completions.push(RankedCompletion {
@@ -859,7 +870,7 @@ impl Transaction<'_> {
                         imp_handle.module(),
                         name.as_str(),
                         completion_data_handle_path(imp_handle),
-                        completion_data_doc_range(export.docstring_range),
+                        export.docstring_range,
                     )),
                 ),
                 ExportLocation::OtherModule(_, _) => (false, CompletionItemKind::VARIABLE, None),

--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -612,7 +612,7 @@ impl Transaction<'_> {
                         &ast,
                         self.config_finder(),
                         handle.dupe(),
-                        handle_to_import_from,
+                        handle_to_import_from.dupe(),
                         &name,
                         import_format,
                     );

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -245,7 +245,6 @@ pub(crate) enum CompletionResolveData {
         module: String,
         symbol: String,
         path: Option<String>,
-        #[serde(with = "serde_text_range_option")]
         doc_range: Option<TextRange>,
     },
 }
@@ -293,33 +292,6 @@ fn filesystem_docstring(range: TextRange, path: &str) -> Option<lsp_types::Docum
             value: Docstring::clean(slice),
         },
     ))
-}
-
-mod serde_text_range_option {
-    use ruff_text_size::TextRange;
-    use ruff_text_size::TextSize;
-    use serde::Deserialize;
-    use serde::Deserializer;
-    use serde::Serializer;
-
-    pub fn serialize<S>(value: &Option<TextRange>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match value {
-            Some(range) => serializer
-                .serialize_some(&(u32::from(range.start()), u32::from(range.end()))),
-            None => serializer.serialize_none(),
-        }
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<TextRange>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let opt = Option::<(u32, u32)>::deserialize(deserializer)?;
-        Ok(opt.map(|(start, end)| TextRange::new(TextSize::new(start), TextSize::new(end))))
-    }
 }
 
 const RESOLVE_EXPORT_INITIAL_GAS: Gas = Gas::new(100);

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -245,7 +245,8 @@ pub(crate) enum CompletionResolveData {
         module: String,
         symbol: String,
         path: Option<String>,
-        doc_range: Option<(u32, u32)>,
+        #[serde(with = "serde_text_range_option")]
+        doc_range: Option<TextRange>,
     },
 }
 
@@ -254,15 +255,19 @@ impl CompletionResolveData {
         module: ModuleName,
         symbol: impl Into<String>,
         path: Option<String>,
-        doc_range: Option<(u32, u32)>,
+        doc_range: Option<TextRange>,
     ) -> serde_json::Value {
+        let module_name = module.as_str().to_owned();
+        let symbol = symbol.into();
         serde_json::to_value(Self::Export {
-            module: module.as_str().to_owned(),
-            symbol: symbol.into(),
+            module: module_name.clone(),
+            symbol: symbol.clone(),
             path,
             doc_range,
         })
-        .expect("completion resolve data serialization should never fail")
+        .unwrap_or_else(|err| {
+            panic!("failed to serialize completion resolve data for {module_name}::{symbol}: {err}")
+        })
     }
 }
 
@@ -270,14 +275,14 @@ pub(crate) fn completion_data_handle_path(handle: &Handle) -> Option<String> {
     Some(handle.path().as_path().to_string_lossy().into_owned())
 }
 
-pub(crate) fn completion_data_doc_range(range: Option<TextRange>) -> Option<(u32, u32)> {
-    range.map(|r| (u32::from(r.start()), u32::from(r.end())))
+pub(crate) fn completion_data_doc_range(range: Option<TextRange>) -> Option<TextRange> {
+    range
 }
 
-fn filesystem_docstring(range: (u32, u32), path: &str) -> Option<lsp_types::Documentation> {
+fn filesystem_docstring(range: TextRange, path: &str) -> Option<lsp_types::Documentation> {
     let contents = fs::read_to_string(path).ok()?;
-    let start = range.0 as usize;
-    let end = range.1 as usize;
+    let start = range.start().to_usize();
+    let end = range.end().to_usize();
     if start > end || end > contents.len() {
         return None;
     }
@@ -288,6 +293,33 @@ fn filesystem_docstring(range: (u32, u32), path: &str) -> Option<lsp_types::Docu
             value: Docstring::clean(slice),
         },
     ))
+}
+
+mod serde_text_range_option {
+    use ruff_text_size::TextRange;
+    use ruff_text_size::TextSize;
+    use serde::Deserialize;
+    use serde::Deserializer;
+    use serde::Serializer;
+
+    pub fn serialize<S>(value: &Option<TextRange>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(range) => serializer
+                .serialize_some(&(u32::from(range.start()), u32::from(range.end()))),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<TextRange>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let opt = Option::<(u32, u32)>::deserialize(deserializer)?;
+        Ok(opt.map(|(start, end)| TextRange::new(TextSize::new(start), TextSize::new(end))))
+    }
 }
 
 const RESOLVE_EXPORT_INITIAL_GAS: Gas = Gas::new(100);

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -278,7 +278,7 @@ fn filesystem_docstring(range: (u32, u32), path: &str) -> Option<lsp_types::Docu
     let contents = fs::read_to_string(path).ok()?;
     let start = range.0 as usize;
     let end = range.1 as usize;
-    if start >= end || end > contents.len() {
+    if start > end || end > contents.len() {
         return None;
     }
     let slice = contents.get(start..end)?;

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -274,10 +274,6 @@ pub(crate) fn completion_data_handle_path(handle: &Handle) -> Option<String> {
     Some(handle.path().as_path().to_string_lossy().into_owned())
 }
 
-pub(crate) fn completion_data_doc_range(range: Option<TextRange>) -> Option<TextRange> {
-    range
-}
-
 fn filesystem_docstring(range: TextRange, path: &str) -> Option<lsp_types::Documentation> {
     let contents = fs::read_to_string(path).ok()?;
     let start = range.start().to_usize();

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -8,6 +8,7 @@
 use std::cmp::Ordering;
 use std::cmp::Reverse;
 use std::collections::HashSet;
+use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -59,6 +60,7 @@ use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
 use serde::Deserialize;
+use serde::Serialize;
 use starlark_map::ordered_set::OrderedSet;
 use starlark_map::small_map::SmallMap;
 use vec1::Vec1;
@@ -234,6 +236,58 @@ impl From<TypeCheckingMode> for pyrefly_config::resolve_unconfigured::Unconfigur
             TypeCheckingMode::All => Inner::All,
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum CompletionResolveData {
+    Export {
+        module: String,
+        symbol: String,
+        path: Option<String>,
+        doc_range: Option<(u32, u32)>,
+    },
+}
+
+impl CompletionResolveData {
+    pub(crate) fn export_value(
+        module: ModuleName,
+        symbol: impl Into<String>,
+        path: Option<String>,
+        doc_range: Option<(u32, u32)>,
+    ) -> serde_json::Value {
+        serde_json::to_value(Self::Export {
+            module: module.as_str().to_owned(),
+            symbol: symbol.into(),
+            path,
+            doc_range,
+        })
+        .expect("completion resolve data serialization should never fail")
+    }
+}
+
+pub(crate) fn completion_data_handle_path(handle: &Handle) -> Option<String> {
+    Some(handle.path().as_path().to_string_lossy().into_owned())
+}
+
+pub(crate) fn completion_data_doc_range(range: Option<TextRange>) -> Option<(u32, u32)> {
+    range.map(|r| (u32::from(r.start()), u32::from(r.end())))
+}
+
+fn filesystem_docstring(range: (u32, u32), path: &str) -> Option<lsp_types::Documentation> {
+    let contents = fs::read_to_string(path).ok()?;
+    let start = range.0 as usize;
+    let end = range.1 as usize;
+    if start >= end || end > contents.len() {
+        return None;
+    }
+    let slice = contents.get(start..end)?;
+    Some(lsp_types::Documentation::MarkupContent(
+        lsp_types::MarkupContent {
+            kind: lsp_types::MarkupKind::Markdown,
+            value: Docstring::clean(slice),
+        },
+    ))
 }
 
 const RESOLVE_EXPORT_INITIAL_GAS: Gas = Gas::new(100);
@@ -4013,6 +4067,63 @@ impl<'a> Transaction<'a> {
                 self.resolve_named_import(handle, *module, target_name, FindPreference::default())
             }
         }
+    }
+
+    fn documentation_for_completion_export(
+        &self,
+        module: ModuleName,
+        symbol: &str,
+    ) -> Option<lsp_types::Documentation> {
+        for (handle, export) in self.search_exports_exact(symbol, None).unwrap_or_default() {
+            if handle.module() == module {
+                let docstring_range = export.docstring_range?;
+                let module = self.get_module_info(&handle)?;
+                let docstring = Docstring(docstring_range, module).resolve();
+                return Some(lsp_types::Documentation::MarkupContent(
+                    lsp_types::MarkupContent {
+                        kind: lsp_types::MarkupKind::Markdown,
+                        value: docstring,
+                    },
+                ));
+            }
+        }
+        None
+    }
+
+    pub fn resolve_completion_item(&self, mut item: CompletionItem) -> CompletionItem {
+        if item.documentation.is_some() {
+            return item;
+        }
+        let Some(data_value) = item.data.clone() else {
+            return item;
+        };
+        let data = match serde_json::from_value::<CompletionResolveData>(data_value) {
+            Ok(data) => data,
+            Err(err) => {
+                tracing::debug!("Invalid completion resolve data: {err}");
+                return item;
+            }
+        };
+        match data {
+            CompletionResolveData::Export {
+                module,
+                symbol,
+                path,
+                doc_range,
+            } => {
+                let module = ModuleName::from_str(&module);
+                if let Some(documentation) =
+                    self.documentation_for_completion_export(module, &symbol)
+                {
+                    item.documentation = Some(documentation);
+                } else if let (Some(path), Some(range)) = (path.as_deref(), doc_range)
+                    && let Some(documentation) = filesystem_docstring(range, path)
+                {
+                    item.documentation = Some(documentation);
+                }
+            }
+        }
+        item
     }
 
     /// Used to avoid making use of reexports of private modules for some LSP

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -10,8 +10,8 @@ use lsp_types::CompletionItemKind;
 use lsp_types::CompletionItemTag;
 use pretty_assertions::assert_eq;
 use pyrefly_build::handle::Handle;
-use pyrefly_python::sys_info::PythonVersion;
 use pyrefly_python::module_name::ModuleName;
+use pyrefly_python::sys_info::PythonVersion;
 use ruff_text_size::TextSize;
 
 use crate::state::lsp::CompletionResolveData;

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -11,8 +11,10 @@ use lsp_types::CompletionItemTag;
 use pretty_assertions::assert_eq;
 use pyrefly_build::handle::Handle;
 use pyrefly_python::sys_info::PythonVersion;
+use pyrefly_python::module_name::ModuleName;
 use ruff_text_size::TextSize;
 
+use crate::state::lsp::CompletionResolveData;
 use crate::state::lsp::ImportFormat;
 use crate::state::require::Require;
 use crate::state::state::State;
@@ -100,8 +102,20 @@ fn get_test_report(
             } else {
                 false
             };
+            let builtin_module = ModuleName::builtins();
+            let is_builtin = data
+                .as_ref()
+                .and_then(|value| {
+                    serde_json::from_value::<CompletionResolveData>(value.clone()).ok()
+                })
+                .is_some_and(|info| match info {
+                    CompletionResolveData::Export { module, .. } => {
+                        module == builtin_module.as_str()
+                    }
+                });
+
             if (filter.include_keywords || kind != Some(CompletionItemKind::KEYWORD))
-                && (filter.include_builtins || data != Some(serde_json::json!("builtin")))
+                && (filter.include_builtins || !is_builtin)
             {
                 report.push_str("\n- (");
                 report.push_str(&format!("{:?}", kind.unwrap()));

--- a/pyrefly/lib/test/lsp/lsp_interaction/basic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/basic.rs
@@ -46,8 +46,8 @@ fn test_initialize_basic() {
                 "resolveProvider": false,
             },
             "completionProvider": {
-                "triggerCharacters": [".", "'", "\""],
                 "resolveProvider": true,
+                "triggerCharacters": [".", "'", "\""],
             },
             "declarationProvider": true,
             "documentHighlightProvider": true,

--- a/pyrefly/lib/test/lsp/lsp_interaction/basic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/basic.rs
@@ -46,8 +46,8 @@ fn test_initialize_basic() {
                 "resolveProvider": false,
             },
             "completionProvider": {
+                "triggerCharacters": [".", "'", "\""],
                 "resolveProvider": true,
-                "triggerCharacters": [".", "'", "\""]
             },
             "declarationProvider": true,
             "documentHighlightProvider": true,

--- a/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
@@ -452,6 +452,78 @@ fn test_completion_with_autoimport() {
 }
 
 #[test]
+fn test_completion_item_resolve_autoimport_documentation() {
+    let root = get_test_files_root();
+    let root_path = root.path().join("tests_requiring_config");
+
+    let mut interaction = LspInteraction::new_with_indexing_mode(IndexingMode::LazyBlocking);
+
+    interaction.set_root(root_path.clone());
+    interaction
+        .initialize(InitializeSettings::default())
+        .unwrap();
+
+    let file = root_path.join("foo.py");
+    interaction.client.did_open("foo.py");
+
+    interaction
+        .client
+        .send_notification::<DidChangeTextDocument>(json!({
+            "textDocument": {
+                "uri": Url::from_file_path(&file).unwrap().to_string(),
+                "languageId": "python",
+                "version": 2
+            },
+            "contentChanges": [{
+                "text": "this_is_a_very_long_function_name_so_we_can".to_owned()
+            }],
+        }));
+
+    let target_item: RefCell<Option<CompletionItem>> = RefCell::new(None);
+    interaction
+        .client
+        .completion("foo.py", 0, 43)
+        .expect_response_with(|response| {
+            if let Some(CompletionResponse::List(list)) = response {
+                if let Some(item) = list.items.iter().find(|item| {
+                    item.label
+                        == "this_is_a_very_long_function_name_so_we_can_deterministically_test_autoimport_with_fuzzy_search"
+                }) {
+                    *target_item.borrow_mut() = Some(item.clone());
+                    return true;
+                }
+            }
+            false
+        })
+        .unwrap();
+
+    let item = target_item
+        .into_inner()
+        .expect("expected autoimport completion item");
+    assert!(item.documentation.is_none());
+
+    interaction
+        .client
+        .completion_item_resolve(&item)
+        .expect_response_with(|resolved| {
+            resolved
+                .documentation
+                .as_ref()
+                .is_some_and(|doc| match doc {
+                    lsp_types::Documentation::MarkupContent(content) => content
+                        .value
+                        .contains("Autoimport docstring for completionItem/resolve tests."),
+                    lsp_types::Documentation::String(text) => {
+                        text.contains("Autoimport docstring for completionItem/resolve tests.")
+                    }
+                })
+        })
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
 fn test_completion_with_autoimport_submodule() {
     let root = get_test_files_root();
     let root_path = root.path().join("autoimport_submodule");

--- a/pyrefly/lib/test/lsp/lsp_interaction/object_model.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/object_model.rs
@@ -23,6 +23,7 @@ use crossbeam_channel::RecvTimeoutError;
 use crossbeam_channel::Sender;
 use lsp_server::RequestId;
 use lsp_server::ResponseError;
+use lsp_types::CompletionItem;
 use lsp_types::CompletionList;
 use lsp_types::CompletionResponse;
 use lsp_types::ConfigurationItem;
@@ -60,6 +61,7 @@ use lsp_types::request::References;
 use lsp_types::request::RegisterCapability;
 use lsp_types::request::Rename;
 use lsp_types::request::Request as _;
+use lsp_types::request::ResolveCompletionItem;
 use lsp_types::request::SemanticTokensFullRequest;
 use lsp_types::request::SemanticTokensRangeRequest;
 use lsp_types::request::Shutdown;
@@ -525,6 +527,13 @@ impl TestClient {
                 "character": col
             }
         }))
+    }
+
+    pub fn completion_item_resolve(
+        &self,
+        item: &CompletionItem,
+    ) -> ClientRequestHandle<'_, ResolveCompletionItem> {
+        self.send_request(serde_json::to_value(item).unwrap())
     }
 
     pub fn diagnostic(

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/tests_requiring_config/autoimport_provider.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/tests_requiring_config/autoimport_provider.py
@@ -7,6 +7,7 @@
 def this_is_a_very_long_function_name_so_we_can_deterministically_test_autoimport_with_fuzzy_search() -> (
     None
 ):
+    """Autoimport docstring for completionItem/resolve tests."""
     return
 
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1689

now captures enough metadata on each auto-import/builtin completion (module name, optional docstring range, and filesystem path) via the revamped CompletionResolveData.

Transaction::resolve_completion_item parses this payload, tries to pull docstrings from the in-memory state, and falls back to reading the source file directly when necessary, so completionItem/resolve can populate documentation

advertises resolve_provider: true, whitelists the new method for post-mutation handling, and routes completionItem/resolve requests to the transaction helper.

gained a client helper for completionItem/resolve, and the fixture test_files/tests_requiring_config/autoimport_provider.py now contains a docstring that we can assert on.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added test_completion_item_resolve_autoimport_documentation (plus minor harness tweaks)

Updated the unit-style completion dump test