### PR TITLE
don't error on import failures caused by platform gating

### DIFF
--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -2101,7 +2101,6 @@ impl Scopes {
     pub fn swap_current_flow_with(&mut self, flow: &mut Flow) {
         mem::swap(&mut self.current_mut().flow, flow);
     }
-
     pub fn mark_flow_termination(&mut self, from_static_test: bool) {
         self.current_mut().flow.has_terminated = true;
         if self.current_mut().with_depth == 0 && !from_static_test {
@@ -2116,6 +2115,14 @@ impl Scopes {
     /// Check if the current flow has definitely terminated (e.g., after a return, raise, break, or continue)
     pub fn is_definitely_unreachable(&self) -> bool {
         self.current().flow.is_definitely_unreachable
+    }
+
+    /// Check if the current flow is unreachable due to a statically-evaluated test
+    /// (e.g., `if sys.platform != "darwin": return 0` on linux). In this state,
+    /// `has_terminated` is true but `is_definitely_unreachable` is false because the
+    /// code may be reachable in other environments.
+    pub fn is_unreachable_from_static_test(&self) -> bool {
+        self.current().flow.has_terminated && !self.current().flow.is_definitely_unreachable
     }
 
     /// Set or clear the last statement expression key for the current flow.

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -1365,11 +1365,13 @@ impl<'a> BindingsBuilder<'a> {
                     let val = if self.lookup.export_exists(m, &name) {
                         Binding::Import(Box::new((m, name.into_key().clone(), None)))
                     } else {
-                        self.error(
-                            x.range,
-                            ErrorInfo::Kind(ErrorKind::MissingModuleAttribute),
-                            format!("Could not import `{name}` from `{m}`"),
-                        );
+                        if !self.scopes.is_unreachable_from_static_test() {
+                            self.error(
+                                x.range,
+                                ErrorInfo::Kind(ErrorKind::MissingModuleAttribute),
+                                format!("Could not import `{name}` from `{m}`"),
+                            );
+                        }
                         Binding::Any(AnyStyle::Error)
                     };
                     let key = self.insert_binding(key, val);
@@ -1431,11 +1433,13 @@ impl<'a> BindingsBuilder<'a> {
                         // See: https://typing.python.org/en/latest/guides/writing_stubs.html#incomplete-stubs
                         Binding::ImportViaGetattr(Box::new((m, x.name.id.clone())))
                     } else if is_not_found {
-                        self.error(
-                            x.range,
-                            ErrorInfo::Kind(ErrorKind::MissingModuleAttribute),
-                            format!("Could not import `{}` from `{m}`", x.name.id),
-                        );
+                        if !self.scopes.is_unreachable_from_static_test() {
+                            self.error(
+                                x.range,
+                                ErrorInfo::Kind(ErrorKind::MissingModuleAttribute),
+                                format!("Could not import `{}` from `{m}`", x.name.id),
+                            );
+                        }
                         Binding::Any(AnyStyle::Error)
                     } else {
                         Binding::Any(AnyStyle::Explicit)

--- a/pyrefly/lib/test/sys_info.rs
+++ b/pyrefly/lib/test/sys_info.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use pyrefly_python::sys_info::PythonPlatform;
 use pyrefly_python::sys_info::PythonVersion;
 
 use crate::test::util::TestEnv;
@@ -285,6 +286,27 @@ else:
     y = 1
 
 assert_type(y, Literal[''])
+"#,
+);
+
+testcase!(
+    test_negative_platform_gate_import,
+    TestEnv::new_with_platform(PythonPlatform::linux()),
+    r#"
+import sys
+
+def darwin_only_example() -> int:
+    if sys.platform != "darwin":
+        return 0
+
+    from fcntl import F_FULLFSYNC  # If tested on mac laptop this will be a Pyrefly FP
+    return F_FULLFSYNC
+
+def linux_only_example() -> int:
+    if sys.platform != "linux":
+        return 0
+    from socket import SO_DOMAIN   # If tested on Linux machine this will be a Pyrefly FP
+    return SO_DOMAIN
 "#,
 );
 

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -101,6 +101,7 @@ fn default_path(module: ModuleName) -> PathBuf {
 pub struct TestEnv {
     modules: Vec<(ModuleName, ModulePath, Option<Arc<FileContents>>)>,
     version: PythonVersion,
+    platform: PythonPlatform,
     untyped_def_behavior: UntypedDefBehavior,
     infer_with_first_use: bool,
     site_package_path: Vec<PathBuf>,
@@ -123,6 +124,7 @@ impl TestEnv {
         TestEnv {
             modules: Vec::new(),
             version: PythonVersion::default(),
+            platform: PythonPlatform::default(),
             untyped_def_behavior: UntypedDefBehavior::default(),
             infer_with_first_use: true,
             site_package_path: Vec::new(),
@@ -148,6 +150,12 @@ impl TestEnv {
     pub fn new_with_version(version: PythonVersion) -> Self {
         let mut res = Self::new();
         res.version = version;
+        res
+    }
+
+    pub fn new_with_platform(platform: PythonPlatform) -> Self {
+        let mut res = Self::new();
+        res.platform = platform;
         res
     }
 
@@ -259,7 +267,7 @@ impl TestEnv {
     }
 
     pub fn sys_info(&self) -> SysInfo {
-        SysInfo::new(self.version, PythonPlatform::linux())
+        SysInfo::new(self.version, self.platform.clone())
     }
 
     pub fn get_memory(&self) -> Vec<(PathBuf, Option<Arc<FileContents>>)> {
@@ -275,7 +283,7 @@ impl TestEnv {
     pub fn config(&self) -> ArcId<ConfigFile> {
         let mut config = ConfigFile::default();
         config.python_environment.python_version = Some(self.version);
-        config.python_environment.python_platform = Some(PythonPlatform::linux());
+        config.python_environment.python_platform = Some(self.platform.clone());
         config.python_environment.site_package_path = Some(self.site_package_path.clone());
         config.root.untyped_def_behavior = Some(self.untyped_def_behavior);
         config.root.infer_with_first_use = Some(self.infer_with_first_use);


### PR DESCRIPTION
Summary:
We shouldn't error on failed imports gated off by static checks

fixes #2615

Differential Revision: D95427836


