### PR TITLE
Make `tuple()` constructor return structural `Type::Tuple`

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -794,13 +794,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         {
             self.add_specialization_errors(e, arguments_range, errors, context);
         }
-        if let Some(mut ret) = dunder_new_ret {
+        let result = if let Some(mut ret) = dunder_new_ret {
             ret.subst_mut(&cls.targs().substitution_map());
             ret
         } else if constructor_kind == ConstructorKind::TypeOfSelf {
             self.heap.mk_self_type(cls)
         } else {
             self.heap.mk_class_type(cls)
+        };
+        // Normalize builtins.tuple instances to structural Type::Tuple so downstream
+        // match arms (concat, unpacking, except, etc.) handle them directly.
+        if let Type::ClassType(ref ct) = result
+            && ct.class_object().is_builtin("tuple")
+            && ct.targs().as_slice().len() == 1
+        {
+            let targ = ct.targs().as_slice()[0].clone();
+            self.heap.mk_unbounded_tuple(targ)
+        } else {
+            result
         }
     }
 

--- a/pyrefly/lib/test/tuple.rs
+++ b/pyrefly/lib/test/tuple.rs
@@ -390,6 +390,46 @@ def test(y: Iterable[Any], z: Iterable[int]):
 );
 
 testcase!(
+    test_tuple_constructor_assert_type,
+    r#"
+from typing import assert_type, Iterable
+def test(x: Iterable[int]) -> None:
+    assert_type(tuple(x), tuple[int, ...])
+"#,
+);
+
+testcase!(
+    test_tuple_constructor_concat,
+    r#"
+from typing import assert_type, Iterable, Literal
+def test(x: Iterable[int]) -> None:
+    assert_type(tuple(x) + (3,), tuple[*tuple[int, ...], Literal[3]])
+"#,
+);
+
+testcase!(
+    test_namedtuple_constructor_nominal,
+    r#"
+from typing import NamedTuple, assert_type
+class Point(NamedTuple):
+    x: int
+    y: int
+p = Point(1, 2)
+assert_type(p, Point)
+"#,
+);
+
+testcase!(
+    test_tuple_subclass_constructor_nominal,
+    r#"
+from typing import assert_type
+class MyTuple(tuple[int, ...]): pass
+m = MyTuple([1, 2])
+assert_type(m, MyTuple)
+"#,
+);
+
+testcase!(
     test_tuple_aug_assign,
     r#"
 def test() -> None:


### PR DESCRIPTION
Summary:
Calling `tuple()` previously returned a nominal `Type::ClassType(tuple[T])`, which many downstream operations (concat, starred unpacking, except clause decomposition, etc.) didn't recognize because they only pattern-match on `Type::Tuple`. This forced at least 8 call sites to normalize via `as_tuple()`, and operations that didn't normalize were subtly broken.

Fix this at the source: post-process `construct_class` to convert the return type to `Type::Tuple(Tuple::Unbounded(T))` when the class is exactly `builtins.tuple`. This uses `is_builtin("tuple")` so it only fires for the exact builtin, not for NamedTuples or tuple subclasses, which correctly remain as nominal `ClassType`.

The existing `as_tuple()` normalizations downstream are kept because they still serve NamedTuples and tuple subclasses — they just become no-ops for plain `tuple()` calls.

Differential Revision: D95478317


