### PR TITLE
fix: assert callable narrows too much

### DIFF
--- a/crates/pyrefly_bundled/third_party/typeshed/stdlib/builtins.pyi
+++ b/crates/pyrefly_bundled/third_party/typeshed/stdlib/builtins.pyi
@@ -4099,7 +4099,7 @@ def breakpoint(*args: Any, **kws: Any) -> None:
     By default, this drops you into the pdb debugger.
     """
     ...
-def callable(obj: object, /) -> TypeIs[Callable[..., object]]:
+def callable(obj: object, /) -> TypeIs[Callable[..., Any]]:
     """
     Return whether the object is callable (i.e., some kind of function).
 

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -1099,6 +1099,16 @@ def f(
 );
 
 testcase!(
+    test_assert_callable_narrow_any,
+    r#"
+from typing import Any, assert_type
+def f(x: object):
+    assert callable(x)
+    assert_type(x(), Any)
+    "#,
+);
+
+testcase!(
     test_narrow_union,
     r#"
 from typing import Any, Callable, assert_type


### PR DESCRIPTION
# Summary

Fix assert callable(x) narrowing because callability does not imply an object return type

Fixes #911

# Test Plan

```bash
cargo test test_assert_callable_narrow_any
cargo test test_builtins_callable_narrow
```