### PR TITLE
Better exhaustiveness detection on non-final class unions

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -1648,12 +1648,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         self.is_dict_like(&base_ty)
     }
 
-    fn is_flag_enum(&self, cls: &ClassType) -> bool {
-        self.get_metadata_for_class(cls.class_object())
-            .enum_metadata()
-            .is_some_and(|meta| meta.is_flag)
-    }
-
     pub(crate) fn with_type_for_exhaustiveness_check(&self, info: Arc<TypeInfo>) -> TypeInfo {
         info.arc_clone().map_ty(|mut ty| {
             self.expand_vars_mut(&mut ty);
@@ -1665,24 +1659,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     }
 
     /// Determines if a type should be checked for match exhaustiveness.
-    /// We check exhaustiveness when the type has a finite, known set of possible values.
     pub(crate) fn should_check_exhaustiveness(&self, ty: &Type) -> bool {
         match ty {
             Type::ClassType(cls) => {
-                // Final classes can't have subclasses, so they are exhaustible, with the exception
-                // of Flag enums, whose members can be combined into new members via bitwise ops
-                !self.is_flag_enum(cls) && self.is_final(cls.class_object())
-                    // bool is effectively Literal[True] | Literal[False]
-                    || cls.is_builtin("bool")
+                let metadata = self.get_metadata_for_class(cls.class_object());
+                !metadata.is_protocol() && !metadata.is_typed_dict()
             }
-
-            // Literal types have explicit values
             Type::Literal(_) => true,
-
-            // None is a singleton
             Type::None => true,
-
-            // Unions are exhaustible if all members are exhaustible types
             Type::Union(union) => {
                 !union.members.is_empty()
                     && union
@@ -1690,7 +1674,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         .iter()
                         .all(|m| self.should_check_exhaustiveness(m))
             }
-
             _ => false,
         }
     }

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -1684,10 +1684,9 @@ def f(c: Color) -> str:
 );
 
 testcase!(
-    bug = "isinstance exhaustiveness not yet working for all union patterns",
     test_if_elif_isinstance_exhaustive,
     r#"
-def f(x: int | str) -> str:  # E: Function declared to return `str`, but one or more paths are missing an explicit `return`
+def f(x: int | str) -> str:
     if isinstance(x, int):
         return "int"
     elif isinstance(x, str):
@@ -1748,10 +1747,9 @@ def f(x: Literal["a", "b", "c"]) -> str:
 );
 
 testcase!(
-    bug = "mixed is/isinstance narrowing exhaustiveness not yet working",
     test_if_elif_mixed_narrowing,
     r#"
-def f(x: int | None) -> str:  # E: Function declared to return `str`, but one or more paths are missing an explicit `return`
+def f(x: int | None) -> str:
     if x is None:
         return "none"
     elif isinstance(x, int):

--- a/pyrefly/lib/test/pattern_match.rs
+++ b/pyrefly/lib/test/pattern_match.rs
@@ -774,3 +774,44 @@ def handle(o: object) -> int:
     return 1
 "#,
 );
+
+// https://github.com/facebook/pyrefly/issues/1896
+testcase!(
+    test_match_as_binding_with_early_return,
+    r#"
+from typing import assert_type
+
+class Error:
+    message: str
+class Success:
+    value: int
+class Pending:
+    pass
+
+def handle_error(e: Error) -> None: ...
+
+def process(result: Error | Success | Pending) -> None:
+    match result:
+        case Success():
+            return
+        case Pending():
+            return
+        case Error() as err:
+            assert_type(err, Error)
+            handle_error(err)
+
+def process2(result: Error | Success) -> str:
+    match result:
+        case Success():
+            return str(result.value)
+        case Error():
+            return result.message
+
+def process3(result: Error | Success) -> str:
+    match result:
+        case Success() as s:
+            return str(s.value)
+        case Error() as e:
+            return e.message
+"#,
+);


### PR DESCRIPTION
Summary: We initially restricted this to final classes only, but I think it should be safe to do for all nominal classes

Differential Revision: D95852489


