### PR TITLE
Widen None to None | Any in first-use inference for empty containers

### DIFF
--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -1866,7 +1866,18 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                     }
                     Variable::PartialContained(_) => {
                         drop(v1_ref);
-                        variables.update(*v1, Variable::Answer(t2.clone()));
+                        // When an empty container's element is pinned to None, widen to
+                        // None | Any. A bare None in the first use almost always means the
+                        // container will later hold some other (unknown) type, analogous
+                        // to how `self.x = None` is inferred as `None | Any` for attributes.
+                        let answer = if t2.is_none() {
+                            self.solver
+                                .heap
+                                .mk_union(vec![t2.clone(), Type::any_implicit()])
+                        } else {
+                            t2.clone()
+                        };
+                        variables.update(*v1, Variable::Answer(answer));
                         Ok(())
                     }
                     Variable::Unwrap | Variable::Recursive => {
@@ -1991,7 +2002,14 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                             .clone()
                             .promote_implicit_literals(self.type_order.stdlib());
                         drop(v2_ref);
-                        variables.update(*v2, Variable::Answer(t1_p));
+                        // Widen None to None | Any (see comment at the other
+                        // PartialContained pinning site above).
+                        let answer = if t1_p.is_none() {
+                            self.solver.heap.mk_union(vec![t1_p, Type::any_implicit()])
+                        } else {
+                            t1_p
+                        };
+                        variables.update(*v2, Variable::Answer(answer));
                         Ok(())
                     }
                     Variable::Unwrap | Variable::Recursive => {


### PR DESCRIPTION
Summary:
This is a proof-of-concept for addressing false positives caused by Pyrefly's first-use inference pinning empty container element types to `None`.

When a user writes `d = {}; d["password"] = None`, Pyrefly infers `dict[str, None]` from the first value assigned. Subsequent assignments of non-None values (e.g. `d["name"] = "alice"`) are rejected because `str` is not assignable to `None`. This pattern is extremely common in real-world Python code (config builders, accumulators, serializers), causing ~14,800 FPs across 67 packages.

The fix: when a `PartialContained` type variable (created for empty container literals) is being pinned to `None`, widen the inferred type to `None | Any` instead. This is analogous to how Pyrefly already handles `self.x = None` for class attributes, where a bare `None` initialization is widened to `None | Any` because it almost always means the attribute will later hold some other type.

This change is made at the two sites in the solver's subset checking where `PartialContained` vars get constrained. It only affects empty containers (`[]`, `{}`, `set()`), not annotated variables or non-None first uses.

Differential Revision: D95621711


