### PR TITLE
feat: Support checking Python files without extension when explicitly specified

### DIFF
--- a/crates/pyrefly_util/src/globs.rs
+++ b/crates/pyrefly_util/src/globs.rs
@@ -99,6 +99,16 @@ impl Glob {
         bytes.contains(&b'*') || bytes.contains(&b'?') || bytes.contains(&b'[')
     }
 
+    /// Returns true if this pattern is "explicit" - i.e., it has no wildcards
+    /// and directly specifies a file path.
+    fn is_explicit_file_pattern(&self) -> bool {
+        // Check if any component contains glob characters
+        self.as_path().components().all(|comp| match comp {
+            Component::Normal(part) => !Self::contains_glob_char(part),
+            _ => true,
+        })
+    }
+
     fn pattern_relative_to_root(root: &Path, pattern: &Pattern) -> Pattern {
         let from_root = Path::new(pattern.as_str())
             .absolutize_from(Path::new(&Pattern::escape(root.to_string_lossy().as_ref())));
@@ -147,13 +157,17 @@ impl Glob {
 
     /// Returns true if the given file should be included in results.
     /// Filters out non-Python files and dot files.
-    fn should_include_file(path: &Path) -> bool {
-        // Check if it's a Python file
-        if !Self::is_python_extension(path.extension()) {
+    ///
+    /// If `is_explicit` is true, the extension check is skipped, allowing
+    /// files without Python extensions to be included (for explicitly specified files).
+    /// Dot files are always excluded regardless of the `is_explicit` flag.
+    fn should_include_file(path: &Path, is_explicit: bool) -> bool {
+        // Check if it's a Python file (skip for explicitly specified files)
+        if !is_explicit && !Self::is_python_extension(path.extension()) {
             return false;
         }
 
-        // Check if it's a dot file
+        // Check if it's a dot file (always excluded)
         if let Some(file_name) = path.file_name().and_then(OsStr::to_str)
             && file_name.starts_with('.')
         {
@@ -167,13 +181,14 @@ impl Glob {
         path: PathBuf,
         results: &mut Vec<PathBuf>,
         filter: &GlobFilter,
+        is_explicit: bool,
     ) -> anyhow::Result<()> {
         if filter.is_excluded(&path) {
             return Ok(());
         }
         if path.is_dir() {
             Self::resolve_dir(&path, results, filter)?;
-        } else if Self::should_include_file(&path) {
+        } else if Self::should_include_file(&path, is_explicit) {
             results.push(path);
         }
         Ok(())
@@ -188,7 +203,8 @@ impl Glob {
             let entry = entry
                 .with_context(|| format!("When iterating over directory `{}`", path.display()))?;
             let path = entry.path();
-            Self::resolve_path(path, results, filter)?;
+            // Directory listings are never explicit
+            Self::resolve_path(path, results, filter, false)?;
         }
         Ok(())
     }
@@ -207,7 +223,8 @@ impl Glob {
                 break;
             }
             let path = path?;
-            Self::resolve_path(path, &mut result, filter)?;
+            // Glob pattern results are never explicit (they came from a glob match)
+            Self::resolve_path(path, &mut result, filter, false)?;
         }
         Ok(result)
     }
@@ -319,6 +336,20 @@ impl Glob {
                 filter
             ));
         }
+
+        // Check if this is an explicitly specified file (no wildcards)
+        let is_explicit = self.is_explicit_file_pattern();
+        let pattern_path = self.as_path();
+
+        // For explicit patterns, check if the file exists and include it directly
+        if is_explicit && pattern_path.is_file() {
+            let mut result = Vec::new();
+            if Self::should_include_file(pattern_path, true) {
+                result.push(pattern_path.to_path_buf());
+            }
+            return Ok(result);
+        }
+
         let pattern_str = pattern.as_str().to_owned();
         let result = Self::resolve_pattern_with_limit(&pattern_str, filter, limit)
             .with_context(|| format!("When resolving pattern `{pattern_str}`"))?;
@@ -444,7 +475,8 @@ impl Globs {
                         line.to_str_lossy()
                     )
                 })?;
-                Glob::resolve_path(root.join(path), &mut result, &GlobFilter::empty())?;
+                // Eden glob results are from glob matching, not explicit
+                Glob::resolve_path(root.join(path), &mut result, &GlobFilter::empty(), false)?;
             }
             Ok(result)
         }
@@ -1438,5 +1470,60 @@ mod tests {
         let project_root = root.join("project");
         let filter = GlobFilter::new(Globs::empty(), Some(&project_root));
         assert!(!filter.is_excluded(&root.join("my_file.py")));
+    }
+
+    #[test]
+    fn test_explicitly_specified_files_without_extension() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        TestPath::setup_test_directory(
+            root,
+            vec![
+                TestPath::file_with_contents("myscript", "#!/usr/bin/env python3\nprint('hello')"),
+                TestPath::file_with_contents("another_script", "import sys\nprint(sys.version)"),
+                TestPath::dir(
+                    "scripts",
+                    vec![
+                        TestPath::file_with_contents("tool", "# Python script\nprint('tool')"),
+                        TestPath::file("regular.py"),
+                    ],
+                ),
+            ],
+        );
+
+        // Test single file without extension
+        let files = Globs::new_with_root(root, vec!["myscript".to_owned()])
+            .unwrap()
+            .files()
+            .unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0], root.join("myscript"));
+
+        // Test multiple files without extensions
+        let files = Globs::new_with_root(
+            root,
+            vec!["myscript".to_owned(), "another_script".to_owned()],
+        )
+        .unwrap()
+        .files()
+        .unwrap();
+        assert_eq!(files.len(), 2);
+
+        // Test file in subdirectory without extension
+        let files = Globs::new_with_root(root, vec!["scripts/tool".to_owned()])
+            .unwrap()
+            .files()
+            .unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0], root.join("scripts/tool"));
+
+        // Test that glob patterns still filter by extension (wildcards should still require .py extension)
+        let files = Globs::new_with_root(root, vec!["*".to_owned()])
+            .unwrap()
+            .files()
+            .unwrap();
+        // Should not include files without extensions when using wildcard
+        assert!(!files.contains(&root.join("myscript")));
+        assert!(!files.contains(&root.join("another_script")));
     }
 }


### PR DESCRIPTION
Fixes #1725
## Summary
Adds support for checking Python files without `.py` extension when explicitly specified on the command line (e.g., `pyrefly check myscript`). Currently, pyrefly only checks files with Python extensions (`.py`, `.pyi`, `.pyw`, `.ipynb`). This prevents checking Python scripts without extensions, which are common for executable scripts in `bin/` directories or shell-style tools.

## Changes
- **Added** `is_explicit_file_pattern()` to detect file patterns without wildcards (`*`, `?`, `[`)
- **Modified** `should_include_file()` to skip extension check for explicitly specified files
- **Updated** all `resolve_path()` calls to pass `is_explicit` flag

## Examples
```bash
  # ✅ Now works - explicit file without extension
  $ pyrefly check myscript

  # ✅ Multiple files without extension
  $ pyrefly check tool1 tool2 setup

  # ✅ Glob patterns unchanged - still filters by .py
  $ pyrefly check '*.py'
  $ pyrefly check 'src/**'- **Preserved** existing behavior: glob patterns still filter by `.py`, dot files always excluded
```
## Test Plan
- Added test_explicitly_specified_files_without_extension with comprehensive coverage