### PR TITLE
fix ParamSpec forwarding doesn't work #823

### DIFF
--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -601,6 +601,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .filter_map(|kw| kw.arg.map(|id| &id.id))
             .collect();
 
+        let iargs = self_arg.iter().chain(args.iter());
         // Creates a reversed copy of the parameters that we iterate through from back to front,
         // so that we can easily peek at and pop from the end.
         let mut rparams: Vec<&Param> = params.items().iter().rev().collect::<Vec<_>>();
@@ -643,7 +644,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             };
             Ok(param_list_owner.push(ps).items().iter().rev().collect())
         };
-        for arg in self_arg.iter().chain(args.iter()) {
+        for arg in iargs {
             let mut arg_pre = arg.pre_eval(self, arg_errors);
             while arg_pre.step() {
                 let param = if let Some(p) = rparams.last() {


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #823

deferred ParamSpec resolution now recognizes the case where the solver has bound the callee’s ParamSpec to a quantified P, and it reuses the existing `*P.args / **P.kwargs` validation path instead of incorrectly forcing P into a concrete ParamList.

removes the bogus Expected 'P' to be a ParamSpec value error when one generic helper forwards another helper’s `Callable[P, R], *args: P.args, **kwargs: P.kwargs`.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

added a regression test