### PR TITLE
Remove ClassType <: SelfType subtyping rule (#2658)

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -6351,6 +6351,28 @@
   "generics_self_basic.py": [
     {
       "code": -2,
+      "column": 16,
+      "concise_description": "Returned type `Shape` is not assignable to declared return type `Self@Shape`",
+      "description": "Returned type `Shape` is not assignable to declared return type `Self@Shape`",
+      "line": 20,
+      "name": "bad-return",
+      "severity": "error",
+      "stop_column": 23,
+      "stop_line": 20
+    },
+    {
+      "code": -2,
+      "column": 16,
+      "concise_description": "Returned type `Shape` is not assignable to declared return type `Self@Shape`",
+      "description": "Returned type `Shape` is not assignable to declared return type `Self@Shape`",
+      "line": 33,
+      "name": "bad-return",
+      "severity": "error",
+      "stop_column": 23,
+      "stop_line": 33
+    },
+    {
+      "code": -2,
       "column": 26,
       "concise_description": "`Self` may not be subscripted",
       "description": "`Self` may not be subscripted",
@@ -6429,6 +6451,17 @@
       "severity": "error",
       "stop_column": 37,
       "stop_line": 82
+    },
+    {
+      "code": -2,
+      "column": 16,
+      "concise_description": "Returned type `Foo3` is not assignable to declared return type `Self@Foo3`",
+      "description": "Returned type `Foo3` is not assignable to declared return type `Self@Foo3`",
+      "line": 87,
+      "name": "bad-return",
+      "severity": "error",
+      "stop_column": 22,
+      "stop_line": 87
     },
     {
       "code": -2,

--- a/conformance/third_party/conformance.result
+++ b/conformance/third_party/conformance.result
@@ -106,14 +106,9 @@
   ],
   "generics_self_advanced.py": [],
   "generics_self_attributes.py": [],
-  "generics_self_basic.py": [
-    "Line 20: Expected 1 errors",
-    "Line 33: Expected 1 errors"
-  ],
+  "generics_self_basic.py": [],
   "generics_self_protocols.py": [],
-  "generics_self_usage.py": [
-    "Line 87: Expected 1 errors"
-  ],
+  "generics_self_usage.py": [],
   "generics_syntax_compatibility.py": [],
   "generics_syntax_declarations.py": [],
   "generics_syntax_infer_variance.py": [],

--- a/conformance/third_party/results.json
+++ b/conformance/third_party/results.json
@@ -1,9 +1,9 @@
 {
   "total": 140,
-  "pass": 129,
-  "fail": 11,
-  "pass_rate": 0.92,
-  "differences": 33,
+  "pass": 131,
+  "fail": 9,
+  "pass_rate": 0.94,
+  "differences": 30,
   "passing": [
     "aliases_explicit.py",
     "aliases_newtype.py",
@@ -67,7 +67,9 @@
     "generics_paramspec_specialization.py",
     "generics_self_advanced.py",
     "generics_self_attributes.py",
+    "generics_self_basic.py",
     "generics_self_protocols.py",
+    "generics_self_usage.py",
     "generics_syntax_compatibility.py",
     "generics_syntax_declarations.py",
     "generics_syntax_infer_variance.py",
@@ -144,8 +146,6 @@
     "directives_disjoint_base.py": 6,
     "exceptions_context_managers.py": 2,
     "generics_scoping.py": 4,
-    "generics_self_basic.py": 2,
-    "generics_self_usage.py": 1,
     "typeforms_typeform.py": 2
   },
   "comment": "@generated"

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -2026,15 +2026,6 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
             {
                 self.is_subset_eq(&got, want)
             }
-            (Type::ClassType(got), Type::SelfType(want)) => ok_or(
-                self.type_order
-                    .has_superclass(got.class_object(), want.class_object()),
-                SubsetError::Other,
-            ),
-            (Type::Type(box Type::ClassType(got)), Type::SelfType(want)) => ok_or(
-                self.type_order.has_metaclass(got.class_object(), want),
-                SubsetError::Other,
-            ),
             (Type::SelfType(_), Type::SelfType(_)) => Ok(()),
             (Type::SelfType(got), _) => self.is_subset_eq(&Type::ClassType(got.clone()), want),
             (Type::Tuple(l), Type::Tuple(u)) => self.is_subset_tuple(l, u),

--- a/pyrefly/lib/test/constructors.rs
+++ b/pyrefly/lib/test/constructors.rs
@@ -1078,7 +1078,9 @@ def g() -> list[ParentItem] | None:
 
 // Overloaded __new__ where one overload has an explicit return annotation
 // and one doesn't. The unannotated overload should assume Self; the
-// annotated overload should keep its declared return type.
+// annotated overload should keep its declared return type. The explicit-return
+// overload is an inconsistent overload error because `C` is not a subtype of
+// the implementation's `Self@C`.
 testcase!(
     test_overloaded_new_mixed_annotation,
     r#"
@@ -1086,7 +1088,7 @@ from typing import assert_type, overload
 
 class C:
     @overload
-    def __new__(cls, x: int) -> "C": ...
+    def __new__(cls, x: int) -> "C": ...  # E: Overload return type `C` is not assignable to implementation return type `Self@C`
     @overload
     def __new__(cls, x: str): ...
     def __new__(cls, x: int | str):

--- a/pyrefly/lib/test/enums.rs
+++ b/pyrefly/lib/test/enums.rs
@@ -876,6 +876,7 @@ constructor: Callable[[str], SeFileType] = SeFileType
 );
 
 testcase!(
+    bug = "Enum cls() should produce Self, not the concrete class type",
     test_enum_call_with_self_type,
     r#"
 from enum import Enum
@@ -893,8 +894,8 @@ class SeFileType(Enum):
     @classmethod
     def from_code(cls, code: str) -> Self:
         assert_type(cls, type[Self])
-        assert_type(cls(code), Self)
-        return cls(code)
+        assert_type(cls(code), Self)  # E: assert_type(SeFileType, Self@SeFileType) failed
+        return cls(code)  # E: Returned type `SeFileType` is not assignable to declared return type `Self@SeFileType`
     "#,
 );
 

--- a/pyrefly/lib/test/generic_basic.rs
+++ b/pyrefly/lib/test/generic_basic.rs
@@ -274,11 +274,11 @@ _Ts = TypeVarTuple("_Ts")
 
 class partial(Generic[_P1, _P2, _T, _R_co, *_Ts]):
     @overload
-    def __new__(cls, __func: Callable[_P1, _R_co]) -> partial[_P1, _P1, Any, _R_co]: ...
+    def __new__(cls, __func: Callable[_P1, _R_co]) -> partial[_P1, _P1, Any, _R_co]: ... # E: Overload return type `partial[Ellipsis, Ellipsis, Any, object, *tuple[()]]` is not assignable to implementation return type `Self@partial`
     @overload
-    def __new__(cls, __func: Callable[Concatenate[*_Ts, _P2], _R_co], *args: *_Ts) -> partial[Concatenate[*_Ts, _P2], _P2, Any, _R_co, *_Ts]: ...
+    def __new__(cls, __func: Callable[Concatenate[*_Ts, _P2], _R_co], *args: *_Ts) -> partial[Concatenate[*_Ts, _P2], _P2, Any, _R_co, *_Ts]: ... # E: Overload return type `partial[Concatenate[*tuple[Unknown, ...], _P2], Ellipsis, Any, object, *tuple[Unknown, ...]]` is not assignable to implementation return type `Self@partial`
     @overload
-    def __new__(cls, __func: Callable[_P1, _R_co], *args: *_Ts, **kwargs: _T) -> partial[_P1, ..., _T, _R_co, *_Ts]: ...
+    def __new__(cls, __func: Callable[_P1, _R_co], *args: *_Ts, **kwargs: _T) -> partial[_P1, ..., _T, _R_co, *_Ts]: ... # E: Overload return type `partial[Ellipsis, Ellipsis, object, object, *tuple[Unknown, ...]]` is not assignable to implementation return type `Self@partial`
     def __new__(cls, __func, *args, **kwargs):
         return super().__new__(cls)
     def __call__(self, *args: _P2.args, **kwargs: _P2.kwargs) -> _R_co: ...

--- a/pyrefly/lib/test/typing_self.rs
+++ b/pyrefly/lib/test/typing_self.rs
@@ -195,18 +195,17 @@ class C:
 );
 
 testcase!(
-    bug = "conformance: Should error when returning concrete class instead of Self",
     test_self_return_concrete_class,
     r#"
 from typing import Self
 
 class Shape:
     def method(self) -> Self:
-        return Shape()  # should error: returns Shape, not Self
+        return Shape()  # E: Returned type `Shape` is not assignable to declared return type `Self@Shape`
 
     @classmethod
     def cls_method(cls) -> Self:
-        return Shape()  # should error: returns Shape, not Self
+        return Shape()  # E: Returned type `Shape` is not assignable to declared return type `Self@Shape`
 "#,
 );
 
@@ -412,25 +411,23 @@ class E(Enum):
 
 // Passing a concrete class to `cls.__new__` is incorrect when `cls` could be a subclass.
 testcase!(
-    bug = "Should error: concrete type[C] is not assignable to type[Self@C]",
     test_cls_new_with_concrete_class,
     r#"
 class C:
     @classmethod
     def create(cls) -> C:
-        return cls.__new__(C)
+        return cls.__new__(C)  # E: Argument `type[C]` is not assignable to parameter `cls` with type `type[Self@C]` in function `object.__new__`
 "#,
 );
 
 // Self is pinned when `[self]` is inferred, so `append(other: C)` fails against `Self@C`.
 testcase!(
-    bug = "Should error: C is not assignable to Self@C in list.append",
     test_self_in_container_pinning,
     r#"
 class C:
     def foo(self, other: C) -> list:
         xs = [self]
-        xs.append(other)
+        xs.append(other)  # E: Argument `C` is not assignable to parameter `object` with type `Self@C` in function `list.append`
         return xs
 "#,
 );
@@ -602,6 +599,7 @@ def test(c: MyClass) -> None:
 // Regression test for a previously unhandled crash when computing intersection
 // of SelfType and ClassType (after removing SelfType <: ClassType)
 testcase!(
+    bug = "Should not error",
     test_classmethod_self_return_with_issubclass_narrowing,
     r#"
 from typing import Self, assert_type
@@ -611,7 +609,7 @@ class Parent:
     def decode(cls, data: dict) -> Self:
         if issubclass(cls, Child):
             # This narrowing creates an intersection of a Self type with a concrete type
-            return cls(data, legacy=True)
+            return cls(data, legacy=True) # E: Returned type `Child` is not assignable to declared return type `Self@Parent`
         return cls(data)
 
     def __init__(self, data: dict) -> None:
@@ -631,6 +629,7 @@ assert_type(Child.decode({}), Child)
 // `ClassType(Child) & SelfType(Parent[int])` when the upcast back to `Parent`
 // preserves the same inherited instantiation.
 testcase!(
+    bug = "After `issubclass(cls, Child)` narrowing, `cls()` of type `Child` should be assignable to `Self@Parent` since `Child` is a subclass of `Parent`",
     test_classmethod_self_return_with_generic_issubclass_narrowing,
     r#"
 from typing import Self, assert_type
@@ -639,7 +638,7 @@ class Parent[T]:
     @classmethod
     def decode(cls) -> Self:
         if issubclass(cls, Child):
-            return cls()
+            return cls()  # E: Returned type `Child` is not assignable to declared return type `Self@Parent`
         return cls()
 
     def __init__(self) -> None:
@@ -708,16 +707,15 @@ class Base:
 );
 
 testcase!(
-    bug = "Should raise error in the overloads when returning concrete class instead of Self",
     test_overload_returning_self,
     r#"
 from typing import Self, overload
 
 class C:
     @overload
-    def clone(self, x: int) -> C: ...
+    def clone(self, x: int) -> C: ... # E: Overload return type `C` is not assignable to implementation return type `Self@C`
     @overload
-    def clone(self, x: str) -> C: ...
+    def clone(self, x: str) -> C: ... # E: Overload return type `C` is not assignable to implementation return type `Self@C`
     def clone(self, x) -> Self: ...
     "#,
 );


### PR DESCRIPTION
Summary:
This PR removes the unsound `ClassType <: SelfType` subtyping rule and fixes related issues around `Self` type handling in decorators and overload checks.

Next steps:
- Handle final class as an exceptional case where Class <: Self can be permitted
- Handle Enums as an exceptional case (see added test case)
- Fix the issue with decorator


Test Plan: Conformance test cases, new regression tests in `typing_self.rs` and `constructors.rs`, and checking for errors in the wild via mypy-primer.

Reviewed By: samwgoldman

Differential Revision: D96217881

Pulled By: fangyi-zhou


