### PR TITLE
Fix false positive type var scoping checks when `Self` is used

### DIFF
--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -932,6 +932,9 @@ impl Type {
                 //   when visiting Vars. See https://github.com/facebook/pyrefly/issues/2016.
                 Type::ClassType(cls) => recurse_targs(cls.targs()),
                 Type::TypedDict(TypedDict::TypedDict(td)) => recurse_targs(td.targs()),
+                // `Self` is a keyword, not a user-written type variable reference, so we don't
+                // recurse into it when looking for type variable references.
+                Type::SelfType(_) => {}
                 _ => ty.recurse(&mut |ty| visit(ty, f)),
             }
         }
@@ -1003,6 +1006,8 @@ impl Type {
             match ty {
                 Type::ClassType(cls) => recurse_targs(cls.targs_mut()),
                 Type::TypedDict(TypedDict::TypedDict(td)) => recurse_targs(td.targs_mut()),
+                // `Self` is a keyword, not a user-written type variable reference.
+                Type::SelfType(_) => {}
                 _ => ty.recurse_mut(&mut |ty| visit(ty, f)),
             }
         }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -4344,10 +4344,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         range: TextRange,
         errors: &ErrorCollector,
     ) {
-        if let Type::SelfType(_) = ty {
-            // Skip scoping check for `Self` since there is no type variable in the syntax.
-            return;
-        }
         let mut names = Vec::new();
         ty.collect_raw_legacy_type_variables(&mut names);
         for name in names {

--- a/pyrefly/lib/test/typing_self.rs
+++ b/pyrefly/lib/test/typing_self.rs
@@ -296,7 +296,6 @@ child2: Child = Child.create_annotated()  # OK with explicit Self annotation
 
 // Regression test for https://github.com/facebook/pyrefly/issues/2526
 testcase!(
-    bug = "Should not error due to type var scope when Self is used",
     test_self_no_invalid_typevar,
     r#"
 from typing import Generic, Self, TypeVar


### PR DESCRIPTION
# Summary

Fixes #2526 

When `Self` is used, there's no need to check for type var scoping
because they don't actually appear in the surface syntax.

# Test Plan

Added a minimised regression test