### PR TITLE
Fix stack overflow in is_subset_eq by reducing recursion limit (#2175)

### DIFF
--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -60,7 +60,11 @@ use crate::types::types::Var;
 /// in the output. The usual cause is that we failed to visit all the necessary `Type` fields.
 const VAR_LEAK: &str = "Internal error: a variable has leaked from one module to another.";
 
-const INITIAL_GAS: Gas = Gas::new(1000);
+/// A number chosen such that all practical types are less than this depth,
+/// but low enough to avoid stack overflow. Rust's default stack size is 8MB,
+/// and each recursive call to is_subset_eq can use several KB of stack space
+/// due to large enums (Type) and lock guards.
+const INITIAL_GAS: Gas = Gas::new(200);
 
 #[derive(Debug)]
 enum Variable {


### PR DESCRIPTION
  ## Summary                                                                                                                                                             
  - Reduce `INITIAL_GAS` from 1000 to 200 to prevent stack overflow during subset checking                                                                               
  - Add regression tests for recursive type patterns                                                                                                                     
                                                                                                                                                                         
  ## Problem                                                                                                                                                             
  Issue #2175 reports stack overflow (SIGSEGV) during type checking of recursive type patterns. The recursion limit of 1000 exceeded stack capacity, causing crashes.    
                                                                                                                                                                         
  ## Solution                                                                                                                                                            
  Reduce `INITIAL_GAS` to 200, which is:                                                                                                                                 
  - 8× the original value (25) that was deemed "too low"                                                                                                                 
  - 5× lower than the crash-causing value (1000)                                                                                                                         
  - Consistent with other gas limits in the codebase (100 for LSP/IDE)                                                                                                   
                                                                                                                                                                         
  Alternative approaches considered:                                                                                                                                     
  - Adding general cycle detection to `is_subset_eq_impl` - interfered with type inference                                                                               
  - Using `stacker` crate for dynamic stack growth                                                                                        
                                                                                                                                                                         
  ## Test plan                                                                                                                                                           
  - [x] All 74 protocol tests pass                                                                                                                                       
  - [x] All 38 generic_basic tests pass                                                                                                                                  
  - [x] All 24 class_subtyping tests pass                                                                                                                                
  - [x] All 9 cycles tests pass (including 2 new regression tests)
  - recursive_type_subset_check_no_overflow   
  - mutually_recursive_classes_subset                                                                                                       
  - [x] Linting and formatting pass                                                                                                                                      
                                                                                                                                                                            