### PR TITLE
Fix false positive not-a-type errors for except clause targets

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -3421,16 +3421,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 .collect(),
             _ => {
                 let exception_types = self.expr_infer(ann, errors);
-                match exception_types {
-                    Type::Tuple(Tuple::Concrete(ts)) => ts
-                        .into_iter()
-                        .map(|t| check_exception_type(t, ann.range()))
-                        .collect(),
-                    Type::Tuple(Tuple::Unbounded(t)) => {
-                        vec![check_exception_type(*t, ann.range())]
-                    }
-                    _ => vec![check_exception_type(exception_types, ann.range())],
-                }
+                self.decompose_except_types(exception_types, ann.range(), &check_exception_type)
             }
         };
         let exceptions = self.unions(exceptions);
@@ -3438,6 +3429,39 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             self.heap.mk_class_type(t)
         } else {
             exceptions
+        }
+    }
+
+    /// Decompose a type used in an `except` clause into individual exception types,
+    /// validating each one via `check`. In Python, an `except` clause accepts a single
+    /// exception class or a tuple of exception classes. The type may also be a union
+    /// (e.g. `type[X] | tuple[type[X], ...]`), in which case each member is processed
+    /// independently.
+    fn decompose_except_types(
+        &self,
+        ty: Type,
+        range: TextRange,
+        check: &impl Fn(Type, TextRange) -> Type,
+    ) -> Vec<Type> {
+        // Normalize nominal tuple ClassTypes (e.g. from `tuple()` constructor calls)
+        // to structural Type::Tuple so they match the tuple arms below.
+        let ty = match ty {
+            Type::ClassType(cls) => match self.as_tuple(&cls) {
+                Some(tuple) => Type::Tuple(tuple),
+                None => Type::ClassType(cls),
+            },
+            other => other,
+        };
+        match ty {
+            Type::Tuple(Tuple::Concrete(ts)) => ts.into_iter().map(|t| check(t, range)).collect(),
+            Type::Tuple(Tuple::Unbounded(t)) => {
+                vec![check(*t, range)]
+            }
+            Type::Union(box Union { members, .. }) => members
+                .into_iter()
+                .flat_map(|t| self.decompose_except_types(t, range, check))
+                .collect(),
+            _ => vec![check(ty, range)],
         }
     }
 

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -320,6 +320,35 @@ except x2 as e7:
 );
 
 testcase!(
+    test_exception_handler_dynamic_tuple,
+    r#"
+from typing import assert_type
+
+class Exception1(Exception): pass
+class Exception2(Exception): pass
+
+# Dynamic tuple from tuple() constructor call
+error_list = [Exception1, Exception2]
+dynamic_errors = tuple(error_list)
+try:
+    pass
+except dynamic_errors as e1:
+    assert_type(e1, Exception1 | Exception2)
+
+# Union-typed parameter: single exception class or tuple of exception classes
+def handle(
+    errors: type[Exception] | tuple[type[Exception], ...],
+    value: str,
+) -> int:
+    try:
+        return int(value)
+    except errors as e2:
+        assert_type(e2, Exception)
+        return 0
+"#,
+);
+
+testcase!(
     test_exception_group_handler,
     r#"
 from typing import reveal_type


### PR DESCRIPTION
Summary:
Pyrefly rejected valid except targets when the exception type was a nominal tuple ClassType (e.g. from a `tuple()` constructor call) or a union containing tuple types (e.g. `type[Exception] | tuple[type[Exception], ...]`). Both patterns are common in real-world Python code and are accepted by CPython at runtime.

The root cause was that except clause validation only recognized structural `Type::Tuple` variants, but `tuple()` calls produce a nominal `Type::ClassType`. Similarly, union types containing tuples were passed directly to `untype()`, which doesn't know that tuples-of-exception-classes are valid except targets.

The fix extracts a `decompose_except_types` method that normalizes nominal tuples to structural ones via the existing `as_tuple()` helper, and recursively decomposes union members so each branch is validated independently.

Fixes https://github.com/facebook/pyrefly/issues/2617

Reviewed By: yangdanny97

Differential Revision: D95311753


