### PR TITLE
fix: Recognize string type annotation in explicit type arguments

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -4191,6 +4191,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         type_form_context: TypeFormContext,
         errors: &ErrorCollector,
     ) -> Type {
+        if let Expr::StringLiteral(string_literal) = x
+            && let Some(string_literal) = string_literal.as_single_part_string()
+            && let Ok(string_type_expression) = Ast::parse_type_literal(string_literal)
+        {
+            return self.expr_untype(&string_type_expression, type_form_context, errors);
+        }
         let result = match x {
             Expr::List(x)
                 if matches!(

--- a/pyrefly/lib/test/type_alias.rs
+++ b/pyrefly/lib/test/type_alias.rs
@@ -526,12 +526,21 @@ x5: X = ["foo"]  # Not OK
 );
 
 testcase!(
-    bug = "Doesn't detect as a TypeAlias, but it is one. Maybe this is reasonable.",
     test_type_alias_with_string,
     r#"
-class Y: pass
-class C[T]: pass
-X = C["Y"] # E: Expected a type form, got instance of `Literal['Y']`
+from typing import TYPE_CHECKING, assert_type
+
+if TYPE_CHECKING:
+    class A: 
+        pass
+
+class C[T]: 
+    pass
+
+x = C["A"]()
+
+assert_type(x, C[A])
+C["1"]()  # E: Expected a type form, got instance of `Literal[1]`
 "#,
 );
 


### PR DESCRIPTION
# Summary

Fix by treating explicit generic type-argument slices as type expressions, including forward-reference strings like C["A"]

Fixes #1474

# Test Plan

```bash
cargo test -p pyrefly test_type_alias_with_string
```
