### PR TITLE
fix Expressions within lambdas should also affect inference #633

### DIFF
--- a/pyrefly/lib/alt/answers_solver.rs
+++ b/pyrefly/lib/alt/answers_solver.rs
@@ -1587,11 +1587,16 @@ pub struct ThreadState {
     /// which checks before pushing its own frame).
     partial_answers: RefCell<FxHashMap<(Idx<Key>, usize), Arc<TypeInfo>>>,
     /// Solve-time mapping from per-module lambda parameter IDs to the
-    /// thread-local Var that represents that parameter in the current solve.
+    /// thread-local Var that represents that parameter while its owner lambda
+    /// is actively being solved.
     ///
     /// The `ModulePath` is needed to distinguish the in-memory and on-disk
     /// versions of the same module, which can coexist in the IDE (issue #3789).
-    lambda_param_vars: RefCell<FxHashMap<(ModuleName, ModulePath, LambdaParamId), Var>>,
+    active_lambda_param_vars: RefCell<FxHashMap<(ModuleName, ModulePath, LambdaParamId), Var>>,
+    /// The most recent completed Var for a lambda parameter ID. This allows a
+    /// `Binding::LambdaParameter` that forces its owner first to reuse the
+    /// finished parameter Var after the owner lambda returns.
+    completed_lambda_param_vars: RefCell<FxHashMap<(ModuleName, ModulePath, LambdaParamId), Var>>,
     /// Active trace side-effect sink for the current calculation.
     /// Set before `K::solve`, taken after. `None` when tracing is disabled
     /// or between calculations. Saved sinks form a stack to handle recursive
@@ -1611,7 +1616,8 @@ impl ThreadState {
             debug: RefCell::new(false),
             recursion_limit_config,
             partial_answers: RefCell::new(FxHashMap::default()),
-            lambda_param_vars: RefCell::new(FxHashMap::default()),
+            active_lambda_param_vars: RefCell::new(FxHashMap::default()),
+            completed_lambda_param_vars: RefCell::new(FxHashMap::default()),
             trace_sink: RefCell::new(None),
             trace_sink_stack: RefCell::new(Vec::new()),
         }
@@ -1869,31 +1875,67 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         self.answers.get_class_fields(cls)
     }
 
-    pub(crate) fn set_lambda_param_var(&self, id: LambdaParamId, var: Var) {
+    pub(crate) fn set_active_lambda_param_var(&self, id: LambdaParamId, var: Var) {
         self.thread_state
-            .lambda_param_vars
+            .active_lambda_param_vars
             .borrow_mut()
             .insert((self.module().name(), self.module().path().dupe(), id), var);
     }
 
     pub(crate) fn clear_lambda_param_vars(&self) {
-        self.thread_state.lambda_param_vars.borrow_mut().clear();
+        self.thread_state
+            .active_lambda_param_vars
+            .borrow_mut()
+            .clear();
+        self.thread_state
+            .completed_lambda_param_vars
+            .borrow_mut()
+            .clear();
     }
 
-    pub(crate) fn get_lambda_param_var(&self, id: LambdaParamId) -> Option<Var> {
+    pub(crate) fn clear_active_lambda_param_var(&self, id: LambdaParamId) {
         self.thread_state
-            .lambda_param_vars
+            .active_lambda_param_vars
+            .borrow_mut()
+            .remove(&(self.module().name(), self.module().path().dupe(), id));
+    }
+
+    pub(crate) fn get_active_lambda_param_var(&self, id: LambdaParamId) -> Option<Var> {
+        self.thread_state
+            .active_lambda_param_vars
             .borrow()
             .get(&(self.module().name(), self.module().path().dupe(), id))
             .copied()
     }
 
-    pub(crate) fn get_or_create_lambda_param_var(&self, id: LambdaParamId) -> Var {
-        if let Some(var) = self.get_lambda_param_var(id) {
+    pub(crate) fn set_completed_lambda_param_var(&self, id: LambdaParamId, var: Var) {
+        self.thread_state
+            .completed_lambda_param_vars
+            .borrow_mut()
+            .insert((self.module().name(), self.module().path().dupe(), id), var);
+    }
+
+    pub(crate) fn clear_completed_lambda_param_var(&self, id: LambdaParamId) {
+        self.thread_state
+            .completed_lambda_param_vars
+            .borrow_mut()
+            .remove(&(self.module().name(), self.module().path().dupe(), id));
+    }
+
+    pub(crate) fn get_completed_lambda_param_var(&self, id: LambdaParamId) -> Option<Var> {
+        self.thread_state
+            .completed_lambda_param_vars
+            .borrow()
+            .get(&(self.module().name(), self.module().path().dupe(), id))
+            .copied()
+    }
+
+    pub(crate) fn get_or_create_active_lambda_param_var(&self, id: LambdaParamId) -> Var {
+        if let Some(var) = self.get_active_lambda_param_var(id) {
             var
         } else {
             let var = self.solver().fresh_unwrap(self.uniques);
-            self.set_lambda_param_var(id, var);
+            self.set_active_lambda_param_var(id, var);
             var
         }
     }
@@ -1908,13 +1950,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         id: LambdaParamId,
         owner: Option<Idx<Key>>,
     ) -> Var {
-        if let Some(var) = self.get_lambda_param_var(id) {
+        if let Some(var) = self.get_active_lambda_param_var(id) {
+            return var;
+        }
+        if let Some(var) = self.get_completed_lambda_param_var(id) {
             return var;
         }
         if let Some(owner_idx) = owner {
             let _ = self.get_idx(owner_idx);
         }
-        self.get_or_create_lambda_param_var(id)
+        self.get_active_lambda_param_var(id)
+            .or_else(|| self.get_completed_lambda_param_var(id))
+            .unwrap_or_else(|| self.get_or_create_active_lambda_param_var(id))
     }
 
     pub fn stack(&self) -> &CalcStack {

--- a/pyrefly/lib/alt/answers_solver.rs
+++ b/pyrefly/lib/alt/answers_solver.rs
@@ -1876,7 +1876,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .insert((self.module().name(), self.module().path().dupe(), id), var);
     }
 
-    fn get_lambda_param_var(&self, id: LambdaParamId) -> Option<Var> {
+    pub(crate) fn clear_lambda_param_vars(&self) {
+        self.thread_state.lambda_param_vars.borrow_mut().clear();
+    }
+
+    pub(crate) fn get_lambda_param_var(&self, id: LambdaParamId) -> Option<Var> {
         self.thread_state
             .lambda_param_vars
             .borrow()
@@ -1884,7 +1888,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .copied()
     }
 
-    fn get_or_create_lambda_param_var(&self, id: LambdaParamId) -> Var {
+    pub(crate) fn get_or_create_lambda_param_var(&self, id: LambdaParamId) -> Var {
         if let Some(var) = self.get_lambda_param_var(id) {
             var
         } else {
@@ -1904,6 +1908,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         id: LambdaParamId,
         owner: Option<Idx<Key>>,
     ) -> Var {
+        if let Some(var) = self.get_lambda_param_var(id) {
+            return var;
+        }
         if let Some(owner_idx) = owner {
             let _ = self.get_idx(owner_idx);
         }
@@ -2080,6 +2087,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // answer rather than the stale pre-iteration answer.
         if let Some(v) = calculation.get() {
             result = v;
+        }
+        if self.stack().is_empty() {
+            self.clear_lambda_param_vars();
         }
         result
     }

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -477,10 +477,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         };
                         if let Some(parameters) = &lambda.parameters {
                             params.extend(parameters.vararg.iter().map(|x| {
-                                let var = self.solver().fresh_unwrap(self.uniques);
-                                self.set_lambda_param_var(
+                                let var = self.get_or_create_lambda_param_var(
                                     self.bindings().get_lambda_param_id(&x.name),
-                                    var,
                                 );
                                 Param::Varargs(
                                     Some(x.name.id.clone()),
@@ -488,10 +486,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 )
                             }));
                             params.extend(parameters.kwarg.iter().map(|x| {
-                                let var = self.solver().fresh_unwrap(self.uniques);
-                                self.set_lambda_param_var(
+                                let var = self.get_or_create_lambda_param_var(
                                     self.bindings().get_lambda_param_id(&x.name),
-                                    var,
                                 );
                                 Param::Kwargs(Some(x.name.id.clone()), self.solver().force_var(var))
                             }));
@@ -3699,11 +3695,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Vec<(&'b Name, Var)> {
         param_ids
             .iter()
-            .map(|(name, id)| {
-                let var = self.solver().fresh_unwrap(self.uniques);
-                self.set_lambda_param_var(*id, var);
-                (*name, var)
-            })
+            .map(|(name, id)| (*name, self.get_or_create_lambda_param_var(*id)))
             .collect()
     }
 }

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -452,7 +452,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     hint,
                     errors,
                     |cur_hint, callable_errors| {
-                        let param_vars = self.allocate_lambda_param_vars(&param_ids);
+                        let mut inserted_param_ids = Vec::new();
+                        let param_vars =
+                            self.allocate_lambda_param_vars(&param_ids, &mut inserted_param_ids);
 
                         // Pass any contextual information to the parameter bindings used in the lambda body as a side
                         // effect, by setting an answer for the vars created at binding time.
@@ -477,8 +479,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         };
                         if let Some(parameters) = &lambda.parameters {
                             params.extend(parameters.vararg.iter().map(|x| {
-                                let var = self.get_or_create_lambda_param_var(
-                                    self.bindings().get_lambda_param_id(&x.name),
+                                let id = self.bindings().get_lambda_param_id(&x.name);
+                                self.clear_completed_lambda_param_var(id);
+                                let var = self.get_or_create_active_lambda_param_var_with_tracking(
+                                    id,
+                                    &mut inserted_param_ids,
                                 );
                                 Param::Varargs(
                                     Some(x.name.id.clone()),
@@ -486,8 +491,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 )
                             }));
                             params.extend(parameters.kwarg.iter().map(|x| {
-                                let var = self.get_or_create_lambda_param_var(
-                                    self.bindings().get_lambda_param_id(&x.name),
+                                let id = self.bindings().get_lambda_param_id(&x.name);
+                                self.clear_completed_lambda_param_var(id);
+                                let var = self.get_or_create_active_lambda_param_var_with_tracking(
+                                    id,
+                                    &mut inserted_param_ids,
                                 );
                                 Param::Kwargs(Some(x.name.id.clone()), self.solver().force_var(var))
                             }));
@@ -524,6 +532,28 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         } else {
                             ret
                         };
+                        for (_, id) in &param_ids {
+                            if let Some(var) = self.get_active_lambda_param_var(*id) {
+                                self.set_completed_lambda_param_var(*id, var);
+                            }
+                        }
+                        if let Some(parameters) = &lambda.parameters {
+                            for x in parameters.vararg.iter() {
+                                let id = self.bindings().get_lambda_param_id(&x.name);
+                                if let Some(var) = self.get_active_lambda_param_var(id) {
+                                    self.set_completed_lambda_param_var(id, var);
+                                }
+                            }
+                            for x in parameters.kwarg.iter() {
+                                let id = self.bindings().get_lambda_param_id(&x.name);
+                                if let Some(var) = self.get_active_lambda_param_var(id) {
+                                    self.set_completed_lambda_param_var(id, var);
+                                }
+                            }
+                        }
+                        for id in inserted_param_ids {
+                            self.clear_active_lambda_param_var(id);
+                        }
                         self.heap.mk_callable(params, ret)
                     },
                     |callable| callable,
@@ -3689,13 +3719,38 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 }
 
 impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
+    fn get_or_create_active_lambda_param_var_with_tracking(
+        &self,
+        id: LambdaParamId,
+        inserted_param_ids: &mut Vec<LambdaParamId>,
+    ) -> Var {
+        if let Some(var) = self.get_active_lambda_param_var(id) {
+            var
+        } else {
+            let var = self.solver().fresh_unwrap(self.uniques);
+            self.set_active_lambda_param_var(id, var);
+            inserted_param_ids.push(id);
+            var
+        }
+    }
+
     fn allocate_lambda_param_vars<'b>(
         &self,
         param_ids: &[(&'b Name, LambdaParamId)],
+        inserted_param_ids: &mut Vec<LambdaParamId>,
     ) -> Vec<(&'b Name, Var)> {
         param_ids
             .iter()
-            .map(|(name, id)| (*name, self.get_or_create_lambda_param_var(*id)))
+            .map(|(name, id)| {
+                self.clear_completed_lambda_param_var(*id);
+                (
+                    *name,
+                    self.get_or_create_active_lambda_param_var_with_tracking(
+                        *id,
+                        inserted_param_ids,
+                    ),
+                )
+            })
             .collect()
     }
 }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -2089,7 +2089,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             self.binding_to_type_info(binding, errors)
         };
         type_info.visit_mut(&mut |ty| {
-            self.pin_all_placeholder_types(ty, true, range, errors);
+            let pin_partial_types = !matches!(binding, Binding::LambdaParameter(..));
+            self.pin_all_placeholder_types(ty, pin_partial_types, range, errors);
             self.expand_mut(ty);
         });
         Arc::new(type_info)

--- a/pyrefly/lib/error/signature_diff.rs
+++ b/pyrefly/lib/error/signature_diff.rs
@@ -431,16 +431,16 @@ class B(A):
         );
         assert_eq!(messages.len(), 1, "Expected one error, got {messages:?}");
         let expected = r#"Class member `B.foo` overrides parent class `A` in an inconsistent manner
-  `B.foo` has type `(self: Unknown) -> None`, which is not consistent with `(self: B, x: int) -> int` in `A.foo` (the type of read-write attributes cannot be changed)
+  `B.foo` has type `(self: B) -> None`, which is not consistent with `(self: B, x: int) -> int` in `A.foo` (the type of read-write attributes cannot be changed)
   Signature mismatch:
   expected: def foo(self: B, x: int) -> int: ...
-                          ^^^^^^^^^     ^^^ return type
-                          |
-                          parameters
-  found:    (self: Unknown) -> None
-                   ^^^^^^^     ^^^^ return type
-                   |
-                   parameters"#;
+                           ^^^^^^^^     ^^^ return type
+                           |
+                           parameters
+  found:    (self: B) -> None
+                    ^    ^^^^ return type
+                    |
+                    parameters"#;
         assert_eq!(messages[0], expected);
     }
 

--- a/pyrefly/lib/error/signature_diff.rs
+++ b/pyrefly/lib/error/signature_diff.rs
@@ -431,16 +431,16 @@ class B(A):
         );
         assert_eq!(messages.len(), 1, "Expected one error, got {messages:?}");
         let expected = r#"Class member `B.foo` overrides parent class `A` in an inconsistent manner
-  `B.foo` has type `(self: B) -> None`, which is not consistent with `(self: B, x: int) -> int` in `A.foo` (the type of read-write attributes cannot be changed)
+  `B.foo` has type `(self: Unknown) -> None`, which is not consistent with `(self: B, x: int) -> int` in `A.foo` (the type of read-write attributes cannot be changed)
   Signature mismatch:
   expected: def foo(self: B, x: int) -> int: ...
-                           ^^^^^^^^     ^^^ return type
-                           |
-                           parameters
-  found:    (self: B) -> None
-                    ^    ^^^^ return type
-                    |
-                    parameters"#;
+                          ^^^^^^^^^     ^^^ return type
+                          |
+                          parameters
+  found:    (self: Unknown) -> None
+                   ^^^^^^^     ^^^^ return type
+                   |
+                   parameters"#;
         assert_eq!(messages[0], expected);
     }
 

--- a/pyrefly/lib/test/contextual.rs
+++ b/pyrefly/lib/test/contextual.rs
@@ -399,6 +399,18 @@ assert_type(foo(lambda x: str(x))(1), str)
 "#,
 );
 
+testcase!(
+    test_context_lambda_body_infers_tparam,
+    r#"
+from typing import Callable, assert_type
+
+def build_list[T](capacity: int, callback: Callable[[list[T]], None]) -> list[T]: ...
+
+xs = build_list(10, lambda l: l.append(""))
+assert_type(xs, list[str])
+"#,
+);
+
 // This case is tricky. The call to `f` uses `g` to determine the paramspec `P`
 // We then use `P` to contextually type the lambda. Importantly, the lambda's params
 // need to match, including stuff like parameter name.


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #633

Fixed the root cause in binding solving: lambda parameter bindings were pinning partial types too early, which collapsed contextual type vars to Any.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added a regression test to cover issue #633: lambda body should infer the type parameter from list[T] and propagate to the return type.