### PR TITLE
fix special-case NotImplementedType in binop signatures to match runtime semantics #1129

### DIFF
--- a/crates/pyrefly_types/src/stdlib.rs
+++ b/crates/pyrefly_types/src/stdlib.rs
@@ -114,6 +114,8 @@ pub struct Stdlib {
     builtins_type: StdlibResult<ClassType>,
     /// Introduced in Python 3.10.
     ellipsis_type: Option<StdlibResult<ClassType>>,
+    /// Introduced in Python 3.10.
+    not_implemented_type: Option<StdlibResult<ClassType>>,
     /// Moved from `_typeshed` to `types` in 3.10.
     none_type: StdlibResult<ClassType>,
     function_type: StdlibResult<ClassType>,
@@ -248,6 +250,9 @@ impl Stdlib {
             ellipsis_type: version
                 .at_least(3, 10)
                 .then(|| lookup_concrete(types, "EllipsisType")),
+            not_implemented_type: version
+                .at_least(3, 10)
+                .then(|| lookup_concrete(types, "NotImplementedType")),
             none_type: lookup_concrete(none_location, "NoneType"),
             iterable: lookup_generic(typing, "Iterable", 1),
             async_iterable: lookup_generic(typing, "AsyncIterable", 1),
@@ -358,6 +363,10 @@ impl Stdlib {
 
     pub fn ellipsis_type(&self) -> Option<&ClassType> {
         Some(Self::primitive(self.ellipsis_type.as_ref()?))
+    }
+
+    pub fn not_implemented_type(&self) -> Option<&ClassType> {
+        Some(Self::primitive(self.not_implemented_type.as_ref()?))
     }
 
     pub fn none_type(&self) -> &ClassType {

--- a/crates/pyrefly_types/src/stdlib.rs
+++ b/crates/pyrefly_types/src/stdlib.rs
@@ -115,6 +115,8 @@ pub struct Stdlib {
     builtins_type: StdlibResult<ClassType>,
     /// At runtime, `types.EllipsisType` is new in 3.10, but typeshed defines it unconditionally.
     ellipsis_type: StdlibResult<ClassType>,
+    /// At runtime, `types.NotImplementedType` is new in 3.10, but typeshed defines it unconditionally.
+    not_implemented_type: StdlibResult<ClassType>,
     /// Moved from `_typeshed` to `types` in 3.10.
     none_type: StdlibResult<ClassType>,
     function_type: StdlibResult<ClassType>,
@@ -254,6 +256,7 @@ impl Stdlib {
             enumerate: lookup_generic(builtins, "enumerate", 1),
             builtins_type: lookup_concrete(builtins, "type"),
             ellipsis_type: lookup_concrete(types, "EllipsisType"),
+            not_implemented_type: lookup_concrete(types, "NotImplementedType"),
             none_type: lookup_concrete(none_location, "NoneType"),
             iterable: lookup_generic(typing, "Iterable", 1),
             iterator: lookup_generic(typing, "Iterator", 1),
@@ -370,6 +373,10 @@ impl Stdlib {
 
     pub fn ellipsis_type(&self) -> &ClassType {
         Self::primitive(&self.ellipsis_type)
+    }
+
+    pub fn not_implemented_type(&self) -> &ClassType {
+        Self::primitive(&self.not_implemented_type)
     }
 
     pub fn none_type(&self) -> &ClassType {

--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -202,6 +202,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         Some(result_ty)
     }
 
+    /// Operands must be distributed over unions before calling this method, so only a union
+    /// member whose result is entirely `NotImplementedType` advances to the reflected dunder.
     fn try_binop_calls(
         &self,
         calls: &[(&Name, &Type, &Type)],
@@ -210,7 +212,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         context: &dyn Fn() -> ErrorContext,
     ) -> Type {
         let mut first_call = None;
-        let mut successful_ret = self.heap.mk_never();
         let not_implemented_type = self.stdlib.not_implemented_type();
         for (dunder, target, arg) in calls {
             let method_type_dunder = self.type_of_magic_dunder_attr(
@@ -254,18 +255,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     continue;
                 }
                 errors.extend(callee_errors);
-                if ret_without_not_implemented != ret {
-                    successful_ret = self.union(successful_ret, ret_without_not_implemented);
-                    continue;
-                }
-                return self.union(successful_ret, ret_without_not_implemented);
+                return ret_without_not_implemented;
             } else if first_call.is_none() {
                 first_call = Some((callee_errors, call_errors, ret));
             }
         }
-        if !successful_ret.is_never() {
-            successful_ret
-        } else if let Some((callee_errors, call_errors, ret)) = first_call {
+        if let Some((callee_errors, call_errors, ret)) = first_call {
             errors.extend(callee_errors);
             errors.extend(call_errors);
             ret

--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -210,6 +210,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         context: &dyn Fn() -> ErrorContext,
     ) -> Type {
         let mut first_call = None;
+        let mut successful_ret = self.heap.mk_never();
+        let not_implemented_type = self.stdlib.not_implemented_type();
         for (dunder, target, arg) in calls {
             let method_type_dunder = self.type_of_magic_dunder_attr(
                 target,
@@ -238,13 +240,32 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             // Soft errors (e.g. unknown-argument-type) must not reject an otherwise
             // valid dunder call, so gate on hard errors only.
             if !call_errors.has_hard() {
+                let ret_without_not_implemented = match &not_implemented_type {
+                    Some(not_implemented_type) => self.distribute_over_union(&ret, |ret| {
+                        if matches!(ret, Type::ClassType(cls) if cls == *not_implemented_type) {
+                            self.heap.mk_never()
+                        } else {
+                            ret.clone()
+                        }
+                    }),
+                    None => ret.clone(),
+                };
+                if ret_without_not_implemented.is_never() {
+                    continue;
+                }
                 errors.extend(callee_errors);
-                return ret;
+                if ret_without_not_implemented != ret {
+                    successful_ret = self.union(successful_ret, ret_without_not_implemented);
+                    continue;
+                }
+                return self.union(successful_ret, ret_without_not_implemented);
             } else if first_call.is_none() {
                 first_call = Some((callee_errors, call_errors, ret));
             }
         }
-        if let Some((callee_errors, call_errors, ret)) = first_call {
+        if !successful_ret.is_never() {
+            successful_ret
+        } else if let Some((callee_errors, call_errors, ret)) = first_call {
             errors.extend(callee_errors);
             errors.extend(call_errors);
             ret

--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -205,6 +205,8 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         Some(result_ty)
     }
 
+    /// Operands must be distributed over unions before calling this method, so only a union
+    /// member whose result is entirely `NotImplementedType` advances to the reflected dunder.
     fn try_binop_calls(
         &self,
         calls: &[(&Name, &Type, &Type)],
@@ -213,7 +215,6 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         context: &dyn Fn() -> ErrorContext,
     ) -> Type {
         let mut first_call = None;
-        let mut successful_ret = self.heap.mk_never();
         let not_implemented_type = self.stdlib.not_implemented_type();
         for (dunder, target, arg) in calls {
             let method_type_dunder = self.type_of_magic_dunder_attr(
@@ -254,18 +255,12 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     continue;
                 }
                 errors.extend(callee_errors);
-                if ret_without_not_implemented != ret {
-                    successful_ret = self.union(successful_ret, ret_without_not_implemented);
-                    continue;
-                }
-                return self.union(successful_ret, ret_without_not_implemented);
+                return ret_without_not_implemented;
             } else if first_call.is_none() {
                 first_call = Some((callee_errors, call_errors, ret));
             }
         }
-        if !successful_ret.is_never() {
-            successful_ret
-        } else if let Some((callee_errors, call_errors, ret)) = first_call {
+        if let Some((callee_errors, call_errors, ret)) = first_call {
             errors.extend(callee_errors);
             errors.extend(call_errors);
             ret

--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -213,6 +213,8 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         context: &dyn Fn() -> ErrorContext,
     ) -> Type {
         let mut first_call = None;
+        let mut successful_ret = self.heap.mk_never();
+        let not_implemented_type = self.stdlib.not_implemented_type();
         for (dunder, target, arg) in calls {
             let method_type_dunder = self.type_of_magic_dunder_attr(
                 target,
@@ -241,13 +243,29 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             // Soft errors (e.g. unknown-argument-type) must not reject an otherwise
             // valid dunder call, so gate on hard errors only.
             if !call_errors.has_hard() {
+                let ret_without_not_implemented = self.distribute_over_union(&ret, |ret| {
+                    if matches!(ret, Type::ClassType(cls) if cls == not_implemented_type) {
+                        self.heap.mk_never()
+                    } else {
+                        ret.clone()
+                    }
+                });
+                if ret_without_not_implemented.is_never() {
+                    continue;
+                }
                 errors.extend(callee_errors);
-                return ret;
+                if ret_without_not_implemented != ret {
+                    successful_ret = self.union(successful_ret, ret_without_not_implemented);
+                    continue;
+                }
+                return self.union(successful_ret, ret_without_not_implemented);
             } else if first_call.is_none() {
                 first_call = Some((callee_errors, call_errors, ret));
             }
         }
-        if let Some((callee_errors, call_errors, ret)) = first_call {
+        if !successful_ret.is_never() {
+            successful_ret
+        } else if let Some((callee_errors, call_errors, ret)) = first_call {
             errors.extend(callee_errors);
             errors.extend(call_errors);
             ret

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -645,6 +645,34 @@ assert_type(a, A)
     "#,
 );
 
+testcase!(
+    test_binop_not_implemented_type_uses_runtime_fallback,
+    r#"
+from types import NotImplementedType
+from typing import assert_type
+
+class A:
+    def __add__(self, other: object) -> NotImplementedType:
+        return NotImplemented
+
+class B:
+    def __radd__(self, other: A) -> int:
+        return 1
+
+assert_type(A() + B(), int)
+
+class C:
+    def __add__(self, other: object) -> int | NotImplementedType:
+        return 1 if isinstance(other, C) else NotImplemented
+
+class D:
+    def __radd__(self, other: C) -> str:
+        return ""
+
+assert_type(C() + D(), int | str)
+    "#,
+);
+
 // We try __iadd__ and some fallback dunders. When all fail, the least confusing option is to use __iadd__.
 testcase!(
     test_iadd_error,

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -649,7 +649,7 @@ testcase!(
     test_binop_not_implemented_type_uses_runtime_fallback,
     r#"
 from types import NotImplementedType
-from typing import assert_type
+from typing import assert_type, overload
 
 class A:
     def __add__(self, other: object) -> NotImplementedType:
@@ -669,7 +669,25 @@ class D:
     def __radd__(self, other: C) -> str:
         return ""
 
-assert_type(C() + D(), int | str)
+assert_type(C() + D(), int)
+
+class E:
+    pass
+
+class F:
+    def __radd__(self, other: "G") -> str:
+        return ""
+
+class G:
+    @overload
+    def __add__(self, other: E) -> int: ...
+    @overload
+    def __add__(self, other: F) -> NotImplementedType: ...
+    def __add__(self, other: E | F) -> int | NotImplementedType:
+        return 1 if isinstance(other, E) else NotImplemented
+
+def add_union(other: E | F) -> None:
+    assert_type(G() + other, int | str)
     "#,
 );
 

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -667,6 +667,34 @@ assert_type(a, A)
     "#,
 );
 
+testcase!(
+    test_binop_not_implemented_type_uses_runtime_fallback,
+    r#"
+from types import NotImplementedType
+from typing import assert_type
+
+class A:
+    def __add__(self, other: object) -> NotImplementedType:
+        return NotImplemented
+
+class B:
+    def __radd__(self, other: A) -> int:
+        return 1
+
+assert_type(A() + B(), int)
+
+class C:
+    def __add__(self, other: object) -> int | NotImplementedType:
+        return 1 if isinstance(other, C) else NotImplemented
+
+class D:
+    def __radd__(self, other: C) -> str:
+        return ""
+
+assert_type(C() + D(), int | str)
+    "#,
+);
+
 // We try __iadd__ and some fallback dunders. When all fail, the least confusing option is to use __iadd__.
 testcase!(
     test_iadd_error,

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -671,7 +671,7 @@ testcase!(
     test_binop_not_implemented_type_uses_runtime_fallback,
     r#"
 from types import NotImplementedType
-from typing import assert_type
+from typing import assert_type, overload
 
 class A:
     def __add__(self, other: object) -> NotImplementedType:
@@ -691,7 +691,25 @@ class D:
     def __radd__(self, other: C) -> str:
         return ""
 
-assert_type(C() + D(), int | str)
+assert_type(C() + D(), int)
+
+class E:
+    pass
+
+class F:
+    def __radd__(self, other: "G") -> str:
+        return ""
+
+class G:
+    @overload
+    def __add__(self, other: E) -> int: ...
+    @overload
+    def __add__(self, other: F) -> NotImplementedType: ...
+    def __add__(self, other: E | F) -> int | NotImplementedType:
+        return 1 if isinstance(other, E) else NotImplemented
+
+def add_union(other: E | F) -> None:
+    assert_type(G() + other, int | str)
     "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1129

fixed the binop resolution path so NotImplementedType no longer leaks as a possible operator result.

successful dunder calls now strip only the exact NotImplementedType branch, keep searching reflected dunders when needed, and union any concrete results that can actually occur at runtime.





# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

a regression test covering both pure fallback and mixed `int | NotImplementedType` behavior.