### PR TITLE
if *args: Any and **kwargs: Any are present, treat signature like `...` for assignability purposes

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -2094,28 +2094,6 @@
     },
     {
       "code": -2,
-      "column": 20,
-      "concise_description": "`Proto7` is not assignable to `Proto6`",
-      "description": "`Proto7` is not assignable to `Proto6`\n  `Proto7.__call__` has type `(self: Proto7, a: float, /, b: int, *, k: str, m: str) -> None`, which is not assignable to `(self: Proto7, a: int, /, *args: Any, *, k: str, **kwargs: Any) -> None`, the type of `Proto6.__call__`",
-      "line": 157,
-      "name": "bad-assignment",
-      "severity": "error",
-      "stop_column": 22,
-      "stop_line": 157
-    },
-    {
-      "code": -2,
-      "column": 25,
-      "concise_description": "`Proto8` is not assignable to `Proto5[Any]`",
-      "description": "`Proto8` is not assignable to `Proto5[Any]`\n  `Proto8.__call__` has type `(self: Proto8) -> None`, which is not assignable to `(self: Proto8, *args: Any, **kwargs: Any) -> None`, the type of `Proto5.__call__`",
-      "line": 159,
-      "name": "bad-assignment",
-      "severity": "error",
-      "stop_column": 27,
-      "stop_line": 159
-    },
-    {
-      "code": -2,
       "column": 26,
       "concise_description": "`() -> str` is not assignable to `(int, ...) -> str`",
       "description": "`() -> str` is not assignable to `(int, ...) -> str`",

--- a/conformance/third_party/conformance.result
+++ b/conformance/third_party/conformance.result
@@ -22,8 +22,8 @@
   "annotations_methods.py": [],
   "annotations_typeexpr.py": [],
   "callables_annotation.py": [
-    "Line 156: Unexpected errors ['`Proto4[Ellipsis]` is not assignable to `Proto3`\\n  `Proto4[Ellipsis].__call__` has type `(Proto4[Ellipsis], int, ...) -> None`, which is not assignable to `(self: Proto4[Ellipsis], a: int, *args: Any, **kwargs: Any) -> None`, the type of `Proto3.__call__`']",
-    "Line 157: Unexpected errors ['`Proto7` is not assignable to `Proto6`\\n  `Proto7.__call__` has type `(self: Proto7, a: float, /, b: int, *, k: str, m: str) -> None`, which is not assignable to `(self: Proto7, a: int, /, *args: Any, *, k: str, **kwargs: Any) -> None`, the type of `Proto6.__call__`']"
+    "Line 159: Expected 1 errors",
+    "Line 156: Unexpected errors ['`Proto4[Ellipsis]` is not assignable to `Proto3`\\n  `Proto4[Ellipsis].__call__` has type `(Proto4[Ellipsis], int, ...) -> None`, which is not assignable to `(self: Proto4[Ellipsis], a: int, *args: Any, **kwargs: Any) -> None`, the type of `Proto3.__call__`']"
   ],
   "callables_kwargs.py": [],
   "callables_protocol.py": [],

--- a/crates/pyrefly_config/src/args.rs
+++ b/crates/pyrefly_config/src/args.rs
@@ -186,6 +186,17 @@ pub struct ConfigOverrideArgs {
         num_args = 0..=1
     )]
     tensor_shapes: Option<bool>,
+    /// Whether to strictly check callable subtyping for signatures with `*args: Any, **kwargs: Any`.
+    /// When false (the default), callables with `*args: Any, **kwargs: Any` are treated as
+    /// compatible with any signature (similar to `...` behavior).
+    /// When true, parameter list compatibility is checked strictly even when `*args: Any, **kwargs: Any` is present.
+    #[arg(
+        long,
+        default_missing_value = "true",
+        require_equals = true,
+        num_args = 0..=1
+    )]
+    strict_callable_subtyping: Option<bool>,
 }
 
 impl ConfigOverrideArgs {
@@ -367,6 +378,9 @@ impl ConfigOverrideArgs {
         }
         if let Some(x) = &self.tensor_shapes {
             config.root.tensor_shapes = Some(*x);
+        }
+        if let Some(x) = &self.strict_callable_subtyping {
+            config.root.strict_callable_subtyping = Some(*x);
         }
         let apply_error_settings = |error_config: &mut ErrorDisplayConfig| {
             for error_kind in &self.error {

--- a/crates/pyrefly_config/src/base.rs
+++ b/crates/pyrefly_config/src/base.rs
@@ -125,6 +125,13 @@ pub struct ConfigBase {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recursion_overflow_handler: Option<RecursionOverflowHandler>,
 
+    /// Whether to strictly check callable subtyping for signatures with `*args: Any, **kwargs: Any`.
+    /// When false (the default), callables with `*args: Any, **kwargs: Any` are treated as
+    /// compatible with any signature (similar to `...` behavior).
+    /// When true, parameter list compatibility is checked strictly even when `*args: Any, **kwargs: Any` is present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strict_callable_subtyping: Option<bool>,
+
     /// Any unknown config items
     #[serde(default, flatten)]
     pub(crate) extras: ExtraConfigs,
@@ -202,5 +209,9 @@ impl ConfigBase {
                 })
             }
         })
+    }
+
+    pub fn get_strict_callable_subtyping(base: &Self) -> Option<bool> {
+        base.strict_callable_subtyping
     }
 }

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -818,6 +818,14 @@ impl ConfigFile {
                  self.root.tensor_shapes.unwrap())
     }
 
+    pub fn strict_callable_subtyping(&self, path: &Path) -> bool {
+        self.get_from_sub_configs(ConfigBase::get_strict_callable_subtyping, path)
+            .unwrap_or_else(||
+                 // we can use unwrap here, because the value in the root config must
+                 // be set in `ConfigFile::configure()`.
+                 self.root.strict_callable_subtyping.unwrap())
+    }
+
     pub fn enabled_ignores(&self, path: &Path) -> &SmallSet<Tool> {
         self.get_from_sub_configs(ConfigBase::get_enabled_ignores, path)
             .unwrap_or_else(||
@@ -1079,6 +1087,10 @@ impl ConfigFile {
 
         if self.root.tensor_shapes.is_none() {
             self.root.tensor_shapes = Some(false);
+        }
+
+        if self.root.strict_callable_subtyping.is_none() {
+            self.root.strict_callable_subtyping = Some(false);
         }
 
         let tools_from_permissive_ignores = match self.root.permissive_ignores {
@@ -1402,6 +1414,7 @@ mod tests {
              ignore-missing-imports = []
              ignore-errors-in-generated-code = false
              infer-with-first-use = false
+             strict-callable-subtyping = false
              [sub-config.errors]
              assert-type = false
              invalid-yield = false
@@ -1454,6 +1467,7 @@ mod tests {
                     disable_type_errors_in_ide: None,
                     ignore_errors_in_generated_code: Some(true),
                     infer_with_first_use: None,
+                    strict_callable_subtyping: None,
                     tensor_shapes: None,
                     replace_imports_with_any: Some(vec![ModuleWildcard::new("fibonacci").unwrap()]),
                     ignore_missing_imports: Some(vec![ModuleWildcard::new("sprout").unwrap()]),
@@ -1475,6 +1489,7 @@ mod tests {
                         disable_type_errors_in_ide: None,
                         ignore_errors_in_generated_code: Some(false),
                         infer_with_first_use: Some(false),
+                        strict_callable_subtyping: Some(false),
                         tensor_shapes: None,
                         replace_imports_with_any: Some(Vec::new()),
                         ignore_missing_imports: Some(Vec::new()),
@@ -1862,6 +1877,7 @@ baseline = "baseline.json"
                 disable_type_errors_in_ide: Some(true),
                 ignore_errors_in_generated_code: Some(false),
                 infer_with_first_use: Some(true),
+                strict_callable_subtyping: Some(false),
                 tensor_shapes: None,
                 extras: Default::default(),
                 permissive_ignores: Some(false),
@@ -2172,6 +2188,7 @@ baseline = "baseline.json"
                 disable_type_errors_in_ide: Some(true),
                 ignore_errors_in_generated_code: Some(false),
                 infer_with_first_use: Some(true),
+                strict_callable_subtyping: Some(false),
                 tensor_shapes: None,
                 extras: Default::default(),
                 permissive_ignores: Some(false),
@@ -2207,6 +2224,7 @@ baseline = "baseline.json"
                 disable_type_errors_in_ide: Some(true),
                 ignore_errors_in_generated_code: Some(false),
                 infer_with_first_use: Some(true),
+                strict_callable_subtyping: Some(false),
                 tensor_shapes: None,
                 extras: Default::default(),
                 permissive_ignores: Some(false),

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -319,6 +319,7 @@ pub struct Solver {
     pub infer_with_first_use: bool,
     pub heap: TypeHeap,
     pub tensor_shapes: bool,
+    pub strict_callable_subtyping: bool,
 }
 
 impl Display for Solver {
@@ -336,13 +337,18 @@ const TYPE_LIMIT: usize = 20;
 
 impl Solver {
     /// Create a new solver.
-    pub fn new(infer_with_first_use: bool, tensor_shapes: bool) -> Self {
+    pub fn new(
+        infer_with_first_use: bool,
+        tensor_shapes: bool,
+        strict_callable_subtyping: bool,
+    ) -> Self {
         Self {
             variables: Default::default(),
             instantiation_errors: Default::default(),
             infer_with_first_use,
             heap: TypeHeap::new(),
             tensor_shapes,
+            strict_callable_subtyping,
         }
     }
 

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -1039,6 +1039,8 @@ impl<'a> Transaction<'a> {
                 infer_with_first_use: config
                     .infer_with_first_use(module_data.handle.path().as_path()),
                 tensor_shapes: config.tensor_shapes(module_data.handle.path().as_path()),
+                strict_callable_subtyping: config
+                    .strict_callable_subtyping(module_data.handle.path().as_path()),
                 recursion_limit_config: config.recursion_limit_config(),
             };
 
@@ -1973,6 +1975,8 @@ impl<'a> Transaction<'a> {
                 untyped_def_behavior: config.untyped_def_behavior(m.handle.path().as_path()),
                 infer_with_first_use: config.infer_with_first_use(m.handle.path().as_path()),
                 tensor_shapes: config.tensor_shapes(m.handle.path().as_path()),
+                strict_callable_subtyping: config
+                    .strict_callable_subtyping(m.handle.path().as_path()),
                 recursion_limit_config: config.recursion_limit_config(),
             };
             let mut old = Steps::default();

--- a/pyrefly/lib/state/steps.rs
+++ b/pyrefly/lib/state/steps.rs
@@ -48,6 +48,7 @@ pub struct Context<'a, Lookup> {
     pub untyped_def_behavior: UntypedDefBehavior,
     pub infer_with_first_use: bool,
     pub tensor_shapes: bool,
+    pub strict_callable_subtyping: bool,
     pub recursion_limit_config: Option<RecursionLimitConfig>,
 }
 
@@ -375,7 +376,11 @@ impl Step {
         ast: Arc<ModModule>,
         exports: Arc<Exports>,
     ) -> Arc<(Bindings, Arc<Answers>)> {
-        let solver = Solver::new(ctx.infer_with_first_use, ctx.tensor_shapes);
+        let solver = Solver::new(
+            ctx.infer_with_first_use,
+            ctx.tensor_shapes,
+            ctx.strict_callable_subtyping,
+        );
         let enable_index = ctx.require.keep_index();
         let enable_trace = ctx.require.keep_answers_trace();
         let bindings = Bindings::new(

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -1310,7 +1310,7 @@ class Proto7(Protocol):
 def test(p4: Proto4[...], p7: Proto7):
     # Both should be OK per conformance spec - pyrefly incorrectly errors
     ok10: Proto3 = p4  # E: `Proto4[Ellipsis]` is not assignable to `Proto3`
-    ok11: Proto6 = p7  # E: `Proto7` is not assignable to `Proto6`
+    ok11: Proto6 = p7
 "#,
 );
 

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -215,10 +215,11 @@ class Derived(Base):
 testcase!(
     test_override_parameter_kinds,
     r#"
-from typing import assert_type, override
+from typing import assert_type, override, Any
 
 class Base:
     def g(self, /, x: int, *args: str, y: bool, **kwargs: float) -> None: ...
+    def method(self, a: int, /, *args: Any, k: str, **kwargs: Any) -> None: ...
 
 class Derived(Base):
     @override
@@ -227,6 +228,76 @@ class Derived(Base):
         assert_type(args, tuple[str, ...])
         assert_type(y, bool)
         assert_type(kwargs, dict[str, float])
+    @override
+    def method(self, a: float, /, b: int, *, k: str, m: str) -> None: ...
+    "#,
+);
+
+testcase!(
+    test_override_parameter_gradual_basic,
+    r#"
+from typing import override, Any
+
+class GradualBase:
+    def method1(self, a: int, /, *args: Any, k: int, **kwargs: Any) -> None: ...
+
+class Child(GradualBase):
+    @override
+    def method1(self) -> None: ...
+
+class Base:
+    def method1(self) -> None: ...
+
+class GradualChild(Base):
+    @override
+    def method1(self, a: int, /, *args: Any, k: int, **kwargs: Any) -> None: ...
+    "#,
+);
+
+testcase!(
+    test_override_parameter_gradual_abstract,
+    r#"
+from abc import ABC, abstractmethod
+from typing import Any
+
+class Processor(ABC):
+    @abstractmethod
+    def process(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+class ConcreteProcessor(Processor):
+    def process(self, data: str, count: int = 1) -> str:
+        return data * count
+    "#,
+);
+
+testcase!(
+    test_override_parameter_gradual_parent_overload,
+    r#"
+from argparse import ArgumentParser as BaseArgumentParser
+from typing import Any
+
+class ArgumentParser(BaseArgumentParser):
+    def add_subparsers(self, *args: Any, **kwargs: Any):
+        return super().add_subparsers(*args, **kwargs)
+    "#,
+);
+
+testcase!(
+    test_override_parameter_gradual_child_overload,
+    r#"
+from typing import overload, Any
+class Base:
+    def test(self, *args: Any, **kwargs: Any):
+        pass
+
+class Child(Base):
+    @overload
+    def test(self, x: int): pass
+    @overload
+    def test(self, x: str): pass
+    def test(self, x):
+        pass
     "#,
 );
 

--- a/pyrefly/lib/test/protocol.rs
+++ b/pyrefly/lib/test/protocol.rs
@@ -963,3 +963,25 @@ class Options1(Protocol):
 op1: Options1 = _protocols_modules1  # E: `Module[_protocols_modules1]` is not assignable to `Options1`
 "#,
 );
+
+testcase!(
+    test_protocol_any_args_kwargs,
+    r#"
+from typing import Generic, Sized, Iterable, Any, TypeVar, Protocol, Self
+
+class NativeSeries(Protocol):
+    def filter(self, *args: Any, **kwargs: Any) -> Any: ...
+
+class MySeries:
+    def filter(self, _predicate: Iterable[bool]) -> Self:
+        return self
+
+T = TypeVar('T', bound=NativeSeries)
+
+class Foo(Generic[T]):
+    ...
+
+def to_foo() -> Foo[MySeries]:
+    ...
+"#,
+);

--- a/schemas/test-pyproject.toml
+++ b/schemas/test-pyproject.toml
@@ -30,6 +30,7 @@ infer-with-first-use = true
 ignore-errors-in-generated-code = false
 disable-type-errors-in-ide = false
 tensor-shapes = false
+strict-callable-subtyping = false
 recursion-depth-limit = 100
 recursion-overflow-handler = "break-with-placeholder"
 

--- a/schemas/test-pyrefly.toml
+++ b/schemas/test-pyrefly.toml
@@ -26,6 +26,7 @@ infer-with-first-use = true
 ignore-errors-in-generated-code = false
 disable-type-errors-in-ide = false
 tensor-shapes = false
+strict-callable-subtyping = false
 recursion-depth-limit = 100
 recursion-overflow-handler = "break-with-placeholder"
 


### PR DESCRIPTION
Summary:
This ignores any other parameters (though they are preserved when we eventually call the function)

Pyright accepts this snippet:

```
from typing import override, Any

class Base:
    def method1(self, a: int, /, *args: Any, k: int, **kwargs: Any) -> None: ...

class Derived(Base):
    override
    def method1(self) -> None: ...

class Base2:
    def method1(self) -> None: ...

class Derived2(Base2):
    override
    def method1(self, a: int, /, *args: Any, k: int, **kwargs: Any) -> None: ...
```

Spec says: https://typing.python.org/en/latest/spec/callables.html#meaning-of-in-callable

> If the input signature in a function definition includes both a *args and **kwargs parameter and both are typed as Any (explicitly or implicitly because it has no annotation), a type checker should treat this as the equivalent of .... Any other parameters in the signature are unaffected and are retained as part of the signature

Differential Revision: D89676164
