### PR TITLE
fix Support bare class names for in-based narrowing #937

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -762,10 +762,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     let mut literal_types = Vec::new();
                     for expr in exprs {
                         let expr_ty = self.expr_infer(&expr, errors);
-                        if matches!(expr_ty, Type::Literal(_) | Type::None) {
-                            literal_types.push(expr_ty);
-                        } else {
-                            return ty.clone();
+                        match expr_ty {
+                            Type::Literal(_) | Type::None => {
+                                literal_types.push(expr_ty);
+                            }
+                            Type::ClassDef(cls) => {
+                                literal_types.push(Type::type_form(self.promote_silently(&cls)));
+                            }
+                            Type::Type(box Type::ClassType(_)) => {
+                                literal_types.push(expr_ty);
+                            }
+                            _ => {
+                                return ty.clone();
+                            }
                         }
                     }
                     return self.intersect(ty, &self.unions(literal_types));
@@ -807,10 +816,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     let mut literal_types = Vec::new();
                     for expr in exprs {
                         let expr_ty = self.expr_infer(&expr, errors);
-                        if matches!(expr_ty, Type::Literal(_) | Type::None) {
-                            literal_types.push(expr_ty);
-                        } else {
-                            return ty.clone();
+                        match expr_ty {
+                            Type::Literal(_) | Type::None => {
+                                literal_types.push(expr_ty);
+                            }
+                            Type::ClassDef(cls) => {
+                                literal_types.push(Type::type_form(self.promote_silently(&cls)));
+                            }
+                            Type::Type(box Type::ClassType(_)) => {
+                                literal_types.push(expr_ty);
+                            }
+                            _ => {
+                                return ty.clone();
+                            }
                         }
                     }
                     return self.distribute_over_union(ty, |t| {
@@ -818,6 +836,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         for right in &literal_types {
                             match (t, right) {
                                 (_, _) if self.literal_equal(t, right) => {
+                                    result = Type::never();
+                                }
+                                (
+                                    Type::Type(box Type::ClassType(left_cls)),
+                                    Type::Type(box Type::ClassType(right_cls)),
+                                ) if left_cls == right_cls => {
                                     result = Type::never();
                                 }
                                 (Type::ClassType(cls), Type::Literal(lit))

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -1699,6 +1699,10 @@ def test(x: Literal["foo", 1] | Color | bool | None, y: object, z: Literal["f", 
         assert_type(y, Literal[1, Color.RED, True])
     else:
         assert_type(y, object)
+
+def test_type_objects(x: type[object]) -> None:
+    if x in (int, float):
+        assert_type(x, type[int] | type[float])
 "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #937

in-based narrowing treats bare class objects in list/tuple/set literals as narrowable values (via ClassDef -> type[...] and direct type[...]), and added a small class-object equality case for not in.




# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added a regression test covering type[object] narrowed by x in (int, float).