### PR TITLE
Fix false positive `missing-attribute` on overridden class variables

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -2217,7 +2217,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // Otherwise, analyze the value to determine the type
         let (inherited_ty, inherited_annotation) =
             self.get_inherited_type_and_annotation(class, name);
-        let is_inherited = if inherited_ty.is_none() {
+        let mut is_inherited = if inherited_ty.is_none() {
             IsInherited::No
         } else {
             IsInherited::Maybe
@@ -2246,15 +2246,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             &errors2,
                         );
                         if errors2.is_empty() {
-                            // The new type is compatible with the inherited one; use the inherited type to
-                            // avoid spurious errors about changing the type of a read-write attribute.
-                            // However, we need to clear the is_abstract_method flag since assigning
-                            // a concrete implementation makes this field non-abstract.
-                            let mut ty = inherited_ty;
-                            ty.transform_toplevel_func_metadata(|meta| {
-                                meta.flags.is_abstract_method = false;
-                            });
-                            ty
+                            // The new type is compatible with the inherited one; use the child's
+                            // inferred type to preserve type precision. Skip the override check
+                            // since we've already validated compatibility above.
+                            is_inherited = IsInherited::No;
+                            self.attribute_expr_infer(e, None, name, errors)
                         } else {
                             // The hint was no good; infer the type without it.
                             self.attribute_expr_infer(e, None, name, errors)

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -807,7 +807,7 @@ class Foo:
 class Bar(Foo):
     x = 1
 
-assert_type(Bar.x, Any | None)
+assert_type(Bar.x, int)
 assert_type(Foo.x, Any | None)
 def test(x: type[Foo]):
     assert_type(x.x, Any | None)
@@ -832,7 +832,7 @@ class Child2(Parent):
 testcase!(
     test_unannotated_empty_tuple_attribute_override,
     r#"
-from typing import Any, assert_type
+from typing import Any, Literal, assert_type
 
 class Foo:
     x = ()
@@ -841,7 +841,7 @@ class Bar(Foo):
     x = ("feature_x",)
 
 assert_type(Foo.x, tuple[Any, ...])
-assert_type(Bar.x, tuple[Any, ...])
+assert_type(Bar.x, tuple[Literal['feature_x']])
     "#,
 );
 
@@ -966,7 +966,7 @@ class A:
 class B(A):
     x = 1
 def f(b: B):
-    assert_type(b.x, int | None)
+    assert_type(b.x, int)
     "#,
 );
 
@@ -993,7 +993,31 @@ class D(C):
     x = [B()]
 
 def f(d: D):
-    assert_type(d.x, list[A])
+    assert_type(d.x, list[B])
+    "#,
+);
+
+testcase!(
+    test_class_variable_override_with_subclass,
+    r#"
+class Request:
+    @classmethod
+    def make(cls) -> "Request":
+        return cls()
+
+class FormRequest(Request):
+    @classmethod
+    def from_response(cls) -> "FormRequest":
+        return cls()
+
+class BaseTest:
+    request_class = Request
+
+class MyTest(BaseTest):
+    request_class = FormRequest
+
+    def test(self) -> None:
+        self.request_class.from_response()
     "#,
 );
 


### PR DESCRIPTION
Summary:
When a subclass overrides an unannotated class variable with a compatible narrower type, pyrefly was widening the child's type to the parent's type. This caused false positives when the child's narrower type has methods not present on the parent's type. For example, if a parent class has `request_class = Request` and a child overrides it with `request_class = FormRequest`, accessing `FormRequest`-specific methods like `from_response()` would produce a spurious `missing-attribute` error because pyrefly stored the type as `type[Request]` instead of `type[FormRequest]`.

The root cause was in `analyze_class_field_value`: when both parent and child lack annotations and the child's value is compatible with the parent's type, the code discarded the child's inferred type and returned the parent's type. This widening was intended to prevent invariant override errors for read-write attributes, but it loses type precision.

The fix changes the compatible branch to use the child's inferred type and sets `is_inherited = IsInherited::No` to skip the now-redundant override check (compatibility has already been validated by the `errors2.is_empty()` check). The `IsInherited` enum is documented as "only used for efficiency" — setting it to `No` just tells the override checker to skip this field, which is safe.

Differential Revision: D94992218


