### PR TITLE
impl implement codeaction/resolve #2540

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/code_actions.rs
+++ b/pyrefly/lib/lsp/non_wasm/code_actions.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::collections::HashMap;
+
+use lsp_types::Location;
+use lsp_types::TextEdit;
+use lsp_types::Url;
+use lsp_types::WorkspaceEdit;
+use pyrefly_python::module::TextRangeWithModule;
+use ruff_text_size::TextRange;
+
+use crate::ModuleInfo;
+
+pub(crate) fn workspace_edit_for_refactor_edits(
+    edits: Vec<(ModuleInfo, TextRange, String)>,
+    to_lsp_location: impl Fn(&TextRangeWithModule) -> Option<Location>,
+) -> Option<WorkspaceEdit> {
+    let mut changes: HashMap<Url, Vec<TextEdit>> = HashMap::new();
+    for (module, edit_range, new_text) in edits {
+        let Some(lsp_location) = to_lsp_location(&TextRangeWithModule {
+            module,
+            range: edit_range,
+        }) else {
+            continue;
+        };
+        changes.entry(lsp_location.uri).or_default().push(TextEdit {
+            range: lsp_location.range,
+            new_text,
+        });
+    }
+    if changes.is_empty() {
+        None
+    } else {
+        Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        })
+    }
+}

--- a/pyrefly/lib/lsp/non_wasm/mod.rs
+++ b/pyrefly/lib/lsp/non_wasm/mod.rs
@@ -7,6 +7,7 @@
 
 mod build_system;
 pub mod call_hierarchy;
+pub mod code_actions;
 pub mod convert_module_package;
 pub mod document_symbols;
 pub mod external_references;

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2305,6 +2305,14 @@ impl<'a> Transaction<'a> {
         quick_fixes::inline_parameter::inline_parameter_code_actions(self, handle, selection)
     }
 
+    pub fn introduce_parameter_action_titles(
+        &self,
+        handle: &Handle,
+        selection: TextRange,
+    ) -> Option<Vec<String>> {
+        quick_fixes::introduce_parameter::introduce_parameter_action_titles(self, handle, selection)
+    }
+
     pub fn introduce_parameter_code_actions(
         &self,
         handle: &Handle,

--- a/pyrefly/lib/test/lsp/lsp_interaction/basic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/basic.rs
@@ -36,7 +36,8 @@ fn test_initialize_basic() {
             "definitionProvider": true,
             "typeDefinitionProvider": true,
             "codeActionProvider": {
-                "codeActionKinds": ["quickfix", "refactor.extract", "refactor.rewrite", "refactor.move", "refactor.inline", "source.fixAll"]
+                "codeActionKinds": ["quickfix", "refactor.extract", "refactor.rewrite", "refactor.move", "refactor.inline", "source.fixAll"],
+                "resolveProvider": true
             },
             "completionProvider": {
                 "resolveProvider": true,

--- a/pyrefly/lib/test/lsp/lsp_interaction/code_action_benchmark.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/code_action_benchmark.rs
@@ -114,7 +114,8 @@ fn test_code_action_latency() {
 
     let file_path = repo_root.join(&file_rel);
     let uri = Url::from_file_path(&file_path).unwrap();
-    interaction.client.did_open(&file_rel);
+    let file_rel_static: &'static str = Box::leak(file_rel.clone().into_boxed_str());
+    interaction.client.did_open(file_rel_static);
 
     // Warm up by waiting for diagnostics on the target file.
     interaction

--- a/pyrefly/lib/test/lsp/lsp_interaction/code_action_benchmark.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/code_action_benchmark.rs
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Benchmark test for measuring code action latency in large codebases.
+//!
+//! Run manually with:
+//! CODE_ACTION_BENCH_PATH=/path/to/repo \
+//! CODE_ACTION_BENCH_FILE=relative/path.py \
+//! CODE_ACTION_BENCH_RANGE=START_LINE:START_COL-END_LINE:END_COL \
+//! CODE_ACTION_BENCH_ITERS=10 \
+//! CODE_ACTION_BENCH_TITLE="Introduce parameter `param`" \
+//! cargo test --release test_code_action_latency -- --ignored --nocapture
+
+use std::cell::RefCell;
+use std::path::PathBuf;
+use std::time::Duration;
+use std::time::Instant;
+
+use lsp_types::CodeAction;
+use lsp_types::CodeActionOrCommand;
+use lsp_types::Url;
+use lsp_types::request::CodeActionRequest;
+use lsp_types::request::CodeActionResolveRequest;
+use pyrefly_util::thread_pool::ThreadCount;
+use pyrefly_util::thread_pool::init_thread_pool;
+use serde_json::json;
+
+use crate::commands::lsp::IndexingMode;
+use crate::test::lsp::lsp_interaction::object_model::InitializeSettings;
+use crate::test::lsp::lsp_interaction::object_model::LspInteraction;
+
+fn parse_range_env(raw: &str) -> (u32, u32, u32, u32) {
+    let (start, end) = raw
+        .split_once('-')
+        .unwrap_or_else(|| panic!("Invalid CODE_ACTION_BENCH_RANGE: {raw}"));
+    let (start_line, start_col) = start
+        .split_once(':')
+        .unwrap_or_else(|| panic!("Invalid CODE_ACTION_BENCH_RANGE: {raw}"));
+    let (end_line, end_col) = end
+        .split_once(':')
+        .unwrap_or_else(|| panic!("Invalid CODE_ACTION_BENCH_RANGE: {raw}"));
+    let start_line = start_line
+        .parse::<u32>()
+        .unwrap_or_else(|_| panic!("Invalid start line in CODE_ACTION_BENCH_RANGE: {raw}"));
+    let start_col = start_col
+        .parse::<u32>()
+        .unwrap_or_else(|_| panic!("Invalid start column in CODE_ACTION_BENCH_RANGE: {raw}"));
+    let end_line = end_line
+        .parse::<u32>()
+        .unwrap_or_else(|_| panic!("Invalid end line in CODE_ACTION_BENCH_RANGE: {raw}"));
+    let end_col = end_col
+        .parse::<u32>()
+        .unwrap_or_else(|_| panic!("Invalid end column in CODE_ACTION_BENCH_RANGE: {raw}"));
+    (start_line, start_col, end_line, end_col)
+}
+
+fn print_stats(label: &str, samples: &[Duration]) {
+    if samples.is_empty() {
+        eprintln!("{label}: no samples");
+        return;
+    }
+    let mut sorted = samples.to_vec();
+    sorted.sort();
+    let count = sorted.len() as u64;
+    let total: Duration = sorted
+        .iter()
+        .copied()
+        .fold(Duration::ZERO, |acc, v| acc + v);
+    let mean_nanos = total.as_nanos() / count as u128;
+    let mean = Duration::from_nanos(mean_nanos as u64);
+    let p50 = sorted[sorted.len() / 2];
+    let p95 = sorted[(((sorted.len() as f64) * 0.95).floor() as usize).min(sorted.len() - 1)];
+    let p99 = sorted[(((sorted.len() as f64) * 0.99).floor() as usize).min(sorted.len() - 1)];
+    eprintln!("{label}: count={count} mean={mean:?} p50={p50:?} p95={p95:?} p99={p99:?}");
+}
+
+#[test]
+#[ignore] // Run manually with env vars. See module docs.
+fn test_code_action_latency() {
+    let repo_path =
+        std::env::var("CODE_ACTION_BENCH_PATH").expect("CODE_ACTION_BENCH_PATH must be set");
+    let file_rel =
+        std::env::var("CODE_ACTION_BENCH_FILE").expect("CODE_ACTION_BENCH_FILE must be set");
+    let range_raw = std::env::var("CODE_ACTION_BENCH_RANGE")
+        .expect("CODE_ACTION_BENCH_RANGE must be set (START:COL-END:COL)");
+    let iterations = std::env::var("CODE_ACTION_BENCH_ITERS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(10);
+    let title_filter = std::env::var("CODE_ACTION_BENCH_TITLE").ok();
+
+    let repo_root = PathBuf::from(&repo_path);
+    assert!(repo_root.exists(), "Repo not found at {repo_path}");
+
+    let mut interaction = LspInteraction::new_with_indexing_mode(IndexingMode::LazyBlocking);
+    init_thread_pool(ThreadCount::AllThreads);
+    interaction.set_root(repo_root.clone());
+
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(None),
+            workspace_folders: Some(vec![(
+                "bench".to_owned(),
+                Url::from_file_path(&repo_root).unwrap(),
+            )]),
+            file_watch: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+    let file_path = repo_root.join(&file_rel);
+    let uri = Url::from_file_path(&file_path).unwrap();
+    interaction.client.did_open(&file_rel);
+
+    // Warm up by waiting for diagnostics on the target file.
+    interaction
+        .client
+        .expect_publish_diagnostics_for_file(file_path)
+        .unwrap();
+
+    let (start_line, start_col, end_line, end_col) = parse_range_env(&range_raw);
+
+    let mut list_samples = Vec::new();
+    let mut resolve_samples = Vec::new();
+
+    for _ in 0..iterations {
+        let action_to_resolve: RefCell<Option<CodeAction>> = RefCell::new(None);
+        let list_start = Instant::now();
+        interaction
+            .client
+            .send_request::<CodeActionRequest>(json!({
+                "textDocument": { "uri": uri },
+                "range": {
+                    "start": { "line": start_line, "character": start_col },
+                    "end": { "line": end_line, "character": end_col }
+                },
+                "context": {
+                    "diagnostics": [],
+                    "triggerKind": 1
+                }
+            }))
+            .expect_response_with(|response| {
+                let Some(actions) = response else {
+                    return false;
+                };
+                for action in actions {
+                    let CodeActionOrCommand::CodeAction(code_action) = action else {
+                        continue;
+                    };
+                    if let Some(expected_title) = title_filter.as_ref() {
+                        if code_action.title != *expected_title {
+                            continue;
+                        }
+                    }
+                    if code_action.data.is_some() {
+                        *action_to_resolve.borrow_mut() = Some(code_action);
+                        return true;
+                    }
+                }
+                false
+            })
+            .unwrap();
+        list_samples.push(list_start.elapsed());
+
+        let Some(action) = action_to_resolve.into_inner() else {
+            panic!("No resolvable code action found. Set CODE_ACTION_BENCH_TITLE to match one.");
+        };
+
+        let resolve_start = Instant::now();
+        interaction
+            .client
+            .send_request::<CodeActionResolveRequest>(serde_json::to_value(action).unwrap())
+            .expect_response_with(|resolved| resolved.edit.is_some())
+            .unwrap();
+        resolve_samples.push(resolve_start.elapsed());
+    }
+
+    eprintln!("\n==== Code Action Benchmark Results ====");
+    print_stats("list", &list_samples);
+    print_stats("resolve", &resolve_samples);
+    eprintln!("======================================\n");
+
+    interaction.shutdown().unwrap();
+}

--- a/pyrefly/lib/test/lsp/lsp_interaction/code_action_resolve.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/code_action_resolve.rs
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::cell::RefCell;
+
+use lsp_types::CodeAction;
+use lsp_types::CodeActionOrCommand;
+use lsp_types::Url;
+use lsp_types::request::CodeActionRequest;
+use lsp_types::request::CodeActionResolveRequest;
+use serde_json::json;
+
+use crate::test::lsp::lsp_interaction::object_model::InitializeSettings;
+use crate::test::lsp::lsp_interaction::object_model::LspInteraction;
+use crate::test::lsp::lsp_interaction::util::get_test_files_root;
+
+#[test]
+fn test_code_action_resolve_introduce_parameter() {
+    let root = get_test_files_root();
+    let root_path = root.path().join("code_action_resolve");
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root_path.to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(None),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let file = "introduce_parameter.py";
+    let file_path = root_path.join(file);
+    let uri = Url::from_file_path(&file_path).unwrap();
+    interaction.client.did_open(file);
+
+    let action_to_resolve: RefCell<Option<CodeAction>> = RefCell::new(None);
+    interaction
+        .client
+        .send_request::<CodeActionRequest>(json!({
+            "textDocument": { "uri": uri },
+            "range": {
+                "start": { "line": 1, "character": 11 },
+                "end": { "line": 1, "character": 16 }
+            },
+            "context": {
+                "diagnostics": [],
+                "triggerKind": 1
+            }
+        }))
+        .expect_response_with(|response| {
+            let Some(actions) = response else {
+                return false;
+            };
+            for action in actions {
+                let CodeActionOrCommand::CodeAction(code_action) = action else {
+                    continue;
+                };
+                if code_action.title == "Introduce parameter `param`" {
+                    *action_to_resolve.borrow_mut() = Some(code_action);
+                    return true;
+                }
+            }
+            false
+        })
+        .unwrap();
+
+    let action = action_to_resolve
+        .into_inner()
+        .expect("expected introduce_parameter code action");
+
+    interaction
+        .client
+        .send_request::<CodeActionResolveRequest>(serde_json::to_value(action).unwrap())
+        .expect_response_with(|resolved| {
+            let Some(edit) = resolved.edit else {
+                return false;
+            };
+            let Some(changes) = edit.changes.as_ref() else {
+                return false;
+            };
+            let Some(edits) = changes.get(&uri) else {
+                return false;
+            };
+            let has_signature_edit = edits.iter().any(|edit| edit.new_text == ", param");
+            let has_replacement_edit = edits.iter().any(|edit| edit.new_text == "param");
+            has_signature_edit && has_replacement_edit
+        })
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}

--- a/pyrefly/lib/test/lsp/lsp_interaction/convert_module_package.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/convert_module_package.rs
@@ -61,7 +61,10 @@ fn test_convert_module_to_package_code_action() {
                 "start": { "line": 0, "character": 0 },
                 "end": { "line": 0, "character": 0 }
             },
-            "context": { "diagnostics": [] }
+            "context": {
+                "diagnostics": [],
+                "triggerKind": 1
+            }
         }))
         .expect_response_with(|response| {
             let Some(actions) = response else {
@@ -120,7 +123,10 @@ fn test_convert_package_to_module_code_action() {
                 "start": { "line": 0, "character": 0 },
                 "end": { "line": 0, "character": 0 }
             },
-            "context": { "diagnostics": [] }
+            "context": {
+                "diagnostics": [],
+                "triggerKind": 1
+            }
         }))
         .expect_response_with(|response| {
             let Some(actions) = response else {

--- a/pyrefly/lib/test/lsp/lsp_interaction/mod.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/mod.rs
@@ -9,6 +9,7 @@
 
 mod basic;
 mod call_hierarchy;
+mod code_action_benchmark;
 mod code_action_resolve;
 mod completion;
 mod configuration;

--- a/pyrefly/lib/test/lsp/lsp_interaction/mod.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/mod.rs
@@ -9,6 +9,7 @@
 
 mod basic;
 mod call_hierarchy;
+mod code_action_resolve;
 mod completion;
 mod configuration;
 mod convert_module_package;

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/code_action_resolve/introduce_parameter.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/code_action_resolve/introduce_parameter.py
@@ -1,0 +1,6 @@
+def foo(x):
+    return x + 1
+
+
+def bar():
+    return foo(10)


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2540

Added codeAction/resolve support and advertised resolveProvider; introduce-parameter actions now return unresolved code actions with data and resolve to edits on demand.

Made refactor computation respect context.only and skip refactors for unfiltered requests without a triggerKind, reducing automatic-request cost.

Added introduce_parameter_action_titles to avoid expensive callsite edits during listing


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

updated LSP tests to expect resolveProvider and set triggerKind for refactor requests.