### PR TITLE
Fix union of T | type[T] failing to match the type[T] branch

### DIFF
--- a/pyrefly/lib/test/generic_basic.rs
+++ b/pyrefly/lib/test/generic_basic.rs
@@ -627,7 +627,6 @@ class I(G, H): ...  # E: Class `I` has inconsistent type arguments for base clas
 );
 
 testcase!(
-    bug = "Union of T | type[T] fails to match the type[T] branch when passed a class",
     test_typevar_union_with_type_of_typevar,
     r#"
 from typing import TypeVar, assert_type
@@ -643,7 +642,7 @@ assert_type(good(Sub), Sub)
 
 # T | type[T] should also work — pyrefly should check the type[T] branch
 def bad(x: T | type[T]) -> T: ...
-assert_type(bad(Sub), Sub)  # E: assert_type(type[Sub], Sub) failed  # E: `type[Sub]` is not assignable to upper bound `Base` of type variable `T`
+assert_type(bad(Sub), Sub)
 "#,
 );
 


### PR DESCRIPTION
Summary:
When matching a value against a union containing both bare TypeVars and wrapped TypeVars (e.g. `T | type[T]`), the solver tried them in arbitrary order. If the bare `T` was tried first, it would eagerly pin the TypeVar to a type that violates bounds (e.g. `type[Sub]` instead of `Sub`), and since var-solving always returns Ok even on bound violations, the more specific `type[T]` branch was never tried.

The fix partitions var-containing union members into bare vars (`T`) and wrapped vars (`type[T]`, `list[T]`, etc.), trying wrapped vars first. Wrapped forms are more specific — they extract the inner type from the argument (e.g. `type[T]` extracts the instance type from a class object), producing better TypeVar solutions that are more likely to satisfy bounds.

fixes https://github.com/facebook/pyrefly/issues/2398

Differential Revision: D93779356


