### PR TITLE
[Pyrefly][Primer][Init] Run pyrefly init --non-interactive before primer check

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -54,10 +54,39 @@ jobs:
 
           echo ''
           cd ..
+
+          BASE_DIR=$(pwd)/primer_base
+          mkdir -p $BASE_DIR
+
+          # Build pyrefly for "new" commit and install wrapper
+          NEW_DIR=$BASE_DIR/pyrefly_new
+          mkdir -p $NEW_DIR
+          cd pyrefly_to_test && git checkout $GITHUB_SHA
+          CARGO_TARGET_DIR=$NEW_DIR/target cargo build --manifest-path pyrefly/Cargo.toml
+          BINARY_DIR=$NEW_DIR/target/debug
+          mv $BINARY_DIR/pyrefly $BINARY_DIR/pyrefly-real
+          cp scripts/pyrefly_primer_wrapper.sh $BINARY_DIR/pyrefly
+          chmod +x $BINARY_DIR/pyrefly
+
+          # Build pyrefly for "old" commit and install wrapper
+          OLD_DIR=$BASE_DIR/pyrefly_old
+          mkdir -p $OLD_DIR
+          git checkout base_commit
+          CARGO_TARGET_DIR=$OLD_DIR/target cargo build --manifest-path pyrefly/Cargo.toml
+          BINARY_DIR=$OLD_DIR/target/debug
+          mv $BINARY_DIR/pyrefly $BINARY_DIR/pyrefly-real
+          # Use the wrapper from the new commit (old commit may not have it)
+          git checkout $GITHUB_SHA -- scripts/pyrefly_primer_wrapper.sh
+          cp scripts/pyrefly_primer_wrapper.sh $BINARY_DIR/pyrefly
+          chmod +x $BINARY_DIR/pyrefly
+
+          cd ..
           # fail action if exit code isn't zero or one
           (
-            mypy_primer \
+            MYPY_PRIMER_NO_REBUILD=1 mypy_primer \
             --repo pyrefly_to_test \
+            --base-dir $BASE_DIR \
+            --cargo-profile dev \
             --new $GITHUB_SHA --old base_commit \
             --num-shards 10 --shard-index ${{ matrix.shard-index }} \
             --debug \

--- a/pyrefly/lib/commands/init.rs
+++ b/pyrefly/lib/commands/init.rs
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// TODO: Remove this comment — added to trigger mypy_primer CI for workflow validation
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;

--- a/pyrefly/lib/commands/init.rs
+++ b/pyrefly/lib/commands/init.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// TODO: Remove this comment — added to trigger mypy_primer CI for workflow validation
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;

--- a/scripts/pyrefly_primer_wrapper.sh
+++ b/scripts/pyrefly_primer_wrapper.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Wrapper script for mypy_primer that runs `pyrefly init --non-interactive`
+# before forwarding arguments to the real pyrefly binary.
+#
+# mypy_primer calls: {pyrefly} check {paths} --summary=none --output-format min-text
+# This wrapper intercepts that call, runs init on the current directory first,
+# then forwards the original arguments to the real pyrefly binary.
+
+# The real pyrefly binary sits alongside this script with a "-real" suffix.
+REAL_PYREFLY="$(dirname "$0")/pyrefly-real"
+
+# Run init on the current working directory (mypy_primer sets cwd to the project dir).
+# --non-interactive ensures no stdin prompts; exit code is ignored since init may
+# legitimately fail (e.g., existing config) and we still want to proceed with check.
+"$REAL_PYREFLY" init --non-interactive . >/dev/null 2>&1 || true
+
+# Forward all original arguments to the real pyrefly binary
+exec "$REAL_PYREFLY" "$@"


### PR DESCRIPTION
Add a wrapper script that runs `pyrefly init --non-interactive .` before forwarding arguments to the real pyrefly binary. This allows mypy_primer to pick up each project's existing mypy/pyright config via config migration.

The workflow now builds pyrefly for both commits manually, swaps in the wrapper script, and runs mypy_primer with MYPY_PRIMER_NO_REBUILD=1.

Tested across all 158 mypy_primer projects. Results:

| Metric | Before | After |
|--------|--------|-------|
| Total errors | 230,074 | 139,603 |
| Net reduction | — | 90,471 (39.3%) |
| Projects improved | — | 94 |
| Projects worsened | — | 9 |
| Projects unchanged | — | 55 |

Top improvements:
- manticore: 19,833 → 161 (-99.2%)
- dd-trace-py: 19,302 → 1,078 (-94.4%)
- core: 26,810 → 13,166 (-50.9%)
- scipy: 16,515 → 4,973 (-69.9%)
- pywin32: 4,503 → 807 (-82.1%)
- stone: 350 → 2 (-99.4%)
- setuptools: 1,244 → 300 (-75.9%)
- alerta: 819 → 137 (-83.3%)
- pandera: 1,287 → 464 (-63.9%)
- spack: 6,666 → 2,784 (-58.2%)



# Test Plan
Also did a manual test on one manticore, which matched the table above.
**Before:**
Top Errors by Count:
missing-attribute: 18,049 instances
unsupported-operation: 632 instances
unknown-name: 153 instances
bad-argument-type: 153 instances
bad-assignment: 133 instances
bad-index: 128 instances
bad-argument-count: 128 instances
missing-import: 93 instances
not-iterable: 75 instances
bad-override: 75 instances
no-matching-overload: 64 instances
missing-argument: 36 instances
unbound-name: 31 instances
missing-source-for-stubs: 20 instances
deprecated: 19 instances
bad-param-name-override: 18 instances
bad-typed-dict-key: 10 instances
not-callable: 8 instances
bad-function-definition: 5 instances
unexpected-positional-argument: 4 instances
invalid-type-var: 3 instances
bad-return: 3 instances
unreachable: 3 instances
missing-module-attribute: 2 instances
abstract-method-call: 2 instances
unexpected-keyword: 2 instances
unresolvable-dunder-all: 1 instance
redundant-condition: 1 instance
read-only: 1 instance
inconsistent-inheritance: 1 instance
 INFO 19,833 errors (28 suppressed)



**After:**
Top Errors by Count:
unknown-name: 72 instances
bad-param-name-override: 19 instances
unsupported-operation: 17 instances
bad-override: 11 instances
bad-assignment: 8 instances
missing-attribute: 8 instances
unbound-name: 7 instances
no-matching-overload: 6 instances
deprecated: 5 instances
bad-function-definition: 5 instances
bad-index: 4 instances
bad-argument-type: 2 instances
unresolvable-dunder-all: 1 instance
unexpected-keyword: 1 instance
bad-typed-dict-key: 1 instance
 INFO 161 errors (24 suppressed)



E2E locally:                                                                                                                  
  1. Set up the directory structure:                                                                                                
  mkdir -p /tmp/primer_test/primer_base/pyrefly_new/target/debug                                                                    
  mkdir -p /tmp/primer_test/primer_base/pyrefly_old/target/debug                                                                    
                                                                                                                                    
  2. Copy real binary as pyrefly-real, wrapper as pyrefly:                                                                          
  cp target/debug/pyrefly /tmp/primer_test/primer_base/pyrefly_new/target/debug/pyrefly-real
  cp scripts/pyrefly_primer_wrapper.sh /tmp/primer_test/primer_base/pyrefly_new/target/debug/pyrefly
  chmod +x /tmp/primer_test/primer_base/pyrefly_new/target/debug/pyrefly
  same for pyrefly_old

  3. Ran mypy_primer:
  MYPY_PRIMER_NO_REBUILD=1 python3 -m mypy_primer \
    --repo /Users/migeedz/pyrefly_analysis/pyrefly \
    --base-dir /tmp/primer_test/primer_base \
    --cargo-profile dev \
    --new HEAD --old HEAD \
    --type-checker pyrefly \
    --project-selector 'dropbox/stone' \
    --output concise --debug

  mypy_primer skipped building, found target/debug/pyrefly (our wrapper), and called it. The wrapper ran init then forwarded to the
  real binary.




