### PR TITLE
Fix not inferring legacy TypeVar in a `var: Callable[...]` annotation (without assignment)

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -3846,8 +3846,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     Type::ClassDef(cls.dupe())
                 }
             },
-            Binding::AnnotatedType(ann, val) => match &self.get_idx(*ann).ty(self.stdlib) {
-                Some(ty) => (*ty).clone(),
+            Binding::AnnotatedType(ann, val) => match self.get_idx(*ann).ty(self.stdlib) {
+                Some(ty) => self.wrap_callable_legacy_typevars(ty),
                 None => self.binding_to_type(val, errors),
             },
             Binding::Type(x) => x.clone(),

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -61,6 +61,30 @@ f("hello")  # E: `str` is not assignable to upper bound `int` of type variable `
 );
 
 testcase!(
+    test_callable_annotation_only_typevar,
+    TestEnv::one_with_path(
+        "foo",
+        "foo.pyi",
+        r#"
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+require_GET: Callable[[F], F]
+"#
+    ),
+    r#"
+from typing import reveal_type
+from foo import require_GET
+def view() -> None:
+    return None
+reveal_type(require_GET)  # E: revealed type: [F: (...) -> Any](F) -> F
+reveal_type(require_GET(view))  # E: revealed type: () -> None
+"#,
+);
+
+testcase!(
     test_list_of_callables_variable_typevar_annotation,
     r#"
 from typing import Callable, TypeVar, assert_type, reveal_type


### PR DESCRIPTION
Fix #2118. Since this issue is blocking my experimentation with pyrefly, I decided to see if I can figure out the problem. After looking at the previous fix and some debugging I think I found the issue and did the "obvious" fix, although admittedly I don't fully understand the details so it might be wrong. Maybe @asukaminato0721 (the author of 59098f44a5dba811b645214ba06d6ed157210415) would be kind enough to see if it makes sense.

---

The commit 59098f44a5dba811b645214ba06d6ed157210415 fixed issue #1555 but only added the `wrap_callable_legacy_typevars` for `NameAssign` bindings. However, I believe the same thing happens with `AnnotatedType` bindings as can appear in stubs. So the following was fixed:

```py
require_GET: Callable[[F], F] = lambda x: x
```

but not

```py
require_GET: Callable[[F], F] = ...
require_GET: Callable[[F], F]
```

# Summary

<!-- Describe the change in this PR -->

Fixes #2118

# Test Plan

I added a test for the original minimal reproducer.

I also ran it on my project which originally showed the issue and it is fixed without visible regressions.