### PR TITLE
Fix intersection logic for final classes and Enums

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -132,6 +132,25 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             if fallback.is_never() {
                 fallback
             } else {
+                let is_effectively_final = |ty: &Type| {
+                    if let Type::ClassType(cls) = ty {
+                        let class = cls.class_object();
+                        if self.get_metadata_for_class(class).is_final() {
+                            return true;
+                        }
+                        if self.get_enum_from_class(class).is_some()
+                            && !self.get_enum_members(class).is_empty()
+                        {
+                            return true;
+                        }
+                    }
+                    false
+                };
+
+                if is_effectively_final(left) || is_effectively_final(right) {
+                    return Type::never();
+                }
+
                 let left_base = self.disjoint_base(left);
                 let right_base = self.disjoint_base(right);
                 if self.has_superclass(left_base, right_base)

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -795,6 +795,42 @@ def g(x):
 );
 
 testcase!(
+    test_isinstance_final_intersection,
+    r#"
+from typing import assert_never, final
+
+@final
+class A: ...
+class B: ...
+
+def f(x: A):
+    if isinstance(x, B):
+        assert_never(x)
+    "#,
+);
+
+testcase!(
+    test_isinstance_enum_intersection,
+    r#"
+from enum import Enum
+from typing import assert_never, reveal_type
+
+class E1(Enum):
+    pass
+
+class E2(Enum):
+    X = 1
+
+class A: ...
+
+def f(x: A):
+    if isinstance(x, E1):
+        reveal_type(x) # E: A & E1
+    if isinstance(x, E2):
+        assert_never(x)
+    "#,
+);
+testcase!(
     test_isinstance_tuple,
     r#"
 from typing import assert_type


### PR DESCRIPTION
#Summary
Corrects intersection logic to identify empty intersections (`Never`) for `@final` classes and populated `Enum`s, as they cannot be subclassed. Empty Enums remain non-final per the specification.

Fixes #1591

# Test Plan
Added regression tests in [pyrefly/lib/test/narrow.rs]
- `test_isinstance_final_intersection`
- `test_isinstance_enum_intersection`

Verified with:
- `python3 test.py` (all passed)