### PR TITLE
fix panic: 'key lacking binding' with augmented assignment and assignment expression #1991

### DIFF
--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -670,6 +670,9 @@ impl<'a> BindingsBuilder<'a> {
                         // We don't track first-usage in this context, since we won't analyze the usage anyway.
                         let mut e = illegal_target.clone();
                         self.ensure_expr(&mut e, &mut Usage::StaticTypeInformation);
+                        // Even though the assignment target is invalid, we still need to analyze the RHS so errors
+                        // (like invalid walrus targets) are reported.
+                        self.ensure_expr(&mut x.value, &mut Usage::StaticTypeInformation);
                     }
                 }
             }

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -1613,6 +1613,14 @@ testcase!(
 );
 
 testcase!(
+    test_crash_on_augassign_walrus_rhs,
+    r#"
+# Regression test for https://github.com/facebook/pyrefly/issues/1991
+1 += (c := 1)  # E: Parse error: Invalid augmented assignment target
+"#,
+);
+
+testcase!(
     test_check_invalid_rhs,
     r#"
 def f(x): pass


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1991

now always walks the RHS of an augmented assignment, even when the target is structurally invalid, so side effects such as walrus bindings are analyzed and report their own errors instead of triggering the crash seen in #1991.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

adds a regression test (test_crash_on_augassign_walrus_rhs) that reproduces 1 += (c := 1) and asserts we emit the existing parser error, guarding against regressions around illegal targets with walrus expressions.