### PR TITLE
fix(docstring): retain doctest arrow prefix

### DIFF
--- a/pyrefly/lib/test/lsp/hover_docstring.rs
+++ b/pyrefly/lib/test/lsp/hover_docstring.rs
@@ -379,30 +379,3 @@ Docstring Result: `Test docstring`
         report.trim(),
     );
 }
-
-#[test]
-fn test_removes_block_quote_symbols_at_start_of_line() {
-    let code = r#"
-def fun() -> None:
-    """
-    >>> d = {"col1": [1, 2], "col2": [3, 4]}
-    """
-    pass
-
-f = fun()
-#   ^
-"#;
-    let report = get_batched_lsp_operations_report(&[("main", code)], test_report_factory(code));
-    assert_eq!(
-        r#"
-# main.py
-8 | f = fun()
-        ^
-Docstring Result: `  
-d = {"col1": [1, 2], "col2": [3, 4]}  
-`
-"#
-        .trim(),
-        report.trim(),
-    );
-}


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Closes #2086.

doctest prefix (`>>> `) should be retained in Python docstring to preserve syntax highlighting.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
