### PR TITLE
impl code action to convert dict to TypedDict / dataclass / pydantic #2144

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2241,6 +2241,7 @@ dependencies = [
  "ruff_notebook",
  "ruff_python_ast",
  "ruff_python_parser",
+ "ruff_python_stdlib",
  "ruff_source_file",
  "ruff_text_size",
  "serde",
@@ -2782,6 +2783,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruff_python_stdlib"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff/?rev=474b00568ad78f02ad8e19b8166cbeb6d69f8511#474b00568ad78f02ad8e19b8166cbeb6d69f8511"
+dependencies = [
+ "bitflags 2.11.0",
+ "unicode-ident",
+]
+
+[[package]]
 name = "ruff_python_trivia"
 version = "0.0.0"
 source = "git+https://github.com/astral-sh/ruff/?rev=474b00568ad78f02ad8e19b8166cbeb6d69f8511#474b00568ad78f02ad8e19b8166cbeb6d69f8511"
@@ -2833,7 +2843,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2846,7 +2856,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3270,7 +3280,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3936,7 +3946,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/pyrefly/Cargo.toml
+++ b/pyrefly/Cargo.toml
@@ -55,6 +55,7 @@ ruff_annotate_snippets = { git = "https://github.com/astral-sh/ruff/", rev = "47
 ruff_notebook = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511", features = ["serde"] }
 ruff_python_parser = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }
+ruff_python_stdlib = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }
 ruff_source_file = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }
 ruff_text_size = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -4605,6 +4605,10 @@ impl Server {
                 transaction.convert_star_import_code_actions(&handle, range)
             );
             timed_refactor_action!(
+                "dict_definition",
+                transaction.dict_definition_code_actions(&handle, range)
+            );
+            timed_refactor_action!(
                 "pytest_fixture_type_annotation",
                 transaction.pytest_fixture_type_annotation_code_actions(
                     &handle,

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -4605,8 +4605,8 @@ impl Server {
                 transaction.convert_star_import_code_actions(&handle, range)
             );
             timed_refactor_action!(
-                "dict_definition",
-                transaction.dict_definition_code_actions(&handle, range)
+                "convert_dict",
+                transaction.convert_dict_code_actions(&handle, range)
             );
             timed_refactor_action!(
                 "pytest_fixture_type_annotation",

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2728,12 +2728,12 @@ impl<'a> Transaction<'a> {
         quick_fixes::convert_star_import::convert_star_import_code_actions(self, handle, selection)
     }
 
-    pub fn dict_definition_code_actions(
+    pub fn convert_dict_code_actions(
         &self,
         handle: &Handle,
         selection: TextRange,
     ) -> Option<Vec<LocalRefactorCodeAction>> {
-        quick_fixes::dict_definition::dict_definition_code_actions(self, handle, selection)
+        quick_fixes::convert_dict::convert_dict_code_actions(self, handle, selection)
     }
 
     /// Determines whether a module is a third-party package.

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2728,6 +2728,14 @@ impl<'a> Transaction<'a> {
         quick_fixes::convert_star_import::convert_star_import_code_actions(self, handle, selection)
     }
 
+    pub fn dict_definition_code_actions(
+        &self,
+        handle: &Handle,
+        selection: TextRange,
+    ) -> Option<Vec<LocalRefactorCodeAction>> {
+        quick_fixes::dict_definition::dict_definition_code_actions(self, handle, selection)
+    }
+
     /// Determines whether a module is a third-party package.
     ///
     /// Checks if the module's path is located within any of the configured

--- a/pyrefly/lib/state/lsp/quick_fixes/convert_dict.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/convert_dict.rs
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use dupe::Dupe;
 use lsp_types::CodeActionKind;
@@ -16,6 +16,7 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprDict;
 use ruff_python_ast::ModModule;
+use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
@@ -45,7 +46,7 @@ struct DictField {
 
 /// Builds code actions that generate a TypedDict, dataclass, or Pydantic model
 /// definition from a selected dict literal.
-pub(crate) fn dict_definition_code_actions(
+pub(crate) fn convert_dict_code_actions(
     transaction: &Transaction<'_>,
     handle: &Handle,
     selection: TextRange,
@@ -63,8 +64,8 @@ pub(crate) fn dict_definition_code_actions(
         };
     let insert_range = TextRange::at(insert_position, TextSize::new(0));
     let stdlib = transaction.get_stdlib(handle);
-    let mut requires_any = false;
-    let fields = collect_dict_fields(transaction, handle, &stdlib, dict_expr, &mut requires_any)?;
+    let fields = collect_dict_fields(transaction, handle, &stdlib, dict_expr)?;
+    let requires_any = fields.iter().any(|field| field.annotation == "Any");
     let base_name = suggest_base_name(ast.as_ref(), dict_range);
     let class_name = unique_name(&to_pascal_case(&base_name), |candidate| {
         name_conflicts(source, candidate)
@@ -136,23 +137,21 @@ fn collect_dict_fields(
     handle: &Handle,
     stdlib: &Stdlib,
     dict_expr: &ExprDict,
-    requires_any: &mut bool,
 ) -> Option<Vec<DictField>> {
-    let mut fields = Vec::new();
-    let mut seen_names = HashSet::new();
+    let mut fields: Vec<DictField> = Vec::new();
+    let mut field_positions: HashMap<String, usize> = HashMap::new();
     for item in &dict_expr.items {
         let key_expr = item.key.as_ref()?;
         let key = string_literal_key(key_expr)?;
-        if !is_valid_identifier(&key) {
+        if !is_identifier(&key) {
             return None;
         }
-        if !seen_names.insert(key.clone()) {
+        let annotation = infer_field_annotation(transaction, handle, stdlib, item.value.range());
+        if let Some(index) = field_positions.get(&key).copied() {
+            fields[index].annotation = annotation;
             continue;
         }
-        let annotation = infer_field_annotation(transaction, handle, stdlib, item.value.range());
-        if annotation == "Any" {
-            *requires_any = true;
-        }
+        field_positions.insert(key.clone(), fields.len());
         fields.push(DictField {
             name: key,
             annotation,
@@ -263,64 +262,6 @@ fn name_conflicts(source: &str, name: &str) -> bool {
         format!("{name}\t="),
     ];
     patterns.iter().any(|pattern| source.contains(pattern))
-}
-
-fn is_valid_identifier(name: &str) -> bool {
-    let mut chars = name.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    if !(first.is_alphabetic() || first == '_') {
-        return false;
-    }
-    if !chars.all(|c| c.is_alphanumeric() || c == '_') {
-        return false;
-    }
-    !is_keyword(name)
-}
-
-fn is_keyword(name: &str) -> bool {
-    matches!(
-        name,
-        "False"
-            | "None"
-            | "True"
-            | "and"
-            | "as"
-            | "assert"
-            | "async"
-            | "await"
-            | "break"
-            | "class"
-            | "continue"
-            | "def"
-            | "del"
-            | "elif"
-            | "else"
-            | "except"
-            | "finally"
-            | "for"
-            | "from"
-            | "global"
-            | "if"
-            | "import"
-            | "in"
-            | "is"
-            | "lambda"
-            | "match"
-            | "nonlocal"
-            | "not"
-            | "or"
-            | "pass"
-            | "raise"
-            | "return"
-            | "try"
-            | "type"
-            | "while"
-            | "with"
-            | "yield"
-            | "case"
-    )
 }
 
 fn build_typed_dict_action(

--- a/pyrefly/lib/state/lsp/quick_fixes/dict_definition.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/dict_definition.rs
@@ -1,0 +1,528 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::collections::HashSet;
+
+use dupe::Dupe;
+use lsp_types::CodeActionKind;
+use pyrefly_build::handle::Handle;
+use pyrefly_python::ast::Ast;
+use pyrefly_python::module::Module;
+use ruff_python_ast::AnyNodeRef;
+use ruff_python_ast::Expr;
+use ruff_python_ast::ExprDict;
+use ruff_python_ast::ModModule;
+use ruff_python_ast::Stmt;
+use ruff_python_ast::helpers::is_docstring_stmt;
+use ruff_text_size::Ranged;
+use ruff_text_size::TextRange;
+use ruff_text_size::TextSize;
+
+use super::extract_shared::code_at_range;
+use super::extract_shared::find_enclosing_statement_range;
+use super::extract_shared::is_exact_expression;
+use super::extract_shared::line_indent_and_start;
+use super::extract_shared::selection_anchor;
+use super::extract_shared::split_selection;
+use super::extract_shared::unique_name;
+use super::types::LocalRefactorCodeAction;
+use crate::state::lsp::Transaction;
+use crate::types::stdlib::Stdlib;
+use crate::types::types::Type;
+
+const BODY_INDENT: &str = "    ";
+const DEFAULT_MODEL_NAME: &str = "Model";
+
+struct DictField {
+    name: String,
+    annotation: String,
+}
+
+/// Builds code actions that generate a TypedDict, dataclass, or Pydantic model
+/// definition from a selected dict literal.
+pub(crate) fn dict_definition_code_actions(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    selection: TextRange,
+) -> Option<Vec<LocalRefactorCodeAction>> {
+    let module_info = transaction.get_module_info(handle)?;
+    let ast = transaction.get_ast(handle)?;
+    let source = module_info.contents();
+    let (dict_range, dict_expr) = find_dict_expression(ast.as_ref(), source, selection)?;
+    let (statement_indent, insert_position) =
+        match find_enclosing_statement_range(ast.as_ref(), dict_range)
+            .and_then(|range| line_indent_and_start(source, range.start()))
+        {
+            Some(result) => result,
+            None => line_indent_and_start(source, dict_range.start())?,
+        };
+    let insert_range = TextRange::at(insert_position, TextSize::new(0));
+    let stdlib = transaction.get_stdlib(handle);
+    let mut requires_any = false;
+    let fields = collect_dict_fields(transaction, handle, &stdlib, dict_expr, &mut requires_any)?;
+    let base_name = suggest_base_name(ast.as_ref(), dict_range);
+    let class_name = unique_name(&to_pascal_case(&base_name), |candidate| {
+        name_conflicts(source, candidate)
+    });
+
+    Some(vec![
+        build_typed_dict_action(
+            &module_info,
+            ast.as_ref(),
+            &class_name,
+            &fields,
+            requires_any,
+            insert_range,
+            &statement_indent,
+        )?,
+        build_dataclass_action(
+            &module_info,
+            ast.as_ref(),
+            &class_name,
+            &fields,
+            requires_any,
+            insert_range,
+            &statement_indent,
+        )?,
+        build_pydantic_action(
+            &module_info,
+            ast.as_ref(),
+            &class_name,
+            &fields,
+            requires_any,
+            insert_range,
+            &statement_indent,
+        )?,
+    ])
+}
+
+fn find_dict_expression<'a>(
+    ast: &'a ModModule,
+    source: &str,
+    selection: TextRange,
+) -> Option<(TextRange, &'a ExprDict)> {
+    if selection.is_empty() {
+        let anchor = selection_anchor(source, selection);
+        for node in Ast::locate_node(ast, anchor) {
+            if let AnyNodeRef::ExprDict(dict_expr) = node {
+                return Some((dict_expr.range(), dict_expr));
+            }
+        }
+        return None;
+    }
+
+    let selection_text = code_at_range(source, selection)?;
+    let (_, _, _, expr_range) = split_selection(selection_text, selection)?;
+    if !is_exact_expression(ast, expr_range) {
+        return None;
+    }
+    for node in Ast::locate_node(ast, expr_range.start()) {
+        if let AnyNodeRef::ExprDict(dict_expr) = node
+            && dict_expr.range() == expr_range
+        {
+            return Some((expr_range, dict_expr));
+        }
+    }
+    None
+}
+
+fn collect_dict_fields(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    stdlib: &Stdlib,
+    dict_expr: &ExprDict,
+    requires_any: &mut bool,
+) -> Option<Vec<DictField>> {
+    let mut fields = Vec::new();
+    let mut seen_names = HashSet::new();
+    for item in &dict_expr.items {
+        let key_expr = item.key.as_ref()?;
+        let key = string_literal_key(key_expr)?;
+        if !is_valid_identifier(&key) {
+            return None;
+        }
+        if !seen_names.insert(key.clone()) {
+            continue;
+        }
+        let annotation = infer_field_annotation(transaction, handle, stdlib, item.value.range());
+        if annotation == "Any" {
+            *requires_any = true;
+        }
+        fields.push(DictField {
+            name: key,
+            annotation,
+        });
+    }
+    Some(fields)
+}
+
+fn string_literal_key(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::StringLiteral(literal) => literal
+            .as_single_part_string()
+            .map(|part| part.as_str().to_owned()),
+        _ => None,
+    }
+}
+
+fn infer_field_annotation(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    stdlib: &Stdlib,
+    range: TextRange,
+) -> String {
+    match transaction.get_type_trace(handle, range) {
+        Some(ty) => type_to_annotation(ty, stdlib).unwrap_or_else(|| "Any".to_owned()),
+        None => "Any".to_owned(),
+    }
+}
+
+fn type_to_annotation(ty: Type, stdlib: &Stdlib) -> Option<String> {
+    let ty = ty.promote_implicit_literals(stdlib);
+    if ty.is_any() {
+        return None;
+    }
+    let parts = ty.get_types_with_locations(Some(stdlib));
+    Some(parts.into_iter().map(|(part, _)| part).collect())
+}
+
+fn suggest_base_name(ast: &ModModule, dict_range: TextRange) -> String {
+    let nodes = Ast::locate_node(ast, dict_range.start());
+    let mut function_name = None;
+    for node in &nodes {
+        if let AnyNodeRef::StmtFunctionDef(def) = node {
+            function_name = Some(def.name.id.to_string());
+            break;
+        }
+    }
+    for node in &nodes {
+        match node {
+            AnyNodeRef::StmtAssign(assign)
+                if assign.value.range() == dict_range && assign.targets.len() == 1 =>
+            {
+                if let Expr::Name(name) = &assign.targets[0] {
+                    return name.id.to_string();
+                }
+            }
+            AnyNodeRef::StmtAnnAssign(assign)
+                if assign
+                    .value
+                    .as_ref()
+                    .is_some_and(|value| value.range() == dict_range) =>
+            {
+                if let Expr::Name(name) = assign.target.as_ref() {
+                    return name.id.to_string();
+                }
+            }
+            _ => {}
+        }
+    }
+    for node in &nodes {
+        if let AnyNodeRef::StmtReturn(ret) = node
+            && ret
+                .value
+                .as_ref()
+                .is_some_and(|value| value.range() == dict_range)
+            && let Some(function_name) = &function_name
+        {
+            return function_name.clone();
+        }
+    }
+    DEFAULT_MODEL_NAME.to_owned()
+}
+
+fn to_pascal_case(name: &str) -> String {
+    let mut result = String::new();
+    let mut capitalize = true;
+    for ch in name.chars() {
+        if ch.is_alphanumeric() {
+            if capitalize {
+                result.extend(ch.to_uppercase());
+                capitalize = false;
+            } else {
+                result.push(ch);
+            }
+        } else {
+            capitalize = true;
+        }
+    }
+    if result.is_empty() {
+        result = DEFAULT_MODEL_NAME.to_owned();
+    }
+    if !result
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_alphabetic() || c == '_')
+    {
+        result = format!("{DEFAULT_MODEL_NAME}{result}");
+    }
+    result
+}
+
+fn name_conflicts(source: &str, name: &str) -> bool {
+    let patterns = [
+        format!("class {name}"),
+        format!("def {name}"),
+        format!("{name} ="),
+        format!("{name}\t="),
+    ];
+    patterns.iter().any(|pattern| source.contains(pattern))
+}
+
+fn is_valid_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_alphabetic() || first == '_') {
+        return false;
+    }
+    if !chars.all(|c| c.is_alphanumeric() || c == '_') {
+        return false;
+    }
+    !is_keyword(name)
+}
+
+fn is_keyword(name: &str) -> bool {
+    matches!(
+        name,
+        "False"
+            | "None"
+            | "True"
+            | "and"
+            | "as"
+            | "assert"
+            | "async"
+            | "await"
+            | "break"
+            | "class"
+            | "continue"
+            | "def"
+            | "del"
+            | "elif"
+            | "else"
+            | "except"
+            | "finally"
+            | "for"
+            | "from"
+            | "global"
+            | "if"
+            | "import"
+            | "in"
+            | "is"
+            | "lambda"
+            | "match"
+            | "nonlocal"
+            | "not"
+            | "or"
+            | "pass"
+            | "raise"
+            | "return"
+            | "try"
+            | "type"
+            | "while"
+            | "with"
+            | "yield"
+            | "case"
+    )
+}
+
+fn build_typed_dict_action(
+    module_info: &Module,
+    ast: &ModModule,
+    class_name: &str,
+    fields: &[DictField],
+    requires_any: bool,
+    insert_range: TextRange,
+    indent: &str,
+) -> Option<LocalRefactorCodeAction> {
+    let mut edits = Vec::new();
+    let mut imports = vec!["TypedDict"];
+    if requires_any {
+        imports.push("Any");
+    }
+    if let Some(import_edit) = build_import_edit(module_info, ast, "typing", &imports) {
+        edits.push(import_edit);
+    }
+    let class_text = build_class_body(indent, class_name, "TypedDict", fields, None);
+    edits.push((module_info.dupe(), insert_range, class_text));
+    Some(LocalRefactorCodeAction {
+        title: format!("Create TypedDict `{class_name}`"),
+        edits,
+        kind: CodeActionKind::REFACTOR_REWRITE,
+    })
+}
+
+fn build_dataclass_action(
+    module_info: &Module,
+    ast: &ModModule,
+    class_name: &str,
+    fields: &[DictField],
+    requires_any: bool,
+    insert_range: TextRange,
+    indent: &str,
+) -> Option<LocalRefactorCodeAction> {
+    let mut edits = Vec::new();
+    let position = import_insertion_point(ast);
+    let mut import_text = String::new();
+    if requires_any && let Some(line) = build_import_line(ast, "typing", &["Any"]) {
+        import_text.push_str(&line);
+    }
+    if let Some(line) = build_import_line(ast, "dataclasses", &["dataclass"]) {
+        import_text.push_str(&line);
+    }
+    if !import_text.is_empty() {
+        edits.push((
+            module_info.dupe(),
+            TextRange::at(position, TextSize::new(0)),
+            import_text,
+        ));
+    }
+    let class_text = build_class_body(indent, class_name, "", fields, Some("@dataclass"));
+    edits.push((module_info.dupe(), insert_range, class_text));
+    Some(LocalRefactorCodeAction {
+        title: format!("Create dataclass `{class_name}`"),
+        edits,
+        kind: CodeActionKind::REFACTOR_REWRITE,
+    })
+}
+
+fn build_pydantic_action(
+    module_info: &Module,
+    ast: &ModModule,
+    class_name: &str,
+    fields: &[DictField],
+    requires_any: bool,
+    insert_range: TextRange,
+    indent: &str,
+) -> Option<LocalRefactorCodeAction> {
+    let mut edits = Vec::new();
+    let position = import_insertion_point(ast);
+    let mut import_text = String::new();
+    if requires_any && let Some(line) = build_import_line(ast, "typing", &["Any"]) {
+        import_text.push_str(&line);
+    }
+    if let Some(line) = build_import_line(ast, "pydantic", &["BaseModel"]) {
+        import_text.push_str(&line);
+    }
+    if !import_text.is_empty() {
+        edits.push((
+            module_info.dupe(),
+            TextRange::at(position, TextSize::new(0)),
+            import_text,
+        ));
+    }
+    let class_text = build_class_body(indent, class_name, "BaseModel", fields, None);
+    edits.push((module_info.dupe(), insert_range, class_text));
+    Some(LocalRefactorCodeAction {
+        title: format!("Create pydantic model `{class_name}`"),
+        edits,
+        kind: CodeActionKind::REFACTOR_REWRITE,
+    })
+}
+
+fn build_class_body(
+    indent: &str,
+    class_name: &str,
+    base: &str,
+    fields: &[DictField],
+    decorator: Option<&str>,
+) -> String {
+    let mut output = String::new();
+    if let Some(decorator) = decorator {
+        output.push_str(indent);
+        output.push_str(decorator);
+        output.push('\n');
+    }
+    output.push_str(indent);
+    output.push_str("class ");
+    output.push_str(class_name);
+    if !base.is_empty() {
+        output.push('(');
+        output.push_str(base);
+        output.push(')');
+    }
+    output.push_str(":\n");
+    if fields.is_empty() {
+        output.push_str(indent);
+        output.push_str(BODY_INDENT);
+        output.push_str("pass\n");
+        return output;
+    }
+    for field in fields {
+        output.push_str(indent);
+        output.push_str(BODY_INDENT);
+        output.push_str(&field.name);
+        output.push_str(": ");
+        output.push_str(&field.annotation);
+        output.push('\n');
+    }
+    output
+}
+
+fn build_import_edit(
+    module_info: &Module,
+    ast: &ModModule,
+    module_name: &str,
+    names: &[&str],
+) -> Option<(Module, TextRange, String)> {
+    let import_text = build_import_line(ast, module_name, names)?;
+    let position = import_insertion_point(ast);
+    Some((
+        module_info.dupe(),
+        TextRange::at(position, TextSize::new(0)),
+        import_text,
+    ))
+}
+
+fn build_import_line(ast: &ModModule, module_name: &str, names: &[&str]) -> Option<String> {
+    let missing = missing_imports(ast, module_name, names);
+    if missing.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "from {module_name} import {}\n",
+        missing.join(", ")
+    ))
+}
+
+fn missing_imports<'a>(ast: &ModModule, module_name: &str, names: &'a [&'a str]) -> Vec<&'a str> {
+    let mut missing: Vec<&str> = names.to_vec();
+    for stmt in &ast.body {
+        let Stmt::ImportFrom(import_from) = stmt else {
+            continue;
+        };
+        let Some(module) = &import_from.module else {
+            continue;
+        };
+        if module.id.as_str() != module_name {
+            continue;
+        }
+        for alias in &import_from.names {
+            let name = alias.name.id.as_str();
+            let is_same_binding = match &alias.asname {
+                None => true,
+                Some(asname) => asname.id.as_str() == name,
+            };
+            if !is_same_binding {
+                continue;
+            }
+            if let Some(index) = missing.iter().position(|candidate| *candidate == name) {
+                missing.remove(index);
+            }
+        }
+    }
+    missing
+}
+
+fn import_insertion_point(ast: &ModModule) -> TextSize {
+    if let Some(first_stmt) = ast.body.iter().find(|stmt| !is_docstring_stmt(stmt)) {
+        first_stmt.range().start()
+    } else {
+        ast.range.end()
+    }
+}

--- a/pyrefly/lib/state/lsp/quick_fixes/dict_definition.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/dict_definition.rs
@@ -16,23 +16,24 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprDict;
 use ruff_python_ast::ModModule;
-use ruff_python_ast::Stmt;
-use ruff_python_ast::helpers::is_docstring_stmt;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
 
+use super::extract_shared::build_from_import_edit;
+use super::extract_shared::build_from_import_line;
 use super::extract_shared::code_at_range;
 use super::extract_shared::find_enclosing_statement_range;
+use super::extract_shared::import_insertion_point;
 use super::extract_shared::is_exact_expression;
 use super::extract_shared::line_indent_and_start;
 use super::extract_shared::selection_anchor;
 use super::extract_shared::split_selection;
+use super::extract_shared::type_to_annotation;
 use super::extract_shared::unique_name;
 use super::types::LocalRefactorCodeAction;
 use crate::state::lsp::Transaction;
 use crate::types::stdlib::Stdlib;
-use crate::types::types::Type;
 
 const BODY_INDENT: &str = "    ";
 const DEFAULT_MODEL_NAME: &str = "Model";
@@ -179,15 +180,6 @@ fn infer_field_annotation(
         Some(ty) => type_to_annotation(ty, stdlib).unwrap_or_else(|| "Any".to_owned()),
         None => "Any".to_owned(),
     }
-}
-
-fn type_to_annotation(ty: Type, stdlib: &Stdlib) -> Option<String> {
-    let ty = ty.promote_implicit_literals(stdlib);
-    if ty.is_any() {
-        return None;
-    }
-    let parts = ty.get_types_with_locations(Some(stdlib));
-    Some(parts.into_iter().map(|(part, _)| part).collect())
 }
 
 fn suggest_base_name(ast: &ModModule, dict_range: TextRange) -> String {
@@ -369,10 +361,10 @@ fn build_dataclass_action(
     let mut edits = Vec::new();
     let position = import_insertion_point(ast);
     let mut import_text = String::new();
-    if requires_any && let Some(line) = build_import_line(ast, "typing", &["Any"]) {
+    if requires_any && let Some(line) = build_from_import_line(ast, "typing", &["Any"]) {
         import_text.push_str(&line);
     }
-    if let Some(line) = build_import_line(ast, "dataclasses", &["dataclass"]) {
+    if let Some(line) = build_from_import_line(ast, "dataclasses", &["dataclass"]) {
         import_text.push_str(&line);
     }
     if !import_text.is_empty() {
@@ -403,10 +395,10 @@ fn build_pydantic_action(
     let mut edits = Vec::new();
     let position = import_insertion_point(ast);
     let mut import_text = String::new();
-    if requires_any && let Some(line) = build_import_line(ast, "typing", &["Any"]) {
+    if requires_any && let Some(line) = build_from_import_line(ast, "typing", &["Any"]) {
         import_text.push_str(&line);
     }
-    if let Some(line) = build_import_line(ast, "pydantic", &["BaseModel"]) {
+    if let Some(line) = build_from_import_line(ast, "pydantic", &["BaseModel"]) {
         import_text.push_str(&line);
     }
     if !import_text.is_empty() {
@@ -470,59 +462,5 @@ fn build_import_edit(
     module_name: &str,
     names: &[&str],
 ) -> Option<(Module, TextRange, String)> {
-    let import_text = build_import_line(ast, module_name, names)?;
-    let position = import_insertion_point(ast);
-    Some((
-        module_info.dupe(),
-        TextRange::at(position, TextSize::new(0)),
-        import_text,
-    ))
-}
-
-fn build_import_line(ast: &ModModule, module_name: &str, names: &[&str]) -> Option<String> {
-    let missing = missing_imports(ast, module_name, names);
-    if missing.is_empty() {
-        return None;
-    }
-    Some(format!(
-        "from {module_name} import {}\n",
-        missing.join(", ")
-    ))
-}
-
-fn missing_imports<'a>(ast: &ModModule, module_name: &str, names: &'a [&'a str]) -> Vec<&'a str> {
-    let mut missing: Vec<&str> = names.to_vec();
-    for stmt in &ast.body {
-        let Stmt::ImportFrom(import_from) = stmt else {
-            continue;
-        };
-        let Some(module) = &import_from.module else {
-            continue;
-        };
-        if module.id.as_str() != module_name {
-            continue;
-        }
-        for alias in &import_from.names {
-            let name = alias.name.id.as_str();
-            let is_same_binding = match &alias.asname {
-                None => true,
-                Some(asname) => asname.id.as_str() == name,
-            };
-            if !is_same_binding {
-                continue;
-            }
-            if let Some(index) = missing.iter().position(|candidate| *candidate == name) {
-                missing.remove(index);
-            }
-        }
-    }
-    missing
-}
-
-fn import_insertion_point(ast: &ModModule) -> TextSize {
-    if let Some(first_stmt) = ast.body.iter().find(|stmt| !is_docstring_stmt(stmt)) {
-        first_stmt.range().start()
-    } else {
-        ast.range.end()
-    }
+    build_from_import_edit(module_info, ast, module_name, names)
 }

--- a/pyrefly/lib/state/lsp/quick_fixes/extract_shared.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/extract_shared.rs
@@ -7,8 +7,8 @@
 
 use pyrefly_build::handle::Handle;
 use pyrefly_python::ast::Ast;
-use pyrefly_python::symbol_kind::SymbolKind;
 use pyrefly_python::module::Module;
+use pyrefly_python::symbol_kind::SymbolKind;
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprContext;
@@ -29,7 +29,6 @@ use crate::ModuleInfo;
 use crate::state::lsp::FindDefinitionItemWithDocstring;
 use crate::state::lsp::FindPreference;
 use crate::state::lsp::Transaction;
-
 use crate::types::stdlib::Stdlib;
 use crate::types::types::Type;
 

--- a/pyrefly/lib/state/lsp/quick_fixes/extract_shared.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/extract_shared.rs
@@ -8,6 +8,7 @@
 use pyrefly_build::handle::Handle;
 use pyrefly_python::ast::Ast;
 use pyrefly_python::symbol_kind::SymbolKind;
+use pyrefly_python::module::Module;
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprContext;
@@ -28,6 +29,9 @@ use crate::ModuleInfo;
 use crate::state::lsp::FindDefinitionItemWithDocstring;
 use crate::state::lsp::FindPreference;
 use crate::state::lsp::Transaction;
+
+use crate::types::stdlib::Stdlib;
+use crate::types::types::Type;
 
 pub(super) fn split_selection<'a>(
     selection_text: &'a str,
@@ -368,6 +372,81 @@ pub(super) fn code_at_range<'a>(source: &'a str, range: TextRange) -> Option<&'a
     } else {
         None
     }
+}
+
+pub(super) fn type_to_annotation(ty: Type, stdlib: &Stdlib) -> Option<String> {
+    let ty = ty.promote_implicit_literals(stdlib);
+    if ty.is_any() {
+        return None;
+    }
+    let parts = ty.get_types_with_locations(Some(stdlib));
+    Some(parts.into_iter().map(|(part, _)| part).collect())
+}
+
+pub(super) fn has_existing_from_import(ast: &ModModule, module_name: &str, name: &str) -> bool {
+    ast.body.iter().any(|stmt| match stmt {
+        Stmt::ImportFrom(import_from) => {
+            if let Some(module) = &import_from.module
+                && module.id.as_str() == module_name
+            {
+                import_from.names.iter().any(|alias| {
+                    if alias.name.id.as_str() != name {
+                        return false;
+                    }
+                    match &alias.asname {
+                        None => true,
+                        Some(asname) => asname.id.as_str() == name,
+                    }
+                })
+            } else {
+                false
+            }
+        }
+        _ => false,
+    })
+}
+
+pub(super) fn build_from_import_line(
+    ast: &ModModule,
+    module_name: &str,
+    names: &[&str],
+) -> Option<String> {
+    let mut missing: Vec<&str> = names.to_vec();
+    for name in names {
+        if has_existing_from_import(ast, module_name, name) {
+            missing.retain(|candidate| candidate != name);
+        }
+    }
+    if missing.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "from {module_name} import {}\n",
+        missing.join(", ")
+    ))
+}
+
+pub(super) fn import_insertion_point(ast: &ModModule) -> TextSize {
+    if let Some(first_stmt) = ast.body.iter().find(|stmt| !is_docstring_stmt(stmt)) {
+        first_stmt.range().start()
+    } else {
+        ast.range.end()
+    }
+}
+
+pub(super) fn build_from_import_edit(
+    module_info: &Module,
+    ast: &ModModule,
+    module_name: &str,
+    names: &[&str],
+) -> Option<(Module, TextRange, String)> {
+    let import_text = build_from_import_line(ast, module_name, names)?;
+    let position = import_insertion_point(ast);
+    Some((
+        module_info.clone(),
+        TextRange::at(position, TextSize::new(0)),
+        import_text,
+    ))
 }
 
 /// Returns true if the function has a @staticmethod or @classmethod decorator.

--- a/pyrefly/lib/state/lsp/quick_fixes/generate_code.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/generate_code.rs
@@ -20,6 +20,7 @@ use ruff_text_size::TextSize;
 
 use super::extract_shared::find_enclosing_statement_range;
 use super::extract_shared::line_indent_and_start;
+use super::extract_shared::type_to_annotation;
 use super::extract_shared::unique_name;
 use crate::state::lsp::Transaction;
 use crate::types::stdlib::Stdlib;
@@ -39,16 +40,6 @@ fn param_name_from_expr(expr: &Expr) -> Option<String> {
         Expr::Attribute(attr) => Some(attr.attr.id.to_string()),
         _ => None,
     }
-}
-
-fn type_to_annotation(ty: Type, stdlib: &Stdlib) -> Option<String> {
-    let ty = ty.promote_implicit_literals(stdlib);
-    if ty.is_any() {
-        return None;
-    }
-    let parts = ty.get_types_with_locations(Some(stdlib));
-    let text: String = parts.into_iter().map(|(part, _)| part).collect();
-    Some(text)
 }
 
 fn infer_annotation(

--- a/pyrefly/lib/state/lsp/quick_fixes/mod.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/mod.rs
@@ -6,6 +6,7 @@
  */
 
 pub(crate) mod convert_star_import;
+pub(crate) mod dict_definition;
 pub(crate) mod extract_field;
 pub(crate) mod extract_function;
 mod extract_shared;

--- a/pyrefly/lib/state/lsp/quick_fixes/mod.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/mod.rs
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+pub(crate) mod convert_dict;
 pub(crate) mod convert_star_import;
-pub(crate) mod dict_definition;
 pub(crate) mod extract_field;
 pub(crate) mod extract_function;
 mod extract_shared;

--- a/pyrefly/lib/state/lsp/quick_fixes/move_module.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/move_module.rs
@@ -9,7 +9,6 @@ use dupe::Dupe;
 use lsp_types::CodeActionKind;
 use pyrefly_build::handle::Handle;
 use pyrefly_python::module::Module;
-use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::module_path::ModulePathDetails;
 use ruff_python_ast::Decorator;
 use ruff_python_ast::ModModule;
@@ -22,6 +21,7 @@ use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
 
 use super::extract_shared::decorator_matches_name;
+use super::extract_shared::has_existing_from_import;
 use super::extract_shared::line_end_position;
 use super::extract_shared::line_indent_and_start;
 use super::extract_shared::member_name_from_stmt;
@@ -379,7 +379,7 @@ fn build_import_edit(
     target_handle: &Handle,
     import_format: ImportFormat,
 ) -> Option<(Module, TextRange, String)> {
-    if has_existing_import(ast, target_handle.module(), member_name) {
+    if has_existing_from_import(ast, target_handle.module().as_str(), member_name) {
         return None;
     }
     let (position, insert_text, _) = insert_import_edit(
@@ -392,29 +392,6 @@ fn build_import_edit(
     );
     let range = TextRange::at(position, TextSize::new(0));
     Some((module_info.dupe(), range, insert_text))
-}
-
-fn has_existing_import(ast: &ModModule, module_name: ModuleName, name: &str) -> bool {
-    ast.body.iter().any(|stmt| match stmt {
-        Stmt::ImportFrom(import_from) => {
-            if let Some(module) = &import_from.module
-                && ModuleName::from_name(&module.id) == module_name
-            {
-                import_from.names.iter().any(|alias| {
-                    if alias.name.id.as_str() != name {
-                        return false;
-                    }
-                    match &alias.asname {
-                        None => true,
-                        Some(asname) => asname.id.as_str() == name,
-                    }
-                })
-            } else {
-                false
-            }
-        }
-        _ => false,
-    })
 }
 
 fn build_module_insertion_edit(

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -248,7 +248,7 @@ fn compute_invert_boolean_actions_allow_errors(
     (module_info, edit_sets, titles)
 }
 
-fn compute_dict_definition_actions(
+fn compute_convert_dict_actions(
     code: &str,
     selection: TextRange,
 ) -> (
@@ -262,7 +262,7 @@ fn compute_dict_definition_actions(
     let transaction = state.transaction();
     let module_info = transaction.get_module_info(handle).unwrap();
     let actions = transaction
-        .dict_definition_code_actions(handle, selection)
+        .convert_dict_code_actions(handle, selection)
         .unwrap_or_default();
     let edit_sets: Vec<Vec<(Module, TextRange, String)>> =
         actions.iter().map(|action| action.edits.clone()).collect();
@@ -1800,14 +1800,14 @@ def foo():
 }
 
 #[test]
-fn dict_definition_code_actions_basic() {
+fn convert_dict_code_actions_basic() {
     let code = r#"def build():
     data = {"a": 1, "b": [1, 2]}
     return data
 "#;
     let dict_start = find_nth_range(code, "{", 1).start();
     let selection = TextRange::new(dict_start, dict_start);
-    let (module_info, actions, titles) = compute_dict_definition_actions(code, selection);
+    let (module_info, actions, titles) = compute_convert_dict_actions(code, selection);
     assert_eq!(3, actions.len());
     assert_eq!(
         vec![
@@ -1854,14 +1854,14 @@ def build():
 }
 
 #[test]
-fn dict_definition_includes_any_imports() {
+fn convert_dict_includes_any_imports() {
     let code = r#"def build(value):
     data = {"a": value}
     return data
 "#;
     let dict_start = find_nth_range(code, "{", 1).start();
     let selection = TextRange::new(dict_start, dict_start);
-    let (module_info, actions, _) = compute_dict_definition_actions(code, selection);
+    let (module_info, actions, _) = compute_convert_dict_actions(code, selection);
     assert_eq!(3, actions.len());
 
     let typed_dict_result = apply_refactor_edits_for_module(&module_info, &actions[0]);
@@ -1899,14 +1899,14 @@ def build(value):
 }
 
 #[test]
-fn dict_definition_rejects_non_literal_keys() {
+fn convert_dict_rejects_non_literal_keys() {
     let code = r#"def build(extra):
     data = {"a": 1, **extra}
     return data
 "#;
     let dict_start = find_nth_range(code, "{", 1).start();
     let selection = TextRange::new(dict_start, dict_start);
-    let (_, actions, _) = compute_dict_definition_actions(code, selection);
+    let (_, actions, _) = compute_convert_dict_actions(code, selection);
     assert!(
         actions.is_empty(),
         "expected no dict definition actions, found {}",

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -248,6 +248,28 @@ fn compute_invert_boolean_actions_allow_errors(
     (module_info, edit_sets, titles)
 }
 
+fn compute_dict_definition_actions(
+    code: &str,
+    selection: TextRange,
+) -> (
+    ModuleInfo,
+    Vec<Vec<(Module, TextRange, String)>>,
+    Vec<String>,
+) {
+    let (handles, state) =
+        mk_multi_file_state_assert_no_errors(&[("main", code)], Require::Everything);
+    let handle = handles.get("main").unwrap();
+    let transaction = state.transaction();
+    let module_info = transaction.get_module_info(handle).unwrap();
+    let actions = transaction
+        .dict_definition_code_actions(handle, selection)
+        .unwrap_or_default();
+    let edit_sets: Vec<Vec<(Module, TextRange, String)>> =
+        actions.iter().map(|action| action.edits.clone()).collect();
+    let titles = actions.iter().map(|action| action.title.clone()).collect();
+    (module_info, edit_sets, titles)
+}
+
 fn assert_no_invert_boolean_action_allow_errors(code: &str, selection: TextRange) {
     let (_, actions, _) = compute_invert_boolean_actions_allow_errors(code, selection);
     assert!(
@@ -1774,6 +1796,121 @@ def foo():
 "#
         .trim(),
         report.trim()
+    );
+}
+
+#[test]
+fn dict_definition_code_actions_basic() {
+    let code = r#"def build():
+    data = {"a": 1, "b": [1, 2]}
+    return data
+"#;
+    let dict_start = find_nth_range(code, "{", 1).start();
+    let selection = TextRange::new(dict_start, dict_start);
+    let (module_info, actions, titles) = compute_dict_definition_actions(code, selection);
+    assert_eq!(3, actions.len());
+    assert_eq!(
+        vec![
+            "Create TypedDict `Data`",
+            "Create dataclass `Data`",
+            "Create pydantic model `Data`",
+        ],
+        titles
+    );
+
+    let typed_dict_result = apply_refactor_edits_for_module(&module_info, &actions[0]);
+    let expected_typed_dict = r#"from typing import TypedDict
+def build():
+    class Data(TypedDict):
+        a: int
+        b: list[int]
+    data = {"a": 1, "b": [1, 2]}
+    return data
+"#;
+    assert_eq!(expected_typed_dict.trim(), typed_dict_result.trim());
+
+    let dataclass_result = apply_refactor_edits_for_module(&module_info, &actions[1]);
+    let expected_dataclass = r#"from dataclasses import dataclass
+def build():
+    @dataclass
+    class Data:
+        a: int
+        b: list[int]
+    data = {"a": 1, "b": [1, 2]}
+    return data
+"#;
+    assert_eq!(expected_dataclass.trim(), dataclass_result.trim());
+
+    let pydantic_result = apply_refactor_edits_for_module(&module_info, &actions[2]);
+    let expected_pydantic = r#"from pydantic import BaseModel
+def build():
+    class Data(BaseModel):
+        a: int
+        b: list[int]
+    data = {"a": 1, "b": [1, 2]}
+    return data
+"#;
+    assert_eq!(expected_pydantic.trim(), pydantic_result.trim());
+}
+
+#[test]
+fn dict_definition_includes_any_imports() {
+    let code = r#"def build(value):
+    data = {"a": value}
+    return data
+"#;
+    let dict_start = find_nth_range(code, "{", 1).start();
+    let selection = TextRange::new(dict_start, dict_start);
+    let (module_info, actions, _) = compute_dict_definition_actions(code, selection);
+    assert_eq!(3, actions.len());
+
+    let typed_dict_result = apply_refactor_edits_for_module(&module_info, &actions[0]);
+    let expected_typed_dict = r#"from typing import TypedDict, Any
+def build(value):
+    class Data(TypedDict):
+        a: Any
+    data = {"a": value}
+    return data
+"#;
+    assert_eq!(expected_typed_dict.trim(), typed_dict_result.trim());
+
+    let dataclass_result = apply_refactor_edits_for_module(&module_info, &actions[1]);
+    let expected_dataclass = r#"from typing import Any
+from dataclasses import dataclass
+def build(value):
+    @dataclass
+    class Data:
+        a: Any
+    data = {"a": value}
+    return data
+"#;
+    assert_eq!(expected_dataclass.trim(), dataclass_result.trim());
+
+    let pydantic_result = apply_refactor_edits_for_module(&module_info, &actions[2]);
+    let expected_pydantic = r#"from typing import Any
+from pydantic import BaseModel
+def build(value):
+    class Data(BaseModel):
+        a: Any
+    data = {"a": value}
+    return data
+"#;
+    assert_eq!(expected_pydantic.trim(), pydantic_result.trim());
+}
+
+#[test]
+fn dict_definition_rejects_non_literal_keys() {
+    let code = r#"def build(extra):
+    data = {"a": 1, **extra}
+    return data
+"#;
+    let dict_start = find_nth_range(code, "{", 1).start();
+    let selection = TextRange::new(dict_start, dict_start);
+    let (_, actions, _) = compute_dict_definition_actions(code, selection);
+    assert!(
+        actions.is_empty(),
+        "expected no dict definition actions, found {}",
+        actions.len()
     );
 }
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2144

Implemented dict-to-model refactor code actions (TypedDict, dataclass, Pydantic) and wired them into LSP refactors, with imports and scoped insertion logic.

note: to keep simple, currently nest case is not considered（fallback to dict）. Will impl in the future pr.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added coverage for the new actions.