### PR TITLE
fix More expressive sys.platform gating #795

### DIFF
--- a/crates/pyrefly_python/src/sys_info.rs
+++ b/crates/pyrefly_python/src/sys_info.rs
@@ -1111,7 +1111,19 @@ impl SysInfo {
 }
 
 pub fn module_platform_guard(body: &[Stmt]) -> Option<PythonPlatform> {
-    body.iter().find_map(platform_guard_from_stmt)
+    let body = match body.split_first() {
+        Some((Stmt::Expr(x), rest)) if x.value.is_string_literal_expr() => rest,
+        _ => body,
+    };
+    for stmt in body {
+        if let Some(platform) = platform_guard_from_stmt(stmt) {
+            return Some(platform);
+        }
+        if !matches!(stmt, Stmt::Import(_) | Stmt::ImportFrom(_)) {
+            return None;
+        }
+    }
+    None
 }
 
 fn platform_guard_from_stmt(stmt: &Stmt) -> Option<PythonPlatform> {
@@ -1189,7 +1201,21 @@ fn string_literal(expr: &Expr) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use ruff_python_ast::PySourceType;
+
     use super::*;
+    use crate::ast::Ast;
+
+    fn parsed_module_platform_guard(code: &str) -> Option<PythonPlatform> {
+        let (module, parse_errors, unsupported_syntax_errors) =
+            Ast::parse(code, PySourceType::Python);
+        assert!(parse_errors.is_empty(), "{parse_errors:?}");
+        assert!(
+            unsupported_syntax_errors.is_empty(),
+            "{unsupported_syntax_errors:?}"
+        );
+        module_platform_guard(&module.body)
+    }
 
     #[test]
     fn test_parse_py_version() {
@@ -1227,6 +1253,48 @@ mod tests {
         );
         assert!(PythonVersion::from_str("").is_err());
         assert!(PythonVersion::from_str("abc").is_err());
+    }
+
+    #[test]
+    fn test_module_platform_guard_allows_leading_docstring_and_imports() {
+        assert_eq!(
+            parsed_module_platform_guard(
+                r#"
+"Windows-only module."
+from __future__ import annotations
+import sys
+assert sys.platform == "win32"
+x = 1
+"#,
+            ),
+            Some(PythonPlatform::windows()),
+        );
+    }
+
+    #[test]
+    fn test_module_platform_guard_stops_after_executable_statement() {
+        assert_eq!(
+            parsed_module_platform_guard(
+                r#"
+import sys
+x = 1
+assert sys.platform == "win32"
+"#,
+            ),
+            None,
+        );
+        assert_eq!(
+            parsed_module_platform_guard(
+                r#"
+import sys
+if __name__ == "__main__":
+    pass
+if sys.platform != "win32":
+    raise RuntimeError()
+"#,
+            ),
+            None,
+        );
     }
 
     #[test]

--- a/crates/pyrefly_python/src/sys_info.rs
+++ b/crates/pyrefly_python/src/sys_info.rs
@@ -26,9 +26,11 @@ use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprBooleanLiteral;
 use ruff_python_ast::ExprCall;
 use ruff_python_ast::ExprList;
+use ruff_python_ast::ExprName;
 use ruff_python_ast::ExprNumberLiteral;
 use ruff_python_ast::ExprSet;
 use ruff_python_ast::ExprSlice;
+use ruff_python_ast::ExprStringLiteral;
 use ruff_python_ast::ExprSubscript;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtIf;
@@ -443,6 +445,14 @@ impl SysInfo {
 
     pub fn type_checking(&self) -> bool {
         self.0.type_checking
+    }
+
+    pub fn with_platform(&self, platform: PythonPlatform) -> Self {
+        if self.type_checking() {
+            SysInfo::new(self.version(), platform)
+        } else {
+            SysInfo::new_without_type_checking(self.version(), platform)
+        }
     }
 }
 
@@ -1097,6 +1107,83 @@ impl SysInfo {
             .filter(|x| x.0 != Some(false))
             .map(|x| (x.1, x.2))
             .take_while_inclusive(|x| x.0.is_some())
+    }
+}
+
+pub fn module_platform_guard(body: &[Stmt]) -> Option<PythonPlatform> {
+    body.iter().find_map(platform_guard_from_stmt)
+}
+
+fn platform_guard_from_stmt(stmt: &Stmt) -> Option<PythonPlatform> {
+    match stmt {
+        Stmt::Assert(x) => platform_guard_from_assert(&x.test),
+        Stmt::If(x) if x.elif_else_clauses.is_empty() && body_is_unconditional_raise(&x.body) => {
+            platform_guard_from_not_eq(&x.test)
+        }
+        _ => None,
+    }
+}
+
+fn body_is_unconditional_raise(body: &[Stmt]) -> bool {
+    matches!(body, [Stmt::Raise(_)])
+}
+
+fn platform_guard_from_assert(test: &Expr) -> Option<PythonPlatform> {
+    let (op, platform) = platform_compare(test)?;
+    match op {
+        CmpOp::Eq => Some(PythonPlatform::new(&platform)),
+        _ => None,
+    }
+}
+
+fn platform_guard_from_not_eq(test: &Expr) -> Option<PythonPlatform> {
+    let (op, platform) = platform_compare(test)?;
+    match op {
+        CmpOp::NotEq => Some(PythonPlatform::new(&platform)),
+        _ => None,
+    }
+}
+
+fn platform_compare(test: &Expr) -> Option<(CmpOp, String)> {
+    let Expr::Compare(compare) = test else {
+        return None;
+    };
+    if compare.ops.len() != 1 || compare.comparators.len() != 1 {
+        return None;
+    }
+    let op = compare.ops[0];
+    if !matches!(op, CmpOp::Eq | CmpOp::NotEq) {
+        return None;
+    }
+    let left = &compare.left;
+    let right = &compare.comparators[0];
+    let platform = extract_platform_literal(left, right)?;
+    Some((op, platform))
+}
+
+fn extract_platform_literal(left: &Expr, right: &Expr) -> Option<String> {
+    if is_sys_platform(left) {
+        string_literal(right)
+    } else if is_sys_platform(right) {
+        string_literal(left)
+    } else {
+        None
+    }
+}
+
+fn is_sys_platform(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Attribute(ExprAttribute { value, attr, .. })
+            if matches!(&**value, Expr::Name(ExprName { id, .. }) if id == "sys")
+                && attr.as_str() == "platform"
+    )
+}
+
+fn string_literal(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::StringLiteral(ExprStringLiteral { value, .. }) => Some(value.to_str().to_owned()),
+        _ => None,
     }
 }
 

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -23,7 +23,6 @@ use pyrefly_python::nesting_context::NestingContext;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_python::sys_info::SysInfo;
 use pyrefly_python::sys_info::module_platform_guard;
-use pyrefly_types::callable::FuncDefIndex;
 use pyrefly_types::class::ClassDefIndex;
 use pyrefly_types::class::ClassFields;
 use pyrefly_types::function::FuncDefIndex;

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -22,6 +22,8 @@ use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::nesting_context::NestingContext;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_python::sys_info::SysInfo;
+use pyrefly_python::sys_info::module_platform_guard;
+use pyrefly_types::callable::FuncDefIndex;
 use pyrefly_types::class::ClassDefIndex;
 use pyrefly_types::class::ClassFields;
 use pyrefly_types::function::FuncDefIndex;
@@ -639,6 +641,9 @@ impl Bindings {
         // needed later for error collection, which runs after the AST may
         // have been evicted.
         let module_ranges = Arc::new(ModuleRanges::compute(&x, &module_info));
+        let override_sys_info =
+            module_platform_guard(&x.body).map(|platform| sys_info.with_platform(platform));
+        let sys_info = override_sys_info.unwrap_or(sys_info);
         let mut builder = BindingsBuilder {
             module_info: module_info.dupe(),
             lookup,

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -465,6 +465,7 @@ impl ModuleDep {
 struct ModuleData {
     handle: Handle,
     config: ArcId<ConfigFile>,
+    effective_sys_info: SysInfo,
     state: ModuleState,
     imports: HashMap<ModuleName, FindingOrError<ModulePath>, BuildNoHash>,
     deps: HashMap<Handle, ModuleDeps>,
@@ -482,6 +483,7 @@ struct ModuleData {
 struct ModuleDataMut {
     handle: Handle,
     config: RwLock<ArcId<ConfigFile>>,
+    effective_sys_info: RwLock<SysInfo>,
     state: ModuleStateMut,
     /// Import resolution cache: module names from import statements → resolved paths.
     /// Only contains deps that were resolved via `find_import`.
@@ -517,6 +519,7 @@ impl ModuleData {
         ModuleDataMut {
             handle: self.handle.dupe(),
             config: RwLock::new(self.config.dupe()),
+            effective_sys_info: RwLock::new(self.effective_sys_info.dupe()),
             state: self.state.clone_for_mutation(),
             imports: RwLock::new(self.imports.clone()),
             deps: RwLock::new(self.deps.clone()),
@@ -528,9 +531,11 @@ impl ModuleData {
 
 impl ModuleDataMut {
     fn new(handle: Handle, require: Require, config: ArcId<ConfigFile>, now: Epoch) -> Self {
+        let effective_sys_info = handle.sys_info().dupe();
         Self {
             handle,
             config: RwLock::new(config),
+            effective_sys_info: RwLock::new(effective_sys_info),
             state: ModuleStateMut::new(require, now),
             imports: Default::default(),
             deps: Default::default(),
@@ -544,6 +549,7 @@ impl ModuleDataMut {
         let ModuleDataMut {
             handle,
             config,
+            effective_sys_info,
             state,
             imports,
             deps,
@@ -553,11 +559,24 @@ impl ModuleDataMut {
         ModuleData {
             handle,
             config: config.into_inner(),
+            effective_sys_info: effective_sys_info.into_inner(),
             state: state.take_and_freeze(),
             imports: imports.into_inner(),
             deps: deps.into_inner(),
             rdeps: rdeps.into_inner(),
             tensor_shapes: tensor_shapes.into_inner(),
+        }
+    }
+
+    fn effective_sys_info(&self) -> SysInfo {
+        if let Some(ast) = self.state.get_ast().as_deref() {
+            let base = self.handle.sys_info();
+            let effective =
+                module_sys_info_override(base, Some(ast)).unwrap_or_else(|| base.dupe());
+            *self.effective_sys_info.write() = effective.dupe();
+            effective
+        } else {
+            self.effective_sys_info.read().dupe()
         }
     }
 
@@ -1456,18 +1475,12 @@ impl<'a> Transaction<'a> {
                     module_ids: &reporter.module_ids,
                     stdlib: stdlib.dupe(),
                 });
-            let sys_info_override = module_sys_info_override(
-                module_data.handle.sys_info(),
-                module_data.state.get_ast().as_deref(),
-            );
-            let sys_info = sys_info_override
-                .as_ref()
-                .unwrap_or(module_data.handle.sys_info());
+            let sys_info = module_data.effective_sys_info();
             let ctx = Context {
                 require,
                 module: module_data.handle.module(),
                 path: module_data.handle.path(),
-                sys_info,
+                sys_info: &sys_info,
                 memory: &self.memory_lookup(),
                 uniques: &self.data.state.uniques,
                 stdlib: &stdlib,
@@ -2698,13 +2711,7 @@ impl<'a> TransactionHandle<'a> {
         path: Option<&ModulePath>,
         dep: ModuleDep,
     ) -> FindingOrError<&'a ArcId<ModuleDataMut>> {
-        let sys_info_override = module_sys_info_override(
-            self.module_data.handle.sys_info(),
-            self.module_data.state.get_ast().as_deref(),
-        );
-        let sys_info = sys_info_override
-            .as_ref()
-            .unwrap_or(self.module_data.handle.sys_info());
+        let sys_info = self.module_data.effective_sys_info();
         let handle = match path {
             Some(path) => {
                 // Explicit path — already resolved. Bypass imports entirely.

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -506,7 +506,7 @@ struct ModuleDataMut {
 }
 
 fn module_sys_info_override(
-    sys_info: &SysInfo,
+    sys_info: SysInfo,
     ast: Option<&ruff_python_ast::ModModule>,
 ) -> Option<SysInfo> {
     let ast = ast?;
@@ -572,7 +572,7 @@ impl ModuleDataMut {
         if let Some(ast) = self.state.get_ast().as_deref() {
             let base = self.handle.sys_info();
             let effective =
-                module_sys_info_override(base, Some(ast)).unwrap_or_else(|| base.dupe());
+                module_sys_info_override(*base, Some(ast)).unwrap_or_else(|| base.dupe());
             *self.effective_sys_info.write() = effective.dupe();
             effective
         } else {

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -38,6 +38,7 @@ use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::module_path::ModulePath;
 use pyrefly_python::module_path::ModulePathDetails;
 use pyrefly_python::sys_info::SysInfo;
+use pyrefly_python::sys_info::module_platform_guard;
 use pyrefly_types::type_alias::TypeAliasIndex;
 use pyrefly_util::arc_id::ArcId;
 use pyrefly_util::demand_tree::DemandCollector;
@@ -500,6 +501,14 @@ struct ModuleDataMut {
     /// are not a dependency of every module; only its resolvability affects the
     /// `tensor_shapes` bit. `None` means "not yet computed".
     tensor_shapes: RwLock<Option<bool>>,
+}
+
+fn module_sys_info_override(
+    sys_info: &SysInfo,
+    ast: Option<&ruff_python_ast::ModModule>,
+) -> Option<SysInfo> {
+    let ast = ast?;
+    module_platform_guard(&ast.body).map(|platform| sys_info.with_platform(platform))
 }
 
 impl ModuleData {
@@ -1447,11 +1456,18 @@ impl<'a> Transaction<'a> {
                     module_ids: &reporter.module_ids,
                     stdlib: stdlib.dupe(),
                 });
+            let sys_info_override = module_sys_info_override(
+                module_data.handle.sys_info(),
+                module_data.state.get_ast().as_deref(),
+            );
+            let sys_info = sys_info_override
+                .as_ref()
+                .unwrap_or(module_data.handle.sys_info());
             let ctx = Context {
                 require,
                 module: module_data.handle.module(),
                 path: module_data.handle.path(),
-                sys_info: module_data.handle.sys_info(),
+                sys_info,
                 memory: &self.memory_lookup(),
                 uniques: &self.data.state.uniques,
                 stdlib: &stdlib,
@@ -1920,13 +1936,17 @@ impl<'a> Transaction<'a> {
             .is_some()
     }
 
-    pub fn get_stdlib(&self, handle: &Handle) -> Arc<Stdlib> {
+    pub fn get_stdlib_for_sys_info(&self, sys_info: &SysInfo) -> Arc<Stdlib> {
         if self.data.stdlib.len() == 1 {
             // Since we know our one must exist, we can shortcut
             return self.data.stdlib.first().unwrap().1.dupe();
         }
 
-        self.data.stdlib.get(handle.sys_info()).unwrap().dupe()
+        self.data.stdlib.get(sys_info).unwrap().dupe()
+    }
+
+    pub fn get_stdlib(&self, handle: &Handle) -> Arc<Stdlib> {
+        self.get_stdlib_for_sys_info(handle.sys_info())
     }
 
     /// Compute the `Stdlib` for each requested `SysInfo`.
@@ -2678,14 +2698,17 @@ impl<'a> TransactionHandle<'a> {
         path: Option<&ModulePath>,
         dep: ModuleDep,
     ) -> FindingOrError<&'a ArcId<ModuleDataMut>> {
+        let sys_info_override = module_sys_info_override(
+            self.module_data.handle.sys_info(),
+            self.module_data.state.get_ast().as_deref(),
+        );
+        let sys_info = sys_info_override
+            .as_ref()
+            .unwrap_or(self.module_data.handle.sys_info());
         let handle = match path {
             Some(path) => {
                 // Explicit path — already resolved. Bypass imports entirely.
-                FindingOrError::new_finding(Handle::new(
-                    module,
-                    path.dupe(),
-                    self.module_data.handle.sys_info().dupe(),
-                ))
+                FindingOrError::new_finding(Handle::new(module, path.dupe(), sys_info.dupe()))
             }
             None => {
                 // No path — needs find_import. Check imports cache first.
@@ -2719,13 +2742,7 @@ impl<'a> TransactionHandle<'a> {
                         finding
                     }
                 };
-                path.map(|path| {
-                    Handle::new(
-                        module,
-                        path.dupe(),
-                        self.module_data.handle.sys_info().dupe(),
-                    )
-                })
+                path.map(|path| Handle::new(module, path.dupe(), sys_info.dupe()))
             }
         };
 

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -21,6 +21,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::MutexGuard;
+use std::sync::OnceLock;
 use std::sync::RwLockReadGuard;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
@@ -513,6 +514,71 @@ fn module_sys_info_override(
     module_platform_guard(&ast.body).map(|platform| sys_info.with_platform(platform))
 }
 
+thread_local! {
+    static COMPUTING_STDLIB: RefCell<Vec<SysInfo>> = const { RefCell::new(Vec::new()) };
+}
+
+struct ComputingStdlibGuard(SysInfo);
+
+impl ComputingStdlibGuard {
+    fn new(sys_info: SysInfo) -> Self {
+        COMPUTING_STDLIB.with(|stack| stack.borrow_mut().push(sys_info));
+        Self(sys_info)
+    }
+}
+
+impl Drop for ComputingStdlibGuard {
+    fn drop(&mut self) {
+        COMPUTING_STDLIB.with(|stack| {
+            let last = stack
+                .borrow_mut()
+                .pop()
+                .expect("computing stdlib stack should not be empty");
+            assert_eq!(
+                last, self.0,
+                "computing stdlib stack should be popped in LIFO order"
+            );
+        });
+    }
+}
+
+fn is_computing_stdlib(sys_info: SysInfo) -> bool {
+    COMPUTING_STDLIB.with(|stack| stack.borrow().contains(&sys_info))
+}
+
+struct StdlibEntry {
+    bootstrap: Arc<Stdlib>,
+    ready: OnceLock<Arc<Stdlib>>,
+}
+
+impl StdlibEntry {
+    fn computing() -> Self {
+        Self {
+            bootstrap: Arc::new(Stdlib::for_bootstrapping()),
+            ready: OnceLock::new(),
+        }
+    }
+
+    fn ready(stdlib: Arc<Stdlib>) -> Self {
+        let entry = Self::computing();
+        assert!(
+            entry.ready.set(stdlib).is_ok(),
+            "new stdlib entry should be empty"
+        );
+        entry
+    }
+
+    fn get(&self, sys_info: SysInfo) -> Arc<Stdlib> {
+        if let Some(stdlib) = self.ready.get() {
+            return stdlib.dupe();
+        }
+        if is_computing_stdlib(sys_info) {
+            return self.bootstrap.dupe();
+        }
+        self.ready.wait().dupe()
+    }
+}
+
 impl ModuleData {
     /// Make a copy of the data that can be mutated.
     fn clone_for_mutation(&self) -> ModuleDataMut {
@@ -681,7 +747,7 @@ pub struct TransactionTimingCounters {
 /// It is used to store uncommitted transaction state in between transaction runs.
 pub(crate) struct TransactionData<'a> {
     state: &'a State,
-    stdlib: SmallMap<SysInfo, Arc<Stdlib>>,
+    stdlib: LockedMap<SysInfo, StdlibEntry>,
     updated_modules: LockedMap<Handle, ArcId<ModuleDataMut>>,
     updated_loaders: LockedMap<ArcId<ConfigFile>, Arc<LoaderFindCache>>,
     memory_overlay: MemoryFilesOverlay,
@@ -1455,8 +1521,14 @@ impl<'a> Transaction<'a> {
 
             computed = true;
             let require = guard.require();
-            let stdlib = self.get_stdlib(&module_data.handle);
+            let sys_info = if todo >= Step::Exports {
+                module_data.effective_sys_info()
+            } else {
+                module_data.handle.sys_info().dupe()
+            };
             let config = module_data.config.read();
+            self.compute_stdlib([(sys_info.dupe(), config.dupe())]);
+            let stdlib = self.get_stdlib_for_sys_info(&sys_info);
 
             // Compute and record the `tensor_shapes` bit. Storing it here makes it a
             // find-only dependency: the `dirty.find()` clean-check re-derives this value
@@ -1475,7 +1547,6 @@ impl<'a> Transaction<'a> {
                     module_ids: &reporter.module_ids,
                     stdlib: stdlib.dupe(),
                 });
-            let sys_info = module_data.effective_sys_info();
             let ctx = Context {
                 require,
                 module: module_data.handle.module(),
@@ -1905,7 +1976,9 @@ impl<'a> Transaction<'a> {
 
         // Slow path: need full solve_exported_key for computation.
         let load = module_data.state.get_load().unwrap();
-        let stdlib = self.get_stdlib(&module_data.handle);
+        let sys_info = module_data.effective_sys_info();
+        self.compute_stdlib([(sys_info.dupe(), module_data.config.read().dupe())]);
+        let stdlib = self.get_stdlib_for_sys_info(&sys_info);
         let lookup = self.lookup(module_data);
         answers.1.solve_exported_key(
             &lookup,
@@ -1950,82 +2023,90 @@ impl<'a> Transaction<'a> {
     }
 
     pub fn get_stdlib_for_sys_info(&self, sys_info: &SysInfo) -> Arc<Stdlib> {
-        if self.data.stdlib.len() == 1 {
-            // Since we know our one must exist, we can shortcut
-            return self.data.stdlib.first().unwrap().1.dupe();
-        }
-
-        self.data.stdlib.get(sys_info).unwrap().dupe()
+        self.data
+            .stdlib
+            .get(sys_info)
+            .unwrap_or_else(|| panic!("stdlib was not computed for {sys_info:?}"))
+            .get(*sys_info)
     }
 
     pub fn get_stdlib(&self, handle: &Handle) -> Arc<Stdlib> {
+        if let Some(entry) = self.data.stdlib.get(handle.sys_info()) {
+            return entry.get(*handle.sys_info());
+        }
+        if let Some((sys_info, entry)) = self
+            .data
+            .stdlib
+            .iter_unordered()
+            .find(|(sys_info, _)| sys_info.version() == handle.sys_info().version())
+        {
+            return entry.get(*sys_info);
+        }
         self.get_stdlib_for_sys_info(handle.sys_info())
     }
 
     /// Compute the `Stdlib` for each requested `SysInfo`.
     ///
-    /// Stdlib is derived from bundled (immutable) typeshed stubs, so the result
-    /// is deterministic for a given `SysInfo`. We skip recomputation for any
-    /// `SysInfo` already present in the stdlib map — this avoids 80-150 ms of
-    /// redundant single-threaded work on rechecks and multi-epoch runs.
+    /// Stdlib is derived from the typeshed selected by the module config. Every
+    /// config sharing a `SysInfo` must therefore select the same typeshed. We skip
+    /// recomputation for any `SysInfo` already present in the stdlib map — this
+    /// avoids 80-150 ms of redundant work on rechecks and multi-epoch runs.
     ///
     /// Returns `true` if all entries were already cached (no work done).
-    fn compute_stdlib(&mut self, handles: &[Handle]) -> bool {
-        // Filter out SysInfos that already have a computed stdlib.
-        let sys_infos: SmallSet<SysInfo> = handles.iter().map(|h| h.sys_info().dupe()).collect();
-        let missing: SmallSet<SysInfo> = sys_infos
-            .into_iter()
-            .filter(|k| !self.data.stdlib.contains_key(k))
-            .collect();
-        if missing.is_empty() {
-            return true;
+    fn compute_stdlib(
+        &self,
+        modules: impl IntoIterator<Item = (SysInfo, ArcId<ConfigFile>)>,
+    ) -> bool {
+        let mut configs: SmallMap<SysInfo, ArcId<ConfigFile>> = SmallMap::new();
+        for (sys_info, config) in modules {
+            if let Some(existing) = configs.get(&sys_info) {
+                assert_eq!(
+                    existing.typeshed_path, config.typeshed_path,
+                    "modules sharing a SysInfo must agree on typeshed_path"
+                );
+            } else {
+                configs.insert(sys_info, config);
+            }
         }
         // Use defaults (disabled) for stdlib - depth limiting is for user code
         let thread_state = ThreadState::new(None);
-        for k in missing.into_iter_hashed() {
-            // The stdlib is cached per `SysInfo`, so every handle sharing this `SysInfo`
-            // must resolve to the same `typeshed_path`; otherwise the cached stdlib would
-            // depend on which handle happened to be seen first. Enforce that invariant
-            // rather than silently loading the stdlib from an arbitrary handle's typeshed.
-            let typeshed_path = handles
-                .iter()
-                .filter(|h| h.sys_info() == &*k)
-                .map(|h| self.data.state.get_config(h).typeshed_path.clone())
-                .reduce(|a, b| {
-                    assert_eq!(
-                        a, b,
-                        "handles sharing a SysInfo must agree on typeshed_path"
-                    );
-                    a
-                })
-                .flatten();
-            // Load the stdlib from the user-provided typeshed if one is set; otherwise
-            // use the bundled typeshed.
-            let stdlib_config = typeshed_path
+        let mut cached = true;
+        for (sys_info, config) in configs {
+            let (entry, _) = self.data.stdlib.ensure(&sys_info, StdlibEntry::computing);
+            if entry.ready.get().is_some() || is_computing_stdlib(sys_info) {
+                continue;
+            }
+            cached = false;
+            let stdlib_config = config
+                .typeshed_path
+                .clone()
                 .map_or_else(BundledTypeshedStdlib::config, custom_typeshed_stdlib_config);
             let loader = self.get_cached_loader(&stdlib_config);
-            self.data
-                .stdlib
-                .insert_hashed(k.to_owned(), Arc::new(Stdlib::for_bootstrapping()));
-            let v = Arc::new(Stdlib::new(
-                k.version(),
-                &|module, name| {
-                    let path = loader
-                        .find_import(module, None, Some(&self.timing))
-                        .finding()?;
-                    self.lookup_stdlib(&Handle::new(module, path, (*k).dupe()), name, &thread_state)
-                },
-                &|module, name| {
-                    let path = loader
-                        .find_import(module, None, Some(&self.timing))
-                        .finding()?;
-                    let handle = Handle::new(module, path, (*k).dupe());
-                    self.lookup_export_location(&handle, name)
-                },
-            ));
-            self.data.stdlib.insert_hashed(k, v);
+            let _guard = ComputingStdlibGuard::new(sys_info);
+            entry.ready.get_or_init(|| {
+                Arc::new(Stdlib::new(
+                    sys_info.version(),
+                    &|module, name| {
+                        let path = loader
+                            .find_import(module, None, Some(&self.timing))
+                            .finding()?;
+                        self.lookup_stdlib(
+                            &Handle::new(module, path, sys_info.dupe()),
+                            name,
+                            &thread_state,
+                        )
+                    },
+                    &|module, name| {
+                        let path = loader
+                            .find_import(module, None, Some(&self.timing))
+                            .finding()?;
+                        let handle = Handle::new(module, path, sys_info.dupe());
+                        self.lookup_export_location(&handle, name)
+                    },
+                ))
+            });
         }
-        false
+        cached
     }
 
     fn work(&self) -> Result<(), Cancelled> {
@@ -2144,7 +2225,11 @@ impl<'a> Transaction<'a> {
         // Compute stdlib once before the epoch loop. Stdlib is deterministic for a
         // given SysInfo and does not depend on user code, so it only needs to run once.
         let stdlib_start = Timer::start();
-        let stdlib_cached = self.compute_stdlib(handles);
+        let stdlib_cached = self.compute_stdlib(
+            handles
+                .iter()
+                .map(|handle| (handle.sys_info().dupe(), self.data.state.get_config(handle))),
+        );
         let compute_stdlib_time = stdlib_start.elapsed();
         {
             let mut stats = self.stats.lock();
@@ -2252,7 +2337,9 @@ impl<'a> Transaction<'a> {
         let load = module_data.state.get_load()?;
         let answers = module_data.state.get_answers()?;
         let errors = &load.errors;
-        let stdlib = self.get_stdlib(handle);
+        let sys_info = module_data.effective_sys_info();
+        self.compute_stdlib([(sys_info.dupe(), module_data.config.read().dupe())]);
+        let stdlib = self.get_stdlib_for_sys_info(&sys_info);
         let recurser = VarRecurser::new();
         let config = module_data.config.read();
         let thread_state = ThreadState::new(config.recursion_limit_config());
@@ -2494,13 +2581,15 @@ impl<'a> Transaction<'a> {
             let m = self.get_module(&m.handle);
             let alt = StepsMut::new_loaded(m.state.get_load().unwrap());
             let require = m.state.require();
-            let stdlib = self.get_stdlib(&m.handle);
+            let sys_info = m.effective_sys_info();
+            self.compute_stdlib([(sys_info.dupe(), m.config.read().dupe())]);
+            let stdlib = self.get_stdlib_for_sys_info(&sys_info);
             let config = m.config.read();
             let ctx = Context {
                 require,
                 module: m.handle.module(),
                 path: m.handle.path(),
-                sys_info: m.handle.sys_info(),
+                sys_info: &sys_info,
                 memory: &self.memory_lookup(),
                 uniques: &self.data.state.uniques,
                 stdlib: &stdlib,
@@ -3159,7 +3248,10 @@ impl<'a> LookupAnswer for TransactionHandle<'a> {
                     "target module has Answers but no Load; this should be unreachable \
                      because Load is computed before Answers",
                 );
-                let stdlib = self.transaction.get_stdlib(&module_data.handle);
+                let sys_info = module_data.effective_sys_info();
+                self.transaction
+                    .compute_stdlib([(sys_info.dupe(), module_data.config.read().dupe())]);
+                let stdlib = self.transaction.get_stdlib_for_sys_info(&sys_info);
                 let lookup = self.transaction.lookup(module_data);
                 target_answers.solve_idx_erased(
                     any_idx,
@@ -3373,7 +3465,15 @@ impl State {
         let readable = self.state.read();
         let state_lock_blocked = start.elapsed();
         let now = readable.now;
-        let stdlib = readable.stdlib.clone();
+        let stdlib = LockedMap::new();
+        for (sys_info, cached_stdlib) in readable.stdlib.iter() {
+            assert!(
+                stdlib
+                    .insert(sys_info.dupe(), StdlibEntry::ready(cached_stdlib.dupe()))
+                    .is_none(),
+                "readable stdlib should not contain duplicate SysInfo keys"
+            );
+        }
         Transaction {
             readable,
             stats: Mutex::new(TelemetryTransactionStats {
@@ -3507,7 +3607,16 @@ impl State {
             "Attempted to commit a stale transaction from epoch {:?} into state at epoch {:?}",
             base, state.now
         );
-        state.stdlib = stdlib;
+        state.stdlib = stdlib
+            .into_iter()
+            .map(|(sys_info, entry)| {
+                let stdlib = entry
+                    .ready
+                    .into_inner()
+                    .expect("committed stdlib entry should be fully computed");
+                (sys_info, stdlib)
+            })
+            .collect();
         state.now = now;
         for (handle, new_module_data) in updated_modules {
             state.modules.insert(

--- a/pyrefly/lib/test/state.rs
+++ b/pyrefly/lib/test/state.rs
@@ -8,6 +8,7 @@
 //! Tests of the `State` object.
 
 use std::fs;
+use std::panic;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -1340,4 +1341,29 @@ fn test_stdlib_cached_on_recheck() {
         "Cached stdlib should skip pre-warming entirely"
     );
     state.commit_transaction(t2, None);
+}
+
+#[test]
+fn test_stdlib_single_entry_shortcut_requires_matching_sys_info() {
+    let env = TestEnv::one("foo", "x: int = 1");
+    let state = State::new(env.config_finder(), TEST_THREAD_COUNT);
+    let linux = SysInfo::new(PythonVersion::default(), PythonPlatform::linux());
+    let windows = SysInfo::new(PythonVersion::default(), PythonPlatform::windows());
+    let handle = Handle::new(
+        ModuleName::from_str("foo"),
+        ModulePath::memory(PathBuf::from("foo.py")),
+        linux,
+    );
+
+    let mut transaction = state.new_transaction(Require::Exports, None);
+    transaction.set_memory(env.get_memory());
+    transaction.run(&[handle], Require::Everything, None);
+
+    assert!(
+        panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            transaction.get_stdlib_for_sys_info(&windows);
+        }))
+        .is_err(),
+        "a single cached stdlib must not be returned for a different SysInfo"
+    );
 }

--- a/pyrefly/lib/test/sys_info.rs
+++ b/pyrefly/lib/test/sys_info.rs
@@ -277,6 +277,22 @@ assert_type(Z(), str)
 );
 
 testcase!(
+    test_module_platform_guard_imports,
+    TestEnv::one(
+        "winonly",
+        r#"
+import sys
+assert sys.platform == "win32"
+import winreg
+x = winreg.OpenKey
+"#,
+    ),
+    r#"
+import winonly
+"#,
+);
+
+testcase!(
     test_os_name,
     r#"
 from typing import assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #795

completes the platform-guarded import behavior so modules guarded by assert sys.platform == ... are type-checked and their imports are resolved using the correct platform SysInfo.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

introduces a regression test that a win32-guarded module can import winreg without errors.

