### PR TITLE
Do not allow `Callable` to be passed as an argument of `type`

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -9853,6 +9853,17 @@
     },
     {
       "code": -2,
+      "column": 7,
+      "concise_description": "Argument `type[Callable]` is not assignable to parameter `x` with type `type[@_]` in function `func5`",
+      "description": "Argument `type[Callable]` is not assignable to parameter `x` with type `type[@_]` in function `func5`\n  `type` cannot accept special form `Callable` as an argument",
+      "line": 70,
+      "name": "bad-argument-type",
+      "severity": "error",
+      "stop_column": 15,
+      "stop_line": 70
+    },
+    {
+      "code": -2,
       "column": 12,
       "concise_description": "Expected 1 type argument for `type`, got 2",
       "description": "Expected 1 type argument for `type`, got 2",

--- a/conformance/third_party/conformance.result
+++ b/conformance/third_party/conformance.result
@@ -280,7 +280,6 @@
   "specialtypes_none.py": [],
   "specialtypes_promotions.py": [],
   "specialtypes_type.py": [
-    "Line 70: Expected 1 errors",
     "Line 84: Unexpected errors ['assert_type(type, type[Any]) failed']",
     "Line 99: Unexpected errors ['Object of class `type` has no attribute `unknown`']",
     "Line 100: Unexpected errors ['Object of class `type` has no attribute `unknown`']",

--- a/conformance/third_party/results.json
+++ b/conformance/third_party/results.json
@@ -3,7 +3,7 @@
   "pass": 106,
   "fail": 32,
   "pass_rate": 0.77,
-  "differences": 133,
+  "differences": 132,
   "passing": [
     "aliases_explicit.py",
     "aliases_newtype.py",
@@ -144,7 +144,7 @@
     "qualifiers_annotated.py": 6,
     "qualifiers_final_annotation.py": 7,
     "specialtypes_never.py": 1,
-    "specialtypes_type.py": 5
+    "specialtypes_type.py": 4
   },
   "comment": "@generated"
 }

--- a/pyrefly/lib/alt/special_calls.rs
+++ b/pyrefly/lib/alt/special_calls.rs
@@ -435,18 +435,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     format!("Expected class object, got `{}`", self.for_display(ty)),
                 );
             } else {
-                self.check_type(
-                    &ty,
-                    &self.stdlib.builtins_type().clone().to_type(),
-                    range,
-                    errors,
-                    &|| {
-                        TypeCheckContext::of_kind(TypeCheckKind::CallArgument(
-                            Some(Name::new_static("class_or_tuple")),
-                            Some(func_kind.clone()),
-                        ))
-                    },
-                );
+                if let Type::Type(box Type::SpecialForm(SpecialForm::Callable)) = &ty {
+                    // Callable is a special form that is not a `type` but can be used in `isinstance` checks
+                } else {
+                    self.check_type(
+                        &ty,
+                        &self.stdlib.builtins_type().clone().to_type(),
+                        range,
+                        errors,
+                        &|| {
+                            TypeCheckContext::of_kind(TypeCheckKind::CallArgument(
+                                Some(Name::new_static("class_or_tuple")),
+                                Some(func_kind.clone()),
+                            ))
+                        },
+                    );
+                }
             }
         }
     }

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -15,6 +15,7 @@ use std::mem;
 
 use pyrefly_types::quantified::Quantified;
 use pyrefly_types::simplify::intersect;
+use pyrefly_types::special_form::SpecialForm;
 use pyrefly_types::types::TArgs;
 use pyrefly_types::types::Union;
 use pyrefly_util::gas::Gas;
@@ -1251,6 +1252,8 @@ pub enum SubsetError {
     InternalError(String),
     /// Protocol class names cannot be assigned to `type[P]` when `P` is a protocol
     TypeOfProtocolNeedsConcreteClass(Name),
+    /// A `type` cannot accept special forms like `Callable`
+    TypeCannotAcceptSpecialForms(SpecialForm),
     // TODO(rechen): replace this with specific reasons
     Other,
 }
@@ -1280,6 +1283,10 @@ impl SubsetError {
             SubsetError::InternalError(msg) => Some(format!("Pyrefly internal error: {msg}")),
             SubsetError::TypeOfProtocolNeedsConcreteClass(want) => Some(format!(
                 "Only concrete classes may be assigned to `type[{want}]` because `{want}` is a protocol"
+            )),
+            SubsetError::TypeCannotAcceptSpecialForms(form) => Some(format!(
+                "`type` cannot accept special form `{}` as an argument",
+                form
             )),
             SubsetError::Other => None,
         }

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -2009,3 +2009,22 @@ def test():
     x: (yield from [1])  # E:
     "#,
 );
+
+testcase!(
+    test_passing_callable_as_type_not_allowed,
+    r#"
+from typing import Callable, Type, Any
+def takes_type(x: type): ...
+def takes_Type(x: Type): ...
+def takes_type_any(x: type[Any]): ...
+def takes_Type_any(x: Type[Any]): ...
+takes_type(Callable) # E: is not assignable to parameter `x` with type `type` in function
+takes_type(Callable[..., int]) # E: is not assignable to parameter `x` with type `type` in function
+takes_Type(Callable) # E: is not assignable to parameter `x` with type `type[Unknown]` in function
+takes_Type(Callable[..., int]) # E: is not assignable to parameter `x` with type `type[Unknown]` in function
+takes_type_any(Callable) # E: is not assignable to parameter `x` with type `type[Any]` in function
+takes_type_any(Callable[..., int]) # E: is not assignable to parameter `x` with type `type[Any]` in function
+takes_Type_any(Callable) # E: is not assignable to parameter `x` with type `type[Any]` in function
+takes_Type_any(Callable[..., int]) # E: is not assignable to parameter `x` with type `type[Any]` in function
+"#,
+);


### PR DESCRIPTION

# Summary

According to the spec:
https://typing.python.org/en/latest/spec/special-types.html#type
> Any other special constructs like `tuple` or `Callable` are not allowed as an argument to type.

Therefore, this diff disallows `Callable` from being passed to `type` in the subtyping implementation, whereas permitting its use in calls to `isinstance`.

P.S. The conformance testsuite and the spec seems to disagree on whether `tuple` should be allowed, which I filed an issue in the typing repository.

We should consider restricting other special forms to be passed as arguments to `type` as well, but the rules regarding special forms are a bit not clear to me.

# Test Plan

`python test.py`