### PR TITLE
fix Bounded type var with covariant Iterator assignment #2742

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -810,8 +810,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 .solver()
                 .freshen_class_targs(cls.targs_mut(), self.uniques);
 
-            let matched_hint = self.is_subset_eq(&self.heap.mk_class_type(cls.clone()), hint);
-            self.solver().generalize_class_targs(cls.targs_mut());
+            let matched_hint = if hint.any(|ty| match ty {
+                Type::ClassType(cls) | Type::SelfType(cls) => self
+                    .get_metadata_for_class(cls.class_object())
+                    .is_protocol(),
+                _ => false,
+            }) {
+                false
+            } else {
+                let matched_hint = self.is_subset_eq(&self.heap.mk_class_type(cls.clone()), hint);
+                self.solver().generalize_class_targs(cls.targs_mut());
+                matched_hint
+            };
             (vs, matched_hint)
         } else {
             (QuantifiedHandle::empty(), false)
@@ -999,6 +1009,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 &errors,
             );
         }
+        self.solver().generalize_class_targs(cls.targs_mut());
         self.solver()
             .finish_class_targs(cls.targs_mut(), self.uniques);
         let specialization_errors = self

--- a/pyrefly/lib/test/generic_restrictions.rs
+++ b/pyrefly/lib/test/generic_restrictions.rs
@@ -235,6 +235,25 @@ def func2(a: T2) -> T2:
 );
 
 testcase!(
+    test_bounded_typevar_covariant_iterator_assignment,
+    r#"
+from typing import Iterator
+
+class NumberStream[_R: int]:
+    def __init__(self, start: _R) -> None:
+        self._val = start
+
+    def __iter__(self) -> Iterator[_R]:
+        return iter([self._val])
+
+    def __next__(self) -> _R:
+        return self._val
+
+stream: Iterator[int | None] = NumberStream(start=0)
+ "#,
+);
+
+testcase!(
     test_bounded_typevar_attribute_access,
     r#"
 from typing import TypeVar, assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2742

The change defers applying the outer constructor hint until after `__new__` and `__init__` have inferred the class type arguments, then generalizes/finalizes them.

That stops a covariant protocol hint like `Iterator[int | None]` from widening `_R` before `NumberStream(start=0)` has already pinned `_R` to int.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test from issue.