### PR TITLE
Fix: unbound-name now considers range() and non-empty literals #1706

### DIFF
--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -638,9 +638,10 @@ impl FlowStyle {
                     // we have to be lax about whether boolean ops define new names
                     match merge_style {
                         MergeStyle::BoolOp => FlowStyle::Other,
-                        MergeStyle::Loop | MergeStyle::Exclusive | MergeStyle::Inclusive => {
-                            FlowStyle::PossiblyUninitialized
-                        }
+                        MergeStyle::Loop
+                        | MergeStyle::LoopDefinitelyRuns
+                        | MergeStyle::Exclusive
+                        | MergeStyle::Inclusive => FlowStyle::PossiblyUninitialized,
                     }
                 }
             }
@@ -2334,6 +2335,11 @@ enum MergeStyle {
     /// This is a loopback merge for the top of a loop; the base flow is part of the
     /// merge.
     Loop,
+    /// This is a loopback merge for a loop that definitely runs at least once
+    /// (e.g., `for _ in range(3)` or `for _ in [1, 2, 3]`). The base flow is NOT
+    /// counted as a branch for the purpose of determining if names are always defined,
+    /// since the loop body will always execute at least once.
+    LoopDefinitelyRuns,
     /// This is a fork in which the current flow should be discarded - for example
     /// the end of an `if` statement with an `else` branch.
     ///
@@ -2443,10 +2449,19 @@ impl<'a> BindingsBuilder<'a> {
     ) -> FlowInfo {
         let base_idx = merge_item.base.as_ref().map(|base| base.idx());
         let mut flow_infos = merge_item.branches;
+        // Track the number of branch values before adding base (for LoopDefinitelyRuns)
+        let n_branch_flow_infos = flow_infos.len();
+        // Track if base has a value for this name (for LoopDefinitelyRuns init check)
+        let base_has_value = merge_item
+            .base
+            .as_ref()
+            .map_or(false, |b| b.value.is_some());
         // If this is a loop, we want to use the current default in any phis we produce,
-        // and the base flow is part of the merge.
-        let loop_prior = if matches!(merge_style, MergeStyle::Loop)
-            && let Some(base) = merge_item.base
+        // and the base flow is part of the merge for type inference purposes.
+        let loop_prior = if matches!(
+            merge_style,
+            MergeStyle::Loop | MergeStyle::LoopDefinitelyRuns
+        ) && let Some(base) = merge_item.base
         {
             let loop_prior = base.loop_prior;
             flow_infos.push(base);
@@ -2499,7 +2514,14 @@ impl<'a> BindingsBuilder<'a> {
             }
             branch_idxs.insert(branch_idx);
         }
-        let this_name_always_defined = n_values == n_branches;
+        // For LoopDefinitelyRuns, a name is always defined if:
+        // - It was defined before the loop (base_has_value), OR
+        // - It's defined in all loop body branches (since the loop definitely runs at least once)
+        // For regular loops and other merges, a name is always defined if it's in all branches.
+        let this_name_always_defined = match merge_style {
+            MergeStyle::LoopDefinitelyRuns => base_has_value || n_branch_flow_infos == n_branches,
+            _ => n_values == n_branches,
+        };
         match value_idxs.len() {
             // If there are no values, then this name isn't assigned at all
             // and is only narrowed (it's most likely a capture, but could be
@@ -2574,14 +2596,21 @@ impl<'a> BindingsBuilder<'a> {
         merge_style: MergeStyle,
     ) {
         // Include the current flow in the merge if the merge style calls for it.
-        if matches!(merge_style, MergeStyle::Loop | MergeStyle::Inclusive) {
+        if matches!(
+            merge_style,
+            MergeStyle::Loop | MergeStyle::LoopDefinitelyRuns | MergeStyle::Inclusive
+        ) {
             branches.push(mem::take(&mut self.scopes.current_mut().flow));
         }
 
         // Short circuit when there is only one flow. Note that we can never short
         // circuit for loops, because (a) we need to merge with the base flow, and
         // (b) we have already promised the phi keys so we'll panic if we short-circuit.
-        if !matches!(merge_style, MergeStyle::Loop) && branches.len() == 1 {
+        if !matches!(
+            merge_style,
+            MergeStyle::Loop | MergeStyle::LoopDefinitelyRuns
+        ) && branches.len() == 1
+        {
             self.scopes.current_mut().flow = branches.pop().unwrap();
             return;
         }
@@ -2592,14 +2621,20 @@ impl<'a> BindingsBuilder<'a> {
         // we'll use the terminated branches.
         let (terminated_branches, live_branches): (Vec<_>, Vec<_>) =
             branches.into_iter().partition(|flow| flow.has_terminated);
-        let has_terminated = live_branches.is_empty() && !matches!(merge_style, MergeStyle::Loop);
+        let has_terminated = live_branches.is_empty()
+            && !matches!(
+                merge_style,
+                MergeStyle::Loop | MergeStyle::LoopDefinitelyRuns
+            );
         let flows = if has_terminated {
             terminated_branches
         } else {
             live_branches
         };
 
-        // For a loop, we merge the base so there's one extra branch being merged.
+        // For a regular loop, we merge the base so there's one extra branch being merged.
+        // For LoopDefinitelyRuns, we don't count the base as an extra branch because we
+        // know the loop body will definitely execute at least once.
         let n_branches = flows.len()
             + if matches!(merge_style, MergeStyle::Loop) {
                 1
@@ -2693,6 +2728,7 @@ impl<'a> BindingsBuilder<'a> {
         orelse: Vec<Stmt>,
         parent: &NestingContext,
         is_while_true: bool,
+        loop_definitely_runs: bool,
     ) {
         let finished_loop = self.scopes.finish_loop();
         let (breaks, other_exits): (Vec<Flow>, Vec<Flow>) = finished_loop
@@ -2711,7 +2747,13 @@ impl<'a> BindingsBuilder<'a> {
         // it is as long as it's different from the loop's range.
         let other_range = TextRange::new(range.start(), range.start());
         // Create the loopback merge, which is the flow at the top of the loop.
-        self.merge_flow(finished_loop.base, other_exits, range, MergeStyle::Loop);
+        // Use LoopDefinitelyRuns when we know the loop will execute at least once.
+        let merge_style = if loop_definitely_runs {
+            MergeStyle::LoopDefinitelyRuns
+        } else {
+            MergeStyle::Loop
+        };
+        self.merge_flow(finished_loop.base, other_exits, range, merge_style);
         // When control falls off the end of a loop (either the `while` test fails or the loop
         // finishes), we're at the loopback flow but the test (if there is one) is negated.
         self.bind_narrow_ops(

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -13,7 +13,11 @@ use ruff_python_ast::Arguments;
 use ruff_python_ast::AtomicNodeIndex;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprCall;
+use ruff_python_ast::ExprList;
 use ruff_python_ast::ExprName;
+use ruff_python_ast::ExprNumberLiteral;
+use ruff_python_ast::ExprSet;
+use ruff_python_ast::ExprTuple;
 use ruff_python_ast::Identifier;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtAssign;
@@ -56,6 +60,53 @@ use crate::state::loader::FindingOrError;
 use crate::types::alias::resolve_typeshed_alias;
 use crate::types::special_form::SpecialForm;
 use crate::types::types::Type;
+
+/// Checks if an iterable expression is guaranteed to be non-empty and thus
+/// the for-loop body will definitely execute at least once.
+///
+/// Returns true for:
+/// - `range(N)` where N is a positive integer literal
+/// - Non-empty list literals like `[1, 2, 3]`
+/// - Non-empty tuple literals like `(1, 2, 3)`
+/// - Non-empty set literals like `{1, 2, 3}`
+fn is_definitely_nonempty_iterable(iter: &Expr) -> bool {
+    match iter {
+        // Check for range(N) where N is a positive integer literal
+        Expr::Call(ExprCall {
+            func, arguments, ..
+        }) => {
+            // Check if the function is `range`
+            if let Expr::Name(ExprName { id, .. }) = &**func {
+                if id.as_str() == "range" && arguments.keywords.is_empty() {
+                    // range(stop) - positive stop means at least one iteration
+                    // range(start, stop) - we only handle range(stop) for simplicity
+                    if let [arg] = &*arguments.args {
+                        if let Expr::NumberLiteral(ExprNumberLiteral { value, .. }) = arg {
+                            if let Some(n) = value.as_int().and_then(|i| i.as_i64()) {
+                                return n > 0;
+                            }
+                        }
+                        // Also handle negative literals like range(-5) which iterate 0 times
+                        if let Expr::UnaryOp(unary) = arg {
+                            if matches!(unary.op, ruff_python_ast::UnaryOp::USub) {
+                                // range(-N) always iterates 0 times
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+            false
+        }
+        // Check for non-empty list literals
+        Expr::List(ExprList { elts, .. }) => !elts.is_empty(),
+        // Check for non-empty tuple literals
+        Expr::Tuple(ExprTuple { elts, .. }) => !elts.is_empty(),
+        // Check for non-empty set literals
+        Expr::Set(ExprSet { elts, .. }) => !elts.is_empty(),
+        _ => false,
+    }
+}
 
 impl<'a> BindingsBuilder<'a> {
     fn assert(&mut self, assert_range: TextRange, mut test: Expr, msg: Option<Expr>) {
@@ -665,6 +716,9 @@ impl<'a> BindingsBuilder<'a> {
                 Ast::expr_lvalue(&x.target, &mut |name| {
                     loop_header_targets.insert(name.id.clone());
                 });
+                // Check if the iterable is definitely non-empty before binding
+                // (must be done before x.iter is moved)
+                let loop_definitely_runs = is_definitely_nonempty_iterable(&x.iter);
                 self.bind_target_with_expr(&mut x.target, &mut x.iter, &|expr, ann| {
                     Binding::IterableValue(ann, expr.clone(), IsAsync::new(x.is_async))
                 });
@@ -673,7 +727,14 @@ impl<'a> BindingsBuilder<'a> {
                 // targets - which get re-bound each iteration - are excluded from the loop Phi logic.
                 self.setup_loop(x.range, &loop_header_targets);
                 self.stmts(x.body, parent);
-                self.teardown_loop(x.range, &NarrowOps::new(), x.orelse, parent, false);
+                self.teardown_loop(
+                    x.range,
+                    &NarrowOps::new(),
+                    x.orelse,
+                    parent,
+                    false,
+                    loop_definitely_runs,
+                );
             }
             Stmt::While(mut x) => {
                 self.setup_loop(x.range, &SmallSet::new());
@@ -691,7 +752,15 @@ impl<'a> BindingsBuilder<'a> {
                 );
                 self.insert_binding(KeyExpect(x.test.range()), BindingExpect::Bool(*x.test));
                 self.stmts(x.body, parent);
-                self.teardown_loop(x.range, &narrow_ops, x.orelse, parent, is_while_true);
+                // For while True: loops, the loop body definitely runs at least once
+                self.teardown_loop(
+                    x.range,
+                    &narrow_ops,
+                    x.orelse,
+                    parent,
+                    is_while_true,
+                    is_while_true,
+                );
             }
             Stmt::If(x) => {
                 let mut exhaustive = false;

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -1402,3 +1402,105 @@ for _ in []:
         continue
     "#,
 );
+
+// Tests for issue #1706: unbound-name should consider range() with nonzero literal
+// and non-empty literal containers as definitely executing at least once
+testcase!(
+    test_for_range_nonzero_literal_defines_variable,
+    r#"
+from typing import assert_type, Literal
+def foo():
+    for _ in range(3):
+        x = "a"
+    assert_type(x, Literal["a"])
+    "#,
+);
+
+testcase!(
+    test_for_range_one_defines_variable,
+    r#"
+from typing import assert_type, Literal
+def foo():
+    for _ in range(1):
+        x = "a"
+    assert_type(x, Literal["a"])
+    "#,
+);
+
+testcase!(
+    test_for_nonempty_list_defines_variable,
+    r#"
+from typing import assert_type, Literal
+def foo():
+    for _ in [1, 2, 3]:
+        x = "a"
+    assert_type(x, Literal["a"])
+    "#,
+);
+
+testcase!(
+    test_for_nonempty_tuple_defines_variable,
+    r#"
+from typing import assert_type, Literal
+def foo():
+    for _ in (1, 2, 3):
+        x = "a"
+    assert_type(x, Literal["a"])
+    "#,
+);
+
+testcase!(
+    test_for_nonempty_set_defines_variable,
+    r#"
+from typing import assert_type, Literal
+def foo():
+    for _ in {1, 2, 3}:
+        x = "a"
+    assert_type(x, Literal["a"])
+    "#,
+);
+
+// These should still produce errors because the loop may not execute
+testcase!(
+    test_for_range_zero_may_not_define_variable,
+    r#"
+from typing import assert_type, Literal
+def foo():
+    for _ in range(0):
+        x = "a"
+    assert_type(x, Literal["a"])  # E: `x` may be uninitialized
+    "#,
+);
+
+testcase!(
+    test_for_empty_list_may_not_define_variable,
+    r#"
+from typing import assert_type, Literal
+def foo():
+    for _ in []:
+        x = "a"
+    assert_type(x, Literal["a"])  # E: `x` may be uninitialized
+    "#,
+);
+
+testcase!(
+    test_for_dynamic_range_may_not_define_variable,
+    r#"
+from typing import assert_type, Literal
+def foo(n: int):
+    for _ in range(n):
+        x = "a"
+    assert_type(x, Literal["a"])  # E: `x` may be uninitialized
+    "#,
+);
+
+testcase!(
+    test_for_dynamic_list_may_not_define_variable,
+    r#"
+from typing import assert_type, Literal
+def foo(xs: list[int]):
+    for _ in xs:
+        x = "a"
+    assert_type(x, Literal["a"])  # E: `x` may be uninitialized
+    "#,
+);


### PR DESCRIPTION

# Summary
For-loops iterating over definitely non-empty iterables now correctly recognize that variables assigned in the loop body will always be defined.
This adds special case handling for:
  - `range(N)` where N is a positive integer literal (e.g., `range(3)`)
  - Non-empty list literals (e.g., `[1, 2, 3]`)
  - Non-empty tuple literals (e.g., `(1, 2, 3)`)
  - Non-empty set literals (e.g., `{1, 2, 3}`)
  
  Before this change:
  ```python
  for _ in range(3):
      work = 1
  print(work)  # ERROR: `work` may be uninitialized
  ```

  After this change:
  ```python
  for _ in range(3):
      work = 1
  print(work)  # No error - loop definitely runs at least once
  ```

Fixes #1706

# Test Plan
- Added 9 new test cases in flow_branching.rs
- All Test Cases Passed
- Manually tested in the playground

<!-- Run test.py and commit any changes to generated files -->
