### PR TITLE
feat : Add missing-override-decorator error for strict override enforcement

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -199,6 +199,8 @@ pub enum ErrorKind {
     MissingImport,
     /// Accessing an attribute that does not exist on a module.
     MissingModuleAttribute,
+    /// A method overrides a parent class method but does not have the `@override` decorator.
+    MissingOverrideDecorator,
     /// The source code for an imported package is missing.
     MissingSource,
     /// We are using bundled stubs for a package but the source code is missing.
@@ -309,6 +311,7 @@ impl ErrorKind {
             ErrorKind::UnannotatedReturn => Severity::Ignore,
             ErrorKind::UnannotatedAttribute => Severity::Ignore,
             ErrorKind::MissingSource => Severity::Ignore,
+            ErrorKind::MissingOverrideDecorator => Severity::Ignore,
             ErrorKind::OpenUnpacking => Severity::Ignore,
             _ => Severity::Error,
         }

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -111,6 +111,7 @@ pub struct TestEnv {
     unannotated_attribute_error: bool,
     implicit_abstract_class_error: bool,
     open_unpacking_error: bool,
+    missing_override_decorator_error: bool,
     default_require_level: Require,
 }
 
@@ -131,6 +132,7 @@ impl TestEnv {
             unannotated_attribute_error: false,
             implicit_abstract_class_error: false,
             open_unpacking_error: false,
+            missing_override_decorator_error: false,
             default_require_level: Require::Exports,
         }
     }
@@ -191,6 +193,11 @@ impl TestEnv {
 
     pub fn enable_open_unpacking_error(mut self) -> Self {
         self.open_unpacking_error = true;
+        self
+    }
+
+    pub fn enable_missing_override_decorator_error(mut self) -> Self {
+        self.missing_override_decorator_error = true;
         self
     }
 
@@ -289,6 +296,9 @@ impl TestEnv {
         }
         if self.open_unpacking_error {
             errors.set_error_severity(ErrorKind::OpenUnpacking, Severity::Error);
+        }
+        if self.missing_override_decorator_error {
+            errors.set_error_severity(ErrorKind::MissingOverrideDecorator, Severity::Error);
         }
         let mut sourcedb = MapDatabase::new(config.get_sys_info());
         for (name, path, _) in self.modules.iter() {

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -769,6 +769,32 @@ os.perkeo  # missing-attribute
 In this example, `os.bacarat` is treated as a module name, so failing to find it results in an `missing-import`.
 `from os import joker` does not tell us if `joker` is a module, class, function, etc., so it is treated as the more general `missing-module-attribute`.
 
+## missing-override-decorator
+
+A method overrides a parent class method but does not have the `@override` decorator.
+
+This error supports strict override enforcement as specified in the [typing spec](https://typing.python.org/en/latest/spec/class-compat.html#strict-enforcement-per-project). When enabled, it requires all overriding methods to be explicitly marked with `@typing.override`.
+
+```python
+from typing import override
+
+class Base:
+    def foo(self) -> None: ...
+
+class Derived(Base):
+    def foo(self) -> None: ...  # missing-override-decorator
+
+    @override
+    def foo(self) -> None: ...  # OK
+```
+
+The default severity of this diagnostic is `ignore`. To enable strict override enforcement, set the severity to `error` in your configuration:
+
+```toml
+[tool.pyrefly]
+errors = { missing-override-decorator = "error" }
+```
+
 ## missing-source
 
 Pyrefly was able to find a stubs package but no corresponding source package. For example, this can


### PR DESCRIPTION
# Summary
Adds a new `missing-override-decorator` error that is emitted when a method overrides a parent class method but does not have the `@override` decorator.

This error is off-by-default (severity: ignore) and can be enabled via configuration:

  ```toml
  [tool.pyrefly]
  errors = { missing-override-decorator = "error" }
  ```

Fixes #1869

# Test Plan
- Added 10 new test cases in class_overrides.rs
- Ran test.py, all tests passed

# Changes:
- Added MissingOverrideDecorator error kind with default severity Ignore
- Added detection logic in check_consistent_override_for_field
- Added 10 test cases covering methods, classmethods, staticmethods, properties, fields, and multiple inheritance
- Added documentation to error-kinds.mdx

# Docx changes
<img width="2320" height="1216" alt="CleanShot 2025-12-17 at 03 00 37@2x" src="https://github.com/user-attachments/assets/b9043fa2-0d5b-41bf-acb7-f6bc0b32db06" />

