### PR TITLE
fix Pyrefly reports duplicate [bad-specialization] errors #2176

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -953,8 +953,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if let CallTargetLookup::Ok(call_target) = self.as_call_target(t.clone()) {
                     let args = arguments.args.map(CallArg::expr_maybe_starred);
                     let kws = arguments.keywords.map(CallKeyword::new);
-                    let ret =
-                        self.call_infer(*call_target, &args, &kws, range, errors, None, None, None);
+                    let swallowed_errors = self.error_swallower();
+                    let ret = self.call_infer(
+                        *call_target,
+                        &args,
+                        &kws,
+                        range,
+                        &swallowed_errors,
+                        None,
+                        None,
+                        None,
+                    );
                     if let Type::TypeGuard(t) = ret {
                         return *t;
                     }
@@ -966,8 +975,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if let CallTargetLookup::Ok(call_target) = self.as_call_target(t.clone()) {
                     let args = arguments.args.map(CallArg::expr_maybe_starred);
                     let kws = arguments.keywords.map(CallKeyword::new);
-                    let ret =
-                        self.call_infer(*call_target, &args, &kws, range, errors, None, None, None);
+                    let swallowed_errors = self.error_swallower();
+                    let ret = self.call_infer(
+                        *call_target,
+                        &args,
+                        &kws,
+                        range,
+                        &swallowed_errors,
+                        None,
+                        None,
+                        None,
+                    );
                     if let Type::TypeIs(t) = ret {
                         return self.distribute_over_union(&t, |right| {
                             self.intersect_with_fallback(ty, right, &|| {
@@ -997,8 +1015,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if let CallTargetLookup::Ok(call_target) = self.as_call_target(t.clone()) {
                     let args = arguments.args.map(CallArg::expr_maybe_starred);
                     let kws = arguments.keywords.map(CallKeyword::new);
-                    let ret =
-                        self.call_infer(*call_target, &args, &kws, range, errors, None, None, None);
+                    let swallowed_errors = self.error_swallower();
+                    let ret = self.call_infer(
+                        *call_target,
+                        &args,
+                        &kws,
+                        range,
+                        &swallowed_errors,
+                        None,
+                        None,
+                        None,
+                    );
                     if let Type::TypeIs(t) = ret {
                         return self.subtract(ty, &t);
                     }

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -2574,6 +2574,20 @@ assert_type(is_str("hello"), bool)
 );
 
 testcase!(
+    test_typeguard_bad_specialization_no_duplicate,
+    r#"
+from typing import TypeGuard
+
+def f[T: str](x: T) -> TypeGuard[T]:
+    return True
+
+def g(x: int | str):
+    if f(x):  # E: `int | str` is not assignable to upper bound `str` of type variable `T`
+        pass
+    "#,
+);
+
+testcase!(
     test_isinstance_invalid_special_form,
     r#"
 from typing import Final


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2176

Prevented duplicate bad-specialization diagnostics by swallowing errors during TypeGuard/TypeIs re-evaluation in narrowing.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added a regression test matching issue #2176 to assert a single error