### PR TITLE
Fix: divmod returns invalid type(s) when used in a loop

### DIFF
--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -74,6 +74,7 @@ impl CallWithTypes {
             }
             TypeOrExpr::Expr(e) => {
                 let t = solver.expr_infer(e, errors);
+                let t = solver.solver().expand_loop_recursive(t);
                 TypeOrExpr::Type(self.0.push(t), e.range())
             }
             TypeOrExpr::Type(t, r) => TypeOrExpr::Type(t, r),

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -110,7 +110,11 @@ impl<'a> TypeOrExpr<'a> {
     ) -> Type {
         match self {
             TypeOrExpr::Type(ty, _) => ty.clone(),
-            TypeOrExpr::Expr(x) => solver.expr_infer(x, errors),
+            TypeOrExpr::Expr(x) => {
+                let ty = solver.expr_infer(x, errors);
+                // Keep loop-recursive types usable during call inference.
+                solver.solver().expand_loop_recursive(ty)
+            }
         }
     }
 

--- a/pyrefly/lib/test/flow_looping.rs
+++ b/pyrefly/lib/test/flow_looping.rs
@@ -226,6 +226,21 @@ def f(cond):
 );
 
 testcase!(
+    test_for_loop_divmod_reassignment,
+    r#"
+from typing import assert_type
+def process(value: int | float) -> None:
+    for _ in range(2):
+        v, value = divmod(value, 7)
+
+        assert_type(v, int | float)
+        assert_type(value, int | float)
+
+    assert_type(value, int | float)
+"#,
+);
+
+testcase!(
     test_for_simple,
     r#"
 from typing import assert_type


### PR DESCRIPTION
# Summary

Fix by expanding loop-recursive argument types to their prior type during call-argument typing, so overload resolution sees a stable concrete type instead of a loop-recursive placeholder

Fixes #1561

# Test Plan

```bash
cargo test -p pyrefly flow_looping
```
