### PR TITLE
Suppress lint error from fbcode_build cfg directive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ resolver = "2"
 [workspace.package]
 license = "MIT"
 repository = "https://github.com/facebook/pyrefly"
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/crates/pyrefly_config/Cargo.toml
+++ b/crates/pyrefly_config/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2024"
 repository = "https://github.com/facebook/pyrefly"
 license = "MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0.98"
 clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }


### PR DESCRIPTION
Eliminates linting noise in cargo builds