### PR TITLE
Skip first-use inference for dict value types

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -965,14 +965,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 },
                 |ty| ty.to_type(),
             );
-            let value_ty = value_hint.map_or_else(
-                || {
-                    self.solver()
-                        .fresh_partial_contained(self.uniques, range)
-                        .to_type(self.heap)
-                },
-                |ty| ty.to_type(),
-            );
+            // For empty dict literals, we don't infer the value type from first use.
+            // Inferring value types from the first assignment (e.g. `d["key"] = None`)
+            // causes false positives when later assignments use different value types,
+            // which is extremely common in real-world Python code.
+            let value_ty =
+                value_hint.map_or_else(|| self.heap.mk_any_implicit(), |ty| ty.to_type());
             self.heap.mk_class_type(self.stdlib.dict(key_ty, value_ty))
         } else {
             // Use a map to track fields by name so later fields override earlier ones

--- a/pyrefly/lib/commands/infer.rs
+++ b/pyrefly/lib/commands/infer.rs
@@ -653,7 +653,7 @@ def foo() -> str:
     "#,
             r#"
     def foo() -> None:
-        x: dict[str, int] = {}
+        x = {}
         x["a"] = 1
     "#,
             Some(flags),

--- a/pyrefly/lib/test/delayed_inference.rs
+++ b/pyrefly/lib/test/delayed_inference.rs
@@ -398,7 +398,7 @@ assert_type(x, list[int])
 testcase!(
     test_empty_container_constructor_call,
     r#"
-from typing import assert_type
+from typing import assert_type, Any
 
 x = list()
 x.append(1)
@@ -410,7 +410,19 @@ assert_type(y, set[int])
 
 z = dict()
 z['k'] = 3
-assert_type(z, dict[str, int])
+assert_type(z, dict[str, Any])
+    "#,
+);
+
+testcase!(
+    test_dict_constructor_vs_literal,
+    r#"
+from typing import assert_type, Any
+
+# dict() goes through construct_class, not dict_items_infer
+a = dict()
+a['k'] = 3
+assert_type(a, dict[str, Any])
     "#,
 );
 
@@ -426,7 +438,7 @@ assert_type(x, list[int])  # E: assert_type(list[Literal[1]], list[int])
 
 y = dict({})
 y['k'] = 3
-assert_type(y, dict[str, int])  # E: assert_type(dict[Literal['k'], Literal[3]], dict[str, int])
+assert_type(y, dict[str, int])  # E: assert_type(dict[Literal['k'], Any], dict[str, int])
     "#,
 );
 

--- a/pyrefly/lib/test/dict.rs
+++ b/pyrefly/lib/test/dict.rs
@@ -32,10 +32,10 @@ def test(cond: bool):
 testcase!(
     test_unpack_empty,
     r#"
-from typing import assert_type
+from typing import assert_type, Any
 x = {**{}}
 x['x'] = 0
-assert_type(x, dict[str, int])
+assert_type(x, dict[str, Any])
     "#,
 );
 

--- a/pyrefly/lib/test/generic_basic.rs
+++ b/pyrefly/lib/test/generic_basic.rs
@@ -338,7 +338,7 @@ from typing import assert_type, Any
 def f():
     x = {}
     x.update(a = 1)
-    assert_type(x, dict[str, int])
+    assert_type(x, dict[str, Any])
 
 def g():
     x: dict[int, int] = {}

--- a/pyrefly/lib/test/inference.rs
+++ b/pyrefly/lib/test/inference.rs
@@ -42,7 +42,7 @@ assert_type(result, tuple[list[int], list[int]])
 
 # Same pattern with dict
 dict_result = pair({}, {"a": 1})
-assert_type(dict_result, tuple[dict[str, int], dict[str, int]])
+assert_type(dict_result, tuple[dict[str, int], dict[str, int]])  # E: assert_type(tuple[dict[str, Any], dict[str, Any]], tuple[dict[str, int], dict[str, int]])
 "#,
 );
 


### PR DESCRIPTION
Summary:
This is a proof-of-concept for addressing ~14,800 false positives across 67 packages caused by Pyrefly's first-use inference on empty dict value types.

Currently, when a user writes `d = {}` followed by `d["key"] = None`, Pyrefly infers the dict type as `dict[str, None]` based on the first value assigned. This causes false positives when subsequent assignments use different value types (e.g. `d["name"] = "alice"` is rejected because `str` is not assignable to `None`). This is extremely common in real-world Python code — config builders, accumulators, serializers, test setup code, etc.

The fix: for empty dict literals, only infer the key type from first use, while leaving the value type as `Any`. This is a one-line change in `dict_items_infer` — instead of creating a `PartialContained` type variable for the value, we use `Any` directly. The key type still benefits from first-use inference (e.g. `d["key"] = value` pins the key type to `str`).

Trade-off: we lose some precision on homogeneous dicts (e.g. `d = {}; d["a"] = 1; d["b"] = 2` was `dict[str, int]`, now `dict[str, Any]`). But this is a net win because the false positive rate on heterogeneous dicts vastly outweighs the precision loss on homogeneous ones.

Differential Revision: D95618922


