### PR TITLE
feat : Add "Did you mean?" suggestions for mistyped stdlib imports

### DIFF
--- a/pyrefly/lib/module/finder.rs
+++ b/pyrefly/lib/module/finder.rs
@@ -13,6 +13,7 @@ use pyrefly_python::COMPILED_FILE_SUFFIXES;
 use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::module_path::ModulePath;
 use pyrefly_python::module_path::ModuleStyle;
+use pyrefly_util::suggest::best_suggestion;
 use ruff_python_ast::name::Name;
 use starlark_map::small_map::SmallMap;
 use vec1::Vec1;
@@ -625,6 +626,7 @@ pub fn find_import_filtered(
             config.structured_import_lookup_path(origin),
             module,
             &config.source,
+            suggest_stdlib_import(module),
         ))
     }
 }
@@ -677,6 +679,23 @@ fn recommended_stubs_package(module: ModuleName) -> Option<ModuleName> {
         "django" => Some(ModuleName::from_str("django-stubs")),
         _ => None,
     }
+}
+
+/// Suggest a similar stdlib module name for a mistyped import.
+/// Uses Levenshtein distance to find the closest match from typeshed's stdlib modules.
+fn suggest_stdlib_import(missing: ModuleName) -> Option<ModuleName> {
+    let ts = typeshed().ok()?;
+    let missing_str = missing.as_str();
+
+    // For single-component module names, use best_suggestion with first component
+    // For multi-component, we compare full module name strings
+    let missing_name = Name::new(missing_str);
+
+    // Collect all stdlib module names and find the best suggestion
+    let candidates: Vec<Name> = ts.modules().map(|m| Name::new(m.as_str())).collect();
+
+    best_suggestion(&missing_name, candidates.iter().map(|c| (c, 0)))
+        .map(|suggestion| ModuleName::from_str(suggestion.as_str()))
 }
 
 #[cfg(test)]
@@ -1010,6 +1029,7 @@ mod tests {
                 config.structured_import_lookup_path(None),
                 ModuleName::from_str("spp_priority.d"),
                 &config.source,
+                None,
             )),
         );
     }
@@ -2198,5 +2218,39 @@ mod tests {
         } else {
             panic!("Expected Finding result for 'conans', got: {:?}", result);
         }
+    }
+
+    #[test]
+    fn test_suggest_stdlib_import() {
+        // Test that we suggest 'math' for 'mathh' (one character typo)
+        let suggestion = suggest_stdlib_import(ModuleName::from_str("mathh"));
+        assert_eq!(
+            suggestion,
+            Some(ModuleName::from_str("math")),
+            "Should suggest 'math' for 'mathh'"
+        );
+
+        // Test that we suggest 'os' for 'oss' (one character typo)
+        let suggestion = suggest_stdlib_import(ModuleName::from_str("oss"));
+        assert_eq!(
+            suggestion,
+            Some(ModuleName::from_str("os")),
+            "Should suggest 'os' for 'oss'"
+        );
+
+        // Test that we suggest 'json' for 'jsn' (missing character)
+        let suggestion = suggest_stdlib_import(ModuleName::from_str("jsn"));
+        assert_eq!(
+            suggestion,
+            Some(ModuleName::from_str("json")),
+            "Should suggest 'json' for 'jsn'"
+        );
+
+        // Test that we don't suggest for completely unrelated names
+        let suggestion = suggest_stdlib_import(ModuleName::from_str("xyzabc123"));
+        assert_eq!(
+            suggestion, None,
+            "Should not suggest for completely unrelated names"
+        );
     }
 }

--- a/pyrefly/lib/playground.rs
+++ b/pyrefly/lib/playground.rs
@@ -675,7 +675,7 @@ mod tests {
             "Parse error: Expected `import`, found newline",
         ];
         let expected_details = &[
-            "  Looked in these locations:\n  Build system source database",
+            "  Looked in these locations:\n  Build system source database\n  Did you mean `nt`?",
             "",
         ];
         let expected_error_kinds = &[ErrorKind::MissingImport, ErrorKind::ParseError];

--- a/pyrefly/lib/state/loader.rs
+++ b/pyrefly/lib/state/loader.rs
@@ -51,6 +51,7 @@ impl FindError {
         path: Vec<ImportLookupPathPart>,
         module: ModuleName,
         config_source: &ConfigSource,
+        suggestion: Option<ModuleName>,
     ) -> FindError {
         let config_suffix = match config_source {
             ConfigSource::File(p) => format!(" (from config in `{}`)", p.display()),
@@ -78,6 +79,9 @@ impl FindError {
             format!("Looked in these locations{config_suffix}:")
         }];
         explanation.extend(nonempty_paths);
+        if let Some(suggested) = suggestion {
+            explanation.push(format!("Did you mean `{suggested}`?"));
+        }
         FindError::NotFound(module, Arc::new(explanation))
     }
 


### PR DESCRIPTION
# Summary

When a user imports a mistyped stdlib module, pyrefly now suggests the closest match using Levenshtein distance.

Uses the existing `best_suggestion` function (already used for attribute errors) with typeshed's stdlib modules as candidates.
**Before:**
```
  ERROR sandbox.py:1:8-11: Could not find import of mathh [missing-import]
    Looked in these locations:
    ...
```

**After:**
```
  ERROR sandbox.py:1:8-11: Could not find import of mathh [missing-import]
    Looked in these locations:
    ...
    Did you mean math?
```

**More examples:**
  - `import jsn` → `Did you mean 'json'?`
  - `import oss` → `Did you mean 'os'?`
  - `import collecions` → `Did you mean 'collections'?`

<!-- Describe the change in this PR -->

Fixes #1858

# Test Plan
[x] Added unit test `test_suggest_stdlib_import` in `finder.rs`
[x] Updated existing `test_invalid_import` in `playground.rs` to expect the new suggestion
[x] Ran `python3 test.py` - all 3114 tests pass
[x] Manually tested in playground with various typos
