### PR TITLE
impl change_signature #2207

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -4780,6 +4780,10 @@ impl Server {
                 transaction.introduce_parameter_code_actions(&handle, range)
             );
             timed_refactor_action!(
+                "change_signature",
+                transaction.change_signature_code_actions(&handle, range)
+            );
+            timed_refactor_action!(
                 "convert_star_import",
                 transaction.convert_star_import_code_actions(&handle, range)
             );

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -4807,6 +4807,10 @@ impl Server {
                 transaction.introduce_parameter_code_actions(&handle, range)
             );
             timed_refactor_action!(
+                "change_signature",
+                transaction.change_signature_code_actions(&handle, range)
+            );
+            timed_refactor_action!(
                 "convert_star_import",
                 transaction.convert_star_import_code_actions(&handle, range)
             );

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3746,6 +3746,14 @@ impl<'a> Transaction<'a> {
         quick_fixes::convert_dict::convert_dict_code_actions(self, handle, selection)
     }
 
+    pub fn change_signature_code_actions(
+        &self,
+        handle: &Handle,
+        selection: TextRange,
+    ) -> Option<Vec<LocalRefactorCodeAction>> {
+        quick_fixes::change_signature::change_signature_code_actions(self, handle, selection)
+    }
+
     /// Determines whether a module is a third-party package.
     ///
     /// Checks if the module's path is located within any of the configured

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3547,6 +3547,14 @@ impl<'a> Transaction<'a> {
         quick_fixes::convert_dict::convert_dict_code_actions(self, handle, selection)
     }
 
+    pub fn change_signature_code_actions(
+        &self,
+        handle: &Handle,
+        selection: TextRange,
+    ) -> Option<Vec<LocalRefactorCodeAction>> {
+        quick_fixes::change_signature::change_signature_code_actions(self, handle, selection)
+    }
+
     /// Determines whether a module is a third-party package.
     ///
     /// Checks if the module's path is located within any of the configured

--- a/pyrefly/lib/state/lsp/quick_fixes.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes.rs
@@ -6,6 +6,7 @@
  */
 
 pub(crate) mod add_override;
+pub(crate) mod change_signature;
 pub(crate) mod convert_dict;
 pub(crate) mod convert_star_import;
 pub(crate) mod enum_member;

--- a/pyrefly/lib/state/lsp/quick_fixes/change_signature.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/change_signature.rs
@@ -9,14 +9,20 @@ use dupe::Dupe;
 use lsp_types::CodeActionKind;
 use pyrefly_build::handle::Handle;
 use pyrefly_python::ast::Ast;
+use pyrefly_python::module_path::ModulePath;
 use pyrefly_util::visit::Visit;
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprCall;
+use ruff_python_ast::ExprContext;
 use ruff_python_ast::ModModule;
 use ruff_python_ast::Parameters;
+use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtClassDef;
 use ruff_python_ast::StmtFunctionDef;
+use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::visitor::walk_expr;
+use ruff_python_ast::visitor::walk_stmt;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
@@ -109,22 +115,35 @@ pub(crate) fn change_signature_code_actions(
     let selected_name = editable_params.get(editable_index)?.name.clone();
     let mut actions = Vec::new();
 
-    let remove_change = SignatureChange::Remove {
-        index: editable_index,
-    };
-    if let Some(edits) = build_signature_edits(
+    let selected_param = function_ctx
+        .function_def
+        .parameters
+        .args
+        .get(selected_index)?;
+    if !parameter_is_referenced_in_body(
         transaction,
         handle,
-        &function_ctx,
-        &editable_params,
-        receiver_text.as_deref(),
-        remove_change,
+        module_info.path(),
+        function_ctx.function_def,
+        selected_param,
     ) {
-        actions.push(LocalRefactorCodeAction {
-            title: format!("Remove parameter `{selected_name}`"),
-            edits,
-            kind: CodeActionKind::REFACTOR_REWRITE,
-        });
+        let remove_change = SignatureChange::Remove {
+            index: editable_index,
+        };
+        if let Some(edits) = build_signature_edits(
+            transaction,
+            handle,
+            &function_ctx,
+            &editable_params,
+            receiver_text.as_deref(),
+            remove_change,
+        ) {
+            actions.push(LocalRefactorCodeAction {
+                title: format!("Remove parameter `{selected_name}`"),
+                edits,
+                kind: CodeActionKind::REFACTOR_REWRITE,
+            });
+        }
     }
 
     if editable_index > 0 {
@@ -203,6 +222,53 @@ fn method_context_from_class(
         },
         is_staticmethod: function_has_decorator(function_def, "staticmethod"),
         is_classmethod: function_has_decorator(function_def, "classmethod"),
+    })
+}
+
+fn parameter_is_referenced_in_body(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    module_path: &ModulePath,
+    function_def: &StmtFunctionDef,
+    parameter: &ruff_python_ast::ParameterWithDefault,
+) -> bool {
+    struct NameCollector {
+        name: String,
+        ranges: Vec<TextRange>,
+    }
+
+    impl Visitor<'_> for NameCollector {
+        fn visit_stmt(&mut self, stmt: &Stmt) {
+            walk_stmt(self, stmt);
+        }
+
+        fn visit_expr(&mut self, expr: &Expr) {
+            if let Expr::Name(name) = expr
+                && name.id.as_str() == self.name
+                && !matches!(name.ctx, ExprContext::Invalid)
+            {
+                self.ranges.push(name.range());
+            }
+            walk_expr(self, expr);
+        }
+    }
+
+    let mut collector = NameCollector {
+        name: parameter.name().id.to_string(),
+        ranges: Vec::new(),
+    };
+    for stmt in &function_def.body {
+        collector.visit_stmt(stmt);
+    }
+
+    collector.ranges.into_iter().any(|range| {
+        transaction
+            .find_definition(handle, range.start(), FindPreference::default())
+            .into_iter()
+            .any(|definition| {
+                definition.module.path() == module_path
+                    && definition.definition_range == parameter.name().range()
+            })
     })
 }
 

--- a/pyrefly/lib/state/lsp/quick_fixes/change_signature.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/change_signature.rs
@@ -26,6 +26,7 @@ use ruff_python_ast::visitor::walk_stmt;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
+use vec1::Vec1;
 
 use super::extract_shared::MethodInfo;
 use super::extract_shared::code_at_range;
@@ -264,6 +265,8 @@ fn parameter_is_referenced_in_body(
     collector.ranges.into_iter().any(|range| {
         transaction
             .find_definition(handle, range.start(), FindPreference::default())
+            .map(Vec1::into_vec)
+            .unwrap_or_default()
             .into_iter()
             .any(|definition| {
                 definition.module.path() == module_path
@@ -363,8 +366,9 @@ fn build_callsite_edits(
             function_ctx.function_def.name.range.start(),
             FindPreference::default(),
         )
+        .map(Vec1::into_vec)
+        .unwrap_or_default()
         .into_iter()
-        .flat_map(|defs| defs.into_iter())
         .find(|def| {
             def.module.path() == module_info.path()
                 && def

--- a/pyrefly/lib/state/lsp/quick_fixes/change_signature.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/change_signature.rs
@@ -1,0 +1,423 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use dupe::Dupe;
+use lsp_types::CodeActionKind;
+use pyrefly_build::handle::Handle;
+use pyrefly_python::ast::Ast;
+use pyrefly_util::visit::Visit;
+use ruff_python_ast::AnyNodeRef;
+use ruff_python_ast::Expr;
+use ruff_python_ast::ExprCall;
+use ruff_python_ast::ModModule;
+use ruff_python_ast::Parameters;
+use ruff_python_ast::StmtClassDef;
+use ruff_python_ast::StmtFunctionDef;
+use ruff_text_size::Ranged;
+use ruff_text_size::TextRange;
+use ruff_text_size::TextSize;
+
+use super::extract_shared::MethodInfo;
+use super::extract_shared::code_at_range;
+use super::extract_shared::first_parameter_name;
+use super::extract_shared::function_has_decorator;
+use super::types::LocalRefactorCodeAction;
+use crate::state::lsp::FindPreference;
+use crate::state::lsp::Transaction;
+
+#[derive(Clone, Debug)]
+struct MethodContext {
+    info: MethodInfo,
+    is_staticmethod: bool,
+    is_classmethod: bool,
+}
+
+#[derive(Clone, Debug)]
+struct FunctionContext<'a> {
+    function_def: &'a StmtFunctionDef,
+    method: Option<MethodContext>,
+}
+
+#[derive(Clone, Debug)]
+struct ParamSlot {
+    name: String,
+    text: String,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum SignatureChange {
+    Remove { index: usize },
+    Move { index: usize, delta: isize },
+}
+
+pub(crate) fn change_signature_code_actions(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    selection: TextRange,
+) -> Option<Vec<LocalRefactorCodeAction>> {
+    let position = selection.start();
+    let module_info = transaction.get_module_info(handle)?;
+    let ast = transaction.get_ast(handle)?;
+    let function_ctx = find_function_context(ast.as_ref(), position)?;
+    if !supports_change_signature(&function_ctx) {
+        return None;
+    }
+
+    let receiver_count = function_ctx
+        .method
+        .as_ref()
+        .is_some_and(|method| !method.is_staticmethod) as usize;
+    let selected_index = function_ctx
+        .function_def
+        .parameters
+        .args
+        .iter()
+        .position(|param| param.name().range().contains_inclusive(position))?;
+    if selected_index < receiver_count {
+        return None;
+    }
+
+    let editable_params = function_ctx
+        .function_def
+        .parameters
+        .args
+        .iter()
+        .skip(receiver_count)
+        .map(|param| {
+            Some(ParamSlot {
+                name: param.name().id.to_string(),
+                text: code_at_range(module_info.contents(), param.range())?.to_owned(),
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
+    let receiver_text = if receiver_count == 1 {
+        Some(
+            code_at_range(
+                module_info.contents(),
+                function_ctx.function_def.parameters.args.first()?.range(),
+            )?
+            .to_owned(),
+        )
+    } else {
+        None
+    };
+    let editable_index = selected_index - receiver_count;
+    let selected_name = editable_params.get(editable_index)?.name.clone();
+    let mut actions = Vec::new();
+
+    let remove_change = SignatureChange::Remove {
+        index: editable_index,
+    };
+    if let Some(edits) = build_signature_edits(
+        transaction,
+        handle,
+        &function_ctx,
+        &editable_params,
+        receiver_text.as_deref(),
+        remove_change,
+    ) {
+        actions.push(LocalRefactorCodeAction {
+            title: format!("Remove parameter `{selected_name}`"),
+            edits,
+            kind: CodeActionKind::REFACTOR_REWRITE,
+        });
+    }
+
+    if editable_index > 0 {
+        let move_left = SignatureChange::Move {
+            index: editable_index,
+            delta: -1,
+        };
+        if let Some(edits) = build_signature_edits(
+            transaction,
+            handle,
+            &function_ctx,
+            &editable_params,
+            receiver_text.as_deref(),
+            move_left,
+        ) {
+            actions.push(LocalRefactorCodeAction {
+                title: format!("Move parameter `{selected_name}` left"),
+                edits,
+                kind: CodeActionKind::REFACTOR_REWRITE,
+            });
+        }
+    }
+
+    if editable_index + 1 < editable_params.len() {
+        let move_right = SignatureChange::Move {
+            index: editable_index,
+            delta: 1,
+        };
+        if let Some(edits) = build_signature_edits(
+            transaction,
+            handle,
+            &function_ctx,
+            &editable_params,
+            receiver_text.as_deref(),
+            move_right,
+        ) {
+            actions.push(LocalRefactorCodeAction {
+                title: format!("Move parameter `{selected_name}` right"),
+                edits,
+                kind: CodeActionKind::REFACTOR_REWRITE,
+            });
+        }
+    }
+
+    (!actions.is_empty()).then_some(actions)
+}
+
+fn find_function_context(ast: &ModModule, position: TextSize) -> Option<FunctionContext<'_>> {
+    let covering_nodes = Ast::locate_node(ast, position);
+    for (idx, node) in covering_nodes.iter().enumerate() {
+        if let AnyNodeRef::StmtFunctionDef(function_def) = node {
+            let method = match covering_nodes.get(idx + 1) {
+                Some(AnyNodeRef::StmtClassDef(class_def)) => {
+                    Some(method_context_from_class(class_def, function_def)?)
+                }
+                _ => None,
+            };
+            return Some(FunctionContext {
+                function_def,
+                method,
+            });
+        }
+    }
+    None
+}
+
+fn method_context_from_class(
+    class_def: &StmtClassDef,
+    function_def: &StmtFunctionDef,
+) -> Option<MethodContext> {
+    let receiver_name = first_parameter_name(&function_def.parameters)?;
+    Some(MethodContext {
+        info: MethodInfo {
+            class_name: class_def.name.id.to_string(),
+            receiver_name,
+        },
+        is_staticmethod: function_has_decorator(function_def, "staticmethod"),
+        is_classmethod: function_has_decorator(function_def, "classmethod"),
+    })
+}
+
+fn supports_change_signature(function_ctx: &FunctionContext<'_>) -> bool {
+    let parameters = &function_ctx.function_def.parameters;
+    if !parameters.posonlyargs.is_empty()
+        || !parameters.kwonlyargs.is_empty()
+        || parameters.vararg.is_some()
+        || parameters.kwarg.is_some()
+    {
+        return false;
+    }
+    if function_ctx.function_def.decorator_list.is_empty() {
+        return true;
+    }
+    function_ctx
+        .method
+        .as_ref()
+        .is_some_and(|method| method.is_staticmethod || method.is_classmethod)
+}
+
+fn build_signature_edits(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    function_ctx: &FunctionContext<'_>,
+    editable_params: &[ParamSlot],
+    receiver_text: Option<&str>,
+    change: SignatureChange,
+) -> Option<Vec<(pyrefly_python::module::Module, TextRange, String)>> {
+    let module_info = transaction.get_module_info(handle)?;
+    let new_order = apply_change_order(editable_params, change)?;
+    let signature_text = render_signature(receiver_text, &new_order);
+    let signature_range = parameters_inner_range(&function_ctx.function_def.parameters)?;
+    let mut edits = vec![(module_info.dupe(), signature_range, signature_text)];
+    edits.extend(build_callsite_edits(
+        transaction,
+        handle,
+        &module_info,
+        function_ctx,
+        editable_params,
+        &new_order,
+    )?);
+    Some(edits)
+}
+
+fn apply_change_order(params: &[ParamSlot], change: SignatureChange) -> Option<Vec<ParamSlot>> {
+    let mut updated = params.to_vec();
+    match change {
+        SignatureChange::Remove { index } => {
+            if index >= updated.len() {
+                return None;
+            }
+            updated.remove(index);
+        }
+        SignatureChange::Move { index, delta } => {
+            let target = index.checked_add_signed(delta)?;
+            if index >= updated.len() || target >= updated.len() {
+                return None;
+            }
+            updated.swap(index, target);
+        }
+    }
+    Some(updated)
+}
+
+fn render_signature(receiver_text: Option<&str>, params: &[ParamSlot]) -> String {
+    let mut parts = Vec::new();
+    if let Some(receiver_text) = receiver_text {
+        parts.push(receiver_text.to_owned());
+    }
+    parts.extend(params.iter().map(|param| param.text.clone()));
+    parts.join(", ")
+}
+
+fn parameters_inner_range(parameters: &Parameters) -> Option<TextRange> {
+    let start = parameters.range().start().checked_add(TextSize::from(1))?;
+    let end = parameters.range().end().checked_sub(TextSize::from(1))?;
+    Some(TextRange::new(start, end))
+}
+
+fn build_callsite_edits(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    module_info: &crate::module::module_info::ModuleInfo,
+    function_ctx: &FunctionContext<'_>,
+    old_params: &[ParamSlot],
+    new_params: &[ParamSlot],
+) -> Option<Vec<(pyrefly_python::module::Module, TextRange, String)>> {
+    let definition = transaction
+        .find_definition(
+            handle,
+            function_ctx.function_def.name.range.start(),
+            FindPreference::default(),
+        )
+        .into_iter()
+        .flat_map(|defs| defs.into_iter())
+        .find(|def| {
+            def.module.path() == module_info.path()
+                && def
+                    .definition_range
+                    .contains_range(function_ctx.function_def.name.range)
+        })?;
+
+    let mut edits = Vec::new();
+    for module_handle in transaction.handles() {
+        let Some(other_module_info) = transaction.get_module_info(&module_handle) else {
+            continue;
+        };
+        let Some(refs) = transaction.local_references_from_definition(
+            &module_handle,
+            definition.metadata.clone(),
+            definition.definition_range,
+            &definition.module,
+            true,
+        ) else {
+            continue;
+        };
+        if refs.is_empty() {
+            continue;
+        }
+        let Some(ast) = transaction.get_ast(&module_handle) else {
+            continue;
+        };
+        let ref_set: std::collections::HashSet<TextRange> = refs.into_iter().collect();
+        let mut module_edits = Vec::new();
+        let mut failed = false;
+        ast.as_ref().visit(&mut |expr| {
+            if failed {
+                return;
+            }
+            let Expr::Call(call) = expr else {
+                return;
+            };
+            if !ref_set
+                .iter()
+                .any(|range| call.func.range().contains(range.start()))
+            {
+                return;
+            }
+            let Some(new_call) = rewrite_call_arguments(
+                call,
+                other_module_info.contents(),
+                function_ctx,
+                old_params,
+                new_params,
+            ) else {
+                failed = true;
+                return;
+            };
+            module_edits.push((other_module_info.dupe(), call.arguments.range(), new_call));
+        });
+        if failed {
+            return None;
+        }
+        edits.extend(module_edits);
+    }
+    Some(edits)
+}
+
+fn rewrite_call_arguments(
+    call: &ExprCall,
+    source: &str,
+    function_ctx: &FunctionContext<'_>,
+    old_params: &[ParamSlot],
+    new_params: &[ParamSlot],
+) -> Option<String> {
+    if call.arguments.args.iter().any(|arg| arg.is_starred_expr())
+        || call.arguments.keywords.iter().any(|kw| kw.arg.is_none())
+    {
+        return None;
+    }
+    let explicit_receiver = explicit_receiver_text(call, source, function_ctx.method.as_ref())?;
+    let positional_skip = explicit_receiver.is_some() as usize;
+    let mut parts = Vec::new();
+    if let Some(receiver) = explicit_receiver {
+        parts.push(receiver);
+    }
+    for param in new_params {
+        let old_index = old_params
+            .iter()
+            .position(|candidate| candidate.name == param.name)?;
+        let argument = if let Some(keyword) = call.arguments.find_keyword(param.name.as_str()) {
+            Some(&keyword.value)
+        } else {
+            call.arguments.find_positional(old_index + positional_skip)
+        };
+        let Some(argument) = argument else {
+            continue;
+        };
+        let argument_text = code_at_range(source, argument.range())?.to_owned();
+        parts.push(format!("{}={}", param.name, argument_text));
+    }
+    Some(format!("({})", parts.join(", ")))
+}
+
+fn explicit_receiver_text(
+    call: &ExprCall,
+    source: &str,
+    method_ctx: Option<&MethodContext>,
+) -> Option<Option<String>> {
+    let Some(method_ctx) = method_ctx else {
+        return Some(None);
+    };
+    if method_ctx.is_staticmethod || method_ctx.is_classmethod {
+        return Some(None);
+    }
+    let Expr::Attribute(attribute) = call.func.as_ref() else {
+        return None;
+    };
+    let Expr::Name(name) = attribute.value.as_ref() else {
+        return Some(None);
+    };
+    if name.id.as_str() != method_ctx.info.class_name {
+        return Some(None);
+    }
+    let receiver = call.arguments.find_positional(0)?;
+    Some(Some(code_at_range(source, receiver.range())?.to_owned()))
+}

--- a/pyrefly/lib/state/lsp/quick_fixes/change_signature.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/change_signature.rs
@@ -26,6 +26,7 @@ use ruff_python_ast::visitor::walk_stmt;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
+use vec1::Vec1;
 
 use super::extract_shared::MethodInfo;
 use super::extract_shared::code_at_range;
@@ -33,6 +34,7 @@ use super::extract_shared::first_parameter_name;
 use super::extract_shared::function_has_decorator;
 use super::types::LocalRefactorCodeAction;
 use crate::state::lsp::FindPreference;
+use crate::state::lsp::ReferenceOptions;
 use crate::state::lsp::Transaction;
 
 #[derive(Clone, Debug)]
@@ -264,6 +266,8 @@ fn parameter_is_referenced_in_body(
     collector.ranges.into_iter().any(|range| {
         transaction
             .find_definition(handle, range.start(), FindPreference::default())
+            .map(Vec1::into_vec)
+            .unwrap_or_default()
             .into_iter()
             .any(|definition| {
                 definition.module.path() == module_path
@@ -363,8 +367,9 @@ fn build_callsite_edits(
             function_ctx.function_def.name.range.start(),
             FindPreference::default(),
         )
+        .map(Vec1::into_vec)
+        .unwrap_or_default()
         .into_iter()
-        .flat_map(|defs| defs.into_iter())
         .find(|def| {
             def.module.path() == module_info.path()
                 && def
@@ -382,7 +387,7 @@ fn build_callsite_edits(
             definition.metadata.clone(),
             definition.definition_range,
             &definition.module,
-            true,
+            ReferenceOptions::textual_only(true),
         ) else {
             continue;
         };

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -4189,11 +4189,11 @@ def caller():
 }
 
 #[test]
-fn change_signature_remove_parameter_updates_calls() {
+fn change_signature_remove_unused_parameter_updates_calls() {
     let code = r#"
 def greet(name, message):
 #                ^
-    return f"{message}, {name}"
+    return name
 
 def caller():
     greet("Ada", "Hello")
@@ -4204,13 +4204,29 @@ def caller():
     let expected = r#"
 def greet(name):
 #                ^
-    return f"{message}, {name}"
+    return name
 
 def caller():
     greet(name="Ada")
     greet(name="Bob")
 "#;
     assert_eq!(expected.trim(), updated.trim());
+}
+
+#[test]
+fn change_signature_does_not_remove_used_parameter() {
+    let code = r#"
+def greet(name, message):
+#                ^
+    return f"{message}, {name}"
+"#;
+    let (_, _, titles) = compute_change_signature_actions(code);
+    assert!(
+        !titles
+            .iter()
+            .any(|title| title == "Remove parameter `message`"),
+        "did not expect remove-parameter action for used parameter, found {titles:?}"
+    );
 }
 
 #[test]

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -4255,6 +4255,31 @@ def caller():
 }
 
 #[test]
+fn change_signature_move_parameter_right_updates_calls() {
+    let code = r#"
+def greet(name, message):
+#         ^
+    return f"{message}, {name}"
+
+def caller():
+    greet("Ada", "Hello")
+    greet(name="Bob", message="Hi")
+"#;
+    let updated = apply_change_signature_action(code, "Move parameter `name` right")
+        .expect("expected move-parameter action");
+    let expected = r#"
+def greet(message, name):
+#         ^
+    return f"{message}, {name}"
+
+def caller():
+    greet(message="Hello", name="Ada")
+    greet(message="Hi", name="Bob")
+"#;
+    assert_eq!(expected.trim(), updated.trim());
+}
+
+#[test]
 fn change_signature_move_method_parameter_left_updates_bound_and_unbound_calls() {
     let code = r#"
 class Greeter:

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -412,6 +412,46 @@ fn assert_no_introduce_parameter_action(code: &str) {
     );
 }
 
+fn compute_change_signature_actions(
+    code: &str,
+) -> (
+    ModuleInfo,
+    Vec<Vec<(Module, TextRange, String)>>,
+    Vec<String>,
+) {
+    let (handles, state) =
+        mk_multi_file_state_assert_no_errors(&[("main", code)], Require::Everything);
+    let handle = handles.get("main").unwrap();
+    let transaction = state.transaction();
+    let module_info = transaction.get_module_info(handle).unwrap();
+    let selection = cursor_selection(code);
+    let actions = transaction
+        .change_signature_code_actions(handle, selection)
+        .unwrap_or_default();
+    let edit_sets: Vec<Vec<(Module, TextRange, String)>> =
+        actions.iter().map(|action| action.edits.clone()).collect();
+    let titles = actions.iter().map(|action| action.title.clone()).collect();
+    (module_info, edit_sets, titles)
+}
+
+fn apply_change_signature_action(code: &str, title: &str) -> Option<String> {
+    let (module_info, actions, titles) = compute_change_signature_actions(code);
+    let index = titles.iter().position(|candidate| candidate == title)?;
+    Some(apply_refactor_edits_for_module(
+        &module_info,
+        &actions[index],
+    ))
+}
+
+fn assert_no_change_signature_action(code: &str) {
+    let (_, actions, _) = compute_change_signature_actions(code);
+    assert!(
+        actions.is_empty(),
+        "expected no change-signature actions, found {}",
+        actions.len()
+    );
+}
+
 fn assert_no_extract_variable_action(code: &str) {
     let (_, actions, _) = compute_extract_variable_actions(code);
     assert!(
@@ -4146,6 +4186,95 @@ def caller():
     accept(**values)
 "#;
     assert_no_introduce_parameter_action(code);
+}
+
+#[test]
+fn change_signature_remove_parameter_updates_calls() {
+    let code = r#"
+def greet(name, message):
+#                ^
+    return f"{message}, {name}"
+
+def caller():
+    greet("Ada", "Hello")
+    greet(name="Bob", message="Hi")
+"#;
+    let updated = apply_change_signature_action(code, "Remove parameter `message`")
+        .expect("expected remove-parameter action");
+    let expected = r#"
+def greet(name):
+#                ^
+    return f"{message}, {name}"
+
+def caller():
+    greet(name="Ada")
+    greet(name="Bob")
+"#;
+    assert_eq!(expected.trim(), updated.trim());
+}
+
+#[test]
+fn change_signature_move_parameter_left_updates_calls() {
+    let code = r#"
+def greet(name, message):
+#                ^
+    return f"{message}, {name}"
+
+def caller():
+    greet("Ada", "Hello")
+    greet(name="Bob", message="Hi")
+"#;
+    let updated = apply_change_signature_action(code, "Move parameter `message` left")
+        .expect("expected move-parameter action");
+    let expected = r#"
+def greet(message, name):
+#                ^
+    return f"{message}, {name}"
+
+def caller():
+    greet(message="Hello", name="Ada")
+    greet(message="Hi", name="Bob")
+"#;
+    assert_eq!(expected.trim(), updated.trim());
+}
+
+#[test]
+fn change_signature_move_method_parameter_left_updates_bound_and_unbound_calls() {
+    let code = r#"
+class Greeter:
+    def greet(self, name, message):
+#                         ^
+        return f"{message}, {name}"
+
+def caller():
+    greeter = Greeter()
+    greeter.greet("Ada", "Hello")
+    Greeter.greet(greeter, "Bob", "Hi")
+"#;
+    let updated = apply_change_signature_action(code, "Move parameter `message` left")
+        .expect("expected move-parameter action");
+    let expected = r#"
+class Greeter:
+    def greet(self, message, name):
+#                         ^
+        return f"{message}, {name}"
+
+def caller():
+    greeter = Greeter()
+    greeter.greet(message="Hello", name="Ada")
+    Greeter.greet(greeter, message="Hi", name="Bob")
+"#;
+    assert_eq!(expected.trim(), updated.trim());
+}
+
+#[test]
+fn change_signature_rejects_variadic_functions() {
+    let code = r#"
+def greet(name, *args):
+#         ^
+    return args
+"#;
+    assert_no_change_signature_action(code);
 }
 
 mod extract_field_tests {


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes part of #2207

Implemented change_signature as a new local refactor.

The current scope is the non-interactive subset that fits Pyrefly’s existing code-action model:

when the cursor is on a simple positional-or-keyword parameter, it now offers Remove parameter, Move parameter left, and Move parameter right, and rewrites matching call sites.

That includes bound and unbound method calls.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add related test.