### PR TITLE
Fix SelfType attribute lookup when base class is Any

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -1512,7 +1512,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             AttributeBase1::SelfType(cls) => match self.get_self_attribute(cls, attr_name) {
                 Some(attr) => acc.found_class_attribute(attr, base),
-                None => acc.not_found(NotFoundOn::ClassInstance(cls.class_object().dupe(), base)),
+                None => {
+                    let metadata = self.get_metadata_for_class(cls.class_object());
+                    if metadata.has_base_any() {
+                        acc.found_type(Type::Any(AnyStyle::Implicit), base)
+                    } else {
+                        acc.not_found(NotFoundOn::ClassInstance(cls.class_object().dupe(), base))
+                    }
+                }
             },
             AttributeBase1::Intersect(bases, fallback) => {
                 // For now, only handle the simplest case: if exactly one base has a successful lookup, use it.

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -1054,6 +1054,16 @@ class Test(B):
 );
 
 testcase!(
+    test_any_as_base_class_suppresses_missing_attribute_in_method,
+    r#"
+from typing import Any
+class MyTest(Any):
+    def foo(self):
+        self.bar()  # should not error: Any is in base-class hierarchy
+"#,
+);
+
+testcase!(
     test_field_using_method_scope_type_variable,
     r#"
 from typing import assert_type, Any


### PR DESCRIPTION
# Summary

Fixes #2269.

### What changed
- When looking up attributes from `AttributeBase1::SelfType`, if the underlying class has `Any` in its base hierarchy, fall back to `Any` instead of reporting `missing-attribute`.

### Why
Pyrefly already suppresses missing-attribute errors for other attribute bases when `has_base_any()` is true, but `SelfType` didn’t apply the same rule. This caused a `missing-attribute` error inside methods for classes inheriting from `Any`.

### Tests
- Added `test_any_as_base_class_suppresses_missing_attribute_in_method`
- `cargo test` passes

# Test Plan

- `cargo test`