### PR TITLE
fix LSP: Completions for attribute override definitions #2431

### DIFF
--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -863,25 +863,12 @@ impl Transaction<'_> {
         handle: &Handle,
         base_type: Type,
         expected_type: Option<&Type>,
-        filter: Option<&Identifier>,
         completions: &mut Vec<RankedCompletion>,
     ) {
         self.ad_hoc_solve(handle, "completion_attributes", |solver| {
-            let matcher = filter.map(|_| SkimMatcherV2::default().smart_case());
             solver
                 .completions(base_type, None, true)
                 .iter()
-                .filter(|attr| {
-                    if let Some(filter) = filter
-                        && let Some(ref matcher) = matcher
-                    {
-                        matcher
-                            .fuzzy_match(attr.name.as_str(), filter.as_str())
-                            .is_some()
-                    } else {
-                        true
-                    }
-                })
                 .for_each(|attr| {
                     let kind = match attr.ty {
                         Some(Type::BoundMethod(_)) => Some(CompletionItemKind::METHOD),
@@ -950,12 +937,18 @@ impl Transaction<'_> {
         let Some(class_type) = self.get_type(handle, &key) else {
             return;
         };
+        let mut attribute_completions = Vec::new();
         self.add_attribute_completions_for_type(
             handle,
             class_type,
             None,
-            Some(identifier),
-            completions,
+            &mut attribute_completions,
+        );
+        let prefix = identifier.as_str();
+        completions.extend(
+            attribute_completions
+                .into_iter()
+                .filter(|item| item.item.label.starts_with(prefix)),
         );
     }
 
@@ -1104,7 +1097,6 @@ impl Transaction<'_> {
                         handle,
                         base_type,
                         expected_type.as_ref(),
-                        None,
                         &mut result,
                     );
                 }

--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -21,6 +21,7 @@ use pyrefly_python::dunder;
 use pyrefly_python::keywords::get_keywords;
 use pyrefly_python::module::Module;
 use pyrefly_python::module_name::ModuleName;
+use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_types::display::LspDisplayMode;
 use pyrefly_types::literal::Lit;
 use pyrefly_types::types::Union;
@@ -29,6 +30,7 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::ExprContext;
 use ruff_python_ast::Identifier;
 use ruff_python_ast::ModModule;
+use ruff_python_ast::StmtClassDef;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
@@ -836,6 +838,127 @@ impl Transaction<'_> {
         }
     }
 
+    fn enclosing_class_def_for_completion(
+        ast: &ModModule,
+        position: TextSize,
+    ) -> Option<(&StmtClassDef, bool)> {
+        let covering_nodes = Ast::locate_node(ast, position);
+        let mut saw_function = false;
+        for node in covering_nodes.iter() {
+            match node {
+                AnyNodeRef::StmtFunctionDef(_) => {
+                    saw_function = true;
+                }
+                AnyNodeRef::StmtClassDef(class_def) => {
+                    return Some((class_def, saw_function));
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    fn add_attribute_completions_for_type(
+        &self,
+        handle: &Handle,
+        base_type: Type,
+        expected_type: Option<&Type>,
+        filter: Option<&Identifier>,
+        completions: &mut Vec<RankedCompletion>,
+    ) {
+        self.ad_hoc_solve(handle, "completion_attributes", |solver| {
+            let matcher = filter.map(|_| SkimMatcherV2::default().smart_case());
+            solver
+                .completions(base_type, None, true)
+                .iter()
+                .filter(|attr| {
+                    if let Some(filter) = filter
+                        && let Some(ref matcher) = matcher
+                    {
+                        matcher
+                            .fuzzy_match(attr.name.as_str(), filter.as_str())
+                            .is_some()
+                    } else {
+                        true
+                    }
+                })
+                .for_each(|attr| {
+                    let kind = match attr.ty {
+                        Some(Type::BoundMethod(_)) => Some(CompletionItemKind::METHOD),
+                        Some(Type::Function(_) | Type::Overload(_)) => {
+                            Some(CompletionItemKind::FUNCTION)
+                        }
+                        Some(Type::Module(_)) => Some(CompletionItemKind::MODULE),
+                        Some(Type::ClassDef(_)) => Some(CompletionItemKind::CLASS),
+                        _ => Some(CompletionItemKind::FIELD),
+                    };
+                    let detail = attr
+                        .ty
+                        .clone()
+                        .map(|t| t.as_lsp_string(LspDisplayMode::Hover));
+                    let documentation = self.get_docstring_for_attribute(handle, attr);
+                    let is_incompatible = self.is_incompatible_with_expected_type(
+                        handle,
+                        expected_type,
+                        attr.ty.as_ref(),
+                    );
+                    let source = if attr.is_reexport {
+                        CompletionSource::Reexport
+                    } else {
+                        CompletionSource::Local
+                    };
+                    completions.push(RankedCompletion {
+                        item: CompletionItem {
+                            label: attr.name.as_str().to_owned(),
+                            detail,
+                            kind,
+                            documentation,
+                            tags: if attr.is_deprecated {
+                                Some(vec![CompletionItemTag::DEPRECATED])
+                            } else {
+                                None
+                            },
+                            ..Default::default()
+                        },
+                        source,
+                        is_incompatible,
+                    });
+                });
+        });
+    }
+
+    fn add_class_body_override_completions(
+        &self,
+        handle: &Handle,
+        position: TextSize,
+        identifier: &Identifier,
+        allow_inside_function: bool,
+        completions: &mut Vec<RankedCompletion>,
+    ) {
+        let Some(ast) = self.get_ast(handle) else {
+            return;
+        };
+        let Some((class_def, saw_function)) =
+            Self::enclosing_class_def_for_completion(ast.as_ref(), position)
+        else {
+            return;
+        };
+        if saw_function && !allow_inside_function {
+            return;
+        }
+        let key = Key::Definition(ShortIdentifier::new(&class_def.name));
+        let Some(class_type) = self.get_type(handle, &key) else {
+            return;
+        };
+        self.add_attribute_completions_for_type(
+            handle,
+            class_type,
+            None,
+            Some(identifier),
+            completions,
+        );
+    }
+
     /// Core completion implementation returning items and incomplete flag.
     pub(crate) fn completion_sorted_opt_with_incomplete<F>(
         &self,
@@ -977,52 +1100,13 @@ impl Transaction<'_> {
                 if let Some(answers) = self.get_answers(handle)
                     && let Some(base_type) = answers.get_type_trace(base_range)
                 {
-                    self.ad_hoc_solve(handle, "completion_attributes", |solver| {
-                        solver
-                            .completions(base_type, None, true)
-                            .iter()
-                            .for_each(|x| {
-                                let kind = match x.ty {
-                                    Some(Type::BoundMethod(_)) => Some(CompletionItemKind::METHOD),
-                                    Some(Type::Function(_) | Type::Overload(_)) => {
-                                        Some(CompletionItemKind::FUNCTION)
-                                    }
-                                    Some(Type::Module(_)) => Some(CompletionItemKind::MODULE),
-                                    Some(Type::ClassDef(_)) => Some(CompletionItemKind::CLASS),
-                                    _ => Some(CompletionItemKind::FIELD),
-                                };
-                                let ty = &x.ty;
-                                let detail =
-                                    ty.clone().map(|t| t.as_lsp_string(LspDisplayMode::Hover));
-                                let documentation = self.get_docstring_for_attribute(handle, x);
-                                let is_incompatible = self.is_incompatible_with_expected_type(
-                                    handle,
-                                    expected_type.as_ref(),
-                                    ty.as_ref(),
-                                );
-                                let source = if x.is_reexport {
-                                    CompletionSource::Reexport
-                                } else {
-                                    CompletionSource::Local
-                                };
-                                result.push(RankedCompletion {
-                                    item: CompletionItem {
-                                        label: x.name.as_str().to_owned(),
-                                        detail,
-                                        kind,
-                                        documentation,
-                                        tags: if x.is_deprecated {
-                                            Some(vec![CompletionItemTag::DEPRECATED])
-                                        } else {
-                                            None
-                                        },
-                                        ..Default::default()
-                                    },
-                                    source,
-                                    is_incompatible,
-                                });
-                            });
-                    });
+                    self.add_attribute_completions_for_type(
+                        handle,
+                        base_type,
+                        expected_type.as_ref(),
+                        None,
+                        &mut result,
+                    );
                 }
             }
             Some(IdentifierWithContext {
@@ -1045,6 +1129,17 @@ impl Transaction<'_> {
                 }
                 if matches!(context, IdentifierContext::MethodDef { .. }) {
                     Self::add_magic_method_completions(&identifier, &mut result);
+                }
+                if matches!(context, IdentifierContext::MethodDef { .. })
+                    || matches!(context, IdentifierContext::Expr(ExprContext::Store))
+                {
+                    self.add_class_body_override_completions(
+                        handle,
+                        position,
+                        &identifier,
+                        matches!(context, IdentifierContext::MethodDef { .. }),
+                        &mut result,
+                    );
                 }
                 self.add_kwargs_completions(handle, position, &mut result);
                 Self::add_keyword_completions(handle, &mut result);

--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -838,11 +838,9 @@ impl Transaction<'_> {
         }
     }
 
-    fn enclosing_class_def_for_completion(
-        ast: &ModModule,
-        position: TextSize,
-    ) -> Option<(&StmtClassDef, bool)> {
-        let covering_nodes = Ast::locate_node(ast, position);
+    fn enclosing_class_def_for_completion<'a>(
+        covering_nodes: &'a [AnyNodeRef<'a>],
+    ) -> Option<(&'a StmtClassDef, bool)> {
         let mut saw_function = false;
         for node in covering_nodes.iter() {
             match node {
@@ -917,16 +915,13 @@ impl Transaction<'_> {
     fn add_class_body_override_completions(
         &self,
         handle: &Handle,
-        position: TextSize,
+        covering_nodes: &[AnyNodeRef],
         identifier: &Identifier,
         allow_inside_function: bool,
         completions: &mut Vec<RankedCompletion>,
     ) {
-        let Some(ast) = self.get_ast(handle) else {
-            return;
-        };
         let Some((class_def, saw_function)) =
-            Self::enclosing_class_def_for_completion(ast.as_ref(), position)
+            Self::enclosing_class_def_for_completion(covering_nodes)
         else {
             return;
         };
@@ -973,9 +968,16 @@ impl Transaction<'_> {
         let mut result: Vec<RankedCompletion> = Vec::new();
         let mut is_incomplete = false;
         let mut allow_function_call_parens = false;
+        let ast = self.get_ast(handle);
+        let covering_nodes = ast
+            .as_ref()
+            .map(|module| Ast::locate_node(module.as_ref(), position));
         // Because of parser error recovery, `from x impo...` looks like `from x import impo...`
         // If the user might be typing the `import` keyword, add that as an autocomplete option.
-        match self.identifier_at(handle, position) {
+        match covering_nodes
+            .as_deref()
+            .and_then(Self::identifier_from_covering_nodes)
+        {
             Some(IdentifierWithContext {
                 identifier,
                 context:
@@ -1122,12 +1124,13 @@ impl Transaction<'_> {
                 if matches!(context, IdentifierContext::MethodDef { .. }) {
                     Self::add_magic_method_completions(&identifier, &mut result);
                 }
-                if matches!(context, IdentifierContext::MethodDef { .. })
-                    || matches!(context, IdentifierContext::Expr(ExprContext::Store))
+                if (matches!(context, IdentifierContext::MethodDef { .. })
+                    || matches!(context, IdentifierContext::Expr(ExprContext::Store)))
+                    && let Some(covering_nodes) = covering_nodes.as_deref()
                 {
                     self.add_class_body_override_completions(
                         handle,
-                        position,
+                        covering_nodes,
                         &identifier,
                         matches!(context, IdentifierContext::MethodDef { .. }),
                         &mut result,
@@ -1169,9 +1172,10 @@ impl Transaction<'_> {
             }
             None => {
                 // todo(kylei): optimization, avoid duplicate ast walkss
-                if let Some(mod_module) = self.get_ast(handle) {
+                if let Some(mod_module) = ast.as_ref() {
                     let expected_type = self.expected_call_argument_type(handle, position);
-                    let nodes = Ast::locate_node(&mod_module, position);
+                    let nodes = covering_nodes
+                        .unwrap_or_else(|| Ast::locate_node(mod_module.as_ref(), position));
                     if nodes.is_empty() {
                         Self::add_keyword_completions(handle, &mut result);
                         self.add_local_variable_completions(

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -682,7 +682,7 @@ impl<'a> Transaction<'a> {
         Self::identifier_from_covering_nodes(&covering_nodes)
     }
 
-    fn identifier_from_covering_nodes(
+    pub(crate) fn identifier_from_covering_nodes(
         covering_nodes: &[AnyNodeRef],
     ) -> Option<IdentifierWithContext> {
         match (

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -1211,6 +1211,65 @@ Completion Results:
 }
 
 #[test]
+fn completion_class_override_members() {
+    let code = r#"
+from typing import *
+from abc import ABC, abstractmethod
+
+class A(ABC):
+    @property
+    @abstractmethod
+    def error_message(self):
+        """
+        Child classes must provide an error message string.
+        """
+        ...
+
+class B(A):
+    erro = ""
+#   ^
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, false);
+    let handle = handles.get("main").unwrap();
+    let position = extract_cursors_for_test(code)[0];
+    let txn = state.transaction();
+    let completions = txn.completion(handle, position, ImportFormat::Absolute, true, None);
+    assert!(
+        completions.iter().any(|item| item.label == "error_message"),
+        "Expected inherited override completion, got {:?}",
+        completions
+            .iter()
+            .map(|item| item.label.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn attribute_completion_remains_unfiltered() {
+    let code = r#"
+class A:
+    name = 1
+
+a = A()
+a.zz
+#  ^
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, false);
+    let handle = handles.get("main").unwrap();
+    let position = extract_cursors_for_test(code)[0];
+    let txn = state.transaction();
+    let completions = txn.completion(handle, position, ImportFormat::Absolute, true, None);
+    assert!(
+        completions.iter().any(|item| item.label == "name"),
+        "Expected normal attribute completions to remain unfiltered, got {:?}",
+        completions
+            .iter()
+            .map(|item| item.label.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn builtins_doesnt_autoimport() {
     let code = r#"
 isins

--- a/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
@@ -380,7 +380,7 @@ fn test_completion_class_override_members() {
     interaction.client.did_open("foo.py");
     interaction.client.did_change(
         "foo.py",
-        "from typing import *\nfrom abc import ABC, abstractmethod\n\nclass A(ABC):\n    @property\n    @abstractmethod\n    def error_message(self):\n        \"\"\"\n        Child classes must provide a error message string.\n        \"\"\"\n        ...\n\nclass B(A):\n    erro = \"\"\n",
+        "from typing import *\nfrom abc import ABC, abstractmethod\n\nclass A(ABC):\n    @property\n    @abstractmethod\n    def error_message(self):\n        \"\"\"\n        Child classes must provide an error message string.\n        \"\"\"\n        ...\n\nclass B(A):\n    erro = \"\"\n",
     );
 
     interaction

--- a/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
@@ -395,6 +395,29 @@ fn test_completion_class_override_members() {
 }
 
 #[test]
+fn test_attribute_completion_remains_unfiltered() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().join("basic"));
+    interaction
+        .initialize(InitializeSettings::default())
+        .unwrap();
+
+    interaction.client.did_open("foo.py");
+    interaction
+        .client
+        .did_change("foo.py", "class A:\n    name = 1\n\na = A()\na.zz");
+
+    interaction
+        .client
+        .completion("foo.py", 4, 4)
+        .expect_completion_response_with(|list| list.items.iter().any(|item| item.label == "name"))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
 fn test_import_completion_skips_hidden_directories() {
     let root = get_test_files_root();
     let workspace = root.path().join("basic");

--- a/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
@@ -369,6 +369,32 @@ fn test_completion_keywords() {
 }
 
 #[test]
+fn test_completion_class_override_members() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().join("basic"));
+    interaction
+        .initialize(InitializeSettings::default())
+        .unwrap();
+
+    interaction.client.did_open("foo.py");
+    interaction.client.did_change(
+        "foo.py",
+        "from typing import *\nfrom abc import ABC, abstractmethod\n\nclass A(ABC):\n    @property\n    @abstractmethod\n    def error_message(self):\n        \"\"\"\n        Child classes must provide a error message string.\n        \"\"\"\n        ...\n\nclass B(A):\n    erro = \"\"\n",
+    );
+
+    interaction
+        .client
+        .completion("foo.py", 13, 8)
+        .expect_completion_response_with(|list| {
+            list.items.iter().any(|item| item.label == "error_message")
+        })
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
 fn test_import_completion_skips_hidden_directories() {
     let root = get_test_files_root();
     let workspace = root.path().join("basic");

--- a/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
@@ -369,55 +369,6 @@ fn test_completion_keywords() {
 }
 
 #[test]
-fn test_completion_class_override_members() {
-    let root = get_test_files_root();
-    let mut interaction = LspInteraction::new();
-    interaction.set_root(root.path().join("basic"));
-    interaction
-        .initialize(InitializeSettings::default())
-        .unwrap();
-
-    interaction.client.did_open("foo.py");
-    interaction.client.did_change(
-        "foo.py",
-        "from typing import *\nfrom abc import ABC, abstractmethod\n\nclass A(ABC):\n    @property\n    @abstractmethod\n    def error_message(self):\n        \"\"\"\n        Child classes must provide an error message string.\n        \"\"\"\n        ...\n\nclass B(A):\n    erro = \"\"\n",
-    );
-
-    interaction
-        .client
-        .completion("foo.py", 13, 8)
-        .expect_completion_response_with(|list| {
-            list.items.iter().any(|item| item.label == "error_message")
-        })
-        .unwrap();
-
-    interaction.shutdown().unwrap();
-}
-
-#[test]
-fn test_attribute_completion_remains_unfiltered() {
-    let root = get_test_files_root();
-    let mut interaction = LspInteraction::new();
-    interaction.set_root(root.path().join("basic"));
-    interaction
-        .initialize(InitializeSettings::default())
-        .unwrap();
-
-    interaction.client.did_open("foo.py");
-    interaction
-        .client
-        .did_change("foo.py", "class A:\n    name = 1\n\na = A()\na.zz");
-
-    interaction
-        .client
-        .completion("foo.py", 4, 4)
-        .expect_completion_response_with(|list| list.items.iter().any(|item| item.label == "name"))
-        .unwrap();
-
-    interaction.shutdown().unwrap();
-}
-
-#[test]
 fn test_import_completion_skips_hidden_directories() {
     let root = get_test_files_root();
     let workspace = root.path().join("basic");


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2431

Added class-body completion logic to surface base-class members (filtered by the fuzzy match) and refactored attribute completion generation into a shared helper.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added an LSP interaction test for override completions.