### PR TITLE
fix: Incorrect return path identification with try/finally

### DIFF
--- a/pyrefly/lib/test/returns.rs
+++ b/pyrefly/lib/test/returns.rs
@@ -74,6 +74,17 @@ def f(b: bool) -> int:
 );
 
 testcase!(
+    test_return_try_finally_explicit_return,
+    r#"
+def f() -> int:
+    try:
+        return 1
+    finally:
+        print("done")
+"#,
+);
+
+testcase!(
     test_return_never,
     r#"
 from typing import NoReturn


### PR DESCRIPTION
# Summary

Update to: Only let the finally block override the try path analysis when the finally block itself always terminates, for example it always returns or always raises.

If the finally block can fall through, analyze the try body, else, and handlers as usual.

Fixes #1091

# Test Plan

```bash
cargo test test_return_try_finally_explicit_return
```