### PR TITLE
Try to fix ParamSpec test for windows.

### DIFF
--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/paramspec_inlay_hint_test.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/paramspec_inlay_hint_test.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import ParamSpec
+from typing_extensions import ParamSpec
 
 P = ParamSpec("P")
 


### PR DESCRIPTION
Summary:
Up until 3.10 typing_extensions defined ParamSpec locally. Starting in 3.10 and greater typing extensions instead re-exports ParamSpec from typing.

I believe this may have been the issue causing this test to fail. All the flaky tests we have seen on Windows have been features that have been gated by specific versions.

In order to account for this, we can always trying getting ParamSpec from typing_extensions since it will always be available there.

Reviewed By: kinto0

Differential Revision: D90777432


