### PR TITLE
fix: Narrowing for isinstance and type[T] is unsound

### DIFF
--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -1366,6 +1366,18 @@ def f[T](x, y: type[T]) -> T:
 );
 
 testcase!(
+    test_isinstance_type_classinfo_no_negative_narrow,
+    r#"
+from typing import assert_type
+def f(cls: type[int], x: int | str) -> None:
+    if isinstance(x, cls):
+        assert_type(x, int)
+    else:
+        assert_type(x, int | str)
+    "#,
+);
+
+testcase!(
     test_isinstance_type_self,
     r#"
 from typing import Self, TypeGuard


### PR DESCRIPTION
# Summary

Fix unsound isinstance negative narrowing by skipping else-branch refinement when the classinfo is a runtime type[T] value rather than a literal class/ tuple/union of classes.

Fixes #713

# Test Plan

```
cargo test -p pyrefly -- test_isinstance_type_classinfo_no_negative_narrow
```
