### PR TITLE
Support adjacent __new__.__defaults__ for functional namedtuples

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -257,6 +257,9 @@ pub struct BindingsBuilder<'a> {
     lambda_yield_keys: Vec<(TextRange, Box<[Idx<KeyYield>]>, Box<[Idx<KeyYieldFrom>]>)>,
     /// See `BindingsInner::subsequently_initialized`.
     subsequently_initialized: SmallSet<Idx<KeyAnnotation>>,
+    /// Temporary storage for adjacent __new__.__defaults__ expression detected by stmts().
+    /// Set before calling stmt() for a namedtuple assignment, drained by the NamedTuple arms.
+    pub(super) adjacent_namedtuple_defaults: Option<Expr>,
 }
 
 /// An enum tracking whether we are in a generator expression
@@ -512,6 +515,7 @@ impl Bindings {
             deferred_bound_names: Vec::new(),
             lambda_yield_keys: Vec::new(),
             subsequently_initialized: SmallSet::new(),
+            adjacent_namedtuple_defaults: None,
         };
         builder.init_static_scope(&x.body, true);
         if module_info.name() != ModuleName::builtins() {
@@ -738,6 +742,24 @@ impl CurrentIdx {
     }
 }
 
+/// Check if a statement is `name.__new__.__defaults__ = <tuple|None>` and return the RHS.
+/// Only matches tuple literals and None — other RHS forms are left for normal type checking.
+fn extract_adjacent_new_defaults(stmt: &Stmt, name: &str) -> Option<Expr> {
+    if let Stmt::Assign(assign) = stmt
+        && let [Expr::Attribute(outer)] = assign.targets.as_slice()
+        && outer.attr.id == "__defaults__"
+        && let Expr::Attribute(inner) = outer.value.as_ref()
+        && inner.attr.id == "__new__"
+        && let Expr::Name(target_name) = inner.value.as_ref()
+        && target_name.id == name
+        && matches!(*assign.value, Expr::Tuple(_) | Expr::NoneLiteral(_))
+    {
+        Some((*assign.value).clone())
+    } else {
+        None
+    }
+}
+
 impl<'a> BindingsBuilder<'a> {
     /// Whether to infer empty container types and unsolved type variables based on first use.
     pub fn infer_with_first_use(&self) -> bool {
@@ -940,8 +962,30 @@ impl<'a> BindingsBuilder<'a> {
     }
 
     pub fn stmts(&mut self, xs: Vec<Stmt>, parent: &NestingContext) {
-        for x in xs {
+        let mut iter = xs.into_iter().peekable();
+        while let Some(x) = iter.next() {
+            // Check if this is a functional namedtuple followed by __new__.__defaults__.
+            // Guard order is intentional: the cheap peek at the next statement comes before
+            // the expensive as_special_export scope lookup, so we only pay that cost when
+            // the adjacent __new__.__defaults__ pattern is actually present (very rare).
+            if let Stmt::Assign(assign) = &x
+                && let [Expr::Name(name)] = assign.targets.as_slice()
+                && let Expr::Call(call) = assign.value.as_ref()
+                && let Some(defaults_expr) = iter
+                    .peek()
+                    .and_then(|next| extract_adjacent_new_defaults(next, &name.id))
+                && let Some(special) = self.as_special_export(&call.func)
+                && matches!(
+                    special,
+                    SpecialExport::TypingNamedTuple | SpecialExport::CollectionsNamedTuple
+                )
+            {
+                iter.next(); // consume the __new__.__defaults__ statement
+                self.adjacent_namedtuple_defaults = Some(defaults_expr);
+            }
             self.stmt(x, parent);
+            // Clear unconsumed defaults (safety — should already be drained by NamedTuple arms)
+            self.adjacent_namedtuple_defaults = None;
         }
     }
 

--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -180,6 +180,7 @@ impl<'a> BindingsBuilder<'a> {
                                     members,
                                     &mut call.arguments.keywords,
                                     false,
+                                    None,
                                 ))
                             } else {
                                 None
@@ -195,6 +196,7 @@ impl<'a> BindingsBuilder<'a> {
                                     &mut call.func,
                                     members,
                                     false,
+                                    None,
                                 ))
                             } else {
                                 None
@@ -1084,6 +1086,33 @@ impl<'a> BindingsBuilder<'a> {
         );
     }
 
+    /// Apply `__new__.__defaults__` override to the defaults vector.
+    /// Follows Python's right-alignment: a tuple of N values makes the last N fields optional.
+    /// `None` clears all defaults. Non-tuple/non-None values should not reach here
+    /// (filtered by extract_adjacent_new_defaults).
+    fn apply_adjacent_defaults(
+        defaults_expr: &Expr,
+        n_members: usize,
+        defaults: &mut Vec<Option<Expr>>,
+    ) {
+        match defaults_expr {
+            Expr::NoneLiteral(_) => {
+                defaults.iter_mut().for_each(|d| *d = None);
+            }
+            Expr::Tuple(tuple) => {
+                let elts = &tuple.elts;
+                defaults.iter_mut().for_each(|d| *d = None);
+                let n_defaults = elts.len().min(n_members);
+                // Right-align: skip leading elements if more defaults than fields
+                let start = elts.len() - n_defaults;
+                for (i, elt) in elts[start..].iter().enumerate() {
+                    defaults[n_members - n_defaults + i] = Some(elt.clone());
+                }
+            }
+            _ => unreachable!("extract_adjacent_new_defaults only matches Tuple and NoneLiteral"),
+        }
+    }
+
     // This functional form supports renaming illegal identifiers and specifying defaults
     // but cannot specify the type of each element
     pub fn synthesize_collections_named_tuple_def(
@@ -1094,6 +1123,7 @@ impl<'a> BindingsBuilder<'a> {
         members: &mut [Expr],
         keywords: &mut [Keyword],
         bind_to_name: bool,
+        adjacent_defaults: Option<Expr>,
     ) -> Idx<KeyClass> {
         let (mut class_object, class_indices) = if bind_to_name {
             self.class_object_and_indices(&class_name)
@@ -1147,6 +1177,12 @@ impl<'a> BindingsBuilder<'a> {
                 );
             }
         }
+        // Apply adjacent __new__.__defaults__ override.
+        // This replaces any defaults= kwarg, matching runtime semantics where
+        // assigning __new__.__defaults__ replaces the prior defaults tuple.
+        if let Some(ref defaults_expr) = adjacent_defaults {
+            Self::apply_adjacent_defaults(defaults_expr, n_members, &mut defaults);
+        }
         let member_definitions_with_defaults: Vec<(String, TextRange, Option<Expr>, Option<Expr>)> =
             member_definitions
                 .into_iter()
@@ -1172,6 +1208,7 @@ impl<'a> BindingsBuilder<'a> {
     }
 
     // This functional form allows specifying types for each element, but not default values
+    // (unless adjacent __new__.__defaults__ is present)
     pub fn synthesize_typing_named_tuple_def(
         &mut self,
         class_name: Identifier,
@@ -1179,6 +1216,7 @@ impl<'a> BindingsBuilder<'a> {
         func: &mut Expr,
         members: &[Expr],
         bind_to_name: bool,
+        adjacent_defaults: Option<Expr>,
     ) -> Idx<KeyClass> {
         let (mut class_object, class_indices) = if bind_to_name {
             self.class_object_and_indices(&class_name)
@@ -1186,19 +1224,26 @@ impl<'a> BindingsBuilder<'a> {
             self.anon_class_object_and_indices(&class_name)
         };
         self.ensure_expr(func, class_object.usage());
-        let member_definitions: Vec<(String, TextRange, Option<Expr>, Option<Expr>)> = self
-            .parse_typing_namedtuple_fields(members, class_name.range)
-            .0
-            .into_iter()
-            .map(|(name, range, annotation)| {
-                if let Some(mut ann) = annotation {
-                    self.ensure_type(&mut ann, &mut None);
-                    (name, range, Some(ann), None)
-                } else {
-                    (name, range, None, None)
-                }
-            })
-            .collect();
+        let (parsed_fields, _has_dynamic) =
+            self.parse_typing_namedtuple_fields(members, class_name.range);
+        let n_members = parsed_fields.len();
+        let mut defaults: Vec<Option<Expr>> = vec![None; n_members];
+        if let Some(ref defaults_expr) = adjacent_defaults {
+            Self::apply_adjacent_defaults(defaults_expr, n_members, &mut defaults);
+        }
+        let member_definitions: Vec<(String, TextRange, Option<Expr>, Option<Expr>)> =
+            parsed_fields
+                .into_iter()
+                .zip(defaults)
+                .map(|((name, range, annotation), default)| {
+                    if let Some(mut ann) = annotation {
+                        self.ensure_type(&mut ann, &mut None);
+                        (name, range, Some(ann), default)
+                    } else {
+                        (name, range, None, default)
+                    }
+                })
+                .collect();
         self.synthesize_class_def(
             class_name,
             class_object,

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -609,12 +609,15 @@ impl<'a> BindingsBuilder<'a> {
                                     call.arguments.args.split_first_mut()
                                 {
                                     self.check_functional_definition_name(&name.id, arg_name);
+                                    let adjacent_defaults =
+                                        self.adjacent_namedtuple_defaults.take();
                                     self.synthesize_typing_named_tuple_def(
                                         Ast::expr_name_identifier(name.clone()),
                                         parent,
                                         &mut call.func,
                                         members,
                                         true,
+                                        adjacent_defaults,
                                     );
                                     return;
                                 }
@@ -624,6 +627,8 @@ impl<'a> BindingsBuilder<'a> {
                                     call.arguments.args.split_first_mut()
                                 {
                                     self.check_functional_definition_name(&name.id, arg_name);
+                                    let adjacent_defaults =
+                                        self.adjacent_namedtuple_defaults.take();
                                     self.synthesize_collections_named_tuple_def(
                                         Ast::expr_name_identifier(name.clone()),
                                         parent,
@@ -631,6 +636,7 @@ impl<'a> BindingsBuilder<'a> {
                                         members,
                                         &mut call.arguments.keywords,
                                         true,
+                                        adjacent_defaults,
                                     );
                                     return;
                                 }

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -622,3 +622,128 @@ Point = collections.namedtuple("Point", ["x", "y"])
 p = Point(x=1, y=2)
     "#,
 );
+
+// Basic: adjacent __new__.__defaults__ makes trailing field optional
+testcase!(
+    test_namedtuple_adjacent_defaults_basic,
+    r#"
+from collections import namedtuple
+Point = namedtuple("Point", ["x", "y", "z"])
+Point.__new__.__defaults__ = (0,)
+p = Point(1, 2)  # should succeed — z defaults to 0
+"#,
+);
+
+// typing.NamedTuple form
+testcase!(
+    test_typing_namedtuple_adjacent_defaults,
+    r#"
+from typing import NamedTuple
+Point = NamedTuple("Point", [("x", int), ("y", int), ("z", int)])
+Point.__new__.__defaults__ = (0,)
+p = Point(1, 2)  # should succeed — z defaults to 0
+"#,
+);
+
+// Multiple defaults
+testcase!(
+    test_namedtuple_adjacent_defaults_multiple,
+    r#"
+from collections import namedtuple
+Point = namedtuple("Point", ["x", "y", "z"])
+Point.__new__.__defaults__ = (0, 0)
+p = Point(1)  # should succeed — y and z default
+"#,
+);
+
+// None RHS means no defaults (all required)
+testcase!(
+    test_namedtuple_adjacent_defaults_none,
+    r#"
+from collections import namedtuple
+Point = namedtuple("Point", ["x", "y", "z"])
+Point.__new__.__defaults__ = None
+p = Point(1, 2)  # E: Missing argument `z` in function `Point.__new__`
+"#,
+);
+
+// Tuple longer than field count clamps to all-optional
+testcase!(
+    test_namedtuple_adjacent_defaults_overflow,
+    r#"
+from collections import namedtuple
+Point = namedtuple("Point", ["x", "y"])
+Point.__new__.__defaults__ = (0, 0, 0)
+p = Point()  # should succeed — all fields optional when defaults >= fields
+"#,
+);
+
+// Non-adjacent: intervening statement breaks the pattern
+testcase!(
+    test_namedtuple_defaults_non_adjacent,
+    r#"
+from collections import namedtuple
+Point = namedtuple("Point", ["x", "y", "z"])
+x = 1
+Point.__new__.__defaults__ = (0,)
+p = Point(1, 2)  # E: Missing argument `z` in function `Point.__new__`
+"#,
+);
+
+// Class-syntax namedtuple is unaffected
+testcase!(
+    test_class_namedtuple_unaffected,
+    r#"
+from typing import NamedTuple
+class Point(NamedTuple):
+    x: int
+    y: int
+    z: int
+p = Point(1, 2)  # E: Missing argument `z` in function `Point.__new__`
+"#,
+);
+
+// Non-literal RHS is not consumed (variable reference falls through to normal type checking)
+testcase!(
+    test_namedtuple_defaults_non_literal_rhs,
+    r#"
+from collections import namedtuple
+Point = namedtuple("Point", ["x", "y", "z"])
+defs = (0,)
+Point.__new__.__defaults__ = defs
+p = Point(1, 2)  # E: Missing argument `z` in function `Point.__new__`
+"#,
+);
+
+// __new__.__defaults__ replaces defaults= kwarg entirely (not merging)
+testcase!(
+    test_namedtuple_defaults_replaces_kwarg,
+    r#"
+from collections import namedtuple
+Point = namedtuple("Point", ["x", "y", "z"], defaults=(1,))
+Point.__new__.__defaults__ = (2, 3)
+p = Point(1)  # should succeed — y and z now have defaults from __new__.__defaults__
+"#,
+);
+
+// Empty tuple means no defaults (all required)
+testcase!(
+    test_namedtuple_adjacent_defaults_empty_tuple,
+    r#"
+from collections import namedtuple
+Point = namedtuple("Point", ["x", "y", "z"])
+Point.__new__.__defaults__ = ()
+p = Point(1, 2)  # E: Missing argument `z` in function `Point.__new__`
+"#,
+);
+
+// None overrides existing defaults= kwarg (clears all defaults)
+testcase!(
+    test_namedtuple_none_overrides_kwarg,
+    r#"
+from collections import namedtuple
+Point = namedtuple("Point", ["x", "y", "z"], defaults=(1,))
+Point.__new__.__defaults__ = None
+p = Point(1, 2)  # E: Missing argument `z` in function `Point.__new__`
+"#,
+);


### PR DESCRIPTION
# Summary

Support the canonical `P.__new__.__defaults__ = (val,)` idiom adjacent to functional namedtuple definitions, making trailing fields optional in the constructor.

This is the standard pre-class-syntax way to add defaults to namedtuples:
```python
Point = namedtuple("Point", ["x", "y", "z"])
Point.__new__.__defaults__ = (0,)   # makes z optional
p = Point(1, 2)  # valid — z defaults to 0
```

Works for both `collections.namedtuple` and `typing.NamedTuple` functional forms. Detection uses forward peek in `stmts()` , only the immediately adjacent statement is checked, matching Pyright's behavior.

Things worth mentioning:
- Only tuple/None literal RHS is consumed; non-literal RHS (e.g., variable references) flows through normal type checking
- Right-aligned defaults following Python semantics (N defaults → last N fields optional)
- `__new__.__defaults__` replaces any existing `defaults=` kwarg, matching runtime behavior

Fixes #2611

# Test Plan

- Added 11 test cases covering: basic usage, typing.NamedTuple form, multiple defaults, None clearing, overflow clamping, non-adjacent (should not match), class-syntax unaffected, non-literal RHS fallthrough, replaces kwarg, empty tuple, None overriding kwarg
- All 52 named_tuple tests pass
- Full test suite (4379 tests) passes with no regressions
- Linting and conformance tests pass