### PR TITLE
fix bad-argument-type false positive in an untyped classmethod with *args #2605

### DIFF
--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -982,13 +982,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             let parent_hint = parent_param_hints
                 .as_mut()
                 .and_then(|hint| hint.take_vararg());
+            // If the first parameter is variadic, implicit self/cls is packed into *args.
+            // Don't use it as the vararg element type; consume it so it won't apply later.
+            let _ = std::mem::take(self_type);
+            let mut vararg_self_type = None;
             let ParamTypeResult {
                 ty, is_unannotated, ..
             } = self.get_param_type_and_requiredness(
                 &x.name,
                 None,
                 stub_or_impl,
-                self_type,
+                &mut vararg_self_type,
                 parent_hint,
                 errors,
             );

--- a/pyrefly/lib/test/inference.rs
+++ b/pyrefly/lib/test/inference.rs
@@ -127,6 +127,17 @@ def h(cls) -> None: ...  # E: `h` is missing an annotation for parameter `cls`
 );
 
 testcase!(
+    test_classmethod_vararg_call_does_not_bind_self,
+    r#"
+class C:
+    @classmethod
+    def create(*args, **kwargs): ...
+
+C.create(42)
+"#,
+);
+
+testcase!(
     test_implicit_any_with_complete_annotations,
     TestEnv::new().enable_implicit_any_error(),
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2605

Fixed classmethod vararg inference so implicit self/cls doesn’t get used as the `*args` element type, which was causing the false bad-argument-type on calls. 


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test