### PR TITLE
fix Using a Literal key to update values in a TypeDict #329

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -635,13 +635,6 @@ impl<'a> BindingsBuilder<'a> {
         self.table.get::<K>().0.idx_to_key(idx)
     }
 
-    /// Return the `BindingAnnotation` stored at `idx`, if it still exists.
-    /// Used by literal-key detection to recover the concrete type of an annotated name.
-    pub fn get_annotation_by_idx(&self, idx: Idx<KeyAnnotation>) -> Option<&BindingAnnotation> {
-        let annotations = self.table.get::<KeyAnnotation>();
-        annotations.1.get(idx)
-    }
-
     /// Declare a `Key` as a usage, which can be used for name lookups. Like `idx_for_promise`,
     /// this is a promise to later provide a `Binding` corresponding this key.
     pub fn declare_current_idx(&mut self, key: Key) -> CurrentIdx {

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -133,7 +133,6 @@ impl TestAssertion {
             }
             Self::AssertIsNone if let Some(arg0) = args.first() => {
                 Some(NarrowOps::from_single_narrow_op(
-                    builder,
                     arg0,
                     AtomicNarrowOp::Is(Expr::NoneLiteral(ExprNoneLiteral {
                         node_index: AtomicNodeIndex::default(),
@@ -144,7 +143,6 @@ impl TestAssertion {
             }
             Self::AssertIsNotNone if let Some(arg0) = args.first() => {
                 Some(NarrowOps::from_single_narrow_op(
-                    builder,
                     arg0,
                     AtomicNarrowOp::IsNot(Expr::NoneLiteral(ExprNoneLiteral {
                         node_index: AtomicNodeIndex::default(),
@@ -158,7 +156,6 @@ impl TestAssertion {
                     && let Some(arg1) = args.get(1) =>
             {
                 Some(NarrowOps::from_single_narrow_op(
-                    builder,
                     arg0,
                     AtomicNarrowOp::IsInstance(arg1.clone()),
                     arg0.range(),
@@ -169,7 +166,6 @@ impl TestAssertion {
                     && let Some(arg1) = args.get(1) =>
             {
                 Some(NarrowOps::from_single_narrow_op(
-                    builder,
                     arg0,
                     AtomicNarrowOp::IsNotInstance(arg1.clone()),
                     arg0.range(),
@@ -180,7 +176,6 @@ impl TestAssertion {
                     && let Some(arg1) = args.get(1) =>
             {
                 Some(NarrowOps::from_single_narrow_op(
-                    builder,
                     arg0,
                     AtomicNarrowOp::Eq(arg1.clone()),
                     arg0.range(),
@@ -191,7 +186,6 @@ impl TestAssertion {
                     && let Some(arg1) = args.get(1) =>
             {
                 Some(NarrowOps::from_single_narrow_op(
-                    builder,
                     arg0,
                     AtomicNarrowOp::NotEq(arg1.clone()),
                     arg0.range(),
@@ -202,7 +196,6 @@ impl TestAssertion {
                     && let Some(arg1) = args.get(1) =>
             {
                 Some(NarrowOps::from_single_narrow_op(
-                    builder,
                     arg0,
                     AtomicNarrowOp::Is(arg1.clone()),
                     arg0.range(),
@@ -213,7 +206,6 @@ impl TestAssertion {
                     && let Some(arg1) = args.get(1) =>
             {
                 Some(NarrowOps::from_single_narrow_op(
-                    builder,
                     arg0,
                     AtomicNarrowOp::IsNot(arg1.clone()),
                     arg0.range(),
@@ -224,7 +216,6 @@ impl TestAssertion {
                     && let Some(arg1) = args.get(1) =>
             {
                 Some(NarrowOps::from_single_narrow_op(
-                    builder,
                     arg0,
                     AtomicNarrowOp::In(arg1.clone()),
                     arg0.range(),
@@ -235,7 +226,6 @@ impl TestAssertion {
                     && let Some(arg1) = args.get(1) =>
             {
                 Some(NarrowOps::from_single_narrow_op(
-                    builder,
                     arg0,
                     AtomicNarrowOp::NotIn(arg1.clone()),
                     arg0.range(),

--- a/pyrefly/lib/binding/narrow.rs
+++ b/pyrefly/lib/binding/narrow.rs
@@ -8,7 +8,6 @@
 use std::fmt;
 
 use pyrefly_python::ast::Ast;
-use pyrefly_types::literal::Lit;
 use pyrefly_util::assert_words;
 use pyrefly_util::display::DisplayWith;
 use pyrefly_util::display::DisplayWithCtx;
@@ -18,6 +17,7 @@ use ruff_python_ast::Arguments;
 use ruff_python_ast::BoolOp;
 use ruff_python_ast::CmpOp;
 use ruff_python_ast::Expr;
+use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprBoolOp;
 use ruff_python_ast::ExprCall;
 use ruff_python_ast::ExprCompare;
@@ -39,8 +39,6 @@ use starlark_map::small_set::SmallSet;
 use vec1::Vec1;
 
 use crate::binding::binding::Binding;
-use crate::binding::binding::BindingAnnotation;
-use crate::binding::binding::FunctionParameter;
 use crate::binding::binding::Key;
 use crate::binding::bindings::BindingsBuilder;
 use crate::binding::scope::NameReadInfo;
@@ -52,7 +50,7 @@ use crate::types::facet::FacetKind;
 use crate::types::types::Type;
 
 assert_words!(AtomicNarrowOp, 11);
-assert_words!(NarrowOp, 13);
+assert_words!(NarrowOp, 16);
 
 #[derive(Clone, Debug)]
 pub enum AtomicNarrowOp {
@@ -184,7 +182,11 @@ impl DisplayWith<ModuleInfo> for NarrowOp {
         match self {
             Self::Atomic(prop, op) => match prop {
                 None => write!(f, "{}", op.display_with(ctx)),
-                Some(prop) => write!(f, "[{}] {}", prop.chain, op.display_with(ctx)),
+                Some(prop) => {
+                    write!(f, "[")?;
+                    prop.fmt_chain(f, ctx)?;
+                    write!(f, "] {}", op.display_with(ctx))
+                }
             },
             Self::And(ops) => {
                 write!(
@@ -252,8 +254,30 @@ pub enum FacetOrigin {
 
 #[derive(Clone, Debug)]
 pub struct FacetSubject {
-    pub chain: FacetChain,
+    pub resolved: Vec<FacetKind>,
+    pub pending: Option<Box<Expr>>,
     pub origin: FacetOrigin,
+}
+
+impl FacetSubject {
+    pub fn to_chain(&self) -> Option<FacetChain> {
+        if self.pending.is_some() {
+            return None;
+        }
+        Vec1::try_from_vec(self.resolved.clone())
+            .ok()
+            .map(FacetChain::new)
+    }
+
+    fn fmt_chain(&self, f: &mut fmt::Formatter<'_>, ctx: &ModuleInfo) -> fmt::Result {
+        for facet in &self.resolved {
+            write!(f, "{facet}")?;
+        }
+        if let Some(pending) = self.pending.as_deref() {
+            write!(f, "[{}]", pending.display_with(ctx))?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -268,16 +292,21 @@ impl NarrowingSubject {
             Self::Name(name) => Self::Facets(
                 name.clone(),
                 FacetSubject {
-                    chain: FacetChain::new(Vec1::new(prop)),
+                    resolved: vec![prop],
+                    pending: None,
                     origin: FacetOrigin::Direct,
                 },
             ),
             Self::Facets(name, facets) => {
-                let props = Vec1::from_vec_push(facets.chain.facets().to_vec(), prop);
+                let mut resolved = facets.resolved.clone();
+                if facets.pending.is_none() {
+                    resolved.push(prop);
+                }
                 Self::Facets(
                     name.clone(),
                     FacetSubject {
-                        chain: FacetChain::new(props),
+                        resolved,
+                        pending: facets.pending.clone(),
                         origin: facets.origin,
                     },
                 )
@@ -401,14 +430,9 @@ impl NarrowOps {
         }
     }
 
-    pub fn from_single_narrow_op(
-        builder: &BindingsBuilder,
-        left: &Expr,
-        op: AtomicNarrowOp,
-        range: TextRange,
-    ) -> Self {
+    pub fn from_single_narrow_op(left: &Expr, op: AtomicNarrowOp, range: TextRange) -> Self {
         let mut narrow_ops = Self::new();
-        for subject in expr_to_subjects(builder, left) {
+        for subject in expr_to_subjects(left) {
             let (name, prop) = match subject {
                 NarrowingSubject::Name(name) => (name, None),
                 NarrowingSubject::Facets(name, facets) => (name, Some(facets)),
@@ -554,12 +578,9 @@ impl NarrowOps {
                 match ops.next() {
                     None => Self::new(),
                     Some((op, range)) => {
-                        let mut narrow_ops =
-                            NarrowOps::from_single_narrow_op(builder, left, op, range);
+                        let mut narrow_ops = NarrowOps::from_single_narrow_op(left, op, range);
                         for (op, range) in ops {
-                            narrow_ops.and_all(NarrowOps::from_single_narrow_op(
-                                builder, left, op, range,
-                            ));
+                            narrow_ops.and_all(NarrowOps::from_single_narrow_op(left, op, range));
                         }
                         narrow_ops
                     }
@@ -600,12 +621,7 @@ impl NarrowOps {
                 && arguments.args.len() == 1
                 && arguments.keywords.is_empty() =>
             {
-                Self::from_single_narrow_op(
-                    builder,
-                    &arguments.args[0],
-                    AtomicNarrowOp::IsTruthy,
-                    *range,
-                )
+                Self::from_single_narrow_op(&arguments.args[0], AtomicNarrowOp::IsTruthy, *range)
             }
             Expr::Call(ExprCall {
                 node_index: _,
@@ -619,7 +635,6 @@ impl NarrowOps {
                     &arguments.args[1] =>
             {
                 Self::from_single_narrow_op(
-                    builder,
                     &arguments.args[0],
                     AtomicNarrowOp::HasAttr(Name::new(value.to_string())),
                     *range,
@@ -637,7 +652,6 @@ impl NarrowOps {
                     &arguments.args[1] =>
             {
                 Self::from_single_narrow_op(
-                    builder,
                     &arguments.args[0],
                     AtomicNarrowOp::GetAttr(
                         Name::new(value.to_string()),
@@ -654,7 +668,7 @@ impl NarrowOps {
                 // When the guard is something like `x.get("key")`, we narrow it like `x["key"]` if `x` resolves to a dict
                 // in the answers step.
                 // This cannot be a TypeGuard/TypeIs function call, since the first argument is a string literal
-                Self::from_single_narrow_op(builder, e, AtomicNarrowOp::IsTruthy, e.range())
+                Self::from_single_narrow_op(e, AtomicNarrowOp::IsTruthy, e.range())
             }
             Expr::Call(ExprCall {
                 node_index: _,
@@ -665,7 +679,6 @@ impl NarrowOps {
                 // This may be a function call that narrows the type of its first argument. Record
                 // it as a possible narrowing operation that we'll resolve in the answers phase.
                 Self::from_single_narrow_op(
-                    builder,
                     &posargs[0],
                     AtomicNarrowOp::Call(Box::new((**func).clone()), args.clone()),
                     *range,
@@ -673,7 +686,6 @@ impl NarrowOps {
             }
             Expr::Named(named) => {
                 let mut target_narrow = Self::from_single_narrow_op(
-                    builder,
                     &named.target,
                     AtomicNarrowOp::IsTruthy,
                     named.target.range(),
@@ -724,7 +736,7 @@ impl NarrowOps {
                     ops
                 }
             }
-            e => Self::from_single_narrow_op(builder, e, AtomicNarrowOp::IsTruthy, e.range()),
+            e => Self::from_single_narrow_op(e, AtomicNarrowOp::IsTruthy, e.range()),
         }
     }
 
@@ -793,195 +805,101 @@ impl NarrowOps {
     }
 }
 
-/// Given an expression, determine whether it is a chain of properties (attribute/concrete index) rooted at a name,
-/// and if so, return the name and the chain of properties.
-/// For example: x.y.[0].z
-/// Return a literal string encoded directly in `expr` (e.g. `"foo"`).
-fn literal_string_from_expr(expr: &Expr) -> Option<String> {
-    match expr {
-        Expr::StringLiteral(ExprStringLiteral { value, .. }) => Some(value.to_string()),
-        _ => None,
-    }
-}
-
-fn literal_string_from_type(ty: &Type) -> Option<String> {
-    match ty {
-        Type::Literal(Lit::Str(value)) => Some(value.to_string()),
-        _ => None,
-    }
-}
-
-fn is_literal_constructor(expr: &Expr) -> bool {
-    match expr {
-        Expr::Name(name) => name.id.as_str() == "Literal",
-        Expr::Attribute(attr) => attr.attr.id.as_str() == "Literal",
-        _ => false,
-    }
-}
-
-fn literal_annotation_args(slice: &Expr) -> Vec<&Expr> {
-    match slice {
-        Expr::Tuple(t) => t.elts.iter().collect(),
-        Expr::List(t) => t.elts.iter().collect(),
-        other => vec![other],
-    }
-}
-
-fn literal_string_from_annotation_expr(expr: &Expr) -> Option<String> {
-    let Expr::Subscript(subscript) = expr else {
-        return None;
-    };
-    if !is_literal_constructor(&subscript.value) {
-        return None;
-    }
-    let args = literal_annotation_args(&subscript.slice);
-    if args.len() != 1 {
-        return None;
-    }
-    match args[0] {
-        Expr::StringLiteral(ExprStringLiteral { value, .. }) => Some(value.to_string()),
-        _ => None,
-    }
-}
-
-fn literal_string_from_name_annotation(
-    builder: &BindingsBuilder,
-    name: &Identifier,
-) -> Option<String> {
-    let name_read = builder.scopes.look_up_name_for_read(Hashed::new(&name.id));
-    let (_, binding) = match name_read {
-        NameReadInfo::Flow { idx, .. } => builder.get_original_binding(idx)?,
-        _ => return None,
-    };
-    let binding = binding?;
-    match binding {
-        Binding::NameAssign {
-            annotation: Some((_, ann_idx)),
-            ..
-        } => builder
-            .get_annotation_by_idx(*ann_idx)
-            .and_then(literal_string_from_binding_annotation),
-        Binding::FunctionParameter(FunctionParameter::Annotated(ann_idx)) => builder
-            .get_annotation_by_idx(*ann_idx)
-            .and_then(literal_string_from_binding_annotation),
-        _ => None,
-    }
-}
-
-fn literal_string_from_expr_with_builder(builder: &BindingsBuilder, expr: &Expr) -> Option<String> {
-    literal_string_from_expr(expr).or_else(|| match expr {
-        Expr::Name(name) => {
-            literal_string_from_name_annotation(builder, &Ast::expr_name_identifier(name.clone()))
-        }
-        _ => None,
-    })
-}
-
-fn literal_string_from_binding_annotation(annotation: &BindingAnnotation) -> Option<String> {
-    match annotation {
-        BindingAnnotation::Type(_, ty) => literal_string_from_type(ty),
-        BindingAnnotation::AnnotateExpr(_, expr, _) => literal_string_from_annotation_expr(expr),
-    }
-}
-
-/// Internal helper that accepts a literal resolver callback so callers can plug in builder/solver logic.
-/// Given an expression, determine whether it is a chain of properties (attribute/concrete index) rooted at a name,
-/// and if so, return the name and the chain of properties.
-/// For example: x.y.[0].z
-pub(crate) fn identifier_and_chain_for_expr_with_resolver<F>(
+/// Given an expression, determine whether it is a chain of properties (attribute/concrete index)
+/// rooted at a name, and if so, return the name and the facets (allowing a trailing unresolved subscript).
+/// For example: x.y[0].z, or x["key"], or x[key] (pending facet).
+pub(crate) fn identifier_and_facet_subject_for_expr(
     expr: &Expr,
-    resolver: &mut F,
-) -> Option<(Identifier, FacetChain)>
-where
-    F: FnMut(&Expr) -> Option<String>,
-{
-    fn f<F>(
-        expr: &Expr,
-        mut rev_chain: Vec<FacetKind>,
-        resolver: &mut F,
-    ) -> Option<(Identifier, FacetChain)>
-    where
-        F: FnMut(&Expr) -> Option<String>,
-    {
-        if let Expr::Attribute(attr) = expr {
-            match &*attr.value {
-                Expr::Name(name) => {
-                    let mut final_chain =
-                        Vec1::from_vec_push(rev_chain, FacetKind::Attribute(attr.attr.id.clone()));
-                    final_chain.reverse();
-                    Some((
-                        Ast::expr_name_identifier(name.clone()),
-                        FacetChain::new(final_chain),
-                    ))
-                }
-                parent @ (Expr::Attribute(_) | Expr::Subscript(_)) => {
-                    rev_chain.push(FacetKind::Attribute(attr.attr.id.clone()));
-                    f(parent, rev_chain, resolver)
-                }
-                _ => None,
+) -> Option<(Identifier, FacetSubject)> {
+    #[derive(Clone)]
+    enum FacetStep<'a> {
+        Attribute(&'a ExprAttribute),
+        Subscript(&'a ExprSubscript),
+    }
+
+    fn collect_steps<'a>(expr: &'a Expr, steps: &mut Vec<FacetStep<'a>>) -> Option<Identifier> {
+        match expr {
+            Expr::Name(name) => Some(Ast::expr_name_identifier(name.clone())),
+            Expr::Attribute(attr) => {
+                let ident = collect_steps(&attr.value, steps)?;
+                steps.push(FacetStep::Attribute(attr));
+                Some(ident)
             }
-        } else if let Expr::Subscript(subscript @ ExprSubscript { slice, .. }) = expr
-            && let Expr::NumberLiteral(ExprNumberLiteral {
+            Expr::Subscript(subscript) => {
+                let ident = collect_steps(&subscript.value, steps)?;
+                steps.push(FacetStep::Subscript(subscript));
+                Some(ident)
+            }
+            _ => None,
+        }
+    }
+
+    fn literal_facet_from_expr(expr: &Expr) -> Option<FacetKind> {
+        match expr {
+            Expr::StringLiteral(ExprStringLiteral { value, .. }) => {
+                Some(FacetKind::Key(value.to_string()))
+            }
+            Expr::NumberLiteral(ExprNumberLiteral {
                 value: Number::Int(idx),
                 ..
-            }) = &**slice
-            && let Some(idx) = idx.as_usize()
-        {
-            match &*subscript.value {
-                Expr::Name(name) => {
-                    let mut final_chain = Vec1::from_vec_push(rev_chain, FacetKind::Index(idx));
-                    final_chain.reverse();
-                    Some((
-                        Ast::expr_name_identifier(name.clone()),
-                        FacetChain::new(final_chain),
-                    ))
-                }
-                parent @ (Expr::Attribute(_) | Expr::Subscript(_)) => {
-                    rev_chain.push(FacetKind::Index(idx));
-                    f(parent, rev_chain, resolver)
-                }
-                _ => None,
-            }
-        } else if let Expr::Subscript(subscript @ ExprSubscript { slice, .. }) = expr {
-            if let Some(key) = resolver(slice) {
-                match &*subscript.value {
-                    Expr::Name(name) => {
-                        let mut final_chain = Vec1::from_vec_push(rev_chain, FacetKind::Key(key));
-                        final_chain.reverse();
-                        Some((
-                            Ast::expr_name_identifier(name.clone()),
-                            FacetChain::new(final_chain),
-                        ))
-                    }
-                    parent @ (Expr::Attribute(_) | Expr::Subscript(_)) => {
-                        rev_chain.push(FacetKind::Key(key));
-                        f(parent, rev_chain, resolver)
-                    }
-                    _ => None,
-                }
-            } else {
-                None
-            }
-        } else {
-            None
+            }) => idx.as_usize().map(FacetKind::Index),
+            _ => None,
         }
     }
-    f(expr, Vec::new(), resolver)
+
+    let mut steps = Vec::new();
+    let identifier = collect_steps(expr, &mut steps)?;
+    if steps.is_empty() {
+        return None;
+    }
+    let mut resolved = Vec::new();
+    let mut pending = None;
+    for (idx, step) in steps.iter().enumerate() {
+        match step {
+            FacetStep::Attribute(attr) => {
+                if pending.is_some() {
+                    return None;
+                }
+                resolved.push(FacetKind::Attribute(attr.attr.id.clone()));
+            }
+            FacetStep::Subscript(subscript) => {
+                if pending.is_some() {
+                    return None;
+                }
+                if let Some(facet) = literal_facet_from_expr(&subscript.slice) {
+                    resolved.push(facet);
+                } else if idx == steps.len() - 1 {
+                    pending = Some(subscript.slice.clone());
+                } else {
+                    return None;
+                }
+            }
+        }
+    }
+    if resolved.is_empty() && pending.is_none() {
+        return None;
+    }
+    Some((
+        identifier,
+        FacetSubject {
+            resolved,
+            pending,
+            origin: FacetOrigin::Direct,
+        },
+    ))
 }
 
 pub fn identifier_and_chain_for_expr(expr: &Expr) -> Option<(Identifier, FacetChain)> {
-    identifier_and_chain_for_expr_with_resolver(expr, &mut literal_string_from_expr)
+    let (identifier, subject) = identifier_and_facet_subject_for_expr(expr)?;
+    subject.to_chain().map(|chain| (identifier, chain))
 }
 
-/// Builder-aware variant of `identifier_and_chain_for_expr` that can resolve literal keys
-/// from names annotated with `Literal["key"]`.
-pub fn identifier_and_chain_for_expr_with_builder(
-    builder: &BindingsBuilder,
-    expr: &Expr,
-) -> Option<(Identifier, FacetChain)> {
-    identifier_and_chain_for_expr_with_resolver(expr, &mut |expr| {
-        literal_string_from_expr_with_builder(builder, expr)
-    })
+fn literal_string_from_expr(expr: &Expr) -> Option<String> {
+    if let Expr::StringLiteral(ExprStringLiteral { value, .. }) = expr {
+        Some(value.to_string())
+    } else {
+        None
+    }
 }
 
 /// Similar to identifier_and_chain_for_expr, except if we encounter a non-concrete subscript in the chain
@@ -1086,11 +1004,13 @@ fn dict_get_subject_for_call_expr(call_expr: &ExprCall) -> Option<NarrowingSubje
         let key = value.to_string();
         if let Some((identifier, facets)) = identifier_and_chain_for_expr(&attr.value) {
             // x.y.z.get("key")
-            let props = Vec1::from_vec_push(facets.facets().to_vec(), FacetKind::Key(key.clone()));
+            let mut resolved = facets.facets().to_vec();
+            resolved.push(FacetKind::Key(key.clone()));
             return Some(NarrowingSubject::Facets(
                 identifier.id,
                 FacetSubject {
-                    chain: FacetChain::new(props),
+                    resolved,
+                    pending: None,
                     origin: FacetOrigin::GetMethod,
                 },
             ));
@@ -1099,7 +1019,8 @@ fn dict_get_subject_for_call_expr(call_expr: &ExprCall) -> Option<NarrowingSubje
             return Some(NarrowingSubject::Facets(
                 name.id.clone(),
                 FacetSubject {
-                    chain: FacetChain::new(Vec1::new(FacetKind::Key(key))),
+                    resolved: vec![FacetKind::Key(key)],
+                    pending: None,
                     origin: FacetOrigin::GetMethod,
                 },
             ));
@@ -1108,21 +1029,13 @@ fn dict_get_subject_for_call_expr(call_expr: &ExprCall) -> Option<NarrowingSubje
     None
 }
 
-pub fn expr_to_subjects(builder: &BindingsBuilder, expr: &Expr) -> Vec<NarrowingSubject> {
-    fn f(builder: &BindingsBuilder, expr: &Expr, res: &mut Vec<NarrowingSubject>) {
+pub fn expr_to_subjects(expr: &Expr) -> Vec<NarrowingSubject> {
+    fn f(expr: &Expr, res: &mut Vec<NarrowingSubject>) {
         match expr {
             Expr::Name(name) => res.push(NarrowingSubject::Name(name.id.clone())),
             Expr::Attribute(_) | Expr::Subscript(_) => {
-                if let Some((identifier, facets)) =
-                    identifier_and_chain_for_expr_with_builder(builder, expr)
-                {
-                    res.push(NarrowingSubject::Facets(
-                        identifier.id,
-                        FacetSubject {
-                            chain: facets,
-                            origin: FacetOrigin::Direct,
-                        },
-                    ));
+                if let Some((identifier, subject)) = identifier_and_facet_subject_for_expr(expr) {
+                    res.push(NarrowingSubject::Facets(identifier.id, subject));
                 }
             }
             Expr::Call(call) => {
@@ -1131,13 +1044,13 @@ pub fn expr_to_subjects(builder: &BindingsBuilder, expr: &Expr) -> Vec<Narrowing
                 }
             }
             Expr::Named(ExprNamed { target, value, .. }) => {
-                f(builder, target, res);
-                f(builder, value, res);
+                f(target, res);
+                f(value, res);
             }
             _ => {}
         }
     }
     let mut res = Vec::new();
-    f(builder, expr, &mut res);
+    f(expr, &mut res);
     res
 }

--- a/pyrefly/lib/binding/pattern.rs
+++ b/pyrefly/lib/binding/pattern.rs
@@ -347,7 +347,7 @@ impl<'a> BindingsBuilder<'a> {
         self.ensure_expr(&mut x.subject, subject.usage());
         let subject_idx =
             self.insert_binding_current(subject, Binding::Expr(None, *x.subject.clone()));
-        let match_narrowing_subject = expr_to_subjects(self, &x.subject).first().cloned();
+        let match_narrowing_subject = expr_to_subjects(&x.subject).first().cloned();
         let mut exhaustive = false;
         self.start_fork(x.range);
         // Type narrowing operations that are carried over from one case to the next. For example, in:


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #329

now threads a BindingsBuilder through NarrowOps, so expr_to_subjects can resolve data[key] by inspecting the binding that defines key.  We added helper logic that looks up the original Binding (either a NameAssign or FunctionParameter) to pull its Literal annotation via the new BindingsBuilder::get_annotation_by_idx helper. The existing literal-subscript walkers were generalized to accept resolver callbacks, and the resolver backed by annotations is used everywhere in the binder.

gained literal_string_key_from_expr, letting expression inference recover literal keys from either syntax or inferred type.  subscript_infer now calls this helper so TypeInfo::at_facet is entered even when the index expression is a Literal-typed variable.

switches Binding::AssignToSubscript over to the same resolver (via the newly exported _with_resolver helpers) so assignments such as data[key] = [] update the correct TypedDict facet even when key is a literal-typed variable.

other assertion helpers were updated to pass the builder into from_single_narrow_op, ensuring unit-test helpers keep benefiting from the new literal detection.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add tests
