### PR TITLE
Add missing TEST_ROOT env var for scrut tests

### DIFF
--- a/.github/workflows/pyrefly.yml
+++ b/.github/workflows/pyrefly.yml
@@ -50,5 +50,6 @@ jobs:
         JQ: jq
         TEST_PY: ${{ github.workspace }}/test.py
         PYREFLY_PY: ${{ github.workspace }}/pyrefly/python
+        TEST_ROOT: ${{ github.workspace }}/test/tensor_shapes
       run: env -u GITHUB_ACTIONS scrut test test
       if: ${{ matrix.os != 'windows-latest' }}

--- a/test.py
+++ b/test.py
@@ -150,6 +150,7 @@ class CargoExecutor(Executor):
                     "JQ": jq_path if jq_path else "",
                     "TEST_PY": str(script_dir / "test.py"),
                     "PYREFLY_PY": str(script_dir / "pyrefly" / "python"),
+                    "TEST_ROOT": str(script_dir / "test" / "tensor_shapes"),
                     "PATH": os.environ.get("PATH", ""),
                 },
             )


### PR DESCRIPTION
## Summary
- The tensor_shapes scrut tests reference `$TEST_ROOT` but it was not defined in the scrut environment variables in `test.py`, causing 2 test failures
- Added `TEST_ROOT` pointing to `test/tensor_shapes` in the scrut env dict
- This issue is causing CIs to fail on main branch

## Test plan
- [x] Ran `scrut test test` locally — all 86 tests pass (previously 2 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)