### PR TITLE
Fix list concatenation under contextual list hint

### DIFF
--- a/pyrefly/lib/test/assign.rs
+++ b/pyrefly/lib/test/assign.rs
@@ -124,6 +124,33 @@ d: list[Any] = ["test"]
 );
 
 testcase!(
+    test_assign_list_concat_with_contextual_hint,
+    r#"
+from typing import assert_type, reveal_type
+
+class Base: ...
+class A(Base): ...
+class B(Base): ...
+
+# List literal with mixed subclasses works with contextual hint
+l1: list[Base] = [A(), B()]
+
+# List concatenation with contextual hint should also work
+l2: list[Base] = [A()] + [B()]
+
+# List concatenation with list comprehension operands
+l3: list[Base] = [A() for _ in range(1)] + [B()]
+
+# Without contextual hint, reveal_type should show the inferred union type
+reveal_type([A()] + [B()])  # E: revealed type: list[A | B]
+
+# Non-fresh operands (variables) should NOT be coerced
+xs: list[A] = [A()]
+l4: list[Base] = xs + [B()]  # E: `list[A | B]` is not assignable to `list[Base]`
+"#,
+);
+
+testcase!(
     test_assign_at_types,
     r#"
 a: int = 3

--- a/pyrefly/lib/test/returns.rs
+++ b/pyrefly/lib/test/returns.rs
@@ -419,3 +419,38 @@ def test():
     yield from [2, 3] # E: This `yield from` expression is unreachable
 "#,
 );
+
+// Regression test for https://github.com/facebook/pyrefly/issues/2141
+// List concatenation with contextual return type hint should work
+testcase!(
+    test_return_list_concat_contextual_hint,
+    r#"
+from abc import ABC, abstractmethod
+
+class Base(ABC):
+    @abstractmethod
+    def foo(self, x: int) -> None: ...
+
+class A(Base):
+    def foo(self, x: int) -> None:
+        print(x)
+
+class B(Base):
+    def foo(self, x: int) -> None:
+        pass
+
+# This should type-check without error: the return type hint list[Base]
+# provides context for inferring [A()] + [B()] as list[Base].
+def return_object(name: str) -> list[Base]:
+    return [A()] + [B()]
+
+# Non-list-returning variant still works (for comparison)
+def return_object_non_list(name: str) -> Base:
+    o = None
+    if name == "a":
+        o = A()
+    else:
+        o = B()
+    return o
+"#,
+);


### PR DESCRIPTION
Fixes #2141.

### What
When a `list[T]` contextual hint is available (assignment/return annotation) and **both** operands of `+` are fresh list-producing expressions (list literal or list comprehension), propagate the hint into both operands.

This makes cases like:
- `l2: list[Base] = [A()] + [B()]`
- `def f() -> list[Base]: return [A()] + [B()]`
work without making `list` covariant globally.

### Why
List literals already use contextual typing via `decompose_list`, but `+` previously inferred operands without passing the hint (except `[X] * int`). That caused `[A()] + [B()]` to be inferred as `list[A | B]` and fail against `list[Base]` due to invariance.

### Tests
- Added assignment regression test covering `l2` and ensuring no-context `reveal_type([A()] + [B()])` remains `list[A | B]`.
- Added return regression test for #2141.

### Notes
The hint is only propagated when *both* operands are fresh to avoid masking invariance errors for expressions involving non-fresh operands.