### PR TITLE
fix: Don't mark 'import X as X' as unused import

### DIFF
--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -1827,6 +1827,14 @@ impl Scopes {
         self.register_import_internal(name, true);
     }
 
+    /// Register an import that uses the `X as X` pattern (e.g., `import os as os`
+    /// or `from math import tau as tau`). Per the Python typing spec, this is an
+    /// explicit re-export and should not be flagged as unused.
+    /// See: https://typing.python.org/en/latest/spec/distributing.html#import-conventions
+    pub fn register_reexport_import(&mut self, name: &Identifier) {
+        self.register_import_internal(name, true);
+    }
+
     fn register_import_internal(&mut self, name: &Identifier, skip_unused_check: bool) {
         if matches!(self.current().kind, ScopeKind::Module) {
             self.current_mut().imports.insert(


### PR DESCRIPTION
# Summary
Per the Python typing spec, 'import X as X' and 'from Y import X as X' are explicit re-exports and should not be flagged as unused imports.

 ### Changes
  - Added `register_reexport_import()` function in `scope.rs`
  - Detect redundant alias pattern in both `import X as X` and `from Y import X as X`
  - Added 4 tests covering re-export and non-re-export cases

### Reference
 https://typing.python.org/en/latest/spec/distributing.html#import-conventions

Fixes #1961

## Test Plan
  - [x] All 3287 tests pass
  - [x] `python3 test.py` passes
  - [x] Manually verified in VSCode:

**(reexport_ok.py)** - `X as X` pattern has NO warnings:
<img width="1590" height="572" alt="CleanShot 2025-12-30 at 16 38 50@2x" src="https://github.com/user-attachments/assets/778a40f9-1565-46ab-b072-f0bace39e3db" />

**(unused_bad.py)** - `X as Y` pattern shows warnings:
<img width="1894" height="635" alt="CleanShot 2025-12-30 at 16 39 23@2x" src="https://github.com/user-attachments/assets/fc674f3a-84a0-4e9a-aaee-bae280aaea34" />


