### PR TITLE
Restore the old mypy primer blocklist

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -62,8 +62,8 @@ jobs:
           NEW_DIR=$BASE_DIR/pyrefly_new
           mkdir -p $NEW_DIR
           cd pyrefly_to_test && git checkout $GITHUB_SHA
-          CARGO_TARGET_DIR=$NEW_DIR/target cargo build --manifest-path pyrefly/Cargo.toml
-          BINARY_DIR=$NEW_DIR/target/debug
+          CARGO_TARGET_DIR=$NEW_DIR/target cargo build --release --manifest-path pyrefly/Cargo.toml
+          BINARY_DIR=$NEW_DIR/target/release
           mv $BINARY_DIR/pyrefly $BINARY_DIR/pyrefly-real
           cp scripts/pyrefly_primer_wrapper.sh $BINARY_DIR/pyrefly
           chmod +x $BINARY_DIR/pyrefly
@@ -72,8 +72,8 @@ jobs:
           OLD_DIR=$BASE_DIR/pyrefly_old
           mkdir -p $OLD_DIR
           git checkout base_commit
-          CARGO_TARGET_DIR=$OLD_DIR/target cargo build --manifest-path pyrefly/Cargo.toml
-          BINARY_DIR=$OLD_DIR/target/debug
+          CARGO_TARGET_DIR=$OLD_DIR/target cargo build --release --manifest-path pyrefly/Cargo.toml
+          BINARY_DIR=$OLD_DIR/target/release
           mv $BINARY_DIR/pyrefly $BINARY_DIR/pyrefly-real
           # Use the wrapper from the new commit (old commit may not have it)
           git checkout $GITHUB_SHA -- scripts/pyrefly_primer_wrapper.sh
@@ -86,7 +86,7 @@ jobs:
             MYPY_PRIMER_NO_REBUILD=1 mypy_primer \
             --repo pyrefly_to_test \
             --base-dir $BASE_DIR \
-            --cargo-profile dev \
+            --cargo-profile release \
             --new $GITHUB_SHA --old base_commit \
             --num-shards 10 --shard-index ${{ matrix.shard-index }} \
             --debug \

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -90,7 +90,7 @@ jobs:
             --new $GITHUB_SHA --old base_commit \
             --num-shards 10 --shard-index ${{ matrix.shard-index }} \
             --debug \
-            --project-selector '.*' \
+            --project-selector '^(?!.*(python-attrs/attrs|scipy/scipy|scikit-learn/scikit-learn|pandas-dev/pandas|pandas-dev/pandas-stubs|apache/spark|spack/spack|sympy/sympy|PyCQA/flake8-pyi|Gobot1234/steam\.py|rotki/rotki|enthought/comtypes|pytest-dev/pytest|internetarchive/openlibrary|narwhals-dev/narwhals|ibis-project/ibis|trailofbits/manticore|dulwich/dulwich|freqtrade/freqtrade|pydata/xarray|schemathesis/schemathesis|pwndbg/pwndbg|graphql-python/graphql-core|davidhalter/parso))' \
             --type-checker pyrefly \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt


### PR DESCRIPTION
Summary:
Mypy primer is pretty heavyweight, and github CI is underpowered.

I was looking at runs from before it started timing out, and realized that a lot of things
that take 1-2s to check internally take much longer.

I think it's possible that a few projects (e.g. pandas, sympy) might just be too big to
type check massively in parallel on a tiny, underpowered server.

Working off that assumption, let's try restoring the old "determinism blocklist" - these
projects tend to be some of the biggest, just because the things that trigger nondeterminism
also make type check expensive.

Differential Revision: D95741691


