### PR TITLE
Allow `typing.Mapping` to form type aliases

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -600,19 +600,7 @@
       "stop_line": 65
     }
   ],
-  "aliases_recursive.py": [
-    {
-      "code": -2,
-      "column": 45,
-      "concise_description": "Expected a type form, got instance of `Literal['RecursiveMapping']`",
-      "description": "Expected a type form, got instance of `Literal['RecursiveMapping']`",
-      "line": 42,
-      "name": "not-a-type",
-      "severity": "error",
-      "stop_column": 63,
-      "stop_line": 42
-    }
-  ],
+  "aliases_recursive.py": [],
   "aliases_type_statement.py": [
     {
       "code": -2,

--- a/conformance/third_party/conformance.result
+++ b/conformance/third_party/conformance.result
@@ -20,8 +20,7 @@
     "Line 63: Expected 1 errors",
     "Line 69: Expected 1 errors",
     "Line 72: Expected 1 errors",
-    "Line 75: Expected 1 errors",
-    "Line 42: Unexpected errors [\"Expected a type form, got instance of `Literal['RecursiveMapping']`\"]"
+    "Line 75: Expected 1 errors"
   ],
   "aliases_type_statement.py": [
     "Line 82: Expected 1 errors",

--- a/conformance/third_party/results.json
+++ b/conformance/third_party/results.json
@@ -3,7 +3,7 @@
   "pass": 106,
   "fail": 32,
   "pass_rate": 0.77,
-  "differences": 132,
+  "differences": 131,
   "passing": [
     "aliases_explicit.py",
     "aliases_newtype.py",
@@ -114,7 +114,7 @@
   ],
   "failing": {
     "aliases_implicit.py": 5,
-    "aliases_recursive.py": 12,
+    "aliases_recursive.py": 11,
     "aliases_type_statement.py": 4,
     "aliases_typealiastype.py": 4,
     "aliases_variance.py": 4,

--- a/pyrefly/lib/binding/target.rs
+++ b/pyrefly/lib/binding/target.rs
@@ -545,6 +545,7 @@ impl<'a> BindingsBuilder<'a> {
                         | SpecialExport::TypingTuple
                         | SpecialExport::BuiltinsType
                         | SpecialExport::TypingType
+                        | SpecialExport::TypingMapping
                 )
             ),
             Expr::BinOp(ExprBinOp {

--- a/pyrefly/lib/export/special.rs
+++ b/pyrefly/lib/export/special.rs
@@ -69,6 +69,7 @@ pub enum SpecialExport {
     BuiltinsFrozenset,
     BuiltinsFloat,
     Deprecated,
+    TypingMapping,
 }
 
 impl SpecialExport {
@@ -129,6 +130,7 @@ impl SpecialExport {
             "frozenset" => Some(Self::BuiltinsFrozenset),
             "float" => Some(Self::BuiltinsFloat),
             "deprecated" => Some(Self::Deprecated),
+            "Mapping" => Some(Self::TypingMapping),
             _ => None,
         }
     }
@@ -158,7 +160,8 @@ impl SpecialExport {
             | Self::TypingType
             | Self::TypingDict
             | Self::TypingList
-            | Self::TypingTuple => {
+            | Self::TypingTuple
+            | Self::TypingMapping => {
                 matches!(m.as_str(), "typing" | "typing_extensions")
             }
             Self::CollectionsNamedTuple => matches!(m.as_str(), "collections"),


### PR DESCRIPTION
# Summary

- Add `typing.Mapping` as a special export
- Recongnise that subscript in `typing.Mapping` to be a type alias

This fix is targeted to the failing conformance test suite (although I guess recursive aliases are still not working since recursive types are not supported afaik). Nonetheless, I think we need a longer term solution since there are other related "special exports" (e.g. `collections.abc.Mapping`, `typing.MutableMapping`, `typing.Sequence`).

# Test Plan

`python test.py`