### PR TITLE
fix Problem with displaying whitespace chars literals #1975

### DIFF
--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -1267,6 +1267,13 @@ pub mod tests {
             Type::Literal(Lit::Bool(false)).to_string(),
             "Literal[False]"
         );
+        assert_eq!(
+            Type::Literal(Lit::Bytes(
+                vec![b' ', b'\t', b'\n', b'\r', 0x0b, 0x0c].into_boxed_slice()
+            ))
+            .to_string(),
+            r"Literal[b' \t\n\r\x0b\x0c']"
+        );
 
         // Enum literals (not all of these types make sense, we're only providing what's relevant)
         let my_enum = ClassType::new(fake_class("MyEnum", "mod.ule", 5), TArgs::default());

--- a/crates/pyrefly_types/src/literal.rs
+++ b/crates/pyrefly_types/src/literal.rs
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::char;
 use std::fmt;
 use std::fmt::Display;
 
@@ -62,10 +61,15 @@ impl Display for Lit {
             }
             Lit::Bytes(bytes) => {
                 write!(f, "b'")?;
-                for byte in bytes {
-                    match char::from_u32(*byte as u32) {
-                        Some(ch) => write!(f, "{ch}")?,
-                        None => write!(f, "\\x{byte:02x}")?,
+                for byte in bytes.iter().copied() {
+                    match byte {
+                        b'\t' => write!(f, "\\t")?,
+                        b'\n' => write!(f, "\\n")?,
+                        b'\r' => write!(f, "\\r")?,
+                        b'\\' => write!(f, "\\\\")?,
+                        b'\'' => write!(f, "\\'")?,
+                        0x20..=0x7e => write!(f, "{}", byte as char)?,
+                        _ => write!(f, "\\x{byte:02x}")?,
                     }
                 }
                 write!(f, "'")


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1975

Adjusted byte literal display to escape control characters, quotes, and backslashes so defaults render as readable escapes instead of raw whitespace, and added a regression test for whitespace/control bytes.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add a literal-bytes display assertion covering whitespace/control bytes.