### PR TITLE
[easy] Tweak error messages when applying special forms

### DIFF
--- a/pyrefly/lib/alt/specials.rs
+++ b/pyrefly/lib/alt/specials.rs
@@ -477,7 +477,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 range,
                 ErrorInfo::Kind(ErrorKind::BadSpecialization),
                 format!(
-                    "``Unpack requires exactly one argument but got {}",
+                    "`Unpack` requires exactly one argument but got {}",
                     arguments.len()
                 ),
             ),
@@ -498,6 +498,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 TypeFormContext::TypeArgument,
                 errors,
             )),
+            SpecialForm::Annotated => self.error(
+                errors,
+                range,
+                ErrorInfo::Kind(ErrorKind::BadSpecialization),
+                format!(
+                    "`Annotated` requires at least two arguments but got {}",
+                    arguments.len()
+                ),
+            ),
             // Keep this in sync with `SpecialForm::can_be_subscripted``
             SpecialForm::SelfType
             | SpecialForm::LiteralString
@@ -516,8 +525,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             | SpecialForm::Protocol
             | SpecialForm::ReadOnly
             | SpecialForm::NotRequired
-            | SpecialForm::Required
-            | SpecialForm::Annotated => self.error(
+            | SpecialForm::Required => self.error(
                 errors,
                 range,
                 ErrorInfo::Kind(ErrorKind::InvalidAnnotation),

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -844,6 +844,7 @@ c2: type[C, C] = C  # E: Expected 1 type argument for `type`, got 2
     "#,
 );
 
+// Q: Shall we unify the error messages when `Annotated` is applied in annotations vs expressions?
 testcase!(
     test_annotated,
     r#"
@@ -851,6 +852,10 @@ from typing import Annotated, assert_type
 def f(x: Annotated[int, "test"], y: Annotated[int, "test", "test"]):
     assert_type(x, int)
     assert_type(y, int)
+def g(x: Annotated[int]): # E: `Annotated` needs at least one piece of metadata in addition to the type
+    pass
+X = Annotated[int, "meta"]
+Y = Annotated[int] # E: `Annotated` requires at least two arguments but got 1
     "#,
 );
 


### PR DESCRIPTION
# Summary
1. Fix misplaces backticks around `Unpack`.
2. Add a separate `Annotated` error message for incorrect number of arguments. This is because `Annotated` is allowed to be used outside annotations, so the original error message wouldn't be fully accurate.

# Test Plan

`python test.py`