### PR TITLE
fix [feature] warn when passing str to something that accepts iterable[str] or sequence[str] #673

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -301,6 +301,8 @@ pub enum ErrorKind {
     RedundantCondition,
     /// Raised by a call to reveal_type().
     RevealType,
+    /// Passing a string to something that expects an iterable of strings.
+    StringAsIterable,
     /// DEPRECATED: use [ImplicitAnyAttribute] (`implicit-any-attribute`) instead.
     /// Kept so that existing `# pyrefly: ignore[unannotated-attribute]` comments
     /// and config entries continue to work. This variant is never emitted by
@@ -442,6 +444,7 @@ impl ErrorKind {
             ErrorKind::Deprecated => Severity::Warn,
             ErrorKind::DivisionByZero => Severity::Warn,
             ErrorKind::ExplicitAny => Severity::Ignore,
+            ErrorKind::StringAsIterable => Severity::Warn,
             ErrorKind::ImplicitAbstractClass => Severity::Ignore,
             ErrorKind::ImplicitAny => Severity::Ignore,
             ErrorKind::ImplicitAnyAttribute => Severity::Ignore,

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -553,9 +553,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if got.is_error() || got.is_any() || want.is_any() {
             return;
         }
-        if want.contains_type_variable() {
-            return;
-        }
         if !matches!(got, Type::ClassType(cls) if cls.is_builtin("str")) {
             return;
         }
@@ -1241,7 +1238,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 let (got, ok) = self.check_expr_argument(
                                     x,
                                     hint,
-                                    kw.range,
+                                    x.range(),
                                     arg_errors,
                                     call_errors,
                                     tcc,

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -524,8 +524,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Some(HintRef::new(hint, Some(call_errors))),
             arg_errors,
         );
-        let ok =
-            self.check_type_with_call_context(got.ty(), hint, range, call_errors, tcc, call_context);
+        let ok = self.check_type_with_call_context(
+            got.ty(),
+            hint,
+            range,
+            call_errors,
+            tcc,
+            call_context,
+        );
         (got.into_ty(), ok)
     }
 

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -554,6 +554,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if got.is_error() || got.is_any() || want.is_any() {
             return;
         }
+        if want.contains_type_variable() {
+            return;
+        }
         if !self.is_definitely_str_like(got) {
             return;
         }

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -54,7 +54,6 @@ use crate::types::callable::Param;
 use crate::types::callable::ParamList;
 use crate::types::callable::Params;
 use crate::types::callable::Required;
-use crate::types::class::ClassType;
 use crate::types::quantified::Quantified;
 use crate::types::types::Type;
 use crate::types::types::Var;
@@ -557,13 +556,27 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if want.contains_type_variable() {
             return;
         }
-        if !self.is_definitely_str_like(got) {
+        if !matches!(got, Type::ClassType(cls) if cls.is_builtin("str")) {
             return;
         }
-        if self.want_explicitly_allows_str(want) {
-            return;
-        }
-        if !self.is_iterable_or_sequence_of_str(want) {
+        let want_is_iterable_str = match want {
+            Type::ClassType(cls) => {
+                let cls_object = cls.class_object();
+                let iterable = self.stdlib.iterable(Type::any_implicit());
+                let sequence = self.stdlib.sequence(Type::any_implicit());
+                let is_iterable =
+                    cls_object == iterable.class_object() || cls_object == sequence.class_object();
+                if !is_iterable {
+                    return;
+                }
+                matches!(
+                    cls.targs().as_slice(),
+                    [elem] if matches!(elem, Type::ClassType(elem_cls) if elem_cls.is_builtin("str"))
+                )
+            }
+            _ => false,
+        };
+        if !want_is_iterable_str {
             return;
         }
         let got_display = self
@@ -581,73 +594,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             )
             .with_detail("Did you mean to pass an iterable of strings?".to_owned())
             .emit();
-    }
-
-    fn want_explicitly_allows_str(&self, ty: &Type) -> bool {
-        let ty = self.solver().expand_vars(ty.clone());
-        self.want_explicitly_allows_str_inner(&ty)
-    }
-
-    fn want_explicitly_allows_str_inner(&self, ty: &Type) -> bool {
-        match ty {
-            Type::Union(u) => u
-                .members
-                .iter()
-                .any(|member| self.want_explicitly_allows_str_inner(member)),
-            _ => self.is_str_like_leaf(ty),
-        }
-    }
-
-    fn is_definitely_str_like(&self, ty: &Type) -> bool {
-        let ty = self.solver().expand_vars(ty.clone());
-        self.is_definitely_str_like_inner(&ty)
-    }
-
-    fn is_definitely_str_like_inner(&self, ty: &Type) -> bool {
-        match ty {
-            Type::Union(u) => u
-                .members
-                .iter()
-                .all(|member| self.is_definitely_str_like_inner(member)),
-            _ => self.is_str_like_leaf(ty),
-        }
-    }
-
-    fn is_str_like_leaf(&self, ty: &Type) -> bool {
-        match ty {
-            Type::ClassType(cls) if cls.is_builtin("str") => true,
-            Type::LiteralString(_) => true,
-            Type::Literal(lit) if lit.value.is_string() => true,
-            _ => false,
-        }
-    }
-
-    fn is_iterable_or_sequence_of_str(&self, ty: &Type) -> bool {
-        let ty = self.solver().expand_vars(ty.clone());
-        self.is_iterable_or_sequence_of_str_inner(&ty)
-    }
-
-    fn is_iterable_or_sequence_of_str_inner(&self, ty: &Type) -> bool {
-        match ty {
-            Type::Union(u) => u
-                .members
-                .iter()
-                .any(|member| self.is_iterable_or_sequence_of_str_inner(member)),
-            Type::ClassType(cls) if self.is_iterable_or_sequence_class(cls) => {
-                match cls.targs().as_slice().first() {
-                    Some(elem) => self.is_definitely_str_like_inner(elem),
-                    None => false,
-                }
-            }
-            _ => false,
-        }
-    }
-
-    fn is_iterable_or_sequence_class(&self, cls: &ClassType) -> bool {
-        let cls_object = cls.class_object();
-        let iterable = self.stdlib.iterable(Type::any_implicit());
-        let sequence = self.stdlib.sequence(Type::any_implicit());
-        cls_object == iterable.class_object() || cls_object == sequence.class_object()
     }
 
     fn is_param_spec_args(&self, x: &CallArg, q: &Quantified, errors: &ErrorCollector) -> bool {

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -54,6 +54,7 @@ use crate::types::callable::Param;
 use crate::types::callable::ParamList;
 use crate::types::callable::Params;
 use crate::types::callable::Required;
+use crate::types::class::ClassType;
 use crate::types::quantified::Quantified;
 use crate::types::types::Type;
 use crate::types::types::Var;
@@ -367,7 +368,8 @@ impl CallArgPreEval<'_> {
         match self {
             Self::Type(ty, done) => {
                 *done = true;
-                solver.check_type_with_call_context(
+                let arg_ty = (*ty).clone();
+                let ok = solver.check_type_with_call_context(
                     ty,
                     hint,
                     range,
@@ -375,20 +377,31 @@ impl CallArgPreEval<'_> {
                     tcc,
                     call_context,
                 );
-                Some((*ty).clone())
+                if ok {
+                    solver.warn_if_string_as_iterable(&arg_ty, hint, range, call_errors);
+                }
+                Some(arg_ty)
             }
             Self::Expr(x, done) => {
                 *done = true;
-                Some(solver.expr_with_separate_check_errors_with_call_context(
+                let (got, ok) = solver.check_expr_argument(
                     x,
-                    Some((hint, call_errors, tcc)),
+                    hint,
+                    range,
                     arg_errors,
+                    call_errors,
+                    tcc,
                     call_context,
-                ))
+                );
+                if ok {
+                    solver.warn_if_string_as_iterable(&got, hint, range, call_errors);
+                }
+                Some(got)
             }
             Self::Star(ty, done) => {
                 *done = vararg;
-                solver.check_type_with_call_context(
+                let arg_ty = ty.clone();
+                let ok = solver.check_type_with_call_context(
                     ty,
                     hint,
                     range,
@@ -396,11 +409,14 @@ impl CallArgPreEval<'_> {
                     tcc,
                     call_context,
                 );
-                Some(ty.clone())
+                if ok {
+                    solver.warn_if_string_as_iterable(&arg_ty, hint, range, call_errors);
+                }
+                Some(arg_ty)
             }
             Self::Fixed(tys, i) => {
                 let arg_ty = tys[*i].clone();
-                solver.check_type_with_call_context(
+                let ok = solver.check_type_with_call_context(
                     &arg_ty,
                     hint,
                     range,
@@ -408,6 +424,9 @@ impl CallArgPreEval<'_> {
                     tcc,
                     call_context,
                 );
+                if ok {
+                    solver.warn_if_string_as_iterable(&arg_ty, hint, range, call_errors);
+                }
                 *i += 1;
                 Some(arg_ty)
             }
@@ -498,6 +517,136 @@ impl<'a> PosParam<'a> {
 }
 
 impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
+    fn check_expr_argument(
+        &self,
+        expr: &Expr,
+        hint: &Type,
+        range: TextRange,
+        arg_errors: &ErrorCollector,
+        call_errors: &ErrorCollector,
+        tcc: &dyn Fn() -> TypeCheckContext,
+        call_context: &CallContext,
+    ) -> (Type, bool) {
+        if hint.is_any() {
+            return (
+                self.expr_infer_type_info_with_hint(expr, None, arg_errors)
+                    .into_ty(),
+                false,
+            );
+        }
+        let got = self.expr_infer_type_info_with_hint(
+            expr,
+            Some(HintRef::new(hint, Some(call_errors))),
+            arg_errors,
+        );
+        let ok =
+            self.check_type_with_call_context(got.ty(), hint, range, call_errors, tcc, call_context);
+        (got.into_ty(), ok)
+    }
+
+    fn warn_if_string_as_iterable(
+        &self,
+        got: &Type,
+        want: &Type,
+        range: TextRange,
+        errors: &ErrorCollector,
+    ) {
+        if got.is_error() || got.is_any() || want.is_any() {
+            return;
+        }
+        if !self.is_definitely_str_like(got) {
+            return;
+        }
+        if self.want_explicitly_allows_str(want) {
+            return;
+        }
+        if !self.is_iterable_or_sequence_of_str(want) {
+            return;
+        }
+        let got_display = self
+            .for_display(self.stdlib.str().clone().to_type())
+            .deterministic_printing();
+        let want_display = self.for_display(want.clone()).deterministic_printing();
+        errors
+            .error_builder(
+                range,
+                ErrorKind::StringAsIterable,
+                format!(
+                    "Passing `{}` to `{}` treats the string as an iterable of characters",
+                    got_display, want_display
+                ),
+            )
+            .with_detail("Did you mean to pass an iterable of strings?".to_owned())
+            .emit();
+    }
+
+    fn want_explicitly_allows_str(&self, ty: &Type) -> bool {
+        let ty = self.solver().expand_vars(ty.clone());
+        self.want_explicitly_allows_str_inner(&ty)
+    }
+
+    fn want_explicitly_allows_str_inner(&self, ty: &Type) -> bool {
+        match ty {
+            Type::Union(u) => u
+                .members
+                .iter()
+                .any(|member| self.want_explicitly_allows_str_inner(member)),
+            _ => self.is_str_like_leaf(ty),
+        }
+    }
+
+    fn is_definitely_str_like(&self, ty: &Type) -> bool {
+        let ty = self.solver().expand_vars(ty.clone());
+        self.is_definitely_str_like_inner(&ty)
+    }
+
+    fn is_definitely_str_like_inner(&self, ty: &Type) -> bool {
+        match ty {
+            Type::Union(u) => u
+                .members
+                .iter()
+                .all(|member| self.is_definitely_str_like_inner(member)),
+            _ => self.is_str_like_leaf(ty),
+        }
+    }
+
+    fn is_str_like_leaf(&self, ty: &Type) -> bool {
+        match ty {
+            Type::ClassType(cls) if cls.is_builtin("str") => true,
+            Type::LiteralString(_) => true,
+            Type::Literal(lit) if lit.value.is_string() => true,
+            _ => false,
+        }
+    }
+
+    fn is_iterable_or_sequence_of_str(&self, ty: &Type) -> bool {
+        let ty = self.solver().expand_vars(ty.clone());
+        self.is_iterable_or_sequence_of_str_inner(&ty)
+    }
+
+    fn is_iterable_or_sequence_of_str_inner(&self, ty: &Type) -> bool {
+        match ty {
+            Type::Union(u) => u
+                .members
+                .iter()
+                .any(|member| self.is_iterable_or_sequence_of_str_inner(member)),
+            Type::ClassType(cls) if self.is_iterable_or_sequence_class(cls) => {
+                match cls.targs().as_slice().first() {
+                    Some(elem) => self.is_definitely_str_like_inner(elem),
+                    None => false,
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn is_iterable_or_sequence_class(&self, cls: &ClassType) -> bool {
+        let cls_object = cls.class_object();
+        let iterable = self.stdlib.iterable(Type::any_implicit());
+        let sequence = self.stdlib.sequence(Type::any_implicit());
+        cls_object == iterable.class_object() || cls_object == sequence.class_object()
+    }
+
     fn is_param_spec_args(&self, x: &CallArg, q: &Quantified, errors: &ErrorCollector) -> bool {
         match x {
             CallArg::Star(x, _) => {
@@ -1138,18 +1287,36 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         .with_context(context.map(|ctx| ctx()))
                     };
                     let arg_ty = match kw.value {
-                        TypeOrExpr::Expr(x) => self
-                            .expr_with_separate_check_errors_with_call_context(
-                                x,
-                                hint.map(|ty| (ty, call_errors, tcc)),
-                                arg_errors,
-                                call_context,
-                            ),
+                        TypeOrExpr::Expr(x) => {
+                            if let Some(hint) = hint {
+                                let (got, ok) = self.check_expr_argument(
+                                    x,
+                                    hint,
+                                    kw.range,
+                                    arg_errors,
+                                    call_errors,
+                                    tcc,
+                                    call_context,
+                                );
+                                if ok {
+                                    self.warn_if_string_as_iterable(
+                                        &got,
+                                        hint,
+                                        kw.range,
+                                        call_errors,
+                                    );
+                                }
+                                got
+                            } else {
+                                self.expr_infer_type_info_with_hint(x, None, arg_errors)
+                                    .into_ty()
+                            }
+                        }
                         TypeOrExpr::Type(x, range) => {
                             if let Some(hint) = &hint
                                 && !hint.is_any()
                             {
-                                self.check_type_with_call_context(
+                                let ok = self.check_type_with_call_context(
                                     x,
                                     hint,
                                     range,
@@ -1157,6 +1324,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                     tcc,
                                     call_context,
                                 );
+                                if ok {
+                                    self.warn_if_string_as_iterable(x, hint, range, call_errors);
+                                }
                             }
                             (*x).clone()
                         }

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -364,21 +364,29 @@ impl CallArgPreEval<'_> {
             })
             .with_context(context.map(|ctx| ctx()))
         };
-        match self {
-            Self::Type(ty, done) => {
-                *done = true;
-                let arg_ty = (*ty).clone();
-                let ok = solver.check_type_with_call_context(
-                    ty,
+        let warn_if_ok = |arg_ty: &Type, ok| {
+            if ok {
+                solver.warn_if_string_as_iterable(arg_ty, hint, range, call_errors);
+            }
+        };
+        let check_type_argument = |arg_ty: &Type| {
+            warn_if_ok(
+                arg_ty,
+                solver.check_type_with_call_context(
+                    arg_ty,
                     hint,
                     range,
                     call_errors,
                     tcc,
                     call_context,
-                );
-                if ok {
-                    solver.warn_if_string_as_iterable(&arg_ty, hint, range, call_errors);
-                }
+                ),
+            );
+        };
+        match self {
+            Self::Type(ty, done) => {
+                *done = true;
+                let arg_ty = (*ty).clone();
+                check_type_argument(&arg_ty);
                 Some(arg_ty)
             }
             Self::Expr(x, done) => {
@@ -392,40 +400,18 @@ impl CallArgPreEval<'_> {
                     tcc,
                     call_context,
                 );
-                if ok {
-                    solver.warn_if_string_as_iterable(&got, hint, range, call_errors);
-                }
+                warn_if_ok(&got, ok);
                 Some(got)
             }
             Self::Star(ty, done) => {
                 *done = vararg;
                 let arg_ty = ty.clone();
-                let ok = solver.check_type_with_call_context(
-                    ty,
-                    hint,
-                    range,
-                    call_errors,
-                    tcc,
-                    call_context,
-                );
-                if ok {
-                    solver.warn_if_string_as_iterable(&arg_ty, hint, range, call_errors);
-                }
+                check_type_argument(&arg_ty);
                 Some(arg_ty)
             }
             Self::Fixed(tys, i) => {
                 let arg_ty = tys[*i].clone();
-                let ok = solver.check_type_with_call_context(
-                    &arg_ty,
-                    hint,
-                    range,
-                    call_errors,
-                    tcc,
-                    call_context,
-                );
-                if ok {
-                    solver.warn_if_string_as_iterable(&arg_ty, hint, range, call_errors);
-                }
+                check_type_argument(&arg_ty);
                 *i += 1;
                 Some(arg_ty)
             }

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -56,7 +56,7 @@ struct CalledOverload<'f> {
 
 impl CalledOverload<'_> {
     fn num_errors(&self) -> usize {
-        self.call_errors.len() + self.specialization_errors.len()
+        self.call_errors.len_for_overload_matching() + self.specialization_errors.len()
     }
 }
 
@@ -826,24 +826,39 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let mut overload_ctor_targs = ctor_targs.as_ref().map(|x| (**x).clone());
         let tparams = callable.0.as_deref();
 
-        let call_errors = self.error_collector();
-        let (res, specialization_errors, expected_types) = self.callable_infer(
-            callable.1.signature.clone(),
-            Some(&metadata.kind),
-            tparams,
-            self_obj.cloned(),
-            args,
-            keywords,
-            arguments_range,
-            errors,
-            &call_errors,
-            // We intentionally drop the context here, as arg errors don't need it,
-            // and if there are any call errors, we'll log a "No matching overloads"
-            // error with the necessary context.
-            None,
-            hint,
-            overload_ctor_targs.as_mut(),
-        );
+        let mut try_call = |hint| {
+            let call_errors = self.error_collector();
+            let (res, specialization_errors, expected_types) = self.callable_infer(
+                callable.1.signature.clone(),
+                Some(&metadata.kind),
+                tparams,
+                self_obj.cloned(),
+                args,
+                keywords,
+                arguments_range,
+                errors,
+                &call_errors,
+                // We intentionally drop the context here, as arg errors don't need it,
+                // and if there are any call errors, we'll log a "No matching overloads"
+                // error with the necessary context.
+                None,
+                hint,
+                overload_ctor_targs.as_mut(),
+            );
+            (call_errors, specialization_errors, res, expected_types)
+        };
+        // We want to use our hint to contextually type the arguments, but errors resulting
+        // from the hint should not influence overload selection. If there are call errors, we
+        // try again without a hint in case we can still match this overload.
+        let (call_errors, specialization_errors, res, expected_types) = try_call(hint);
+        let (call_errors, specialization_errors, res, expected_types) = if tparams.is_some()
+            && hint.is_some()
+            && call_errors.len_for_overload_matching() + specialization_errors.len() > 0
+        {
+            try_call(None)
+        } else {
+            (call_errors, specialization_errors, res, expected_types)
+        };
 
         CalledOverload {
             func: callable,

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -56,7 +56,7 @@ struct CalledOverload<'f> {
 
 impl CalledOverload<'_> {
     fn num_errors(&self) -> usize {
-        self.call_errors.len_for_overload_matching() + self.specialization_errors.len()
+        self.call_errors.len() + self.specialization_errors.len()
     }
 }
 
@@ -853,7 +853,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let (call_errors, specialization_errors, res, expected_types) = try_call(hint);
         let (call_errors, specialization_errors, res, expected_types) = if tparams.is_some()
             && hint.is_some()
-            && call_errors.len_for_overload_matching() + specialization_errors.len() > 0
+            && call_errors.len() + specialization_errors.len() > 0
         {
             try_call(None)
         } else {

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -851,14 +851,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // from the hint should not influence overload selection. If there are call errors, we
         // try again without a hint in case we can still match this overload.
         let (call_errors, specialization_errors, res, expected_types) = try_call(hint);
-        let (call_errors, specialization_errors, res, expected_types) = if tparams.is_some()
-            && hint.is_some()
-            && call_errors.len() + specialization_errors.len() > 0
-        {
-            try_call(None)
-        } else {
-            (call_errors, specialization_errors, res, expected_types)
-        };
+        let (call_errors, specialization_errors, res, expected_types) =
+            if tparams.is_some() && hint.is_some() && !call_errors.is_empty() {
+                try_call(None)
+            } else {
+                (call_errors, specialization_errors, res, expected_types)
+            };
 
         CalledOverload {
             func: callable,

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -55,8 +55,17 @@ struct CalledOverload<'f> {
 }
 
 impl CalledOverload<'_> {
-    fn num_errors(&self) -> usize {
-        self.call_errors.len() + self.specialization_errors.len()
+    fn num_match_errors(&self) -> usize {
+        self.call_errors.len_excluding(ErrorKind::StringAsIterable)
+            + self.specialization_errors.len()
+    }
+
+    fn has_match_errors(&self) -> bool {
+        self.num_match_errors() > 0
+    }
+
+    fn has_hard_call_errors(&self) -> bool {
+        self.call_errors.len_excluding(ErrorKind::StringAsIterable) > 0
     }
 }
 
@@ -544,12 +553,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 ctor_targs,
             );
             self.solver().restore_vars(snapshot);
-            let n_errors = called_overload.num_errors();
+            let n_errors = called_overload.num_match_errors();
             if n_errors == 0 {
                 matched_overloads.push(called_overload);
             } else {
                 match &closest_unmatched_overload {
-                    Some(overload) if overload.num_errors() <= n_errors => {}
+                    Some(overload) if overload.num_match_errors() <= n_errors => {}
                     _ => {
                         closest_unmatched_overload = Some(called_overload);
                     }
@@ -665,7 +674,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 &None,
                             );
                             self.solver().restore_vars(snapshot);
-                            res.num_errors() == 0
+                            !res.has_match_errors()
                         })
                         .map(|(split_point, _)| split_point + 1)
                 };
@@ -701,7 +710,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     // specialization errors that the matched-overload step already accounted for,
                     // so we only fall back to the no-hint version on hard call errors. See
                     // `test::generic_restriction::test_nested_call_of_overloaded_function_preserves_bound`.
-                    if contextual_overload.call_errors.is_empty() {
+                    if !contextual_overload.has_hard_call_errors() {
                         contextual_overload
                     } else {
                         overload

--- a/pyrefly/lib/error/collector.rs
+++ b/pyrefly/lib/error/collector.rs
@@ -189,6 +189,20 @@ impl ErrorCollector {
         self.errors.lock().len()
     }
 
+    /// Returns the number of errors relevant to overload matching.
+    /// Warnings should not disqualify an overload, so we skip them here.
+    pub fn len_for_overload_matching(&self) -> usize {
+        let mut errors = self.errors.lock();
+        errors
+            .iter()
+            .filter(|err| err.error_kind() != ErrorKind::StringAsIterable)
+            .count()
+    }
+
+    pub fn is_empty_for_overload_matching(&self) -> bool {
+        self.len_for_overload_matching() == 0
+    }
+
     /// Checks whether an error is suppressed, considering ignore-all directives,
     /// per-line suppressions, and (for errors inside multi-line f/t-strings)
     /// suppressions on the f-string's start or end lines.

--- a/pyrefly/lib/error/collector.rs
+++ b/pyrefly/lib/error/collector.rs
@@ -82,6 +82,14 @@ impl ModuleErrors {
         self.items.len()
     }
 
+    fn len_excluding(&mut self, excluded: ErrorKind) -> usize {
+        self.cleanup();
+        self.items
+            .iter()
+            .filter(|err| err.error_kind() != excluded)
+            .count()
+    }
+
     /// Iterates over all errors, including ignored ones.
     fn iter(&mut self) -> impl ExactSizeIterator<Item = &Error> {
         self.cleanup();
@@ -187,6 +195,10 @@ impl ErrorCollector {
 
     pub fn len(&self) -> usize {
         self.errors.lock().len()
+    }
+
+    pub fn len_excluding(&self, excluded: ErrorKind) -> usize {
+        self.errors.lock().len_excluding(excluded)
     }
 
     /// Checks whether an error is suppressed, considering ignore-all directives,

--- a/pyrefly/lib/error/collector.rs
+++ b/pyrefly/lib/error/collector.rs
@@ -189,20 +189,6 @@ impl ErrorCollector {
         self.errors.lock().len()
     }
 
-    /// Returns the number of errors relevant to overload matching.
-    /// Warnings should not disqualify an overload, so we skip them here.
-    pub fn len_for_overload_matching(&self) -> usize {
-        let mut errors = self.errors.lock();
-        errors
-            .iter()
-            .filter(|err| err.error_kind() != ErrorKind::StringAsIterable)
-            .count()
-    }
-
-    pub fn is_empty_for_overload_matching(&self) -> bool {
-        self.len_for_overload_matching() == 0
-    }
-
     /// Checks whether an error is suppressed, considering ignore-all directives,
     /// per-line suppressions, and (for errors inside multi-line f/t-strings)
     /// suppressions on the f-string's start or end lines.

--- a/pyrefly/lib/test/calls.rs
+++ b/pyrefly/lib/test/calls.rs
@@ -161,6 +161,22 @@ f(0)  # E: `f` is deprecated
 );
 
 testcase!(
+    test_string_as_iterable_warning,
+    r#"
+from typing import Iterable, Sequence
+
+def takes_iter(xs: Iterable[str]) -> None: ...
+def takes_seq(xs: Sequence[str]) -> None: ...
+def takes_iter_or_str(xs: Iterable[str] | str) -> None: ...
+
+takes_iter("hello")  # E: Passing `str` to `Iterable[str]` treats the string as an iterable of characters
+takes_seq("hello")  # E: Passing `str` to `Sequence[str]` treats the string as an iterable of characters
+takes_iter_or_str("hello")
+takes_iter(["hello"])
+    "#,
+);
+
+testcase!(
     test_deprecated_overloaded_signature,
     r#"
 from typing import overload

--- a/pyrefly/lib/test/calls.rs
+++ b/pyrefly/lib/test/calls.rs
@@ -169,9 +169,10 @@ def takes_iter(xs: Iterable[str]) -> None: ...
 def takes_seq(xs: Sequence[str]) -> None: ...
 def takes_iter_or_str(xs: Iterable[str] | str) -> None: ...
 
-takes_iter("hello")  # E: Passing `str` to `Iterable[str]` treats the string as an iterable of characters
-takes_seq("hello")  # E: Passing `str` to `Sequence[str]` treats the string as an iterable of characters
-takes_iter_or_str("hello")
+s: str = "hello"
+takes_iter(s)  # E: Passing `str` to `Iterable[str]` treats the string as an iterable of characters
+takes_seq(s)  # E: Passing `str` to `Sequence[str]` treats the string as an iterable of characters
+takes_iter_or_str(s)
 takes_iter(["hello"])
     "#,
 );

--- a/pyrefly/lib/test/calls.rs
+++ b/pyrefly/lib/test/calls.rs
@@ -178,6 +178,19 @@ takes_iter(["hello"])
 );
 
 testcase!(
+    test_string_as_iterable_warning_does_not_break_overload_matching,
+    r#"
+from traceback import format_exception
+
+def f(exc: BaseException) -> None:
+    "".join(format_exception(exc))
+
+s: str = "hello"
+"".join(s)  # E: Passing `str` to `Iterable[str]` treats the string as an iterable of characters
+    "#,
+);
+
+testcase!(
     test_deprecated_overloaded_signature,
     r#"
 from typing import overload

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -1453,6 +1453,8 @@ Pyrefly uses this diagnostic to communicate the output of the [`reveal_type`](ht
 
 ## string-as-iterable
 
+Default severity: `warn`
+
 This warning is raised when a string is passed to a parameter expecting an `Iterable[str]` or
 `Sequence[str]`. While `str` is technically iterable, it iterates by individual characters, which
 is often not what you intended.

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -1451,6 +1451,21 @@ Pyrefly uses this diagnostic to communicate the output of the [`reveal_type`](ht
 
 `reveal_type` is a *directive* — it is always shown in CLI output regardless of the [`min-severity`](../configuration#min-severity) threshold, and is never subject to suppression or baseline exclusion. To hide it, set `reveal-type = "ignore"` in the [`errors`](../configuration#errors) table.
 
+## string-as-iterable
+
+This warning is raised when a string is passed to a parameter expecting an `Iterable[str]` or
+`Sequence[str]`. While `str` is technically iterable, it iterates by individual characters, which
+is often not what you intended.
+
+```python
+from typing import Iterable
+
+def takes_items(xs: Iterable[str]) -> None:
+    ...
+
+takes_items("hello")  # Passing `str` treats it as an iterable of characters
+```
+
 ## unannotated-attribute
 
 Default severity: `ignore`


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #673

Implemented the new string-as-iterable warning and documented it, with checks that fire only when the argument is definitely str and the parameter is Iterable[str]/Sequence[str] without explicitly allowing str.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test