### PR TITLE
[easy] Improve error message for assignments to final variables

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -9623,8 +9623,8 @@
     {
       "code": -2,
       "column": 5,
-      "concise_description": "Cannot assign to var x because it is marked final",
-      "description": "Cannot assign to var x because it is marked final",
+      "concise_description": "Cannot assign to variable `x` because it is marked final",
+      "description": "Cannot assign to variable `x` because it is marked final",
       "line": 145,
       "name": "bad-assignment",
       "severity": "error",
@@ -9634,8 +9634,8 @@
     {
       "code": -2,
       "column": 15,
-      "concise_description": "Assignment target is marked final",
-      "description": "Assignment target is marked final",
+      "concise_description": "Cannot assign to variable `x` because it is marked final",
+      "description": "Cannot assign to variable `x` because it is marked final",
       "line": 147,
       "name": "bad-assignment",
       "severity": "error",

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -2775,7 +2775,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             errors,
                             e.range(),
                             ErrorInfo::Kind(ErrorKind::BadAssignment),
-                            "Assignment target is marked final".to_owned(),
+                            format!(
+                                "Cannot assign to {} because it is marked final",
+                                annot.target
+                            ),
                         );
                     }
                     self.expr(e, annot.ty(self.stdlib).as_ref().map(|t| (t, tcc)), errors)
@@ -2812,7 +2815,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             errors,
                             *range,
                             ErrorInfo::Kind(ErrorKind::BadAssignment),
-                            "Assignment target is marked final".to_owned(),
+                            format!(
+                                "Cannot assign to {} because it is marked final",
+                                annot.target
+                            ),
                         );
                     }
                     if let Some(annot_ty) = annot.ty(self.stdlib)

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -1893,12 +1893,12 @@ pub enum AnnotationTarget {
 impl Display for AnnotationTarget {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Param(name) => write!(f, "param {name}"),
-            Self::ArgsParam(name) => write!(f, "args {name}"),
-            Self::KwargsParam(name) => write!(f, "kwargs {name}"),
-            Self::Return(name) => write!(f, "{name} return"),
-            Self::Assign(name, _initialized) => write!(f, "var {name}"),
-            Self::ClassMember(name) => write!(f, "attr {name}"),
+            Self::Param(name) => write!(f, "parameter `{name}`"),
+            Self::ArgsParam(name) => write!(f, "args `{name}`"),
+            Self::KwargsParam(name) => write!(f, "kwargs `{name}`"),
+            Self::Return(name) => write!(f, "`{name}` return"),
+            Self::Assign(name, _initialized) => write!(f, "variable `{name}`"),
+            Self::ClassMember(name) => write!(f, "attribute `{name}`"),
         }
     }
 }

--- a/pyrefly/lib/test/assign.rs
+++ b/pyrefly/lib/test/assign.rs
@@ -477,7 +477,7 @@ testcase!(
     r#"
 from typing import Final
 x: Final = [""]
-x += [""]  # E: Cannot assign to var x because it is marked final
+x += [""]  # E: Cannot assign to variable `x` because it is marked final
 x[0] += ""
 "#,
 );

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -373,6 +373,18 @@ class C:
 );
 
 testcase!(
+    test_final_reassign,
+    r#"
+from typing import Final
+x: Final[int] = 0
+x = 1  # E: `x` is marked final
+x += 1  # E: Cannot assign to variable `x` because it is marked final
+y = x = 3 # E: Cannot assign to variable `x` because it is marked final
+y = (x := 3) # E: Cannot assign to variable `x` because it is marked final
+"#,
+);
+
+testcase!(
     test_reveal_type,
     r#"
 from typing import reveal_type


### PR DESCRIPTION
# Summary

- Unify two different error messages depending on call sites
- Add backticks around variable names


# Test Plan
`python test.py`
