### PR TITLE
Fix false positive bad-override for methods without self parameter

### DIFF
--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -1404,6 +1404,9 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
             {
                 self.is_subset_eq(&l_no_self, &u_no_self)
             }
+            (Type::BoundMethod(l), Type::BoundMethod(u)) => {
+                self.is_subset_eq(&l.func.clone().as_type(), &u.func.clone().as_type())
+            }
             (
                 Type::Callable(box l)
                 | Type::Function(box Function {

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -1231,3 +1231,16 @@ class B(A):
     f: Callable[[Any], int]  # E: overrides parent class `A` in an inconsistent manner
     "#,
 );
+
+testcase!(
+    test_override_method_without_self,
+    r#"
+class A:
+    def foo() -> int:
+        return 42
+
+class B(A):
+    def foo() -> int:
+        return 100
+    "#,
+);


### PR DESCRIPTION
Resolves https://github.com/facebook/pyrefly/issues/2564

When checking overrides, `BoundMethod` types are compared by first stripping the self parameter via `bind_boundmethod`. This calls `split_first_param`, which returns None when there are no parameters, causing the match guard to fail and fall through to a catch-all error, even when signatures are identical. 

The diff adds a fallback arm that compares the underlying function types directly when self stripping fails.