### PR TITLE
Display typevar bounds, constraints, and defaults in foralls

### DIFF
--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -112,7 +112,27 @@ pub struct TParam {
 
 impl Display for TParam {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.name())
+        write!(f, "{}", self.name())?;
+        // Display bounds/constraints
+        match self.restriction() {
+            Restriction::Bound(t) => write!(f, ": {}", t)?,
+            Restriction::Constraints(ts) => {
+                write!(f, ": (")?;
+                for (i, t) in ts.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", t)?;
+                }
+                write!(f, ")")?;
+            }
+            Restriction::Unrestricted => {}
+        }
+        // Display default
+        if let Some(default) = self.default() {
+            write!(f, " = {}", default)?;
+        }
+        Ok(())
     }
 }
 

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -1937,7 +1937,7 @@ def get_type_t[T]() -> type[T]:
     return cast(type[T], 0)
 def foo[T](x: type[T]):
     # mypy reveals the same thing we do (the type of `type.__new__`), while pyright reveals `Unknown`.
-    reveal_type(get_type_t().__new__)  # E: Overload[\n  [Self@type](cls: type[Self@type], o: object, /) -> type[Any]\n  [Self](cls: type[Self], name: str, bases: tuple[type[Any], ...], namespace: dict[str, Any], /, **kwds: Any) -> Self\n]
+    reveal_type(get_type_t().__new__)  # E: Overload[\n  [Self@type: type](cls: type[Self@type], o: object, /) -> type[Any]\n  [Self](cls: type[Self], name: str, bases: tuple[type[Any], ...], namespace: dict[str, Any], /, **kwds: Any) -> Self\n]
     "#,
 );
 

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -54,7 +54,7 @@ testcase!(
 from typing import Callable, TypeVar, reveal_type
 T = TypeVar("T", bound=int)
 f: Callable[[T], T] = lambda x: x
-reveal_type(f)  # E: revealed type: [T](T) -> T
+reveal_type(f)  # E: revealed type: [T: int](T) -> T
 reveal_type(f(1))  # E: revealed type: int
 f("hello")  # E: `str` is not assignable to upper bound `int` of type variable `T`
 "#,
@@ -993,7 +993,7 @@ class C(B): ...
 
 def f[T: B](x: T) -> T: ...
 
-c1: Callable[[A], A] = f # E: `[T](x: T) -> T` is not assignable to `(A) -> A`
+c1: Callable[[A], A] = f # E: `[T: B](x: T) -> T` is not assignable to `(A) -> A`
 c2: Callable[[B], B] = f # OK
 c3: Callable[[C], C] = f # OK
     "#,

--- a/pyrefly/lib/test/generic_restrictions.rs
+++ b/pyrefly/lib/test/generic_restrictions.rs
@@ -255,7 +255,7 @@ class C[T = int]:
     def meth(self, /) -> Self:
         return self
     attr: T
-reveal_type(C.meth)  # E: [T](self: C[T], /) -> C[T]
+reveal_type(C.meth)  # E: [T = int](self: C[T], /) -> C[T]
 assert_type(C.attr, int)  # E: assert_type(Any, int) failed  # E: Generic attribute `attr` of class `C` is not visible on the class
  "#,
 );
@@ -976,4 +976,67 @@ from typing import assert_type
 def f[T1, T2 = T1](x: T1, y: T2 | None = None) -> tuple[T1, T2]: ...
 assert_type(f(1), tuple[int, int])  # E: assert_type(tuple[int, Any], tuple[int, int])
     "#,
+);
+
+// Issue #2179: display typevar bounds, constraints, and defaults in foralls
+testcase!(
+    test_reveal_typevar_bounds_in_forall,
+    r#"
+from typing import reveal_type
+
+def f[T: str](x: T) -> T: ...
+def g[T: int](x: T) -> T: ...
+reveal_type(f)  # E: revealed type: [T: str](x: T) -> T
+reveal_type(g)  # E: revealed type: [T: int](x: T) -> T
+"#,
+);
+
+testcase!(
+    test_reveal_typevar_constraints_in_forall,
+    r#"
+from typing import reveal_type
+
+def f[T: (str, int)](x: T) -> T: ...
+reveal_type(f)  # E: revealed type: [T: (str, int)](x: T) -> T
+"#,
+);
+
+testcase!(
+    test_reveal_typevar_default_in_forall,
+    r#"
+from typing import reveal_type
+
+def f[T = int](x: T) -> T: ...
+reveal_type(f)  # E: revealed type: [T = int](x: T) -> T
+"#,
+);
+
+testcase!(
+    test_reveal_typevar_bound_with_default_in_forall,
+    r#"
+from typing import reveal_type
+
+def f[T: str = str](x: T) -> T: ...
+reveal_type(f)  # E: revealed type: [T: str = str](x: T) -> T
+"#,
+);
+
+testcase!(
+    test_reveal_multiple_typevars_with_bounds_in_forall,
+    r#"
+from typing import reveal_type
+
+def f[T: str, U: int](x: T, y: U) -> tuple[T, U]: ...
+reveal_type(f)  # E: revealed type: [T: str, U: int](x: T, y: U) -> tuple[T, U]
+"#,
+);
+
+testcase!(
+    test_reveal_mixed_typevars_in_forall,
+    r#"
+from typing import reveal_type
+
+def f[T, U: int, V = str](x: T, y: U, z: V) -> tuple[T, U, V]: ...
+reveal_type(f)  # E: revealed type: [T, U: int, V = str](x: T, y: U, z: V) -> tuple[T, U, V]
+"#,
 );


### PR DESCRIPTION
# Summary

Display type variable bounds, constraints, and defaults when formatting forall types. Previously, `reveal_type` showed identical signatures for functions with different type variable restrictions:

```python
def f[T: str](x: T) -> T: ...
def g[T: int](x: T) -> T: ...
reveal_type(f)  # Before: [T](x: T) -> T
reveal_type(g)  # Before: [T](x: T) -> T  (identical!)
```

Now the bounds are shown:

```python
reveal_type(f)  # After: [T: str](x: T) -> T
reveal_type(g)  # After: [T: int](x: T) -> T
```

Also supports:
- Constraints: `[T: (str, int)]`
- Defaults: `[T = int]`
- Combined: `[T: str = str]`

Fixes #2179

# Test Plan

- Added 6 new test cases covering bounds, constraints, defaults, and combinations
- Updated 4 existing tests to reflect the new display format
- Verified locally using the sandbox

<img width="2400" height="1574" alt="image" src="https://github.com/user-attachments/assets/bbcd5080-0641-40c4-a626-80c1f232ac3c" />