### PR TITLE
[EZ] Add a note about running test.py on external build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@ the project root. BUCK files are not exported to GitHub, so:
   you are confident the feature is complete.
 - By default, `test.py` auto-detects the build tool based on BUCK file presence.
   You can override this with `--mode buck` or `--mode cargo`.
+- For external builds, always use `python3 test.py` instead of `./test.py`.
 - To run just formatting and linting (much faster than running tests):
   `./test.py --no-test --no-conformance`
 


### PR DESCRIPTION
# Summary

External build don't have `fbpython`, which is on the shebang line.

My agent always tries to run `test.py`, realising I don't have `fbpython`, and switches to `python3 test.py`. Hopefully this tweak will resolve this issue.

# Test Plan

eyeballs

Asked Claude as well
<img width="941" height="144" alt="Screenshot 2026-02-12 at 01 45 30" src="https://github.com/user-attachments/assets/bacbe6c6-a019-4e03-a96d-42089379dca4" />
