### PR TITLE
Disable type inference on abstract methods

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -3317,6 +3317,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         implicit_return,
                         yields,
                         yield_froms,
+                        body_is_trivial,
+                        class_metadata_key,
                     } => {
                         let is_generator = !(yields.is_empty() && yield_froms.is_empty());
                         let returns = returns.iter().map(|k| self.get_idx(*k).arc_clone_ty());
@@ -3333,6 +3335,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                     .chain(iter::once(implicit_return.arc_clone_ty()))
                                     .collect(),
                             )
+                        };
+                        // If this is a method with a trivial body (e.g., `raise NotImplementedError()`)
+                        // in a class that extends ABC, treat it as an abstract method and return Any
+                        // instead of Never. This handles transitive ABC inheritance.
+                        let is_abstract_method = *body_is_trivial
+                            && return_ty.is_never()
+                            && class_metadata_key
+                                .is_some_and(|key| self.get_idx(key).extends_abc());
+                        let return_ty = if is_abstract_method {
+                            Type::any_implicit()
+                        } else {
+                            return_ty
                         };
                         if is_generator {
                             let yield_ty = self.unions({

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -1215,6 +1215,11 @@ pub enum ReturnTypeKind {
         /// whether these two fields are empty or not.
         yields: Box<[Idx<KeyYield>]>,
         yield_froms: Box<[Idx<KeyYieldFrom>]>,
+        /// Whether the function body is trivial (e.g., `pass`, `raise NotImplementedError()`).
+        /// Used to detect abstract methods in ABC subclasses.
+        body_is_trivial: bool,
+        /// The class metadata key, if this function is a method. Used to check if the class extends ABC.
+        class_metadata_key: Option<Idx<KeyClassMetadata>>,
     },
 }
 

--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -45,6 +45,7 @@ use crate::binding::binding::IsAsync;
 use crate::binding::binding::Key;
 use crate::binding::binding::KeyAnnotation;
 use crate::binding::binding::KeyClass;
+use crate::binding::binding::KeyClassMetadata;
 use crate::binding::binding::KeyDecorator;
 use crate::binding::binding::KeyLegacyTypeParam;
 use crate::binding::binding::KeyUndecoratedFunction;
@@ -371,6 +372,8 @@ impl<'a> BindingsBuilder<'a> {
         should_infer_return_type: bool,
         stub_or_impl: FunctionStubOrImpl,
         decorators: Box<[Idx<KeyDecorator>]>,
+        body_is_trivial: bool,
+        class_metadata_key: Option<Idx<KeyClassMetadata>>,
     ) {
         let is_generator =
             !(yields_and_returns.yields.is_empty() && yields_and_returns.yield_froms.is_empty());
@@ -450,6 +453,8 @@ impl<'a> BindingsBuilder<'a> {
                         implicit_return,
                         yields: yield_keys,
                         yield_froms: yield_from_keys,
+                        body_is_trivial,
+                        class_metadata_key,
                     }
                 }
                 (None, _) => {
@@ -525,6 +530,7 @@ impl<'a> BindingsBuilder<'a> {
         parent: &NestingContext,
         undecorated_idx: Idx<KeyUndecoratedFunction>,
         class_key: Option<Idx<KeyClass>>,
+        metadata_key: Option<Idx<KeyClassMetadata>>,
     ) -> (FunctionStubOrImpl, Option<SelfAssignments>) {
         let stub_or_impl = if (body.first().is_some_and(is_docstring)
             && decorators.is_abstract_method)
@@ -613,6 +619,8 @@ impl<'a> BindingsBuilder<'a> {
                         false, // this disables return type inference
                         stub_or_impl,
                         decorators.decorators.clone(),
+                        body_is_trivial,
+                        metadata_key,
                     );
                     self_assignments
                 }
@@ -643,6 +651,8 @@ impl<'a> BindingsBuilder<'a> {
                         false, // this disables return type inference
                         stub_or_impl,
                         decorators.decorators.clone(),
+                        body_is_trivial,
+                        metadata_key,
                     );
                     self_assignments
                 }
@@ -673,6 +683,8 @@ impl<'a> BindingsBuilder<'a> {
                         true,
                         stub_or_impl,
                         decorators.decorators.clone(),
+                        body_is_trivial,
+                        metadata_key,
                     );
                     self_assignments
                 }
@@ -716,6 +728,7 @@ impl<'a> BindingsBuilder<'a> {
             parent,
             undecorated_idx,
             class_key,
+            metadata_key,
         );
 
         // Pop the annotation scope to get back to the parent scope, and handle this

--- a/pyrefly/lib/test/abstract_methods.rs
+++ b/pyrefly/lib/test/abstract_methods.rs
@@ -432,7 +432,6 @@ a = A()
 );
 
 testcase!(
-    bug = "Type should be inferred as returning Any (https://github.com/facebook/pyrefly/issues/2072)",
     test_abstract_method_abc,
     r#"
 from abc import ABC
@@ -442,8 +441,29 @@ class A(ABC):
         raise NotImplementedError()
 
 class B(A):
-    def foo(self):  # E: Class member `B.foo` overrides parent class `A` in an inconsistent manner
+    def foo(self):
         x = 1
         print(x)
+"#,
+);
+
+testcase!(
+    test_abstract_method_abc_transitive,
+    r#"
+from abc import ABC
+
+class A(ABC):
+    def foo(self):
+        raise NotImplementedError()
+
+class B(A):
+    def bar(self):
+        raise NotImplementedError()
+
+class C(B):
+    def foo(self):
+        pass
+    def bar(self):
+        pass
 "#,
 );


### PR DESCRIPTION
Summary:
We incorrectly infer abstract method types as if they are regular methods, which causes an overload error downstream.

Instead, as suggested in the comments (https://github.com/facebook/pyrefly/issues/2072), we could consider special casing them by disabeling inference on them.

RFC:
I am implementing this by storing the following
- metadata key
- trivial function bodies

the reason is what we want to thread this information to the solver stage and then infer any on methods where the surrounding class is abstract and the function body is trivial

Reviewed By: stroxler

Differential Revision: D90561905


