### PR TITLE
Fix sandbox output panel disappearing when resize handle dragged fully down

### DIFF
--- a/website/src/sandbox/Sandbox.tsx
+++ b/website/src/sandbox/Sandbox.tsx
@@ -87,7 +87,10 @@ interface SandboxProps {
 
 // Minimum heights for editor and results panes (in pixels)
 const MIN_EDITOR_HEIGHT = 100;
-const MIN_RESULTS_HEIGHT = 60;
+// Results panel needs enough height to show the tab bar and remain draggable
+const MIN_RESULTS_HEIGHT = 120;
+// Height of the resize handle between editor and results
+const RESIZE_HANDLE_HEIGHT = 6;
 
 export default function Sandbox({
     sampleFilename,
@@ -381,7 +384,9 @@ export default function Sandbox({
                 if (newContainerHeight > 0 && editorHeight !== null) {
                     // Clamp the editor height to stay within valid bounds
                     const maxEditorHeight =
-                        newContainerHeight - MIN_RESULTS_HEIGHT;
+                        newContainerHeight -
+                        MIN_RESULTS_HEIGHT -
+                        RESIZE_HANDLE_HEIGHT;
                     const clampedHeight = Math.max(
                         MIN_EDITOR_HEIGHT,
                         Math.min(editorHeight, maxEditorHeight)
@@ -412,8 +417,9 @@ export default function Sandbox({
             const mouseY = e.clientY;
             const newEditorHeight = mouseY - containerTop;
 
-            // Enforce minimum heights
-            const maxEditorHeight = containerHeight - MIN_RESULTS_HEIGHT;
+            // Enforce minimum heights (accounting for resize handle between editor and results)
+            const maxEditorHeight =
+                containerHeight - MIN_RESULTS_HEIGHT - RESIZE_HANDLE_HEIGHT;
             const clampedEditorHeight = Math.max(
                 MIN_EDITOR_HEIGHT,
                 Math.min(newEditorHeight, maxEditorHeight)
@@ -1450,6 +1456,9 @@ const styles = stylex.create({
         display: 'flex',
         flexDirection: 'column',
         flex: 1,
+        height: '100vh', // Fixed viewport height to prevent container from growing infinitely
+        maxHeight: '100vh',
+        overflow: 'hidden',
     },
     sandboxPadding: {
         paddingHorizontal: '10px',
@@ -1624,6 +1633,7 @@ const styles = stylex.create({
         flexDirection: 'column',
         flex: 1,
         minHeight: 0, // Allow flex children to shrink below content size
+        overflow: 'hidden', // Prevent content from pushing container beyond viewport
     },
     // Draggable resize handle between editor and results
     resizeHandle: {


### PR DESCRIPTION
# Summary

The sandbox output panel ("Type Checking Errors" / "Runtime Output") could be dragged completely out of view when using the resize handle, with no way to recover it without refreshing the page.

Fixes #2211

# Test Plan

1. Run the sandbox locally (`npm run start` in website directory)
3. Drag the resize handle between the editor and output panel all the way down
4. Verify the output panel stops at a minimum height and remains visible
5. Verify you can drag it back up
6. Verify normal resizing still works smoothly
