### PR TITLE
Fix NamedTuple subclass not assignable to TypeVar bound=NamedTuple (#2455)

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1411,6 +1411,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         .mk_type_form(self.heap.mk_type_form(self.heap.mk_any_implicit()));
                 } else if cls.has_toplevel_qname("typing", "Any") {
                     *ty = self.heap.mk_type_form(self.heap.mk_any_explicit())
+                } else if cls.has_toplevel_qname("typing", "NamedTuple") {
+                    // When `NamedTuple` is used as a type annotation (e.g. TypeVar bound),
+                    // resolve to `NamedTupleFallback` — the class that actually appears in
+                    // the MRO of user-defined NamedTuple subclasses.
+                    *ty = self.heap.mk_type_form(
+                        self.heap
+                            .mk_class_type(self.stdlib.named_tuple_fallback().clone()),
+                    );
                 } else {
                     // All other classes (including Tensor) get promoted and wrapped in type_form
                     *ty = self.heap.mk_type_form(self.promote(cls, range, errors));

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -622,3 +622,23 @@ Point = collections.namedtuple("Point", ["x", "y"])
 p = Point(x=1, y=2)
     "#,
 );
+
+// https://github.com/facebook/pyrefly/issues/2455
+testcase!(
+    test_named_tuple_typevar_bound,
+    r#"
+from typing import TypeVar, NamedTuple, assert_type
+
+MyCustomModelT = TypeVar(name="MyCustomModelT", bound=NamedTuple)
+
+class ImplementedModel(NamedTuple):
+    name: str
+    age: int
+
+def arbitrary_method(_name: str, _age: int, _model: type[MyCustomModelT]) -> MyCustomModelT:
+    return _model(name=_name, age=_age)  # E: Unexpected keyword argument `name` in function `tuple.__new__`  # E: Unexpected keyword argument `age` in function `tuple.__new__`
+
+o = arbitrary_method("a", 2, ImplementedModel)
+assert_type(o, ImplementedModel)
+"#,
+);


### PR DESCRIPTION
Summary:
When `NamedTuple` is used as a base class, pyrefly substitutes `NamedTupleFallback`
into the MRO. However, when `NamedTuple` is used as a type annotation (e.g. in a
TypeVar bound), it resolved to the `typing.NamedTuple` class — a completely different
class not in any NamedTuple subclass's MRO. This caused `bad-specialization` errors
when passing NamedTuple subclasses to TypeVar-bounded parameters.

Fix: In `canonicalize_all_class_types`, when `typing.NamedTuple` appears as a
ClassDef in a type annotation context, resolve it to `NamedTupleFallback` — the
class that actually appears in user-defined NamedTuple subclasses' MRO.

fixes https://github.com/facebook/pyrefly/issues/2455

Differential Revision: D95804828


