### PR TITLE
fix: Inferred return type of Never when a method body contains a for loop

### DIFF
--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -1146,23 +1146,6 @@ def f():
 );
 
 testcase!(
-    test_walrus_reuse_name_in_if_condition,
-    r#"
-from re import compile
-
-interface_re = compile(r"^foo")
-ipv4_re = compile(r"bar$")
-line = str()
-
-if match := interface_re.match(line):
-    pass
-
-if line and (match := ipv4_re.search(line)):
-    print(match)
-    "#,
-);
-
-testcase!(
     test_unbound_local_name_error_in_def,
     r#"
 def f():


### PR DESCRIPTION
# Summary

Fix implicit return inference so trailing for loops no longer cause functions without explicit return to be inferred as returning Never

Fixes #1491

# Test Plan

```
cargo test -p pyrefly test_infer_return_in_for_loop
```

