### PR TITLE
fix: Narrow typevar bounds in isinstance check

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -1586,7 +1586,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Type {
         match ty {
             Type::Var(v) => {
-                if let Some(_guard) = self.recurse(*v) {
+                if let Some(quantified) = self.solver().quantified_type_for_solver_variable(*v) {
+                    quantified
+                } else if let Some(_guard) = self.recurse(*v) {
                     let forced = self.solver().force_var(*v);
                     self.force_for_narrowing(&forced, range, errors)
                 } else {

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -434,6 +434,17 @@ impl Solver {
         }
     }
 
+    pub fn quantified_type_for_solver_variable(&self, solver_variable: Var) -> Option<Type> {
+        let variables_lock = self.variables.lock();
+        let solver_variable_entry = variables_lock.get(solver_variable);
+        match &*solver_variable_entry {
+            Variable::Quantified(quantified_type_parameter) | Variable::PartialQuantified(quantified_type_parameter) => {
+                Some(Type::Quantified(Box::new((**quantified_type_parameter).clone())))
+            }
+            _ => None,
+        }
+    }
+
     fn deep_force_mut_with_limit(&self, t: &mut Type, limit: usize, recurser: &VarRecurser) {
         if limit == 0 {
             // TODO: Should probably add an error here, and use any_error,

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -2107,6 +2107,19 @@ def test_isinstance[T: Mapping[str, int] | Sequence[int]](arg: T) -> T:
 );
 
 testcase!(
+    test_isinstance_narrow_bounded_type_param,
+    r#"
+from typing import reveal_type
+
+def test[T: int | str](value: T) -> T:
+    if isinstance(value, int):
+        reveal_type(value) # E: int & T
+        return value
+    return value
+    "#,
+);
+
+testcase!(
     test_match_intersection_against_constrained_typevar,
     r#"
 class A: ...


### PR DESCRIPTION
# Summary

When narrowing encounters a solver `Var` that represents a quantified type parameter, preserve it as `Type::Quantified` instead of forcing it to its bound.
This allows `isinstance` narrowing to compute an anonymous intersection like `T & int`, which remains assignable to the original `T`.

Fixes #1274

# Test Plan

```bash
cargo test -p pyrefly test_isinstance_narrow_bounded_type_param --lib
```
