### PR TITLE
fix Exception message for incorrect dict literal is too wide #893

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1545,49 +1545,63 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             let mut key_tys = Vec::new();
             let mut value_tys = Vec::new();
             let mut has_type_mismatch = false;
+            let check_items = hint
+                .filter(|hint| hint.errors().is_some())
+                .is_some_and(|hint| hint.types().len() == 1);
+            let infer_with_hint = |expr: &Expr, hint: Option<HintRef>, errors: &ErrorCollector| {
+                let ty = self.expr_infer_with_hint(expr, hint, errors);
+                match hint {
+                    Some(hint) => {
+                        let want = match hint.types() {
+                            [hint] => hint.clone(),
+                            hints => Type::union(hints.to_vec()),
+                        };
+                        let matches_hint = self.is_subset_eq(&ty, &want);
+                        let ty = if matches_hint {
+                            want
+                        } else {
+                            ty.promote_implicit_literals(self.stdlib)
+                        };
+                        (ty, matches_hint)
+                    }
+                    None => (ty.promote_implicit_literals(self.stdlib), true),
+                }
+            };
             items.iter().for_each(|x| match &x.key {
                 Some(key) => {
-                    let key_t = self.expr_infer_with_hint_promote(
-                        key,
-                        key_hint.as_ref().and_then(|key_hint| {
-                            hint.as_ref()
-                                .map(|hint| HintRef::new(key_hint, hint.errors()))
-                        }),
-                        errors,
-                    );
-                    let value_t = self.expr_infer_with_hint_promote(
-                        &x.value,
-                        value_hint.as_ref().and_then(|value_hint| {
-                            hint.as_ref()
-                                .map(|hint| HintRef::new(value_hint, hint.errors()))
-                        }),
-                        errors,
-                    );
-                    if let Some(hint) = hint
+                    let key_hint_ref = key_hint.as_ref().and_then(|key_hint| {
+                        hint.as_ref()
+                            .map(|hint| HintRef::new(key_hint, hint.errors()))
+                    });
+                    let value_hint_ref = value_hint.as_ref().and_then(|value_hint| {
+                        hint.as_ref()
+                            .map(|hint| HintRef::new(value_hint, hint.errors()))
+                    });
+                    let (key_t, key_matches_hint) = infer_with_hint(key, key_hint_ref, errors);
+                    let (value_t, value_matches_hint) =
+                        infer_with_hint(&x.value, value_hint_ref, errors);
+                    if check_items
+                        && let Some(hint) = hint
                         && let Some(check_errors) = hint.errors()
                     {
                         let tcc: &dyn Fn() -> TypeCheckContext =
-                            &|| TypeCheckContext::of_kind(TypeCheckKind::AnnAssign);
+                            &|| TypeCheckContext::of_kind(TypeCheckKind::DictLiteralItem);
                         if let Some(key_hint) = &key_hint
-                            && !self.check_type(
-                                &key_t,
-                                key_hint,
-                                key.range(),
-                                check_errors,
-                                tcc,
-                            )
+                            && !key_matches_hint
                         {
+                            self.check_type(&key_t, key_hint, key.range(), check_errors, tcc);
                             has_type_mismatch = true;
                         }
                         if let Some(value_hint) = &value_hint
-                            && !self.check_type(
+                            && !value_matches_hint
+                        {
+                            self.check_type(
                                 &value_t,
                                 value_hint,
                                 x.value.range(),
                                 check_errors,
                                 tcc,
-                            )
-                        {
+                            );
                             has_type_mismatch = true;
                         }
                     }
@@ -1637,31 +1651,40 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     } else if let Some((key_t, value_t)) = self.unwrap_mapping(&ty) {
                         // Non-anonymous-typed-dict unpacking disables anonymous typed dict creation
                         can_create_anonymous_typed_dict = false;
-                        if let Some(hint) = hint
+                        let key_matches_hint = key_hint
+                            .as_ref()
+                            .is_some_and(|key_hint| self.is_subset_eq(&key_t, key_hint));
+                        let value_matches_hint = value_hint
+                            .as_ref()
+                            .is_some_and(|value_hint| self.is_subset_eq(&value_t, value_hint));
+                        if check_items
+                            && let Some(hint) = hint
                             && let Some(check_errors) = hint.errors()
                         {
                             let tcc: &dyn Fn() -> TypeCheckContext =
-                                &|| TypeCheckContext::of_kind(TypeCheckKind::AnnAssign);
+                                &|| TypeCheckContext::of_kind(TypeCheckKind::DictLiteralItem);
                             if let Some(key_hint) = &key_hint
-                                && !self.check_type(
+                                && !key_matches_hint
+                            {
+                                self.check_type(
                                     &key_t,
                                     key_hint,
                                     x.value.range(),
                                     check_errors,
                                     tcc,
-                                )
-                            {
+                                );
                                 has_type_mismatch = true;
                             }
                             if let Some(value_hint) = &value_hint
-                                && !self.check_type(
+                                && !value_matches_hint
+                            {
+                                self.check_type(
                                     &value_t,
                                     value_hint,
                                     x.value.range(),
                                     check_errors,
                                     tcc,
-                                )
-                            {
+                                );
                                 has_type_mismatch = true;
                             }
                         }

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -96,6 +96,7 @@ use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
 use crate::error::context::ErrorContext;
 use crate::error::context::TypeCheckContext;
+use crate::error::context::TypeCheckKind;
 use crate::solver::solver::CallContext;
 use crate::types::callable::DefaultValue;
 use crate::types::callable::Param;
@@ -1543,6 +1544,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 .any(|x| x.key.is_some() && !x.value.is_none_literal_expr());
             let mut key_tys = Vec::new();
             let mut value_tys = Vec::new();
+            let mut has_type_mismatch = false;
             items.iter().for_each(|x| match &x.key {
                 Some(key) => {
                     let key_t = self.expr_infer_with_hint_promote(
@@ -1561,6 +1563,34 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         }),
                         errors,
                     );
+                    if let Some(hint) = hint
+                        && let Some(check_errors) = hint.errors()
+                    {
+                        let tcc: &dyn Fn() -> TypeCheckContext =
+                            &|| TypeCheckContext::of_kind(TypeCheckKind::AnnAssign);
+                        if let Some(key_hint) = &key_hint
+                            && !self.check_type(
+                                &key_t,
+                                key_hint,
+                                key.range(),
+                                check_errors,
+                                tcc,
+                            )
+                        {
+                            has_type_mismatch = true;
+                        }
+                        if let Some(value_hint) = &value_hint
+                            && !self.check_type(
+                                &value_t,
+                                value_hint,
+                                x.value.range(),
+                                check_errors,
+                                tcc,
+                            )
+                        {
+                            has_type_mismatch = true;
+                        }
+                    }
                     if !key_t.is_error() {
                         key_tys.push(key_t);
                     }
@@ -1607,6 +1637,34 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     } else if let Some((key_t, value_t)) = self.unwrap_mapping(&ty) {
                         // Non-anonymous-typed-dict unpacking disables anonymous typed dict creation
                         can_create_anonymous_typed_dict = false;
+                        if let Some(hint) = hint
+                            && let Some(check_errors) = hint.errors()
+                        {
+                            let tcc: &dyn Fn() -> TypeCheckContext =
+                                &|| TypeCheckContext::of_kind(TypeCheckKind::AnnAssign);
+                            if let Some(key_hint) = &key_hint
+                                && !self.check_type(
+                                    &key_t,
+                                    key_hint,
+                                    x.value.range(),
+                                    check_errors,
+                                    tcc,
+                                )
+                            {
+                                has_type_mismatch = true;
+                            }
+                            if let Some(value_hint) = &value_hint
+                                && !self.check_type(
+                                    &value_t,
+                                    value_hint,
+                                    x.value.range(),
+                                    check_errors,
+                                    tcc,
+                                )
+                            {
+                                has_type_mismatch = true;
+                            }
+                        }
                         if !key_t.is_error() {
                             if let Some(key_hint) = &key_hint
                                 && self.is_subset_eq(&key_t, key_hint)
@@ -1636,6 +1694,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                 }
             });
+            if has_type_mismatch
+                && let Some(hint) = hint
+                && hint.errors().is_some()
+            {
+                return match hint.types() {
+                    [hint] => hint.clone(),
+                    hints => Type::union(hints.to_vec()),
+                };
+            }
             let any_field_has_open_placeholder = typed_dict_fields_map.values().any(|field| {
                 field
                     .ty

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1489,12 +1489,23 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if key_hint.is_none() && value_hint.is_none() {
                     None
                 } else {
-                    Some((key_hint, value_hint))
+                    Some((hint.clone(), key_hint, value_hint))
                 }
             },
             |hints| {
-                let (key_hint, value_hint) = hints.unwrap_or_default();
-                self.dict_items_infer_inner(range, &items, hint, key_hint, value_hint, errors)
+                let (decomposed_hint, key_hint, value_hint) = match hints {
+                    Some((hint, key_hint, value_hint)) => (Some(hint), key_hint, value_hint),
+                    None => (None, None, None),
+                };
+                self.dict_items_infer_inner(
+                    range,
+                    &items,
+                    hint,
+                    decomposed_hint,
+                    key_hint,
+                    value_hint,
+                    errors,
+                )
             },
         )
     }
@@ -1504,6 +1515,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         range: TextRange,
         items: &[&DictItem],
         hint: Option<HintRef>,
+        decomposed_hint: Option<Type>,
         key_hint: Option<Type>,
         value_hint: Option<Type>,
         errors: &ErrorCollector,
@@ -1721,10 +1733,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 && let Some(hint) = hint
                 && hint.errors().is_some()
             {
-                return match hint.types() {
-                    [hint] => hint.clone(),
-                    hints => Type::union(hints.to_vec()),
-                };
+                return decomposed_hint
+                    .expect("dict item mismatch requires a successfully decomposed hint");
             }
             let any_field_has_open_placeholder = typed_dict_fields_map.values().any(|field| {
                 field

--- a/pyrefly/lib/error/context.rs
+++ b/pyrefly/lib/error/context.rs
@@ -190,6 +190,8 @@ pub enum TypeCheckKind {
     /// var: SomeType = some_value check. This is separate from AnnotatedName because we can
     /// emit a more compact error message for this case.
     AnnAssign,
+    /// Check a dict literal key/value against a contextual dict hint.
+    DictLiteralItem,
     /// Check one portion of an unpacked assignment (e.g. `x, y = foo()`) against the expected type.
     UnpackedAssign,
     /// Class used in an `except C` clause.
@@ -246,6 +248,7 @@ impl TypeCheckKind {
             Self::AnnotatedName(..) => ErrorKind::BadAssignment,
             Self::IterationVariableMismatch(..) => ErrorKind::BadAssignment,
             Self::AnnAssign => ErrorKind::BadAssignment,
+            Self::DictLiteralItem => ErrorKind::BadAssignment,
             Self::UnpackedAssign => ErrorKind::BadAssignment,
             Self::ExceptionClass => ErrorKind::InvalidInheritance,
             Self::YieldValue => ErrorKind::InvalidYield,

--- a/pyrefly/lib/error/display.rs
+++ b/pyrefly/lib/error/display.rs
@@ -216,7 +216,7 @@ impl TypeCheckKind {
             // TODO(stroxler): In an unpacked assignment to a name we would ideally provide the name in
             // the error message, but without a refactor of `bind_target` we don't have easy access to
             // that information when creating the binding, so we're stuck with just types for now.
-            Self::AnnAssign | Self::UnpackedAssign => format!(
+            Self::AnnAssign | Self::DictLiteralItem | Self::UnpackedAssign => format!(
                 "`{}` is not assignable to `{}`",
                 ctx.display(got),
                 ctx.display(want)

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -908,7 +908,7 @@ def test1(*cmd: str, **keywords: str) -> None:
     cmd = ("mycmd",)
     cmd = (1,)  # E: `tuple[Literal[1]]` is not assignable to variable `cmd` with type `tuple[str, ...]`
     keywords = {"key": "value"}
-    keywords = {"key": 0}  # E: `dict[str, int]` is not assignable to variable `keywords` with type `dict[str, str]`
+    keywords = {"key": 0}  # E: `int` is not assignable to `str`
 class MyDict(TypedDict):
     x: int
     y: int

--- a/pyrefly/lib/test/contextual.rs
+++ b/pyrefly/lib/test/contextual.rs
@@ -208,11 +208,11 @@ testcase!(
     r#"
 from typing import Iterable, MutableMapping, Literal
 x1: dict[str, int] = {"a": 1}
-x2: dict[str, int] = {"a": "oops"}  # E: `dict[str, str]` is not assignable to `dict[str, int]`
-x3: dict[str, Literal[1]] = {"a": 2} # E: `dict[str, int]` is not assignable to `dict[str, Literal[1]]`
+x2: dict[str, int] = {"a": "oops"}  # E: `str` is not assignable to `int`
+x3: dict[str, Literal[1]] = {"a": 2} # E: `int` is not assignable to `Literal[1]`
 x4: MutableMapping[str, int] = {"a": 1}
 x5: Iterable[str] = {"a": 1}
-x6: Iterable[int] = {"oops": 1}  # E: `dict[str, int]` is not assignable to `Iterable[int]`
+x6: Iterable[int] = {"oops": 1}  # E: `str` is not assignable to `int`
 x7: Iterable[Literal[4]] = {4: "a"}
 x8: object = {"a": 1}
 x9: list[str] = {"a": 1}  # E: `dict[str, int]` is not assignable to `list[str]`

--- a/pyrefly/lib/test/dict.rs
+++ b/pyrefly/lib/test/dict.rs
@@ -5,6 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use ruff_text_size::Ranged;
+use ruff_text_size::TextSize;
+
+use crate::test::util;
 use crate::testcase;
 
 testcase!(
@@ -201,7 +205,6 @@ assert_type(f(d), TD)  # E: assert_type(dict[str, int], TD)
 assert_type(f({"x": 0}), TD)  # E: `dict[str, int]` is not assignable to upper bound `TD`  # E: assert_type(dict[str, int], TD)
     "#,
 );
-
 // Regression test: deeply nested dict literals previously caused exponential memory growth
 // because AnonymousTypedDictInner stored the value type both in `fields` and a redundant
 // `value_type` field, doubling the cloned type tree at each nesting level. The fix removed
@@ -233,3 +236,23 @@ d = {"photo": [images[0]], "enabled": ["yes"]}
 same(d, [dict(photo=[images[0]], enabled=["yes"], **extra)])
     "#,
 );
+
+#[test]
+fn test_dict_literal_error_range_points_to_value() {
+    util::init_test();
+    let code = r#"x: dict[str, str] = {
+    "1": 2,
+}
+"#;
+    let (handle, state) = util::mk_state(code);
+    let errors = state
+        .transaction()
+        .get_errors([&handle])
+        .collect_errors()
+        .ordinary;
+    assert_eq!(errors.len(), 1);
+    let err = &errors[0];
+    let value_offset = code.find("2").expect("missing dict value literal");
+    let expected_start = TextSize::try_from(value_offset).unwrap();
+    assert_eq!(err.range().start(), expected_start);
+}

--- a/pyrefly/lib/test/new_type.rs
+++ b/pyrefly/lib/test/new_type.rs
@@ -145,7 +145,7 @@ Thing = NewType("Thing", int)
 ThingType = type[Thing]  # E: NewType `Thing` is not a class and cannot be used with `type` or `Type`
 OtherThingType = Type[Thing]  # E: NewType `Thing` is not a class and cannot be used with `type` or `Type`
 
-mapping: dict[int, ThingType] = {1: Thing}  # E: `dict[int, type[Thing]]` is not assignable to `dict[int, type[Any]]`
+mapping: dict[int, ThingType] = {1: Thing}  # E: `type[Thing]` is not assignable to `type[Any]`
 
 def func(x: ThingType) -> None: ...
 func(Thing)  # E: Argument `type[Thing]` is not assignable to parameter `x` with type `type[Any]` in function `func`

--- a/pyrefly/lib/test/recursive_alias.rs
+++ b/pyrefly/lib/test/recursive_alias.rs
@@ -196,7 +196,7 @@ type X[K, V] = dict[K, V] | list[X[str, V]]
 
 x1: X = {0: 1}
 x2: X[int, int] = {0: 1}
-x3: X[str, int] = {0: 1}  # E: `dict[int, int]` is not assignable to `dict[str, int] | list[X[str, int]]`
+x3: X[str, int] = {0: 1}  # E: `int` is not assignable to `str`
 
 x4: X = [{'ok': 1}]
 x5: X[int, int] = [{'ok': 1}]

--- a/pyrefly/lib/test/recursive_alias.rs
+++ b/pyrefly/lib/test/recursive_alias.rs
@@ -196,7 +196,7 @@ type X[K, V] = dict[K, V] | list[X[str, V]]
 
 x1: X = {0: 1}
 x2: X[int, int] = {0: 1}
-x3: X[str, int] = {0: 1}  # E: `int` is not assignable to `str`
+x3: X[str, int] = {0: 1}  # E: `dict[int, int]` is not assignable to `dict[str, int] | list[X[str, int]]`
 
 x4: X = [{'ok': 1}]
 x5: X[int, int] = [{'ok': 1}]

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -732,7 +732,7 @@ testcase!(
     r#"
 from typing import assert_type
 x1: dict[str, int] = {"foo": 1, **{"bar": 2}}
-x2: dict[str, int] = {"foo": 1, **{"bar": "bar"}}  # E: `dict[str, int | str]` is not assignable to `dict[str, int]`
+x2: dict[str, int] = {"foo": 1, **{"bar": "bar"}}  # E: `str` is not assignable to `int`
 assert_type({"foo": 1, **{"bar": "bar"}}, dict[str, int | str])
 {"foo": 1, **1}  # E: Expected a mapping, got Literal[1]
 "#,
@@ -744,7 +744,7 @@ testcase!(
 from typing import Mapping, assert_type
 def test(m: Mapping[str, int]) -> None:
     x1: dict[str, int] = {**m}
-    x2: dict[int, int] = {**m} # E: `dict[str, int]` is not assignable to `dict[int, int]`
+    x2: dict[int, int] = {**m} # E: `str` is not assignable to `int`
     assert_type({"foo": 1, **m}, dict[str, int])
 "#,
 );
@@ -756,7 +756,7 @@ from typing import assert_type
 class Counter[T](dict[T, int]): ...
 def test(c: Counter[str]) -> None:
     x1: dict[str, int] = {**c}
-    x2: dict[int, int] = {**c}  # E: `dict[str, int]` is not assignable to `dict[int, int]`
+    x2: dict[int, int] = {**c}  # E: `str` is not assignable to `int`
     assert_type({"foo": 1, **c}, dict[str, int])
 "#,
 );
@@ -1533,7 +1533,7 @@ testcase!(
     test_typing_alias,
     r#"
 from typing import Dict, assert_type
-y: Dict[str, int] = {"test": "test"} # E: `dict[str, str]` is not assignable to `dict[str, int]`
+y: Dict[str, int] = {"test": "test"} # E: `str` is not assignable to `int`
 assert_type(y, dict[str, int])
 "#,
 );


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #893

Narrowed dict-literal assignment errors to the first mismatching key/value/unpack when a dict[...] hint is present, so the caret lands on the wrong entry instead of the whole { ... }.

to decide: only show first error for now. Maybe show full error? But will it too noisy?

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added a unit test that asserts the error range points at the offending value literal.
