### PR TITLE
fix LSP shows NewType import as unused #2696

### DIFF
--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -1221,11 +1221,13 @@ impl<'a> BindingsBuilder<'a> {
         &mut self,
         name: &ExprName,
         parent: &NestingContext,
+        func: &mut Expr,
         new_type_name: &mut Expr,
         base: &mut Expr,
     ) {
         let class_name = Ast::expr_name_identifier(name.clone());
         let (mut class_object, class_indices) = self.class_object_and_indices(&class_name);
+        self.ensure_expr(func, class_object.usage());
         self.ensure_expr(new_type_name, class_object.usage());
         self.check_functional_definition_name(&name.id, new_type_name);
         self.ensure_type(base, &mut None);

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -640,6 +640,7 @@ impl<'a> BindingsBuilder<'a> {
                                     self.synthesize_typing_new_type(
                                         name,
                                         parent,
+                                        &mut call.func,
                                         new_type_name,
                                         base,
                                     );

--- a/pyrefly/lib/test/lsp/diagnostic.rs
+++ b/pyrefly/lib/test/lsp/diagnostic.rs
@@ -136,6 +136,19 @@ def process(items: List[str]):
 }
 
 #[test]
+fn test_new_type_import_used() {
+    let code = r#"
+from typing import NewType
+
+UserID = NewType("UserID", int)
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, true);
+    let handle = handles.get("main").unwrap();
+    let report = get_unused_import_diagnostics(&state, handle);
+    assert_eq!(report, "No unused imports");
+}
+
+#[test]
 fn test_star_import_not_reported_as_unused() {
     let code = r#"
 from typing import *


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2696

Marked the NewType call target as used during synthesis so from typing import NewType is no longer flagged as unused.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added an LSP unused-import regression test for NewType.