### PR TITLE
Auto-detect .venv interpreter when configured path is invalid

### DIFF
--- a/crates/pyrefly_config/src/util.rs
+++ b/crates/pyrefly_config/src/util.rs
@@ -45,6 +45,10 @@ pub(crate) enum ConfigOrigin<T> {
     #[serde(skip)]
     Auto(T),
 
+    /// This value was auto-discovered as a fallback when configured path was invalid.
+    #[serde(skip)]
+    Fallback(T),
+
     /// This value was explicitly provided by the IDE using "workspace.configuration" using LSP protocol.
     #[serde(skip)]
     Lsp(T),
@@ -88,6 +92,7 @@ impl<T> Deref for ConfigOrigin<T> {
             Self::CommandLine(value)
             | Self::ConfigFile(value)
             | Self::Auto(value)
+            | Self::Fallback(value)
             | Self::Lsp(value) => value,
         }
     }
@@ -99,6 +104,7 @@ impl<T> DerefMut for ConfigOrigin<T> {
             Self::CommandLine(value)
             | Self::ConfigFile(value)
             | Self::Auto(value)
+            | Self::Fallback(value)
             | Self::Lsp(value) => value,
         }
     }
@@ -126,6 +132,11 @@ impl<T> ConfigOrigin<T> {
         Self::Auto(value)
     }
 
+    /// Construct a new [`ConfigOrigin::Fallback`] with the given value.
+    pub(crate) fn fallback(value: T) -> Self {
+        Self::Fallback(value)
+    }
+
     /// Construct a new [`ConfigOrigin::Lsp`] with the given value.
     pub(crate) fn lsp(value: T) -> Self {
         Self::Lsp(value)
@@ -142,6 +153,7 @@ impl<T> ConfigOrigin<T> {
             ConfigOrigin::ConfigFile(value) => ConfigOrigin::ConfigFile(f(value)),
             ConfigOrigin::CommandLine(value) => ConfigOrigin::CommandLine(f(value)),
             ConfigOrigin::Auto(value) => ConfigOrigin::Auto(f(value)),
+            ConfigOrigin::Fallback(value) => ConfigOrigin::Fallback(f(value)),
             ConfigOrigin::Lsp(value) => ConfigOrigin::Lsp(f(value)),
         }
     }
@@ -151,6 +163,7 @@ impl<T> ConfigOrigin<T> {
             ConfigOrigin::ConfigFile(ref value) => ConfigOrigin::ConfigFile(value),
             ConfigOrigin::CommandLine(ref value) => ConfigOrigin::CommandLine(value),
             ConfigOrigin::Auto(ref value) => ConfigOrigin::Auto(value),
+            ConfigOrigin::Fallback(ref value) => ConfigOrigin::Fallback(value),
             ConfigOrigin::Lsp(ref value) => ConfigOrigin::Lsp(value),
         }
     }
@@ -171,10 +184,12 @@ impl<T, E> ConfigOrigin<Result<T, E>> {
             ConfigOrigin::ConfigFile(Ok(value)) => Ok(ConfigOrigin::ConfigFile(value)),
             ConfigOrigin::CommandLine(Ok(value)) => Ok(ConfigOrigin::CommandLine(value)),
             ConfigOrigin::Auto(Ok(value)) => Ok(ConfigOrigin::Auto(value)),
+            ConfigOrigin::Fallback(Ok(value)) => Ok(ConfigOrigin::Fallback(value)),
             ConfigOrigin::Lsp(Ok(value)) => Ok(ConfigOrigin::Lsp(value)),
             ConfigOrigin::ConfigFile(Err(err))
             | ConfigOrigin::CommandLine(Err(err))
             | ConfigOrigin::Auto(Err(err))
+            | ConfigOrigin::Fallback(Err(err))
             | ConfigOrigin::Lsp(Err(err)) => Err(err),
         }
     }


### PR DESCRIPTION
## Summary
This PR improves the interpreter discovery logic to automatically fall back to a `.venv` directory in the project root if the configured `python-interpreter-path` is invalid or refers to a non-existent file.

## Motivation
Modern Python workflows (using tools like `uv`, `poetry`, or standard `pip`) often create a local `.venv` directory in the project root by default. Currently, users are often required to explicitly configure the full path to this interpreter in `pyproject.toml` or [pyrefly.toml]

This change aims to reduce configuration boilerplate by attempting to auto-discover the `.venv` directory if the initially configured path fails validation. This makes the "out-of-the-box" experience much smoother for standard project layouts.

## Changes
- Modified `ConfigFile::configure` in [crates/pyrefly_config/src/config.rs]
- Added a check: if `interpreter.exists()` returns `false`, the config now attempts to find a valid environment using `crate::environment::venv::find(root)`.
- If a valid `.venv` is found, [pyrefly] automatically switches to using it instead of throwing an error or falling back to a system interpreter.