### PR TITLE
optimize can_be_recursive

### DIFF
--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -946,17 +946,18 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
         }
     }
 
-    fn can_be_recursive(&self, ty: &Type) -> bool {
-        match ty {
-            Type::ClassType(cls) => self.type_order.is_protocol(cls.class_object()),
-            Type::UntypedAlias(_) => true,
+    fn can_be_recursive(&self, t1: &Type, t2: &Type) -> bool {
+        match (t1, t2) {
+            // We only care if the RHS is a protocol
+            (_, Type::ClassType(cls)) => self.type_order.is_protocol(cls.class_object()),
+            (Type::UntypedAlias(_), _) | (_, Type::UntypedAlias(_)) => true,
             _ => false,
         }
     }
 
     /// Implementation of subset equality for Type, other than Var.
     pub fn is_subset_eq_impl(&mut self, got: &Type, want: &Type) -> Result<(), SubsetError> {
-        let recursive_check = if self.can_be_recursive(got) || self.can_be_recursive(want) {
+        let recursive_check = if self.can_be_recursive(got, want) {
             Some((got.clone(), want.clone()))
         } else {
             None

--- a/pyrefly/lib/state/loader.rs
+++ b/pyrefly/lib/state/loader.rs
@@ -243,8 +243,8 @@ impl LoaderFindCache {
     ) -> FindingOrError<ModulePath> {
         self.cache
             .ensure(&(module.dupe(), origin.cloned()), || {
-                let mut phantom_paths = Vec::new();
-                let result = find_import(&self.config, module, origin, Some(&mut phantom_paths));
+                let phantom_paths = Vec::new();
+                let result = find_import(&self.config, module, origin, None);
                 (result, Arc::new(phantom_paths))
             })
             .0
@@ -261,8 +261,8 @@ impl LoaderFindCache {
         let cached = self
             .cache
             .ensure(&(module.dupe(), origin.cloned()), || {
-                let mut phantom_paths = Vec::new();
-                let result = find_import(&self.config, module, origin, Some(&mut phantom_paths));
+                let phantom_paths = Vec::new();
+                let result = find_import(&self.config, module, origin, None);
                 (result, Arc::new(phantom_paths))
             })
             .0;


### PR DESCRIPTION
Summary:
D92216744 refactored some of the recursive assumptions code.

We actually only call is_subset_protocol if the RHS is a protocol, the LHS doesn't matter. Avoiding the LHS check means that we can store fewer recursive assumptions, and clone less.

There appears to be a modest performance benefit.

Reviewed By: rchen152

Differential Revision: D93043272


