### PR TITLE
fix: Calling generic function in if expr cause "bad-argument-type" error

### DIFF
--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -28,6 +28,8 @@ use crate::solver::solver::OpenTypedDictSubsetError;
 use crate::solver::solver::Subset;
 use crate::solver::solver::SubsetError;
 use crate::solver::solver::TypedDictSubsetError;
+use crate::types::equality::TypeEq;
+use crate::types::equality::TypeEqCtx;
 use crate::types::callable::Function;
 use crate::types::callable::Param;
 use crate::types::callable::ParamList;
@@ -954,6 +956,11 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
             }
             (_, Type::Any(_)) => Ok(()),
             (Type::Never(_), _) => Ok(()),
+            (Type::Quantified(left), Type::Quantified(right))
+                if left.type_eq(right, &mut TypeEqCtx::default()) =>
+            {
+                Ok(())
+            }
             (_, Type::ClassType(want)) if want.is_builtin("object") => {
                 Ok(()) // everything is an instance of `object`
             }

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -1000,6 +1000,18 @@ if g:
 );
 
 testcase!(
+    test_generic_callable_in_condition,
+    r#"
+from typing import Callable, Iterable
+
+def test[T](it: Iterable[T], f: Callable[[T], bool]) -> None:
+    for e in it:
+        if f(e):
+            pass
+    "#,
+);
+
+testcase!(
     test_pass_literals_through_identity,
     r#"
 from typing import Callable, Literal, reveal_type


### PR DESCRIPTION
# Summary

Compare Type::Quantified values with TypeEq and TypeEqCtx so subset checks treat matching type parameters as compatible even when they were created as separate instances

Fixes #1048

# Test Plan

```bash
cargo test -p pyrefly test_generic_callable_in_condition
```
