### PR TITLE
fix [feature] error when == or != is used on values that are incompatible types #721

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -186,10 +186,10 @@ pub enum ErrorKind {
     /// do not recognize as always executing (we recognize constructors and some test setup
     /// methods).
     ImplicitlyDefinedAttribute,
-    /// Overload residual branch pruning left no valid branch for a solved type variable.
-    IncompatibleOverloadResidual,
     /// Equality or inequality comparison between incompatible types.
     IncompatibleComparison,
+    /// Overload residual branch pruning left no valid branch for a solved type variable.
+    IncompatibleOverloadResidual,
     /// An inconsistency between inherited fields or methods from multiple base classes.
     InconsistentInheritance,
     /// An inconsistency between the signature of a function overload and the implementation.
@@ -426,6 +426,7 @@ impl ErrorKind {
             ErrorKind::ImplicitAnyTypeArgument => Severity::Ignore,
             ErrorKind::ImplicitImport => Severity::Warn,
             ErrorKind::ImplicitlyDefinedAttribute => Severity::Ignore,
+            ErrorKind::IncompatibleComparison => Severity::Ignore,
             ErrorKind::InvalidDecorator => Severity::Warn,
             ErrorKind::MissingOverrideDecorator => Severity::Ignore,
             ErrorKind::MissingSource => Severity::Ignore,

--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -188,6 +188,8 @@ pub enum ErrorKind {
     ImplicitlyDefinedAttribute,
     /// Overload residual branch pruning left no valid branch for a solved type variable.
     IncompatibleOverloadResidual,
+    /// Equality or inequality comparison between incompatible types.
+    IncompatibleComparison,
     /// An inconsistency between inherited fields or methods from multiple base classes.
     InconsistentInheritance,
     /// An inconsistency between the signature of a function overload and the implementation.

--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -668,6 +668,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 comparator.range(),
                 errors,
             );
+            self.check_incompatible_comparison(
+                &current_left,
+                &right,
+                *op,
+                comparator.range(),
+                errors,
+            );
 
             let right_range = comparator.range();
             let result = self.compare_types(
@@ -1033,6 +1040,35 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 );
                 Type::any_error()
             }
+    /// Checks for incompatible equality comparisons between types that cannot overlap.
+    fn check_incompatible_comparison(
+        &self,
+        left: &Type,
+        right: &Type,
+        op: CmpOp,
+        range: TextRange,
+        errors: &ErrorCollector,
+    ) {
+        if !matches!(op, CmpOp::Eq | CmpOp::NotEq) {
+            return;
+        }
+        if left.is_any() || right.is_any() || left.is_never() || right.is_never() {
+            return;
+        }
+        if self.intersects(&[left.clone(), right.clone()]).is_never() {
+            let left_display = self.for_display(left.clone());
+            let right_display = self.for_display(right.clone());
+            self.error(
+                errors,
+                range,
+                ErrorInfo::Kind(ErrorKind::IncompatibleComparison),
+                format!(
+                    "Comparison `{}` between incompatible types `{}` and `{}`",
+                    op.as_str(),
+                    left_display,
+                    right_display
+                ),
+            );
         }
     }
 }

--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -1040,6 +1040,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 );
                 Type::any_error()
             }
+        }
+    }
     /// Checks for incompatible equality comparisons between types that cannot overlap.
     fn check_incompatible_comparison(
         &self,

--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -1057,13 +1057,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if left.is_any() || right.is_any() || left.is_never() || right.is_never() {
             return;
         }
-        let Some(left_builtin) = self.builtin_scalar_name(left) else {
+        let Some(left_ty) = self.comparison_base(left) else {
             return;
         };
-        let Some(right_builtin) = self.builtin_scalar_name(right) else {
+        let Some(right_ty) = self.comparison_base(right) else {
             return;
         };
-        if Self::builtin_eq_group(&left_builtin) == Self::builtin_eq_group(&right_builtin) {
+        let left_base = self.disjoint_base(&left_ty);
+        let right_base = self.disjoint_base(&right_ty);
+        if left_base == right_base
+            || self.has_superclass(&left_base, &right_base)
+            || self.has_superclass(&right_base, &left_base)
+        {
             return;
         }
         let left_display = self.for_display(left.clone());
@@ -1081,31 +1086,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         );
     }
 
-    fn builtin_scalar_name(&self, ty: &Type) -> Option<String> {
-        let class_type = match ty {
-            Type::ClassType(cls) => cls.clone(),
-            Type::Literal(lit) => lit.value.general_class_type(self.stdlib).clone(),
-            Type::LiteralString(_) => self.stdlib.str().clone(),
-            _ => return None,
-        };
-        let class = class_type.class_object();
-        if class.qname().module_name().as_str() != "builtins" {
-            return None;
-        }
-        let name = class.name().as_str();
-        match name {
-            "bool" | "int" | "float" | "complex" | "str" | "bytes" | "bytearray" | "memoryview" => {
-                Some(name.to_owned())
-            }
+    fn comparison_base(&self, ty: &Type) -> Option<Type> {
+        match ty {
+            Type::ClassType(_) | Type::Tuple(_) => Some(ty.clone()),
+            Type::Literal(lit) => Some(Type::ClassType(
+                lit.value.general_class_type(self.stdlib).clone(),
+            )),
+            Type::LiteralString(_) => Some(Type::ClassType(self.stdlib.str().clone())),
             _ => None,
-        }
-    }
-
-    fn builtin_eq_group(name: &str) -> std::borrow::Cow<'_, str> {
-        match name {
-            "bool" | "int" | "float" | "complex" => std::borrow::Cow::Borrowed("numeric"),
-            "bytes" | "bytearray" | "memoryview" => std::borrow::Cow::Borrowed("bytes-like"),
-            _ => std::borrow::Cow::Borrowed(name),
         }
     }
 }

--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -1055,20 +1055,54 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if left.is_any() || right.is_any() || left.is_never() || right.is_never() {
             return;
         }
-        if self.intersects(&[left.clone(), right.clone()]).is_never() {
-            let left_display = self.for_display(left.clone());
-            let right_display = self.for_display(right.clone());
-            self.error(
-                errors,
-                range,
-                ErrorInfo::Kind(ErrorKind::IncompatibleComparison),
-                format!(
-                    "Comparison `{}` between incompatible types `{}` and `{}`",
-                    op.as_str(),
-                    left_display,
-                    right_display
-                ),
-            );
+        let Some(left_builtin) = self.builtin_scalar_name(left) else {
+            return;
+        };
+        let Some(right_builtin) = self.builtin_scalar_name(right) else {
+            return;
+        };
+        if Self::builtin_eq_group(&left_builtin) == Self::builtin_eq_group(&right_builtin) {
+            return;
+        }
+        let left_display = self.for_display(left.clone());
+        let right_display = self.for_display(right.clone());
+        self.error(
+            errors,
+            range,
+            ErrorInfo::Kind(ErrorKind::IncompatibleComparison),
+            format!(
+                "Comparison `{}` between incompatible types `{}` and `{}`",
+                op.as_str(),
+                left_display,
+                right_display
+            ),
+        );
+    }
+
+    fn builtin_scalar_name(&self, ty: &Type) -> Option<String> {
+        let class_type = match ty {
+            Type::ClassType(cls) => cls.clone(),
+            Type::Literal(lit) => lit.value.general_class_type(self.stdlib).clone(),
+            Type::LiteralString(_) => self.stdlib.str().clone(),
+            _ => return None,
+        };
+        let class = class_type.class_object();
+        if class.qname().module_name().as_str() != "builtins" {
+            return None;
+        }
+        let name = class.name().as_str();
+        match name {
+            "bool" | "int" | "float" | "complex" | "str" | "bytes" | "bytearray"
+            | "memoryview" => Some(name.to_owned()),
+            _ => None,
+        }
+    }
+
+    fn builtin_eq_group(name: &str) -> std::borrow::Cow<'_, str> {
+        match name {
+            "bool" | "int" | "float" | "complex" => std::borrow::Cow::Borrowed("numeric"),
+            "bytes" | "bytearray" | "memoryview" => std::borrow::Cow::Borrowed("bytes-like"),
+            _ => std::borrow::Cow::Borrowed(name),
         }
     }
 }

--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -48,6 +48,14 @@ use crate::types::literal::Lit;
 use crate::types::tuple::Tuple;
 use crate::types::types::Type;
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EqualityCompatibilityGroup {
+    Numeric,
+    BytesLike,
+    SetLike,
+    Str,
+}
+
 impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     fn callable_dunder_helper(
         &self,
@@ -1057,18 +1065,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if left.is_any() || right.is_any() || left.is_never() || right.is_never() {
             return;
         }
-        let Some(left_ty) = self.comparison_base(left) else {
+        let Some(left_group) = self.equality_compatibility_group(left) else {
             return;
         };
-        let Some(right_ty) = self.comparison_base(right) else {
+        let Some(right_group) = self.equality_compatibility_group(right) else {
             return;
         };
-        let left_base = self.disjoint_base(&left_ty);
-        let right_base = self.disjoint_base(&right_ty);
-        if left_base == right_base
-            || self.has_superclass(&left_base, &right_base)
-            || self.has_superclass(&right_base, &left_base)
-        {
+        if left_group == right_group {
             return;
         }
         let left_display = self.for_display(left.clone());
@@ -1086,13 +1089,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         );
     }
 
-    fn comparison_base(&self, ty: &Type) -> Option<Type> {
-        match ty {
-            Type::ClassType(_) | Type::Tuple(_) => Some(ty.clone()),
-            Type::Literal(lit) => Some(Type::ClassType(
-                lit.value.general_class_type(self.stdlib).clone(),
-            )),
-            Type::LiteralString(_) => Some(Type::ClassType(self.stdlib.str().clone())),
+    fn equality_compatibility_group(&self, ty: &Type) -> Option<EqualityCompatibilityGroup> {
+        let class = match ty {
+            Type::ClassType(cls) => cls.class_object(),
+            Type::Literal(lit) => lit.value.general_class_type(self.stdlib).class_object(),
+            Type::LiteralString(_) => self.stdlib.str().class_object(),
+            _ => return None,
+        };
+        match (class.qname().module_name().as_str(), class.name().as_str()) {
+            ("builtins", "bool" | "int" | "float" | "complex") | ("decimal", "Decimal") => {
+                Some(EqualityCompatibilityGroup::Numeric)
+            }
+            ("builtins", "bytes" | "bytearray" | "memoryview") => {
+                Some(EqualityCompatibilityGroup::BytesLike)
+            }
+            ("builtins", "set" | "frozenset") => Some(EqualityCompatibilityGroup::SetLike),
+            ("builtins", "str") => Some(EqualityCompatibilityGroup::Str),
             _ => None,
         }
     }

--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -1092,8 +1092,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
         let name = class.name().as_str();
         match name {
-            "bool" | "int" | "float" | "complex" | "str" | "bytes" | "bytearray"
-            | "memoryview" => Some(name.to_owned()),
+            "bool" | "int" | "float" | "complex" | "str" | "bytes" | "bytearray" | "memoryview" => {
+                Some(name.to_owned())
+            }
             _ => None,
         }
     }

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -124,6 +124,16 @@ class CandidateWeight(Generic[Weight]):
 );
 
 testcase!(
+    test_incompatible_equality_comparison,
+    r#"
+def compare(x: int, y: str, z: int | str) -> None:
+    x == y  # E: Comparison `==` between incompatible types `int` and `str`
+    x != y  # E: Comparison `!=` between incompatible types `int` and `str`
+    z == y
+"#,
+);
+
+testcase!(
     test_negative_literals,
     r#"
 from typing import Literal

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use crate::test::util::TestEnv;
 use crate::testcase;
 
 testcase!(
@@ -125,11 +126,36 @@ class CandidateWeight(Generic[Weight]):
 
 testcase!(
     test_incompatible_equality_comparison,
+    TestEnv::new().enable_incompatible_comparison_error(),
     r#"
-def compare(x: int, y: str, z: int | str) -> None:
+from decimal import Decimal
+
+def compare(
+    x: int,
+    y: str,
+    z: int | str,
+    f: float,
+    b: bytes,
+    ba: bytearray,
+    s: set[int],
+    fs: frozenset[int],
+    d: Decimal,
+) -> None:
     x == y  # E: Comparison `==` between incompatible types `int` and `str`
     x != y  # E: Comparison `!=` between incompatible types `int` and `str`
     z == y
+    x == f
+    x == d
+    b == ba
+    s == fs
+"#,
+);
+
+testcase!(
+    test_incompatible_equality_comparison_default_off,
+    r#"
+def compare(x: int, y: str) -> None:
+    x == y
 "#,
 );
 

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -114,6 +114,7 @@ pub struct TestEnv {
     open_unpacking_error: bool,
     missing_override_decorator_error: bool,
     not_required_key_access_error: bool,
+    incompatible_comparison_error: bool,
     strict_callable_subtyping: bool,
     spec_compliant_overloads: bool,
     default_require_level: Require,
@@ -144,6 +145,7 @@ impl TestEnv {
             open_unpacking_error: false,
             missing_override_decorator_error: false,
             not_required_key_access_error: false,
+            incompatible_comparison_error: false,
             strict_callable_subtyping: false,
             spec_compliant_overloads: false,
             default_require_level: Require::Exports,
@@ -278,6 +280,11 @@ impl TestEnv {
         self
     }
 
+    pub fn enable_incompatible_comparison_error(mut self) -> Self {
+        self.incompatible_comparison_error = true;
+        self
+    }
+
     pub fn enable_strict_callable_subtyping(mut self) -> Self {
         self.strict_callable_subtyping = true;
         self
@@ -409,6 +416,9 @@ impl TestEnv {
         }
         if self.not_required_key_access_error {
             errors.set_error_severity(ErrorKind::NotRequiredKeyAccess, Severity::Error);
+        }
+        if self.incompatible_comparison_error {
+            errors.set_error_severity(ErrorKind::IncompatibleComparison, Severity::Error);
         }
         config.extra_file_extensions = self.extra_file_extensions.clone();
         let mut sourcedb = MapDatabase::new(config.get_sys_info());

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -655,8 +655,10 @@ def project[S](func: Callable[[S], S], y: S) -> Callable[[], S]:
 project(f, 1)  # Overload type was not compatible with solved type variables: S = int
 ## incompatible-comparison
 
-This error is raised when an equality (`==`) or inequality (`!=`) comparison is
-made between types that cannot overlap. This is almost always a bug.
+This error is raised when Pyrefly can prove that an equality (`==`) or inequality
+(`!=`) comparison is made between incompatible built-in scalar types (for example,
+`int` versus `str`). This check is currently limited to primitive scalar types and
+does not analyze unions, `None`, or user-defined classes.
 
 ```python
 x: int = 1

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -653,6 +653,15 @@ def project[S](func: Callable[[S], S], y: S) -> Callable[[], S]:
     return lambda: y
 
 project(f, 1)  # Overload type was not compatible with solved type variables: S = int
+## incompatible-comparison
+
+This error is raised when an equality (`==`) or inequality (`!=`) comparison is
+made between types that cannot overlap. This is almost always a bug.
+
+```python
+x: int = 1
+y: str = ""
+if x == y: ...  # Comparison `==` between incompatible types `int` and `str` [incompatible-comparison]
 ```
 
 ## inconsistent-inheritance

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -634,6 +634,22 @@ class C:
         self.y = 0  # error, `y` may be undefined if `f` does not execute
 ```
 
+## incompatible-comparison
+
+This error is raised when Pyrefly can prove that an equality (`==`) or inequality
+(`!=`) comparison is made between incompatible built-in types (for example, `int`
+versus `str`). This check is currently limited to a small allowlist: numeric
+types (including `decimal.Decimal`), bytes-like types, set-like types, and `str`.
+It does not analyze unions, `None`, or user-defined classes.
+
+The default severity of this diagnostic is `ignore`.
+
+```python
+x: int = 1
+y: str = ""
+if x == y: ...  # Comparison `==` between incompatible types `int` and `str` [incompatible-comparison]
+```
+
 ## incompatible-overload-residual
 
 This error is raised when we match an overloaded function against a type containing a type variable and cannot find a consistent type for that variable.
@@ -653,17 +669,6 @@ def project[S](func: Callable[[S], S], y: S) -> Callable[[], S]:
     return lambda: y
 
 project(f, 1)  # Overload type was not compatible with solved type variables: S = int
-## incompatible-comparison
-
-This error is raised when Pyrefly can prove that an equality (`==`) or inequality
-(`!=`) comparison is made between incompatible built-in scalar types (for example,
-`int` versus `str`). This check is currently limited to primitive scalar types and
-does not analyze unions, `None`, or user-defined classes.
-
-```python
-x: int = 1
-y: str = ""
-if x == y: ...  # Comparison `==` between incompatible types `int` and `str` [incompatible-comparison]
 ```
 
 ## inconsistent-inheritance


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #721

Added a new incompatible-comparison diagnostic for ==/!= when operand types cannot overlap
Only triggers for built‑in scalar families (numeric, bytes-like, str) and only when the families are disjoint.
Skips user types, TypeVar, and type[...] comparisons.

add `if let guard` for now since or else it will break the compile..

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
add tests