### PR TITLE
Fix false positive bad-instantiation for dataclass implementing protocol with `__dataclass_fields__`

### DIFF
--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -1339,6 +1339,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
         let mut abstract_members = SmallSet::new();
         for field_name in fields_to_check {
+            // If the class has a synthesized concrete implementation (e.g., `__dataclass_fields__`
+            // from @dataclass), that satisfies any protocol requirement for this field.
+            if self
+                .get_class_member(cls, &field_name)
+                .is_some_and(|f| !f.is_abstract() && !f.is_uninit_class_var())
+            {
+                continue;
+            }
             if let Some(field) =
                 self.get_non_synthesized_class_member_and_defining_class(cls, &field_name)
                 && (field.value.is_abstract() ||

--- a/pyrefly/lib/test/dataclasses.rs
+++ b/pyrefly/lib/test/dataclasses.rs
@@ -1756,7 +1756,6 @@ class DC3:
 );
 
 testcase!(
-    bug = "False positive bad-instantiation due to abstract __dataclass_fields__ from protocol",
     test_dataclass_protocol_dataclass_fields,
     r#"
 from dataclasses import dataclass, Field
@@ -1769,6 +1768,6 @@ class P(Protocol):
 class C(P):
     x: int
 
-C(42)  # E: Cannot instantiate `C` because the following members are abstract: `__dataclass_fields__` [bad-instantiation]
+C(42)
 "#,
 );


### PR DESCRIPTION
## Summary

- Fixes a false positive `bad-instantiation` error when a `@dataclass` implements a `Protocol` that declares `__dataclass_fields__: ClassVar[dict[str, Field[Any]]]`
- This regression was introduced by #2428, which synthesized `__dataclass_fields__` as a `ClassVar` for dataclasses
- Root cause: `calculate_abstract_members` used `get_non_synthesized_class_member_and_defining_class` to look up fields, which skips synthesized fields. The dataclass's synthesized `__dataclass_fields__` was invisible, so the MRO traversal found the protocol's uninitialized `ClassVar` instead — flagging it as abstract
- Fix: before the existing check, use `get_class_member` (which includes synthesized fields) to detect concrete implementations. If the class already has a non-abstract, non-uninitialized implementation, the requirement is satisfied and we skip it

Fixes #2477

## Test plan

- Added regression test `test_dataclass_protocol_dataclass_fields` in `pyrefly/lib/test/dataclasses.rs`
- `test.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)