### PR TITLE
fix: 'Go to symbol' now includes methods inside a class

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/document_symbols.rs
+++ b/pyrefly/lib/lsp/non_wasm/document_symbols.rs
@@ -61,6 +61,14 @@ fn recurse_stmt_adding_symbols<'a>(
         Stmt::ClassDef(stmt_class_def) => {
             let mut children = Vec::new();
             children.append(&mut recursed_symbols);
+
+            // Functions defined inside a class are methods.
+            for child in &mut children {
+                if child.kind == lsp_types::SymbolKind::FUNCTION {
+                    child.kind = lsp_types::SymbolKind::METHOD;
+                }
+            }
+
             let name = match stmt_class_def.name.as_str() {
                 "" => "unknown".to_owned(),
                 name => name.to_owned(),

--- a/pyrefly/lib/test/lsp/lsp_interaction/document_symbols.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/document_symbols.rs
@@ -101,11 +101,20 @@ fn test_document_symbols_normal_file() {
                 .iter()
                 .any(|s| s.name == "normal_function" && s.kind == lsp_types::SymbolKind::FUNCTION);
 
-            let has_class = symbols
+            let class_symbol = symbols
                 .iter()
-                .any(|s| s.name == "NormalClass" && s.kind == lsp_types::SymbolKind::CLASS);
+                .find(|s| s.name == "NormalClass" && s.kind == lsp_types::SymbolKind::CLASS);
+            
+            let has_class_and_method = match class_symbol {
+                Some(c) => {
+                     c.children.as_ref().map_or(false, |children| {
+                        children.iter().any(|s| s.name == "normal_method" && s.kind == lsp_types::SymbolKind::METHOD)
+                     })
+                },
+                None => false,
+            };
 
-            has_function && has_class
+            has_function && has_class_and_method
         })
         .unwrap();
 


### PR DESCRIPTION
# Summary

Logic was added to post-process symbols inside a ClassDef.
it allows Stmt::FunctionDef to remain simple (always creating a FUNCTION), and shifts the responsibility of context-awareness (knowing it is a method) to the parent ClassDef.
Any child symbol with SymbolKind::FUNCTION is now converted to SymbolKind::METHOD

Fixes #2051 

# Test Plan

I updated the existing test 
test_document_symbols_normal_file in pyrefly/lib/test/lsp/lsp_interaction/document_symbols.rs
The test uses an existing file normal.py which contains NormalClass and normal_method.
I updated the test assertion to verify that normal_method inside NormalClass has SymbolKind::METHOD.
