### PR TITLE
Revert back to `debug = 1` for now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ displaydoc = { git = "https://github.com/yaahc/displaydoc", rev = "7dc6e324b1788
 quickcheck = { git = "https://github.com/jakoschiko/quickcheck", rev = "6ecdf5bb4b0132ce66670b4d46453aa022ea892c" }
 
 [profile.release]
-debug = true
+debug = 1
 lto = true
 codegen-units = 1
 strip = false


### PR DESCRIPTION
Summary:
We aren't sure why but the build seems to have broken, we're getting
a failure with `rustc` on exactly one of the build jobs (build binaries)
with an error
```
rustc-LLVM ERROR: out of memory
Allocation failed
```

Let's roll back the change to see whether debug symbols are indeed
causing an OOM; sadly this means we still can't debug some issues,
but we can't do it with a broken build in any case.

Differential Revision: D89101563


