### PR TITLE
impl introduce_factory #2207

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -4761,6 +4761,10 @@ impl Server {
                 )
             );
             timed_refactor_action!(
+                "introduce_factory",
+                transaction.introduce_factory_code_actions(&handle, range)
+            );
+            timed_refactor_action!(
                 "introduce_parameter",
                 transaction.introduce_parameter_code_actions(&handle, range)
             );

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -4776,6 +4776,10 @@ impl Server {
                 )
             );
             timed_refactor_action!(
+                "introduce_factory",
+                transaction.introduce_factory_code_actions(&handle, range)
+            );
+            timed_refactor_action!(
                 "introduce_parameter",
                 transaction.introduce_parameter_code_actions(&handle, range)
             );

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3525,7 +3525,7 @@ impl<'a> Transaction<'a> {
     }
 
     pub fn introduce_factory_code_actions(
-        &self,
+        &mut self,
         handle: &Handle,
         selection: TextRange,
     ) -> Option<Vec<LocalRefactorCodeAction>> {

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3524,6 +3524,14 @@ impl<'a> Transaction<'a> {
         quick_fixes::safe_delete::safe_delete_code_actions(self, handle, selection)
     }
 
+    pub fn introduce_factory_code_actions(
+        &self,
+        handle: &Handle,
+        selection: TextRange,
+    ) -> Option<Vec<LocalRefactorCodeAction>> {
+        quick_fixes::introduce_factory::introduce_factory_code_actions(self, handle, selection)
+    }
+
     pub fn introduce_parameter_code_actions(
         &self,
         handle: &Handle,

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3830,6 +3830,14 @@ impl<'a> Transaction<'a> {
         quick_fixes::safe_delete::safe_delete_code_actions(self, handle, selection)
     }
 
+    pub fn introduce_factory_code_actions(
+        &self,
+        handle: &Handle,
+        selection: TextRange,
+    ) -> Option<Vec<LocalRefactorCodeAction>> {
+        quick_fixes::introduce_factory::introduce_factory_code_actions(self, handle, selection)
+    }
+
     pub fn introduce_parameter_code_actions(
         &self,
         handle: &Handle,

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3831,7 +3831,7 @@ impl<'a> Transaction<'a> {
     }
 
     pub fn introduce_factory_code_actions(
-        &self,
+        &mut self,
         handle: &Handle,
         selection: TextRange,
     ) -> Option<Vec<LocalRefactorCodeAction>> {

--- a/pyrefly/lib/state/lsp/quick_fixes.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes.rs
@@ -18,6 +18,7 @@ pub(crate) mod generate_code;
 pub(crate) mod inline_method;
 pub(crate) mod inline_parameter;
 pub(crate) mod inline_variable;
+pub(crate) mod introduce_factory;
 pub(crate) mod introduce_parameter;
 pub(crate) mod invert_boolean;
 pub(crate) mod move_members;

--- a/pyrefly/lib/state/lsp/quick_fixes.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes.rs
@@ -19,6 +19,7 @@ pub(crate) mod generate_code;
 pub(crate) mod inline_method;
 pub(crate) mod inline_parameter;
 pub(crate) mod inline_variable;
+pub(crate) mod introduce_factory;
 pub(crate) mod introduce_parameter;
 pub(crate) mod invert_boolean;
 pub(crate) mod move_members;

--- a/pyrefly/lib/state/lsp/quick_fixes/introduce_factory.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/introduce_factory.rs
@@ -20,6 +20,7 @@ use ruff_python_ast::StmtClassDef;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
+use vec1::Vec1;
 
 use super::extract_shared::line_end_position;
 use super::extract_shared::line_indent_and_start;
@@ -54,6 +55,8 @@ pub(crate) fn introduce_factory_code_actions(
             class_def.name.range().start(),
             FindPreference::default(),
         )
+        .map(Vec1::into_vec)
+        .unwrap_or_default()
         .into_iter()
         .find(|def| {
             def.module.path() == module_info.path()

--- a/pyrefly/lib/state/lsp/quick_fixes/introduce_factory.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/introduce_factory.rs
@@ -154,14 +154,18 @@ fn build_constructor_callsite_edits(
             let Expr::Call(call) = expr else {
                 return;
             };
-            if !call_matches_reference(call, &ref_set) {
-                return;
+            match constructor_call_kind(call, &ref_set) {
+                ConstructorCallKind::Unrelated => {}
+                ConstructorCallKind::Unsupported => failed = true,
+                ConstructorCallKind::Rewritable => {
+                    let Some((range, text)) = build_factory_call_edit(call, &ref_set, factory_name)
+                    else {
+                        failed = true;
+                        return;
+                    };
+                    module_edits.push((module_info.dupe(), range, text));
+                }
             }
-            let Some((range, text)) = build_factory_call_edit(call, &ref_set, factory_name) else {
-                failed = true;
-                return;
-            };
-            module_edits.push((module_info.dupe(), range, text));
         });
         if failed {
             return None;
@@ -171,10 +175,29 @@ fn build_constructor_callsite_edits(
     Some(edits)
 }
 
-fn call_matches_reference(call: &ExprCall, ref_set: &HashSet<TextRange>) -> bool {
-    ref_set
-        .iter()
-        .any(|range| call.func.range().contains(range.start()))
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConstructorCallKind {
+    Unrelated,
+    Rewritable,
+    Unsupported,
+}
+
+fn constructor_call_kind(call: &ExprCall, ref_set: &HashSet<TextRange>) -> ConstructorCallKind {
+    match call.func.as_ref() {
+        Expr::Name(name) => ref_set
+            .contains(&name.range())
+            .then_some(ConstructorCallKind::Rewritable)
+            .unwrap_or(ConstructorCallKind::Unrelated),
+        Expr::Attribute(attribute) => ref_set
+            .contains(&attribute.attr.range())
+            .then_some(ConstructorCallKind::Rewritable)
+            .unwrap_or(ConstructorCallKind::Unrelated),
+        _ => ref_set
+            .iter()
+            .any(|range| call.func.range().contains(range.start()))
+            .then_some(ConstructorCallKind::Unsupported)
+            .unwrap_or(ConstructorCallKind::Unrelated),
+    }
 }
 
 fn build_factory_call_edit(

--- a/pyrefly/lib/state/lsp/quick_fixes/introduce_factory.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/introduce_factory.rs
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::collections::HashSet;
+
+use dupe::Dupe;
+use lsp_types::CodeActionKind;
+use pyrefly_build::handle::Handle;
+use pyrefly_python::ast::Ast;
+use pyrefly_python::symbol_kind::SymbolKind;
+use pyrefly_util::visit::Visit;
+use ruff_python_ast::Expr;
+use ruff_python_ast::ExprCall;
+use ruff_python_ast::ModModule;
+use ruff_python_ast::StmtClassDef;
+use ruff_text_size::Ranged;
+use ruff_text_size::TextRange;
+use ruff_text_size::TextSize;
+
+use super::extract_shared::line_end_position;
+use super::extract_shared::line_indent_and_start;
+use super::extract_shared::member_name_from_stmt;
+use super::extract_shared::selection_anchor;
+use super::extract_shared::unique_name;
+use super::types::LocalRefactorCodeAction;
+use crate::state::lsp::FindPreference;
+use crate::state::lsp::Transaction;
+
+const DEFAULT_FACTORY_NAME: &str = "create";
+const DEFAULT_INDENT: &str = "    ";
+
+/// Builds introduce-factory refactor actions for a selected class name.
+pub(crate) fn introduce_factory_code_actions(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    selection: TextRange,
+) -> Option<Vec<LocalRefactorCodeAction>> {
+    let module_info = transaction.get_module_info(handle)?;
+    let ast = transaction.get_ast(handle)?;
+    let source = module_info.contents();
+    let selection_point = selection_anchor(source, selection);
+    let class_def = find_class_at_selection(ast.as_ref(), selection_point)?;
+    if !contains_point(class_def.name.range(), selection_point) {
+        return None;
+    }
+
+    let definition = transaction
+        .find_definition(
+            handle,
+            class_def.name.range().start(),
+            FindPreference::default(),
+        )
+        .into_iter()
+        .find(|def| {
+            def.module.path() == module_info.path()
+                && def.definition_range.contains_range(class_def.name.range())
+                && def.metadata.symbol_kind() == Some(SymbolKind::Class)
+        })?;
+
+    let factory_name = generate_factory_name(class_def);
+    let factory_edit =
+        build_factory_insertion_edit(&module_info, class_def, source, factory_name.as_str())?;
+    let callsite_edits =
+        build_constructor_callsite_edits(transaction, &definition, factory_name.as_str())?;
+
+    let mut edits = vec![factory_edit];
+    edits.extend(callsite_edits);
+    Some(vec![LocalRefactorCodeAction {
+        title: format!(
+            "Introduce factory `{factory_name}` for `{}`",
+            class_def.name.id
+        ),
+        edits,
+        kind: CodeActionKind::REFACTOR_REWRITE,
+    }])
+}
+
+fn find_class_at_selection(ast: &ModModule, selection_point: TextSize) -> Option<&StmtClassDef> {
+    Ast::locate_node(ast, selection_point)
+        .into_iter()
+        .find_map(|node| node.as_stmt_class_def().copied())
+}
+
+fn contains_point(range: TextRange, point: TextSize) -> bool {
+    range.start() <= point && point < range.end()
+}
+
+fn generate_factory_name(class_def: &StmtClassDef) -> String {
+    let existing_names: HashSet<String> = class_def
+        .body
+        .iter()
+        .filter_map(member_name_from_stmt)
+        .collect();
+    unique_name(DEFAULT_FACTORY_NAME, |name| existing_names.contains(name))
+}
+
+fn build_factory_insertion_edit(
+    module_info: &pyrefly_python::module::Module,
+    class_def: &StmtClassDef,
+    source: &str,
+    factory_name: &str,
+) -> Option<(pyrefly_python::module::Module, TextRange, String)> {
+    let (class_indent, _) = line_indent_and_start(source, class_def.range().start())?;
+    let insert_position = line_end_position(source, class_def.body.last()?.range().end());
+    let method_indent = format!("{class_indent}{DEFAULT_INDENT}");
+    let body_indent = format!("{method_indent}{DEFAULT_INDENT}");
+    let insert_text = format!(
+        "\n{method_indent}@staticmethod\n{method_indent}def {factory_name}(*args, **kwargs):\n{body_indent}return {}(*args, **kwargs)\n",
+        class_def.name.id
+    );
+    Some((
+        module_info.dupe(),
+        TextRange::at(insert_position, TextSize::new(0)),
+        insert_text,
+    ))
+}
+
+fn build_constructor_callsite_edits(
+    transaction: &Transaction<'_>,
+    definition: &crate::state::lsp::FindDefinitionItemWithDocstring,
+    factory_name: &str,
+) -> Option<Vec<(pyrefly_python::module::Module, TextRange, String)>> {
+    let mut edits = Vec::new();
+    for module_handle in transaction.handles() {
+        let Some(module_info) = transaction.get_module_info(&module_handle) else {
+            continue;
+        };
+        let Some(refs) = transaction.local_references_from_definition(
+            &module_handle,
+            definition.metadata.clone(),
+            definition.definition_range,
+            &definition.module,
+            false,
+        ) else {
+            continue;
+        };
+        if refs.is_empty() {
+            continue;
+        }
+        let Some(ast) = transaction.get_ast(&module_handle) else {
+            continue;
+        };
+        let ref_set: HashSet<TextRange> = refs.into_iter().collect();
+        let mut module_edits = Vec::new();
+        let mut failed = false;
+        ast.as_ref().visit(&mut |expr| {
+            if failed {
+                return;
+            }
+            let Expr::Call(call) = expr else {
+                return;
+            };
+            if !call_matches_reference(call, &ref_set) {
+                return;
+            }
+            let Some((range, text)) = build_factory_call_edit(call, &ref_set, factory_name) else {
+                failed = true;
+                return;
+            };
+            module_edits.push((module_info.dupe(), range, text));
+        });
+        if failed {
+            return None;
+        }
+        edits.extend(module_edits);
+    }
+    Some(edits)
+}
+
+fn call_matches_reference(call: &ExprCall, ref_set: &HashSet<TextRange>) -> bool {
+    ref_set
+        .iter()
+        .any(|range| call.func.range().contains(range.start()))
+}
+
+fn build_factory_call_edit(
+    call: &ExprCall,
+    ref_set: &HashSet<TextRange>,
+    factory_name: &str,
+) -> Option<(TextRange, String)> {
+    match call.func.as_ref() {
+        Expr::Name(name) if ref_set.contains(&name.range()) => {
+            Some((name.range(), format!("{}.{}", name.id, factory_name)))
+        }
+        Expr::Attribute(attribute) if ref_set.contains(&attribute.attr.range()) => Some((
+            attribute.attr.range(),
+            format!("{}.{}", attribute.attr.id, factory_name),
+        )),
+        _ => None,
+    }
+}

--- a/pyrefly/lib/state/lsp/quick_fixes/introduce_factory.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/introduce_factory.rs
@@ -11,6 +11,9 @@ use dupe::Dupe;
 use lsp_types::CodeActionKind;
 use pyrefly_build::handle::Handle;
 use pyrefly_python::ast::Ast;
+use pyrefly_python::module::Module;
+use pyrefly_python::module::TextRangeWithModule;
+use pyrefly_python::module_path::ModulePathDetails;
 use pyrefly_python::symbol_kind::SymbolKind;
 use pyrefly_util::visit::Visit;
 use ruff_python_ast::Expr;
@@ -20,7 +23,6 @@ use ruff_python_ast::StmtClassDef;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
-use vec1::Vec1;
 
 use super::extract_shared::line_end_position;
 use super::extract_shared::line_indent_and_start;
@@ -28,6 +30,7 @@ use super::extract_shared::member_name_from_stmt;
 use super::extract_shared::selection_anchor;
 use super::extract_shared::unique_name;
 use super::types::LocalRefactorCodeAction;
+use crate::state::lsp::FindDefinitionItemWithDocstring;
 use crate::state::lsp::FindPreference;
 use crate::state::lsp::Transaction;
 
@@ -36,7 +39,7 @@ const DEFAULT_INDENT: &str = "    ";
 
 /// Builds introduce-factory refactor actions for a selected class name.
 pub(crate) fn introduce_factory_code_actions(
-    transaction: &Transaction<'_>,
+    transaction: &mut Transaction<'_>,
     handle: &Handle,
     selection: TextRange,
 ) -> Option<Vec<LocalRefactorCodeAction>> {
@@ -55,8 +58,8 @@ pub(crate) fn introduce_factory_code_actions(
             class_def.name.range().start(),
             FindPreference::default(),
         )
-        .map(Vec1::into_vec)
-        .unwrap_or_default()
+        .ok()?
+        .into_vec()
         .into_iter()
         .find(|def| {
             def.module.path() == module_info.path()
@@ -68,7 +71,7 @@ pub(crate) fn introduce_factory_code_actions(
     let factory_edit =
         build_factory_insertion_edit(&module_info, class_def, source, factory_name.as_str())?;
     let callsite_edits =
-        build_constructor_callsite_edits(transaction, &definition, factory_name.as_str())?;
+        build_constructor_callsite_edits(transaction, handle, &definition, factory_name.as_str())?;
 
     let mut edits = vec![factory_edit];
     edits.extend(callsite_edits);
@@ -102,11 +105,11 @@ fn generate_factory_name(class_def: &StmtClassDef) -> String {
 }
 
 fn build_factory_insertion_edit(
-    module_info: &pyrefly_python::module::Module,
+    module_info: &Module,
     class_def: &StmtClassDef,
     source: &str,
     factory_name: &str,
-) -> Option<(pyrefly_python::module::Module, TextRange, String)> {
+) -> Option<(Module, TextRange, String)> {
     let (class_indent, _) = line_indent_and_start(source, class_def.range().start())?;
     let insert_position = line_end_position(source, class_def.body.last()?.range().end());
     let method_indent = format!("{class_indent}{DEFAULT_INDENT}");
@@ -123,15 +126,29 @@ fn build_factory_insertion_edit(
 }
 
 fn build_constructor_callsite_edits(
-    transaction: &Transaction<'_>,
-    definition: &crate::state::lsp::FindDefinitionItemWithDocstring,
+    transaction: &mut Transaction<'_>,
+    handle: &Handle,
+    definition: &FindDefinitionItemWithDocstring,
     factory_name: &str,
-) -> Option<Vec<(pyrefly_python::module::Module, TextRange, String)>> {
+) -> Option<Vec<(Module, TextRange, String)>> {
     let mut edits = Vec::new();
+    let mut references = transaction
+        .find_global_references_from_definition(
+            *handle.sys_info(),
+            definition.metadata.clone(),
+            TextRangeWithModule::new(definition.module.dupe(), definition.definition_range),
+            false,
+        )
+        .ok()?;
+    // Unsaved modules may not be in the filesystem reverse-dependency graph.
     for module_handle in transaction.handles() {
-        let Some(module_info) = transaction.get_module_info(&module_handle) else {
+        if !matches!(module_handle.path().details(), ModulePathDetails::Memory(_))
+            || references
+                .iter()
+                .any(|(module, _)| module.path() == module_handle.path())
+        {
             continue;
-        };
+        }
         let Some(refs) = transaction.local_references_from_definition(
             &module_handle,
             definition.metadata.clone(),
@@ -141,12 +158,22 @@ fn build_constructor_callsite_edits(
         ) else {
             continue;
         };
-        if refs.is_empty() {
-            continue;
+        if !refs.is_empty() {
+            let module_info = transaction
+                .get_module_info(&module_handle)
+                .expect("modules containing references must have module information");
+            references.push((module_info, refs));
         }
-        let Some(ast) = transaction.get_ast(&module_handle) else {
-            continue;
-        };
+    }
+    for (module_info, refs) in references {
+        let module_handle = Handle::new(
+            module_info.name(),
+            module_info.path().dupe(),
+            *handle.sys_info(),
+        );
+        let ast = transaction
+            .get_ast(&module_handle)
+            .expect("modules containing references must have an AST");
         let ref_set: HashSet<TextRange> = refs.into_iter().collect();
         let mut module_edits = Vec::new();
         let mut failed = false;
@@ -187,19 +214,30 @@ enum ConstructorCallKind {
 
 fn constructor_call_kind(call: &ExprCall, ref_set: &HashSet<TextRange>) -> ConstructorCallKind {
     match call.func.as_ref() {
-        Expr::Name(name) => ref_set
-            .contains(&name.range())
-            .then_some(ConstructorCallKind::Rewritable)
-            .unwrap_or(ConstructorCallKind::Unrelated),
-        Expr::Attribute(attribute) => ref_set
-            .contains(&attribute.attr.range())
-            .then_some(ConstructorCallKind::Rewritable)
-            .unwrap_or(ConstructorCallKind::Unrelated),
-        _ => ref_set
-            .iter()
-            .any(|range| call.func.range().contains(range.start()))
-            .then_some(ConstructorCallKind::Unsupported)
-            .unwrap_or(ConstructorCallKind::Unrelated),
+        Expr::Name(name) => {
+            if ref_set.contains(&name.range()) {
+                ConstructorCallKind::Rewritable
+            } else {
+                ConstructorCallKind::Unrelated
+            }
+        }
+        Expr::Attribute(attribute) => {
+            if ref_set.contains(&attribute.attr.range()) {
+                ConstructorCallKind::Rewritable
+            } else {
+                ConstructorCallKind::Unrelated
+            }
+        }
+        _ => {
+            if ref_set
+                .iter()
+                .any(|range| call.func.range().contains(range.start()))
+            {
+                ConstructorCallKind::Unsupported
+            } else {
+                ConstructorCallKind::Unrelated
+            }
+        }
     }
 }
 

--- a/pyrefly/lib/state/lsp/quick_fixes/introduce_factory.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/introduce_factory.rs
@@ -32,6 +32,7 @@ use super::extract_shared::unique_name;
 use super::types::LocalRefactorCodeAction;
 use crate::state::lsp::FindDefinitionItemWithDocstring;
 use crate::state::lsp::FindPreference;
+use crate::state::lsp::ReferenceOptions;
 use crate::state::lsp::Transaction;
 
 const DEFAULT_FACTORY_NAME: &str = "create";
@@ -125,6 +126,10 @@ fn build_factory_insertion_edit(
     ))
 }
 
+/// Rewrites constructor references in modules that depend on the selected class.
+///
+/// The global lookup covers disk-backed reverse dependencies. Loaded in-memory modules are
+/// checked separately because unsaved buffers may not be represented in that dependency graph.
 fn build_constructor_callsite_edits(
     transaction: &mut Transaction<'_>,
     handle: &Handle,
@@ -137,10 +142,9 @@ fn build_constructor_callsite_edits(
             *handle.sys_info(),
             definition.metadata.clone(),
             TextRangeWithModule::new(definition.module.dupe(), definition.definition_range),
-            false,
+            ReferenceOptions::textual_only(false),
         )
         .ok()?;
-    // Unsaved modules may not be in the filesystem reverse-dependency graph.
     for module_handle in transaction.handles() {
         if !matches!(module_handle.path().details(), ModulePathDetails::Memory(_))
             || references
@@ -154,7 +158,7 @@ fn build_constructor_callsite_edits(
             definition.metadata.clone(),
             definition.definition_range,
             &definition.module,
-            false,
+            ReferenceOptions::textual_only(false),
         ) else {
             continue;
         };

--- a/pyrefly/lib/state/lsp/quick_fixes/introduce_factory.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/introduce_factory.rs
@@ -125,6 +125,10 @@ fn build_factory_insertion_edit(
     ))
 }
 
+/// Rewrites constructor references in modules that depend on the selected class.
+///
+/// The global lookup covers disk-backed reverse dependencies. Loaded in-memory modules are
+/// checked separately because unsaved buffers may not be represented in that dependency graph.
 fn build_constructor_callsite_edits(
     transaction: &mut Transaction<'_>,
     handle: &Handle,
@@ -140,7 +144,6 @@ fn build_constructor_callsite_edits(
             false,
         )
         .ok()?;
-    // Unsaved modules may not be in the filesystem reverse-dependency graph.
     for module_handle in transaction.handles() {
         if !matches!(module_handle.path().details(), ModulePathDetails::Memory(_))
             || references

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -451,6 +451,42 @@ fn assert_no_change_signature_action(code: &str) {
         actions.len()
     );
 }
+fn compute_introduce_factory_actions(
+    code: &str,
+) -> (
+    ModuleInfo,
+    Vec<Vec<(Module, TextRange, String)>>,
+    Vec<String>,
+) {
+    let (handles, state) =
+        mk_multi_file_state_assert_no_errors(&[("main", code)], Require::Everything);
+    let handle = handles.get("main").unwrap();
+    let transaction = state.transaction();
+    let module_info = transaction.get_module_info(handle).unwrap();
+    let selection = cursor_selection(module_info.contents());
+    let actions = transaction
+        .introduce_factory_code_actions(handle, selection)
+        .unwrap_or_default();
+    let edit_sets: Vec<Vec<(Module, TextRange, String)>> =
+        actions.iter().map(|action| action.edits.clone()).collect();
+    let titles = actions.iter().map(|action| action.title.clone()).collect();
+    (module_info, edit_sets, titles)
+}
+
+fn apply_first_introduce_factory_action(code: &str) -> Option<String> {
+    let (module_info, actions, _) = compute_introduce_factory_actions(code);
+    let edits = actions.first()?;
+    Some(apply_refactor_edits_for_module(&module_info, edits))
+}
+
+fn assert_no_introduce_factory_action(code: &str) {
+    let (_, actions, _) = compute_introduce_factory_actions(code);
+    assert!(
+        actions.is_empty(),
+        "expected no introduce-factory actions, found {}",
+        actions.len()
+    );
+}
 
 fn assert_no_extract_variable_action(code: &str) {
     let (_, actions, _) = compute_extract_variable_actions(code);
@@ -4565,6 +4601,132 @@ def greet(name, *args):
     return args
 "#;
     assert_no_change_signature_action(code);
+}
+fn introduce_factory_basic_refactor() {
+    let code = r#"
+class Service:
+#     ^
+    def __init__(self, value):
+        self.value = value
+
+def build():
+    return Service(1)
+"#;
+    let updated =
+        apply_first_introduce_factory_action(code).expect("expected introduce-factory action");
+    let expected = r#"
+class Service:
+#     ^
+    def __init__(self, value):
+        self.value = value
+
+    @staticmethod
+    def create(*args, **kwargs):
+        return Service(*args, **kwargs)
+
+def build():
+    return Service.create(1)
+"#;
+    assert_eq!(expected, updated);
+}
+
+#[test]
+fn introduce_factory_uses_unique_name() {
+    let code = r#"
+class Service:
+#     ^
+    create = 0
+
+    def __init__(self, value):
+        self.value = value
+
+def build():
+    return Service(1)
+"#;
+    let updated =
+        apply_first_introduce_factory_action(code).expect("expected introduce-factory action");
+    let expected = r#"
+class Service:
+#     ^
+    create = 0
+
+    def __init__(self, value):
+        self.value = value
+
+    @staticmethod
+    def create_1(*args, **kwargs):
+        return Service(*args, **kwargs)
+
+def build():
+    return Service.create_1(1)
+"#;
+    assert_eq!(expected, updated);
+}
+
+#[test]
+fn introduce_factory_updates_other_modules() {
+    let class_code = r#"
+class Service:
+#     ^
+    def __init__(self, value):
+        self.value = value
+"#;
+    let consumer_code = r#"
+from main import Service
+
+service = Service(1)
+"#;
+    let (handles, state) = mk_multi_file_state_assert_no_errors(
+        &[("main", class_code), ("consumer", consumer_code)],
+        Require::Everything,
+    );
+    let main_handle = handles.get("main").unwrap();
+    let consumer_handle = handles.get("consumer").unwrap();
+    let transaction = state.transaction();
+    let main_info = transaction.get_module_info(main_handle).unwrap();
+    let consumer_info = transaction.get_module_info(consumer_handle).unwrap();
+    let selection = cursor_selection(main_info.contents());
+    let actions = transaction
+        .introduce_factory_code_actions(main_handle, selection)
+        .unwrap_or_default();
+    let edits = &actions[0].edits;
+
+    let updated_main = apply_refactor_edits_for_module(&main_info, edits);
+    let updated_consumer = apply_refactor_edits_for_module(&consumer_info, edits);
+    let expected_main = r#"
+class Service:
+#     ^
+    def __init__(self, value):
+        self.value = value
+
+    @staticmethod
+    def create(*args, **kwargs):
+        return Service(*args, **kwargs)
+"#;
+    let expected_consumer = r#"
+from main import Service
+
+service = Service.create(1)
+"#;
+
+    assert_eq!(expected_main, updated_main);
+    assert_eq!(expected_consumer, updated_consumer);
+}
+
+#[test]
+fn introduce_factory_rejects_unsupported_subscript_calls() {
+    let code = r#"
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Box(Generic[T]):
+#     ^
+    pass
+
+value = Box[int]()
+"#;
+    assert_no_introduce_factory_action(code);
 }
 
 mod extract_field_tests {

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -461,7 +461,7 @@ fn compute_introduce_factory_actions(
     let (handles, state) =
         mk_multi_file_state_assert_no_errors(&[("main", code)], Require::Everything);
     let handle = handles.get("main").unwrap();
-    let transaction = state.transaction();
+    let mut transaction = state.transaction();
     let module_info = transaction.get_module_info(handle).unwrap();
     let selection = cursor_selection(module_info.contents());
     let actions = transaction
@@ -4723,7 +4723,7 @@ service = Service(1)
     );
     let main_handle = handles.get("main").unwrap();
     let consumer_handle = handles.get("consumer").unwrap();
-    let transaction = state.transaction();
+    let mut transaction = state.transaction();
     let main_info = transaction.get_module_info(main_handle).unwrap();
     let consumer_info = transaction.get_module_info(consumer_handle).unwrap();
     let selection = cursor_selection(main_info.contents());

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -4248,6 +4248,47 @@ def build():
 }
 
 #[test]
+fn introduce_factory_ignores_non_constructor_class_calls() {
+    let code = r#"
+class Service:
+#     ^
+    @classmethod
+    def create(cls):
+        return cls(0)
+
+    def __init__(self, value):
+        self.value = value
+
+def build():
+    existing = Service.create()
+    direct = Service(1)
+    return existing, direct
+"#;
+    let updated =
+        apply_first_introduce_factory_action(code).expect("expected introduce-factory action");
+    let expected = r#"
+class Service:
+#     ^
+    @classmethod
+    def create(cls):
+        return cls(0)
+
+    def __init__(self, value):
+        self.value = value
+
+    @staticmethod
+    def create_1(*args, **kwargs):
+        return Service(*args, **kwargs)
+
+def build():
+    existing = Service.create()
+    direct = Service.create_1(1)
+    return existing, direct
+"#;
+    assert_eq!(expected, updated);
+}
+
+#[test]
 fn introduce_factory_updates_other_modules() {
     let class_code = r#"
 class Service:

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -412,6 +412,43 @@ fn assert_no_introduce_parameter_action(code: &str) {
     );
 }
 
+fn compute_introduce_factory_actions(
+    code: &str,
+) -> (
+    ModuleInfo,
+    Vec<Vec<(Module, TextRange, String)>>,
+    Vec<String>,
+) {
+    let (handles, state) =
+        mk_multi_file_state_assert_no_errors(&[("main", code)], Require::Everything);
+    let handle = handles.get("main").unwrap();
+    let transaction = state.transaction();
+    let module_info = transaction.get_module_info(handle).unwrap();
+    let selection = cursor_selection(module_info.contents());
+    let actions = transaction
+        .introduce_factory_code_actions(handle, selection)
+        .unwrap_or_default();
+    let edit_sets: Vec<Vec<(Module, TextRange, String)>> =
+        actions.iter().map(|action| action.edits.clone()).collect();
+    let titles = actions.iter().map(|action| action.title.clone()).collect();
+    (module_info, edit_sets, titles)
+}
+
+fn apply_first_introduce_factory_action(code: &str) -> Option<String> {
+    let (module_info, actions, _) = compute_introduce_factory_actions(code);
+    let edits = actions.first()?;
+    Some(apply_refactor_edits_for_module(&module_info, edits))
+}
+
+fn assert_no_introduce_factory_action(code: &str) {
+    let (_, actions, _) = compute_introduce_factory_actions(code);
+    assert!(
+        actions.is_empty(),
+        "expected no introduce-factory actions, found {}",
+        actions.len()
+    );
+}
+
 fn assert_no_extract_variable_action(code: &str) {
     let (_, actions, _) = compute_extract_variable_actions(code);
     assert!(
@@ -4146,6 +4183,134 @@ def caller():
     accept(**values)
 "#;
     assert_no_introduce_parameter_action(code);
+}
+
+#[test]
+fn introduce_factory_basic_refactor() {
+    let code = r#"
+class Service:
+#     ^
+    def __init__(self, value):
+        self.value = value
+
+def build():
+    return Service(1)
+"#;
+    let updated =
+        apply_first_introduce_factory_action(code).expect("expected introduce-factory action");
+    let expected = r#"
+class Service:
+#     ^
+    def __init__(self, value):
+        self.value = value
+
+    @staticmethod
+    def create(*args, **kwargs):
+        return Service(*args, **kwargs)
+
+def build():
+    return Service.create(1)
+"#;
+    assert_eq!(expected, updated);
+}
+
+#[test]
+fn introduce_factory_uses_unique_name() {
+    let code = r#"
+class Service:
+#     ^
+    create = 0
+
+    def __init__(self, value):
+        self.value = value
+
+def build():
+    return Service(1)
+"#;
+    let updated =
+        apply_first_introduce_factory_action(code).expect("expected introduce-factory action");
+    let expected = r#"
+class Service:
+#     ^
+    create = 0
+
+    def __init__(self, value):
+        self.value = value
+
+    @staticmethod
+    def create_1(*args, **kwargs):
+        return Service(*args, **kwargs)
+
+def build():
+    return Service.create_1(1)
+"#;
+    assert_eq!(expected, updated);
+}
+
+#[test]
+fn introduce_factory_updates_other_modules() {
+    let class_code = r#"
+class Service:
+#     ^
+    def __init__(self, value):
+        self.value = value
+"#;
+    let consumer_code = r#"
+from main import Service
+
+service = Service(1)
+"#;
+    let (handles, state) = mk_multi_file_state_assert_no_errors(
+        &[("main", class_code), ("consumer", consumer_code)],
+        Require::Everything,
+    );
+    let main_handle = handles.get("main").unwrap();
+    let consumer_handle = handles.get("consumer").unwrap();
+    let transaction = state.transaction();
+    let main_info = transaction.get_module_info(main_handle).unwrap();
+    let consumer_info = transaction.get_module_info(consumer_handle).unwrap();
+    let selection = cursor_selection(main_info.contents());
+    let actions = transaction
+        .introduce_factory_code_actions(main_handle, selection)
+        .unwrap_or_default();
+    let edits = &actions[0].edits;
+
+    let updated_main = apply_refactor_edits_for_module(&main_info, edits);
+    let updated_consumer = apply_refactor_edits_for_module(&consumer_info, edits);
+    let expected_main = r#"
+class Service:
+#     ^
+    def __init__(self, value):
+        self.value = value
+
+    @staticmethod
+    def create(*args, **kwargs):
+        return Service(*args, **kwargs)
+"#;
+    let expected_consumer = r#"
+from main import Service
+
+service = Service.create(1)
+"#;
+
+    assert_eq!(expected_main, updated_main);
+    assert_eq!(expected_consumer, updated_consumer);
+}
+
+#[test]
+fn introduce_factory_rejects_unsupported_subscript_calls() {
+    let code = r#"
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Box(Generic[T]):
+#     ^
+    pass
+
+value = Box[int]()
+"#;
+    assert_no_introduce_factory_action(code);
 }
 
 mod extract_field_tests {

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -422,7 +422,7 @@ fn compute_introduce_factory_actions(
     let (handles, state) =
         mk_multi_file_state_assert_no_errors(&[("main", code)], Require::Everything);
     let handle = handles.get("main").unwrap();
-    let transaction = state.transaction();
+    let mut transaction = state.transaction();
     let module_info = transaction.get_module_info(handle).unwrap();
     let selection = cursor_selection(module_info.contents());
     let actions = transaction
@@ -4307,7 +4307,7 @@ service = Service(1)
     );
     let main_handle = handles.get("main").unwrap();
     let consumer_handle = handles.get("consumer").unwrap();
-    let transaction = state.transaction();
+    let mut transaction = state.transaction();
     let main_info = transaction.get_module_info(main_handle).unwrap();
     let consumer_info = transaction.get_module_info(consumer_handle).unwrap();
     let selection = cursor_selection(main_info.contents());

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -4664,6 +4664,47 @@ def build():
 }
 
 #[test]
+fn introduce_factory_ignores_non_constructor_class_calls() {
+    let code = r#"
+class Service:
+#     ^
+    @classmethod
+    def create(cls):
+        return cls(0)
+
+    def __init__(self, value):
+        self.value = value
+
+def build():
+    existing = Service.create()
+    direct = Service(1)
+    return existing, direct
+"#;
+    let updated =
+        apply_first_introduce_factory_action(code).expect("expected introduce-factory action");
+    let expected = r#"
+class Service:
+#     ^
+    @classmethod
+    def create(cls):
+        return cls(0)
+
+    def __init__(self, value):
+        self.value = value
+
+    @staticmethod
+    def create_1(*args, **kwargs):
+        return Service(*args, **kwargs)
+
+def build():
+    existing = Service.create()
+    direct = Service.create_1(1)
+    return existing, direct
+"#;
+    assert_eq!(expected, updated);
+}
+
+#[test]
 fn introduce_factory_updates_other_modules() {
     let class_code = r#"
 class Service:


### PR DESCRIPTION


# Summary

<!-- Describe the change in this PR -->

Fixes part of #2207

The feature adds a static factory such as `Service.create(*args, **kwargs)` and rewrites constructor calls from `Service(...)` to `Service.create(...)`.

Matching now distinguishes actual constructors from calls such as `Service.some_classmethod(...)`; unsupported forms such as `Box[int]()` suppress the action to prevent an incomplete refactor.

Reference collection now uses reverse-dependency-based global references for workspace files.

Only uncovered in-memory modules are checked individually because unsaved editor buffers may not appear in the filesystem dependency graph.

This avoids querying local references for every loaded module while preserving edits in open files.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added coverage for same-file rewrites, cross-module rewrites, unique-name fallback, and unsupported-call rejection.