### PR TITLE
fix part of Exhaustiveness check in match statement #1286

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -276,11 +276,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         &self,
         left: &Type,
         right_expr: &Expr,
+        source: NarrowSource,
         errors: &ErrorCollector,
     ) -> Type {
+        let force_allow_negative = matches!(source, NarrowSource::Pattern);
         let mut res = Vec::new();
         for (right, allows_negative_narrow) in self.expr_as_class_info(right_expr, errors) {
             res.push(self.distribute_over_union(left, |l| {
+                let allows_negative_narrow = allows_negative_narrow || force_allow_negative;
                 if allows_negative_narrow
                     && let Some((tparams, right)) = self.unwrap_class_object_silently(&right)
                 {
@@ -1052,7 +1055,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
                 self.narrow_isinstance(ty, &right)
             }
-            AtomicNarrowOp::IsNotInstance(v, _source) => self.narrow_is_not_instance(ty, v, errors),
+            AtomicNarrowOp::IsNotInstance(v, source) => {
+                self.narrow_is_not_instance(ty, v, *source, errors)
+            }
             AtomicNarrowOp::TypeEq(v) => {
                 // If type(X) == Y then X has to be exactly Y, not a subclass of Y
                 // We can't model that, so we narrow it exactly like isinstance(X, Y)

--- a/pyrefly/lib/binding/pattern.rs
+++ b/pyrefly/lib/binding/pattern.rs
@@ -488,7 +488,6 @@ impl<'a> BindingsBuilder<'a> {
         if exhaustive {
             self.finish_exhaustive_fork();
         } else {
-            self.finish_non_exhaustive_fork(&negated_prev_ops);
             // Compute exhaustiveness info if we can determine the narrowing subject
             // and have accumulated narrow ops for it.
             let exhaustiveness_info = match_narrowing_subject.and_then(|narrowing_subject| {
@@ -511,10 +510,10 @@ impl<'a> BindingsBuilder<'a> {
                     },
                 );
             }
-            // Always create Key::Exhaustive binding for return analysis.
+            // Always create Key::Exhaustive binding for return analysis and control-flow checks.
             // When exhaustiveness_info is None, the solver will conservatively
             // assume the match is not exhaustive (resolves to Type::None).
-            self.insert_binding(
+            let exhaustive_key = self.insert_binding(
                 Key::Exhaustive(ExhaustivenessKind::Match, x.range),
                 Binding::Exhaustive(Box::new(ExhaustiveBinding {
                     kind: ExhaustivenessKind::Match,
@@ -523,6 +522,7 @@ impl<'a> BindingsBuilder<'a> {
                     exhaustiveness_info,
                 })),
             );
+            self.finish_non_exhaustive_fork(&negated_prev_ops, Some(exhaustive_key));
         }
     }
 }

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -3320,6 +3320,7 @@ impl<'a> BindingsBuilder<'a> {
         &mut self,
         negated_prev_ops_if_nonexhaustive: Option<&NarrowOps>,
         is_bool_op: bool,
+        base_termination_key: Option<Idx<Key>>,
     ) {
         let fork = self.scopes.current_mut().forks.pop().unwrap();
         assert!(
@@ -3335,6 +3336,9 @@ impl<'a> BindingsBuilder<'a> {
                 NarrowUseLocation::End(fork.range),
                 &Usage::Narrowing(None),
             );
+            if let Some(key) = base_termination_key {
+                self.scopes.current_mut().flow.last_stmt_expr = Some(key);
+            }
             self.merge_flow(fork.base, branches, fork.range, MergeStyle::Inclusive);
         } else {
             self.merge_flow(
@@ -3356,7 +3360,7 @@ impl<'a> BindingsBuilder<'a> {
     /// Panics if called when no fork is active, or if a branch is started (which
     /// means the caller forgot to call `finish_branch` and is always a bug).
     pub fn finish_exhaustive_fork(&mut self) {
-        self.finish_fork_impl(None, false)
+        self.finish_fork_impl(None, false, None)
     }
 
     /// Finish a non-exhaustive fork in which the base flow is part of the merge. It negates
@@ -3366,14 +3370,18 @@ impl<'a> BindingsBuilder<'a> {
     ///
     /// Panics if called when no fork is active, or if a branch is started (which
     /// means the caller forgot to call `finish_branch` and is always a bug).
-    pub fn finish_non_exhaustive_fork(&mut self, negated_prev_ops: &NarrowOps) {
-        self.finish_fork_impl(Some(negated_prev_ops), false)
+    pub fn finish_non_exhaustive_fork(
+        &mut self,
+        negated_prev_ops: &NarrowOps,
+        base_termination_key: Option<Idx<Key>>,
+    ) {
+        self.finish_fork_impl(Some(negated_prev_ops), false, base_termination_key)
     }
 
     /// Finish the fork for a boolean operation. This requires lax handling of
     /// possibly-uninitialized locals, see the inline comment in `FlowStyle::merge`.
     pub fn finish_bool_op_fork(&mut self) {
-        self.finish_fork_impl(None, true)
+        self.finish_fork_impl(None, true, None)
     }
 
     /// Finish a `MatchOr`, which behaves like an exhaustive fork except that we know

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -1044,7 +1044,7 @@ impl<'a> BindingsBuilder<'a> {
                 if exhaustive {
                     self.finish_exhaustive_fork();
                 } else {
-                    self.finish_non_exhaustive_fork(&negated_prev_ops);
+                    self.finish_non_exhaustive_fork(&negated_prev_ops, None);
                 }
                 // If we have a statically evaluated test like `sys.version_info`, we should set `is_definitely_unreachable` to false
                 // to reduce false positive unreachable errors, since some code paths can still be hit at runtime

--- a/pyrefly/lib/test/pattern_match.rs
+++ b/pyrefly/lib/test/pattern_match.rs
@@ -118,6 +118,50 @@ def my_method(str_or_int: str | int) -> str:
 );
 
 testcase!(
+    test_match_exhaustive_user_classes_assert_never,
+    r#"
+from typing import assert_never, assert_type
+
+class A: ...
+
+class B: ...
+
+def f0(x: A | B):
+    match x:
+        case A():
+            assert_type(x, A)
+        case B():
+            assert_type(x, B)
+        case _:
+            assert_never(x)
+"#,
+);
+
+testcase!(
+    test_match_exhaustive_enum_assign,
+    r#"
+from enum import IntEnum
+
+class Rating(IntEnum):
+    Again = 1
+    Hard = 2
+    Good = 3
+    Easy = 4
+
+def foo() -> Rating: ...
+
+def f0():
+    x = foo()
+    match x:
+        case Rating.Again:
+            y = 1
+        case Rating.Easy | Rating.Good | Rating.Hard:
+            y = 2
+    print(y)
+"#,
+);
+
+testcase!(
     test_class_match_with_args_not_exhaustive,
     r#"
 from typing import assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes part of #1286


Aligned match-case negative narrowing with Pyright’s control-flow behavior by allowing IsNotInstance from patterns to narrow even for non-final classes, which makes _ branches unreachable for exhaustive class unions.

Added a regression test that mirrors the issue scenario with user-defined classes and assert_never in the wildcard branch.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
