### PR TITLE
Re-enable mypy-primer on non-CPython projects

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -91,7 +91,7 @@ jobs:
             --new $GITHUB_SHA --old base_commit \
             --num-shards 10 --shard-index ${{ matrix.shard-index }} \
             --debug \
-            --project-selector '^(?!.*(python-attrs/attrs|scipy/scipy|scikit-learn/scikit-learn|pandas-dev/pandas|pandas-dev/pandas-stubs|apache/spark|spack/spack|sympy/sympy|PyCQA/flake8-pyi|Gobot1234/steam\.py|rotki/rotki|enthought/comtypes|pytest-dev/pytest|internetarchive/openlibrary|narwhals-dev/narwhals|ibis-project/ibis|trailofbits/manticore|dulwich/dulwich|freqtrade/freqtrade|pydata/xarray|schemathesis/schemathesis|pwndbg/pwndbg|graphql-python/graphql-core|davidhalter/parso|python/cpython))' \
+            --project-selector '^(?!.*(python/cpython))' \
             --type-checker pyrefly \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -6,6 +6,7 @@ on:
     paths:
     - 'pyrefly/lib/**'
     - 'pyrefly/third_party/**'
+    - '.github/workflows/mypy_primer.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Summary:
I re-enabled the blocklist as part of debugging a CI outage.

Now that the outage is cleared, and cpython is the primary suspect, it makes sense
to see what happens if we revert that change (so that we run everything again, *except*
for cpython which we know has some problems).

Differential Revision: D95759318


