### PR TITLE
Splitting unknown-name error code

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -256,10 +256,8 @@ pub enum ErrorKind {
     UnexpectedKeyword,
     /// An error caused by passing a positional argument for a keyword-only parameter.
     UnexpectedPositionalArgument,
-    /// Attempting to use `assert_type` without importing it from `typing`.
-    UnimportedAssertType,
-    /// Attempting to use `reveal_type` without importing it from `typing`.
-    UnimportedRevealType,
+    /// Attempting to use a type checker directive without importing it from `typing`.
+    UnimportedDirective,
     /// Attempting to use a name that is not defined.
     UnknownName,
     /// Identity comparison (`is` or `is not`) between types that are provably disjoint

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -376,14 +376,9 @@ impl<'a> BindingsBuilder<'a> {
                     .scopes
                     .suggest_similar_name(&name.id, name.range.start());
                 if is_special_name(name.id.as_str()) {
-                    let error_kind = if name.id.as_str() == "reveal_type" {
-                        ErrorKind::UnimportedRevealType
-                    } else {
-                        ErrorKind::UnimportedAssertType
-                    };
                     self.error(
                         name.range,
-                        ErrorInfo::Kind(error_kind),
+                        ErrorInfo::Kind(ErrorKind::UnimportedDirective),
                         format!(
                             "`{}` must be imported from `typing` for runtime usage",
                             name

--- a/test/snippet.md
+++ b/test/snippet.md
@@ -37,7 +37,7 @@ $ $PYREFLY snippet "import sys; print(sys.version)"
 $ echo "x: int = 5" > $TMPDIR/test.py && \
 > touch $TMPDIR/pyrefly.toml && \
 > $PYREFLY snippet "import test; reveal_type(test.x)" -c $TMPDIR/pyrefly.toml
-ERROR `reveal_type` must be imported from `typing` for runtime usage [unimported-reveal-type]
+ERROR `reveal_type` must be imported from `typing` for runtime usage [unimported-directive]
  --> snippet:1:14
   |
 1 | import test; reveal_type(test.x)

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -1208,20 +1208,13 @@ def takes_kwonly(*, x: int) -> int:
 takes_kwonly(1)  # should be `takes_kwonly(x=1)`!
 ```
 
-## unimported-assert-type
+## unimported-directive
 
-Attempting to call `assert_type` without importing it from `typing` first.
-
-```python
-assert_type(1, int)  # error
-```
-
-## unimported-reveal-type
-
-Attempting to call `reveal_type` without importing it from `typing` first.
+Attempting to call a [type checker directive](https://typing.python.org/en/latest/spec/directives.html#type-checker-directives) without importing it from `typing` first.
 
 ```python
 reveal_type(1)  # error
+assert_type(1, int)  # error
 ```
 
 ## unknown-name


### PR DESCRIPTION
# Summary

This PR adds two new error kinds, `UnimportedAssertType` and `UnimportedRevealType`, to make error reporting more specific when `assert_type` or `reveal_type` are used without being imported. Instead of falling back to the generic `unknown-name` error, the binding logic now emits these dedicated error types. Both were added to the `ErrorKind` enum with a default severity of `Error`. I also updated the documentation to describe the new error kinds and adjusted the relevant test expectations to match the new diagnostics, while keeping the existing Rust unit tests unchanged to ensure everything still aligns with the intended error behavior.


Fixes #2550

# Test Plan

I verified that `cargo test test_assert_type_variations` and `cargo test test_reveal_type_variations` both run and pass after the changes. I also made sure the new configuration values are properly sorted and parsed as expected by the existing framework. With this update, users can now suppress these specific diagnostics using `# pyrefly: ignore[unimported-reveal-type]` (or the corresponding assert type rule) without having to ignore all `unknown-name` errors, which keeps suppression more precise and intentional.

