### PR TITLE
Update PyCharm documentation link in IDE guide

### DIFF
--- a/website/docs/IDE.mdx
+++ b/website/docs/IDE.mdx
@@ -74,7 +74,7 @@ PyCharm users can enable native Pyrefly support in the settings:
 
 4. Select which options should be enabled.
 
-For more information, refer to [PyCharm documentation](https://www.jetbrains.com/help/pycharm/2025.3/lsp-tools.html#pyrefly).
+For more information, refer to [PyCharm documentation](https://www.jetbrains.com/help/pycharm/lsp-tools.html#pyrefly).
 
 ### Neovim
 


### PR DESCRIPTION
# Summary

Removed the hardcoded documentation version from the link
