### PR TITLE
fix Renaming a kwarg does not work across files. #1583

### DIFF
--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2414,7 +2414,8 @@ impl<'a> Transaction<'a> {
         results
     }
 
-    /// Return the cached AST for a module, parsing it if the module is not open.
+    /// Return the cached AST for a module, parsing its contents if unavailable.
+    /// Files that Pyrefly has not explicitly opened may have module information but no cached AST.
     fn get_ast_or_parse_module(&self, handle: &Handle, module: &ModuleInfo) -> Arc<ModModule> {
         let module_handle = Handle::new(
             module.name(),

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2387,20 +2387,7 @@ impl<'a> Transaction<'a> {
 
         let mut results: Vec<FindDefinitionItem> = Vec::with_capacity(location_count);
         for (module_info, ranges) in modules_to_ranges.into_iter() {
-            let ast = {
-                let handle = Handle::new(
-                    module_info.name(),
-                    module_info.path().dupe(),
-                    handle.sys_info().dupe(),
-                );
-                self.get_ast(&handle).unwrap_or_else(|| {
-                    // We may not have the AST available for the handle if it's not opened -- in that case,
-                    // Re-parse the module to get the AST.
-                    Ast::parse(module_info.contents(), module_info.source_type())
-                        .0
-                        .into()
-                })
-            };
+            let ast = self.get_ast_or_parse_module(handle, &module_info);
 
             for range in ranges.into_iter() {
                 let (metadata, definition_range) = if let Some(param_range) =
@@ -2425,6 +2412,17 @@ impl<'a> Transaction<'a> {
             }
         }
         results
+    }
+
+    /// Return the cached AST for a module, parsing it if the module is not open.
+    fn get_ast_or_parse_module(&self, handle: &Handle, module: &ModuleInfo) -> Arc<ModModule> {
+        let module_handle = Handle::new(
+            module.name(),
+            module.path().dupe(),
+            handle.sys_info().dupe(),
+        );
+        self.get_ast(&module_handle)
+            .unwrap_or_else(|| Ast::parse(module.contents(), module.source_type()).0.into())
     }
 
     fn get_callee_location(
@@ -3824,16 +3822,13 @@ impl<'a> Transaction<'a> {
         };
         // Only callable parameters can be referenced by keyword arguments. Attributes, modules,
         // and other variable kinds are covered by the regular reference indexes above.
-        if is_parameter_definition
-            && let Some(keyword_references) = self
-                .keyword_argument_references_from_parameter_definition(
-                    handle,
-                    module,
-                    definition_range,
-                    &definition_name,
-                )
-        {
-            references.extend(keyword_references);
+        if is_parameter_definition {
+            references.extend(self.keyword_argument_references_from_parameter_definition(
+                handle,
+                module,
+                definition_range,
+                &definition_name,
+            ));
         }
         references.sort_by_key(|range| range.start());
         references.dedup();
@@ -3962,29 +3957,13 @@ impl<'a> Transaction<'a> {
         definition_module: &ModuleInfo,
         definition_range: TextRange,
         expected_name: &Name,
-    ) -> Option<Vec<TextRange>> {
+    ) -> Vec<TextRange> {
         let keyword_args = self.collect_local_keyword_arguments_by_name(handle, expected_name);
         if keyword_args.is_empty() {
-            return Some(Vec::new());
+            return Vec::new();
         }
 
-        let definition_ast = if handle.path() == definition_module.path() {
-            self.get_ast(handle)?
-        } else {
-            let definition_handle = Handle::new(
-                definition_module.name(),
-                definition_module.path().dupe(),
-                handle.sys_info().dupe(),
-            );
-            self.get_ast(&definition_handle).unwrap_or_else(|| {
-                Ast::parse(
-                    definition_module.contents(),
-                    definition_module.source_type(),
-                )
-                .0
-                .into()
-            })
-        };
+        let definition_ast = self.get_ast_or_parse_module(handle, definition_module);
 
         let mut references = Vec::new();
         for (kw_identifier, callee_kind) in keyword_args {
@@ -4010,7 +3989,7 @@ impl<'a> Transaction<'a> {
             }
         }
 
-        Some(references)
+        references
     }
 
     fn local_variable_references_from_local_definition(

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2403,12 +2403,23 @@ impl<'a> Transaction<'a> {
             };
 
             for range in ranges.into_iter() {
-                let refined_param_range =
-                    self.refine_param_location_for_callee(ast.as_ref(), range, identifier);
-                // TODO(grievejia): Should we filter out unrefinable ranges here?
+                let (metadata, definition_range) = if let Some(param_range) =
+                    self.refine_param_location_for_callee(ast.as_ref(), range, identifier)
+                {
+                    (
+                        DefinitionMetadata::Variable(Some(SymbolKind::Parameter)),
+                        param_range,
+                    )
+                } else {
+                    // TODO(grievejia): Should we filter out unrefinable ranges here?
+                    (
+                        DefinitionMetadata::Variable(Some(SymbolKind::Variable)),
+                        range,
+                    )
+                };
                 results.push(FindDefinitionItem {
-                    metadata: DefinitionMetadata::Variable(Some(SymbolKind::Variable)),
-                    definition_range: refined_param_range.unwrap_or(range),
+                    metadata,
+                    definition_range,
                     module: module_info.dupe(),
                 })
             }
@@ -3694,7 +3705,6 @@ impl<'a> Transaction<'a> {
     fn local_references_from_external_definition(
         &self,
         handle: &Handle,
-        definition_metadata: &DefinitionMetadata,
         definition_range: TextRange,
         module: &Module,
     ) -> Option<Vec<TextRange>> {
@@ -3702,25 +3712,26 @@ impl<'a> Transaction<'a> {
         let index = index.lock();
         let mut references = Vec::new();
 
-        // Lazily computed data for fallback comparison.
-        let definition_line = || module.to_lsp_position(definition_range.start()).line;
-        let definition_name = || module.code_at(definition_range);
+        let definition_line = module.to_lsp_position(definition_range.start()).line;
+        let definition_name = module.code_at(definition_range);
+        let matches_definition = |candidate_range: TextRange, candidate_name: &str| {
+            candidate_range == definition_range
+                || (candidate_name == definition_name
+                    && module.to_lsp_position(candidate_range.start()).line == definition_line)
+        };
 
         for ((imported_module_name, imported_name), ranges) in index
             .externally_defined_variable_references
             .iter()
             .chain(&index.renamed_imports)
         {
-            if let Some((imported_handle, _, export)) = self.resolve_named_import(
+            if let Some((imported_handle, resolved_name, export)) = self.resolve_named_import(
                 handle,
                 *imported_module_name,
                 imported_name.clone(),
                 FindPreference::default(),
             ) && imported_handle.path().as_path() == module.path().as_path()
-                && (export.location == definition_range
-                    || (imported_name.as_str() == definition_name()
-                        && module.to_lsp_position(export.location.start()).line
-                            == definition_line()))
+                && matches_definition(export.location, resolved_name.as_str())
             {
                 references.extend(ranges.iter().copied());
             }
@@ -3730,37 +3741,10 @@ impl<'a> Transaction<'a> {
         {
             if attribute_module_path == module.path() {
                 for (def_range, ref_range) in def_and_ref_ranges {
-                    if *def_range == definition_range
-                        || (module.code_at(*def_range) == definition_name()
-                            && module.to_lsp_position(def_range.start()).line == definition_line())
-                    {
+                    if matches_definition(*def_range, module.code_at(*def_range)) {
                         references.push(*ref_range);
                     }
                 }
-            }
-        }
-
-        let symbol_kind = match definition_metadata {
-            DefinitionMetadata::Variable(kind) | DefinitionMetadata::VariableOrAttribute(kind) => {
-                *kind
-            }
-            _ => None,
-        };
-
-        if matches!(
-            symbol_kind,
-            Some(SymbolKind::Parameter) | Some(SymbolKind::Variable)
-        ) {
-            let definition_name = Name::new(module.code_at(definition_range));
-            if let Some(kwarg_references) = self
-                .keyword_argument_references_from_parameter_definition(
-                    handle,
-                    module,
-                    definition_range,
-                    &definition_name,
-                )
-            {
-                references.extend(kwarg_references);
             }
         }
         Some(references)
@@ -3781,15 +3765,14 @@ impl<'a> Transaction<'a> {
                 definition_name,
             ),
             DefinitionMetadata::Module => Vec::new(),
-            DefinitionMetadata::Variable(symbol_kind) => self
+            DefinitionMetadata::Variable(_) => self
                 .local_variable_references_from_local_definition(
                     handle,
                     definition_range,
                     definition_name,
-                    symbol_kind,
                 )
                 .unwrap_or_default(),
-            DefinitionMetadata::VariableOrAttribute(symbol_kind) => [
+            DefinitionMetadata::VariableOrAttribute(_) => [
                 self.local_attribute_references_from_local_definition(
                     handle,
                     definition_range,
@@ -3799,7 +3782,6 @@ impl<'a> Transaction<'a> {
                     handle,
                     definition_range,
                     definition_name,
-                    symbol_kind,
                 )
                 .unwrap_or_default(),
             ]
@@ -3826,15 +3808,12 @@ impl<'a> Transaction<'a> {
         module: &Module,
         include_declaration: bool,
     ) -> Option<Vec<TextRange>> {
+        let definition_name = Name::new(module.code_at(definition_range));
+        let is_parameter_definition =
+            definition_metadata.symbol_kind() == Some(SymbolKind::Parameter);
         let mut references = if handle.path() != module.path() {
-            self.local_references_from_external_definition(
-                handle,
-                &definition_metadata,
-                definition_range,
-                module,
-            )?
+            self.local_references_from_external_definition(handle, definition_range, module)?
         } else {
-            let definition_name = Name::new(module.code_at(definition_range));
             self.local_references_from_local_definition(
                 handle,
                 definition_metadata,
@@ -3843,6 +3822,19 @@ impl<'a> Transaction<'a> {
                 include_declaration,
             )?
         };
+        // Only callable parameters can be referenced by keyword arguments. Attributes, modules,
+        // and other variable kinds are covered by the regular reference indexes above.
+        if is_parameter_definition
+            && let Some(keyword_references) = self
+                .keyword_argument_references_from_parameter_definition(
+                    handle,
+                    module,
+                    definition_range,
+                    &definition_name,
+                )
+        {
+            references.extend(keyword_references);
+        }
         references.sort_by_key(|range| range.start());
         references.dedup();
         Some(references)
@@ -3964,37 +3956,6 @@ impl<'a> Transaction<'a> {
         results
     }
 
-    /// Finds all local keyword argument references that correspond to a specific parameter definition.
-    ///
-    /// Given a parameter's definition range and name, this function identifies all keyword arguments
-    /// in function calls within the same module that refer to this parameter. This is useful for
-    /// LSP features like "Find All References" for function parameters.
-    ///
-    /// # Arguments
-    ///
-    /// * `handle` - Handle to the module containing the parameter definition
-    /// * `definition_range` - The text range where the parameter is defined
-    /// * `expected_name` - The name of the parameter to search for
-    ///
-    /// # Returns
-    ///
-    /// Returns `Some(Vec<TextRange>)` containing the text ranges of all keyword argument usages
-    /// that reference this parameter definition, or `None` if the AST cannot be retrieved.
-    fn local_keyword_argument_references_from_parameter_definition(
-        &self,
-        handle: &Handle,
-        definition_range: TextRange,
-        expected_name: &Name,
-    ) -> Option<Vec<TextRange>> {
-        let definition_module = self.get_module_info(handle)?;
-        self.keyword_argument_references_from_parameter_definition(
-            handle,
-            &definition_module,
-            definition_range,
-            expected_name,
-        )
-    }
-
     fn keyword_argument_references_from_parameter_definition(
         &self,
         handle: &Handle,
@@ -4057,7 +4018,6 @@ impl<'a> Transaction<'a> {
         handle: &Handle,
         definition_range: TextRange,
         expected_name: &Name,
-        symbol_kind: Option<SymbolKind>,
     ) -> Option<Vec<TextRange>> {
         let mut references = Vec::new();
         if let Some(mod_module) = self.get_ast(handle) {
@@ -4093,20 +4053,6 @@ impl<'a> Transaction<'a> {
             mod_module.visit(&mut |x| f(x, &is_valid_use, &mut references));
         }
 
-        if let Some(kind) = symbol_kind
-            && (kind == SymbolKind::Parameter || kind == SymbolKind::Variable)
-        {
-            let kwarg_references = self
-                .local_keyword_argument_references_from_parameter_definition(
-                    handle,
-                    definition_range,
-                    expected_name,
-                );
-
-            if let Some(refs) = kwarg_references {
-                references.extend(refs);
-            }
-        }
         Some(references)
     }
 

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3689,8 +3689,8 @@ impl<'a> Transaction<'a> {
     }
 
     /// Find references to an external definition within the given handle's module.
-    /// When the exact byte-range comparison fails (e.g. CRLF/LF differences),
-    /// falls back to comparing line numbers, which are encoding-invariant.
+    /// When the exact byte-range comparison fails (e.g. CRLF/LF differences), fall back to
+    /// comparing symbol names and line numbers, which are encoding-invariant.
     fn local_references_from_external_definition(
         &self,
         handle: &Handle,
@@ -3702,8 +3702,9 @@ impl<'a> Transaction<'a> {
         let index = index.lock();
         let mut references = Vec::new();
 
-        // Lazily computed line number for fallback comparison.
+        // Lazily computed data for fallback comparison.
         let definition_line = || module.to_lsp_position(definition_range.start()).line;
+        let definition_name = || module.code_at(definition_range);
 
         for ((imported_module_name, imported_name), ranges) in index
             .externally_defined_variable_references
@@ -3717,7 +3718,9 @@ impl<'a> Transaction<'a> {
                 FindPreference::default(),
             ) && imported_handle.path().as_path() == module.path().as_path()
                 && (export.location == definition_range
-                    || module.to_lsp_position(export.location.start()).line == definition_line())
+                    || (imported_name.as_str() == definition_name()
+                        && module.to_lsp_position(export.location.start()).line
+                            == definition_line()))
             {
                 references.extend(ranges.iter().copied());
             }
@@ -3728,7 +3731,8 @@ impl<'a> Transaction<'a> {
             if attribute_module_path == module.path() {
                 for (def_range, ref_range) in def_and_ref_ranges {
                     if *def_range == definition_range
-                        || module.to_lsp_position(def_range.start()).line == definition_line()
+                        || (module.code_at(*def_range) == definition_name()
+                            && module.to_lsp_position(def_range.start()).line == definition_line())
                     {
                         references.push(*ref_range);
                     }
@@ -4037,10 +4041,9 @@ impl<'a> Transaction<'a> {
                         definition_ast.as_ref(),
                         callee_def_range,
                         &kw_identifier,
-                    ) {
-                        if param_range == definition_range {
-                            references.push(kw_identifier.range);
-                        }
+                    ) && param_range == definition_range
+                    {
+                        references.push(kw_identifier.range);
                     }
                 }
             }

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3694,6 +3694,7 @@ impl<'a> Transaction<'a> {
     fn local_references_from_external_definition(
         &self,
         handle: &Handle,
+        definition_metadata: &DefinitionMetadata,
         definition_range: TextRange,
         module: &Module,
     ) -> Option<Vec<TextRange>> {
@@ -3732,6 +3733,30 @@ impl<'a> Transaction<'a> {
                         references.push(*ref_range);
                     }
                 }
+            }
+        }
+
+        let symbol_kind = match definition_metadata {
+            DefinitionMetadata::Variable(kind) | DefinitionMetadata::VariableOrAttribute(kind) => {
+                *kind
+            }
+            _ => None,
+        };
+
+        if matches!(
+            symbol_kind,
+            Some(SymbolKind::Parameter) | Some(SymbolKind::Variable)
+        ) {
+            let definition_name = Name::new(module.code_at(definition_range));
+            if let Some(kwarg_references) = self
+                .keyword_argument_references_from_parameter_definition(
+                    handle,
+                    module,
+                    definition_range,
+                    &definition_name,
+                )
+            {
+                references.extend(kwarg_references);
             }
         }
         Some(references)
@@ -3798,7 +3823,12 @@ impl<'a> Transaction<'a> {
         include_declaration: bool,
     ) -> Option<Vec<TextRange>> {
         let mut references = if handle.path() != module.path() {
-            self.local_references_from_external_definition(handle, definition_range, module)?
+            self.local_references_from_external_definition(
+                handle,
+                &definition_metadata,
+                definition_range,
+                module,
+            )?
         } else {
             let definition_name = Name::new(module.code_at(definition_range));
             self.local_references_from_local_definition(
@@ -3952,12 +3982,46 @@ impl<'a> Transaction<'a> {
         definition_range: TextRange,
         expected_name: &Name,
     ) -> Option<Vec<TextRange>> {
-        let ast = self.get_ast(handle)?;
-        let keyword_args = self.collect_local_keyword_arguments_by_name(handle, expected_name);
-        let mut references = Vec::new();
-
         let definition_module = self.get_module_info(handle)?;
+        self.keyword_argument_references_from_parameter_definition(
+            handle,
+            &definition_module,
+            definition_range,
+            expected_name,
+        )
+    }
 
+    fn keyword_argument_references_from_parameter_definition(
+        &self,
+        handle: &Handle,
+        definition_module: &ModuleInfo,
+        definition_range: TextRange,
+        expected_name: &Name,
+    ) -> Option<Vec<TextRange>> {
+        let keyword_args = self.collect_local_keyword_arguments_by_name(handle, expected_name);
+        if keyword_args.is_empty() {
+            return Some(Vec::new());
+        }
+
+        let definition_ast = if handle.path() == definition_module.path() {
+            self.get_ast(handle)?
+        } else {
+            let definition_handle = Handle::new(
+                definition_module.name(),
+                definition_module.path().dupe(),
+                handle.sys_info().dupe(),
+            );
+            self.get_ast(&definition_handle).unwrap_or_else(|| {
+                Ast::parse(
+                    definition_module.contents(),
+                    definition_module.source_type(),
+                )
+                .0
+                .into()
+            })
+        };
+
+        let mut references = Vec::new();
         for (kw_identifier, callee_kind) in keyword_args {
             let callee_locations =
                 self.get_callee_location(handle, &callee_kind, FindPreference::default());
@@ -3968,13 +4032,12 @@ impl<'a> Transaction<'a> {
             } in callee_locations
             {
                 if module.path() == definition_module.path() {
-                    // Refine to get the actual parameter location
+                    // Refine to get the actual parameter location.
                     if let Some(param_range) = self.refine_param_location_for_callee(
-                        ast.as_ref(),
+                        definition_ast.as_ref(),
                         callee_def_range,
                         &kw_identifier,
                     ) {
-                        // If the parameter location matches our definition, this is a valid reference
                         if param_range == definition_range {
                             references.push(kw_identifier.range);
                         }

--- a/pyrefly/lib/test/lsp/lsp_interaction/rename.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/rename.rs
@@ -257,6 +257,65 @@ fn test_rename_editable_package_symbols_is_allowed() {
 }
 
 #[test]
+fn test_rename_kwarg_across_files() {
+    let root = get_test_files_root();
+    let root_path = root.path().join("rename_kwargs_across_files");
+    let scope_uri = Url::from_file_path(root_path.clone()).unwrap();
+
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root_path.clone());
+    interaction
+        .initialize(InitializeSettings {
+            workspace_folders: Some(vec![("test".to_owned(), scope_uri.clone())]),
+            configuration: Some(Some(json!([{ "indexing_mode": "lazy_blocking" }]))),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let defs = root_path.join("defs.py");
+    let uses = root_path.join("uses.py");
+
+    interaction.client.did_open("defs.py");
+    interaction.client.did_open("uses.py");
+
+    interaction
+        .client
+        .send_request::<Rename>(json!({
+            "textDocument": {
+                "uri": Url::from_file_path(&defs).unwrap().to_string()
+            },
+            "position": {
+                "line": 0,
+                "character": 16
+            },
+            "newName": "note"
+        }))
+        .expect_response(json!({
+            "changes": {
+                Url::from_file_path(&defs).unwrap().to_string(): [
+                    {
+                        "newText":"note",
+                        "range":{"start":{"line":0,"character":16},"end":{"line":0,"character":23}}
+                    },
+                    {
+                        "newText":"note",
+                        "range":{"start":{"line":1,"character":14},"end":{"line":1,"character":21}}
+                    },
+                ],
+                Url::from_file_path(&uses).unwrap().to_string(): [
+                    {
+                        "newText":"note",
+                        "range":{"start":{"line":3,"character":31},"end":{"line":3,"character":38}}
+                    },
+                ]
+            }
+        }))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
 fn test_rename() {
     let root = get_test_files_root();
     let root_path = root.path().join("tests_requiring_config");

--- a/pyrefly/lib/test/lsp/lsp_interaction/rename.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/rename.rs
@@ -305,7 +305,7 @@ fn test_rename_kwarg_across_files() {
                 Url::from_file_path(&uses).unwrap().to_string(): [
                     {
                         "newText":"note",
-                        "range":{"start":{"line":3,"character":31},"end":{"line":3,"character":38}}
+                        "range":{"start":{"line":6,"character":31},"end":{"line":6,"character":38}}
                     },
                 ]
             }

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/rename_kwargs_across_files/defs.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/rename_kwargs_across_files/defs.py
@@ -1,0 +1,2 @@
+def greet(name, message):
+    return f"{message}, {name}"

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/rename_kwargs_across_files/pyrefly.toml
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/rename_kwargs_across_files/pyrefly.toml
@@ -1,0 +1,1 @@
+search_path = ["."]

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/rename_kwargs_across_files/uses.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/rename_kwargs_across_files/uses.py
@@ -1,0 +1,4 @@
+from defs import greet
+
+def call():
+    return greet(name="Alice", message="Hello")

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/rename_kwargs_across_files/uses.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/rename_kwargs_across_files/uses.py
@@ -1,4 +1,7 @@
 from defs import greet
 
+def farewell(message):
+    return message
+
 def call():
-    return greet(name="Alice", message="Hello")
+    return greet(name="Alice", message="Hello"), farewell(message="Goodbye")


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1583

Updated cross-module rename logic so keyword-argument references are included when the parameter definition lives in a different file. This now resolves keyword args by name, then refines against the definition module’s AST to match the exact parameter.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added a cross-file rename test and fixtures to cover kwarg renames across modules
