### PR TITLE
fix github CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ codegen-units = 1
 strip = false
 
 [profile.release-with-debug]
+inherits = "release"
 debug = true
 lto = true
 codegen-units = 1


### PR DESCRIPTION
Summary:
according to claude:

  I added inherits = "release" to the [profile.release-with-debug] section in /data/users/kylei/fbsource/fbcode/pyrefly/Cargo.toml:14. This tells Cargo that
   the release-with-debug profile should inherit all settings from the release profile, and then the explicitly specified fields (debug = true, etc.) will
  override the inherited values.

  This should fix the GitHub CI build failure while maintaining the intended behavior of having a release profile with full debug symbols for debugging
  purposes.

Differential Revision: D89322138


