### PR TITLE
fix class_metadata and regression test

### DIFF
--- a/pyrefly/lib/test/generic_basic.rs
+++ b/pyrefly/lib/test/generic_basic.rs
@@ -576,7 +576,6 @@ def g(t: type):
 );
 
 testcase!(
-    bug = "conformance: Should error on inconsistent type variable ordering in base classes",
     test_inconsistent_type_var_ordering_in_bases,
     r#"
 from typing import Generic, TypeVar
@@ -586,7 +585,7 @@ T2 = TypeVar("T2")
 
 class Grandparent(Generic[T1, T2]): ...
 class Parent(Grandparent[T1, T2]): ...
-class BadChild(Parent[T1, T2], Grandparent[T2, T1]): ...  # should be an error
+class BadChild(Parent[T1, T2], Grandparent[T2, T1]): ...  # E: Class `BadChild` has inconsistent type arguments for base class `Grandparent`: `Grandparent[T1, T2]` and `Grandparent[T2, T1]`
 "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->
This PR addresses issue #2371 by reporting inconsistent type args when the same direct base class appears with different type parameters across inheritance paths. It also adds a regression test

Fixes #2371 

# Test Plan

<!-- Describe how you tested this PR -->

python3 test.py

<!-- Run test.py and commit any changes to generated files -->
