### PR TITLE
fix invalid-yield false positive with lambda expression #949

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -45,6 +45,7 @@ use ruff_python_ast::Keyword;
 use ruff_python_ast::Number;
 use ruff_python_ast::StringLiteralValue;
 use ruff_python_ast::name::Name;
+use ruff_python_ast::visitor::Visitor;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use starlark_map::Hashed;
@@ -89,6 +90,43 @@ pub enum TypeOrExpr<'a> {
     /// Bundles a `Type` with a `TextRange`, allowing us to give good errors.
     Type(&'a Type, TextRange),
     Expr(&'a Expr),
+}
+
+fn lambda_yield_ranges(body: &Expr) -> (Vec<TextRange>, Vec<TextRange>) {
+    struct Collector {
+        yields: Vec<TextRange>,
+        yield_froms: Vec<TextRange>,
+    }
+
+    impl<'a> Visitor<'a> for Collector {
+        fn visit_expr(&mut self, expr: &'a Expr) {
+            match expr {
+                Expr::Lambda(_)
+                | Expr::Generator(_)
+                | Expr::ListComp(_)
+                | Expr::SetComp(_)
+                | Expr::DictComp(_) => {
+                    // Skip nested scopes: yields there shouldn't affect the outer lambda.
+                }
+                Expr::Yield(x) => {
+                    self.yields.push(x.range);
+                    ruff_python_ast::visitor::walk_expr(self, expr);
+                }
+                Expr::YieldFrom(x) => {
+                    self.yield_froms.push(x.range);
+                    ruff_python_ast::visitor::walk_expr(self, expr);
+                }
+                _ => ruff_python_ast::visitor::walk_expr(self, expr),
+            }
+        }
+    }
+
+    let mut collector = Collector {
+        yields: Vec::new(),
+        yield_froms: Vec::new(),
+    };
+    collector.visit_expr(body);
+    (collector.yields, collector.yield_froms)
 }
 
 impl Ranged for TypeOrExpr<'_> {
@@ -430,6 +468,25 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     return_hint.as_ref().map(|hint| hint.as_ref()),
                     errors,
                 );
+                let (yields, yield_froms) = lambda_yield_ranges(&lambda.body);
+                let ret = if !(yields.is_empty() && yield_froms.is_empty()) {
+                    let yield_ty = self.unions(
+                        yields
+                            .iter()
+                            .map(|range| self.get(&KeyYield(*range)).yield_ty.clone())
+                            .chain(
+                                yield_froms
+                                    .iter()
+                                    .map(|range| self.get(&KeyYieldFrom(*range)).yield_ty.clone()),
+                            )
+                            .collect(),
+                    );
+                    self.stdlib
+                        .generator(yield_ty, self.heap.mk_any_implicit(), ret)
+                        .to_type()
+                } else {
+                    ret
+                };
                 self.heap.mk_callable(params, ret)
             }
             Expr::Tuple(x) => self.tuple_infer(x, hint, errors),

--- a/pyrefly/lib/test/yields.rs
+++ b/pyrefly/lib/test/yields.rs
@@ -461,16 +461,15 @@ async def main() -> None:
 );
 
 testcase!(
-    bug = "We don't understand yield in lambda, and misattribute the yield to the surrounding function",
     test_lambda_yield,
     r#"
 from typing import assert_type
 def f(x: int):
-    callback = lambda: (yield x)  # E: Invalid `yield` outside of a function
+    callback = lambda: (yield x)
     l = [i for i in callback()]
-    assert_type(l, list[int])  # E: assert_type(list[Any], list[int])
+    assert_type(l, list[int])
     return l
-assert_type(f(1), list[int])  # E: assert_type(list[Any], list[int])
+assert_type(f(1), list[int])
 "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #949

Bound yield/yield from in lambdas as real yields and inferred lambdas with yields as generator-returning callables so the return type flows correctly.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

update tests