### PR TITLE
[conformance] Disallow repeated type alias declaration in type stmt

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -824,6 +824,17 @@
     },
     {
       "code": -2,
+      "column": 6,
+      "concise_description": "Cannot redefine existing name `BadTypeAlias14` as a type alias",
+      "description": "Cannot redefine existing name `BadTypeAlias14` as a type alias",
+      "line": 52,
+      "name": "redefinition",
+      "severity": "error",
+      "stop_column": 20,
+      "stop_line": 52
+    },
+    {
+      "code": -2,
       "column": 5,
       "concise_description": "`type` statement is not allowed in this context",
       "description": "`type` statement is not allowed in this context",

--- a/conformance/third_party/conformance.result
+++ b/conformance/third_party/conformance.result
@@ -25,7 +25,6 @@
   "aliases_type_statement.py": [
     "Line 82: Expected 1 errors",
     "Line 84: Expected 1 errors",
-    "Lines 51, 52: Expected error (tag 'TA14')",
     "Lines 88, 89: Expected error (tag 'RTA6+')"
   ],
   "aliases_typealiastype.py": [

--- a/conformance/third_party/results.json
+++ b/conformance/third_party/results.json
@@ -3,7 +3,7 @@
   "pass": 109,
   "fail": 29,
   "pass_rate": 0.79,
-  "differences": 128,
+  "differences": 127,
   "passing": [
     "aliases_explicit.py",
     "aliases_newtype.py",
@@ -118,7 +118,7 @@
   "failing": {
     "aliases_implicit.py": 5,
     "aliases_recursive.py": 11,
-    "aliases_type_statement.py": 4,
+    "aliases_type_statement.py": 3,
     "aliases_typealiastype.py": 4,
     "aliases_variance.py": 4,
     "annotations_forward_refs.py": 4,

--- a/pyrefly/lib/test/type_alias.rs
+++ b/pyrefly/lib/test/type_alias.rs
@@ -1116,10 +1116,13 @@ type RecursiveTypeAlias7 = RecursiveTypeAlias6
 );
 
 testcase!(
-    bug = "conformance: Should error on redeclared type aliases",
     test_type_statement_redeclaration_conformance,
     r#"
-type BadTypeAlias14 = int  # should error: redeclared
 type BadTypeAlias14 = int
+type BadTypeAlias14 = int # E: Cannot redefine existing name `BadTypeAlias14` as a type alias
+
+class C:
+    type T = int
+    type T = int # E: Cannot redefine existing name `T` as a type alias
 "#,
 );


### PR DESCRIPTION
# Summary

Errors when re-declaring a type alias, per requirement in the conformance test suite.

# Test Plan

`test.py`