### PR TITLE
fix pyrefly does not track mapping keys after explicit check #289

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -1201,7 +1201,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     (Some(_), None) => return type_info.clone(),
                     (None, _) => self.force_for_narrowing(type_info.ty(), range, errors),
                 };
-                if matches!(base_ty, Type::TypedDict(_)) {
+                if self.is_dict_like(&base_ty) {
                     let key_facet = FacetKind::Key(key.to_string());
                     let facets = match resolved_chain {
                         Some(chain) => {
@@ -1229,7 +1229,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     (Some(_), None) => return type_info.clone(),
                     (None, _) => self.force_for_narrowing(type_info.ty(), range, errors),
                 };
-                if matches!(base_ty, Type::TypedDict(_)) {
+                if self.is_dict_like(&base_ty) {
                     let key_facet = FacetKind::Key(key.to_string());
                     let facets = match resolved_chain {
                         Some(chain) => {

--- a/pyrefly/lib/test/subscript_narrow.rs
+++ b/pyrefly/lib/test/subscript_narrow.rs
@@ -216,6 +216,20 @@ def use2(mapping: dict[str, int | None]) -> None:
 );
 
 testcase!(
+    test_dict_contains_literal_key_get_narrow,
+    r#"
+from typing import assert_type
+
+def use(options: dict[str, str]) -> None:
+    if "contains" in options:
+        assert_type(options.get("contains"), str)
+        assert_type(options["contains"], str)
+    else:
+        assert_type(options.get("contains"), str | None)
+"#,
+);
+
+testcase!(
     test_typeddict_get_literal_key_narrow,
     TestEnv::new().enable_not_required_key_access_error(),
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #289

Expanded key‑existence narrowing to dict‑like types so "key" in mapping now makes mapping.get("key") return the value type (not None)


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added a regression test for the dict case. This matches the expected behavior described in issue 289.