### PR TITLE
Expand type alias bodies before substituting, rather than after

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -1506,16 +1506,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     Type::Annotated(inner) => *inner,
                     _ => return,
                 };
+                // Recursively expand any Refs in the inlined body, so that all nested
+                // alias bodies are inlined before we apply the outer substitution.
+                visiting.insert(key);
+                self.expand_type_alias_refs_inner(&mut body, visiting);
+                visiting.shift_remove(&key);
                 // Apply type arguments if the reference was parameterized.
                 // For generic aliases used without explicit args, promote_forall
                 // in untype_opt will have already injected implicit Any args.
                 if let Some(args) = &r.args {
                     args.substitute_into_mut(&mut body);
                 }
-                // Recursively expand any Refs in the inlined body
-                visiting.insert(key);
-                self.expand_type_alias_refs_inner(&mut body, visiting);
-                visiting.shift_remove(&key);
                 *ty = body;
             }
             _ => ty.recurse_mut(&mut |child: &mut Type| {

--- a/pyrefly/lib/test/type_alias.rs
+++ b/pyrefly/lib/test/type_alias.rs
@@ -1240,3 +1240,26 @@ class D:
         self.x = c.y
 "#,
 );
+
+testcase!(
+    test_chained_type_alias_substitution,
+    r#"
+from typing import TypeVar, TypeAlias, assert_type
+
+_T = TypeVar("_T")
+_U = TypeVar("_U")
+
+A: TypeAlias = list[_T]
+B: TypeAlias = A[_U]
+C: TypeAlias = B[int]
+
+def f1(x: A[int]) -> None:
+    assert_type(x, list[int])
+
+def f2(x: B[int]) -> None:
+    assert_type(x, list[int])
+
+def f3(x: C) -> None:
+    assert_type(x, list[int])
+    "#,
+);


### PR DESCRIPTION
Summary: Fixes https://github.com/facebook/pyrefly/issues/2527.

Differential Revision: D95344020


