### PR TITLE
fix propagate narrowed types across functions #1201

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -31,6 +31,7 @@ use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::Identifier;
 use ruff_python_ast::ModModule;
 use ruff_python_ast::Parameter;
+use ruff_python_ast::Parameters;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::TypeParam;
 use ruff_python_ast::TypeParams;
@@ -248,6 +249,8 @@ pub struct BindingsBuilder<'a> {
     deferred_bound_names: Vec<DeferredBoundName>,
     /// Yield and yield-from indices for lambdas that contain yields.
     lambda_yield_keys: Vec<(TextRange, Box<[Idx<KeyYield>]>, Box<[Idx<KeyYieldFrom>]>)>,
+    /// Narrow ops extracted from assertion-only helper functions.
+    assertion_narrows: SmallMap<Idx<KeyUndecoratedFunction>, NarrowOps>,
 }
 
 /// An enum tracking whether we are in a generator expression
@@ -495,6 +498,7 @@ impl Bindings {
             semantic_syntax_errors: RefCell::new(Vec::new()),
             deferred_bound_names: Vec::new(),
             lambda_yield_keys: Vec::new(),
+            assertion_narrows: SmallMap::new(),
         };
         builder.init_static_scope(&x.body, true);
         if module_info.name() != ModuleName::builtins() {
@@ -1121,6 +1125,36 @@ impl<'a> BindingsBuilder<'a> {
             }
             NameReadInfo::NotFound => NameLookupResult::NotFound,
         }
+    }
+
+    pub(crate) fn register_assertion_narrows(
+        &mut self,
+        undecorated_idx: Idx<KeyUndecoratedFunction>,
+        narrows: NarrowOps,
+    ) {
+        self.assertion_narrows.insert(undecorated_idx, narrows);
+    }
+
+    pub(crate) fn assertion_narrows_for_call(
+        &mut self,
+        func: &Expr,
+    ) -> Option<(&NarrowOps, &Parameters)> {
+        let Expr::Name(name) = func else {
+            return None;
+        };
+        let mut usage = Usage::Narrowing(None);
+        let idx = self
+            .lookup_name(Hashed::new(&name.id), &mut usage)
+            .found()?;
+        let (_, binding) = self.get_original_binding(idx)?;
+        let Binding::Function(decorated_idx, ..) = binding? else {
+            return None;
+        };
+        let decorated = self.idx_to_binding(*decorated_idx)?;
+        let undecorated_idx = decorated.undecorated_idx;
+        let narrows = self.assertion_narrows.get(&undecorated_idx)?;
+        let undecorated = self.idx_to_binding(undecorated_idx)?;
+        Some((narrows, &undecorated.def.parameters))
     }
 
     /// Defer creation of a BoundName binding until after AST traversal.

--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -32,6 +32,7 @@ use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use starlark_map::small_map::SmallMap;
+use starlark_map::small_set::SmallSet;
 
 use crate::binding::binding::AnnotationTarget;
 use crate::binding::binding::Binding;
@@ -61,6 +62,9 @@ use crate::binding::binding::ReturnTypeKind;
 use crate::binding::bindings::BindingsBuilder;
 use crate::binding::bindings::LegacyTParamCollector;
 use crate::binding::expr::Usage;
+use crate::binding::narrow::AtomicNarrowOp;
+use crate::binding::narrow::NarrowOp;
+use crate::binding::narrow::NarrowOps;
 use crate::binding::scope::FlowStyle;
 use crate::binding::scope::InstanceAttribute;
 use crate::binding::scope::Scope;
@@ -522,6 +526,52 @@ impl<'a> BindingsBuilder<'a> {
         }
     }
 
+    fn assertion_narrows_for_body(
+        &self,
+        parameters: &Parameters,
+        body_no_docstring: &[Stmt],
+    ) -> Option<NarrowOps> {
+        let [Stmt::Assert(assert_stmt)] = body_no_docstring else {
+            return None;
+        };
+        let narrow_ops = NarrowOps::from_expr(self, Some(&assert_stmt.test));
+        if narrow_ops.0.is_empty() {
+            return None;
+        }
+        let mut param_names = SmallSet::new();
+        for param in parameters.posonlyargs.iter() {
+            param_names.insert(param.name().id.clone());
+        }
+        for param in parameters.args.iter() {
+            param_names.insert(param.name().id.clone());
+        }
+        for param in parameters.kwonlyargs.iter() {
+            param_names.insert(param.name().id.clone());
+        }
+        if let Some(vararg) = &parameters.vararg {
+            param_names.insert(vararg.name.id.clone());
+        }
+        if let Some(kwarg) = &parameters.kwarg {
+            param_names.insert(kwarg.name.id.clone());
+        }
+        for (name, (op, _)) in narrow_ops.0.iter() {
+            if !param_names.contains(name) {
+                return None;
+            }
+            if !Self::assertion_narrow_op_supported(op) {
+                return None;
+            }
+        }
+        Some(narrow_ops)
+    }
+
+    fn assertion_narrow_op_supported(op: &NarrowOp) -> bool {
+        match op {
+            NarrowOp::Atomic(None, AtomicNarrowOp::Call(..)) => true,
+            NarrowOp::Atomic(_, _) | NarrowOp::And(_) | NarrowOp::Or(_) => false,
+        }
+    }
+
     fn function_body(
         &mut self,
         parameters: &mut Box<Parameters>,
@@ -534,7 +584,11 @@ impl<'a> BindingsBuilder<'a> {
         parent: &NestingContext,
         undecorated_idx: Idx<KeyUndecoratedFunction>,
         class_key: Option<Idx<KeyClass>>,
-    ) -> (FunctionStubOrImpl, Option<SelfAssignments>) {
+    ) -> (
+        FunctionStubOrImpl,
+        Option<SelfAssignments>,
+        Option<NarrowOps>,
+    ) {
         // If the first statement in the body is a docstring, remove it
         let body_no_docstring = if let Some(s) = body.first()
             && is_docstring(s)
@@ -582,6 +636,14 @@ impl<'a> BindingsBuilder<'a> {
         } else {
             FunctionStubOrImpl::Impl
         };
+        let skip_body_checks = decorators.has_no_type_check
+            || (self.untyped_def_behavior == UntypedDefBehavior::SkipAndInferReturnAny
+                && !is_annotated(&return_ann_with_range, parameters));
+        let assertion_narrows = if stub_or_impl == FunctionStubOrImpl::Impl && !skip_body_checks {
+            self.assertion_narrows_for_body(parameters, body_no_docstring)
+        } else {
+            None
+        };
         let should_report_unused_parameters = stub_or_impl == FunctionStubOrImpl::Impl
             && !body_is_trivial
             && !body_is_not_implemented
@@ -598,10 +660,7 @@ impl<'a> BindingsBuilder<'a> {
             MethodSelfKind::Instance
         };
 
-        let self_assignments = if decorators.has_no_type_check
-            || (self.untyped_def_behavior == UntypedDefBehavior::SkipAndInferReturnAny
-                && !is_annotated(&return_ann_with_range, parameters))
-        {
+        let self_assignments = if skip_body_checks {
             self.mark_as_returns_any(func_name);
             self.unchecked_function_body_scope(
                 parameters,
@@ -704,7 +763,7 @@ impl<'a> BindingsBuilder<'a> {
             }
         };
 
-        (stub_or_impl, self_assignments)
+        (stub_or_impl, self_assignments, assertion_narrows)
     }
 
     pub fn function_def(&mut self, mut x: StmtFunctionDef, parent: &NestingContext) {
@@ -738,7 +797,7 @@ impl<'a> BindingsBuilder<'a> {
         let decorators = self.decorators(mem::take(&mut x.decorator_list), def_idx.usage());
 
         let docstring_range = Docstring::range_from_stmts(x.body.as_slice());
-        let (stub_or_impl, self_assignments) = self.function_body(
+        let (stub_or_impl, self_assignments, assertion_narrows) = self.function_body(
             &mut x.parameters,
             mem::take(&mut x.body),
             &decorators,
@@ -750,6 +809,9 @@ impl<'a> BindingsBuilder<'a> {
             undecorated_idx,
             class_key,
         );
+        if let Some(assertion_narrows) = assertion_narrows {
+            self.register_assertion_narrows(undecorated_idx, assertion_narrows);
+        }
 
         // Pop the annotation scope to get back to the parent scope, and handle this
         // case where we need to track assignments to `self` from methods.

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -55,9 +55,12 @@ use crate::binding::bindings::BindingsBuilder;
 use crate::binding::bindings::LegacyTParamCollector;
 use crate::binding::bindings::NameLookupResult;
 use crate::binding::expr::Usage;
+use crate::binding::narrow::FacetOrigin;
+use crate::binding::narrow::FacetSubject;
 use crate::binding::narrow::NarrowOp;
 use crate::binding::narrow::NarrowOps;
 use crate::binding::narrow::NarrowingSubject;
+use crate::binding::narrow::identifier_and_chain_for_expr;
 use crate::binding::scope::FlowStyle;
 use crate::binding::scope::LoopExit;
 use crate::binding::scope::Scope;
@@ -118,6 +121,20 @@ fn is_definitely_nonempty_iterable(iter: &Expr) -> bool {
     }
 }
 
+fn narrowing_subject_for_argument(arg: &Expr) -> Option<NarrowingSubject> {
+    if let Expr::Name(name) = arg {
+        return Some(NarrowingSubject::Name(name.id.clone()));
+    }
+    let (identifier, chain) = identifier_and_chain_for_expr(arg)?;
+    Some(NarrowingSubject::Facets(
+        identifier.id,
+        FacetSubject {
+            chain,
+            origin: FacetOrigin::Direct,
+        },
+    ))
+}
+
 impl<'a> BindingsBuilder<'a> {
     fn assert(&mut self, assert_range: TextRange, mut test: Expr, msg: Option<Expr>) {
         let test_range = test.range();
@@ -151,6 +168,55 @@ impl<'a> BindingsBuilder<'a> {
         );
         if let Some(false) = static_test {
             self.scopes.mark_flow_termination(true);
+        }
+    }
+
+    fn apply_assertion_narrows_from_call(
+        &mut self,
+        call_range: TextRange,
+        func: &Expr,
+        arguments: &Arguments,
+    ) {
+        let Some((assertion_narrows, parameters)) = self.assertion_narrows_for_call(func) else {
+            return;
+        };
+        if parameters.vararg.is_some() || parameters.kwarg.is_some() {
+            return;
+        }
+        if !arguments.keywords.is_empty() {
+            return;
+        }
+        let mut positional_params = Vec::new();
+        positional_params.extend(parameters.posonlyargs.iter().map(|p| p.name()));
+        positional_params.extend(parameters.args.iter().map(|p| p.name()));
+        if arguments.args.len() > positional_params.len() {
+            return;
+        }
+        let mut call_narrows = NarrowOps::new();
+        for (param_name, (op, _)) in assertion_narrows.0.iter() {
+            let param_index = match positional_params
+                .iter()
+                .position(|param| param.id == *param_name)
+            {
+                Some(index) => index,
+                None => return,
+            };
+            let arg = match arguments.args.get(param_index) {
+                Some(arg) => arg,
+                None => return,
+            };
+            let subject = match narrowing_subject_for_argument(arg) {
+                Some(subject) => subject,
+                None => return,
+            };
+            call_narrows.and_for_subject(&subject, op.for_subject(&subject), call_range);
+        }
+        if !call_narrows.0.is_empty() {
+            self.bind_narrow_ops(
+                &call_narrows,
+                NarrowUseLocation::Span(call_range),
+                &Usage::Narrowing(None),
+            );
         }
     }
 
@@ -1300,6 +1366,15 @@ impl<'a> BindingsBuilder<'a> {
             Stmt::Expr(mut x) => {
                 let mut current = self.declare_current_idx(Key::StmtExpr(x.value.range()));
                 self.ensure_expr(&mut x.value, current.usage());
+                if let Expr::Call(ExprCall {
+                    range: call_range,
+                    func,
+                    arguments,
+                    ..
+                }) = &*x.value
+                {
+                    self.apply_assertion_narrows_from_call(*call_range, func, arguments);
+                }
                 let special_export = if let Expr::Call(ExprCall { func, .. }) = &*x.value {
                     self.as_special_export(func)
                 } else {

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -1233,6 +1233,19 @@ def f(x:  A | B | C, y: A | C):
 );
 
 testcase!(
+    test_assertion_function_narrows_argument,
+    r#"
+from typing import assert_type
+def assert_int(x: object):
+    assert isinstance(x, int)
+
+def f(x: object):
+    assert_int(x)
+    assert_type(x, int)
+    "#,
+);
+
+testcase!(
     test_narrow_and,
     r#"
 from typing import assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1201

Implemented assertion-only helper narrowing across call sites, so a def f(x): assert isinstance(x, int) now narrows the caller’s argument after f(x) when used as a statement. This is recorded during binding and applied in Stmt::Expr calls.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added a regression test that matches the issue example.