### PR TITLE
Fix single-underscore function not exported from custom builtins

### DIFF
--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -191,7 +191,9 @@ struct DefinitionsBuilder<'a> {
 }
 
 fn is_private_name(name: &Name) -> bool {
-    name.starts_with('_')
+    // Names starting with underscore are private, except for a single underscore `_`
+    // which is commonly used as an alias for gettext.
+    name.starts_with('_') && name.as_str() != "_"
 }
 
 fn implicitly_imported_submodule(

--- a/pyrefly/lib/test/imports.rs
+++ b/pyrefly/lib/test/imports.rs
@@ -1077,3 +1077,25 @@ testcase!(
 x: X = X()
 "#,
 );
+
+fn env_extra_builtins_single_underscore() -> TestEnv {
+    TestEnv::one_with_path(
+        "__builtins__",
+        "__builtins__.pyi",
+        r#"
+def gettext(message: str) -> str: ...
+def _(message: str) -> str: ...
+"#,
+    )
+}
+
+testcase!(
+    test_extra_builtins_single_underscore,
+    env_extra_builtins_single_underscore(),
+    r#"
+from typing import assert_type
+# Single underscore `_` is a common alias for gettext and should be exported from builtins
+assert_type(gettext("a"), str)
+assert_type(_("b"), str)
+"#,
+);


### PR DESCRIPTION
# Summary
The `_` function (commonly used as an alias for `gettext` in i18n) was not being exported from `__builtins__.pyi` because `is_private_name()` treated all names starting with underscore as private.
This PR relaxes the rule to allow exactly `_` while keeping other `_*` names private.

Fixes #1906

# Test Plan
- Added `test_extra_builtins_single_underscore` test case that verifies `_` is exported from custom builtins
- Verified existing `test_dont_export_underscore` still passes (ensures `_y` is still private)
- Ran `python3 test.py` - all tests pass