### PR TITLE
Skip classifier comment when no diffs to classify

### DIFF
--- a/scripts/primer_classifier/__main__.py
+++ b/scripts/primer_classifier/__main__.py
@@ -91,10 +91,7 @@ def main() -> int:
     # Parse
     projects = parse_primer_diff(diff_text)
     if not projects:
-        if args.output_format == "json":
-            print('{"summary": {"total_projects": 0}, "classifications": []}')
-        else:
-            print("No diffs to classify.")
+        print("No diffs to classify.", file=sys.stderr)
         return 0
 
     print(


### PR DESCRIPTION
## Summary
- When mypy_primer reports no changes, the classifier was still printing `"No diffs to classify."` to stdout, which got captured into `classification.md` and posted as a PR comment
- Now it only logs to stderr, so the workflow's existing `body.trim()` check in `mypy_primer_classify.yml` skips posting entirely
- The raw mypy_primer comment workflow is unchanged — it still posts its own "no changes" message as before

## Test plan
- Run the classifier with an empty diff file and confirm nothing is written to stdout:
  ```
  echo "" | python -m scripts.primer_classifier --diff-file /dev/stdin --dry-run
  ```
  Should produce no stdout output (only stderr: "No diffs to classify.")