### PR TITLE
Use the original source text for default values in hover text

### DIFF
--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -35,6 +35,7 @@ use crate::class::Class;
 use crate::class::ClassType;
 use crate::display::TypeDisplayContext;
 use crate::equality::TypeEq;
+use crate::equality::TypeEqCtx;
 use crate::keywords::DataclassTransformMetadata;
 use crate::type_output::TypeOutput;
 use crate::types::Type;
@@ -293,13 +294,63 @@ pub enum Param {
     Kwargs(Option<Name>, Type),
 }
 
+/// The default value of an optional parameter, containing its type and an optional
+/// display string for values whose types don't preserve the literal value (e.g. floats).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DefaultValue {
+    pub ty: Type,
+    /// Display string for defaults that can't be recovered from the type alone,
+    /// e.g. `"3.14"` for float literals whose type is just `float`.
+    pub display: Option<String>,
+}
+
+/// Visit/VisitMut/TypeEq delegate to `ty` only; `display` is display-only metadata.
+impl<To> Visit<To> for DefaultValue
+where
+    Type: Visit<To>,
+{
+    const RECURSE_CONTAINS: bool = <Type as Visit<To>>::RECURSE_CONTAINS;
+    fn recurse<'a>(&'a self, f: &mut dyn FnMut(&'a To)) {
+        self.ty.recurse(f);
+    }
+}
+
+impl<To> VisitMut<To> for DefaultValue
+where
+    Type: VisitMut<To>,
+{
+    const RECURSE_CONTAINS: bool = <Type as VisitMut<To>>::RECURSE_CONTAINS;
+    fn recurse_mut(&mut self, f: &mut dyn FnMut(&mut To)) {
+        self.ty.recurse_mut(f);
+    }
+}
+
+impl TypeEq for DefaultValue {
+    fn type_eq(&self, other: &Self, ctx: &mut TypeEqCtx) -> bool {
+        self.ty.type_eq(&other.ty, ctx)
+    }
+}
+
+impl DefaultValue {
+    pub fn new(ty: Type) -> Self {
+        Self { ty, display: None }
+    }
+
+    pub fn with_display(ty: Type, display: String) -> Self {
+        Self {
+            ty,
+            display: Some(display),
+        }
+    }
+}
+
 /// Requiredness for a function parameter.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[derive(Visit, VisitMut, TypeEq)]
 pub enum Required {
     Required,
-    /// The parameter is optional, with the `Type` being the type of its default value, if available.
-    Optional(Option<Type>),
+    /// The parameter is optional, with the default value info if available.
+    Optional(Option<DefaultValue>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -729,10 +780,17 @@ impl Callable {
 }
 
 impl Param {
-    fn fmt_default(&self, default: &Option<Type>) -> String {
+    fn fmt_default(&self, default: &Option<DefaultValue>) -> String {
         match default {
-            Some(Type::Literal(lit)) => format!("{}", lit.value),
-            Some(Type::None) => "None".to_owned(),
+            Some(DefaultValue {
+                ty: Type::Literal(lit),
+                ..
+            }) => format!("{}", lit.value),
+            Some(DefaultValue { ty: Type::None, .. }) => "None".to_owned(),
+            Some(DefaultValue {
+                display: Some(text),
+                ..
+            }) => text.clone(),
             _ => "...".to_owned(),
         }
     }

--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -1120,6 +1120,7 @@ pub mod tests {
 
     use super::*;
     use crate::callable::Callable;
+    use crate::callable::DefaultValue;
     use crate::callable::FuncMetadata;
     use crate::callable::Function;
     use crate::callable::Param;
@@ -1693,12 +1694,12 @@ pub mod tests {
         let param2 = Param::Pos(
             Name::new_static("y"),
             Type::any_explicit(),
-            Required::Optional(Some(Lit::Bool(true).to_implicit_type())),
+            Required::Optional(Some(DefaultValue::new(Lit::Bool(true).to_implicit_type()))),
         );
         let param3 = Param::Pos(
             Name::new_static("z"),
             Type::any_explicit(),
-            Required::Optional(Some(Type::None)),
+            Required::Optional(Some(DefaultValue::new(Type::None))),
         );
         let callable = Callable::list(ParamList::new(vec![param1, param2, param3]), Type::None);
         let callable_type = Type::Callable(Box::new(callable));

--- a/pyrefly/lib/alt/class/dataclass.rs
+++ b/pyrefly/lib/alt/class/dataclass.rs
@@ -654,7 +654,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     | Param::KwOnly(name, ty, Required::Required) => (name, ty, None),
                     Param::Pos(name, ty, Required::Optional(default))
                     | Param::KwOnly(name, ty, Required::Optional(default)) => {
-                        (name, ty, default.as_ref())
+                        (name, ty, default.as_ref().map(|d| &d.ty))
                     }
                     _ => continue,
                 };

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -28,7 +28,10 @@ use pyrefly_util::owner::Owner;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::visit::Visit;
 use ruff_python_ast::Expr;
+use ruff_python_ast::ExprNumberLiteral;
 use ruff_python_ast::Identifier;
+use ruff_python_ast::Number;
+use ruff_python_ast::UnaryOp;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
@@ -61,6 +64,7 @@ use crate::error::context::TypeCheckContext;
 use crate::error::context::TypeCheckKind;
 use crate::solver::solver::QuantifiedHandle;
 use crate::types::callable::Callable;
+use crate::types::callable::DefaultValue;
 use crate::types::callable::FuncDefIndex;
 use crate::types::callable::FuncFlags;
 use crate::types::callable::FuncMetadata;
@@ -79,6 +83,27 @@ use crate::types::types::Forallable;
 use crate::types::types::Overload;
 use crate::types::types::OverloadType;
 use crate::types::types::Type;
+
+/// Extract a display string for default values whose types don't preserve the literal value.
+/// Float literals like `3.14` become `ClassType(float)` which loses the actual value.
+fn default_display_for_expr(expr: &Expr) -> Option<String> {
+    // 1. Unwrap the unary minus if it exists
+    let (is_negative, inner_expr) = match expr {
+        Expr::UnaryOp(x) if x.op == UnaryOp::USub => (true, x.operand.as_ref()),
+        _ => (false, expr),
+    };
+
+    // 2. Extract and format the float
+    if let Expr::NumberLiteral(ExprNumberLiteral {
+        value: Number::Float(f),
+        ..
+    }) = inner_expr
+    {
+        Some(format!("{}{f}", if is_negative { "-" } else { "" }))
+    } else {
+        None
+    }
+}
 
 fn is_class_property_decorator_class_object(cls: &Class) -> bool {
     let cls_name = cls.name();
@@ -817,7 +842,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             {
                 Required::Optional(None)
             }
-            Some(default) => Required::Optional(Some(self.expr(default, check, errors))),
+            Some(default) => {
+                let display = default_display_for_expr(default);
+                let ty = self.expr(default, check, errors);
+                Required::Optional(Some(match display {
+                    Some(d) => DefaultValue::with_display(ty, d),
+                    None => DefaultValue::new(ty),
+                }))
+            }
             None => Required::Required,
         }
     }
@@ -860,10 +892,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     ty.clone()
                 } else if let Some(hint) = hint {
                     hint.clone()
-                } else if let Required::Optional(Some(default_ty)) = &required {
+                } else if let Required::Optional(Some(default_val)) = &required {
                     self.union(
                         self.heap.mk_any_implicit(),
-                        default_ty.clone().promote_implicit_literals(self.stdlib),
+                        default_val
+                            .ty
+                            .clone()
+                            .promote_implicit_literals(self.stdlib),
                     )
                 } else {
                     self.heap.mk_any_implicit()
@@ -871,11 +906,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 (ty, required, true)
             }
         };
-        if let Required::Optional(Some(default)) = required {
+        if let Required::Optional(Some(default_val)) = required {
             // Mark literals as explicit so we don't promote them.
             // This has to happen after the param type has been computed because we do
             // want to promote literals while inferring the type.
-            required = Required::Optional(Some(default.explicit_literals()));
+            required = Required::Optional(Some(DefaultValue {
+                ty: default_val.ty.explicit_literals(),
+                display: default_val.display,
+            }));
         }
         ParamTypeResult {
             ty,
@@ -1620,7 +1658,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     Param::PosOnly(Some(name), _, Required::Optional(Some(default)))
                     | Param::Pos(name, _, Required::Optional(Some(default)))
                     | Param::KwOnly(name, _, Required::Optional(Some(default))) => {
-                        Some((name, default))
+                        Some((name, &default.ty))
                     }
                     _ => None,
                 })

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -1222,3 +1222,39 @@ result = [x for x in x if x in [1]]
         "Second 'in' should show __contains__ hover, got: {report}"
     );
 }
+
+#[test]
+fn hover_shows_float_default_value() {
+    let code = r#"
+def f(y: int = 2, x: float = 3.14) -> None:
+    pass
+
+f(y=1, x=1.0)
+#^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert!(
+        report.contains("x: float = 3.14"),
+        "Expected hover to show float default value '3.14', got: {report}"
+    );
+    assert!(
+        report.contains("y: int = 2"),
+        "Expected hover to show int default value '2', got: {report}"
+    );
+}
+
+#[test]
+fn hover_shows_negative_float_default_value() {
+    let code = r#"
+def f(x: float = -1.5) -> None:
+    pass
+
+f(x=1.0)
+#^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert!(
+        report.contains("x: float = -1.5"),
+        "Expected hover to show negative float default '-1.5', got: {report}"
+    );
+}


### PR DESCRIPTION
The previous approach only supported None and some literals, such as
strings, bools and ints. Values without literals like floats, tuples,
dicts, etc. were unsupported and replaced with `...` in the hover text.

This commit keeps the original behaviour for literals, but introduces
displaying the float value.

The changes required are basically just capturing the float value where
it's first encountered in `function::AnswersSolver::get_requiredness`
and formatting it in `callable::Param::fmt_default`.

Note that the number is rendered using Rust's built-in 'display', which
means a `0.0` literal gets rendered as `0`.

# Summary

Fixes #2697 

Example:

```py
def f(
    x: int = 1,
    y: str = "a",
    b: bool = True,
    f: float = 0.0,
    f2: float = 1.0,
    f3: float = 1.5,
    f4: float = -1,
    f5: float = -1.5,
):
    pass
```

The hover on `func` is:

```
```python
(function) f: def f(
    x: int = 1,
    y: str = 'a',
    b: bool = True,
    f: float = 0,
    f2: float = 1,
    f3: float = 1.5,
    f4: float = -1,
    f5: float = -1.5
) -> None: ...
```

# Test Plan

- `test.py` passes. It generated no changes to be commited. There are some compilation warnings, but I believe they are unrelated to the code in this PR.
- Tested as the LSP on neovim 0.11.6 with default lspconfig settings. I copied `target/release/pyrefly` to a directory in `PATH`.
