### PR TITLE
fix Not inferring generic type for variable typed as Callable with TypeVar #1555

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -107,6 +107,7 @@ use crate::export::special::SpecialExport;
 use crate::solver::solver::SubsetError;
 use crate::types::annotation::Annotation;
 use crate::types::annotation::Qualifier;
+use crate::types::callable::Callable;
 use crate::types::callable::Function;
 use crate::types::callable::FunctionKind;
 use crate::types::callable::Param;
@@ -2627,6 +2628,47 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         })
     }
 
+    fn wrap_callable_legacy_typevars(&self, ty: Type) -> Type {
+        match ty {
+            Type::Callable(callable) => {
+                let (callable, tparams) = self.promote_callable_legacy_typevars(*callable);
+                if tparams.is_empty() {
+                    Type::Callable(Box::new(callable))
+                } else {
+                    Forallable::Callable(callable).forall(Arc::new(TParams::new(tparams)))
+                }
+            }
+            _ => ty,
+        }
+    }
+
+    fn promote_callable_legacy_typevars(&self, mut callable: Callable) -> (Callable, Vec<TParam>) {
+        let mut seen_type_vars: SmallMap<TypeVar, Quantified> = SmallMap::new();
+        let mut tparams = Vec::new();
+        callable.visit_mut(&mut |ty| {
+            if let Type::TypeVar(tv) = ty {
+                let q = seen_type_vars
+                    .entry(tv.dupe())
+                    .or_insert_with(|| {
+                        let q = Quantified::type_var(
+                            tv.qname().id().clone(),
+                            self.uniques,
+                            tv.default().cloned(),
+                            tv.restriction().clone(),
+                        );
+                        tparams.push(TParam {
+                            quantified: q.clone(),
+                            variance: tv.variance(),
+                        });
+                        q
+                    })
+                    .clone();
+                *ty = Type::Quantified(Box::new(q));
+            }
+        });
+        (callable, tparams)
+    }
+
     fn check_implicit_return_against_annotation(
         &self,
         implicit_return: Arc<TypeInfo>,
@@ -3065,7 +3107,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 errors,
                             )
                         }
-                        _ => ty,
+                        _ => {
+                            let ty = if annot_key.is_some() {
+                                self.wrap_callable_legacy_typevars(ty)
+                            } else {
+                                ty
+                            };
+                            ty
+                        }
                     }
                 }
             }

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -26,6 +26,17 @@ f8: Callable[[int], int] = lambda x: x + "foo" # E: Argument `Literal['foo']` is
 );
 
 testcase!(
+    test_callable_variable_typevar_annotation,
+    r#"
+from typing import Callable, TypeVar, reveal_type
+T = TypeVar("T")
+f: Callable[[T], T] = lambda x: x
+reveal_type(f)  # E: revealed type: [T](T) -> T
+reveal_type(f(1))  # E: revealed type: int
+"#,
+);
+
+testcase!(
     test_callable_ellipsis_upper_bound,
     r#"
 from typing import Callable


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1555

Implemented contextual quantification for annotated Callable assignments so legacy TypeVars are no longer treated as concrete values.

now feeds directly annotated assignments through wrap_callable_legacy_typevars, ensuring only annotated Callables get the extra handling.

introduces the helper that scans a Callable signature for Type::TypeVars, converts them to quantified forms, and builds matching TParams, yielding a Forallable::Callable whenever legacy type variables are present.



# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

adds a regression test showing that `f: Callable[[T], T] = lambda x: x` now reports `[T](T) -> T` and calls like `f(1)` resolve to int instead of the unspecialized `TypeVar[T]`.
