### PR TITLE
fix relative pyrefly.org link in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ Here's an overview of some important directories:
   edit these manually. Instead, run `test.py` and include any generated changes
   with your PR.
 - `test` - Markdown end-to-end tests for our IDE features
-- `website` - Source code for [pyrefly.org](pyrefly.org)
+- `website` - Source code for [pyrefly.org](https://pyrefly.org)
 
 ## License
 


### PR DESCRIPTION
# Summary

In [CONTRIBUTING.md](https://github.com/facebook/pyrefly/blob/main/CONTRIBUTING.md), the link to [pyrefly.org](https://pyrefly.org) is written without a URL scheme, so Markdown treats it as a relative path instead of an external website. 

https://github.com/facebook/pyrefly/blob/0c3054d4abfec6b6f37aa0e2e28b94a788d7f08f/CONTRIBUTING.md?plain=1#L141

Clicking on the link in the documentation routes to [this](https://github.com/facebook/pyrefly/blob/main/pyrefly.org) page, which throws a `404 Page not found` error. 

This PR fixes the link by adding `https://`, ensuring it points to the correct site.
