### PR TITLE
fix: Unpacking of tuple typed asTypeVarTuple sometimes yeilds type *tuple[object, ...]

### DIFF
--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -617,6 +617,18 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                 l_after.reverse();
                 u_after.reverse();
 
+                if l_before.is_empty()
+                    && l_after.is_empty()
+                    && u_before.is_empty()
+                    && u_after.is_empty()
+                    && let (Type::Quantified(l_middle_q), Type::Quantified(u_middle_q)) =
+                        (l_middle, u_middle)
+                    && l_middle_q.is_type_var_tuple()
+                    && l_middle_q == u_middle_q
+                {
+                    return Ok(());
+                }
+
                 self.is_subset_eq(
                     &Type::unpacked_tuple(l_before, l_middle.clone(), l_after),
                     u_middle,

--- a/pyrefly/lib/test/tuple.rs
+++ b/pyrefly/lib/test/tuple.rs
@@ -469,6 +469,23 @@ def f(x: TupleChild[int, str]):
 );
 
 testcase!(
+    test_typevartuple_unpack_in_loop_after_callable,
+    r#"
+from typing import Callable
+
+def test[*Ts](
+    x: tuple[*Ts],
+    y: int,
+    predicate: Callable[[tuple[*Ts]], bool],
+) -> None:
+    a: list[tuple[*Ts, int]] = []
+    for _ in range(10):
+        if predicate(x):
+            a.append((*x, y))
+    "#,
+);
+
+testcase!(
     test_starred_empty_tuple_no_panic,
     r#"
 (),*()


### PR DESCRIPTION
# Summary

In the tuple subset logic for unpacked tuples, add an early return for the specific case where both sides are exactly the same TypeVarTuple unpack with no fixed prefix or suffix.

This avoids triggering the generic widening behavior and preserves Ts.

Fixes #792

# Test Plan

```bash
cargo test -p pyrefly test_typevartuple_unpack_in_loop_after_callable
```
