### PR TITLE
fix Missing support for typing.Literal in pydantic #2156

### DIFF
--- a/pyrefly/lib/alt/class/pydantic_lax.rs
+++ b/pyrefly/lib/alt/class/pydantic_lax.rs
@@ -167,7 +167,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
     fn expand_type_for_lax_mode(&self, ty: &Type) -> Type {
         match ty {
-            Type::None => ty.clone(),
+            Type::None | Type::Literal(_) | Type::LiteralString(_) => ty.clone(),
             Type::Type(box inner) => Type::Type(Box::new(self.expand_type_for_lax_mode(inner))),
             // Tuple types: convert to Iterable[T] where T is a union of expanded element types
             Type::Tuple(tuple) => self

--- a/pyrefly/lib/test/pydantic/dataclasses.rs
+++ b/pyrefly/lib/test/pydantic/dataclasses.rs
@@ -29,3 +29,18 @@ class A:
 A(x='0')
     "#,
 );
+
+pydantic_testcase!(
+    test_dataclass_literal_strictness,
+    r#"
+from typing import Literal
+from pydantic.dataclasses import dataclass
+
+@dataclass
+class Example:
+    value: Literal["MyLiteral"]
+
+Example(value="MyLiteral")
+Example(value=2)  # E: Argument `Literal[2]` is not assignable to parameter `value` with type `Literal['MyLiteral']` in function `Example.__init__`
+    "#,
+);

--- a/pyrefly/lib/test/pydantic/strictness.rs
+++ b/pyrefly/lib/test/pydantic/strictness.rs
@@ -175,7 +175,6 @@ reveal_type(Model10.__init__)  # E: revealed type: (self: Model10, *, u: LaxUUID
 );
 
 pydantic_testcase!(
-    bug = "An error should be raised here",
     test_lax_mode_coercion_literals,
     r#"
 from typing import Literal
@@ -184,7 +183,7 @@ from pydantic import BaseModel
 class Model1(BaseModel):
     status: Literal[1]
 
-m = Model1(status="1")
+m = Model1(status="1")  # E: Argument `Literal['1']` is not assignable to parameter `status` with type `Literal[1]` in function `Model1.__init__`
     "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2156

Adjusted Pydantic lax conversion to preserve literal types so Literal[...] fields stay strict even when lax mode is enabled. This prevents converting Literal into Any, which is why pydantic dataclasses were silently accepting bad values.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
update test, add a test