### PR TITLE
impl instance method inline

### DIFF
--- a/pyrefly/lib/state/lsp/quick_fixes/inline_method.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/inline_method.rs
@@ -17,6 +17,7 @@ use ruff_python_ast::ExprCall;
 use ruff_python_ast::ExprContext;
 use ruff_python_ast::ModModule;
 use ruff_python_ast::Stmt;
+use ruff_python_ast::StmtClassDef;
 use ruff_python_ast::StmtFunctionDef;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
@@ -53,11 +54,17 @@ pub(crate) fn inline_method_code_actions(
                 def.metadata.symbol_kind(),
                 Some(SymbolKind::Function | SymbolKind::Method)
             )
-    })?;
+    });
+    let mut function_def_ctx =
+        def.and_then(|def| find_function_def_with_context(ast.as_ref(), def.definition_range));
+    if function_def_ctx.is_none() {
+        function_def_ctx =
+            find_method_def_for_self_call(ast.as_ref(), call.range(), &callee_name, receiver_expr);
+    }
     let FunctionDefContext {
         function_def,
         in_class,
-    } = find_function_def_with_context(ast.as_ref(), def.definition_range)?;
+    } = function_def_ctx?;
     if !function_def.decorator_list.is_empty() {
         return None;
     }
@@ -159,6 +166,81 @@ fn find_function_def_with_context(
     }
 
     search_in_body(&ast.body, definition_range, false)
+}
+
+struct EnclosingMethod<'a> {
+    class_def: &'a StmtClassDef,
+    function_def: &'a StmtFunctionDef,
+}
+
+fn find_enclosing_method(ast: &ModModule, selection: TextRange) -> Option<EnclosingMethod<'_>> {
+    fn search_in_class<'a>(
+        class_def: &'a StmtClassDef,
+        selection: TextRange,
+    ) -> Option<EnclosingMethod<'a>> {
+        for stmt in &class_def.body {
+            match stmt {
+                Stmt::FunctionDef(function_def)
+                    if function_def.range().contains_range(selection) =>
+                {
+                    return Some(EnclosingMethod {
+                        class_def,
+                        function_def,
+                    });
+                }
+                Stmt::ClassDef(inner_class) => {
+                    if let Some(found) = search_in_class(inner_class, selection) {
+                        return Some(found);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    for stmt in &ast.body {
+        if let Stmt::ClassDef(class_def) = stmt
+            && let Some(found) = search_in_class(class_def, selection)
+        {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn find_method_def_for_self_call(
+    ast: &ModModule,
+    selection: TextRange,
+    callee_name: &str,
+    receiver_expr: Option<&Expr>,
+) -> Option<FunctionDefContext> {
+    let receiver_name = match receiver_expr {
+        Some(Expr::Name(name)) => name.id.as_str(),
+        _ => return None,
+    };
+    let EnclosingMethod {
+        class_def,
+        function_def: enclosing_method,
+    } = find_enclosing_method(ast, selection)?;
+    if is_static_or_class_method(enclosing_method) {
+        return None;
+    }
+    let enclosing_receiver = first_parameter_name(&enclosing_method.parameters)?;
+    if enclosing_receiver != receiver_name {
+        return None;
+    }
+    for stmt in &class_def.body {
+        if let Stmt::FunctionDef(function_def) = stmt
+            && function_def.name.id.as_str() == callee_name
+        {
+            return Some(FunctionDefContext {
+                function_def: function_def.clone(),
+                in_class: true,
+            });
+        }
+    }
+    None
 }
 
 /// Returns true if the expression needs parentheses when inlined.

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -2120,6 +2120,30 @@ def compute():
 }
 
 #[test]
+fn inline_method_for_class() {
+    let code = r#"
+class A:
+    def foo(self):
+        return 1
+
+    def bar(self):
+        self.foo()
+#        ^
+"#;
+    let updated = apply_first_inline_method_action(code).expect("expected inline method action");
+    let expected = r#"
+class A:
+    def foo(self):
+        return 1
+
+    def bar(self):
+        1
+#        ^
+"#;
+    assert_eq!(expected, updated);
+}
+
+#[test]
 fn inline_parameter_basic_refactor() {
     let code = r#"
 def add(a, b):


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

enhancement for #2033

find that class method is missing support

Implemented class instance method inline support by adding an AST-based fallback when find_definition can’t resolve self.foo();

it now resolves to the method in the same enclosing class only when the receiver matches the enclosing method’s first parameter and the enclosing method isn’t `@staticmethod`/`@classmethod`.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test