### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build_and_test_website.yml
+++ b/.github/workflows/build_and_test_website.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20.x"
       - name: Install yarn deps
@@ -50,7 +50,7 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Upload build artifacts
         if: ${{ inputs.upload_artifacts }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: website-build-${{ env.date }}
           path: website/build

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -18,11 +18,11 @@ jobs:
   sdist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Build sdist
@@ -39,7 +39,7 @@ jobs:
           "${BINARY_NAME}" check test.py
           python -m "${BINARY_NAME}" --version
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-sdist
           path: pyrefly/dist
@@ -54,11 +54,11 @@ jobs:
           - target: aarch64
             arch: arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: ${{ matrix.platform.arch }}
@@ -77,7 +77,7 @@ jobs:
           "${BINARY_NAME}" check test.py
           python -m "${BINARY_NAME}" --version
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-macos-${{ matrix.platform.target }}
           path: pyrefly/dist
@@ -94,11 +94,11 @@ jobs:
           - target: aarch64-pc-windows-msvc
             arch: x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: ${{ matrix.platform.arch }}
@@ -122,7 +122,7 @@ jobs:
           "${BINARY_NAME}" check test.py
           python -m "${BINARY_NAME}" --version
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-${{ matrix.platform.target }}
           path: pyrefly/dist
@@ -136,11 +136,11 @@ jobs:
           - i686-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
@@ -180,7 +180,7 @@ jobs:
           "${BINARY_NAME}" check test.py
           python -m "${BINARY_NAME}" --version
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-${{ matrix.target }}
           path: pyrefly/dist

--- a/.github/workflows/build_extension.yml
+++ b/.github/workflows/build_extension.yml
@@ -15,7 +15,7 @@ jobs:
       pyrefly_version: ${{ steps.pyrefly-version.outputs.PYREFLY_VERSION }}
     steps:
       - name: Checkout repo (to see version.bzl in next step)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Get all history for all branches and tags
       - name: Get version
@@ -82,7 +82,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Read rust-toolchain file
         # matrix.github_env is necessary to differentiate between windows and linux environment variables
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#environment-files
@@ -116,7 +116,7 @@ jobs:
       - name: build pyrefly binary
         if: ${{ matrix.rust_target == '' }}
         run: cargo build --release --all-features --artifact-dir lsp/bin --manifest-path pyrefly/Cargo.toml -Z unstable-options
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -126,7 +126,7 @@ jobs:
         working-directory: lsp/
       - run: npx vsce package --target ${{ env.platform }} ${{needs.get_version.outputs.pyrefly_version}}
         working-directory: lsp/
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pyrefly-${{ env.platform }}
           path: "lsp/*.vsix"

--- a/.github/workflows/deploy_extension.yml
+++ b/.github/workflows/deploy_extension.yml
@@ -21,7 +21,7 @@ jobs:
         if: ${{ success() }}
         steps:
             - name: upload
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
             - name: publish
               run: npx vsce publish --packagePath $(find . -iname *.vsix)
               env:
@@ -35,6 +35,6 @@ jobs:
         if: ${{ success() }}
         steps:
             - name: upload
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
             - name: publish
               run: npx ovsx publish --packagePath $(find . -iname *.vsix) --pat ${{ secrets.OPENVSX_TOKEN }}

--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -47,18 +47,18 @@ jobs:
         if: ${{ !inputs.is_rollback }}
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       # For regular deployments, download today's artifacts
       - name: Download build artifacts (regular deployment)
         if: ${{ !inputs.is_rollback }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: website-build-${{ env.date }}
           path: website/build
       # For rollbacks, download the specified artifacts
       - name: Download build artifacts (rollback)
         if: ${{ inputs.is_rollback }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: website-build-${{ inputs.artifact_date }}
           path: website/build

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -24,12 +24,12 @@ jobs:
       fail-fast: false
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: pyrefly_to_test
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Install dependencies
@@ -70,7 +70,7 @@ jobs:
         run: |
           echo ${{ github.event.pull_request.number }} | tee pr_number.txt
       - name: Upload mypy_primer diff + PR number
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ matrix.shard-index == 0 }}
         with:
           name: mypy_primer_diffs-${{ matrix.shard-index }}
@@ -78,7 +78,7 @@ jobs:
             diff_${{ matrix.shard-index }}.txt
             pr_number.txt
       - name: Upload mypy_primer diff
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ matrix.shard-index != 0 }}
         with:
           name: mypy_primer_diffs-${{ matrix.shard-index }}

--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -21,7 +21,7 @@ jobs:
     # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download diffs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -47,7 +47,7 @@ jobs:
 
       - name: Post comment
         id: post-comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/needs_triage.yml
+++ b/.github/workflows/needs_triage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label issues that need triage
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label pull requests that need triage
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -27,7 +27,7 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - name: Download dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist
@@ -40,7 +40,7 @@ jobs:
     needs: pypi-publish  # Don't push a tag unless the publish job succeeds
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Get all history for all branches and tags
       - name: Get version

--- a/.github/workflows/pyrefly.yml
+++ b/.github/workflows/pyrefly.yml
@@ -21,7 +21,7 @@ jobs:
           - os: windows-latest
             github_env: $env:GITHUB_ENV
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: set windows cargo home
       # we need to set CARGO_HOME to a high-up directory on Windows machines, since some dependencies cloned
       # by Cargo have long paths and will cause builds/tests to fail

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           # Only for issues and pull requests which are assigned
           include-only-assigned: true

--- a/.github/workflows/test_extension.yml
+++ b/.github/workflows/test_extension.yml
@@ -50,11 +50,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo (to see version.bzl in next step)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Get all history for all branches and tags
       - name: download built vsix
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: pyrefly-${{ matrix.platform }}-${{ matrix.arch }}
       - name: Rename .vsix to .zip
@@ -74,7 +74,7 @@ jobs:
           mkdir -p lsp/bin && mv extracted/extension/bin/* lsp/bin/
         shell: bash
       # Now run the test
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [``](https://github.com/actions/checkout/releases/tag/) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) |  |
| `actions/download-artifact` | [``](https://github.com/actions/download-artifact/releases/tag/) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) |  |
| `actions/github-script` | [``](https://github.com/actions/github-script/releases/tag/) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) |  |
| `actions/setup-node` | [``](https://github.com/actions/setup-node/releases/tag/) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) |  |
| `actions/setup-python` | [``](https://github.com/actions/setup-python/releases/tag/) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) |  |
| `actions/stale` | [``](https://github.com/actions/stale/releases/tag/) | [`v10`](https://github.com/actions/stale/releases/tag/v10) | [Release](https://github.com/actions/stale/releases/tag/v10) |  |
| `actions/upload-artifact` | [``](https://github.com/actions/upload-artifact/releases/tag/) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) |  |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
