### PR TITLE
handle dynamic fields in functional namedtuple declaration

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -1373,6 +1373,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     None if metadata.has_base_any() => {
                         acc.found_type(self.heap.mk_any_implicit(), base)
                     }
+                    None if metadata
+                        .named_tuple_metadata()
+                        .is_some_and(|m| m.has_dynamic_fields) =>
+                    {
+                        acc.found_type(self.heap.mk_any_implicit(), base)
+                    }
                     None => {
                         acc.not_found(NotFoundOn::ClassInstance(class.class_object().dupe(), base))
                     }

--- a/pyrefly/lib/alt/class/named_tuple.rs
+++ b/pyrefly/lib/alt/class/named_tuple.rs
@@ -65,6 +65,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     pub(crate) fn named_tuple_element_types(&self, cls: &ClassType) -> Option<Vec<Type>> {
         let class_metadata = self.get_metadata_for_class(cls.class_object());
         let named_tuple_metadata = class_metadata.named_tuple_metadata()?;
+        // If the namedtuple has dynamic fields, we can't know the element types statically.
+        // Return None so that tuple indexing falls back to regular tuple behavior.
+        if named_tuple_metadata.has_dynamic_fields {
+            return None;
+        }
         Some(
             named_tuple_metadata
                 .elements

--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -457,6 +457,9 @@ pub struct EnumMetadata {
 #[derive(Clone, Debug, TypeEq, PartialEq, Eq)]
 pub struct NamedTupleMetadata {
     pub elements: SmallSet<Name>,
+    /// If true, the namedtuple fields were dynamically generated (e.g., using a
+    /// generator or variable) and couldn't be statically resolved.
+    pub has_dynamic_fields: bool,
 }
 
 /// Defaults for `init_by_name` and `init_by_default`, per-field flags that control the name of

--- a/pyrefly/lib/binding/base_class.rs
+++ b/pyrefly/lib/binding/base_class.rs
@@ -96,7 +96,10 @@ pub enum BaseClass {
     Generic(BaseClassGeneric),
     BaseClassExpr(BaseClassExpr),
     InvalidExpr(Expr),
-    NamedTuple(TextRange),
+    /// A namedtuple base class.
+    /// The bool indicates whether fields were dynamically generated
+    /// (e.g., using a generator or variable that couldn't be statically resolved).
+    NamedTuple(TextRange, bool),
     /// A namedtuple class synthesized anonymously as a base class,
     /// e.g. `class Foo(namedtuple("Foo", ["a", "b"]))`.
     SynthesizedBase(Idx<KeyClass>, TextRange),
@@ -129,7 +132,7 @@ impl Ranged for BaseClass {
             BaseClass::Generic(x) => x.range(),
             BaseClass::BaseClassExpr(base_expr) => base_expr.range(),
             BaseClass::InvalidExpr(expr) => expr.range(),
-            BaseClass::NamedTuple(range) => *range,
+            BaseClass::NamedTuple(range, _) => *range,
             BaseClass::SynthesizedBase(_, range) => *range,
             BaseClass::TypeOf(_, range) => *range,
         }
@@ -141,7 +144,7 @@ impl<'a> BindingsBuilder<'a> {
         match self.as_special_export(&base_expr) {
             Some(SpecialExport::TypedDict) => BaseClass::TypedDict(base_expr.range()),
             Some(SpecialExport::TypingNamedTuple) | Some(SpecialExport::CollectionsNamedTuple) => {
-                BaseClass::NamedTuple(base_expr.range())
+                BaseClass::NamedTuple(base_expr.range(), false)
             }
             Some(SpecialExport::Protocol) => BaseClass::Generic(BaseClassGeneric {
                 kind: BaseClassGenericKind::Protocol,

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -507,6 +507,32 @@ class E(NamedTuple("E", 42)):  # E: Expected valid functional named tuple defini
 );
 
 testcase!(
+    test_named_tuple_dynamic_fields,
+    r#"
+from collections import namedtuple
+from typing import assert_type, Any
+
+fields_map = (('x', int), ('y', str))
+foo1 = namedtuple('foo1', (name for name, _ in fields_map))  # E: Expected valid functional named tuple definition
+
+fields = [name for name, _ in fields_map]
+foo2 = namedtuple('foo2', fields)  # E: Expected valid functional named tuple definition
+
+instance1 = foo1()
+instance2 = foo2()
+
+# attribute access
+assert_type(instance1.x, Any)
+assert_type(instance1.anything, Any)
+assert_type(instance2.y, Any)
+
+# indexing
+assert_type(instance1[0], Any)
+assert_type(instance2[1], Any)
+    "#,
+);
+
+testcase!(
     bug = "namedtuple + mixin is valid in CPython but we reject it",
     test_named_tuple_base_class_call_with_mixin,
     r#"


### PR DESCRIPTION
Summary:
When we have an invalid functional named tuple definition where the fields can't be resolved at binding time, we currently create a named tuple with 0 fields, which causes a lot of downstream errors.

This diff changes it s.t. we track named tuples w/ dynamic fields, and allow arbitrary field accesses/indexing on them downstream. We still raise an error on the definition, to indicate that it's wrong.

fixes https://github.com/facebook/pyrefly/issues/2418

Reviewed By: grievejia

Differential Revision: D94391021


