### PR TITLE
fix TypeVar does not support unary OP despite being upper bounded by type supporting unary OP #1972

### DIFF
--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -444,7 +444,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 || ErrorContext::UnaryOp(x.op.as_str().to_owned(), self.for_display(t.clone()));
             match t {
                 Type::Literal(lit) if let Some(ret) = f(lit) => ret,
-                Type::ClassType(_) | Type::SelfType(_) => {
+                Type::ClassType(_) | Type::SelfType(_) | Type::Quantified(_) => {
                     self.call_method_or_error(t, method, x.range, &[], &[], errors, Some(&context))
                 }
                 Type::Literal(Lit::Enum(lit_enum)) => self.call_method_or_error(

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -287,6 +287,27 @@ assert_type(~c, Literal[100])
 );
 
 testcase!(
+    test_unary_dunders_typevar_bound,
+    r#"
+from typing import Self
+
+class Foo:
+    def __neg__(self) -> Self:
+        return self
+    def __pos__(self) -> Self:
+        return self
+    def __invert__(self) -> Self:
+        return self
+
+def test[F: Foo](foo: F) -> F:
+    a: F = -foo
+    b: F = +foo
+    c: F = ~foo
+    return c
+    "#,
+);
+
+testcase!(
     test_unary_error,
     r#"
 +None  # E: Unary `+` is not supported on `None`


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1972

Updated unary-op inference so bounded type parameters (Type::Quantified) resolve `__neg__`/`__pos__`/`__invert__` via the bound, and added a regression test for a PEP‑695 type parameter bounded by a class returning Self.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

added `test_unary_dunders_typevar_bound` covering `-foo`, `+foo`, `~foo` for `def test[F: Foo](foo: F)`
