### PR TITLE
fix Semantic highlighting incorrect for original name in import X as Y statements #2045

### DIFF
--- a/pyrefly/lib/test/lsp/semantic_tokens.rs
+++ b/pyrefly/lib/test/lsp/semantic_tokens.rs
@@ -883,7 +883,7 @@ line: 1, column: 5, length: 3, text: lib
 token-type: namespace
 
 line: 1, column: 16, length: 4, text: func
-token-type: namespace
+token-type: function
 
 line: 1, column: 24, length: 4, text: func
 token-type: function
@@ -913,7 +913,7 @@ line: 1, column: 5, length: 3, text: foo
 token-type: namespace
 
 line: 1, column: 16, length: 3, text: bar
-token-type: namespace
+token-type: function
 
 line: 1, column: 23, length: 3, text: baz
 token-type: function


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2045

Updated semantic token generation so the original name in from X import Y as Z inherits the resolved symbol kind (class/function/etc.) instead of being treated as a generic namespace, which matches the expected behavior described in issue #2045 (original name should match alias)

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
update expectations so the original imported name is typed as function in aliased imports.
