### PR TITLE
fix: Pyrefly should promote literals when inferring tuple types for attributes

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1560,12 +1560,20 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             self.determine_read_only_reason(name, annotation.as_ref(), &metadata, field_definition);
 
         // Determine the final type, promoting literals when appropriate.
+        let mut has_literal = false;
+        if matches!(initialization, ClassFieldInitialization::Method) {
+            value_ty.universe(&mut |current_type_node| {
+                if matches!(current_type_node, Type::Literal(_) | Type::LiteralString) {
+                    has_literal = true;
+                }
+            });
+        }
         let ty = if annotation
             .as_ref()
             .and_then(|ann| ann.ty.as_ref())
             .is_none()
             && matches!(read_only_reason, None | Some(ReadOnlyReason::NamedTuple))
-            && value_ty.is_literal()
+            && (value_ty.is_literal() || has_literal)
         {
             value_ty.promote_literals(self.stdlib)
         } else {

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -91,6 +91,19 @@ class A:
 );
 
 testcase!(
+    test_unannotated_attribute_tuple_literal_promotion,
+    r#"
+from typing import assert_type
+class A:
+    def __init__(self):
+        self.x = (42, 42)
+def f(a: A):
+    assert_type(a.x, tuple[int, int])
+    a.x = (0, 0)
+    "#,
+);
+
+testcase!(
     test_super_object_bad_assignment,
     r#"
 class A:


### PR DESCRIPTION
# Summary

Fix by promoting nested tuple element literals for unannotated method-initialized attributes 

Fixes #1494

# Test Plan

```sh
cargo test -p pyrefly test_unannotated_attribute_tuple_literal_promotion
```
