### PR TITLE
Do not enforce ordering for attrs classes

### DIFF
--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -784,6 +784,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         alias_keyword: alias_keyword.clone(),
                         init_defaults: init_defaults.clone(),
                         default_can_be_positional,
+                        enforce_field_ordering: true
                     });
                 }
                 // `@dataclass(...)`
@@ -804,6 +805,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         alias_keyword: alias_keyword.clone(),
                         init_defaults: init_defaults.clone(),
                         default_can_be_positional,
+                        enforce_field_ordering: true
                     });
                 }
                 _ => {}
@@ -817,6 +819,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 alias_keyword,
                 init_defaults,
                 default_can_be_positional,
+                enforce_field_ordering: false
             });
         }
         dataclass_metadata

--- a/pyrefly/lib/alt/class/dataclass.rs
+++ b/pyrefly/lib/alt/class/dataclass.rs
@@ -543,7 +543,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     || (field_flags.init_by_name && field_flags.init_by_alias.is_some());
                 let is_kw_only = field_flags.is_kw_only();
                 if !is_kw_only {
-                    if !has_default
+                    if dataclass.enforce_field_ordering
+                        && !has_default
                         && has_seen_default
                         && let Some(range) = cls.field_decl_range(&name)
                     {

--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -453,6 +453,8 @@ pub struct DataclassMetadata {
     pub init_defaults: InitDefaults,
     /// Whether a default can be passed positionally to field specifier calls
     pub default_can_be_positional: bool,
+    /// Whether to enforce that fields without defaults cannot follow fields with defaults.
+    pub enforce_field_ordering: bool,
 }
 
 #[derive(Clone, Debug, TypeEq, PartialEq, Eq)]

--- a/pyrefly/lib/test/dataclass_transform.rs
+++ b/pyrefly/lib/test/dataclass_transform.rs
@@ -412,3 +412,19 @@ class A:
 A(x=0)
     "#,
 );
+
+testcase!(
+    test_dataclass_transform_allows_required_after_default,
+    r#"
+from typing import dataclass_transform, Any
+def field(**kwargs) -> Any: ...
+@dataclass_transform(field_specifiers=(field,))
+def define(cls): ...
+@define
+class Config:
+    size: int = 768
+    name: str
+    rate: float = 0.001
+Config(name="test")
+    "#,
+);


### PR DESCRIPTION
# Summary
This pull request introduces a new mechanism for enforcing field ordering rules in dataclass-like class transformations, specifically to ensure that fields without defaults do not follow fields with defaults when required. The enforcement can be toggled based on the context, and a new test case is added to verify behavior when enforcement is not required.

Field ordering enforcement:

* Added a new `enforce_field_ordering` boolean field to the `DataclassMetadata` struct to control whether the rule "fields without defaults cannot follow fields with defaults" should be enforced.
* Updated the logic in `AnswersSolver` to set `enforce_field_ordering` to `true` for certain dataclass-like transformations (e.g., when using `@dataclass` and similar) and to `false` for others, allowing for flexible enforcement based on the decorator used. [[1]](diffhunk://#diff-4f2b77bb8cfa712de3bb3e0c6b55b101b63330176b6287cce88714adee81adb0R787) [[2]](diffhunk://#diff-4f2b77bb8cfa712de3bb3e0c6b55b101b63330176b6287cce88714adee81adb0R808) [[3]](diffhunk://#diff-4f2b77bb8cfa712de3bb3e0c6b55b101b63330176b6287cce88714adee81adb0R822)
* Modified the field validation logic in `dataclass.rs` to check `enforce_field_ordering` before applying the rule, so that enforcement is context-sensitive.

Testing:

* Added a new test case `test_dataclass_transform_allows_required_after_default` to verify that when `enforce_field_ordering` is `false`, required fields can follow fields with defaults without error.

Fixes #1825

Currently in draft.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
