### PR TITLE
fix: avoid adding parameters for variables defined in the selection during helper extraction

### DIFF
--- a/pyrefly/lib/state/lsp/quick_fixes/extract_function.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/extract_function.rs
@@ -72,8 +72,13 @@ pub(crate) fn extract_function_code_actions(
             continue;
         }
         if ident.synthetic_load {
-            seen_params.insert(ident.name.clone());
-            params.push(ident.name.clone());
+            let defined_earlier_in_selection = store_refs
+                .iter()
+                .any(|store| store.name == ident.name && store.position < ident.position);
+            if !defined_earlier_in_selection {
+                seen_params.insert(ident.name.clone());
+                params.push(ident.name.clone());
+            }
             continue;
         }
         let defs = transaction.find_definition(handle, ident.position, FindPreference::default());


### PR DESCRIPTION
# Summary

This PR fixes an issue where the “Extract into helper" functionality incorrectly added variables as parameters to the extracted function when those variables were actually defined inside the selection. 

Specifically, variables on the left-hand side of augmented assignments (e.g., `total` in `total += price`) were unconditionally added to the extracted method's parameter list, even if the variable was initialised earlier in the same selection (e.g., `total = 0`). 

The fix simply checks `store_refs` for a prior assignment of the variable within the selection before adding it as a parameter.

Fixes #2335 

# Test Plan

1. Added a regression test to cover the changed behaviour.
2. Manual testing: 
2.1. Locally built pyrefly to `/some-dir/pyrefly`
2.2. In editor settings, add the following setting: `”pyrefly.lspPath”: ”/some-dir/pyrefly”`
2.3. Manually test the “Extract into helper” functionality to verify fix. See below for reference. 


https://github.com/user-attachments/assets/58b18f2a-262b-468b-8f28-1a6e7ee35ebe