### PR TITLE
fix Resolve __call__ correctly even when it's a descriptor #254

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -301,8 +301,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             self.as_call_target_impl(ty, Some(quantified), dunder_call)
                         })
                 } else if dunder_call {
-                    // Avoid infinite recursion
-                    CallTargetLookup::Error(vec![])
+                    self.instance_as_dunder_call(&cls).map_or(
+                        CallTargetLookup::Error(vec![]),
+                        |ty| {
+                            let is_self_recursive = matches!(&ty, Type::ClassType(inner) if inner == &cls)
+                                || matches!(&ty, Type::SelfType(inner) if inner.class_object() == cls.class_object());
+                            if is_self_recursive {
+                                CallTargetLookup::Error(vec![])
+                            } else {
+                                self.as_call_target_impl(ty, quantified, /* dunder_call */ true)
+                            }
+                        },
+                    )
                 } else {
                     self.instance_as_dunder_call(&cls).map_or(
                         CallTargetLookup::Error(vec![]),

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -4228,14 +4228,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     /// Return `__call__` as a bound method if instances of `cls` have `__call__`.
     /// This is what the runtime automatically does when we try to call an instance.
     pub fn instance_as_dunder_call(&self, cls: &ClassType) -> Option<Type> {
-        self.get_instance_attribute(cls, &dunder::CALL)
-            .and_then(|attr| attr.as_instance_method())
+        let attr = self.get_instance_attribute(cls, &dunder::CALL)?;
+        self.resolve_dunder_call_attr(attr)
     }
 
     /// Return `__call__` as bound method when called on `Self`.
     pub fn self_as_dunder_call(&self, cls: &ClassType) -> Option<Type> {
-        self.get_self_attribute(cls, &dunder::CALL)
-            .and_then(|attr| attr.as_instance_method())
+        let attr = self.get_self_attribute(cls, &dunder::CALL)?;
+        self.resolve_dunder_call_attr(attr)
     }
 
     /// Return `__call__` as a bound method if instances of `type_var` have `__call__`.
@@ -4246,8 +4246,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         quantified: Quantified,
         upper_bound: &ClassType,
     ) -> Option<Type> {
-        self.get_bounded_quantified_attribute(quantified, upper_bound, &dunder::CALL)
-            .and_then(|attr| attr.as_instance_method())
+        let attr = self.get_bounded_quantified_attribute(quantified, upper_bound, &dunder::CALL)?;
+        self.resolve_dunder_call_attr(attr)
     }
 
     fn callable_params_and_flags(mut ty: Type) -> Option<(ParamList, FuncFlags)> {
@@ -4263,5 +4263,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             _ => None,
         }?;
         Some((params, flags))
+    }
+
+    fn resolve_dunder_call_attr(&self, attr: ClassAttribute) -> Option<Type> {
+        let errors = self.error_swallower();
+        let fake_range = TextRange::default();
+        self.resolve_get_class_attr(&dunder::CALL, attr, fake_range, &errors, None)
+            .ok()
     }
 }

--- a/pyrefly/lib/test/descriptors.rs
+++ b/pyrefly/lib/test/descriptors.rs
@@ -202,6 +202,23 @@ C().d = 42  # E:  Attribute `d` of class `C` is a read-only descriptor with no `
     "#,
 );
 
+testcase!(
+    test_descriptor_dunder_call,
+    r#"
+from typing import assert_type
+class SomeCallable:
+    def __call__(self, x: int) -> str:
+        return "a"
+class Descriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> SomeCallable:
+        return SomeCallable()
+class B:
+    __call__: Descriptor = Descriptor()
+b_instance = B()
+assert_type(b_instance(1), str)
+    "#,
+);
+
 // Test that instance-only attributes with descriptor types are not treated as descriptors.
 // Descriptor protocol only applies to class-body initialized attributes; both annotation-only
 // and method-initialized attributes should allow assignment.


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #254

Implemented descriptor-aware `__call__` resolution.

instance `__call__` lookup now resolves through normal attribute get semantics (including descriptors/properties) via `resolve_get_class_attr` with an error swallower, so a descriptor’s `__get__` return type is used for callability.

in `as_call_target_impl`, when dunder_call is true, we now re-resolve `__call__` once if it doesn’t immediately recurse back to the same class, preventing false “not callable” while still guarding against infinite recursion.



# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added a regression test for issue #254.