### PR TITLE
impl Convert import to relative path / absolute path (and Convert all... variants) #1589

### DIFF
--- a/crates/pyrefly_python/src/module_name.rs
+++ b/crates/pyrefly_python/src/module_name.rs
@@ -399,7 +399,13 @@ impl ModuleName {
                 }
             };
         }
-        Self::from_relative_path_components(components).ok()
+        let module = Self::from_relative_path_components(components).ok()?;
+        // Joining empty components renders one fewer dot, so restore it when there is no suffix.
+        if module.as_str().chars().all(|c| c == '.') {
+            Some(Self::from_string(format!(".{}", module.as_str())))
+        } else {
+            Some(module)
+        }
     }
 
     pub fn append(self, name: &Name) -> Self {
@@ -674,6 +680,9 @@ mod tests {
         assert_module_name("bar.py", "foo/baz.py", ".foo.baz");
         assert_module_name("foo/bar.py", "baz.py", "..baz");
         assert_module_name("foo/bar/boz.py", "baz.py", "...baz");
+        assert_module_name("foo/bar.py", "foo/__init__.py", ".");
+        assert_module_name("foo/bar/baz.py", "foo/__init__.py", "..");
+        assert_module_name("foo/bar.py", "foo/sub/__init__.py", ".sub");
     }
 
     #[test]

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -4784,6 +4784,10 @@ impl Server {
                 )
             );
             timed_refactor_action!(
+                "convert_import",
+                transaction.convert_import_code_actions(&handle, range)
+            );
+            timed_refactor_action!(
                 "introduce_parameter",
                 transaction.introduce_parameter_code_actions(&handle, range)
             );

--- a/pyrefly/lib/state/ide.rs
+++ b/pyrefly/lib/state/ide.rs
@@ -377,7 +377,10 @@ pub(crate) fn insert_import_edit_with_forced_import_format(
 /// For now, we use the following criteria:
 /// 1. Bundled typeshed
 /// 2. In search path or site packages
-fn handle_require_absolute_import(config_finder: &ConfigFinder, handle: &Handle) -> bool {
+pub(crate) fn handle_require_absolute_import(
+    config_finder: &ConfigFinder,
+    handle: &Handle,
+) -> bool {
     if matches!(
         handle.path().details(),
         ModulePathDetails::BundledTypeshed(_)

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3894,6 +3894,13 @@ impl<'a> Transaction<'a> {
     ) -> Option<Vec<LocalRefactorCodeAction>> {
         quick_fixes::change_signature::change_signature_code_actions(self, handle, selection)
     }
+    pub fn convert_import_code_actions(
+        &self,
+        handle: &Handle,
+        selection: TextRange,
+    ) -> Option<Vec<LocalRefactorCodeAction>> {
+        quick_fixes::convert_import::convert_import_code_actions(self, handle, selection)
+    }
 
     /// Determines whether a module is a third-party package.
     ///

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3900,6 +3900,7 @@ impl<'a> Transaction<'a> {
         selection: TextRange,
     ) -> Option<Vec<LocalRefactorCodeAction>> {
         quick_fixes::convert_import::convert_import_code_actions(self, handle, selection)
+            .map(Vec1::into_vec)
     }
 
     /// Determines whether a module is a third-party package.

--- a/pyrefly/lib/state/lsp/quick_fixes.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes.rs
@@ -9,6 +9,7 @@ pub(crate) mod add_override;
 pub(crate) mod assert_not_none;
 pub(crate) mod change_signature;
 pub(crate) mod convert_dict;
+pub(crate) mod convert_import;
 pub(crate) mod convert_star_import;
 pub(crate) mod enum_member;
 pub(crate) mod extract_field;

--- a/pyrefly/lib/state/lsp/quick_fixes/convert_import.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/convert_import.rs
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use dupe::Dupe;
+use lsp_types::CodeActionKind;
+use pyrefly_build::handle::Handle;
+use pyrefly_python::ast::Ast;
+use pyrefly_python::module::Module;
+use pyrefly_python::module_name::ModuleName;
+use ruff_python_ast::Alias;
+use ruff_python_ast::AnyNodeRef;
+use ruff_python_ast::ModModule;
+use ruff_python_ast::Stmt;
+use ruff_python_ast::StmtImport;
+use ruff_python_ast::StmtImportFrom;
+use ruff_python_ast::visitor::Visitor;
+use ruff_text_size::Ranged;
+use ruff_text_size::TextRange;
+use ruff_text_size::TextSize;
+
+use super::extract_shared::line_indent_and_start;
+use super::extract_shared::selection_anchor;
+use crate::state::ide::handle_require_absolute_import;
+use crate::state::lsp::LocalRefactorCodeAction;
+use crate::state::lsp::Transaction;
+
+#[derive(Clone, Copy, Debug)]
+enum ConvertTarget {
+    Relative,
+    Absolute,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ImportStmtRef<'a> {
+    Import(&'a StmtImport),
+    ImportFrom(&'a StmtImportFrom),
+}
+
+pub(crate) fn convert_import_code_actions(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    selection: TextRange,
+) -> Option<Vec<LocalRefactorCodeAction>> {
+    let module_info = transaction.get_module_info(handle)?;
+    let ast = transaction.get_ast(handle)?;
+    let source = module_info.contents();
+    let selection_point = selection_anchor(source, selection);
+    let import_stmt = find_import_stmt(ast.as_ref(), selection_point)?;
+
+    let mut actions = Vec::new();
+    if let Some(action) = convert_single_import_action(
+        transaction,
+        handle,
+        &module_info,
+        source,
+        import_stmt,
+        ConvertTarget::Relative,
+    ) {
+        actions.push(action);
+    }
+    if let Some(action) = convert_single_import_action(
+        transaction,
+        handle,
+        &module_info,
+        source,
+        import_stmt,
+        ConvertTarget::Absolute,
+    ) {
+        actions.push(action);
+    }
+    if let Some(action) = convert_all_imports_action(
+        transaction,
+        handle,
+        &module_info,
+        source,
+        ast.as_ref(),
+        ConvertTarget::Relative,
+    ) {
+        actions.push(action);
+    }
+    if let Some(action) = convert_all_imports_action(
+        transaction,
+        handle,
+        &module_info,
+        source,
+        ast.as_ref(),
+        ConvertTarget::Absolute,
+    ) {
+        actions.push(action);
+    }
+
+    if actions.is_empty() {
+        None
+    } else {
+        actions.sort_by(|a, b| a.title.cmp(&b.title));
+        Some(actions)
+    }
+}
+
+fn convert_single_import_action(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    module_info: &Module,
+    source: &str,
+    stmt: ImportStmtRef<'_>,
+    target: ConvertTarget,
+) -> Option<LocalRefactorCodeAction> {
+    let edit = convert_import_stmt(transaction, handle, source, stmt, target)?;
+    let title = match target {
+        ConvertTarget::Relative => "Convert import to relative path",
+        ConvertTarget::Absolute => "Convert import to absolute path",
+    };
+    Some(LocalRefactorCodeAction {
+        title: title.to_owned(),
+        edits: vec![(module_info.dupe(), edit.0, edit.1)],
+        kind: CodeActionKind::REFACTOR_REWRITE,
+    })
+}
+
+fn convert_all_imports_action(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    module_info: &Module,
+    source: &str,
+    ast: &ModModule,
+    target: ConvertTarget,
+) -> Option<LocalRefactorCodeAction> {
+    let mut edits = Vec::new();
+    for stmt in collect_import_stmts(ast) {
+        if let Some(edit) = convert_import_stmt(transaction, handle, source, stmt, target) {
+            edits.push((module_info.dupe(), edit.0, edit.1));
+        }
+    }
+    if edits.is_empty() {
+        return None;
+    }
+    let title = match target {
+        ConvertTarget::Relative => "Convert all imports to relative path",
+        ConvertTarget::Absolute => "Convert all imports to absolute path",
+    };
+    Some(LocalRefactorCodeAction {
+        title: title.to_owned(),
+        edits,
+        kind: CodeActionKind::REFACTOR_REWRITE,
+    })
+}
+
+fn convert_import_stmt(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    source: &str,
+    stmt: ImportStmtRef<'_>,
+    target: ConvertTarget,
+) -> Option<(TextRange, String)> {
+    let (stmt_range, new_text) = match (stmt, target) {
+        (ImportStmtRef::Import(import), ConvertTarget::Relative) => {
+            let stmt_range = import.range();
+            let indent = line_indent_and_start(source, import.range().start())?.0;
+            let lines = convert_import_to_relative(transaction, handle, import)?;
+            let new_text = join_import_lines(&indent, lines);
+            (stmt_range, new_text)
+        }
+        (ImportStmtRef::ImportFrom(import_from), ConvertTarget::Relative)
+            if import_from.level == 0 =>
+        {
+            let stmt_range = import_from.range();
+            let indent = line_indent_and_start(source, import_from.range().start())?.0;
+            let line = convert_from_import_to_relative(transaction, handle, import_from)?;
+            let new_text = join_import_lines(&indent, vec![line]);
+            (stmt_range, new_text)
+        }
+        (ImportStmtRef::ImportFrom(import_from), ConvertTarget::Absolute)
+            if import_from.level > 0 =>
+        {
+            let stmt_range = import_from.range();
+            let indent = line_indent_and_start(source, import_from.range().start())?.0;
+            let line = convert_from_import_to_absolute(handle, import_from)?;
+            let new_text = join_import_lines(&indent, vec![line]);
+            (stmt_range, new_text)
+        }
+        _ => return None,
+    };
+    Some((stmt_range, new_text))
+}
+
+fn convert_import_to_relative(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    import: &StmtImport,
+) -> Option<Vec<String>> {
+    let mut grouped: Vec<(String, Vec<String>)> = Vec::new();
+    for alias in &import.names {
+        let module_str = alias.name.id.as_str();
+        if module_str.contains('.') && alias.asname.is_none() {
+            return None;
+        }
+        let module_name = ModuleName::from_name(&alias.name.id);
+        let target_handle = transaction
+            .import_handle(handle, module_name, None)
+            .finding()?;
+        if handle_require_absolute_import(transaction.config_finder(), &target_handle) {
+            return None;
+        }
+        let relative_module = relative_module_string(handle, &target_handle)?;
+        let (base, leaf) = split_relative_module(&relative_module, module_str)?;
+        let name_text = render_alias(leaf.as_str(), alias);
+        push_grouped_import(&mut grouped, base, name_text);
+    }
+    if grouped.is_empty() {
+        return None;
+    }
+    Some(
+        grouped
+            .into_iter()
+            .map(|(base, names)| format!("from {base} import {}", names.join(", ")))
+            .collect(),
+    )
+}
+
+fn convert_from_import_to_relative(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    import_from: &StmtImportFrom,
+) -> Option<String> {
+    let module = import_from.module.as_ref()?;
+    let module_name = ModuleName::from_str(module.as_str());
+    let target_handle = transaction
+        .import_handle(handle, module_name, None)
+        .finding()?;
+    if handle_require_absolute_import(transaction.config_finder(), &target_handle) {
+        return None;
+    }
+    let relative_module = relative_module_string(handle, &target_handle)?;
+    let names = render_imported_names(&import_from.names);
+    Some(format!("from {relative_module} import {names}"))
+}
+
+fn convert_from_import_to_absolute(
+    handle: &Handle,
+    import_from: &StmtImportFrom,
+) -> Option<String> {
+    let module = handle.module().new_maybe_relative(
+        handle.path().is_init(),
+        import_from.level,
+        import_from.module.as_ref().map(|module| &module.id),
+    )?;
+    let module_str = module.as_str();
+    if module_str.is_empty() {
+        return None;
+    }
+    let names = render_imported_names(&import_from.names);
+    Some(format!("from {module_str} import {names}"))
+}
+
+fn render_imported_names(names: &[Alias]) -> String {
+    names
+        .iter()
+        .map(|alias| render_alias(alias.name.id.as_str(), alias))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn render_alias(default_name: &str, alias: &Alias) -> String {
+    if let Some(asname) = &alias.asname {
+        format!("{default_name} as {}", asname.id.as_str())
+    } else {
+        default_name.to_owned()
+    }
+}
+
+fn relative_module_string(from: &Handle, to: &Handle) -> Option<String> {
+    let module =
+        ModuleName::relative_module_name_between(from.path().as_path(), to.path().as_path())?;
+    let raw = module.as_str();
+    if raw.is_empty() {
+        Some(".".to_owned())
+    } else {
+        Some(raw.to_owned())
+    }
+}
+
+fn split_relative_module(relative_module: &str, absolute_module: &str) -> Option<(String, String)> {
+    if relative_module == "." {
+        let leaf = absolute_module
+            .rsplit_once('.')
+            .map_or(absolute_module, |(_, leaf)| leaf);
+        return Some((".".to_owned(), leaf.to_owned()));
+    }
+    if let Some((base, leaf)) = relative_module.rsplit_once('.') {
+        let base = if base.is_empty() { "." } else { base };
+        return Some((base.to_owned(), leaf.to_owned()));
+    }
+    Some((".".to_owned(), relative_module.to_owned()))
+}
+
+fn push_grouped_import(grouped: &mut Vec<(String, Vec<String>)>, base: String, name: String) {
+    if let Some((_, names)) = grouped.iter_mut().find(|(key, _)| *key == base) {
+        names.push(name);
+    } else {
+        grouped.push((base, vec![name]));
+    }
+}
+
+fn join_import_lines(indent: &str, lines: Vec<String>) -> String {
+    let mut iter = lines.into_iter();
+    let Some(first) = iter.next() else {
+        return String::new();
+    };
+    if indent.is_empty() {
+        return iter.fold(first, |mut acc, line| {
+            acc.push('\n');
+            acc.push_str(&line);
+            acc
+        });
+    }
+    iter.fold(first, |mut acc, line| {
+        acc.push('\n');
+        acc.push_str(indent);
+        acc.push_str(&line);
+        acc
+    })
+}
+
+fn find_import_stmt(ast: &ModModule, position: TextSize) -> Option<ImportStmtRef<'_>> {
+    for node in Ast::locate_node(ast, position) {
+        match node {
+            AnyNodeRef::StmtImport(import) => return Some(ImportStmtRef::Import(import)),
+            AnyNodeRef::StmtImportFrom(import_from) => {
+                return Some(ImportStmtRef::ImportFrom(import_from));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn collect_import_stmts(ast: &ModModule) -> Vec<ImportStmtRef<'_>> {
+    struct ImportCollector<'a> {
+        imports: Vec<ImportStmtRef<'a>>,
+    }
+
+    impl<'a> Visitor<'a> for ImportCollector<'a> {
+        fn visit_stmt(&mut self, stmt: &'a Stmt) {
+            match stmt {
+                Stmt::Import(import) => self.imports.push(ImportStmtRef::Import(import)),
+                Stmt::ImportFrom(import_from) => {
+                    self.imports.push(ImportStmtRef::ImportFrom(import_from));
+                }
+                _ => {}
+            }
+            ruff_python_ast::visitor::walk_stmt(self, stmt);
+        }
+    }
+
+    let mut collector = ImportCollector {
+        imports: Vec::new(),
+    };
+    collector.visit_body(&ast.body);
+    collector.imports
+}

--- a/pyrefly/lib/state/lsp/quick_fixes/convert_import.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/convert_import.rs
@@ -21,6 +21,7 @@ use ruff_python_ast::visitor::Visitor;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
+use vec1::Vec1;
 
 use super::extract_shared::line_indent_and_start;
 use super::extract_shared::selection_anchor;
@@ -40,11 +41,13 @@ enum ImportStmtRef<'a> {
     ImportFrom(&'a StmtImportFrom),
 }
 
+/// Returns actions only when the selection identifies an import and at least one
+/// selected or file-wide conversion is applicable.
 pub(crate) fn convert_import_code_actions(
     transaction: &Transaction<'_>,
     handle: &Handle,
     selection: TextRange,
-) -> Option<Vec<LocalRefactorCodeAction>> {
+) -> Option<Vec1<LocalRefactorCodeAction>> {
     let module_info = transaction.get_module_info(handle)?;
     let ast = transaction.get_ast(handle)?;
     let source = module_info.contents();
@@ -52,64 +55,36 @@ pub(crate) fn convert_import_code_actions(
     let import_stmt = find_import_stmt(ast.as_ref(), selection_point)?;
 
     let mut actions = Vec::new();
-    if let Some(action) = convert_single_import_action(
-        transaction,
-        handle,
-        &module_info,
-        source,
-        import_stmt,
-        ConvertTarget::Relative,
-    ) {
-        actions.push(action);
-    }
-    if let Some(action) = convert_single_import_action(
-        transaction,
-        handle,
-        &module_info,
-        source,
-        import_stmt,
-        ConvertTarget::Absolute,
-    ) {
-        actions.push(action);
-    }
-    if let Some(action) = convert_all_imports_action(
-        transaction,
-        handle,
-        &module_info,
-        source,
-        ast.as_ref(),
-        ConvertTarget::Relative,
-    ) {
-        actions.push(action);
-    }
-    if let Some(action) = convert_all_imports_action(
-        transaction,
-        handle,
-        &module_info,
-        source,
-        ast.as_ref(),
-        ConvertTarget::Absolute,
-    ) {
-        actions.push(action);
+    for target in [ConvertTarget::Relative, ConvertTarget::Absolute] {
+        actions.extend(build_selected_import_action(
+            transaction,
+            handle,
+            &module_info,
+            import_stmt,
+            target,
+        ));
+        actions.extend(build_all_imports_action(
+            transaction,
+            handle,
+            &module_info,
+            ast.as_ref(),
+            target,
+        ));
     }
 
-    if actions.is_empty() {
-        None
-    } else {
-        actions.sort_by(|a, b| a.title.cmp(&b.title));
-        Some(actions)
-    }
+    actions.sort_by(|a, b| a.title.cmp(&b.title));
+    Vec1::try_from_vec(actions).ok()
 }
 
-fn convert_single_import_action(
+/// Builds an action when the selected statement can be converted to `target`.
+fn build_selected_import_action(
     transaction: &Transaction<'_>,
     handle: &Handle,
     module_info: &Module,
-    source: &str,
     stmt: ImportStmtRef<'_>,
     target: ConvertTarget,
 ) -> Option<LocalRefactorCodeAction> {
-    let edit = convert_import_stmt(transaction, handle, source, stmt, target)?;
+    let edit = rewrite_import(transaction, handle, module_info, stmt, target)?;
     let title = match target {
         ConvertTarget::Relative => "Convert import to relative path",
         ConvertTarget::Absolute => "Convert import to absolute path",
@@ -121,17 +96,17 @@ fn convert_single_import_action(
     })
 }
 
-fn convert_all_imports_action(
+/// Builds an action when at least one import in the file can be converted to `target`.
+fn build_all_imports_action(
     transaction: &Transaction<'_>,
     handle: &Handle,
     module_info: &Module,
-    source: &str,
     ast: &ModModule,
     target: ConvertTarget,
 ) -> Option<LocalRefactorCodeAction> {
     let mut edits = Vec::new();
     for stmt in collect_import_stmts(ast) {
-        if let Some(edit) = convert_import_stmt(transaction, handle, source, stmt, target) {
+        if let Some(edit) = rewrite_import(transaction, handle, module_info, stmt, target) {
             edits.push((module_info.dupe(), edit.0, edit.1));
         }
     }
@@ -149,49 +124,56 @@ fn convert_all_imports_action(
     })
 }
 
-fn convert_import_stmt(
+/// Returns a replacement when the statement has a semantics-preserving conversion to `target`.
+fn rewrite_import(
     transaction: &Transaction<'_>,
     handle: &Handle,
-    source: &str,
+    module_info: &Module,
     stmt: ImportStmtRef<'_>,
     target: ConvertTarget,
 ) -> Option<(TextRange, String)> {
-    let (stmt_range, new_text) = match (stmt, target) {
+    let source = module_info.contents();
+    let stmt_range = match stmt {
+        ImportStmtRef::Import(import) => import.range(),
+        ImportStmtRef::ImportFrom(import_from) => import_from.range(),
+    };
+    // Import statements cannot contain string literals, so any `#` inside the AST range starts a
+    // comment that re-rendering would discard.
+    if module_info.code_at(stmt_range).contains('#') {
+        return None;
+    }
+    let new_text = match (stmt, target) {
         (ImportStmtRef::Import(import), ConvertTarget::Relative) => {
-            let stmt_range = import.range();
             let indent = line_indent_and_start(source, import.range().start())?.0;
-            let lines = convert_import_to_relative(transaction, handle, import)?;
-            let new_text = join_import_lines(&indent, lines);
-            (stmt_range, new_text)
+            let lines = convert_plain_import_to_relative(transaction, handle, import)?;
+            join_import_lines(&indent, lines)
         }
         (ImportStmtRef::ImportFrom(import_from), ConvertTarget::Relative)
             if import_from.level == 0 =>
         {
-            let stmt_range = import_from.range();
             let indent = line_indent_and_start(source, import_from.range().start())?.0;
             let line = convert_from_import_to_relative(transaction, handle, import_from)?;
-            let new_text = join_import_lines(&indent, vec![line]);
-            (stmt_range, new_text)
+            join_import_lines(&indent, Vec1::new(line))
         }
         (ImportStmtRef::ImportFrom(import_from), ConvertTarget::Absolute)
             if import_from.level > 0 =>
         {
-            let stmt_range = import_from.range();
             let indent = line_indent_and_start(source, import_from.range().start())?.0;
             let line = convert_from_import_to_absolute(handle, import_from)?;
-            let new_text = join_import_lines(&indent, vec![line]);
-            (stmt_range, new_text)
+            join_import_lines(&indent, Vec1::new(line))
         }
         _ => return None,
     };
     Some((stmt_range, new_text))
 }
 
-fn convert_import_to_relative(
+/// Converts a plain `import` statement into one or more relative `from` import lines.
+/// Returns `None` if any alias cannot be resolved or safely represented as a relative import.
+fn convert_plain_import_to_relative(
     transaction: &Transaction<'_>,
     handle: &Handle,
     import: &StmtImport,
-) -> Option<Vec<String>> {
+) -> Option<Vec1<String>> {
     let mut grouped: Vec<(String, Vec<String>)> = Vec::new();
     for alias in &import.names {
         let module_str = alias.name.id.as_str();
@@ -199,25 +181,19 @@ fn convert_import_to_relative(
             return None;
         }
         let module_name = ModuleName::from_name(&alias.name.id);
-        let target_handle = transaction
-            .import_handle(handle, module_name, None)
-            .finding()?;
-        if handle_require_absolute_import(transaction.config_finder(), &target_handle) {
-            return None;
-        }
-        let relative_module = relative_module_string(handle, &target_handle)?;
-        let (base, leaf) = split_relative_module(&relative_module, module_str)?;
+        let relative_module = relative_module_for_import(transaction, handle, module_name)?;
+        let (base, leaf) = split_relative_module(&relative_module)?;
         let name_text = render_alias(leaf.as_str(), alias);
         push_grouped_import(&mut grouped, base, name_text);
     }
-    if grouped.is_empty() {
-        return None;
-    }
     Some(
-        grouped
-            .into_iter()
-            .map(|(base, names)| format!("from {base} import {}", names.join(", ")))
-            .collect(),
+        Vec1::try_from_vec(
+            grouped
+                .into_iter()
+                .map(|(base, names)| format!("from {base} import {}", names.join(", ")))
+                .collect(),
+        )
+        .expect("an import statement has at least one alias"),
     )
 }
 
@@ -228,13 +204,7 @@ fn convert_from_import_to_relative(
 ) -> Option<String> {
     let module = import_from.module.as_ref()?;
     let module_name = ModuleName::from_str(module.as_str());
-    let target_handle = transaction
-        .import_handle(handle, module_name, None)
-        .finding()?;
-    if handle_require_absolute_import(transaction.config_finder(), &target_handle) {
-        return None;
-    }
-    let relative_module = relative_module_string(handle, &target_handle)?;
+    let relative_module = relative_module_for_import(transaction, handle, module_name)?;
     let names = render_imported_names(&import_from.names);
     Some(format!("from {relative_module} import {names}"))
 }
@@ -249,6 +219,7 @@ fn convert_from_import_to_absolute(
         import_from.module.as_ref().map(|module| &module.id),
     )?;
     let module_str = module.as_str();
+    // A top-level `from . import ...` has no absolute package name.
     if module_str.is_empty() {
         return None;
     }
@@ -272,29 +243,40 @@ fn render_alias(default_name: &str, alias: &Alias) -> String {
     }
 }
 
-fn relative_module_string(from: &Handle, to: &Handle) -> Option<String> {
-    let module =
-        ModuleName::relative_module_name_between(from.path().as_path(), to.path().as_path())?;
-    let raw = module.as_str();
-    if raw.is_empty() {
-        Some(".".to_owned())
-    } else {
-        Some(raw.to_owned())
+fn relative_module_for_import(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    module_name: ModuleName,
+) -> Option<String> {
+    let target_handle = transaction
+        .import_handle(handle, module_name, None)
+        .finding()?;
+    if handle_require_absolute_import(transaction.config_finder(), &target_handle) {
+        return None;
     }
+    Some(
+        ModuleName::relative_module_name_between(
+            handle.path().as_path(),
+            target_handle.path().as_path(),
+        )?
+        .as_str()
+        .to_owned(),
+    )
 }
 
-fn split_relative_module(relative_module: &str, absolute_module: &str) -> Option<(String, String)> {
-    if relative_module == "." {
-        let leaf = absolute_module
-            .rsplit_once('.')
-            .map_or(absolute_module, |(_, leaf)| leaf);
-        return Some((".".to_owned(), leaf.to_owned()));
+fn split_relative_module(relative_module: &str) -> Option<(String, String)> {
+    let rest = relative_module.trim_start_matches('.');
+    assert!(
+        rest.len() < relative_module.len(),
+        "relative module name must start with a dot"
+    );
+    // A plain import of the current package has no equivalent relative-import spelling.
+    if rest.is_empty() {
+        return None;
     }
-    if let Some((base, leaf)) = relative_module.rsplit_once('.') {
-        let base = if base.is_empty() { "." } else { base };
-        return Some((base.to_owned(), leaf.to_owned()));
-    }
-    Some((".".to_owned(), relative_module.to_owned()))
+    let dots = &relative_module[..relative_module.len() - rest.len()];
+    let (package, leaf) = rest.rsplit_once('.').unwrap_or(("", rest));
+    Some((format!("{dots}{package}"), leaf.to_owned()))
 }
 
 fn push_grouped_import(grouped: &mut Vec<(String, Vec<String>)>, base: String, name: String) {
@@ -305,19 +287,16 @@ fn push_grouped_import(grouped: &mut Vec<(String, Vec<String>)>, base: String, n
     }
 }
 
-fn join_import_lines(indent: &str, lines: Vec<String>) -> String {
-    let mut iter = lines.into_iter();
-    let Some(first) = iter.next() else {
-        return String::new();
-    };
+fn join_import_lines(indent: &str, lines: Vec1<String>) -> String {
+    let (first, remaining) = lines.split_off_first();
     if indent.is_empty() {
-        return iter.fold(first, |mut acc, line| {
+        return remaining.into_iter().fold(first, |mut acc, line| {
             acc.push('\n');
             acc.push_str(&line);
             acc
         });
     }
-    iter.fold(first, |mut acc, line| {
+    remaining.into_iter().fold(first, |mut acc, line| {
         acc.push('\n');
         acc.push_str(indent);
         acc.push_str(&line);

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -606,6 +606,29 @@ fn compute_convert_star_import_actions(
     (module_info, edit_sets, titles)
 }
 
+fn compute_convert_import_actions(
+    code_by_module: &[(&'static str, &str)],
+    module_name: &'static str,
+    selection: TextRange,
+) -> (
+    ModuleInfo,
+    Vec<Vec<(Module, TextRange, String)>>,
+    Vec<String>,
+) {
+    let (handles, state) =
+        mk_multi_file_state_assert_no_errors(code_by_module, Require::Everything);
+    let handle = handles.get(module_name).unwrap();
+    let transaction = state.transaction();
+    let module_info = transaction.get_module_info(handle).unwrap();
+    let actions = transaction
+        .convert_import_code_actions(handle, selection)
+        .unwrap_or_default();
+    let edit_sets: Vec<Vec<(Module, TextRange, String)>> =
+        actions.iter().map(|action| action.edits.clone()).collect();
+    let titles = actions.iter().map(|action| action.title.clone()).collect();
+    (module_info, edit_sets, titles)
+}
+
 fn compute_pull_up_actions(
     code: &str,
 ) -> (
@@ -5826,4 +5849,106 @@ class Derived(Base):
         return 2
 ";
     assert_eq!(expected, after);
+}
+
+#[test]
+fn convert_from_import_to_relative() {
+    let code_a = r#"
+# IMPORT-START
+from pkg.b import Foo
+# IMPORT-END
+"#;
+    let code_b = "class Foo: ...\n";
+    let selection = find_marked_range_with(code_a, "# IMPORT-START", "# IMPORT-END");
+    let (module_info, actions, titles) =
+        compute_convert_import_actions(&[("pkg.a", code_a), ("pkg.b", code_b)], "pkg.a", selection);
+    assert!(
+        titles
+            .iter()
+            .any(|title| title == "Convert import to relative path"),
+        "expected relative import code action"
+    );
+    assert!(
+        titles
+            .iter()
+            .any(|title| title == "Convert all imports to relative path"),
+        "expected convert-all relative code action"
+    );
+    let idx = titles
+        .iter()
+        .position(|title| title == "Convert import to relative path")
+        .unwrap();
+    let updated = apply_refactor_edits_for_module(&module_info, &actions[idx]);
+    let expected = r#"
+# IMPORT-START
+from .b import Foo
+# IMPORT-END
+"#;
+    assert_eq!(expected.trim(), updated.trim());
+}
+
+#[test]
+fn convert_from_import_to_absolute() {
+    let code_a = r#"
+# IMPORT-START
+from .b import Foo
+# IMPORT-END
+"#;
+    let code_b = "class Foo: ...\n";
+    let selection = find_marked_range_with(code_a, "# IMPORT-START", "# IMPORT-END");
+    let (module_info, actions, titles) =
+        compute_convert_import_actions(&[("pkg.a", code_a), ("pkg.b", code_b)], "pkg.a", selection);
+    assert!(
+        titles
+            .iter()
+            .any(|title| title == "Convert import to absolute path"),
+        "expected absolute import code action"
+    );
+    assert!(
+        titles
+            .iter()
+            .any(|title| title == "Convert all imports to absolute path"),
+        "expected convert-all absolute code action"
+    );
+    let idx = titles
+        .iter()
+        .position(|title| title == "Convert import to absolute path")
+        .unwrap();
+    let updated = apply_refactor_edits_for_module(&module_info, &actions[idx]);
+    let expected = r#"
+# IMPORT-START
+from pkg.b import Foo
+# IMPORT-END
+"#;
+    assert_eq!(expected.trim(), updated.trim());
+}
+
+#[test]
+fn convert_import_statement_to_relative() {
+    let code_a = r#"
+# IMPORT-START
+import pkg.b as mod_b
+# IMPORT-END
+"#;
+    let code_b = "class Foo: ...\n";
+    let selection = find_marked_range_with(code_a, "# IMPORT-START", "# IMPORT-END");
+    let (module_info, actions, titles) =
+        compute_convert_import_actions(&[("pkg.a", code_a), ("pkg.b", code_b)], "pkg.a", selection);
+    assert!(
+        titles
+            .iter()
+            .any(|title| title == "Convert import to relative path"),
+        "expected relative import code action"
+    );
+    let idx = titles
+        .iter()
+        .position(|title| title == "Convert import to relative path")
+        .unwrap();
+    let updated = apply_refactor_edits_for_module(&module_info, &actions[idx]);
+    let expected = r#"
+# IMPORT-START
+from . import b as mod_b
+# IMPORT-END
+"#;
+    assert_eq!(expected.trim(), updated.trim());
 }

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -5952,3 +5952,209 @@ from . import b as mod_b
 "#;
     assert_eq!(expected.trim(), updated.trim());
 }
+
+#[test]
+fn convert_multi_level_import_to_relative() {
+    let code = r#"
+# IMPORT-START
+import baz
+# IMPORT-END
+"#;
+    let selection = find_marked_range_with(code, "# IMPORT-START", "# IMPORT-END");
+    let (module_info, actions, titles) =
+        compute_convert_import_actions(&[("foo.bar", code), ("baz", "")], "foo.bar", selection);
+    let idx = titles
+        .iter()
+        .position(|title| title == "Convert import to relative path")
+        .expect("expected relative import code action");
+    let updated = apply_refactor_edits_for_module(&module_info, &actions[idx]);
+    let expected = r#"
+# IMPORT-START
+from .. import baz
+# IMPORT-END
+"#;
+    assert_eq!(expected.trim(), updated.trim());
+}
+
+#[test]
+fn convert_relative_import_without_module_to_absolute() {
+    let code = r#"
+# IMPORT-START
+from . import b
+# IMPORT-END
+"#;
+    let selection = find_marked_range_with(code, "# IMPORT-START", "# IMPORT-END");
+    let mut test_env = TestEnv::new();
+    test_env.add_with_path("pkg", "pkg/__init__.py", "");
+    test_env.add("pkg.a", code);
+    test_env.add("pkg.b", "");
+    let (state, get_handle) = test_env.to_state();
+    let handle = get_handle("pkg.a");
+    let transaction = state.transaction();
+    let module_info = transaction.get_module_info(&handle).unwrap();
+    let actions = transaction
+        .convert_import_code_actions(&handle, selection)
+        .expect("expected import code actions");
+    let action = actions
+        .iter()
+        .find(|action| action.title == "Convert import to absolute path")
+        .expect("expected absolute import code action");
+    let updated = apply_refactor_edits_for_module(&module_info, &action.edits);
+    let expected = r#"
+# IMPORT-START
+from pkg import b
+# IMPORT-END
+"#;
+    assert_eq!(expected.trim(), updated.trim());
+}
+
+#[test]
+fn convert_grouped_import_to_relative() {
+    let code = r#"
+# IMPORT-START
+import pkg.a as x, pkg.b as y
+# IMPORT-END
+"#;
+    let selection = find_marked_range_with(code, "# IMPORT-START", "# IMPORT-END");
+    let (module_info, actions, titles) = compute_convert_import_actions(
+        &[("pkg.main", code), ("pkg.a", ""), ("pkg.b", "")],
+        "pkg.main",
+        selection,
+    );
+    let idx = titles
+        .iter()
+        .position(|title| title == "Convert import to relative path")
+        .expect("expected relative import code action");
+    let updated = apply_refactor_edits_for_module(&module_info, &actions[idx]);
+    let expected = r#"
+# IMPORT-START
+from . import a as x, b as y
+# IMPORT-END
+"#;
+    assert_eq!(expected.trim(), updated.trim());
+}
+
+#[test]
+fn convert_all_imports_in_nested_scopes() {
+    let code = r#"
+# IMPORT-START
+import pkg.a as x
+# IMPORT-END
+
+def f():
+    import pkg.b as y
+"#;
+    let selection = find_marked_range_with(code, "# IMPORT-START", "# IMPORT-END");
+    let (module_info, actions, titles) = compute_convert_import_actions(
+        &[("pkg.main", code), ("pkg.a", ""), ("pkg.b", "")],
+        "pkg.main",
+        selection,
+    );
+    let idx = titles
+        .iter()
+        .position(|title| title == "Convert all imports to relative path")
+        .expect("expected convert-all relative import code action");
+    let updated = apply_refactor_edits_for_module(&module_info, &actions[idx]);
+    let expected = r#"
+# IMPORT-START
+from . import a as x
+# IMPORT-END
+
+def f():
+    from . import b as y
+"#;
+    assert_eq!(expected.trim(), updated.trim());
+}
+
+#[test]
+fn convert_import_does_not_drop_comments() {
+    let code = r#"
+# IMPORT-START
+from pkg.b import (
+    Foo,  # keep this comment
+)
+# IMPORT-END
+"#;
+    let selection = find_marked_range_with(code, "# IMPORT-START", "# IMPORT-END");
+    let (_, _, titles) = compute_convert_import_actions(
+        &[("pkg.a", code), ("pkg.b", "Foo = 0")],
+        "pkg.a",
+        selection,
+    );
+    assert!(
+        !titles.iter().any(|title| title.contains("relative path")),
+        "comment-bearing import should not have a lossy relative rewrite"
+    );
+}
+
+#[test]
+fn convert_stdlib_import_to_relative_is_not_offered() {
+    let code = r#"
+# IMPORT-START
+import typing
+# IMPORT-END
+"#;
+    let selection = find_marked_range_with(code, "# IMPORT-START", "# IMPORT-END");
+    let (_, _, titles) = compute_convert_import_actions(&[("main", code)], "main", selection);
+    assert!(
+        !titles.iter().any(|title| title.contains("relative path")),
+        "stdlib imports must remain absolute"
+    );
+}
+
+#[test]
+fn convert_import_from_init_to_absolute() {
+    let code = r#"
+# IMPORT-START
+from . import child
+# IMPORT-END
+"#;
+    let mut test_env = TestEnv::new();
+    test_env.add_with_path("pkg", "pkg/__init__.py", code);
+    test_env.add("pkg.child", "");
+    let (state, get_handle) = test_env.to_state();
+    let handle = get_handle("pkg");
+    let transaction = state.transaction();
+    let module_info = transaction.get_module_info(&handle).unwrap();
+    let selection = find_marked_range_with(code, "# IMPORT-START", "# IMPORT-END");
+    let actions = transaction
+        .convert_import_code_actions(&handle, selection)
+        .expect("expected import code actions");
+    let action = actions
+        .iter()
+        .find(|action| action.title == "Convert import to absolute path")
+        .expect("expected absolute import code action");
+    let updated = apply_refactor_edits_for_module(&module_info, &action.edits);
+    let expected = r#"
+# IMPORT-START
+from pkg import child
+# IMPORT-END
+"#;
+    assert_eq!(expected.trim(), updated.trim());
+}
+
+#[test]
+fn convert_import_of_current_package_to_relative_is_not_offered() {
+    let code = r#"
+# IMPORT-START
+import pkg
+# IMPORT-END
+"#;
+    let mut test_env = TestEnv::new();
+    test_env.add_with_path("pkg", "pkg/__init__.py", "");
+    test_env.add("pkg.child", code);
+    let (state, get_handle) = test_env.to_state();
+    let handle = get_handle("pkg.child");
+    let selection = find_marked_range_with(code, "# IMPORT-START", "# IMPORT-END");
+    let titles: Vec<String> = state
+        .transaction()
+        .convert_import_code_actions(&handle, selection)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|action| action.title)
+        .collect();
+    assert!(
+        !titles.iter().any(|title| title.contains("relative path")),
+        "the current package cannot be represented by a relative plain import"
+    );
+}


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes part of #1589

Added convert‑import code actions (single + all) for relative/absolute paths, wired them into LSP.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added tests for both from and import forms.
