### PR TITLE
fix ci error

### DIFF
--- a/pyrefly/lib/lsp/wasm/signature_help.rs
+++ b/pyrefly/lib/lsp/wasm/signature_help.rs
@@ -316,7 +316,7 @@ impl Transaction<'_> {
                     let Some(param) = params.get(i) else {
                         return false; // More args than params
                     };
-                    self.ad_hoc_solve(handle, |solver| {
+                    self.ad_hoc_solve(handle, "signature_help_compat", |solver| {
                         solver.is_subset_eq(arg_type, param.as_type())
                     })
                     .unwrap_or(true)


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes https://github.com/facebook/pyrefly/commit/98c1de95322fc38f68034a50f790580b9b659b77 ci error

Added the missing label argument to ad_hoc_solve in signature help so the closure type can be inferred and the call matches the method signature.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
