### PR TITLE
Update third-party Rust crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
  "cfg-if",
  "itoa 1.0.17",
  "rustversion",
- "ryu 1.0.17",
+ "ryu 1.0.23",
  "serde",
  "static_assertions",
 ]
@@ -455,7 +455,7 @@ dependencies = [
  "cfg-if",
  "itoa 1.0.17",
  "rustversion",
- "ryu 1.0.17",
+ "ryu 1.0.23",
  "serde",
  "static_assertions",
 ]
@@ -1484,9 +1484,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.3",
  "libc",
@@ -2760,9 +2760,9 @@ checksum = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"

--- a/crates/pyrefly_build/Cargo.toml
+++ b/crates/pyrefly_build/Cargo.toml
@@ -9,13 +9,13 @@ repository = "https://github.com/facebook/pyrefly"
 license = "MIT"
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 dupe = "0.9.1"
 itertools = "0.14.0"
 pyrefly_python = { path = "../pyrefly_python" }
 pyrefly_util = { path = "../pyrefly_util" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.145", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 starlark_map = "0.13.0"
 static_interner = "0.1.1"
 tempfile = "3.22"

--- a/crates/pyrefly_bundled/Cargo.toml
+++ b/crates/pyrefly_bundled/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 build = "build.rs"
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 starlark_map = "0.13.0"
 tar = "0.4.44"
 zstd = "0.13"

--- a/crates/pyrefly_config/Cargo.toml
+++ b/crates/pyrefly_config/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/facebook/pyrefly"
 license = "MIT"
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 configparser = { version = "3.1.0", features = ["indexmap"] }
 convert_case = "0.11"
@@ -24,7 +24,7 @@ pyrefly_util = { path = "../pyrefly_util" }
 regex = "1.12.2"
 regex-syntax = "0.7.5"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.145", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_jsonrc = "0.1"
 serde_with = { version = "3", features = ["hex", "json"] }
 starlark_map = "0.13.0"

--- a/crates/pyrefly_python/Cargo.toml
+++ b/crates/pyrefly_python/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/facebook/pyrefly"
 license = "MIT"
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 clap = { version = "4.5.42", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 dupe = "0.9.1"
 enum-iterator = "2.3.0"
@@ -30,5 +30,5 @@ static_interner = "0.1.1"
 thiserror = "2.0.18"
 
 [dev-dependencies]
-serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.145", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 toml = { version = "0.9.11", features = ["preserve_order"] }

--- a/crates/pyrefly_util/Cargo.toml
+++ b/crates/pyrefly_util/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 
 [dependencies]
 anstream = "0.6.11"
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 append-only-vec = "0.1.8"
 argfile = "0.2.1"
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
@@ -37,7 +37,7 @@ ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568
 ruff_source_file = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }
 ruff_text_size = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.145", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 starlark_map = "0.13.0"
 static_interner = "0.1.1"
 strsim = "0.10.0"

--- a/crates/tsp_types/Cargo.toml
+++ b/crates/tsp_types/Cargo.toml
@@ -11,4 +11,4 @@ license = "MIT"
 [dependencies]
 lsp-server = "0.7.9"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.145", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }

--- a/pyrefly/Cargo.toml
+++ b/pyrefly/Cargo.toml
@@ -17,7 +17,7 @@ path = "bin/main.rs"
 
 [dependencies]
 anstream = "0.6.11"
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 blake3 = { version = "=1.8.2", features = ["mmap", "rayon", "traits-preview"] }
 clap = { version = "4.5.42", features = ["cargo", "derive", "env", "string", "unicode", "wrap_help"] }
 crossbeam-channel = "0.5.15"
@@ -52,7 +52,7 @@ ruff_python_parser = { git = "https://github.com/astral-sh/ruff/", rev = "474b00
 ruff_source_file = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }
 ruff_text_size = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.145", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_repr = "0.1.14"
 starlark_map = "0.13.0"
 static_assertions = "1.1.0"


### PR DESCRIPTION
Summary:
Bump versions and add new Rust third-party crate dependencies needed by ripgrep.

**Version bumps:**
- `anyhow` 1.0.98 → 1.0.100
- `cfg-if` 1.0 → 1.0.4
- `log` 0.4.27 → 0.4.28
- `memchr` 2.7.5 → 2.7.6
- `serde_json` 1.0.140 → 1.0.145

**New crate dependencies added to Cargo.toml:**
- `arbitrary` 1.4.2
- `crossbeam-deque` 0.8.6
- `crossbeam-epoch` 0.9.18
- `crossbeam-utils` 0.8.21
- `derive_arbitrary` 1.4.2
- `find-msvc-tools` 0.1.5
- `jemalloc-sys` 0.6.1 (package: tikv-jemalloc-sys)
- `jobserver` 0.1.34
- `pcre2-sys` 0.2.10
- `ryu` 1.0.23
- `same-file` 1.0.6
- `serde_core` 1.0.228
- `wasip2` 1.0.1+wasi-0.2.4
- `winapi-util` 0.1.11
- `windows-link` 0.1.1
- `wit-bindgen` 0.46.0

Note for OSS projects: if you are reading this from GitHub pull requests, then it does not mean all of these crates will be added or updates, but only some subset that is used in the project.

Differential Revision: D93193734


