### PR TITLE
fix Usage of a variable should initialise it #828

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -1142,6 +1142,8 @@ impl<'a> BindingsBuilder<'a> {
     /// First-use detection happens later in `process_deferred_bound_names`
     /// when all phi nodes are populated.
     pub fn lookup_name(&mut self, name: Hashed<&Name>, usage: &mut Usage) -> NameLookupResult {
+        let may_prove_initialized =
+            !matches!(usage, Usage::StaticTypeInformation | Usage::TypeAliasRhs);
         let name_read_info = self.scopes.look_up_name_for_read(name, usage);
         match name_read_info {
             NameReadInfo::Flow { idx, initialized } => {
@@ -1149,16 +1151,36 @@ impl<'a> BindingsBuilder<'a> {
                 self.scopes.mark_parameter_used(name.key());
                 self.scopes.mark_import_used(name.key());
                 self.scopes.mark_variable_used(name.key());
+                if may_prove_initialized
+                    && matches!(
+                        initialized,
+                        InitializedInFlow::Conditionally | InitializedInFlow::DeferredCheck(_)
+                    )
+                {
+                    let style = self
+                        .scopes
+                        .flow_style_for_name(name.key())
+                        .map(FlowStyle::assume_initialized)
+                        .unwrap_or(FlowStyle::Other);
+                    self.scopes.define_in_current_flow(name, idx, style);
+                }
                 NameLookupResult::Found { idx, initialized }
             }
             NameReadInfo::Anywhere { key, initialized } => {
                 self.scopes.mark_parameter_used(name.key());
                 self.scopes.mark_import_used(name.key());
                 self.scopes.mark_variable_used(name.key());
-                NameLookupResult::Found {
-                    idx: self.idx_for_promise(key),
-                    initialized,
+                let idx = self.idx_for_promise(key);
+                if may_prove_initialized
+                    && matches!(
+                        initialized,
+                        InitializedInFlow::Conditionally | InitializedInFlow::DeferredCheck(_)
+                    )
+                {
+                    self.scopes
+                        .define_in_current_flow(name, idx, FlowStyle::Other);
                 }
+                NameLookupResult::Found { idx, initialized }
             }
             NameReadInfo::NotFound => NameLookupResult::NotFound,
         }

--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -580,6 +580,19 @@ def test(cond: bool):
 );
 
 testcase!(
+    test_reading_maybe_uninitialized_name_initializes_surviving_flow,
+    r#"
+def f(cond: bool) -> None:
+    if cond:
+        x: int
+    else:
+        x = 1
+    print(x)  # E: `x` may be uninitialized
+    print(x)
+"#,
+);
+
+testcase!(
     test_local_defined_by_mutation_no_shadowing,
     r#"
 def f() -> None:


### PR DESCRIPTION

# Summary

<!-- Describe the change in this PR -->

Fixes #828

runtime name reads now update the current flow only when the name was Conditionally or DeferredCheck initialized. That means a successful read suppresses the duplicate follow-on "may be uninitialized" error on the surviving path, without changing definitely-uninitialized cases like exception-target cleanup.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

a test
