### PR TITLE
Fix TypeGuard/TypeIs validation for functions without explicit return annotation

### DIFF
--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -531,25 +531,30 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 );
             }
         }
-        if matches!(&ret, Type::TypeGuard(_) | Type::TypeIs(_)) {
-            self.validate_type_guard_positional_argument_count(
-                &def.params,
-                def.id_range(),
-                &def.defining_cls,
-                def.metadata.flags.is_staticmethod,
-                errors,
-            );
-        };
+        // Only validate TypeGuard/TypeIs functions when they have an explicit return annotation.
+        // Functions that return a TypeGuard value without an explicit annotation should not be
+        // treated as TypeGuard functions.
+        if has_return_annotation {
+            if matches!(&ret, Type::TypeGuard(_) | Type::TypeIs(_)) {
+                self.validate_type_guard_positional_argument_count(
+                    &def.params,
+                    def.id_range(),
+                    &def.defining_cls,
+                    def.metadata.flags.is_staticmethod,
+                    errors,
+                );
+            }
 
-        if let Type::TypeIs(ty_narrow) = &ret {
-            self.validate_type_is_type_narrowing(
-                &def.params,
-                stmt,
-                &def.defining_cls,
-                def.metadata.flags.is_staticmethod,
-                ty_narrow,
-                errors,
-            );
+            if let Type::TypeIs(ty_narrow) = &ret {
+                self.validate_type_is_type_narrowing(
+                    &def.params,
+                    stmt,
+                    &def.defining_cls,
+                    def.metadata.flags.is_staticmethod,
+                    ty_narrow,
+                    errors,
+                );
+            }
         }
 
         let callable = if let Some(q) = &def.paramspec {

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -2276,3 +2276,46 @@ def g(b: B):
         reveal_type(b)  # E: A & B
     "#,
 );
+
+// Functions returning a TypeGuard value should not be validated as TypeGuard
+// functions unless they have an explicit TypeGuard return annotation.
+testcase!(
+    test_typeguard_return_without_annotation,
+    r#"
+from typing import TypeGuard
+
+def is_int(x: int | str) -> TypeGuard[int]:
+    return isinstance(x, int)
+
+class X:
+    def __init__(self, param: int | str) -> None:
+        self.param = param
+
+    # This function returns a TypeGuard value but does not have a TypeGuard annotation,
+    # so it should not be validated as a TypeGuard function.
+    # No "Type guard functions must accept at least one positional argument" error expected.
+    def has_int(self):
+        return is_int(self.param)
+    "#,
+);
+
+// Same test for TypeIs.
+testcase!(
+    test_typeis_return_without_annotation,
+    r#"
+from typing import TypeIs
+
+def is_int(x: int | str) -> TypeIs[int]:
+    return isinstance(x, int)
+
+class X:
+    def __init__(self, param: int | str) -> None:
+        self.param = param
+
+    # This function returns a TypeIs value but does not have a TypeIs annotation,
+    # so it should not be validated as a TypeIs function.
+    # No "Type guard functions must accept at least one positional argument" error expected.
+    def has_int(self):
+        return is_int(self.param)
+    "#,
+);


### PR DESCRIPTION
# Summary
Functions returning a TypeGuard/TypeIs value were incorrectly being validated as type guard functions even when they had no explicit return annotation.

For example:
```python
  from typing import TypeGuard

  def is_int(x: int | str) -> TypeGuard[int]:
      return isinstance(x, int)

  class X:
      def __init__(self, param: int | str) -> None:
          self.param = param

      def has_int(self):
          return is_int(self.param)
```
has_int was being reported as an invalid TypeGuard function ("Type guard functions must accept at least one positional argument") because Pyrefly inferred its return type as TypeGuard[int] and then validated it as a type guard function.

The fix ensures TypeGuard/TypeIs validation only runs when the function has an explicit return annotation.

Fixes #1998

# Test Plan
- Added test_typeguard_return_without_annotation and test_typeis_return_without_annotation test cases
- Ran python3 test.py - all tests pass
- Verified existing TypeGuard/TypeIs validation tests still pass (test_typeguard_argument_number, test_typeis_argument_number, test_typeis_subtyping)