### PR TITLE
fix Odd warning on shutil.rmtree and ExitStack.callback #2105

### DIFF
--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -581,6 +581,116 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         }
         let mut expected_types: HashMap<TextRange, Type> = HashMap::new();
+        if let Some(paramspec_var) = paramspec {
+            // If we're forwarding args to a callable ParamSpec, prefer an overload that
+            // matches those forwarded arguments instead of pinning P to the first overload.
+            let positional_params = params
+                .items()
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, param)| match param {
+                    Param::PosOnly(_, ty, _) | Param::Pos(_, ty, _) => Some((idx, ty)),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            if let Some((callable_param_idx, _param_ty)) =
+                positional_params.iter().rev().find(|(_, ty)| {
+                    let param_callable = match **ty {
+                        Type::Callable(ref callable) => Some(callable.as_ref()),
+                        Type::Function(ref func) => Some(&func.signature),
+                        _ => None,
+                    };
+                    param_callable.is_some_and(|callable| {
+                        matches!(
+                            &callable.params,
+                            Params::ParamSpec(_, pspec)
+                                if matches!(pspec, Type::Var(v) if *v == paramspec_var)
+                        )
+                    })
+                })
+            {
+                let last_positional_idx = positional_params.last().map(|(idx, _)| *idx);
+                if last_positional_idx == Some(*callable_param_idx) {
+                    let self_offset = usize::from(self_arg.is_some());
+                    if *callable_param_idx >= self_offset {
+                        let arg_index = *callable_param_idx - self_offset;
+                        if let Some(arg) = args.get(arg_index) {
+                            let arg_ty = match arg {
+                                CallArg::Arg(value) | CallArg::Star(value, _) => {
+                                    value.infer(self, arg_errors)
+                                }
+                            };
+                            let mut sigs = Vec::new();
+                            let mut push_sigs = |ty: Type| {
+                                let ty = if let Type::BoundMethod(method) = &ty {
+                                    self.bind_boundmethod(method, &mut |a, b| {
+                                        self.is_subset_eq(a, b)
+                                    })
+                                    .unwrap_or(ty)
+                                } else {
+                                    ty
+                                };
+                                for sig in ty.callable_signatures() {
+                                    sigs.push(sig.clone());
+                                }
+                            };
+                            match &arg_ty {
+                                Type::ClassType(cls) => {
+                                    if let Some(call_ty) = self.instance_as_dunder_call(cls) {
+                                        push_sigs(call_ty);
+                                    }
+                                }
+                                Type::SelfType(cls) => {
+                                    if let Some(call_ty) = self.self_as_dunder_call(cls) {
+                                        push_sigs(call_ty);
+                                    }
+                                }
+                                _ => {
+                                    push_sigs(arg_ty.clone());
+                                }
+                            }
+                            if sigs.len() > 1 {
+                                let forwarded_args = args.get(arg_index + 1..).unwrap_or(&[]);
+                                let mut selected = None;
+                                for sig in sigs {
+                                    let call_errors_local = self.error_collector();
+                                    let _ = self.callable_infer(
+                                        sig.clone(),
+                                        None,
+                                        None,
+                                        None,
+                                        forwarded_args,
+                                        keywords,
+                                        arguments_range,
+                                        &self.error_swallower(),
+                                        &call_errors_local,
+                                        None,
+                                        None,
+                                        None,
+                                    );
+                                    if call_errors_local.is_empty() {
+                                        selected = match &sig.params {
+                                            Params::List(list) => Some(list.clone()),
+                                            Params::Ellipsis | Params::Materialization => {
+                                                Some(ParamList::everything())
+                                            }
+                                            Params::ParamSpec(..) => None,
+                                        };
+                                        break;
+                                    }
+                                }
+                                if let Some(param_list) = selected {
+                                    let _ = self.is_subset_eq(
+                                        &Type::ParamSpecValue(param_list),
+                                        &Type::Var(paramspec_var),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
         // We want to work mostly with references, but some things are taken from elsewhere,
         // so have some owners to capture them.
         let param_list_owner = Owner::new();

--- a/pyrefly/lib/test/paramspec.rs
+++ b/pyrefly/lib/test/paramspec.rs
@@ -94,6 +94,21 @@ reveal_type(foo2)  # E: revealed type: (x: Unknown, y: Unknown) -> Unknown
 );
 
 testcase!(
+    test_paramspec_overload_callback,
+    r#"
+import shutil
+from contextlib import ExitStack
+
+def foo(tmpdir: str) -> None:
+    with ExitStack() as resources:
+        resources.callback(shutil.rmtree, tmpdir, ignore_errors=True)
+
+def bar(tmpdir: str) -> None:
+    shutil.rmtree(tmpdir, ignore_errors=True)
+"#,
+);
+
+testcase!(
     bug = "Generic class constructors don't work with ParamSpec",
     test_param_spec_generic_constructor,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2105

Fixed ParamSpec inference for forwarded callbacks to select the overload that matches the forwarded arguments, even when the callback is a bound `__call__` (protocol/class instance).



# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added a regression test for ExitStack.callback(shutil.rmtree, ..., ignore_errors=True).