### PR TITLE
Actually run the ParamSpec location test on windows.

### DIFF
--- a/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
@@ -515,8 +515,6 @@ fn test_inlay_hint_typevartuple_has_location() {
     interaction.shutdown().unwrap();
 }
 
-/// TODO(jvansch): Figure out why this is timing out on Windows
-#[cfg(not(windows))]
 #[test]
 fn test_inlay_hint_paramspec_has_location() {
     let root = get_test_files_root();


### PR DESCRIPTION
Summary: A previous test update the diff but never actually allowed the test to run in a windows environment.

Differential Revision: D90793146


