### PR TITLE
Implement PEP 800 disjoint bases for subclasses (#1592)

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -97,17 +97,32 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         )
     }
 
-    pub fn disjoint_base<'b>(&'b self, t: &'b Type) -> &'b Class {
-        // TODO: Implement the full disjoint base spec: https://peps.python.org/pep-0800/#specification.
+    /// Return the most specific disjoint base for a type per PEP 800.
+    /// Walks the MRO to find the first ancestor marked `@disjoint_base`.
+    /// TODO: handle multiple incompatible disjoint bases
+    pub fn disjoint_base(&self, t: &Type) -> Class {
         match t {
-            Type::ClassType(cls)
-                if let cls = cls.class_object()
-                    && self.get_metadata_for_class(cls).is_disjoint_base() =>
-            {
-                cls
+            Type::ClassType(cls) => {
+                let class = cls.class_object();
+                // Check the class itself first.
+                if self.get_metadata_for_class(class).is_disjoint_base() {
+                    return class.clone();
+                }
+                // Walk the MRO to find the most specific disjoint base ancestor.
+                let mro = self.get_mro_for_class(class);
+                for ancestor in mro.ancestors_no_object() {
+                    if self
+                        .get_metadata_for_class(ancestor.class_object())
+                        .is_disjoint_base()
+                    {
+                        return ancestor.class_object().clone();
+                    }
+                }
+                // Fall back to object (which is never disjoint with anything).
+                self.stdlib.object().class_object().clone()
             }
-            Type::Tuple(_) => self.stdlib.tuple_object(),
-            _ => self.stdlib.object().class_object(),
+            Type::Tuple(_) => self.stdlib.tuple_object().clone(),
+            _ => self.stdlib.object().class_object().clone(),
         }
     }
 
@@ -157,8 +172,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             } else {
                 let left_base = self.disjoint_base(left);
                 let right_base = self.disjoint_base(right);
-                if self.has_superclass(left_base, right_base)
-                    || self.has_superclass(right_base, left_base)
+                if self.has_superclass(&left_base, &right_base)
+                    || self.has_superclass(&right_base, &left_base)
                 {
                     intersect(vec![left.clone(), right.clone()], fallback, self.heap)
                 } else {

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -2396,6 +2396,21 @@ def f(x: int):
     "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/1592
+testcase!(
+    test_disjoint_bases_subclasses,
+    r#"
+from typing import assert_never
+class A(str):
+    pass
+class B(int):
+    pass
+def f(a: A):
+    if isinstance(a, B):
+        assert_never(a)
+"#,
+);
+
 testcase!(
     test_literals_are_disjoint,
     r#"


### PR DESCRIPTION
Summary:
The `disjoint_base()` function previously only checked if a class itself was
decorated with `disjoint_base`. It did not walk the MRO to find disjoint base
ancestors. This meant that subclasses of disjoint bases (e.g. `class A(str)`
and `class B(int)`) were not recognized as disjoint — their intersection
produced `A & B` instead of `Never`.

Fix: Walk the MRO in `disjoint_base()` to find the most specific ancestor
marked `disjoint_base`. Changed return type from `&Class` to owned `Class`
(cheap — wraps `Arc`) to avoid lifetime issues with the local MRO.

fixes https://github.com/facebook/pyrefly/issues/1592

Differential Revision: D95800401


