### PR TITLE
Add failing unittest for custom reverse relations (related_name keyword)

### DIFF
--- a/pyrefly/lib/test/django/reverse_relations.rs
+++ b/pyrefly/lib/test/django/reverse_relations.rs
@@ -24,3 +24,21 @@ reporter = Reporter()
 reporter.article_set  # E: `Reporter` has no attribute `article_set`
 "#,
 );
+
+django_testcase!(
+    bug = "Reverse relations not yet implemented",
+    test_foreign_key_reverse_custom_name,
+    r#"
+from django.db import models
+
+class Author(models.Model):
+    name = models.CharField(max_length=100)
+
+class Book(models.Model):
+    author = models.ForeignKey(Author, on_delete=models.CASCADE, related_name='written_books')
+
+author = Author()
+# Custom related_name should be used instead of default
+author.written_books  # E: `Author` has no attribute `written_books`
+"#,
+);


### PR DESCRIPTION
Summary: Here, we test the related_name keyword which allows us to customize the reverse relation

Reviewed By: aleivag

Differential Revision: D90517278


