### PR TITLE
Fixed notebook quick-fix position

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -3714,24 +3714,83 @@ impl Server {
         let mut actions = Vec::new();
         let server_state = self.telemetry_state();
         let start = Instant::now();
+        // If the code action is triggered from a notebook cell, we need the cell's
+        // index so that import quick-fixes can be redirected to the current cell
+        // instead of always targeting cell 1 (position 0 of the combined AST).
+        let triggered_cell_index = self.maybe_get_cell_index(uri);
         if allow_quickfix
             && let Some(quickfixes) =
                 transaction.local_quickfix_code_actions_sorted(&handle, range, import_format)
         {
             actions.extend(quickfixes.into_iter().filter_map(
                 |(title, info, range, insert_text)| {
-                    let lsp_location = self.to_lsp_location(&TextRangeWithModule {
-                        module: info,
-                        range,
-                    })?;
+                    // For notebook cells: if the import quick-fix targets a different
+                    // cell than the one where the action was triggered, redirect the
+                    // edit to the top of the current cell.  This mirrors Pylance's
+                    // behaviour where "insert import" always goes into the active cell.
+                    let (edit_uri, edit_range) =
+                        if let Some(current_cell_idx) = triggered_cell_index {
+                            let edit_cell_idx = info.to_cell_for_lsp(range.start());
+                            if edit_cell_idx != Some(current_cell_idx) {
+                                // Redirect to the current cell, inserting at line 0.
+                                let open_files = self.open_files.read();
+                                let notebook_path = self
+                                    .open_notebook_cells
+                                    .read()
+                                    .get(uri)
+                                    .cloned();
+                                let cell_url = notebook_path.and_then(|path| {
+                                    if let Some(LspFile::Notebook(notebook)) =
+                                        open_files.get(&path).map(|f| &**f)
+                                    {
+                                        notebook.get_cell_url(current_cell_idx).cloned()
+                                    } else {
+                                        None
+                                    }
+                                });
+                                if let Some(cell_url) = cell_url {
+                                    let top_of_cell = lsp_types::Range {
+                                        start: lsp_types::Position {
+                                            line: 0,
+                                            character: 0,
+                                        },
+                                        end: lsp_types::Position {
+                                            line: 0,
+                                            character: 0,
+                                        },
+                                    };
+                                    (cell_url, top_of_cell)
+                                } else {
+                                    let lsp_location =
+                                        self.to_lsp_location(&TextRangeWithModule {
+                                            module: info,
+                                            range,
+                                        })?;
+                                    (lsp_location.uri, lsp_location.range)
+                                }
+                            } else {
+                                let lsp_location =
+                                    self.to_lsp_location(&TextRangeWithModule {
+                                        module: info,
+                                        range,
+                                    })?;
+                                (lsp_location.uri, lsp_location.range)
+                            }
+                        } else {
+                            let lsp_location = self.to_lsp_location(&TextRangeWithModule {
+                                module: info,
+                                range,
+                            })?;
+                            (lsp_location.uri, lsp_location.range)
+                        };
                     Some(CodeActionOrCommand::CodeAction(CodeAction {
                         title,
                         kind: Some(CodeActionKind::QUICKFIX),
                         edit: Some(WorkspaceEdit {
                             changes: Some(HashMap::from([(
-                                lsp_location.uri,
+                                edit_uri,
                                 vec![TextEdit {
-                                    range: lsp_location.range,
+                                    range: edit_range,
                                     new_text: insert_text,
                                 }],
                             )])),

--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_code_action.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_code_action.rs
@@ -53,7 +53,8 @@ fn test_notebook_code_action_import() {
         })
         .unwrap();
 
-    // Code actions for later cells will still insert imports to the first cell
+    // Code actions for later cells insert imports into the current cell, not the first cell
+    let cell2_uri = interaction.cell_uri("notebook.ipynb", "cell2");
     interaction
         .code_action_cell("notebook.ipynb", "cell2", 0, 0, 0, 10)
         .expect_response_with(|response| {
@@ -68,7 +69,7 @@ fn test_notebook_code_action_import() {
                     .edit
                     .as_ref()
                     .and_then(|edit| edit.changes.as_ref())
-                    .and_then(|changes| changes.get(&cell1_uri))
+                    .and_then(|changes| changes.get(&cell2_uri))
                 else {
                     return false;
                 };
@@ -76,6 +77,36 @@ fn test_notebook_code_action_import() {
                     text_edit.range.start.line == 0
                         && text_edit.range.start.character == 0
                         && text_edit.new_text.as_str() == "from typing import NamedTuple\n"
+                })
+            })
+        })
+        .unwrap();
+
+    // Code actions for a third cell also insert into that specific cell
+    interaction.open_notebook("notebook.ipynb", vec!["TypedDict", "NamedTuple", "List"]);
+    let cell3_uri = interaction.cell_uri("notebook.ipynb", "cell3");
+    interaction
+        .code_action_cell("notebook.ipynb", "cell3", 0, 0, 0, 4)
+        .expect_response_with(|response| {
+            let Some(actions) = response else {
+                return false;
+            };
+            actions.iter().any(|action| {
+                let CodeActionOrCommand::CodeAction(code_action) = action else {
+                    return false;
+                };
+                let Some(text_edits) = code_action
+                    .edit
+                    .as_ref()
+                    .and_then(|edit| edit.changes.as_ref())
+                    .and_then(|changes| changes.get(&cell3_uri))
+                else {
+                    return false;
+                };
+                text_edits.iter().any(|text_edit| {
+                    text_edit.range.start.line == 0
+                        && text_edit.range.start.character == 0
+                        && text_edit.new_text.as_str() == "from typing import List\n"
                 })
             })
         })


### PR DESCRIPTION
### Summary
This PR fixes the issue where notebook import quick-fixes were incorrectly inserted into the first cell instead of the current active cell. Previously, Pyrefly's auto-import logic calculated a position relative to the entire combined notebook AST. This meant that the best position for an import was always at the very top of the combined source, which corresponds to the first cell.

The fix modifies the code_action handler in server.rs to detect when a quick-fix is triggered from a notebook cell and remaps the insertion position to the top of the currently active cell (line 0, character 0). This matches the behavior of Pylance and other major language servers.

Fixes #2152

### Test Plan

Updated  pyrefly/pyrefly/lib/test/lsp/lsp_interaction/notebook_code_action.rs to include explicit test cases for multiple cells (cell 1, cell 2, and cell 3). Verified that triggering an import in any of these cells correctly targets the respective cell.

Ran: cargo test test_notebook_code_action_import
Result: test result: ok. 1 passed; 0 failed

Manual Verification:
- Built the language server: cargo build --package pyrefly
- Configured VS Code to use the local build.
- Verified that triggering "Insert import" in a later cell (e.g cell 3) correctly inserts the import at the top of cell 3 and not in cell 1.