### PR TITLE
fix Missing-attribute FP on super() calls to abstract methods with bodies #2731

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -890,6 +890,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let metadata = call_target.function_metadata();
         if let Some(meta) = metadata
             && meta.flags.is_abstract_method
+            && meta.flags.lacks_implementation
+            && !meta.flags.defined_in_stub_file
             && self.should_error_for_abstract_call(&call_target)
         {
             let method_name = meta.kind.format(self.module().name());

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -3811,7 +3811,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         &self,
         member: &WithDefiningClass<Arc<ClassField>>,
     ) -> Option<NoAccessReason> {
-        if member.value.is_abstract() {
+        let lacks_runtime_impl = member
+            .value
+            .ty()
+            .visit_toplevel_func_metadata::<bool>(&|meta| {
+                meta.flags.lacks_implementation && !meta.flags.defined_in_stub_file
+            });
+        if member.value.is_abstract() && lacks_runtime_impl {
             return Some(NoAccessReason::SuperMethodNeedsImplementation(
                 member.defining_class.dupe(),
             ));

--- a/pyrefly/lib/test/abstract_methods.rs
+++ b/pyrefly/lib/test/abstract_methods.rs
@@ -346,6 +346,22 @@ c = Child()
 );
 
 testcase!(
+    test_super_abstract_call_with_body,
+    r#"
+from abc import ABC, abstractmethod
+
+class Base(ABC):
+    @abstractmethod
+    def method(self) -> int:
+        return 0
+
+class Child(Base):
+    def method(self) -> int:
+        return super().method() + 1
+"#,
+);
+
+testcase!(
     test_abstract_property,
     TestEnv::new().enable_implicit_abstract_class_error(),
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2731

Allowed super() access to abstract methods when they have a runtime implementation, and avoided abstract-call errors in those cases

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added a regression test for super() on an abstract method with a real body.