### PR TITLE
  Fix unannotated-parameter if first classmethod parameter not named cls (#2327)

### DIFF
--- a/pyrefly/lib/test/inference.rs
+++ b/pyrefly/lib/test/inference.rs
@@ -85,9 +85,7 @@ class C:
 // https://github.com/facebook/pyrefly/issues/2327
 testcase!(
     test_unannotated_parameter_first_param_by_position,
-    TestEnv::new()
-        .enable_unannotated_parameter_error()
-        .enable_unannotated_return_error(),
+    TestEnv::new().enable_unannotated_parameter_error(),
     r#"
 class A:
     def __new__(cls, a: int) -> "A": ...
@@ -115,6 +113,9 @@ class C:
 
     # vararg as first param is NOT an implicit self param
     def vararg_method(*args, **kwargs) -> None: ...  # E: `vararg_method` is missing an annotation for parameter `args` # E: `vararg_method` is missing an annotation for parameter `kwargs`
+
+    # keyword-only params after variadic first param should also error
+    def vararg_method2(*args, name) -> None: ...  # E: `vararg_method2` is missing an annotation for parameter `args` # E: `vararg_method2` is missing an annotation for parameter `name`
 
 # self/cls in standalone functions should still error
 def f(a: str, self, cls, b: int) -> None: ...  # E: `f` is missing an annotation for parameter `self` # E: `f` is missing an annotation for parameter `cls`


### PR DESCRIPTION
  ## Summary

  Fixes #2327

  The `unannotated-parameter` error was using a name-based check (`name != "self" && name != "cls"`) to decide whether to skip the first
  parameter of methods. This caused:

  - **False positives**: Methods whose first parameter was named `_cls`, `_self`, `klass`, etc. were incorrectly flagged
  - **False negatives**: Standalone functions with parameters named `self` or `cls` were incorrectly skipped

  The fix changes the check to be position-based: skip only the first non-variadic parameter when the function is a non-static method in a
  class. This correctly handles:

  - Instance methods with any name for the first parameter (e.g. `_self`, `this`)
  - `@classmethod` methods with any name for the first parameter (e.g. `_cls`, `klass`)
  - `__new__` (implicit staticmethod that still takes `cls`)
  - `__init_subclass__` (implicit classmethod)
  - `@staticmethod` methods (no implicit first parameter — all params checked)
  - Standalone functions (no implicit first parameter — `self`/`cls` names are not special)
  - Vararg-only methods like `def method(*args)` (no implicit self parameter)

  ## Test plan

  - Added `test_unannotated_parameter_first_param_by_position` covering all scenarios above
  - Verified existing `test_implicit_any_self_cls_ignored` still passes