### PR TITLE
Fix false positive on attribute access for TypeVar bounded by `type`

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -1870,6 +1870,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
+    /// Extract the ClassType to use for attribute lookup on a quantified (TypeVar)
+    /// type from the attribute base of its bound.
+    fn quantified_bound_class(&self, base: AttributeBase1) -> Option<ClassType> {
+        match base {
+            AttributeBase1::ClassInstance(cls) => Some(cls),
+            // Handle `type[Any]`, which happens for TypeVars w/ `bound=type`
+            AttributeBase1::TypeAny(_) => Some(self.stdlib.builtins_type().clone()),
+            _ => None,
+        }
+    }
+
     fn as_attribute_base(&self, ty: Type) -> Option<AttributeBase> {
         let mut acc = Vec::new();
         self.as_attribute_base1(ty, &mut acc);
@@ -1979,7 +1990,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     let mut use_fallback = false;
                     if let Some(base) = self.as_attribute_base(ty.clone()) {
                         for base1 in base.0 {
-                            if let AttributeBase1::ClassInstance(cls) = base1 {
+                            if let Some(cls) = self.quantified_bound_class(base1) {
                                 acc.push(AttributeBase1::ClassObject(ClassBase::Quantified(
                                     (*quantified).clone(),
                                     cls,
@@ -2001,7 +2012,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     for ty in constraints {
                         if let Some(base) = self.as_attribute_base(ty.clone()) {
                             for base1 in base.0 {
-                                if let AttributeBase1::ClassInstance(cls) = base1 {
+                                if let Some(cls) = self.quantified_bound_class(base1) {
                                     acc.push(AttributeBase1::ClassObject(ClassBase::Quantified(
                                         (*quantified).clone(),
                                         cls,
@@ -2185,7 +2196,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     let mut use_fallback = false;
                     if let Some(base) = self.as_attribute_base(ty.clone()) {
                         for base1 in base.0 {
-                            if let AttributeBase1::ClassInstance(cls) = base1 {
+                            if let Some(cls) = self.quantified_bound_class(base1) {
                                 acc.push(AttributeBase1::Quantified((*quantified).clone(), cls));
                             } else {
                                 use_fallback = true;
@@ -2204,7 +2215,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     for ty in constraints {
                         if let Some(base) = self.as_attribute_base(ty.clone()) {
                             for base1 in base.0 {
-                                if let AttributeBase1::ClassInstance(cls) = base1 {
+                                if let Some(cls) = self.quantified_bound_class(base1) {
                                     acc.push(AttributeBase1::Quantified(
                                         (*quantified).clone(),
                                         cls,

--- a/pyrefly/lib/test/generic_restrictions.rs
+++ b/pyrefly/lib/test/generic_restrictions.rs
@@ -248,6 +248,17 @@ def func(c: T) -> C:
 );
 
 testcase!(
+    test_bounded_typevar_type_attribute_access,
+    r#"
+from typing import TypeVar, assert_type
+T = TypeVar('T', bound=type)
+def get_class_name(cls: T) -> str:
+    assert_type(cls.__name__, str)
+    return cls.__name__
+ "#,
+);
+
+testcase!(
     test_instantiate_default_typevar,
     r#"
 from typing import assert_type, reveal_type, Callable, Self


### PR DESCRIPTION
Summary:
When a TypeVar has `bound=type`, pyrefly internally represents the bound as
`type[Any]`, which resolves to `AttributeBase1::TypeAny` during attribute
lookup. The quantified TypeVar attribute resolution only handled
`AttributeBase1::ClassInstance`, causing any other variant (including `TypeAny`)
to fall back to `object`. This produced false positives like
"Object of class `object` has no attribute `__name__`" when accessing
attributes that exist on the `type` class.

The fix extracts the bound-to-ClassType mapping into a `quantified_bound_class`
helper that handles both `ClassInstance` (the common case) and `TypeAny`
(the `bound=type` case, mapping to `builtins.type`). This is applied to all
four sites where quantified bounds are resolved: both `T` and `type[T]` paths,
for both `Bound` and `Constraints` restrictions.

Fixes https://github.com/facebook/pyrefly/issues/2614

Differential Revision: D95419868


