### PR TITLE
Fix LiteralString false positive in empty list inference (#2068)

### DIFF
--- a/pyrefly/lib/test/literal.rs
+++ b/pyrefly/lib/test/literal.rs
@@ -335,3 +335,18 @@ b: Collection[str] = ""
 c: Sequence[str] = ""
 "#,
 );
+
+// Regression test for https://github.com/facebook/pyrefly/issues/2068
+// When using an empty list in a loop with str.join, the list element type
+// should be inferred correctly (not as LiteralString).
+testcase!(
+    test_literal_string_join_loop_inference,
+    r#"
+def test():
+    items = ["a", "b"]
+    lines = []
+    for k in items:
+        lines.append(f"*{k}")
+    return "\n".join(lines)
+"#,
+);


### PR DESCRIPTION

  ## Summary

  Fixes #2068 - False positive error when using an empty list in a loop with `str.join`.

  **Before:** pyrefly incorrectly reported `str not assignable to LiteralString` error:
  ```python
  def test():
      items = ["a", "b"]
      lines = []
      for k in items:
          lines.append(f"*{k}")  # ERROR: str not assignable to LiteralString
      return "\n".join(lines)
```
  After: No error (matches pyright behavior).

  Root Cause

  When an empty list (lines = []) is created and used inside a loop, the append call doesn't "pin" the element type because loop bodies might not execute. The str.join call after the loop becomes the first use that pins the type, and the overload join(self: LiteralString, iterable: Iterable[LiteralString]) was incorrectly constraining the list element type to LiteralString.

  Fix

  In solver.rs, when pinning a PartialContained type variable from above (upper bound constraint), promote LiteralString to str. This is correct because:

  - LiteralString is a compile-time marker, not a concrete runtime type
  - Container element types should use runtime types since we can't guarantee all elements will be literal strings
  
Test plan
  - Added regression test test_literal_string_join_loop_inference
  - Verified fix with original issue code