### PR TITLE
Fix optional narrowing in nested loops (#2522)

### DIFF
--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -3330,7 +3330,18 @@ impl<'a> BindingsBuilder<'a> {
     /// variables that are unconditionally reassigned in `for` loop headers
     pub fn setup_loop(&mut self, range: TextRange, loop_header_targets: &SmallSet<Name>) {
         let finally_depth = self.scopes.finally_depth();
-        let base = mem::take(&mut self.scopes.current_mut().flow);
+        let mut base = mem::take(&mut self.scopes.current_mut().flow);
+        // When entering a nested loop, update loop_prior to the current value idx.
+        // This ensures the inner loop's LoopPhi uses the type at the inner loop's
+        // entry point (after assignments between the outer loop head and this point),
+        // rather than the type before the outermost enclosing loop.
+        if self.scopes.loop_depth() > 0 {
+            for (_, info) in base.info.iter_mut() {
+                if let Some(value) = &info.value {
+                    info.loop_prior = value.idx;
+                }
+            }
+        }
         // To account for possible assignments to existing names in a loop, we
         // speculatively insert phi keys upfront.
         self.scopes.current_mut().flow =

--- a/pyrefly/lib/test/flow_looping.rs
+++ b/pyrefly/lib/test/flow_looping.rs
@@ -905,3 +905,17 @@ for part in ['a', 'b', 'c', 'd']:
         lineStart = lineno
 "#,
 );
+
+// Regression test for https://github.com/facebook/pyrefly/issues/2522
+testcase!(
+    test_optional_narrowing_in_nested_loop,
+    r#"
+def sum_matrix(matrix: list[list[int]]) -> int:
+    total: int | None = None
+    for row in matrix:
+        total = 0
+        for val in row:
+            total += val
+    return total or 0
+"#,
+);


### PR DESCRIPTION
Summary:
Previously, types assigned/narrowed in a loop were not reflected in nested loops.

Fixed by updating loop_prior to current value idx when entering a nested loop in setup_loop. Inner loops now see narrowed types from assignments between outer loop head and inner loop entry.

Note: this was claude's idea, it seems plausible to me but I don't know enough to say for sure.

fixes https://github.com/facebook/pyrefly/issues/2522

Differential Revision: D95807323


