### PR TITLE
Limit the width of return type inference

### DIFF
--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -839,6 +839,14 @@ impl Type {
         matches!(self, Type::Union(_))
     }
 
+    /// Returns the number of top-level alternatives in a union, or 1 for non-union types.
+    pub fn union_width(&self) -> usize {
+        match self {
+            Type::Union(u) => u.members.len(),
+            _ => 1,
+        }
+    }
+
     pub fn is_never(&self) -> bool {
         matches!(self, Type::Never(_))
     }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -3121,6 +3121,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             .collect(),
                     )
                 };
+                // Cap excessively wide inferred return types to Any. During iterative
+                // SCC solving, mutual recursion can cause union widths to grow
+                // exponentially across iterations (e.g. 74 → 1247 → 1M in sympy).
+                // Capping at 20 covers 99%+ of naturally-occurring unions while
+                // preventing pathological blowup.
+                const MAX_INFERRED_RETURN_UNION_WIDTH: usize = 20;
+                let return_ty = if return_ty.union_width() > MAX_INFERRED_RETURN_UNION_WIDTH {
+                    self.heap.mk_any_implicit()
+                } else {
+                    return_ty
+                };
                 if is_generator {
                     let yield_ty = self.unions({
                         let yield_tys =


### PR DESCRIPTION
Summary:
Return type inference is not actually correct or incorrect in Python, because of the
presence of gradual typing - Pyrefly is able to infer a return type in most cases, but
it's a static *approximation* that will sometimes be a huge union of static types, which
might not be semantically what an author intended.

I think that the width of the union is one signal about when this is happening - a huge
inferred union is a signal (not a perfect signal, but I do think it's a sign) that
the function in question is not really intended to be statically typed at all. In particular,
if the inferred type is absolutely huge, the type is going to be close to useless - it's
very likely that it will have type errors downstream, and also the hover / inlay types are
going to be unreadably large.

On top of that, the performance of Pyrefly can *severely* bottleneck if we do this without
limit on arbitrarily large functions. Sympy cannot be analyzed using an iterative solver
with return type inference, because there are a few cases of mutually recursive functions
with large numbers of returns (the big ones were in the 30-78 range); at least a few of these
wind up self-referencing in the fixpoint, meaning we expand polynomially and can wind up
with types that are megabytes in size.

This causes iterative fixpont solving to basically break on sympy; it does finish single-threaded,
but with many threads it's highly unstable - it takes a *huge* amount of time because iterating
these massive unions leads to contention on things like the rdeps lock, plus it can lead to
RAM use spikes that periodically lead to crashes (interestingly the crashes reliably took out
not just Pyrefly but the terminal running it! That's a fun experience because you can't even see
the crash, the terminal just goes away).

This commit proposes that we should limit the width of inferred return types. To me, 25 is
an absurdly wide type, so I *think* this should be uncontroversial at the limit proposed in the
first draft of this diff (25). The perf issues on sympy are solved even with this very high limit.
That said, I think on UX grounds we might want to consider much lower limits... even a limit
of exactly 1 (as in, we should not infer union return types at all). The argument there is much
more of a soft one about UX though, my main motivation right now is to unblock determinism
by getting rid of oversized recursive type explosions.

Differential Revision: D94915898


