### PR TITLE
Fix false positive invalid-type-var for generic functions assigned to attributes (#2204)

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -2431,10 +2431,37 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             return ty;
         }
         let class_tparams = self.get_class_tparams(class);
+        // Exclude quantifieds bound by Forall nodes within the type
+        // (e.g. generic functions assigned to attributes have their own
+        // type parameters that should not trigger invalid-type-var errors).
+        let mut forall_bound: SmallSet<&Quantified> = SmallSet::new();
+        fn collect_forall_tparams<'a>(ty: &'a Type, acc: &mut SmallSet<&'a Quantified>) {
+            match ty {
+                Type::Forall(forall) => {
+                    for q in forall.tparams.iter() {
+                        acc.insert(q);
+                    }
+                }
+                Type::BoundMethod(bm) => {
+                    if let BoundMethodType::Forall(forall) = &bm.func {
+                        for q in forall.tparams.iter() {
+                            acc.insert(q);
+                        }
+                    }
+                }
+                _ => {}
+            }
+            ty.recurse(&mut |inner| collect_forall_tparams(inner, acc));
+        }
+        collect_forall_tparams(&ty, &mut forall_bound);
+        let allowed: SmallSet<&Quantified> = class_tparams
+            .iter()
+            .chain(forall_bound.iter().copied())
+            .collect();
         let qs_owner = Owner::new();
         let ts = Owner::new();
         let gradual_fallbacks = qs
-            .difference(&class_tparams.iter().collect())
+            .difference(&allowed)
             .map(|q| {
                 self.error(
                     errors,
@@ -2451,6 +2478,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             })
             .collect::<SmallMap<_, _>>();
         drop(qs);
+        drop(allowed);
+        drop(forall_bound);
         ty.subst(&gradual_fallbacks)
     }
 

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -1107,6 +1107,33 @@ class C2[R]:
 "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/2204
+testcase!(
+    test_generic_function_assigned_to_attribute,
+    r#"
+from typing import reveal_type, assert_type
+def f[T](x: T) -> T:
+    return x
+
+class C:
+    def m[U](self, x: U) -> U:
+        return x
+
+class D:
+    def __init__(self, c: C):
+        self.f = f
+        self.g = c.m
+        self.h = C.m
+
+def test(o: D):
+    reveal_type(o.f) # E: [T](x: T) -> T
+    assert_type(o.f(1), int)
+
+    reveal_type(o.g) # E: [U](self: C, x: U) -> U
+    assert_type(o.g(1), int)
+"#,
+);
+
 testcase!(
     test_attr_unknown,
     r#"


### PR DESCRIPTION
Summary:
fixes https://github.com/facebook/pyrefly/issues/2204

Fixed check_and_sanitize_type_parameters to also exclude Forall-bound tparams within the type of the attribute.

Differential Revision: D95799931


