### PR TITLE
record failed lookups

### DIFF
--- a/pyrefly/lib/alt/class/classdef.rs
+++ b/pyrefly/lib/alt/class/classdef.rs
@@ -25,6 +25,7 @@ use crate::alt::types::class_bases::ClassBases;
 use crate::alt::types::class_metadata::ClassMetadata;
 use crate::alt::types::class_metadata::ClassMro;
 use crate::alt::types::class_metadata::EnumMetadata;
+use crate::binding::binding::AnyExportedKey;
 use crate::binding::binding::KeyAbstractClassCheck;
 use crate::binding::binding::KeyClassBaseType;
 use crate::binding::binding::KeyClassField;
@@ -102,23 +103,41 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     }
 
     pub fn get_metadata_for_class(&self, cls: &Class) -> Arc<ClassMetadata> {
-        self.get_from_class(cls, &KeyClassMetadata(cls.index()))
-            .unwrap_or_else(|| Arc::new(ClassMetadata::recursive()))
+        let key = KeyClassMetadata(cls.index());
+        self.get_from_class(cls, &key).unwrap_or_else(|| {
+            self.exports
+                .record_failed_export(cls.module_name(), AnyExportedKey::KeyClassMetadata(key));
+            Arc::new(ClassMetadata::recursive())
+        })
     }
 
     pub fn get_abstract_members_for_class(&self, cls: &Class) -> Arc<AbstractClassMembers> {
-        self.get_from_class(cls, &KeyAbstractClassCheck(cls.index()))
-            .unwrap_or_else(|| Arc::new(AbstractClassMembers::recursive()))
+        let key = KeyAbstractClassCheck(cls.index());
+        self.get_from_class(cls, &key).unwrap_or_else(|| {
+            self.exports.record_failed_export(
+                cls.module_name(),
+                AnyExportedKey::KeyAbstractClassCheck(key),
+            );
+            Arc::new(AbstractClassMembers::recursive())
+        })
     }
 
     pub fn get_base_types_for_class(&self, cls: &Class) -> Arc<ClassBases> {
-        self.get_from_class(cls, &KeyClassBaseType(cls.index()))
-            .unwrap_or_else(|| Arc::new(ClassBases::recursive()))
+        let key = KeyClassBaseType(cls.index());
+        self.get_from_class(cls, &key).unwrap_or_else(|| {
+            self.exports
+                .record_failed_export(cls.module_name(), AnyExportedKey::KeyClassBaseType(key));
+            Arc::new(ClassBases::recursive())
+        })
     }
 
     pub fn get_mro_for_class(&self, cls: &Class) -> Arc<ClassMro> {
-        self.get_from_class(cls, &KeyClassMro(cls.index()))
-            .unwrap_or_else(|| Arc::new(ClassMro::recursive()))
+        let key = KeyClassMro(cls.index());
+        self.get_from_class(cls, &key).unwrap_or_else(|| {
+            self.exports
+                .record_failed_export(cls.module_name(), AnyExportedKey::KeyClassMro(key));
+            Arc::new(ClassMro::recursive())
+        })
     }
 
     pub fn get_class_field_map(&self, cls: &Class) -> SmallMap<Name, Arc<ClassField>> {

--- a/pyrefly/lib/export/exports.rs
+++ b/pyrefly/lib/export/exports.rs
@@ -23,6 +23,7 @@ use ruff_text_size::TextRange;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 
+use crate::binding::binding::AnyExportedKey;
 use crate::export::definitions::DefinitionStyle;
 use crate::export::definitions::Definitions;
 use crate::export::definitions::DunderAllEntry;
@@ -36,6 +37,16 @@ use crate::state::loader::FindingOrError;
 pub trait LookupExport {
     /// Get the exports of a given module, or an error if the module is not available.
     fn get(&self, module: ModuleName) -> FindingOrError<Exports>;
+
+    /// Record a failed export lookup for incremental invalidation.
+    ///
+    /// When `from module import name` fails because `name` is not in `module`'s exports,
+    /// call this so that the importer is invalidated when `module` later exports `name`.
+    ///
+    /// The default implementation is a no-op, suitable for test environments.
+    fn record_failed_export(&self, _module: ModuleName, _key: AnyExportedKey) {
+        // Default no-op
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Summary:
# This stack

This stack modifies the optimization for incremental updates found in the stack containing D90647539.

Original optimization: Use import statements alone to understand which imports a module uses

Problem: `import foo` will always invalidate `foo`

This stack will modify this optimization to instead track these dependencies based on usages during solve. Every type depended on from a module will be referenced in solve and we only will need to invalidate an entire module when there is an import *.

# This diff
This new API on `LookupExport` allows us to track any time an import or attribute-lookup failed.

In the next diff, we will implement it in `state.rs` to add these failed exports to the map. Without these, our incremental system will not know what to invalidate.

Note: we have to track all export keys entirely, hence the tests in D91172436.

Differential Revision: D91173578


