### PR TITLE
Seed flow entries for implicit captures at function scope creation

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -1115,6 +1115,27 @@ impl<'a> BindingsBuilder<'a> {
         self.bind_name(&name.id, idx, FlowStyle::Other);
     }
 
+    /// For names that are read but not locally-defined (implicit captures),
+    /// this method creates flow entries pointing to the outer scope's binding.
+    pub fn seed_captured_variables(&mut self) {
+        let captures = self.scopes.implicit_capture_names();
+        for name in captures.into_iter() {
+            let hashed_name = Hashed::new(&name);
+            let name_read_info = self
+                .scopes
+                .look_up_name_for_read(hashed_name, &Usage::Narrowing(None));
+            if let NameReadInfo::Anywhere { key, .. } = name_read_info {
+                let idx = self.idx_for_promise(key);
+                let style = self
+                    .scopes
+                    .flow_style_for_name(&name)
+                    .map(FlowStyle::assume_initialized)
+                    .unwrap_or(FlowStyle::Other);
+                self.scopes.define_in_current_flow(hashed_name, idx, style);
+            }
+        }
+    }
+
     /// Look up a name in scope, marking it as used, but without first-use detection.
     ///
     /// This is the primary lookup method for deferred BoundName creation.

--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -311,6 +311,7 @@ impl<'a> BindingsBuilder<'a> {
             .push_function_scope(range, func_name, class_key.is_some(), is_async);
         self.parameters(parameters, undecorated_idx, class_key, method_self_kind);
         self.init_static_scope(&body, false);
+        self.seed_captured_variables();
         if class_key.is_some() && !self.scopes.current_static_contains(&dunder::CLASS) {
             let implicit_range = TextRange::empty(range.start());
             let dunder_class_identifier = Identifier::new(dunder::CLASS.clone(), implicit_range);

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -716,6 +716,24 @@ impl FlowStyle {
             }
         }
     }
+
+    // Transform uninitialized flow styles to FlowStyle::Other
+    // This lets us assume captured variables exist in nested scopes
+    pub fn assume_initialized(self) -> Self {
+        match self {
+            FlowStyle::Import(..)
+            | FlowStyle::ImportAs(_)
+            | FlowStyle::MergeableImport(_)
+            | FlowStyle::FunctionDef { .. }
+            | FlowStyle::ClassDef
+            | FlowStyle::ClassField { .. }
+            | FlowStyle::LoopRecursion
+            | FlowStyle::Other => self,
+            FlowStyle::Uninitialized
+            | FlowStyle::PossiblyUninitialized
+            | FlowStyle::MaybeInitialized { .. } => FlowStyle::Other,
+        }
+    }
 }
 
 /// Because of complications related both to recursion in the binding graph and to
@@ -1231,6 +1249,19 @@ impl Scopes {
 
     pub fn clone_current_flow(&self) -> Flow {
         self.current().flow.clone()
+    }
+
+    /// Returns names that are implicit captures in the current scope:
+    /// read in the body but not locally defined (not in static definitions).
+    /// Parameters are excluded because they are in static definitions.
+    pub fn implicit_capture_names(&self) -> SmallSet<Name> {
+        let scope = self.current();
+        scope
+            .implicit_captures
+            .iter()
+            .filter(|name| scope.stat.0.get_hashed(Hashed::new(*name)).is_none())
+            .cloned()
+            .collect()
     }
 
     pub fn in_class_body(&self) -> bool {
@@ -1823,6 +1854,15 @@ impl Scopes {
         let info = self.get_flow_info(name)?;
         let value = info.value()?;
         Some((value.idx, value.style.clone()))
+    }
+
+    /// Look up the FlowStyle for `name`, skipping class body scopes
+    pub fn flow_style_for_name(&self, name: &Name) -> Option<FlowStyle> {
+        let hashed = Hashed::new(name);
+        self.visit_scopes(|_, scope, _| {
+            let value = scope.flow.get_info_hashed(hashed)?.value()?;
+            Some(value.style.clone())
+        })
     }
 
     /// Look up either `name` or `base_name.name` in the current scope, assuming we are

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -364,6 +364,8 @@ impl Static {
         }
     }
 
+    /// Populate static definitions from a list of statements.
+    /// Returns the set of implicit captures (names read but not locally defined).
     fn stmts(
         &mut self,
         x: &[Stmt],
@@ -373,7 +375,7 @@ impl Static {
         sys_info: &SysInfo,
         get_annotation_idx: &mut impl FnMut(ShortIdentifier) -> Idx<KeyAnnotation>,
         scopes: Option<&Scopes>,
-    ) {
+    ) -> SmallSet<Name> {
         let mut d = Definitions::new(
             x,
             module_info.name(),
@@ -386,6 +388,8 @@ impl Static {
             }
             d.inject_implicit_globals();
         }
+
+        let implicit_captures = d.implicit_captures();
 
         let mut all_wildcards = Vec::with_capacity(d.import_all.len());
         for (m, range) in d.import_all {
@@ -419,6 +423,7 @@ impl Static {
                 self.upsert(name.cloned(), range, StaticStyle::MergeableImport)
             }
         }
+        implicit_captures
     }
 
     fn expr_lvalue(&mut self, x: &Expr) {
@@ -1037,6 +1042,10 @@ pub struct Scope {
     finally_depth: usize,
     /// Depth of with blocks we're in. Resets in new function scopes.
     with_depth: usize,
+    /// Names that are read but not locally defined in this scope — implicit captures
+    /// from enclosing scopes. Populated during `init_current_static` from the
+    /// `Definitions` phase. Used to seed flow entries for captured variables.
+    implicit_captures: SmallSet<Name>,
 }
 
 impl Scope {
@@ -1054,6 +1063,7 @@ impl Scope {
             variables: SmallMap::new(),
             finally_depth: 0,
             with_depth: 0,
+            implicit_captures: SmallSet::new(),
         }
     }
 
@@ -1401,7 +1411,7 @@ impl Scopes {
         get_annotation_idx: &mut impl FnMut(ShortIdentifier) -> Idx<KeyAnnotation>,
     ) {
         let mut initialize = |scope: &mut Scope, myself: Option<&Self>| {
-            scope.stat.stmts(
+            let implicit_captures = scope.stat.stmts(
                 x,
                 module_info,
                 top_level,
@@ -1410,6 +1420,7 @@ impl Scopes {
                 get_annotation_idx,
                 myself,
             );
+            scope.implicit_captures = implicit_captures;
             // Presize the flow, as its likely to need as much space as static
             scope.flow.info.reserve(scope.stat.0.capacity());
         };

--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -159,6 +159,9 @@ pub struct Definitions {
     pub final_names: SmallSet<Name>,
     /// Special exports defined in this module
     pub special_exports: SmallMap<Name, SpecialExport>,
+    /// Names that are read (not just defined) in this scope.
+    /// Used to compute implicit captures when entering nested function scopes.
+    pub name_reads: SmallSet<Name>,
 }
 
 /// Whether `__all__` was explicitly defined by the user or synthesized from module definitions.
@@ -376,6 +379,16 @@ impl Definitions {
                     .push(DunderAllEntry::Name(def.range, name.clone()));
             }
         }
+    }
+
+    /// Names that are read but not locally defined in this scope.
+    /// These are implicit captures from enclosing scopes.
+    pub fn implicit_captures(&self) -> SmallSet<Name> {
+        self.name_reads
+            .iter()
+            .filter(|name| !self.definitions.contains_key(name.as_str()))
+            .cloned()
+            .collect()
     }
 
     /// Add these names to `dunder_all`, if they are defined in the module.
@@ -789,29 +802,35 @@ impl<'a> DefinitionsBuilder<'a> {
                     self.named_in_expr(c);
                 }
             }
-            Stmt::Return(..)
-            | Stmt::Pass(..)
-            | Stmt::Break(..)
-            | Stmt::Continue(..)
-            | Stmt::IpyEscapeCommand(..) => {}
+            Stmt::Return(x) => {
+                if let Some(value) = &x.value {
+                    self.named_in_expr(value);
+                }
+            }
+            Stmt::Pass(..) | Stmt::Break(..) | Stmt::Continue(..) | Stmt::IpyEscapeCommand(..) => {}
         }
         x.recurse(&mut |xs| self.stmt(xs))
     }
 
-    /// Accumulate names defined by walrus operators in an expression.
+    /// Accumulate names defined by walrus operators in an expression,
+    /// and collect all name reads for implicit capture analysis.
     fn named_in_expr(&mut self, x: &Expr) {
         match x {
             Expr::Named(expr_named) => {
                 self.expr_lvalue(&expr_named.target);
+                expr_named.value.recurse(&mut |x| self.named_in_expr(x));
             }
+            Expr::Name(name) => {
+                self.inner.name_reads.insert(name.id.clone());
+            }
+            // These expressions define a scope, so walrus operators only define a name
+            // within that scope, not in the surrounding statement's scope.
+            // Name reads inside them belong to that inner scope, not ours.
             Expr::Lambda(..)
             | Expr::SetComp(..)
             | Expr::DictComp(..)
             | Expr::ListComp(..)
-            | Expr::Generator(..) => {
-                // These expressions define a scope, so walrus operators only define a name
-                // within that scope, not in the surrounding statement's scope.
-            }
+            | Expr::Generator(..) => {}
             _ => x.recurse(&mut |x| self.named_in_expr(x)),
         }
     }

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -994,7 +994,6 @@ except as r: # E: Parse error: Expected one or more exception types
 );
 
 testcase!(
-    bug = "We unsoundly merge narrows dropping missing flow. See the incorrect reveal_type(y) result.",
     test_narrows_in_flow_merge_when_not_in_base_flow,
     r#"
 from typing import reveal_type
@@ -1010,10 +1009,8 @@ def f():
     elif isinstance(x, C):
         assert isinstance(y, C)
         pass
-    # We get this case right, but for a brittle reason: we negate the tests in the base flow.
-    reveal_type(x)  # E: revealed type: A | B | C
-    # The negation trick doesn't work here, and we get an incorrect narrow.
-    reveal_type(y)  # E: revealed type: B | C
+    reveal_type(x)  # E: revealed type: A
+    reveal_type(y)  # E: revealed type: A
 "#,
 );
 

--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -935,3 +935,26 @@ def f():
     x = "foo"
     "#,
 );
+
+testcase!(
+    test_captured_var_in_nested_function_with_flow_merge,
+    r#"
+def test_annotated():
+    x: dict[int, int]
+    x = {}
+    def nested(a: int, bs: list[int]):
+        if not x[0]:
+            return None
+        for b in bs:
+            break
+        return x # E:
+def test_unannotated():
+    x = {}
+    def nested(a: int, bs: list[int]):
+        if not x[0]:
+            return None
+        for b in bs:
+            break
+        return x # E:
+"#,
+);

--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -947,7 +947,7 @@ def test_annotated():
             return None
         for b in bs:
             break
-        return x # E:
+        return x
 def test_unannotated():
     x = {}
     def nested(a: int, bs: list[int]):
@@ -955,6 +955,6 @@ def test_unannotated():
             return None
         for b in bs:
             break
-        return x # E:
+        return x
 "#,
 );


### PR DESCRIPTION
Summary:
# The stack:

D91053724 was intended to prevent variables captured from outer scopes getting flagged as uninitialized when they are narrowed in a nested scope.

It was reverted as part of a SEV, this stack is a second attempt at those changes. The detailed plan is described in D95121249 (phase 1)

# This Diff:


Creates an initialized flow info for captured variables when we create a function scope. This fixes the root cause of the issue described in D91053724

Differential Revision: D95121246


