### PR TITLE
Detect when previous patterns were exhaustive in a trailing `_` case

### DIFF
--- a/pyrefly/lib/binding/pattern.rs
+++ b/pyrefly/lib/binding/pattern.rs
@@ -233,12 +233,16 @@ impl<'a> BindingsBuilder<'a> {
                     );
                     // We're not sure whether the pattern matches all possible instances of a class, and
                     // the placeholder prevents negative narrowing from removing the class in later branches.
-                    let placeholder = NarrowOps::from_single_narrow_op_for_subject(
-                        subject.clone(),
-                        AtomicNarrowOp::Placeholder,
-                        x.cls.range(),
-                    );
-                    narrow_for_subject.and_all(placeholder);
+                    // However, if there are no arguments, it's just an isinstance check, so we don't need
+                    // the placeholder.
+                    if !x.arguments.patterns.is_empty() || !x.arguments.keywords.is_empty() {
+                        let placeholder = NarrowOps::from_single_narrow_op_for_subject(
+                            subject.clone(),
+                            AtomicNarrowOp::Placeholder,
+                            x.cls.range(),
+                        );
+                        narrow_for_subject.and_all(placeholder);
+                    }
                     narrow_for_subject
                 } else {
                     NarrowOps::new()

--- a/pyrefly/lib/test/pattern_match.rs
+++ b/pyrefly/lib/test/pattern_match.rs
@@ -86,7 +86,6 @@ def foo(x: Literal['A'] | Literal['B']):
 );
 
 testcase!(
-    bug = "We currently never negate class matches; ideally we would be smarter about when the match is exhaustive",
     test_negated_exhaustive_class_match,
     r#"
 from typing import assert_type
@@ -96,6 +95,59 @@ def f0(x: int | str):
         case int():
             pass
         case _:
-            assert_type(x, str)  # E: assert_type(int | str, str)
+            assert_type(x, str)
+"#,
+);
+
+testcase!(
+    test_class_match_with_args_not_exhaustive,
+    r#"
+from typing import assert_type
+
+class C:
+    val: int
+
+def f0(x: C):
+    match x:
+        case C(val=1):
+            pass
+        case _:
+            assert_type(x, C)
+"#,
+);
+
+testcase!(
+    test_class_match_with_guard_not_exhaustive,
+    r#"
+from typing import assert_type
+
+def condition() -> bool: ...
+
+def f0(x: int):
+    match x:
+        case int() if condition():
+            pass
+        case _:
+            assert_type(x, int)
+"#,
+);
+
+testcase!(
+    test_class_match_with_positional_args_not_exhaustive,
+    r#"
+from typing import assert_type
+
+class C:
+    val: int
+    __match_args__ = ("val",)
+    def __init__(self, val: int):
+        self.val = val
+
+def f0(x: C):
+    match x:
+        case C(1):
+            pass
+        case _:
+            assert_type(x, C)
 "#,
 );


### PR DESCRIPTION
This PR fixes an issue where Pyrefly incorrectly reported exhaustiveness errors when using `assert_never` in the default case of a `match` statement, specifically when matching against classes (e.g. `case C():`).

for https://github.com/facebook/pyrefly/issues/1286

```python
from typing import assert_never

def f(x: int | str):
    match x:
        case int():
            pass
        case str():
            pass
        case _:
            assert_never(x)  # Pyrefly incorrectly reported error here
```

### Root Cause
When processing Class Patterns (e.g., `case int():`), the solver injected a conservative `Placeholder` operation:

```rust
// lib/binding/pattern.rs
// We're not sure whether the pattern matches all possible instances of a class, and
// the placeholder prevents negative narrowing from removing the class in later branches.
let placeholder = NarrowOps::from_single_narrow_op_for_subject(
    subject.clone(),
    AtomicNarrowOp::Placeholder,
    x.cls.range(),
);
narrow_for_subject.and_all(placeholder);
```

This prevented the solver from narrowing the type in the `else` branch, leaving the subject as `int | str` instead of `Never` even after all cases were covered.

### Fix
This change optimizes `MatchClass` pattern binding in `lib/binding/pattern.rs`. We now explicitly check if the class pattern has **no arguments** (positional or keyword, e.g., `case int():`). If so, we skip adding the `Placeholder`.

```rust
// lib/binding/pattern.rs
// However, if there are no arguments, it's just an isinstance check, so we don't need
// the placeholder.
if !x.arguments.patterns.is_empty() || !x.arguments.keywords.is_empty() {
    let placeholder = NarrowOps::from_single_narrow_op_for_subject(
        subject.clone(),
        AtomicNarrowOp::Placeholder,
        x.cls.range(),
    );
    narrow_for_subject.and_all(placeholder);
}
narrow_for_subject
```

I believe this is safe because, according to [Python's match statement specification](https://docs.python.org/3/reference/compound_stmts.html#class-patterns), a class pattern without arguments is semantically equivalent to an `isinstance()` check. The docs state: *"If the subject value is not an instance of name_or_attr (tested via isinstance()), the class pattern fails"* and *"If no pattern arguments are present, the pattern succeeds."* This allows the solver to correctly deduce that the type has been fully excluded.

#### Comparison with other tools
Neither `mypy` nor `Ty` report this exhaustiveness error for empty class patterns.

### Related Work

**Note**: This is a partial fix focusing on the `MatchClass` empty-argument case to resolve the immediate false positive. 

While researching this issue, I noticed [PR #1833](https://github.com/facebook/pyrefly/pull/1833) which adds an exhaustiveness reporting framework. This fix seems to be fully compatible with that PR - it improves the solver's accuracy to make exhaustiveness reporting correct for class patterns.

## Test Plan
- `lib/test/pattern_match.rs`:
    - Modified `test_negated_exhaustive_class_match` (the reproduction case) to expect success.
    - Added safety tests:
        - `test_class_match_with_args_not_exhaustive` (guarantees we don't regress on guarded/argument patterns)
        - `test_class_match_with_guard_not_exhaustive`
        - `test_class_match_with_positional_args_not_exhaustive`
- Verified all tests pass with `cargo test` (3232 passed).
- Verified formatting and linting with `cargo fmt --check` and `cargo clippy` (no new warnings).