### PR TITLE
Fix panic with duplicate named expressions in type aliases #1883

### DIFF
--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -863,7 +863,17 @@ impl<'a> BindingsBuilder<'a> {
             // binding that we crash looking for if we don't do this.
             Expr::Call(_) => self.ensure_expr(x, static_type_usage),
             // Bind walrus so we don't crash when looking up the assigned name later.
-            Expr::Named(_) => self.ensure_expr(x, static_type_usage),
+            // Named expressions are not allowed inside type aliases (PEP 695).
+            Expr::Named(named) => {
+                if self.scopes.in_type_alias() {
+                    self.error(
+                        named.range,
+                        ErrorInfo::Kind(ErrorKind::InvalidSyntax),
+                        "named expression cannot be used within a type alias".to_owned(),
+                    );
+                }
+                self.ensure_expr(x, static_type_usage);
+            }
             // Bind yield and yield from so we don't crash when checking return type later.
             Expr::Yield(_) => {
                 self.ensure_expr(x, static_type_usage);

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -1540,6 +1540,11 @@ impl Scopes {
         matches!(self.current().kind, ScopeKind::Comprehension { .. })
     }
 
+    /// Check if we're currently in a type alias scope.
+    pub fn in_type_alias(&self) -> bool {
+        matches!(self.current().kind, ScopeKind::TypeAlias)
+    }
+
     /// Check if we're in a synchronous comprehension.
     /// A comprehension is synchronous unless we're in an async function.
     pub fn in_sync_comprehension(&self) -> bool {

--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -554,7 +554,9 @@ impl<'a> DefinitionsBuilder<'a> {
                 }
             }
             Stmt::TypeAlias(x) => {
-                self.named_in_expr(&x.value);
+                // Note: We don't call named_in_expr here because named expressions
+                // are not allowed inside type aliases (PEP 695). Type aliases create
+                // their own scope, so any walrus operators would be scoped there anyway.
                 if matches!(&*x.name, Expr::Name(_)) {
                     self.expr_lvalue(&x.name)
                 }
@@ -826,8 +828,9 @@ match (x7 := 42):
     case int(): pass
 (x8 := 42)[y] = 42
 assert (x9 := 42), (x10 := "oops")
-type y = (x11 := int)
 # Named expressions inside expression-level scopes should not appear in definitions.
+# This includes type aliases which create their own scope (PEP 695).
+type y = (x11 := int)
 lambda x: (z := 42)
 {z := "str" for _ in [1]}
 {(z := "str"):1 for _ in [1]}
@@ -838,7 +841,7 @@ lambda x: (z := 42)
         assert_definition_names(
             &defs,
             &[
-                "x0", "y", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11",
+                "x0", "y", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10",
             ],
         );
     }

--- a/pyrefly/lib/test/type_alias.rs
+++ b/pyrefly/lib/test/type_alias.rs
@@ -874,3 +874,14 @@ x7: TA | C = C()
 c2: Callable[[int], int] = f2  # E: `(x: C | int | str) -> C | int | str` is not assignable to `(int) -> int`
     "#,
 );
+
+testcase!(
+    test_named_expression_in_type_alias,
+    r#"
+# Named expressions (walrus operator) are not allowed inside type aliases (PEP 695).
+# This matches Python's behavior which raises a SyntaxError.
+type T = (a := 1)  # E: named expression cannot be used within a type alias # E: Expected `T` to be a type alias
+type U = (a := 1)  # E: named expression cannot be used within a type alias # E: Expected `U` to be a type alias
+type V = int | (b := str)  # E: named expression cannot be used within a type alias
+    "#,
+);


### PR DESCRIPTION
                                                                                                                                                                  
  Named expressions (walrus operator `:=`) are not allowed inside type aliases per PEP 695. Python raises a SyntaxError for this case.                                   
                                                                                                                                                                         
  Previously, pyrefly would panic with "key lacking binding" when processing code like:                                                                                  
                                                                                                                                                                         
  ```python                                                                                                                                                              
  type T = (a := 1)                                                                                                                                                      
  type U = (a := 1)                                                                                                                                                      
   ```                                                                                                                                                                  
  The root cause was that the definitions phase incorrectly collected walrus operator names from type alias values at module level, but during binding these were        
  processed in the type alias scope, causing a key/binding mismatch.                                                                                                     
                                                                                                                                                                         
  This fix:                                                                                                                                                              
  - Adds in_type_alias() method to check if we're in a type alias scope                                                                                                  
  - Reports "named expression cannot be used within a type alias" error (matching Python's error message)                                                                
  - Removes incorrect walrus name collection from type alias values                                                                                                      
                                                                                                                                                                         
  Fixes #1883                                                                                                                                                            
                                                                                                                                                                         
  Test Plan                                                                                                                                                              
                                                                                                                                                                         
  - Added test_named_expression_in_type_alias test case that verifies the error is reported for walrus operators in type aliases                                                                                                                        
  - All 3160 existing tests pass   