### PR TITLE
Do not insert Bindings for broken definitions

### DIFF
--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -2518,6 +2518,12 @@ impl ScopeTrace {
         let mut exportables = SmallMap::new();
         let scope = self.toplevel_scope();
         for (name, static_info) in scope.stat.0.iter_hashed() {
+            // Definitions with empty names are not actually accessible and should not be considered
+            // as exported. They are likely syntax errors, which are handled elsewhere.
+            if name.as_str() == "" {
+                continue;
+            }
+
             let exportable = match scope.flow.get_value_hashed(name) {
                 Some(FlowValue { idx: key, .. }) => {
                     if let Some(ann) = static_info.annotation() {

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -1070,6 +1070,13 @@ a = True if # E: Parse
 );
 
 testcase!(
+    test_syntax_error_resulting_in_empty_defintion,
+    r#"
+@:a=1 # E: Parse # E: Could not find name `a`
+    "#,
+);
+
+testcase!(
     test_mangled_for,
     r#"
 # This has identical Identifiers in the AST, which seems like the right AST.


### PR DESCRIPTION
# Summary

Closes https://github.com/facebook/pyrefly/issues/2116

This avoid returning this "expression" here:
https://github.com/facebook/pyrefly/blob/02dcdc40150998bdbd915fcb2f8051c50a1161f6/pyrefly/lib/binding/bindings.rs#L515
Which avoids adding a `Binding` for something that really doesn't exist.

Not sure if this is the best preferred way to handle these panics and bogus code.

# Test Plan

Added a testcase. I did run `test.py` but it did not generate any changes. Therefore, I just added the error codes myselff. That seems to have worked.