### PR TITLE
feat(stubgen): Add core stub generation library - ast based solution [1/4]

### DIFF
--- a/pyrefly/lib/lib.rs
+++ b/pyrefly/lib/lib.rs
@@ -45,6 +45,7 @@ mod report;
 mod solver;
 #[doc(hidden)]
 pub mod state;
+pub mod stubgen;
 mod test;
 #[cfg(not(target_arch = "wasm32"))]
 mod tsp;

--- a/pyrefly/lib/stubgen/emit.rs
+++ b/pyrefly/lib/stubgen/emit.rs
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Emits `.pyi` stub syntax from ruff AST nodes.
+//!
+//! Each `emit_*` function writes PEP 484-compliant stub text into an
+//! output `String` buffer. Source annotations are preserved verbatim
+//! by slicing the original source at AST node ranges.
+
+use std::collections::HashSet;
+
+use ruff_python_ast::Expr;
+use ruff_python_ast::ExprName;
+use ruff_python_ast::Operator;
+use ruff_python_ast::ParameterWithDefault;
+use ruff_python_ast::Stmt;
+use ruff_python_ast::StmtClassDef;
+use ruff_python_ast::StmtFunctionDef;
+use ruff_text_size::Ranged;
+
+use crate::export::definitions::Definitions;
+use crate::stubgen::StubgenOptions;
+use crate::stubgen::visibility::VisibilityFilter;
+
+/// Extract the source text for an AST node's range.
+fn source_at<'a>(source: &'a str, node: &impl Ranged) -> &'a str {
+    let range = node.range();
+    &source[range.start().to_usize()..range.end().to_usize()]
+}
+
+/// Returns `true` when `value` is a call to a type-variable constructor
+/// (`TypeVar`, `ParamSpec`, `TypeVarTuple`, `NewType`, `NamedTuple`,
+/// `TypedDict`). These assignments are preserved verbatim in stubs.
+fn is_type_var_call(value: &Expr) -> bool {
+    if let Expr::Call(call) = value
+        && let Expr::Name(name) = &*call.func
+    {
+        return matches!(
+            name.id.as_str(),
+            "TypeVar" | "ParamSpec" | "TypeVarTuple" | "NewType" | "NamedTuple" | "TypedDict"
+        );
+    }
+    false
+}
+
+/// Returns `true` when `value` looks like an old-style type alias RHS --
+/// a subscript (`List[int]`) or a union pipe (`int | str`). These are
+/// emitted verbatim rather than collapsed to `Any`.
+fn is_type_alias_value(value: &Expr) -> bool {
+    match value {
+        Expr::Subscript(_) => true,
+        Expr::BinOp(op) if op.op == Operator::BitOr => true,
+        _ => false,
+    }
+}
+
+fn has_overload_decorator(func: &StmtFunctionDef) -> bool {
+    func.decorator_list.iter().any(|d| {
+        matches!(
+            &d.expression,
+            Expr::Name(ExprName { id, .. }) if id.as_str() == "overload"
+        )
+    })
+}
+
+/// Collect the names of all functions that have at least one `@overload`
+/// variant in `stmts`. Used to drop the non-overloaded implementation.
+pub(crate) fn collect_overloaded_names(stmts: &[Stmt]) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for stmt in stmts {
+        if let Stmt::FunctionDef(func) = stmt
+            && has_overload_decorator(func)
+        {
+            names.insert(func.name.to_string());
+        }
+    }
+    names
+}
+
+/// Returns `true` if `stmt` is the non-overloaded implementation of an
+/// overloaded function (i.e. it should be dropped from the stub).
+pub(crate) fn is_overload_impl(stmt: &Stmt, overloaded: &HashSet<String>) -> bool {
+    if let Stmt::FunctionDef(func) = stmt {
+        overloaded.contains(func.name.as_str()) && !has_overload_decorator(func)
+    } else {
+        false
+    }
+}
+
+/// Emit a single top-level (or class-body) statement into the output buffer.
+/// Returns `true` if something was written.
+pub(crate) fn emit_stmt(
+    source: &str,
+    stmt: &Stmt,
+    filter: &VisibilityFilter,
+    options: &StubgenOptions,
+    out: &mut String,
+    indent: &str,
+    defs: &Definitions,
+) -> bool {
+    match stmt {
+        Stmt::Import(_) | Stmt::ImportFrom(_) => {
+            out.push_str(indent);
+            out.push_str(source_at(source, stmt));
+            out.push('\n');
+            true
+        }
+        Stmt::FunctionDef(func) => {
+            let name = func.name.as_str();
+            if !filter.should_include(name, options.include_private) {
+                return false;
+            }
+            emit_function(source, func, out, indent);
+            true
+        }
+        Stmt::ClassDef(class) => {
+            let name = class.name.as_str();
+            if !filter.should_include(name, options.include_private) {
+                return false;
+            }
+            emit_class(source, class, options, out, indent, defs);
+            true
+        }
+        Stmt::AnnAssign(ann) => {
+            if let Expr::Name(ExprName { id, .. }) = &*ann.target {
+                if !filter.should_include(id.as_str(), options.include_private) {
+                    return false;
+                }
+                out.push_str(indent);
+                out.push_str(id.as_str());
+                out.push_str(": ");
+                out.push_str(source_at(source, &*ann.annotation));
+                if ann.value.is_some() {
+                    out.push_str(" = ...");
+                }
+                out.push('\n');
+                return true;
+            }
+            false
+        }
+        Stmt::Assign(assign) => {
+            if let [Expr::Name(ExprName { id, .. })] = assign.targets.as_slice() {
+                // __all__, TypeVar calls, and type aliases are type-level
+                // declarations that stubs always need regardless of visibility.
+                if id.as_str() == "__all__"
+                    || is_type_var_call(&assign.value)
+                    || is_type_alias_value(&assign.value)
+                {
+                    out.push_str(indent);
+                    out.push_str(source_at(source, stmt));
+                    out.push('\n');
+                    return true;
+                }
+                if !filter.should_include(id.as_str(), options.include_private) {
+                    return false;
+                }
+                out.push_str(indent);
+                out.push_str(id.as_str());
+                out.push_str(": Any = ...\n");
+                return true;
+            }
+            false
+        }
+        Stmt::TypeAlias(_) => {
+            out.push_str(indent);
+            out.push_str(source_at(source, stmt));
+            out.push('\n');
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Emit a function stub: `def name(params) -> RetType: ...`
+fn emit_function(source: &str, func: &StmtFunctionDef, out: &mut String, indent: &str) {
+    for decorator in &func.decorator_list {
+        out.push_str(indent);
+        out.push('@');
+        out.push_str(source_at(source, &decorator.expression));
+        out.push('\n');
+    }
+
+    out.push_str(indent);
+    if func.is_async {
+        out.push_str("async ");
+    }
+    out.push_str("def ");
+    out.push_str(func.name.as_str());
+    out.push('(');
+
+    emit_parameters(source, &func.parameters, out);
+
+    out.push(')');
+
+    if let Some(returns) = &func.returns {
+        out.push_str(" -> ");
+        out.push_str(source_at(source, &**returns));
+    }
+
+    out.push_str(": ...\n");
+}
+
+/// Emit function parameters, preserving source annotations and defaults as `...`.
+fn emit_parameters(source: &str, params: &ruff_python_ast::Parameters, out: &mut String) {
+    let mut first = true;
+    let mut needs_separator = false;
+
+    // Positional-only parameters
+    for param in &params.posonlyargs {
+        if !first {
+            out.push_str(", ");
+        }
+        first = false;
+        emit_param(source, param, out);
+    }
+    if !params.posonlyargs.is_empty() {
+        needs_separator = true;
+    }
+
+    // Regular (positional-or-keyword) parameters
+    for param in &params.args {
+        if needs_separator {
+            out.push_str(", /");
+            needs_separator = false;
+        }
+        if !first {
+            out.push_str(", ");
+        }
+        first = false;
+        emit_param(source, param, out);
+    }
+    if needs_separator && params.args.is_empty() {
+        if !first {
+            out.push_str(", ");
+        }
+        out.push('/');
+        first = false;
+    }
+
+    // *args
+    if let Some(vararg) = &params.vararg {
+        if !first {
+            out.push_str(", ");
+        }
+        first = false;
+        out.push('*');
+        out.push_str(vararg.name.as_str());
+        if let Some(ann) = &vararg.annotation {
+            out.push_str(": ");
+            out.push_str(source_at(source, &**ann));
+        }
+    } else if !params.kwonlyargs.is_empty() {
+        // Bare `*` to signal keyword-only params follow
+        if !first {
+            out.push_str(", ");
+        }
+        first = false;
+        out.push('*');
+    }
+
+    // Keyword-only parameters
+    for param in &params.kwonlyargs {
+        if !first {
+            out.push_str(", ");
+        }
+        first = false;
+        emit_param(source, param, out);
+    }
+
+    // **kwargs
+    if let Some(kwarg) = &params.kwarg {
+        if !first {
+            out.push_str(", ");
+        }
+        out.push_str("**");
+        out.push_str(kwarg.name.as_str());
+        if let Some(ann) = &kwarg.annotation {
+            out.push_str(": ");
+            out.push_str(source_at(source, &**ann));
+        }
+    }
+}
+
+/// Emit a single parameter with its annotation (from source) and default as `...`.
+fn emit_param(source: &str, param: &ParameterWithDefault, out: &mut String) {
+    out.push_str(param.parameter.name.as_str());
+    if let Some(ann) = &param.parameter.annotation {
+        out.push_str(": ");
+        out.push_str(source_at(source, &**ann));
+    }
+    if param.default.is_some() {
+        if param.parameter.annotation.is_some() {
+            out.push_str(" = ...");
+        } else {
+            out.push_str("=...");
+        }
+    }
+}
+
+/// Emit a class stub with its bases and nested method/variable stubs.
+fn emit_class(
+    source: &str,
+    class: &StmtClassDef,
+    options: &StubgenOptions,
+    out: &mut String,
+    indent: &str,
+    defs: &Definitions,
+) {
+    for decorator in &class.decorator_list {
+        out.push_str(indent);
+        out.push('@');
+        out.push_str(source_at(source, &decorator.expression));
+        out.push('\n');
+    }
+
+    out.push_str(indent);
+    out.push_str("class ");
+    out.push_str(class.name.as_str());
+
+    if let Some(type_params) = &class.type_params {
+        out.push_str(source_at(source, &**type_params));
+    }
+
+    if let Some(arguments) = &class.arguments
+        && (!arguments.args.is_empty() || !arguments.keywords.is_empty())
+    {
+        out.push_str(source_at(source, &**arguments));
+    }
+
+    out.push_str(":\n");
+
+    let child_indent = format!("{indent}    ");
+    let mut has_body = false;
+    let overloaded = collect_overloaded_names(&class.body);
+
+    for stmt in &class.body {
+        if is_overload_impl(stmt, &overloaded) {
+            continue;
+        }
+        // Inside a class, we don't filter by module-level __all__ -- all
+        // class members are part of the class's stub.
+        let class_filter = VisibilityFilter::Inferred;
+        if emit_stmt(
+            source,
+            stmt,
+            &class_filter,
+            options,
+            out,
+            &child_indent,
+            defs,
+        ) {
+            has_body = true;
+        }
+    }
+
+    if !has_body {
+        out.push_str(&child_indent);
+        out.push_str("...\n");
+    }
+}
+
+/// Check whether a statement will produce a literal `Any` token in its
+/// stub output, so we know to add `from typing import Any` at the top.
+///
+/// Only unannotated `Assign` statements produce `x: Any = ...`; functions
+/// with missing annotations are emitted without `Any` (parameters are left
+/// bare, return types are omitted).
+pub(crate) fn stmt_uses_any(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Assign(assign) => {
+            if let [Expr::Name(ExprName { id, .. })] = assign.targets.as_slice() {
+                if id.as_str() == "__all__" {
+                    return false;
+                }
+                // TypeVar calls and type-alias subscripts are emitted verbatim
+                // and don't need the `Any` import.
+                if is_type_var_call(&assign.value) || is_type_alias_value(&assign.value) {
+                    return false;
+                }
+                true
+            } else {
+                false
+            }
+        }
+        Stmt::ClassDef(class) => class.body.iter().any(stmt_uses_any),
+        _ => false,
+    }
+}

--- a/pyrefly/lib/stubgen/mod.rs
+++ b/pyrefly/lib/stubgen/mod.rs
@@ -1,0 +1,422 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Generates PEP 484 `.pyi` stub files from Python source.
+//!
+//! Phase 1 (this module): structure-only stubs using the AST and source
+//! annotations. No type inference -- unannotated items get `Any`.
+//!
+//! - [`emit`]: Writes `.pyi` syntax from AST nodes.
+//! - [`visibility`]: Decides which names to include based on `__all__` / privacy.
+
+mod emit;
+pub(crate) mod visibility;
+
+use pyrefly_python::ast::Ast;
+use pyrefly_python::module_name::ModuleName;
+use pyrefly_python::sys_info::SysInfo;
+use ruff_python_ast::PySourceType;
+use ruff_python_ast::Stmt;
+
+use crate::export::definitions::Definitions;
+use crate::stubgen::emit::collect_overloaded_names;
+use crate::stubgen::emit::emit_stmt;
+use crate::stubgen::emit::is_overload_impl;
+use crate::stubgen::emit::stmt_uses_any;
+use crate::stubgen::visibility::VisibilityFilter;
+
+/// Options controlling stub generation.
+pub struct StubgenOptions {
+    /// Include private names (those starting with `_`) in generated stubs.
+    pub include_private: bool,
+}
+
+/// Generate a `.pyi` stub string from Python source code.
+///
+/// This is the main entry point. It parses the source, builds definitions
+/// for `__all__` filtering, and walks the AST to emit stub syntax.
+pub fn generate_stub(source: &str, module_name: &str, options: &StubgenOptions) -> String {
+    let (ast, _parse_errors, _) = Ast::parse(source, PySourceType::Python);
+    let defs = Definitions::new(
+        &ast.body,
+        ModuleName::from_str(module_name),
+        module_name.is_empty() || module_name.ends_with(".__init__"),
+        &SysInfo::default(),
+    );
+    let filter = VisibilityFilter::from_definitions(&defs);
+    let overloaded = collect_overloaded_names(&ast.body);
+
+    let mut out = String::new();
+    let mut needs_any_import = false;
+    let mut last_emitted_class = false;
+
+    for stmt in &ast.body {
+        if is_overload_impl(stmt, &overloaded) {
+            continue;
+        }
+
+        let is_class = matches!(stmt, Stmt::ClassDef(_));
+        let pos_before = out.len();
+
+        let emitted = emit_stmt(source, stmt, &filter, options, &mut out, "", &defs);
+        if emitted {
+            // Blank line before/after class definitions (PEP 8 style).
+            if (is_class || last_emitted_class) && pos_before > 0 {
+                out.insert(pos_before, '\n');
+            }
+            needs_any_import = needs_any_import || stmt_uses_any(stmt);
+            last_emitted_class = is_class;
+        }
+    }
+
+    // Prepend `from typing import Any` if we emitted any `Any` placeholders.
+    if needs_any_import {
+        let mut header = String::from("from typing import Any\n");
+        if !out.is_empty() {
+            header.push('\n');
+        }
+        header.push_str(&out);
+        header
+    } else {
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stub(source: &str) -> String {
+        generate_stub(
+            source,
+            "test_module",
+            &StubgenOptions {
+                include_private: false,
+            },
+        )
+    }
+
+    fn stub_with_private(source: &str) -> String {
+        generate_stub(
+            source,
+            "test_module",
+            &StubgenOptions {
+                include_private: true,
+            },
+        )
+    }
+
+    #[test]
+    fn test_simple_function() {
+        let result = stub("def foo(x: int, y: str) -> bool:\n    return x > 0\n");
+        assert_eq!(result, "def foo(x: int, y: str) -> bool: ...\n");
+    }
+
+    #[test]
+    fn test_function_no_annotations() {
+        let result = stub("def foo(x, y):\n    return x\n");
+        assert_eq!(result, "def foo(x, y): ...\n");
+    }
+
+    #[test]
+    fn test_function_partial_annotations() {
+        let result = stub("def foo(x: int, y) -> str:\n    pass\n");
+        assert_eq!(result, "def foo(x: int, y) -> str: ...\n");
+    }
+
+    #[test]
+    fn test_async_function() {
+        let result = stub("async def fetch(url: str) -> bytes:\n    pass\n");
+        assert_eq!(result, "async def fetch(url: str) -> bytes: ...\n");
+    }
+
+    #[test]
+    fn test_decorated_function() {
+        let result = stub("@staticmethod\ndef foo(x: int) -> int:\n    return x\n");
+        assert_eq!(result, "@staticmethod\ndef foo(x: int) -> int: ...\n");
+    }
+
+    #[test]
+    fn test_function_with_defaults() {
+        let result = stub("def foo(x: int = 0, y: str = 'hello') -> None:\n    pass\n");
+        assert_eq!(result, "def foo(x: int = ..., y: str = ...) -> None: ...\n");
+    }
+
+    #[test]
+    fn test_function_varargs_kwargs() {
+        let result = stub("def foo(*args: int, **kwargs: str) -> None:\n    pass\n");
+        assert_eq!(result, "def foo(*args: int, **kwargs: str) -> None: ...\n");
+    }
+
+    #[test]
+    fn test_function_keyword_only() {
+        let result = stub("def foo(x: int, *, key: str) -> None:\n    pass\n");
+        assert_eq!(result, "def foo(x: int, *, key: str) -> None: ...\n");
+    }
+
+    #[test]
+    fn test_function_positional_only() {
+        let result = stub("def foo(x: int, y: int, /, z: int) -> None:\n    pass\n");
+        assert_eq!(result, "def foo(x: int, y: int, /, z: int) -> None: ...\n");
+    }
+
+    #[test]
+    fn test_annotated_variable() {
+        let result = stub("x: int = 42\n");
+        assert_eq!(result, "x: int = ...\n");
+    }
+
+    #[test]
+    fn test_annotated_variable_no_value() {
+        let result = stub("x: int\n");
+        assert_eq!(result, "x: int\n");
+    }
+
+    #[test]
+    fn test_unannotated_variable() {
+        let result = stub("x = 42\n");
+        assert_eq!(result, "from typing import Any\n\nx: Any = ...\n");
+    }
+
+    #[test]
+    fn test_class_simple() {
+        let result = stub("class Foo:\n    x: int\n    def method(self) -> None:\n        pass\n");
+        assert_eq!(
+            result,
+            "class Foo:\n    x: int\n    def method(self) -> None: ...\n"
+        );
+    }
+
+    #[test]
+    fn test_class_with_bases() {
+        let result = stub("class Foo(Bar, Baz):\n    pass\n");
+        assert_eq!(result, "class Foo(Bar, Baz):\n    ...\n");
+    }
+
+    #[test]
+    fn test_class_with_decorator() {
+        let result = stub("@dataclass\nclass Foo:\n    x: int\n    y: str = 'hello'\n");
+        assert_eq!(
+            result,
+            "@dataclass\nclass Foo:\n    x: int\n    y: str = ...\n"
+        );
+    }
+
+    #[test]
+    fn test_imports_preserved() {
+        let result = stub("import os\nfrom typing import List\n");
+        assert_eq!(result, "import os\nfrom typing import List\n");
+    }
+
+    #[test]
+    fn test_private_names_excluded() {
+        let result = stub("def public() -> None:\n    pass\ndef _private() -> None:\n    pass\n");
+        assert_eq!(result, "def public() -> None: ...\n");
+    }
+
+    #[test]
+    fn test_private_names_included() {
+        let result = stub_with_private(
+            "def public() -> None:\n    pass\ndef _private() -> None:\n    pass\n",
+        );
+        assert_eq!(
+            result,
+            "def public() -> None: ...\ndef _private() -> None: ...\n"
+        );
+    }
+
+    #[test]
+    fn test_dunder_all_filtering() {
+        let source =
+            "__all__ = ['foo']\ndef foo() -> None:\n    pass\ndef bar() -> None:\n    pass\n";
+        let result = stub(source);
+        assert!(result.contains("def foo() -> None: ..."));
+        assert!(!result.contains("bar"));
+    }
+
+    #[test]
+    fn test_type_alias() {
+        let result = stub("type Vector = list[float]\n");
+        assert_eq!(result, "type Vector = list[float]\n");
+    }
+
+    #[test]
+    fn test_dunder_all_preserved() {
+        let source = "__all__ = ['foo']\ndef foo() -> None:\n    pass\n";
+        let result = stub(source);
+        assert!(result.contains("__all__ = ['foo']"));
+    }
+
+    #[test]
+    fn test_mixed_module() {
+        let source = "\
+import os
+from typing import Optional
+
+VERSION: str = '1.0'
+
+class Config:
+    debug: bool
+    def __init__(self, debug: bool = False) -> None:
+        self.debug = debug
+
+def get_config() -> Config:
+    return Config()
+";
+        let result = stub(source);
+        assert!(result.contains("import os"));
+        assert!(result.contains("from typing import Optional"));
+        assert!(result.contains("VERSION: str = ..."));
+        assert!(result.contains("class Config:"));
+        assert!(result.contains("    debug: bool"));
+        assert!(result.contains("    def __init__(self, debug: bool = ...) -> None: ..."));
+        assert!(result.contains("def get_config() -> Config: ..."));
+    }
+
+    // --- PR 4: complex annotation tests ---
+
+    #[test]
+    fn test_union_annotation() {
+        let result = stub("def foo(x: int | str) -> int | None:\n    pass\n");
+        assert_eq!(result, "def foo(x: int | str) -> int | None: ...\n");
+    }
+
+    #[test]
+    fn test_optional_annotation() {
+        let result = stub(
+            "from typing import Optional\ndef foo(x: Optional[str]) -> Optional[int]:\n    pass\n",
+        );
+        assert!(result.contains("def foo(x: Optional[str]) -> Optional[int]: ..."));
+    }
+
+    #[test]
+    fn test_generic_annotations() {
+        let result = stub(
+            "\
+from typing import List, Dict, Tuple, Set
+def foo(a: List[int], b: Dict[str, int]) -> Tuple[str, ...]:
+    pass
+x: Set[float] = set()
+",
+        );
+        assert!(
+            result.contains("def foo(a: List[int], b: Dict[str, int]) -> Tuple[str, ...]: ...")
+        );
+        assert!(result.contains("x: Set[float] = ..."));
+    }
+
+    #[test]
+    fn test_callable_annotation() {
+        let result = stub(
+            "\
+from typing import Callable
+def apply(fn: Callable[[int, str], bool]) -> None:
+    pass
+",
+        );
+        assert!(result.contains("def apply(fn: Callable[[int, str], bool]) -> None: ..."));
+    }
+
+    #[test]
+    fn test_nested_generic_annotation() {
+        let result = stub("def foo(x: dict[str, list[tuple[int, ...]]]) -> None:\n    pass\n");
+        assert_eq!(
+            result,
+            "def foo(x: dict[str, list[tuple[int, ...]]]) -> None: ...\n"
+        );
+    }
+
+    #[test]
+    fn test_class_with_generic_base() {
+        let result = stub(
+            "\
+from typing import Generic, TypeVar
+T = TypeVar('T')
+class Stack(Generic[T]):
+    def push(self, item: T) -> None:
+        pass
+    def pop(self) -> T:
+        pass
+",
+        );
+        assert!(result.contains("class Stack(Generic[T]):"));
+        assert!(result.contains("    def push(self, item: T) -> None: ..."));
+        assert!(result.contains("    def pop(self) -> T: ..."));
+    }
+
+    #[test]
+    fn test_overloaded_function() {
+        let result = stub(
+            "\
+from typing import overload
+@overload
+def process(x: int) -> int: ...
+@overload
+def process(x: str) -> str: ...
+def process(x):
+    return x
+",
+        );
+        assert!(result.contains("@overload\ndef process(x: int) -> int: ..."));
+        assert!(result.contains("@overload\ndef process(x: str) -> str: ..."));
+    }
+
+    #[test]
+    fn test_reexport_import() {
+        let result = stub("from os.path import join\nfrom typing import List\n");
+        assert_eq!(
+            result,
+            "from os.path import join\nfrom typing import List\n"
+        );
+    }
+
+    #[test]
+    fn test_import_as() {
+        let result = stub("import numpy as np\nfrom pathlib import Path as P\n");
+        assert_eq!(
+            result,
+            "import numpy as np\nfrom pathlib import Path as P\n"
+        );
+    }
+
+    #[test]
+    fn test_multiple_decorators() {
+        let result = stub(
+            "\
+class Foo:
+    @property
+    def name(self) -> str:
+        return ''
+    @name.setter
+    def name(self, value: str) -> None:
+        pass
+",
+        );
+        assert!(result.contains("    @property\n    def name(self) -> str: ..."));
+        assert!(result.contains("    @name.setter\n    def name(self, value: str) -> None: ..."));
+    }
+
+    #[test]
+    fn test_class_variable_vs_instance_annotation() {
+        let result = stub(
+            "\
+from typing import ClassVar
+class Foo:
+    count: ClassVar[int] = 0
+    name: str
+",
+        );
+        assert!(result.contains("    count: ClassVar[int] = ..."));
+        assert!(result.contains("    name: str\n"));
+    }
+
+    #[test]
+    fn test_string_literal_annotation() {
+        let result = stub("def foo(x: 'ForwardRef') -> 'ForwardRef':\n    pass\n");
+        assert_eq!(result, "def foo(x: 'ForwardRef') -> 'ForwardRef': ...\n");
+    }
+}

--- a/pyrefly/lib/stubgen/testdata/sample.py
+++ b/pyrefly/lib/stubgen/testdata/sample.py
@@ -1,0 +1,105 @@
+"""A sample module for testing stub generation."""
+
+from typing import (
+    Callable,
+    ClassVar,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    overload,
+)
+
+__all__ = [
+    "VERSION",
+    "Config",
+    "process",
+    "make_config",
+    "Stack",
+    "apply_fn",
+    "Coordinates",
+    "greet",
+    "load_items",
+]
+
+VERSION: str = "1.0.0"
+
+_INTERNAL_COUNTER: int = 0
+
+T = TypeVar("T")
+
+Coordinates = Tuple[float, float]
+
+
+class Config:
+    """Application configuration."""
+
+    DEFAULT_NAME: ClassVar[str] = "default"
+    debug: bool
+    name: str
+
+    def __init__(self, name: str, debug: bool = False) -> None:
+        self.name = name
+        self.debug = debug
+
+    @property
+    def display_name(self) -> str:
+        return self.name.upper()
+
+    @display_name.setter
+    def display_name(self, value: str) -> None:
+        self.name = value.lower()
+
+
+class Stack(Generic[T]):
+    """A generic stack implementation."""
+
+    def __init__(self) -> None:
+        self._items: List[T] = []
+
+    def push(self, item: T) -> None:
+        self._items.append(item)
+
+    def pop(self) -> T:
+        if not self._items:
+            raise IndexError("empty stack")
+        return self._items.pop()
+
+    def peek(self) -> Optional[T]:
+        return self._items[-1] if self._items else None
+
+
+@overload
+def process(x: int) -> int: ...
+
+
+@overload
+def process(x: str) -> str: ...
+
+
+def process(x: Union[int, str]) -> Union[int, str]:
+    return x
+
+
+def make_config(name: str, debug: bool = False) -> Config:
+    """Create a new Config instance."""
+    return Config(name, debug)
+
+
+def apply_fn(fn: Callable[[int], int], values: List[int]) -> List[int]:
+    return [fn(v) for v in values]
+
+
+def greet(name: Optional[str] = None) -> str:
+    return f"Hello, {name or 'World'}!"
+
+
+def load_items(path: str) -> Dict[str, List[Tuple[int, ...]]]:
+    return {}
+
+
+def _private_helper(x: int) -> int:
+    return x * 2

--- a/pyrefly/lib/stubgen/visibility.rs
+++ b/pyrefly/lib/stubgen/visibility.rs
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Determines which names from a Python module should appear in the
+//! generated `.pyi` stub, based on `__all__` or public-name heuristics.
+
+use crate::export::definitions::Definitions;
+use crate::export::definitions::DunderAllEntry;
+use crate::export::definitions::DunderAllKind;
+
+/// The set of names that should appear in the generated stub.
+pub(crate) enum VisibilityFilter {
+    /// `__all__` was explicitly defined; only these names are exported.
+    Explicit(Vec<String>),
+    /// No `__all__`; export all names that pass the privacy check.
+    Inferred,
+}
+
+impl VisibilityFilter {
+    pub(crate) fn from_definitions(defs: &Definitions) -> Self {
+        match defs.dunder_all.kind {
+            DunderAllKind::Specified => {
+                let names = defs
+                    .dunder_all
+                    .entries
+                    .iter()
+                    .filter_map(|entry| match entry {
+                        DunderAllEntry::Name(_, name) => Some(name.to_string()),
+                        _ => None,
+                    })
+                    .collect();
+                VisibilityFilter::Explicit(names)
+            }
+            _ => VisibilityFilter::Inferred,
+        }
+    }
+
+    /// Should `name` appear in the stub?
+    pub(crate) fn should_include(&self, name: &str, include_private: bool) -> bool {
+        match self {
+            VisibilityFilter::Explicit(names) => names.iter().any(|n| n == name),
+            VisibilityFilter::Inferred => {
+                // Dunder names (__init__, __str__, etc.) are always public.
+                // Single underscore `_` is also public (commonly used as gettext alias).
+                // Only single-leading-underscore names (_helper) are private.
+                if name.starts_with("__") && name.ends_with("__") {
+                    true
+                } else if name.starts_with('_') && name != "_" {
+                    include_private
+                } else {
+                    true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

# Summary
Have added an AST-based `.pyi` stub generation from Python source.

- `stubgen/emit.rs`: Emits PEP484 stub syntax from ruff AST nodes, preserving source annotations verbatim via byte-range slicing (will improve on this heuristic in a separate PR)
  - `stubgen/visibility.rs`: Filters exported names using `__all__` or public-name heuristics. The purpose of this file is to control if a function / method should be exposed in the stubs with [this `__all__` scheme for public visibility](https://peps.python.org/pep-0008/#public-and-internal-interfaces).
- `stubgen/mod.rs`: `generate_stub()` entry point with 34 unit tests covering functions, classes, imports, overloads, type aliases, generics, and `__all__` filtering. 

**Disclaimer**: Used AI to generate the tests and to understand the structure of the codebase. AI was also used to **understand the library details** and help plan possible path ways with available API in the codebase so I don't have to go around looking for them.


No type inference yet! Unannotated items get `Any` or bare signatures. The inference layer will be added in a follow-up PR 👍 

Flow visualised for AST based parsing only (look below for code example):

```mermaid
flowchart LR
    A["source.py"] --> B["Ast::parse()"]
    B --> C["Definitions (resolve __all__)"]
    C --> D["VisibilityFilter"]
    D --> E["emit_stmt() per statement"]
    E --> F["stub.pyi"]
    style A fill:#2d3748,stroke:#e2e8f0,color:#e2e8f0
    style F fill:#2d3748,stroke:#e2e8f0,color:#e2e8f0
```

## Test plan
- [x] `cargo test -p pyrefly stubgen` passes
- [x] `python3 test.py --no-test --no-conformance` passes

## Output diff:

---------------
Example python code (this is not commited, just a play example)
```python
from typing import Optional, TypeVar

T = TypeVar("T")

__all__ = ["greet", "Config", "process_items"]

VERSION = "1.0.0"

_CACHE = {}

class Config:
    DEFAULT_TTL = 300
    name: str
    debug: bool

    def __init__(self, name: str, debug: bool = False) -> None:
        self.name = name
        self.debug = debug

    def is_production(self):
        return not self.debug

    @property
    def display_name(self) -> str:
        return self.name.upper()

def greet(name):
    return f"Hello, {name}!"

def process_items(items, transformer, default=None):
    results = []
    for item in items:
        try:
            results.append(transformer(item))
        except Exception:
            results.append(default)
    return results

def _internal_helper(x):
    return x * 2
```

* Pyrefly stubgen:
```python
from typing import Any
__all__ = ['greet', 'Config', 'process_items']
VERSION: Any = ...
class Config:
    DEFAULT_TTL: Any = ...
    name: str
    debug: bool
    def __init__(self, name: str, debug: bool = ...) -> None: ...
    def is_production(self): ...
    @property
    def display_name(self) -> str: ...
def greet(name): ...
def process_items(items, transformer, default=...): ...
```

* MyPy stubgen
```python
from _typeshed import Incomplete
__all__ = ["greet", "Config", "process_items"]
VERSION: str
_CACHE: Incomplete
class Config:
    DEFAULT_TTL: int
    name: str
    debug: bool
    def __init__(self, name: str, debug: bool = False) -> None: ...
    def is_production(self): ...
    @property
    def display_name(self) -> str: ...
def greet(name: Incomplete) -> Incomplete: ...
def process_items(items: Incomplete, transformer: Incomplete, default: Incomplete = None) -> Incomplete: ...
def _internal_helper(x: Incomplete) -> Incomplete: ...
```

### Issue
https://github.com/facebook/pyrefly/issues/2133 

## PR Train (If there is a better way to break this PR pls lmk 🙏) : 
- AST parsing solution: https://github.com/facebook/pyrefly/pull/2721
- Incomplete annotations: https://github.com/facebook/pyrefly/pull/2803 [This will support the missing Incomplete markers as per mypy stubgen]
- CLI commands for ast: https://github.com/Rayahhhmed/pyrefly/pull/4
- Inference for unanotated vars: https://github.com/Rayahhhmed/pyrefly/pull/5