### PR TITLE
Check re-assignment of `Final` variables in less-common binding constructs

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -9611,6 +9611,17 @@
     },
     {
       "code": -2,
+      "column": 14,
+      "concise_description": "Cannot assign to variable `x` because it is marked final",
+      "description": "Cannot assign to variable `x` because it is marked final",
+      "line": 149,
+      "name": "bad-assignment",
+      "severity": "error",
+      "stop_column": 23,
+      "stop_line": 149
+    },
+    {
+      "code": -2,
       "column": 10,
       "concise_description": "Cannot assign to variable `x` because it is marked final",
       "description": "Cannot assign to variable `x` because it is marked final",

--- a/conformance/third_party/conformance.result
+++ b/conformance/third_party/conformance.result
@@ -269,7 +269,6 @@
     "Line 34: Expected 1 errors",
     "Line 38: Expected 1 errors",
     "Line 107: Expected 1 errors",
-    "Line 149: Expected 1 errors",
     "Line 166: Expected 1 errors",
     "Line 170: Expected 1 errors",
     "Line 131: Unexpected errors ['Expected first item to be a string literal', 'Expected first item to be a string literal']",

--- a/conformance/third_party/results.json
+++ b/conformance/third_party/results.json
@@ -3,7 +3,7 @@
   "pass": 105,
   "fail": 33,
   "pass_rate": 0.76,
-  "differences": 138,
+  "differences": 137,
   "passing": [
     "aliases_explicit.py",
     "aliases_newtype.py",
@@ -142,7 +142,7 @@
     "protocols_modules.py": 1,
     "protocols_variance.py": 7,
     "qualifiers_annotated.py": 6,
-    "qualifiers_final_annotation.py": 8,
+    "qualifiers_final_annotation.py": 7,
     "specialtypes_never.py": 1,
     "specialtypes_type.py": 8
   },

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -383,6 +383,8 @@ y = x = 3 # E: Cannot assign to variable `x` because it is marked final
 y = (x := 3) # E: Cannot assign to variable `x` because it is marked final
 x, y = 4, 5 # E: Cannot assign to variable `x` because it is marked final
 [x, y] = [6, 7] # E: Cannot assign to variable `x` because it is marked final
+for x in [1, 2, 3]:  # E: Cannot assign to variable `x` because it is marked final
+    ...
 
 xs: Final[list[int]] = []
 [_, *xs] = [1, 2, 3]  # E: Cannot assign to variable `xs` because it is marked final


### PR DESCRIPTION
# Summary

This diff extends existing re-assignment checks for variables declared as `Final` to a few other binding constructs that are less common (namely unpacking assignments, context manager assignments, and loop variable assignments). Overall, we have 3 more passing conformance test cases.

# Test Plan

`python test.py`
