### PR TITLE
Fix the rest of flaky windows tests.

### DIFF
--- a/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
@@ -474,8 +474,6 @@ fn test_inlay_hint_typevar_has_location() {
     interaction.shutdown().unwrap();
 }
 
-/// TODO(jvansch): Figure out why this is timing out on Windows
-#[cfg(not(windows))]
 #[test]
 fn test_inlay_hint_typevartuple_has_location() {
     let root = get_test_files_root();
@@ -641,8 +639,6 @@ fn test_inlay_hint_anonymous_typed_dict_has_location() {
     interaction.shutdown().unwrap();
 }
 
-// TODO(jvansch): re-enable on windows
-#[cfg(not(windows))]
 #[test]
 fn test_inlay_hint_literal_string_has_location() {
     let root = get_test_files_root();

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/literal_string_inlay_hint_test.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/literal_string_inlay_hint_test.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import LiteralString
+from typing_extensions import LiteralString
 
 
 def get_literal_string(x: LiteralString):

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/typevartuple_inlay_hint_test.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/typevartuple_inlay_hint_test.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import TypeVarTuple
+from typing_extensions import TypeVarTuple
 
 Ts = TypeVarTuple("Ts")
 


### PR DESCRIPTION
Summary: For LiteralString and TypeVarTuple tests, make sure we also import it from typing_extensions so the test is not version dependent.

Differential Revision: D90796722


