### PR TITLE
impl Detect editable installs and auto re-analyze on changes. #2207

### DIFF
--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -40,6 +40,7 @@ use pyrefly_python::sys_info::PythonVersion;
 use pyrefly_python::sys_info::SysInfo;
 use pyrefly_util::absolutize::Absolutize as _;
 use pyrefly_util::arc_id::ArcId;
+use pyrefly_util::editable_install::get_editable_source_paths;
 use pyrefly_util::fs_anyhow;
 use pyrefly_util::globs::FilteredGlobs;
 use pyrefly_util::globs::Glob;
@@ -1375,9 +1376,14 @@ impl ConfigFile {
                 let config_root = InternedPath::from_path(config_root);
                 result.extend(Self::metadata_watch_patterns(config_root));
             }
+            let site_packages: Vec<PathBuf> = config.site_package_path().cloned().collect();
+            let editable_paths = get_editable_source_paths(&site_packages);
+
             config
                 .search_path()
-                .chain(config.site_package_path())
+                .cloned()
+                .chain(site_packages.iter().cloned())
+                .chain(editable_paths.iter().cloned())
                 .cartesian_product(
                     PYTHON_EXTENSIONS
                         .iter()
@@ -1387,10 +1393,20 @@ impl ConfigFile {
                 )
                 .for_each(|(s, suffix)| {
                     result.insert(WatchPattern::root(
-                        InternedPath::from_path(s),
+                        InternedPath::from_path(&s),
                         format!("**/*.{suffix}"),
                     ));
                 });
+
+            for site_package_path in &site_packages {
+                let root = InternedPath::from_path(site_package_path);
+                result.insert(WatchPattern::root(root.dupe(), "**/*.pth".to_owned()));
+                result.insert(WatchPattern::root(root.dupe(), "**/*.egg-link".to_owned()));
+                result.insert(WatchPattern::root(
+                    root,
+                    "**/*.dist-info/direct_url.json".to_owned(),
+                ));
+            }
         }
 
         for source_db in source_dbs {

--- a/crates/pyrefly_util/src/editable_install.rs
+++ b/crates/pyrefly_util/src/editable_install.rs
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::LazyLock;
+
+use lsp_types::Url;
+use serde::Deserialize;
+use starlark_map::small_map::SmallMap;
+
+use crate::lock::Mutex;
+
+/// PEP 610 direct_url.json structure for detecting editable installs.
+#[derive(Deserialize)]
+struct DirectUrl {
+    url: String,
+    #[serde(default)]
+    dir_info: DirInfo,
+}
+
+#[derive(Deserialize, Default)]
+struct DirInfo {
+    #[serde(default)]
+    editable: bool,
+}
+
+/// Cache for editable source paths, keyed by sorted site-packages paths.
+/// This avoids re-scanning site-packages on every check.
+static EDITABLE_PATHS_CACHE: LazyLock<Mutex<SmallMap<Vec<PathBuf>, Vec<PathBuf>>>> =
+    LazyLock::new(|| Mutex::new(SmallMap::new()));
+
+/// Returns true if the path is an editable-install metadata file.
+pub fn is_editable_metadata_file(path: &Path) -> bool {
+    match path.file_name().and_then(|name| name.to_str()) {
+        Some("direct_url.json") => true,
+        Some(name) => name.ends_with(".pth") || name.ends_with(".egg-link"),
+        None => false,
+    }
+}
+
+/// Clear the editable source paths cache.
+pub fn clear_editable_source_paths_cache() {
+    EDITABLE_PATHS_CACHE.lock().clear();
+}
+
+/// Get editable source paths for the given site-packages, using cache.
+pub fn get_editable_source_paths(site_packages: &[PathBuf]) -> Vec<PathBuf> {
+    let mut key: Vec<PathBuf> = site_packages.to_vec();
+    key.sort();
+
+    let mut cache = EDITABLE_PATHS_CACHE.lock();
+    if let Some(paths) = cache.get(&key) {
+        return paths.clone();
+    }
+
+    let paths = detect_editable_packages(site_packages);
+    cache.insert(key, paths.clone());
+    paths
+}
+
+/// Detect editable packages by scanning site-packages for direct_url.json (PEP 610), .pth, and .egg-link files.
+fn detect_editable_packages(site_packages: &[PathBuf]) -> Vec<PathBuf> {
+    let mut editable_paths = Vec::new();
+
+    for sp in site_packages {
+        let Ok(entries) = fs::read_dir(sp) else {
+            continue;
+        };
+
+        let mut dist_info_dirs = Vec::new();
+        for entry in entries.filter_map(|e| e.ok()) {
+            let path = entry.path();
+
+            if path.is_dir() {
+                if path.extension().is_some_and(|ext| ext == "dist-info") {
+                    dist_info_dirs.push(path);
+                }
+                continue;
+            }
+
+            // Parse any .pth or .egg-link files in the site-packages root.
+            if !path.is_file() && !path.is_symlink() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if name.ends_with(".pth") {
+                editable_paths.extend(read_pth_search_paths(&path));
+            } else if name.ends_with(".egg-link")
+                && let Some(path) = read_egg_link_path(&path)
+            {
+                editable_paths.push(path);
+            }
+        }
+
+        for path in dist_info_dirs {
+            let direct_url_path = path.join("direct_url.json");
+            let Ok(content) = fs::read_to_string(&direct_url_path) else {
+                continue;
+            };
+            let Ok(direct_url) = serde_json::from_str::<DirectUrl>(&content) else {
+                continue;
+            };
+
+            if !direct_url.dir_info.editable {
+                continue;
+            }
+
+            let Ok(url) = Url::parse(&direct_url.url) else {
+                continue;
+            };
+            if url.scheme() != "file" {
+                continue;
+            }
+            let Ok(source_path) = url.to_file_path() else {
+                continue;
+            };
+            if source_path.is_dir() {
+                editable_paths.push(source_path);
+            }
+        }
+    }
+
+    editable_paths.sort();
+    editable_paths.dedup();
+    editable_paths
+}
+
+fn read_pth_search_paths(pth_file: &Path) -> Vec<PathBuf> {
+    let mut search_paths = Vec::new();
+    let Ok(metadata) = fs::metadata(pth_file) else {
+        return search_paths;
+    };
+    if metadata.len() > 64 * 1024 {
+        return search_paths;
+    }
+    let Ok(data) = fs::read_to_string(pth_file) else {
+        return search_paths;
+    };
+    let parent = pth_file.parent().unwrap_or_else(|| Path::new(""));
+    for line in data.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with("import ") {
+            continue;
+        }
+        let candidate = Path::new(trimmed);
+        let path = if candidate.is_absolute() {
+            candidate.to_path_buf()
+        } else {
+            parent.join(candidate)
+        };
+        if path.is_dir() {
+            search_paths.push(path);
+        }
+    }
+    search_paths
+}
+
+fn read_egg_link_path(egg_link: &Path) -> Option<PathBuf> {
+    let Ok(data) = fs::read_to_string(egg_link) else {
+        return None;
+    };
+    let first_line = data.lines().find(|line| !line.trim().is_empty())?;
+    let trimmed = first_line.trim();
+    let candidate = Path::new(trimmed);
+    let parent = egg_link.parent().unwrap_or_else(|| Path::new(""));
+    let path = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        parent.join(candidate)
+    };
+    if path.is_dir() { Some(path) } else { None }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use lsp_types::Url;
+
+    use super::get_editable_source_paths;
+
+    #[test]
+    fn test_get_editable_source_paths_finds_editable_package() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let site_packages = temp_dir.path().join("site-packages");
+        fs::create_dir(&site_packages).unwrap();
+
+        let dist_info = site_packages.join("mypackage-1.0.0.dist-info");
+        fs::create_dir(&dist_info).unwrap();
+
+        let source_dir = temp_dir.path().join("mypackage_source");
+        fs::create_dir(&source_dir).unwrap();
+
+        // Use Url::from_file_path to construct a proper file URL that works on all platforms
+        let source_url = Url::from_file_path(&source_dir).unwrap();
+        let direct_url_content = format!(
+            r#"{{"url": "{}", "dir_info": {{"editable": true}}}}"#,
+            source_url.as_str()
+        );
+        fs::write(dist_info.join("direct_url.json"), direct_url_content).unwrap();
+
+        let result = get_editable_source_paths(std::slice::from_ref(&site_packages));
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], source_dir);
+    }
+
+    #[test]
+    fn test_get_editable_source_paths_ignores_non_editable_package() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let site_packages = temp_dir.path().join("site-packages");
+        fs::create_dir(&site_packages).unwrap();
+
+        let dist_info = site_packages.join("requests-2.28.0.dist-info");
+        fs::create_dir(&dist_info).unwrap();
+
+        let source_dir = temp_dir.path().join("requests_source");
+        fs::create_dir(&source_dir).unwrap();
+
+        // Use Url::from_file_path to construct a proper file URL that works on all platforms
+        let source_url = Url::from_file_path(&source_dir).unwrap();
+        let direct_url_content = format!(
+            r#"{{"url": "{}", "dir_info": {{"editable": false}}}}"#,
+            source_url.as_str()
+        );
+        fs::write(dist_info.join("direct_url.json"), direct_url_content).unwrap();
+
+        let result = get_editable_source_paths(&[site_packages]);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_get_editable_source_paths_ignores_missing_direct_url_json() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let site_packages = temp_dir.path().join("site-packages");
+        fs::create_dir(&site_packages).unwrap();
+
+        let dist_info = site_packages.join("somepackage-1.0.0.dist-info");
+        fs::create_dir(&dist_info).unwrap();
+
+        let result = get_editable_source_paths(&[site_packages]);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_get_editable_source_paths_ignores_nonexistent_source_directory() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let site_packages = temp_dir.path().join("site-packages");
+        fs::create_dir(&site_packages).unwrap();
+
+        let dist_info = site_packages.join("mypackage-1.0.0.dist-info");
+        fs::create_dir(&dist_info).unwrap();
+
+        let nonexistent_path = temp_dir.path().join("does_not_exist");
+
+        // Use Url::from_file_path to construct a proper file URL that works on all platforms
+        let nonexistent_url = Url::from_file_path(&nonexistent_path).unwrap();
+        let direct_url_content = format!(
+            r#"{{"url": "{}", "dir_info": {{"editable": true}}}}"#,
+            nonexistent_url.as_str()
+        );
+        fs::write(dist_info.join("direct_url.json"), direct_url_content).unwrap();
+
+        let result = get_editable_source_paths(&[site_packages]);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_get_editable_source_paths_reads_pth_paths() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let site_packages = temp_dir.path().join("site-packages");
+        fs::create_dir(&site_packages).unwrap();
+
+        let source_dir = temp_dir.path().join("editable_source");
+        fs::create_dir(&source_dir).unwrap();
+
+        let pth_content = format!("# comment\n{}\nimport site\n", source_dir.to_string_lossy());
+        fs::write(site_packages.join("editable.pth"), pth_content).unwrap();
+
+        let result = get_editable_source_paths(&[site_packages]);
+
+        assert!(
+            result.contains(&source_dir),
+            "missing source_dir in result: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_get_editable_source_paths_reads_egg_link() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let site_packages = temp_dir.path().join("site-packages");
+        fs::create_dir(&site_packages).unwrap();
+
+        let source_dir = temp_dir.path().join("editable_source");
+        fs::create_dir(&source_dir).unwrap();
+
+        let egg_link_content = format!("{}\n", source_dir.to_string_lossy());
+        fs::write(site_packages.join("editable.egg-link"), egg_link_content).unwrap();
+
+        let result = get_editable_source_paths(&[site_packages]);
+
+        assert!(
+            result.contains(&source_dir),
+            "missing source_dir in result: {result:?}"
+        );
+    }
+}

--- a/crates/pyrefly_util/src/lib.rs
+++ b/crates/pyrefly_util/src/lib.rs
@@ -31,6 +31,7 @@ pub mod args;
 pub mod assert_size;
 pub mod demand_tree;
 pub mod display;
+pub mod editable_install;
 pub mod events;
 pub mod forgetter;
 pub mod fs_anyhow;

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -226,6 +226,8 @@ use pyrefly_python::module_name::ModuleNameWithKind;
 use pyrefly_python::module_path::ModulePath;
 use pyrefly_util::absolutize::Absolutize as _;
 use pyrefly_util::arc_id::ArcId;
+use pyrefly_util::editable_install::clear_editable_source_paths_cache;
+use pyrefly_util::editable_install::is_editable_metadata_file;
 use pyrefly_util::events::CategorizedEvents;
 use pyrefly_util::globs::FilteredGlobs;
 use pyrefly_util::globs::HiddenDirFilter;
@@ -899,6 +901,32 @@ mod tests {
     #[test]
     fn test_should_rewatch() {
         let cases = [
+            (
+                "editable path metadata",
+                CategorizedEvents {
+                    modified: vec![PathBuf::from("site-packages/editable.pth")],
+                    ..Default::default()
+                },
+                true,
+            ),
+            (
+                "editable egg link metadata",
+                CategorizedEvents {
+                    modified: vec![PathBuf::from("site-packages/editable.egg-link")],
+                    ..Default::default()
+                },
+                true,
+            ),
+            (
+                "editable direct URL metadata",
+                CategorizedEvents {
+                    modified: vec![PathBuf::from(
+                        "site-packages/editable.dist-info/direct_url.json",
+                    )],
+                    ..Default::default()
+                },
+                true,
+            ),
             (
                 "dependency metadata",
                 CategorizedEvents {
@@ -4080,7 +4108,7 @@ impl Server {
     fn should_rewatch(events: &CategorizedEvents) -> bool {
         events
             .iter()
-            .any(|path| ConfigFile::is_watched_metadata(path))
+            .any(|path| ConfigFile::is_watched_metadata(path) || is_editable_metadata_file(path))
             || !events.created.is_empty()
             || !events.removed.is_empty()
             || !events.unknown.is_empty()
@@ -4096,6 +4124,7 @@ impl Server {
         if events.is_empty() {
             return;
         }
+        let editable_metadata_changed = events.iter().any(|path| is_editable_metadata_file(path));
 
         // Log the files that changed
         let total = events.created.len()
@@ -4124,6 +4153,10 @@ impl Server {
         });
 
         let should_requery_build_system = should_requery_build_system(&events);
+
+        if editable_metadata_changed {
+            clear_editable_source_paths_cache();
+        }
 
         let rewatch = Self::should_rewatch(&events);
 

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -10,7 +10,6 @@ use std::cmp::Reverse;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::LazyLock;
 
 use dupe::Dupe;
 use fuzzy_matcher::FuzzyMatcher;
@@ -34,6 +33,7 @@ use pyrefly_python::sys_info::SysInfo;
 use pyrefly_types::function::FuncMetadata;
 use pyrefly_types::function::FunctionKind;
 use pyrefly_types::type_alias::TypeAliasData;
+use pyrefly_util::editable_install::get_editable_source_paths;
 use pyrefly_util::gas::Gas;
 use pyrefly_util::lock::Mutex;
 use pyrefly_util::prelude::SliceExt;
@@ -158,25 +158,6 @@ pub struct InlayHintConfig {
     #[serde(default = "default_true")]
     pub variable_types: bool,
 }
-
-/// PEP 610 direct_url.json structure for detecting editable installs.
-#[derive(Deserialize)]
-struct DirectUrl {
-    url: String,
-    #[serde(default)]
-    dir_info: DirInfo,
-}
-
-#[derive(Deserialize, Default)]
-struct DirInfo {
-    #[serde(default)]
-    editable: bool,
-}
-
-/// Cache for editable source paths, keyed by sorted site-packages paths.
-/// This avoids re-scanning site-packages on every check.
-static EDITABLE_PATHS_CACHE: LazyLock<Mutex<SmallMap<Vec<PathBuf>, Vec<PathBuf>>>> =
-    LazyLock::new(|| Mutex::new(SmallMap::new()));
 
 impl Default for InlayHintConfig {
     fn default() -> Self {
@@ -3934,9 +3915,9 @@ impl<'a> Transaction<'a> {
                 }
             }
 
-            // Check editable packages detected via direct_url.json (PEP 610)
+            // Check editable packages detected via direct_url.json (PEP 610), .pth, or .egg-link files.
             let site_packages: Vec<PathBuf> = config.site_package_path().cloned().collect();
-            let editable_paths = Self::get_editable_source_paths(&site_packages);
+            let editable_paths = get_editable_source_paths(&site_packages);
             for editable_path in &editable_paths {
                 if module_path.as_path().starts_with(editable_path) {
                     return true;
@@ -3945,84 +3926,6 @@ impl<'a> Transaction<'a> {
         }
 
         false
-    }
-
-    /// Detect editable packages by scanning site-packages for direct_url.json files (PEP 610).
-    fn detect_editable_packages(site_packages: &[PathBuf]) -> Vec<PathBuf> {
-        let mut editable_paths = Vec::new();
-
-        for sp in site_packages {
-            let Ok(entries) = std::fs::read_dir(sp) else {
-                continue;
-            };
-
-            for entry in entries.filter_map(|e| e.ok()) {
-                let path = entry.path();
-
-                // Look for .dist-info directories
-                if !path.is_dir() {
-                    continue;
-                }
-                if path.extension().is_none_or(|ext| ext != "dist-info") {
-                    continue;
-                }
-
-                let direct_url_path = path.join("direct_url.json");
-                let Ok(content) = std::fs::read_to_string(&direct_url_path) else {
-                    continue;
-                };
-                let Ok(direct_url) = serde_json::from_str::<DirectUrl>(&content) else {
-                    continue;
-                };
-
-                if !direct_url.dir_info.editable {
-                    continue;
-                }
-
-                // Parse the file:// URL and extract the path
-                let Ok(url) = lsp_types::Url::parse(&direct_url.url) else {
-                    continue;
-                };
-                if url.scheme() != "file" {
-                    continue;
-                }
-
-                let path_str = url.path();
-
-                // On Windows, file URLs look like file:///C:/path
-                // url.path() returns "/C:/path", we need to strip the leading "/"
-                #[cfg(windows)]
-                let path_str = path_str.strip_prefix('/').unwrap_or(path_str);
-
-                // Decode percent-encoded characters (e.g., %20 -> space)
-                let Ok(decoded) = percent_encoding::percent_decode_str(path_str).decode_utf8()
-                else {
-                    continue;
-                };
-
-                let source_path = PathBuf::from(decoded.as_ref());
-                if source_path.is_dir() {
-                    editable_paths.push(source_path);
-                }
-            }
-        }
-
-        editable_paths
-    }
-
-    /// Get editable source paths for the given site-packages, using cache.
-    fn get_editable_source_paths(site_packages: &[PathBuf]) -> Vec<PathBuf> {
-        let mut key: Vec<PathBuf> = site_packages.to_vec();
-        key.sort();
-
-        let mut cache = EDITABLE_PATHS_CACHE.lock();
-        if let Some(paths) = cache.get(&key) {
-            return paths.clone();
-        }
-
-        let paths = Self::detect_editable_packages(site_packages);
-        cache.insert(key, paths.clone());
-        paths
     }
 
     pub fn prepare_rename(&self, handle: &Handle, position: TextSize) -> Option<TextRange> {
@@ -5636,95 +5539,5 @@ mod tests {
     fn match_summary(params: &[Param], idx: usize) -> Option<(&str, bool)> {
         Transaction::<'static>::param_name_for_positional_argument(params, idx)
             .map(|match_| (match_.name.as_str(), match_.is_vararg_repeat))
-    }
-
-    #[test]
-    fn test_get_editable_source_paths_finds_editable_package() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let site_packages = temp_dir.path().join("site-packages");
-        fs::create_dir(&site_packages).unwrap();
-
-        let dist_info = site_packages.join("mypackage-1.0.0.dist-info");
-        fs::create_dir(&dist_info).unwrap();
-
-        let source_dir = temp_dir.path().join("mypackage_source");
-        fs::create_dir(&source_dir).unwrap();
-
-        // Use Url::from_file_path to construct a proper file URL that works on all platforms
-        let source_url = lsp_types::Url::from_file_path(&source_dir).unwrap();
-        let direct_url_content = format!(
-            r#"{{"url": "{}", "dir_info": {{"editable": true}}}}"#,
-            source_url.as_str()
-        );
-        fs::write(dist_info.join("direct_url.json"), direct_url_content).unwrap();
-
-        let result =
-            Transaction::<'static>::get_editable_source_paths(std::slice::from_ref(&site_packages));
-
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0], source_dir);
-    }
-
-    #[test]
-    fn test_get_editable_source_paths_ignores_non_editable_package() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let site_packages = temp_dir.path().join("site-packages");
-        fs::create_dir(&site_packages).unwrap();
-
-        let dist_info = site_packages.join("requests-2.28.0.dist-info");
-        fs::create_dir(&dist_info).unwrap();
-
-        let source_dir = temp_dir.path().join("requests_source");
-        fs::create_dir(&source_dir).unwrap();
-
-        // Use Url::from_file_path to construct a proper file URL that works on all platforms
-        let source_url = lsp_types::Url::from_file_path(&source_dir).unwrap();
-        let direct_url_content = format!(
-            r#"{{"url": "{}", "dir_info": {{"editable": false}}}}"#,
-            source_url.as_str()
-        );
-        fs::write(dist_info.join("direct_url.json"), direct_url_content).unwrap();
-
-        let result = Transaction::<'static>::get_editable_source_paths(&[site_packages]);
-
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn test_get_editable_source_paths_ignores_missing_direct_url_json() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let site_packages = temp_dir.path().join("site-packages");
-        fs::create_dir(&site_packages).unwrap();
-
-        let dist_info = site_packages.join("somepackage-1.0.0.dist-info");
-        fs::create_dir(&dist_info).unwrap();
-
-        let result = Transaction::<'static>::get_editable_source_paths(&[site_packages]);
-
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn test_get_editable_source_paths_ignores_nonexistent_source_directory() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let site_packages = temp_dir.path().join("site-packages");
-        fs::create_dir(&site_packages).unwrap();
-
-        let dist_info = site_packages.join("mypackage-1.0.0.dist-info");
-        fs::create_dir(&dist_info).unwrap();
-
-        let nonexistent_path = temp_dir.path().join("does_not_exist");
-
-        // Use Url::from_file_path to construct a proper file URL that works on all platforms
-        let nonexistent_url = lsp_types::Url::from_file_path(&nonexistent_path).unwrap();
-        let direct_url_content = format!(
-            r#"{{"url": "{}", "dir_info": {{"editable": true}}}}"#,
-            nonexistent_url.as_str()
-        );
-        fs::write(dist_info.join("direct_url.json"), direct_url_content).unwrap();
-
-        let result = Transaction::<'static>::get_editable_source_paths(&[site_packages]);
-
-        assert!(result.is_empty());
     }
 }

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -43,6 +43,8 @@ use pyrefly_util::arc_id::ArcId;
 use pyrefly_util::demand_tree::DemandCollector;
 use pyrefly_util::demand_tree::DemandEdge;
 use pyrefly_util::demand_tree::DemandSpan;
+use pyrefly_util::editable_install::clear_editable_source_paths_cache;
+use pyrefly_util::editable_install::is_editable_metadata_file;
 use pyrefly_util::events::CategorizedEvents;
 use pyrefly_util::fs_anyhow;
 use pyrefly_util::lock::Mutex;
@@ -2359,6 +2361,9 @@ impl<'a> Transaction<'a> {
         let watched_metadata_changed = events
             .iter()
             .any(|path| ConfigFile::is_watched_metadata(path));
+        if events.iter().any(|path| is_editable_metadata_file(path)) {
+            clear_editable_source_paths_cache();
+        }
 
         // If any files were added or removed, we need to invalidate the find step.
         if !events.created.is_empty() || !events.removed.is_empty() || !events.unknown.is_empty() {


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes part of #2207

Added a shared editable-install detector (direct_url.json, .pth, .egg-link) with caching and tests, and wired LSP “source vs third-party” logic to use it.

Extended LSP watch patterns to include editable source roots plus editable metadata files, and rewatch/invalidate when those metadata files change.

Cleared editable-path cache on watch events (LSP + CLI watch) so changes pick up new editable roots.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test