### PR TITLE
fix Narrow types based on collection containment #2706

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -98,6 +98,90 @@ fn synthesize_int_slice(idx: i64) -> Expr {
 const NARROW_ENUM_LIMIT: usize = 100;
 
 impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
+    /// Membership narrowing only stays precise when the RHS describes a finite set of values.
+    fn membership_narrow_type(&self, ty: &Type) -> Option<Type> {
+        match ty {
+            Type::Literal(_) | Type::None => Some(ty.clone()),
+            Type::ClassDef(cls) => Some(Type::type_of(self.promote_silently(cls))),
+            Type::Type(inner) if matches!(inner.as_ref(), Type::ClassType(_)) => Some(ty.clone()),
+            Type::Union(union) => {
+                let members: Option<Vec<_>> = union
+                    .members
+                    .iter()
+                    .map(|member| self.membership_narrow_type(member))
+                    .collect();
+                Some(self.unions(members?))
+            }
+            _ => None,
+        }
+    }
+
+    fn membership_narrow_tuple_type(&self, tuple: &Tuple) -> Option<Type> {
+        match tuple {
+            Tuple::Concrete(elts) => {
+                let members: Option<Vec<_>> = elts
+                    .iter()
+                    .map(|elt| self.membership_narrow_type(elt))
+                    .collect();
+                Some(self.unions(members?))
+            }
+            Tuple::Unbounded(elt) => self.membership_narrow_type(elt),
+            Tuple::Unpacked(unpacked) => {
+                let (prefix, middle, suffix) = unpacked.as_ref();
+                let members: Option<Vec<_>> = prefix
+                    .iter()
+                    .chain(std::iter::once(middle))
+                    .chain(suffix.iter())
+                    .map(|elt| self.membership_narrow_type(elt))
+                    .collect();
+                Some(self.unions(members?))
+            }
+        }
+    }
+
+    fn membership_narrow_container_type(&self, ty: &Type) -> Option<Type> {
+        match ty {
+            Type::Var(v) if let Some(_guard) = self.recurse(*v) => {
+                self.membership_narrow_container_type(&self.solver().force_var(*v))
+            }
+            Type::Union(union) => {
+                let members: Option<Vec<_>> = union
+                    .members
+                    .iter()
+                    .map(|member| self.membership_narrow_container_type(member))
+                    .collect();
+                Some(self.unions(members?))
+            }
+            Type::TypedDict(typed_dict) => {
+                let fields = self.typed_dict_fields(typed_dict);
+                if fields.is_empty() {
+                    Some(self.heap.mk_never())
+                } else {
+                    let key_types: Vec<Type> = fields
+                        .keys()
+                        .map(|name| Lit::Str(name.as_str().into()).to_implicit_type())
+                        .collect();
+                    Some(self.unions(key_types))
+                }
+            }
+            Type::Tuple(tuple) => self.membership_narrow_tuple_type(tuple),
+            Type::ClassType(class) => {
+                if let Some(tuple) = self.as_tuple(class) {
+                    return self.membership_narrow_tuple_type(&tuple);
+                }
+                match (
+                    class.class_object().name().as_str(),
+                    class.targs().as_slice(),
+                ) {
+                    ("list" | "set" | "frozenset", [elt]) => self.membership_narrow_type(elt),
+                    ("dict", [key, _]) => self.membership_narrow_type(key),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
     // Get the union of all members of an enum, minus the specified member
     fn subtract_enum_member(&self, instance: Instance, name: &Name) -> Type {
         if self
@@ -1090,48 +1174,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                     let mut literal_types = Vec::new();
                     for expr in exprs {
-                        let expr_ty = self.expr_infer(&expr, errors);
-                        match expr_ty {
-                            Type::Literal(_) | Type::None => {
-                                literal_types.push(expr_ty);
-                            }
-                            // Bare class names (e.g., `int`) infer to ClassDef.
-                            // Convert to type[...] so `x in (int, float)` can
-                            // narrow x to type[int] | type[float].
-                            Type::ClassDef(cls) => {
-                                literal_types.push(Type::type_of(self.promote_silently(&cls)));
-                            }
-                            // Already-wrapped type[X] expressions pass through.
-                            Type::Type(ref f) if matches!(&**f, Type::ClassType(_)) => {
-                                literal_types.push(expr_ty);
-                            }
-                            _ => {
-                                return ty.clone();
-                            }
-                        }
+                        let Some(expr_ty) =
+                            self.membership_narrow_type(&self.expr_infer(&expr, errors))
+                        else {
+                            return ty.clone();
+                        };
+                        literal_types.push(expr_ty);
                     }
                     return self.intersect(ty, &self.unions(literal_types));
                 }
 
-                // Check if the right operand is a TypedDict.
-                // If so, we can narrow the left operand to the union of the TypedDict's keys.
                 let right_ty = self.expr_infer(v, errors);
                 if let Type::Tuple(tuple) = &right_ty
                     && let Some(member_ty) = self.tuple_membership_type(tuple, range, errors)
                 {
                     return self.intersect(ty, &member_ty);
                 }
-                if let Type::TypedDict(typed_dict) = &right_ty {
-                    let fields = self.typed_dict_fields(typed_dict);
-                    if fields.is_empty() {
-                        // Empty TypedDict - the `in` check is always false
-                        return self.heap.mk_never();
-                    }
-                    let key_types: Vec<Type> = fields
-                        .keys()
-                        .map(|name| Lit::Str(name.as_str().into()).to_implicit_type())
-                        .collect();
-                    return self.intersect(ty, &self.unions(key_types));
+                if let Some(container_ty) = self.membership_narrow_container_type(&right_ty) {
+                    return self.intersect(ty, &container_ty);
                 }
 
                 // Check if the right operand is a mapping (e.g. dict[str, int]).
@@ -1139,10 +1199,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if !self.behaves_like_any(&right_ty)
                     && let Some((key_ty, _)) = self.unwrap_mapping(&right_ty)
                 {
-                    self.intersect(ty, &key_ty)
-                } else {
-                    ty.clone()
+                    return self.intersect(ty, &key_ty);
                 }
+
+                if !self.behaves_like_any(&right_ty)
+                    && let Some(iter_ty) = self.unwrap_iterable(&right_ty)
+                    && let Some(iter_ty) = self.membership_narrow_type(&iter_ty)
+                {
+                    return self.intersect(ty, &iter_ty);
+                }
+
+                ty.clone()
             }
             AtomicNarrowOp::NotIn(v) => {
                 // First, check for literal containers. We also unwrap builtin
@@ -1156,27 +1223,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                     let mut literal_types = Vec::new();
                     for expr in exprs {
-                        let expr_ty = self.expr_infer(&expr, errors);
-                        match expr_ty {
-                            Type::Literal(_) | Type::None => {
-                                literal_types.push(expr_ty);
-                            }
-                            // Accept class objects so they don't trigger the
-                            // bail-out below — this allows mixed containers
-                            // like `(int, None)` to still narrow the non-class
-                            // elements. Class objects themselves are not
-                            // subtracted in the `not in` case (see comment in
-                            // distribute_over_union below).
-                            Type::ClassDef(cls) => {
-                                literal_types.push(Type::type_of(self.promote_silently(&cls)));
-                            }
-                            Type::Type(ref f) if matches!(&**f, Type::ClassType(_)) => {
-                                literal_types.push(expr_ty);
-                            }
-                            _ => {
-                                return ty.clone();
-                            }
-                        }
+                        let Some(expr_ty) =
+                            self.membership_narrow_type(&self.expr_infer(&expr, errors))
+                        else {
+                            return ty.clone();
+                        };
+                        literal_types.push(expr_ty);
                     }
                     return self.distribute_over_union(ty, |t| {
                         let mut result = t.clone();

--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -1198,6 +1198,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // If so, we can narrow the left operand to the mapping's key type.
                 if !self.behaves_like_any(&right_ty)
                     && let Some((key_ty, _)) = self.unwrap_mapping(&right_ty)
+                    && !self.behaves_like_any(&key_ty)
                 {
                     return self.intersect(ty, &key_ty);
                 }

--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -1545,6 +1545,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 // If so, we can narrow the left operand to the mapping's key type.
                 if !self.behaves_like_any(&right_ty)
                     && let Some((key_ty, _)) = self.unwrap_mapping(&right_ty)
+                    && !self.behaves_like_any(&key_ty)
                 {
                     return self.intersect(ty, &key_ty);
                 }

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -2173,6 +2173,30 @@ def test(key: str) -> None:
 );
 
 testcase!(
+    test_narrow_in_does_not_widen,
+    r#"
+from typing import Any, Literal, assert_type
+
+list_any: list[Any] = [1]
+list_object: list[object] = [1]
+dict_any: dict[Any, int] = {1: 1}
+dict_object: dict[object, int] = {1: 1}
+
+def test_list(x: Literal[1] | str) -> None:
+    if x in list_any:
+        assert_type(x, Literal[1] | str)
+    if x in list_object:
+        assert_type(x, Literal[1] | str)
+
+def test_dict(x: Literal[1] | str) -> None:
+    if x in dict_any:
+        assert_type(x, Literal[1] | str)
+    if x in dict_object:
+        assert_type(x, Literal[1] | str)
+"#,
+);
+
+testcase!(
     test_narrow_len,
     r#"
 from typing import assert_type, Never, NamedTuple

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -2175,12 +2175,16 @@ def test(key: str) -> None:
 testcase!(
     test_narrow_in_does_not_widen,
     r#"
-from typing import Any, Literal, assert_type
+from typing import Any, Literal, Mapping, assert_type
 
 list_any: list[Any] = [1]
 list_object: list[object] = [1]
+set_any: set[Any] = {1}
+set_object: set[object] = {1}
 dict_any: dict[Any, int] = {1: 1}
 dict_object: dict[object, int] = {1: 1}
+mapping_any: Mapping[Any, int] = {1: 1}
+mapping_object: Mapping[object, int] = {1: 1}
 
 def test_list(x: Literal[1] | str) -> None:
     if x in list_any:
@@ -2188,11 +2192,39 @@ def test_list(x: Literal[1] | str) -> None:
     if x in list_object:
         assert_type(x, Literal[1] | str)
 
+def test_set(x: Literal[1] | str) -> None:
+    if x in set_any:
+        assert_type(x, Literal[1] | str)
+    if x in set_object:
+        assert_type(x, Literal[1] | str)
+
 def test_dict(x: Literal[1] | str) -> None:
     if x in dict_any:
         assert_type(x, Literal[1] | str)
     if x in dict_object:
         assert_type(x, Literal[1] | str)
+
+def test_mapping(x: Literal[1] | str) -> None:
+    if x in mapping_any:
+        assert_type(x, Literal[1] | str)
+    if x in mapping_object:
+        assert_type(x, Literal[1] | str)
+"#,
+);
+
+testcase!(
+    test_in_abstract_mapping_narrows_key,
+    r#"
+from typing import Mapping, assert_type
+
+def parse_resource_id() -> tuple[str, str] | tuple[None, None]: ...
+
+def lookup_resource(registry: Mapping[str, str]) -> str | None:
+    kind, _obj_id = parse_resource_id()
+    if kind not in registry:
+        return None
+    assert_type(kind, str)
+    return registry[kind]
 "#,
 );
 

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -2144,6 +2144,35 @@ def non_literal_arg(x: int | str) -> None:
 );
 
 testcase!(
+    test_narrow_in_typed_collections,
+    r#"
+from typing import Literal, assert_type
+
+LitA = Literal["a"]
+lit_dict: dict[LitA, int] = {"a": 1}
+lit_tuple: tuple[LitA] = ("a",)
+lit_list: list[LitA] = ["a"]
+lit_set: set[LitA] = {"a"}
+lit_frozenset: frozenset[LitA] = frozenset(("a",))
+
+def test(key: str) -> None:
+    if key in lit_dict:
+        assert_type(key, LitA)
+        assert_type(lit_dict[key], int)
+    if key in lit_tuple:
+        assert_type(key, LitA)
+    if key in lit_list:
+        assert_type(key, LitA)
+    if key in lit_set:
+        assert_type(key, LitA)
+    if key in lit_frozenset:
+        assert_type(key, LitA)
+    if key in frozenset(("a",)):
+        assert_type(key, LitA)
+"#,
+);
+
+testcase!(
     test_narrow_len,
     r#"
 from typing import assert_type, Never, NamedTuple

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -2673,6 +2673,96 @@ def test(key: str) -> None:
 );
 
 testcase!(
+    test_narrow_in_iterable_element_type,
+    r#"
+from typing import assert_type
+
+def generate_missing() -> list[str]:
+    return ["a", "b"]
+
+def takes_string(arg: str) -> None: ...
+
+def test_list(arg: str | None) -> None:
+    missing = generate_missing()
+    if arg in missing:
+        assert_type(arg, str)
+        takes_string(arg)
+
+def test_set(arg: str | None, missing: set[str]) -> None:
+    if arg in missing:
+        assert_type(arg, str)
+        takes_string(arg)
+
+def test_frozenset(arg: str | None, missing: frozenset[str]) -> None:
+    if arg in missing:
+        assert_type(arg, str)
+        takes_string(arg)
+"#,
+);
+
+testcase!(
+    test_narrow_in_does_not_widen,
+    r#"
+from typing import Any, Literal, Mapping, assert_type
+
+list_any: list[Any] = [1]
+list_object: list[object] = [1]
+set_any: set[Any] = {1}
+set_object: set[object] = {1}
+dict_any: dict[Any, int] = {1: 1}
+dict_object: dict[object, int] = {1: 1}
+mapping_any: Mapping[Any, int] = {1: 1}
+mapping_object: Mapping[object, int] = {1: 1}
+
+def test_list(x: Literal[1] | str) -> None:
+    if x in list_any:
+        assert_type(x, Literal[1] | str)
+    if x in list_object:
+        assert_type(x, Literal[1] | str)
+
+def test_list_optional(x: str | None) -> None:
+    if x in list_any:
+        assert_type(x, str | None)
+    if x in list_object:
+        assert_type(x, str | None)
+
+def test_set(x: Literal[1] | str) -> None:
+    if x in set_any:
+        assert_type(x, Literal[1] | str)
+    if x in set_object:
+        assert_type(x, Literal[1] | str)
+
+def test_dict(x: Literal[1] | str) -> None:
+    if x in dict_any:
+        assert_type(x, Literal[1] | str)
+    if x in dict_object:
+        assert_type(x, Literal[1] | str)
+
+def test_mapping(x: Literal[1] | str) -> None:
+    if x in mapping_any:
+        assert_type(x, Literal[1] | str)
+    if x in mapping_object:
+        assert_type(x, Literal[1] | str)
+"#,
+);
+
+testcase!(
+    test_in_abstract_mapping_narrows_key,
+    r#"
+from typing import Mapping, assert_type
+
+def parse_resource_id() -> tuple[str, str] | tuple[None, None]: ...
+
+def lookup_resource(registry: Mapping[str, str]) -> str | None:
+    kind, _obj_id = parse_resource_id()
+    if kind not in registry:
+        return None
+    assert_type(kind, str)
+    return registry[kind]
+"#,
+);
+
+testcase!(
     test_narrow_len,
     r#"
 from typing import assert_type, Never, NamedTuple

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -2644,6 +2644,35 @@ def non_literal_arg(x: int | str) -> None:
 );
 
 testcase!(
+    test_narrow_in_typed_collections,
+    r#"
+from typing import Literal, assert_type
+
+LitA = Literal["a"]
+lit_dict: dict[LitA, int] = {"a": 1}
+lit_tuple: tuple[LitA] = ("a",)
+lit_list: list[LitA] = ["a"]
+lit_set: set[LitA] = {"a"}
+lit_frozenset: frozenset[LitA] = frozenset(("a",))
+
+def test(key: str) -> None:
+    if key in lit_dict:
+        assert_type(key, LitA)
+        assert_type(lit_dict[key], int)
+    if key in lit_tuple:
+        assert_type(key, LitA)
+    if key in lit_list:
+        assert_type(key, LitA)
+    if key in lit_set:
+        assert_type(key, LitA)
+    if key in lit_frozenset:
+        assert_type(key, LitA)
+    if key in frozenset(("a",)):
+        assert_type(key, LitA)
+"#,
+);
+
+testcase!(
     test_narrow_len,
     r#"
 from typing import assert_type, Never, NamedTuple

--- a/pyrefly/lib/test/typed_dict.rs
+++ b/pyrefly/lib/test/typed_dict.rs
@@ -2478,6 +2478,23 @@ def test(foo: Foo | Bar) -> None:
 );
 
 testcase!(
+    test_typed_dict_union_key_contains_does_not_narrow,
+    r#"
+from typing import TypedDict, assert_type
+
+class Foo(TypedDict, closed=True):
+    a: int
+
+class Bar(TypedDict, closed=True):
+    b: int
+
+def test(schema: Foo | Bar, key: str) -> None:
+    if key in schema:
+        assert_type(key, str)
+"#,
+);
+
+testcase!(
     test_typed_dict_open_contains_narrowing,
     r#"
 from typing import TypedDict, assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2706

containment narrowing now derives finite membership domains directly from typed RHS containers instead of relying only on the generic iterable/mapping decomposition.

That preserves literal precision for typed dict, tuple, list, set, and frozenset values, and the literal fast path now also recognizes inline frozenset(...) calls

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add the test in issue