### PR TITLE
Actually expose the `commentFoldingRanges` setting

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -216,6 +216,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "If true (default), Pyrefly will stream diagnostics as they become available during recheck, providing incremental feedback. Set to false to only publish diagnostics after the full recheck completes. This is a global setting that applies to all workspaces."
+                },
+                "pyrefly.commentFoldingRanges": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Controls whether comment section folding ranges are included in the editor. When true, comments following the pattern '# Section Name ----' (with 4+ trailing dashes) create collapsible regions, similar to R's code section convention."
                 }
             }
         }

--- a/website/docs/IDE.mdx
+++ b/website/docs/IDE.mdx
@@ -48,7 +48,7 @@ The following configuration options are IDE-specific and exposed as VSCode setti
 - Control hover tooltip links
   - `python.analysis.showHoverGoToLinks` [boolean: true]: Controls whether hover tooltips include "Go to definition" and "Go to type definition" navigation links. Set to `false` for cleaner tooltips with only type information.
 - Control comment section folding
-  - `commentFoldingRanges` [boolean: false]: Controls whether comment section folding ranges are included in the editor. When `true`, comments following the pattern `# Section Name ----` (with 4+ trailing dashes) create collapsible regions, similar to R's code section convention. Set to `true` to enable this feature.
+  - `pyrefly.commentFoldingRanges` [boolean: false]: Controls whether comment section folding ranges are included in the editor. When `true`, comments following the pattern `# Section Name ----` (with 4+ trailing dashes) create collapsible regions, similar to R's code section convention. Set to `true` to enable this feature.
 
 When used with non-VSCode editors, these options can also be configured by sending them via `initializationOptions` in the LSP [initialization](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize) request.
 


### PR DESCRIPTION
# Summary

The `commentFoldingRanges` setting was implemented in the LSP server in https://github.com/facebook/pyrefly/commit/f71dbd180ad41316c620268a2fcd0dbcbbf5f12b and documented in https://github.com/facebook/pyrefly/commit/e7295fbb2dbcebecca280643f215875a18be78a7 but *not exposed* in VSCode's settings UI, making it undiscoverable.

**Changes:**
- Added `pyrefly.commentFoldingRanges` boolean configuration to `lsp/package.json` (default: false)
- Updated `website/docs/IDE.mdx` to specify exact setting name

Users can now enable comment section folding (comments matching `# Section Name ----`) via VSCode settings UI.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
