### PR TITLE
[conformance] fix Passing an unpacked tuple of types as type arguments to the type parameters [T, *Ts] gets error #2363 

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -7364,28 +7364,6 @@
     {
       "code": -2,
       "column": 8,
-      "concise_description": "Unpacked argument cannot be used for type parameter T1",
-      "description": "Unpacked argument cannot be used for type parameter T1",
-      "line": 153,
-      "name": "bad-unpacking",
-      "severity": "error",
-      "stop_column": 29,
-      "stop_line": 153
-    },
-    {
-      "code": -2,
-      "column": 16,
-      "concise_description": "assert_type(tuple[Any], tuple[*tuple[int, ...], int]) failed",
-      "description": "assert_type(tuple[Any], tuple[*tuple[int, ...], int]) failed",
-      "line": 157,
-      "name": "assert-type",
-      "severity": "error",
-      "stop_column": 49,
-      "stop_line": 157
-    },
-    {
-      "code": -2,
-      "column": 8,
       "concise_description": "Unpacked argument cannot be used for type parameter T",
       "description": "Unpacked argument cannot be used for type parameter T",
       "line": 163,

--- a/conformance/third_party/conformance.result
+++ b/conformance/third_party/conformance.result
@@ -133,9 +133,7 @@
   "generics_typevartuple_overloads.py": [],
   "generics_typevartuple_specialization.py": [
     "Line 51: Unexpected errors ['assert_type(tuple[int, *tuple[Any, ...]], tuple[int]) failed']",
-    "Line 94: Unexpected errors ['assert_type(tuple[float, *tuple[Any, ...]], tuple[float]) failed']",
-    "Line 153: Unexpected errors ['Unpacked argument cannot be used for type parameter T1']",
-    "Line 157: Unexpected errors ['assert_type(tuple[Any], tuple[*tuple[int, ...], int]) failed']"
+    "Line 94: Unexpected errors ['assert_type(tuple[float, *tuple[Any, ...]], tuple[float]) failed']"
   ],
   "generics_typevartuple_unpack.py": [],
   "generics_upper_bound.py": [],

--- a/conformance/third_party/results.json
+++ b/conformance/third_party/results.json
@@ -3,7 +3,7 @@
   "pass": 121,
   "fail": 17,
   "pass_rate": 0.88,
-  "differences": 52,
+  "differences": 50,
   "passing": [
     "aliases_explicit.py",
     "aliases_newtype.py",
@@ -141,7 +141,7 @@
     "generics_self_basic.py": 2,
     "generics_self_usage.py": 2,
     "generics_typevartuple_basic.py": 1,
-    "generics_typevartuple_specialization.py": 4,
+    "generics_typevartuple_specialization.py": 2,
     "protocols_modules.py": 1,
     "qualifiers_annotated.py": 6,
     "qualifiers_final_annotation.py": 5

--- a/pyrefly/lib/alt/class/targs.rs
+++ b/pyrefly/lib/alt/class/targs.rs
@@ -355,24 +355,45 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         validate_restriction: bool,
         errors: &ErrorCollector,
     ) -> TArgs {
-        let targs = self.expand_unpacked_targs(targs);
+        let mut targs = self.expand_unpacked_targs(targs);
         let nparams = tparams.len();
-        let nargs = targs.len();
         let mut checked_targs = Vec::new();
         let mut targ_idx = 0;
         let mut name_to_idx = SmallMap::new();
         for (param_idx, param) in tparams.iter().enumerate() {
-            if let Some(arg) = targs.get(targ_idx) {
+            if targ_idx < targs.len() {
                 // Get next type argument
                 match param.kind() {
                     QuantifiedKind::TypeVarTuple => {
+                        if let Some(Type::Unpack(inner)) = targs.get(targ_idx)
+                            && let Type::Tuple(Tuple::Unbounded(elt)) = &**inner
+                        {
+                            let elt = (**elt).clone();
+                            // `*tuple[T, ...]` can satisfy trailing required type params after a
+                            // `TypeVarTuple`, so materialize those as `T` for matching.
+                            let params_end = self
+                                .peek_next_paramspec_param(param_idx + 1, &tparams)
+                                .unwrap_or(tparams.len());
+                            let n_trailing_params = params_end.saturating_sub(param_idx + 1);
+                            if n_trailing_params > 0 {
+                                let args_end = self
+                                    .peek_next_paramspec_arg(targ_idx, &targs)
+                                    .unwrap_or(targs.len());
+                                let n_available_args = args_end.saturating_sub(targ_idx + 1);
+                                let n_missing_args =
+                                    n_trailing_params.saturating_sub(n_available_args);
+                                for _ in 0..n_missing_args {
+                                    targs.insert(targ_idx + 1, elt.clone());
+                                }
+                            }
+                        }
                         // We know that ParamSpec params must be matched by ParamSpec args, so chop off both params and args
                         // at the next ParamSpec when computing how many args the TypeVarTuple should consume.
                         let paramspec_param_idx =
                             self.peek_next_paramspec_param(param_idx + 1, &tparams);
                         let paramspec_arg_idx = self.peek_next_paramspec_arg(targ_idx, &targs);
                         let nparams_for_tvt = paramspec_param_idx.unwrap_or(nparams);
-                        let nargs_for_tvt = paramspec_arg_idx.unwrap_or(nargs);
+                        let nargs_for_tvt = paramspec_arg_idx.unwrap_or(targs.len());
                         let args_to_consume = self.num_typevartuple_args_to_consume(
                             param_idx,
                             nparams_for_tvt,
@@ -387,18 +408,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         ));
                         targ_idx = new_targ_idx;
                     }
-                    QuantifiedKind::ParamSpec if nparams == 1 && !arg.is_kind_param_spec() => {
+                    QuantifiedKind::ParamSpec
+                        if nparams == 1 && !targs[targ_idx].is_kind_param_spec() =>
+                    {
                         // If the only type param is a ParamSpec and the type argument
                         // is not a parameter expression, then treat the entire type argument list
                         // as a parameter list
                         checked_targs.push(self.create_paramspec_value(&targs));
-                        targ_idx = nargs;
+                        targ_idx = targs.len();
                     }
                     QuantifiedKind::ParamSpec => {
+                        let arg = &targs[targ_idx];
                         checked_targs.push(self.create_next_paramspec_arg(arg, range, errors));
                         targ_idx += 1;
                     }
                     QuantifiedKind::TypeVar => {
+                        let arg = &targs[targ_idx];
                         checked_targs.push(self.create_next_typevar_arg(
                             param,
                             arg,
@@ -416,7 +441,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     &tparams,
                     param_idx,
                     &checked_targs,
-                    nargs,
+                    targs.len(),
                     &name_to_idx,
                     range,
                     errors,
@@ -425,7 +450,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             name_to_idx.insert(param.name(), param_idx);
         }
-        if targ_idx < nargs {
+        if targ_idx < targs.len() {
             self.error(
                 errors,
                 range,
@@ -434,7 +459,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     "Expected {} for `{}`, got {}",
                     count(nparams, "type argument"),
                     name,
-                    nargs
+                    targs.len()
                 ),
             );
         }

--- a/pyrefly/lib/test/type_var_tuple.rs
+++ b/pyrefly/lib/test/type_var_tuple.rs
@@ -375,7 +375,6 @@ def func6(b: VariadicTuple[float]):
 );
 
 testcase!(
-    bug = "conformance: TypeVarTuple with unbounded tuple should work with type aliases",
     test_typevartuple_specialization_unbounded,
     r#"
 from typing import TypeVar, TypeVarTuple, assert_type
@@ -384,10 +383,10 @@ T1 = TypeVar("T1")
 Ts = TypeVarTuple("Ts")
 
 TA9 = tuple[*Ts, T1]
-TA10 = TA9[*tuple[int, ...]]  # E: Unpacked argument cannot be used for type parameter T1
+TA10 = TA9[*tuple[int, ...]]
 
 def func11(a: TA10, b: TA9[*tuple[int, ...], str]):
-    assert_type(a, tuple[*tuple[int, ...], int])  # E: assert_type(tuple[Any], tuple[*tuple[int, ...], int]) failed
+    assert_type(a, tuple[*tuple[int, ...], int])
     assert_type(b, tuple[*tuple[int, ...], str])
 "#,
 );


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2363

Updated specialization matching in targs.rs so TypeVarTuple handling can consume `*tuple[T, ...]` while still satisfying trailing required params.

In the `TypeVarTuple` branch, when the current arg is `Type::Unpack(Tuple::Unbounded(_))`, the matcher now materializes missing trailing args as element type T before computing how many args the tuple var should consume.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Converted the unbounded test from a bug case with expected errors to a passing regression in `type_var_tuple.rs`.
