### PR TITLE
fix Allow accessing __class__ bare name #2623

### DIFF
--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -310,6 +310,18 @@ impl<'a> BindingsBuilder<'a> {
             .push_function_scope(range, func_name, class_key.is_some(), is_async);
         self.parameters(parameters, undecorated_idx, class_key, method_self_kind);
         self.init_static_scope(&body, false);
+        if let Some(class_key) = class_key
+            && !self.scopes.current_static_contains(&dunder::CLASS)
+        {
+            let implicit_range = TextRange::empty(range.start());
+            let identifier = Identifier::new(dunder::CLASS.clone(), implicit_range);
+            self.scopes.add_implicit_name_to_current_static(&identifier);
+            let idx = self.insert_binding(
+                Key::Definition(ShortIdentifier::new(&identifier)),
+                Binding::ClassDef(class_key, Box::new([])),
+            );
+            self.bind_name(&identifier.id, idx, FlowStyle::Other);
+        }
         self.stmts(
             body,
             &NestingContext::function(ShortIdentifier::new(func_name), parent.dupe()),

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -1221,6 +1221,10 @@ impl Scopes {
             .any(|scope| matches!(scope.kind, ScopeKind::Function(_) | ScopeKind::Method(_)))
     }
 
+    pub fn current_static_contains(&self, name: &Name) -> bool {
+        self.current().stat.0.contains_key(name)
+    }
+
     /// Enter a with block.
     pub fn enter_with(&mut self) {
         self.current_mut().with_depth += 1;
@@ -1954,6 +1958,18 @@ impl Scopes {
             name.range,
             StaticStyle::PossibleLegacyTParam,
         )
+    }
+
+    /// Add an implicit name to the current static scope.
+    ///
+    /// Callers must always define the name via a `Key::Definition` immediately
+    /// afterward or downstream lookups may panic.
+    pub fn add_implicit_name_to_current_static(&mut self, name: &Identifier) {
+        self.current_mut().stat.upsert(
+            Hashed::new(name.id.clone()),
+            name.range,
+            StaticStyle::SingleDef(None),
+        );
     }
 
     /// Add an adhoc name - if it does not already exist - to the current static

--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -21,6 +21,26 @@ class C:
 );
 
 testcase!(
+    test_method_can_access_dunder_class,
+    r#"
+class Base:
+    def show_class(self) -> type:
+        return __class__
+"#,
+);
+
+testcase!(
+    test_nested_function_can_access_dunder_class,
+    r#"
+class Base:
+    def show_class(self) -> type:
+        def inner() -> type:
+            return __class__
+        return inner()
+"#,
+);
+
+testcase!(
     test_unknown_name_suggests_similar,
     r#"
 long_variable_name = 1


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2623

Added an implicit `__class__` binding for method scopes (only when the method doesn’t define `__class__` itself), so bare `__class__` resolves to the class object.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added scope tests for `__class__` in method bodies and nested functions.