### PR TITLE
impl extract-superclass #2207

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -3333,6 +3333,9 @@ impl Server {
         if let Some(refactors) = transaction.extract_function_code_actions(&handle, range) {
             push_refactor_actions(refactors);
         }
+        if let Some(refactors) = transaction.extract_superclass_code_actions(&handle, range) {
+            push_refactor_actions(refactors);
+        }
         if let Some(refactors) = transaction.inline_variable_code_actions(&handle, range) {
             push_refactor_actions(refactors);
         }

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2005,6 +2005,14 @@ impl<'a> Transaction<'a> {
         quick_fixes::extract_variable::extract_variable_code_actions(self, handle, selection)
     }
 
+    pub fn extract_superclass_code_actions(
+        &self,
+        handle: &Handle,
+        selection: TextRange,
+    ) -> Option<Vec<LocalRefactorCodeAction>> {
+        quick_fixes::extract_superclass::extract_superclass_code_actions(self, handle, selection)
+    }
+
     pub fn pull_members_up_code_actions(
         &self,
         handle: &Handle,

--- a/pyrefly/lib/state/lsp/quick_fixes/extract_superclass.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/extract_superclass.rs
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use dupe::Dupe;
+use lsp_types::CodeActionKind;
+use pyrefly_build::handle::Handle;
+use pyrefly_python::ast::Ast;
+use ruff_python_ast::ModModule;
+use ruff_python_ast::Stmt;
+use ruff_python_ast::StmtClassDef;
+use ruff_python_ast::helpers::is_docstring_stmt;
+use ruff_text_size::Ranged;
+use ruff_text_size::TextRange;
+use ruff_text_size::TextSize;
+
+use super::extract_shared::code_at_range;
+use super::extract_shared::line_end_position;
+use super::extract_shared::line_indent_and_start;
+use super::extract_shared::prepare_insertion_text;
+use super::extract_shared::reindent_block;
+use super::extract_shared::selection_anchor;
+use super::types::LocalRefactorCodeAction;
+use crate::state::lsp::Transaction;
+
+const DEFAULT_INDENT: &str = "    ";
+const DEFAULT_SUPERCLASS_PREFIX: &str = "Base";
+
+/// Builds extract-superclass refactor actions for the supplied selection.
+pub(crate) fn extract_superclass_code_actions(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    selection: TextRange,
+) -> Option<Vec<LocalRefactorCodeAction>> {
+    let module_info = transaction.get_module_info(handle)?;
+    let source = module_info.contents();
+    let ast = transaction.get_ast(handle)?;
+    let selection_point = selection_anchor(source, selection);
+    let class_def = find_class_at_selection(ast.as_ref(), selection_point)?;
+    let members = selected_members(class_def, selection);
+    if members.is_empty() {
+        return None;
+    }
+
+    let (class_indent, insert_position) = class_insertion_point(class_def, source)?;
+    let superclass_name = generate_superclass_name(source, class_def.name.id.as_str());
+    let superclass_text = build_superclass_text(source, &class_indent, &superclass_name, &members)?;
+    let insert_text = prepare_insertion_text(source, insert_position, &superclass_text);
+    let insert_edit = (
+        module_info.dupe(),
+        TextRange::at(insert_position, TextSize::new(0)),
+        insert_text,
+    );
+
+    let base_edit = build_base_insertion_edit(&module_info, class_def, &superclass_name)?;
+    let removal_edits = build_removal_edits(&module_info, class_def, source, &members)?;
+
+    let mut edits = Vec::new();
+    edits.push(insert_edit);
+    edits.push(base_edit);
+    edits.extend(removal_edits);
+
+    Some(vec![LocalRefactorCodeAction {
+        title: format!("Extract superclass `{superclass_name}`"),
+        edits,
+        kind: CodeActionKind::REFACTOR_EXTRACT,
+    }])
+}
+
+fn find_class_at_selection<'a>(
+    ast: &'a ModModule,
+    selection_point: TextSize,
+) -> Option<&'a StmtClassDef> {
+    Ast::locate_node(ast, selection_point)
+        .into_iter()
+        .find_map(|node| node.as_stmt_class_def().copied())
+}
+
+fn selected_members<'a>(class_def: &'a StmtClassDef, selection: TextRange) -> Vec<&'a Stmt> {
+    let members: Vec<&Stmt> = class_def
+        .body
+        .iter()
+        .filter(|stmt| is_member_stmt(stmt))
+        .collect();
+    if members.is_empty() {
+        return Vec::new();
+    }
+    if selection.is_empty() {
+        return members;
+    }
+    members
+        .into_iter()
+        .filter(|stmt| ranges_overlap(selection, stmt.range()))
+        .collect()
+}
+
+fn ranges_overlap(a: TextRange, b: TextRange) -> bool {
+    a.start() < b.end() && b.start() < a.end()
+}
+
+fn is_member_stmt(stmt: &Stmt) -> bool {
+    matches!(
+        stmt,
+        Stmt::FunctionDef(_) | Stmt::ClassDef(_) | Stmt::Assign(_) | Stmt::AnnAssign(_)
+    )
+}
+
+fn class_insertion_point(class_def: &StmtClassDef, source: &str) -> Option<(String, TextSize)> {
+    let anchor = class_def
+        .decorator_list
+        .iter()
+        .map(|decorator| decorator.range().start())
+        .min()
+        .unwrap_or_else(|| class_def.range().start());
+    line_indent_and_start(source, anchor)
+}
+
+fn generate_superclass_name(source: &str, class_name: &str) -> String {
+    let base = format!("{DEFAULT_SUPERCLASS_PREFIX}{class_name}");
+    let mut counter = 1;
+    loop {
+        let candidate = if counter == 1 {
+            base.clone()
+        } else {
+            format!("{base}_{counter}")
+        };
+        let needle = format!("class {candidate}");
+        if !source.contains(&needle) {
+            return candidate;
+        }
+        counter += 1;
+    }
+}
+
+fn build_superclass_text(
+    source: &str,
+    class_indent: &str,
+    superclass_name: &str,
+    members: &[&Stmt],
+) -> Option<String> {
+    let mut text = format!("{class_indent}class {superclass_name}:\n");
+    let member_indent = format!("{class_indent}{DEFAULT_INDENT}");
+    if members.is_empty() {
+        text.push_str(&format!("{member_indent}pass\n\n"));
+        return Some(text);
+    }
+    for member in members {
+        let removal_range = statement_removal_range(source, member)?;
+        let raw = code_at_range(source, removal_range)?;
+        let (from_indent, _) = line_indent_and_start(source, member.range().start())?;
+        let mut reindented = reindent_block(raw, &from_indent, &member_indent);
+        if !reindented.ends_with('\n') {
+            reindented.push('\n');
+        }
+        text.push_str(&reindented);
+    }
+    text.push('\n');
+    Some(text)
+}
+
+fn build_base_insertion_edit(
+    module_info: &pyrefly_python::module::Module,
+    class_def: &StmtClassDef,
+    superclass_name: &str,
+) -> Option<(pyrefly_python::module::Module, TextRange, String)> {
+    if let Some(arguments) = &class_def.arguments {
+        if let Some(first_keyword) = arguments.keywords.first() {
+            let insert_pos = first_keyword.range().start();
+            let insert_text = format!("{superclass_name}, ");
+            return Some((
+                module_info.dupe(),
+                TextRange::at(insert_pos, TextSize::new(0)),
+                insert_text,
+            ));
+        }
+        let insert_pos = arguments.range.end().saturating_sub(TextSize::new(1));
+        let insert_text = if arguments.args.is_empty() {
+            superclass_name.to_owned()
+        } else {
+            format!(", {superclass_name}")
+        };
+        return Some((
+            module_info.dupe(),
+            TextRange::at(insert_pos, TextSize::new(0)),
+            insert_text,
+        ));
+    }
+    let insert_pos = if let Some(type_params) = &class_def.type_params {
+        type_params.range.end()
+    } else {
+        class_def.name.range.end()
+    };
+    Some((
+        module_info.dupe(),
+        TextRange::at(insert_pos, TextSize::new(0)),
+        format!("({superclass_name})"),
+    ))
+}
+
+fn build_removal_edits(
+    module_info: &pyrefly_python::module::Module,
+    class_def: &StmtClassDef,
+    source: &str,
+    members: &[&Stmt],
+) -> Option<Vec<(pyrefly_python::module::Module, TextRange, String)>> {
+    let selected_ranges: Vec<TextRange> = members.iter().map(|stmt| stmt.range()).collect();
+    let remaining_non_docstring = class_def
+        .body
+        .iter()
+        .filter(|stmt| !is_docstring_stmt(stmt))
+        .filter(|stmt| !selected_ranges.iter().any(|range| *range == stmt.range()))
+        .count();
+    let needs_pass = remaining_non_docstring == 0;
+    let mut edits = Vec::new();
+    let mut pass_inserted = false;
+    for stmt in members {
+        let removal_range = statement_removal_range(source, stmt)?;
+        let replacement = if needs_pass && !pass_inserted {
+            let (indent, _) = line_indent_and_start(source, stmt.range().start())?;
+            pass_inserted = true;
+            format!("{indent}pass\n")
+        } else {
+            String::new()
+        };
+        edits.push((module_info.dupe(), removal_range, replacement));
+    }
+    Some(edits)
+}
+
+/// Remove the full statement line, including leading indent and trailing newline.
+fn statement_removal_range(source: &str, stmt: &Stmt) -> Option<TextRange> {
+    let (_, line_start) = line_indent_and_start(source, stmt.range().start())?;
+    let line_end = line_end_position(source, stmt.range().end());
+    Some(TextRange::new(line_start, line_end))
+}

--- a/pyrefly/lib/state/lsp/quick_fixes/mod.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/mod.rs
@@ -8,6 +8,7 @@
 pub(crate) mod extract_field;
 pub(crate) mod extract_function;
 mod extract_shared;
+pub(crate) mod extract_superclass;
 pub(crate) mod extract_variable;
 pub(crate) mod inline_method;
 pub(crate) mod inline_parameter;

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -366,6 +366,19 @@ fn compute_push_down_actions(
     })
 }
 
+fn compute_extract_superclass_actions(
+    code: &str,
+) -> (
+    ModuleInfo,
+    Vec<Vec<(Module, TextRange, String)>>,
+    Vec<String>,
+) {
+    let selection = find_marked_range_with(code, "# SUPER-START", "# SUPER-END");
+    compute_move_actions(code, selection, |transaction, handle, selection| {
+        transaction.extract_superclass_code_actions(handle, selection)
+    })
+}
+
 #[test]
 fn basic_test() {
     let report = get_batched_lsp_operations_report_allow_error(
@@ -998,6 +1011,79 @@ class Base:
 class Child(Base):
     def foo(self):
         pass
+"#;
+    assert_eq!(expected.trim(), updated.trim());
+}
+
+#[test]
+fn extract_superclass_basic() {
+    let code = r#"
+class Foo:
+    def a(self):
+        return 1
+    # SUPER-START
+    def b(self):
+        return 2
+    def c(self):
+        return 3
+    # SUPER-END
+    def d(self):
+        return 4
+"#;
+    let (module_info, actions, titles) = compute_extract_superclass_actions(code);
+    assert_eq!(vec!["Extract superclass `BaseFoo`"], titles);
+    let updated = apply_refactor_edits_for_module(&module_info, &actions[0]);
+    let expected = r#"
+class BaseFoo:
+    def b(self):
+        return 2
+    def c(self):
+        return 3
+
+class Foo(BaseFoo):
+    def a(self):
+        return 1
+    # SUPER-START
+    # SUPER-END
+    def d(self):
+        return 4
+"#;
+    assert_eq!(expected.trim(), updated.trim());
+}
+
+#[test]
+fn extract_superclass_with_metaclass_inserts_pass() {
+    let code = r#"
+class Base:
+    pass
+
+class Meta(type):
+    pass
+
+class Foo(Base, metaclass=Meta):
+    # SUPER-START
+    def only(self):
+        pass
+    # SUPER-END
+"#;
+    let (module_info, actions, titles) = compute_extract_superclass_actions(code);
+    assert_eq!(vec!["Extract superclass `BaseFoo`"], titles);
+    let updated = apply_refactor_edits_for_module(&module_info, &actions[0]);
+    let expected = r#"
+class Base:
+    pass
+
+class Meta(type):
+    pass
+
+class BaseFoo:
+    def only(self):
+        pass
+
+class Foo(Base, BaseFoo, metaclass=Meta):
+    # SUPER-START
+    pass
+    # SUPER-END
 "#;
     assert_eq!(expected.trim(), updated.trim());
 }


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

part of #2207

https://www.jetbrains.com/help/pycharm/extract-superclass.html

Added Extract Superclass refactor to create a new base class in the same file, move the selected members, update the original class bases, and insert pass when the original becomes empty.

Wired the new refactor into LSP code actions.

note: to keep it simple, it does not implement the “Make Abstract” yet.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added tests.