### PR TITLE
Add note about Marimo support in "Notebook support" section

### DIFF
--- a/website/docs/IDE-features.mdx
+++ b/website/docs/IDE-features.mdx
@@ -292,7 +292,7 @@ Pyrefly provides language services for Jupyter notebooks directly in VS Code and
 automatically-detected language servers.
 
 Pyrefly also provides language services to [Marimo notebooks](https://marimo.io/). See
-[Language Server Protocol](https://docs.marimo.io/guides/editor_features/language_server/) for how to enable it.
+[Language Server Protocol](https://docs.marimo.io/guides/editor_features/language_server/#pyrefly) for how to enable it.
 
 Notebook support is experimental. Please report any bugs on our Github.
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

The "notebook support" section doesn't mention Marimo support, which was added in https://github.com/marimo-team/marimo/pull/7567 . I discussed with @mscolnick about adding it to the Pyrefly docs

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
