### PR TITLE
Skip attribute suggestions for partial union failures

### DIFF
--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -2113,6 +2113,68 @@ def f(x: Color) -> Color:
 );
 
 testcase!(
+    test_union_attribute_missing_no_suggestion,
+    r#"
+# When an attribute exists on some union members but not others,
+# we shouldn't suggest similar attributes from the types that have it
+def f(x: str | None):
+    return x.split()  # E: Object of class `NoneType` has no attribute `split`
+"#,
+);
+
+testcase!(
+    test_union_attribute_missing_no_suggestion_three_types,
+    r#"
+# Partial union failure with 3 types: attribute exists on 1, missing on 2
+def f(x: str | int | None):
+    return x.split()  # E: Object of class `NoneType` has no attribute `split`\nObject of class `int` has no attribute `split`
+"#,
+);
+
+testcase!(
+    test_union_attribute_missing_no_suggestion_mostly_have_it,
+    r#"
+# Even if most types have the attribute, if ANY don't, skip suggestion
+class A:
+    upper: int
+    lower: int
+class B:
+    upper: int
+    lower: int
+def f(x: str | A | B):
+    # str has "upper" method, A and B have "upper" attribute
+    # But str doesn't have "lower" attribute, A and B do
+    x.lowerr  # E: Object of class `str` has no attribute `lowerr`
+"#,
+);
+
+testcase!(
+    test_union_both_missing_should_suggest,
+    r#"
+# When an attribute is missing on ALL union members, we should still suggest
+class A:
+    value: int
+class B:
+    value: str
+def f(x: A | B):
+    return x.vaule  # E: Object of class `A` has no attribute `vaule`\nObject of class `B` has no attribute `vaule`\n  Did you mean `value`?
+"#,
+);
+
+testcase!(
+    test_union_all_have_attribute_no_error,
+    r#"
+# When all union members have the attribute, there should be no error
+class A:
+    value: int
+class B:
+    value: str
+def f(x: A | B):
+    return x.value  # No error - both A and B have 'value'
+"#,
+);
+
+testcase!(
     test_class_toplevel_inherited_attr_name,
     r#"
 # at the class top level, inherited attribute names should be considered in scope


### PR DESCRIPTION
When an attribute exists on some union members but not others, skip suggestions to avoid misleading guidance. For example, x.split() on str | None should not suggest rsplit since it also doesn't exist on None.

Fixes #2108

# Summary

Modified `type_of_attr_get` in `pyrefly/lib/alt/attr.rs` to detect partial union failures (where an attribute exists on some union members but not others) and skip suggestions in those cases. This prevents misleading suggestions like recommending `rsplit` when `split` fails on `str | None`.

The fix checks if `found` and `not_found` are both non-empty before suggesting, indicating the attribute exists on some union members but not all.

Suggestions still work correctly when the attribute is missing on all union members or when there's no union involved.

# Test Plan

Added 5 comprehensive test cases in `pyrefly/lib/test/attributes.rs`:
- `test_union_attribute_missing_no_suggestion` - Core fix (str | None)
- `test_union_attribute_missing_no_suggestion_three_types` - Three-type union
- `test_union_attribute_missing_no_suggestion_mostly_have_it` - Two have it, one doesn't
- `test_union_both_missing_should_suggest` - All missing (should still suggest)
- `test_union_all_have_attribute_no_error` - All have it (no error)

All tests pass (`cargo test test_union`). Manually verified with release build that the fix works as expected.