### PR TITLE
fix: highlighting for shadow builtins

### DIFF
--- a/pyrefly/lib/test/lsp/semantic_tokens.rs
+++ b/pyrefly/lib/test/lsp/semantic_tokens.rs
@@ -790,3 +790,57 @@ token-type: variable, token-modifiers: [readonly]
 "#,
     );
 }
+
+#[test]
+fn shadowed_builtin_not_highlighted_as_builtin() {
+    let code = r#"
+from typing import Literal
+
+input = 1
+not_a_builtin = 1
+x: Literal[1] = input
+y: Literal[1] = not_a_builtin
+str(input)
+"#;
+    assert_full_semantic_tokens(
+        &[("main", code)],
+        r#"
+# main.py
+line: 1, column: 5, length: 6, text: typing
+token-type: namespace
+
+line: 1, column: 19, length: 7, text: Literal
+token-type: class, token-modifiers: [defaultLibrary]
+
+line: 3, column: 0, length: 5, text: input
+token-type: variable
+
+line: 4, column: 0, length: 13, text: not_a_builtin
+token-type: variable
+
+line: 5, column: 0, length: 1, text: x
+token-type: variable
+
+line: 5, column: 3, length: 7, text: Literal
+token-type: class, token-modifiers: [defaultLibrary]
+
+line: 5, column: 16, length: 5, text: input
+token-type: variable
+
+line: 6, column: 0, length: 1, text: y
+token-type: variable
+
+line: 6, column: 3, length: 7, text: Literal
+token-type: class, token-modifiers: [defaultLibrary]
+
+line: 6, column: 16, length: 13, text: not_a_builtin
+token-type: variable
+
+line: 7, column: 0, length: 3, text: str
+token-type: class, token-modifiers: [defaultLibrary]
+
+line: 7, column: 4, length: 5, text: input
+token-type: variable
+"#,
+    );
+}


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1849 

fixes the bug where variables shadowing built-ins were highlighted as built-ins instead of variables.

before:
<img width="232" height="78" alt="pyrefly" src="https://github.com/user-attachments/assets/e5122f4e-065f-4b3d-a0b6-6472d6d35b11" />

after fix:
<img width="242" height="150" alt="Screenshot 2025-12-15 174837" src="https://github.com/user-attachments/assets/ccc117b7-ed9b-4e78-a31e-bf116e22ed69" />


**Changes:**
- Ensure locally defined names are not treated as library symbols when applying the `defaultLibrary` modifier
- Always highlight assignment targets as variables in `process_stmt`
- Process the AST before built-in keys so locally defined variables take precedence

# Test Plan

added test `shadowed_builtin_not_highlighted_as_builtin` verifying shadowed built-ins are variables and actual built-ins keep the modifier



<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
