### PR TITLE
Add failing abstract method testcase

### DIFF
--- a/pyrefly/lib/test/abstract_methods.rs
+++ b/pyrefly/lib/test/abstract_methods.rs
@@ -430,3 +430,20 @@ class A(ABC):
 a = A()
 "#,
 );
+
+testcase!(
+    bug = "Type should be inferred as returning Any (https://github.com/facebook/pyrefly/issues/2072)",
+    test_abstract_method_abc,
+    r#"
+from abc import ABC
+
+class A(ABC):
+    def foo(self):
+        raise NotImplementedError()
+
+class B(A):
+    def foo(self):  # E: Class member `B.foo` overrides parent class `A` in an inconsistent manner
+        x = 1
+        print(x)
+"#,
+);


### PR DESCRIPTION
Summary:
We incorrectly infer abstract method types as if they are regular methods, which causes an overload error downstream.

Instead, as suggested in the comments (https://github.com/facebook/pyrefly/issues/2072), we could consider special casing them by disabeling inference on them.

I suspect that we will have to collect and thread some info from the binding stage here because we wait to specifically detect the empty function body. In the solving stage, that would have already been transformed to a "never" type.

Reviewed By: stroxler

Differential Revision: D90560069


