### PR TITLE
Fix collections.namedtuple not recognized when collections.abc is imported

### DIFF
--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -1879,9 +1879,15 @@ impl Scopes {
             // is a special export.
             let value = self.get_flow_info(base_name)?.value()?;
             match &value.style {
-                FlowStyle::MergeableImport(m) | FlowStyle::ImportAs(m) => {
-                    lookup.is_special_export(*m, name)
+                FlowStyle::MergeableImport(m) => {
+                    // For dotted imports like `import collections.abc`, the base module `collections`
+                    // is also implicitly imported, so we should check that too.
+                    let base_module = ModuleName::from_name(base_name);
+                    lookup
+                        .is_special_export(*m, name)
+                        .or_else(|| lookup.is_special_export(base_module, name))
                 }
+                FlowStyle::ImportAs(m) => lookup.is_special_export(*m, name),
                 FlowStyle::Import(m, upstream_name) => lookup.is_special_export(*m, upstream_name),
                 _ => None,
             }

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -598,3 +598,28 @@ class QConfig(namedtuple("QConfig", ["activation", "weight"])):
         return super().__new__(cls, activation, weight)
 "#,
 );
+
+// Regression test for https://github.com/facebook/pyrefly/issues/2622
+// `import collections.abc` should not break special handling of `collections.namedtuple`.
+testcase!(
+    test_named_tuple_collections_submodule_import,
+    r#"
+import collections
+import collections.abc
+
+Point = collections.namedtuple("Point", ["x", "y"])
+p = Point(x=1, y=2)
+    "#,
+);
+
+// `import collections.abc` alone (without explicit `import collections`) should still
+// allow `collections.namedtuple` to work, since `import X.Y` implicitly imports `X`.
+testcase!(
+    test_named_tuple_collections_submodule_import_only,
+    r#"
+import collections.abc
+
+Point = collections.namedtuple("Point", ["x", "y"])
+p = Point(x=1, y=2)
+    "#,
+);


### PR DESCRIPTION
Summary:
When `import collections.abc` follows `import collections`, the flow style for the name `collections` was overwritten with `MergeableImport("collections.abc")`. This caused `as_special_export` to check `is_special_export("collections.abc", "namedtuple")`, which failed because `CollectionsNamedTuple.defined_in()` only matches `"collections"`.

Fix: for `MergeableImport`, use the bound name (which is always the first component of the dotted import path) as the module name for special export checking, instead of the stored full dotted path.

Fixes https://github.com/facebook/pyrefly/issues/2622

Differential Revision: D95422174


