### PR TITLE
fix use all usages within class (or within __init__) to infer type, not just initial assignment #1159

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1872,35 +1872,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         };
 
-        let mut merged_method_assignments = false;
-        if !method_assignments.is_empty()
-            && annotation
-                .as_ref()
-                .and_then(|ann| ann.ty.as_ref())
-                .is_none()
-        {
-            let ignore_errors = self.error_swallower();
-            let mut types = Vec::with_capacity(method_assignments.len() + 1);
-            types.push(value_ty);
-            for assignment in method_assignments {
-                let direct_annotation = assignment
-                    .annotation
-                    .map(|annot| self.get_idx(annot).annotation.clone());
-                let (ty, _, _) = self.analyze_class_field_value(
-                    &assignment.value,
-                    class,
-                    name,
-                    direct_annotation.as_ref(),
-                    true,
-                    assignment.range,
-                    &ignore_errors,
-                );
-                types.push(ty);
-            }
-            value_ty = self.unions(types);
-            merged_method_assignments = true;
-        }
-
         if let Some(annotation) = direct_annotation.as_ref() {
             self.validate_direct_annotation(
                 annotation,
@@ -1924,10 +1895,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // Skip literal promotion for NNModule types: their fields are captured
         // constructor args that must preserve literal types for shape inference.
         let mut has_implicit_literal = value_ty.is_implicit_literal();
-        if !has_implicit_literal
-            && (matches!(initialization, ClassFieldInitialization::Method)
-                || merged_method_assignments)
-        {
+        if !has_implicit_literal && matches!(initialization, ClassFieldInitialization::Method) {
             value_ty.universe(&mut |current_type_node| {
                 has_implicit_literal |= current_type_node.is_implicit_literal();
             });

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1872,6 +1872,35 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         };
 
+        let mut merged_method_assignments = false;
+        if !method_assignments.is_empty()
+            && annotation
+                .as_ref()
+                .and_then(|ann| ann.ty.as_ref())
+                .is_none()
+        {
+            let ignore_errors = self.error_swallower();
+            let mut types = Vec::with_capacity(method_assignments.len() + 1);
+            types.push(value_ty);
+            for assignment in method_assignments {
+                let direct_annotation = assignment
+                    .annotation
+                    .map(|annot| self.get_idx(annot).annotation.clone());
+                let (ty, _, _) = self.analyze_class_field_value(
+                    &assignment.value,
+                    class,
+                    name,
+                    direct_annotation.as_ref(),
+                    true,
+                    assignment.range,
+                    &ignore_errors,
+                );
+                types.push(ty);
+            }
+            value_ty = self.unions(types);
+            merged_method_assignments = true;
+        }
+
         if let Some(annotation) = direct_annotation.as_ref() {
             self.validate_direct_annotation(
                 annotation,
@@ -1895,7 +1924,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // Skip literal promotion for NNModule types: their fields are captured
         // constructor args that must preserve literal types for shape inference.
         let mut has_implicit_literal = value_ty.is_implicit_literal();
-        if !has_implicit_literal && matches!(initialization, ClassFieldInitialization::Method) {
+        if !has_implicit_literal
+            && (matches!(initialization, ClassFieldInitialization::Method)
+                || merged_method_assignments)
+        {
             value_ty.universe(&mut |current_type_node| {
                 has_implicit_literal |= current_type_node.is_implicit_literal();
             });

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -67,6 +67,7 @@ use crate::binding::binding::ExprOrBinding;
 use crate::binding::binding::KeyAnnotation;
 use crate::binding::binding::KeyClassField;
 use crate::binding::binding::KeyClassSynthesizedFields;
+use crate::binding::binding::MethodDefinedAttribute;
 use crate::binding::binding::MethodSelfKind;
 use crate::binding::binding::MethodThatSetsAttr;
 use crate::config::error_kind::ErrorKind;
@@ -1425,6 +1426,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         name: &Name,
         range: TextRange,
         field_definition: &ClassFieldDefinition,
+        method_assignments: &[MethodDefinedAttribute],
         functional_class_def: bool,
         errors: &ErrorCollector,
     ) -> ClassField {
@@ -1454,7 +1456,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let (
             initialization,
             is_function_without_return_annotation,
-            value_ty,
+            mut value_ty,
             annotation,
             is_inherited,
             direct_annotation,
@@ -1892,29 +1894,26 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // Determine the final type, promoting literals when appropriate.
         // Skip literal promotion for NNModule types: their fields are captured
         // constructor args that must preserve literal types for shape inference.
-        let (ty, unpromoted_ty) = if matches!(value_ty, Type::NNModule(_)) {
-            (value_ty, None)
-        } else {
-            let mut has_implicit_literal = value_ty.is_implicit_literal();
-            if !has_implicit_literal && matches!(initialization, ClassFieldInitialization::Method) {
-                value_ty.universe(&mut |current_type_node| {
-                    has_implicit_literal |= current_type_node.is_implicit_literal();
-                });
-            }
-            // Save any unpromoted literal types, we need them for enums
-            if annotation
+        let mut has_implicit_literal = value_ty.is_implicit_literal();
+        if !has_implicit_literal && matches!(initialization, ClassFieldInitialization::Method) {
+            value_ty.universe(&mut |current_type_node| {
+                has_implicit_literal |= current_type_node.is_implicit_literal();
+            });
+        }
+        let mut ty = value_ty.clone();
+        let mut unpromoted_ty = None;
+        if !matches!(value_ty, Type::NNModule(_))
+            && annotation
                 .as_ref()
                 .and_then(|ann| ann.ty.as_ref())
                 .is_none()
-                && matches!(read_only_reason, None | Some(ReadOnlyReason::NamedTuple))
-                && has_implicit_literal
-            {
-                let pre = value_ty.clone();
-                (value_ty.promote_implicit_literals(self.stdlib), Some(pre))
-            } else {
-                (value_ty, None)
-            }
-        };
+            && matches!(read_only_reason, None | Some(ReadOnlyReason::NamedTuple))
+            && has_implicit_literal
+        {
+            // Save any unpromoted literal types, we need them for enums.
+            unpromoted_ty = Some(ty.clone());
+            ty = ty.promote_implicit_literals(self.stdlib);
+        }
 
         // ClassVar[Final] is invalid except in dataclasses, where it's the recommended
         // way to declare a final class variable. Final[ClassVar] is already caught in expr_annotation.
@@ -1968,7 +1967,63 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 _ => {}
             };
         }
-        // Check if this is a Django ForeignKey or OneToOneField
+        let init_assignments: Vec<&MethodDefinedAttribute> = method_assignments
+            .iter()
+            .filter(|assignment| {
+                assignment.method.method_name == dunder::INIT
+                    && matches!(
+                        assignment.method.instance_or_class,
+                        MethodSelfKind::Instance
+                    )
+            })
+            .collect();
+        if matches!(
+            field_definition,
+            ClassFieldDefinition::AssignedInBody { .. }
+        ) && !init_assignments.is_empty()
+            && annotation
+                .as_ref()
+                .and_then(|ann| ann.ty.as_ref())
+                .is_none()
+            && descriptor.is_none()
+        {
+            let ignore_errors = self.error_swallower();
+            let mut types = Vec::with_capacity(init_assignments.len() + 1);
+            types.push(value_ty);
+            for assignment in init_assignments {
+                let direct_annotation = assignment
+                    .annotation
+                    .map(|annot| self.get_idx(annot).annotation.clone());
+                let (ty, _, _) = self.analyze_class_field_value(
+                    &assignment.value,
+                    class,
+                    name,
+                    direct_annotation.as_ref(),
+                    true,
+                    assignment.range,
+                    &ignore_errors,
+                );
+                types.push(ty);
+            }
+            value_ty = self.unions(types);
+            let mut has_implicit_literal = value_ty.is_implicit_literal();
+            if !has_implicit_literal {
+                value_ty.universe(&mut |current_type_node| {
+                    has_implicit_literal |= current_type_node.is_implicit_literal();
+                });
+            }
+            ty = value_ty;
+            if annotation
+                .as_ref()
+                .and_then(|ann| ann.ty.as_ref())
+                .is_none()
+                && matches!(read_only_reason, None | Some(ReadOnlyReason::NamedTuple))
+                && has_implicit_literal
+            {
+                ty = ty.promote_implicit_literals(self.stdlib);
+            }
+        }
+        // Check if this is a Django ForeignKey or OneToOneField.
         let is_foreign_key = metadata.is_django_model()
             && matches!(&ty, Type::ClassType(cls) if self.is_foreign_key_like_field(cls.class_object()));
 

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -2850,6 +2850,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 &field.name,
                 field.range,
                 &field.definition,
+                field.method_assignments.as_ref(),
                 functional_class_def,
                 errors,
             ),

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -130,7 +130,7 @@ assert_bytes!(BindingClassChecks, 4);
 assert_bytes!(BindingClassDisjointBase, 4);
 assert_bytes!(BindingAbstractClassCheck, 4);
 assert_bytes!(BindingClassSubscriptSymmetry, 4);
-assert_words!(BindingClassField, 13);
+assert_words!(BindingClassField, 15);
 assert_bytes!(BindingClassSynthesizedFields, 4);
 assert_bytes!(BindingLegacyTypeParam, 16);
 assert_words!(BindingYield, 4);
@@ -3121,16 +3121,18 @@ pub struct BindingClassField {
     pub name: Name,
     pub range: TextRange,
     pub definition: ClassFieldDefinition,
+    pub method_assignments: Arc<[MethodDefinedAttribute]>,
 }
 
 impl DisplayWith<Bindings> for BindingClassField {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, ctx: &Bindings) -> fmt::Result {
         write!(
             f,
-            "BindingClassField({}, {}, {})",
+            "BindingClassField({}, {}, {}, method_assignments = {})",
             ctx.display(self.class_idx),
             self.name,
             self.definition.display_with(ctx),
+            self.method_assignments.len(),
         )
     }
 }
@@ -3151,6 +3153,14 @@ pub struct MethodThatSetsAttr {
 pub enum MethodSelfKind {
     Instance,
     Class,
+}
+
+#[derive(Clone, Debug)]
+pub struct MethodDefinedAttribute {
+    pub method: MethodThatSetsAttr,
+    pub value: ExprOrBinding,
+    pub annotation: Option<Idx<KeyAnnotation>>,
+    pub range: TextRange,
 }
 
 /// Bindings for fields synthesized by a class, such as a dataclass's `__init__` method. This

--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -75,6 +75,7 @@ use crate::binding::binding::KeyClassSynthesizedFields;
 use crate::binding::binding::KeyExpect;
 use crate::binding::binding::KeyTParams;
 use crate::binding::binding::KeyVariance;
+use crate::binding::binding::MethodDefinedAttribute;
 use crate::binding::bindings::BindingsBuilder;
 use crate::binding::bindings::CurrentIdx;
 use crate::binding::bindings::LegacyTParamCollector;
@@ -452,7 +453,8 @@ impl<'a> BindingsBuilder<'a> {
 
         let django_field_info = self.extract_django_fields_from_class_body(&field_definitions);
         let mut fields = SmallMap::with_capacity(field_definitions.len());
-        for (name, (definition, range)) in field_definitions.into_iter_hashed() {
+        for (name, (definition, range, method_assignments)) in field_definitions.into_iter_hashed()
+        {
             if let ClassFieldDefinition::AssignedInBody { value, .. } = &definition
                 && let ExprOrBinding::Expr(e) = value.as_ref()
             {
@@ -492,6 +494,7 @@ impl<'a> BindingsBuilder<'a> {
                 name: name.into_key(),
                 range,
                 definition,
+                method_assignments: Arc::from(method_assignments.into_boxed_slice()),
             };
             self.insert_binding(key_field, binding);
         }
@@ -1131,6 +1134,7 @@ impl<'a> BindingsBuilder<'a> {
                     name: member_name,
                     range,
                     definition,
+                    method_assignments: Arc::from([] as [MethodDefinedAttribute; 0]),
                 },
             );
         }

--- a/pyrefly/lib/binding/django.rs
+++ b/pyrefly/lib/binding/django.rs
@@ -12,6 +12,7 @@ use starlark_map::small_map::SmallMap;
 
 use crate::binding::binding::ClassFieldDefinition;
 use crate::binding::binding::ExprOrBinding;
+use crate::binding::binding::MethodDefinedAttribute;
 use crate::binding::bindings::BindingsBuilder;
 
 const PRIMARY_KEY: Name = Name::new_static("primary_key");
@@ -80,12 +81,15 @@ impl<'a> BindingsBuilder<'a> {
     /// (primary_key, ForeignKey, choices).
     pub fn extract_django_fields_from_class_body(
         &self,
-        field_definitions: &SmallMap<Name, (ClassFieldDefinition, TextRange)>,
+        field_definitions: &SmallMap<
+            Name,
+            (ClassFieldDefinition, TextRange, Vec<MethodDefinedAttribute>),
+        >,
     ) -> DjangoFieldInfo {
         let mut primary_key_field = None;
         let mut foreign_key_like_fields = Vec::new();
         let mut fields_with_choices = Vec::new();
-        for (name, (definition, _range)) in field_definitions.iter() {
+        for (name, (definition, _range, _method_assignments)) in field_definitions.iter() {
             if let ClassFieldDefinition::AssignedInBody { value, .. } = definition
                 && let ExprOrBinding::Expr(e) = value.as_ref()
             {

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -59,6 +59,7 @@ use crate::binding::binding::KeyDecoratedFunction;
 use crate::binding::binding::KeyVariance;
 use crate::binding::binding::KeyYield;
 use crate::binding::binding::KeyYieldFrom;
+use crate::binding::binding::MethodDefinedAttribute;
 use crate::binding::binding::MethodSelfKind;
 use crate::binding::binding::MethodThatSetsAttr;
 use crate::binding::binding::NarrowUseLocation;
@@ -2782,7 +2783,7 @@ impl Scopes {
     /// - Panics if the current scope is not a class body.
     pub fn finish_class_and_get_field_definitions(
         &mut self,
-    ) -> SmallMap<Name, (ClassFieldDefinition, TextRange)> {
+    ) -> SmallMap<Name, (ClassFieldDefinition, TextRange, Vec<MethodDefinedAttribute>)> {
         let mut field_definitions = SmallMap::new();
         let class_body = self.pop();
         let class_scope = {
@@ -2811,6 +2812,26 @@ impl Scopes {
                 }
             })
             .collect();
+        let method_assignments_for = |field_name: &Name| {
+            method_attrs
+                .iter()
+                .filter(|(name, _, _)| name.key() == field_name)
+                .flat_map(
+                    |(_, method, InstanceAttribute(values, annotation, range, _))| {
+                        values
+                            .iter()
+                            .cloned()
+                            .map(|value| MethodDefinedAttribute {
+                                method: method.clone(),
+                                value,
+                                annotation: *annotation,
+                                range: *range,
+                            })
+                            .collect::<Vec<_>>()
+                    },
+                )
+                .collect::<Vec<_>>()
+        };
 
         class_body.stat.0.iter_hashed().for_each(
             |(name, static_info)| {
@@ -2874,7 +2895,11 @@ impl Scopes {
                         definition: value.idx,
                     },
                 };
-                field_definitions.insert_hashed(name.owned(), (definition, static_info.range));
+                let method_assignments = method_assignments_for(name.key());
+                field_definitions.insert_hashed(
+                    name.owned(),
+                    (definition, static_info.range, method_assignments),
+                );
             }
         });
         // Merge assignments from different methods.
@@ -2890,6 +2915,7 @@ impl Scopes {
                         receiver_kind: existing_receiver,
                     },
                     _,
+                    existing_method_assignments,
                 )) = field_definitions.get_mut(name.key())
                 {
                     if existing_method.recognized_attribute_defining_method
@@ -2900,6 +2926,14 @@ impl Scopes {
                     } else {
                         // Merge: Either both are constructors (e.g. __new__ and __init__), or both are
                         // helper methods. We combine all their assignments.
+                        existing_method_assignments.extend(values.iter().cloned().map(|value| {
+                            MethodDefinedAttribute {
+                                method: method.clone(),
+                                value,
+                                annotation,
+                                range,
+                            }
+                        }));
                         existing_values.extend(values);
                         if existing_annot.is_none() {
                             *existing_annot = annotation;
@@ -2911,6 +2945,16 @@ impl Scopes {
                         }
                     }
                 } else if !field_definitions.contains_key_hashed(name.as_ref()) {
+                    let method_assignments = values
+                        .iter()
+                        .cloned()
+                        .map(|value| MethodDefinedAttribute {
+                            method: method.clone(),
+                            value,
+                            annotation,
+                            range,
+                        })
+                        .collect();
                     field_definitions.insert_hashed(
                         name,
                         (
@@ -2921,6 +2965,7 @@ impl Scopes {
                                 receiver_kind,
                             },
                             range,
+                            method_assignments,
                         ),
                     );
                 }

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -82,6 +82,41 @@ def f(a: A):
 );
 
 testcase!(
+    bug = "https://github.com/facebook/pyrefly/issues/1159",
+    test_infers_attribute_union_from_class_and_method_assignments,
+    r#"
+from typing import assert_type
+
+class A:
+    value = 1
+
+    def promote(self, flag: bool) -> None:
+        if flag:
+            self.value = "a"  # E: `Literal['a']` is not assignable to attribute `value` with type `int`
+
+def takes(a: A) -> None:
+    assert_type(a.value, int)
+    "#,
+);
+
+testcase!(
+    test_infers_attribute_union_from_class_and_init_assignments,
+    r#"
+from typing import assert_type
+
+class A:
+    value = 1
+
+    def __init__(self, flag: bool) -> None:
+        if flag:
+            self.value = "a"
+
+def takes(a: A) -> None:
+    assert_type(a.value, int | str)
+    "#,
+);
+
+testcase!(
     test_unannotated_attribute_bad_assignment,
     r#"
 class A:

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -82,6 +82,7 @@ def f(a: A):
 );
 
 testcase!(
+    bug = "https://github.com/facebook/pyrefly/issues/1159",
     test_infers_attribute_union_from_class_and_method_assignments,
     r#"
 from typing import assert_type
@@ -2489,7 +2490,7 @@ testcase!(
 from typing import assert_type
 class A:
     a = 1
-    def set_a(self, value: str):
+    def __init__(self, value: str):
         self.a = value
 def f(a: A):
     assert_type(a.a, int | str)

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -82,7 +82,6 @@ def f(a: A):
 );
 
 testcase!(
-    bug = "https://github.com/facebook/pyrefly/issues/1159",
     test_infers_attribute_union_from_class_and_method_assignments,
     r#"
 from typing import assert_type
@@ -2481,6 +2480,19 @@ class A:
 def f(a: A):
     assert_type(a.x, Any | None)
     assert_type(a.y, None)
+    "#,
+);
+
+testcase!(
+    test_class_attr_infers_from_method_assignments,
+    r#"
+from typing import assert_type
+class A:
+    a = 1
+    def set_a(self, value: str):
+        self.a = value
+def f(a: A):
+    assert_type(a.a, int | str)
     "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1159

Implemented the issue 1159 request to use assignments within the class (e.g., a = 1 then self.a = "a") when inferring attribute types, so the method assignment widens the inferred type instead of erroring.



# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add tests