### PR TITLE
Fix duplicate completions when typing TypedDict key in .get()

### DIFF
--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -1015,13 +1015,20 @@ impl Transaction<'_> {
                         &mut result,
                         in_string_literal,
                     );
-                    self.add_literal_completions(handle, position, &mut result, in_string_literal);
-                    self.add_dict_key_completions(
+                    let dict_key_claimed = self.add_dict_key_completions(
                         handle,
                         mod_module.as_ref(),
                         position,
                         &mut result,
                     );
+                    if !dict_key_claimed {
+                        self.add_literal_completions(
+                            handle,
+                            position,
+                            &mut result,
+                            in_string_literal,
+                        );
+                    }
                     // in foo(x=<>, y=2<>), the first containing node is AnyNodeRef::Arguments(_)
                     // in foo(<>), the first containing node is AnyNodeRef::ExprCall
                     if let Some(first) = nodes.first()

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -290,9 +290,6 @@ dim.get("")
         report.contains(
             r#"
 Completion Results:
-- (Value) 'x': Literal['x'] inserting `x`
-- (Value) 'y': Literal['y'] inserting `y`
-- (Value) 'z': Literal['z'] inserting `z`
 - (Field) x: int
 - (Field) y: int
 - (Field) z: int
@@ -324,9 +321,6 @@ dim.get(key="")
         report.contains(
             r#"
 Completion Results:
-- (Value) 'x': Literal['x'] inserting `x`
-- (Value) 'y': Literal['y'] inserting `y`
-- (Value) 'z': Literal['z'] inserting `z`
 - (Field) x: int
 - (Field) y: int
 - (Field) z: int


### PR DESCRIPTION
## Summary

- Makes `add_dict_key_completions` return a `bool` indicating whether it claimed the position (i.e., cursor is inside a dict/TypedDict key string literal)
- When dict key completions are shown, skips `add_literal_completions` to avoid showing redundant `Literal['x']` entries alongside the dict field completions
- Fixes duplicate completion entries that appeared when typing inside a TypedDict `.get()` call

Follow-up from #2241.

## Test plan

- `dict_key_completion_from_typed_dict_get` and `dict_key_completion_from_typed_dict_get_keyword` updated to confirm that `Literal['x']` entries no longer appear alongside field completions

🤖 Generated with [Claude Code](https://claude.com/claude-code)