### PR TITLE
Fix pypa/gh-action-pypi-publish version to use SHA pinning

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -33,8 +33,7 @@ jobs:
           path: dist
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
-  push-tag:
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13  push-tag:
     name: Push version tag
     runs-on: ubuntu-latest
     needs: pypi-publish  # Don't push a tag unless the publish job succeeds


### PR DESCRIPTION
## Summary

Fix incorrect version reference for `pypa/gh-action-pypi-publish`.

## Problem

A previous PR I made incorrectly changed the action reference from `release/v1` (valid branch) to `v1` (non-existent tag). The `v1` tag doesn't exist in the pypa/gh-action-pypi-publish repository.

## Solution

Updated to use SHA pinning for release/v1.13:
```yaml
uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13
```

This follows [GitHub's security best practices](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) for third-party actions by pinning to an immutable SHA.

## Files Changed

- `.github/workflows/publish_to_pypi.yml`
