### PR TITLE
Exclude all CPython subdirectories from github mypy primer

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -62,8 +62,8 @@ jobs:
           NEW_DIR=$BASE_DIR/pyrefly_new
           mkdir -p $NEW_DIR
           cd pyrefly_to_test && git checkout $GITHUB_SHA
-          CARGO_TARGET_DIR=$NEW_DIR/target cargo build --manifest-path pyrefly/Cargo.toml
-          BINARY_DIR=$NEW_DIR/target/debug
+          CARGO_TARGET_DIR=$NEW_DIR/target cargo build --release --manifest-path pyrefly/Cargo.toml
+          BINARY_DIR=$NEW_DIR/target/release
           mv $BINARY_DIR/pyrefly $BINARY_DIR/pyrefly-real
           cp scripts/pyrefly_primer_wrapper.sh $BINARY_DIR/pyrefly
           chmod +x $BINARY_DIR/pyrefly
@@ -72,8 +72,8 @@ jobs:
           OLD_DIR=$BASE_DIR/pyrefly_old
           mkdir -p $OLD_DIR
           git checkout base_commit
-          CARGO_TARGET_DIR=$OLD_DIR/target cargo build --manifest-path pyrefly/Cargo.toml
-          BINARY_DIR=$OLD_DIR/target/debug
+          CARGO_TARGET_DIR=$OLD_DIR/target cargo build --release --manifest-path pyrefly/Cargo.toml
+          BINARY_DIR=$OLD_DIR/target/release
           mv $BINARY_DIR/pyrefly $BINARY_DIR/pyrefly-real
           # Use the wrapper from the new commit (old commit may not have it)
           git checkout $GITHUB_SHA -- scripts/pyrefly_primer_wrapper.sh
@@ -86,7 +86,7 @@ jobs:
             MYPY_PRIMER_NO_REBUILD=1 mypy_primer \
             --repo pyrefly_to_test \
             --base-dir $BASE_DIR \
-            --cargo-profile dev \
+            --cargo-profile release \
             --new $GITHUB_SHA --old base_commit \
             --num-shards 10 --shard-index ${{ matrix.shard-index }} \
             --debug \

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -90,7 +90,7 @@ jobs:
             --new $GITHUB_SHA --old base_commit \
             --num-shards 10 --shard-index ${{ matrix.shard-index }} \
             --debug \
-            --project-selector '^(?!.*(python-attrs/attrs|scipy/scipy|scikit-learn/scikit-learn|pandas-dev/pandas|pandas-dev/pandas-stubs|apache/spark|spack/spack|sympy/sympy|PyCQA/flake8-pyi|Gobot1234/steam\.py|rotki/rotki|enthought/comtypes|pytest-dev/pytest|internetarchive/openlibrary|narwhals-dev/narwhals|ibis-project/ibis|trailofbits/manticore|dulwich/dulwich|freqtrade/freqtrade|pydata/xarray|schemathesis/schemathesis|pwndbg/pwndbg|graphql-python/graphql-core|davidhalter/parso))' \
+            --project-selector '^(?!.*(python-attrs/attrs|scipy/scipy|scikit-learn/scikit-learn|pandas-dev/pandas|pandas-dev/pandas-stubs|apache/spark|spack/spack|sympy/sympy|PyCQA/flake8-pyi|Gobot1234/steam\.py|rotki/rotki|enthought/comtypes|pytest-dev/pytest|internetarchive/openlibrary|narwhals-dev/narwhals|ibis-project/ibis|trailofbits/manticore|dulwich/dulwich|freqtrade/freqtrade|pydata/xarray|schemathesis/schemathesis|pwndbg/pwndbg|graphql-python/graphql-core|davidhalter/parso|python/cpython))' \
             --type-checker pyrefly \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -90,7 +90,7 @@ jobs:
             --new $GITHUB_SHA --old base_commit \
             --num-shards 10 --shard-index ${{ matrix.shard-index }} \
             --debug \
-            --project-selector '.*' \
+            --project-selector '^(?!.*(python-attrs/attrs|scipy/scipy|scikit-learn/scikit-learn|pandas-dev/pandas|pandas-dev/pandas-stubs|apache/spark|spack/spack|sympy/sympy|PyCQA/flake8-pyi|Gobot1234/steam\.py|rotki/rotki|enthought/comtypes|pytest-dev/pytest|internetarchive/openlibrary|narwhals-dev/narwhals|ibis-project/ibis|trailofbits/manticore|dulwich/dulwich|freqtrade/freqtrade|pydata/xarray|schemathesis/schemathesis|pwndbg/pwndbg|graphql-python/graphql-core|davidhalter/parso))' \
             --type-checker pyrefly \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt


### PR DESCRIPTION
Summary:
I'm having trouble figuring out exactly what the problem is (I cannot repro
slowness locally), but very clearly it's the three CPython subdirectories
that are stuck in CI.

I still have no theory what actually causes this, although I'm much less
concerned now that it's something fixpoint-related, given that a fixpoint
issue would presumably reproduce locally.

I think for now we might want to just disable them - given that it's exactly
three subdirectories of the same project causing us problems (and all three are
very small subprojects), I very strongly suspect something in mypy primer
configuration is messing up pyrefly, as opposed to something in the core type
checker being to blame.

This should allow us to debug at leisure without interrupting CI on PRs.

Differential Revision: D95752934


