### PR TITLE
fix dict ** unpacking does not respect descriptor #2751

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -24,8 +24,10 @@ use pyrefly_types::types::TArgs;
 use pyrefly_types::types::Union;
 use pyrefly_types::types::Var;
 use pyrefly_util::suggest::best_suggestion;
+use ruff_python_ast::Expr;
 use ruff_python_ast::helpers::is_dunder;
 use ruff_python_ast::name::Name;
+use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use starlark_map::small_set::SmallSet;
 use vec1::Vec1;
@@ -35,6 +37,7 @@ use crate::alt::answers::LookupAnswer;
 use crate::alt::answers_solver::AnswersSolver;
 use crate::alt::callable::CallArg;
 use crate::alt::class::class_field::ClassAttribute;
+use crate::alt::class::class_field::DescriptorBase;
 use crate::alt::expr::TypeOrExpr;
 use crate::binding::binding::ExprOrBinding;
 use crate::binding::binding::KeyExport;
@@ -572,6 +575,65 @@ impl ClassBase {
 }
 
 impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
+    fn descriptor_base_for_unpacking(attr_base: AttributeBase1) -> Option<DescriptorBase> {
+        match attr_base {
+            AttributeBase1::ClassInstance(cls)
+            | AttributeBase1::Quantified(_, cls)
+            | AttributeBase1::SelfType(cls)
+            | AttributeBase1::SuperInstance(cls, _) => Some(DescriptorBase::Instance(cls)),
+            AttributeBase1::ClassObject(cls) => Some(DescriptorBase::ClassDef(cls)),
+            AttributeBase1::TensorInstance(tensor) => {
+                Some(DescriptorBase::Instance(tensor.base_class))
+            }
+            _ => None,
+        }
+    }
+
+    /// Infer the type to use for `**expr` mapping checks.
+    ///
+    /// Normal attribute reads intentionally do not treat annotation-only fields with descriptor
+    /// types as descriptors. For unpacking, that leads to false positives for ORM-style fields
+    /// whose runtime value is produced by `__get__`. When the unpacked expression is an
+    /// attribute access and its raw field type defines `__get__`, use the descriptor getter
+    /// result if it behaves like a mapping.
+    pub fn infer_unpack_mapping_expr(&self, x: &Expr, errors: &ErrorCollector) -> Type {
+        let ty = self.expr_infer(x, errors);
+        if matches!(ty, Type::TypedDict(_)) || self.unwrap_mapping(&ty).is_some() {
+            return ty;
+        }
+        let Expr::Attribute(attr) = x else {
+            return ty;
+        };
+        let base_ty = self.expr_infer(&attr.value, errors);
+        let mut descriptor_tys = Vec::new();
+        for (found, on) in self.lookup_attr(&base_ty, &attr.attr.id).found {
+            let Some(base) = Self::descriptor_base_for_unpacking(on) else {
+                continue;
+            };
+            let raw_ty = match found {
+                Attribute::ClassAttribute(ClassAttribute::ReadWrite(raw_ty))
+                | Attribute::ClassAttribute(ClassAttribute::ReadOnly(raw_ty, _)) => raw_ty,
+                _ => continue,
+            };
+            if let Some(descriptor_ty) = self.resolve_descriptor_get_from_raw_type(
+                &attr.attr.id,
+                &raw_ty,
+                base,
+                x.range(),
+                errors,
+            ) && (matches!(descriptor_ty, Type::TypedDict(_))
+                || self.unwrap_mapping(&descriptor_ty).is_some())
+            {
+                descriptor_tys.push(descriptor_ty);
+            }
+        }
+        if descriptor_tys.is_empty() {
+            ty
+        } else {
+            self.unions(descriptor_tys)
+        }
+    }
+
     /// Compute the get (i.e. read) type of an attribute. If the attribute cannot be found or read,
     /// error and return `Any`. Use this to infer the type of a direct attribute fetch.
     pub fn type_of_attr_get(

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -983,7 +983,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         for kw in keywords {
             match kw.arg {
                 None => {
-                    let ty = kw.value.infer(self, arg_errors);
+                    let ty = match kw.value {
+                        TypeOrExpr::Expr(expr) => self.infer_unpack_mapping_expr(expr, arg_errors),
+                        TypeOrExpr::Type(ty, _) => ty.clone(),
+                    };
                     if let Type::TypedDict(typed_dict) = ty {
                         for (name, field) in self.typed_dict_fields(&typed_dict).into_iter() {
                             let name = name_owner.push(name);

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -4729,6 +4729,44 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
+    pub(crate) fn resolve_descriptor_get_from_raw_type(
+        &self,
+        attr_name: &Name,
+        ty: &Type,
+        base: DescriptorBase,
+        range: TextRange,
+        errors: &ErrorCollector,
+    ) -> Option<Type> {
+        let Type::ClassType(cls) = ty else {
+            return None;
+        };
+        let getter = self
+            .get_class_member(cls.class_object(), &dunder::GET)
+            .is_some();
+        if !getter {
+            return None;
+        }
+        let setter = self
+            .get_class_member(cls.class_object(), &dunder::SET)
+            .is_some();
+        self.resolve_get_class_attr(
+            attr_name,
+            ClassAttribute::descriptor(
+                Descriptor {
+                    range,
+                    cls: cls.clone(),
+                    getter,
+                    setter,
+                },
+                base,
+            ),
+            range,
+            errors,
+            None,
+        )
+        .ok()
+    }
+
     fn resolve_descriptor_getter(
         &self,
         attr_name: &Name,

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1050,7 +1050,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                 }
                 None => {
-                    let ty = self.expr_infer(&x.value, errors);
+                    let ty = self.infer_unpack_mapping_expr(&x.value, errors);
                     // If the unpacked value is an anonymous typed dict, merge its fields.
                     // Later fields override earlier ones with the same name.
                     if can_create_anonymous_typed_dict

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -714,6 +714,25 @@ def test(kwargs: Mapping[str, int]):
 );
 
 testcase!(
+    test_splat_kwargs_descriptor_attribute,
+    r#"
+from typing import Any
+
+class Column[T]:
+    def __get__(self, obj: Any, objtype: Any = None) -> T: ...
+    def __set__(self, obj: Any, value: T) -> None: ...
+
+class CallbackModel:
+    data: Column[dict[str, int]]
+
+def f(**kwargs: int): ...
+
+def test(model: CallbackModel) -> None:
+    f(**model.data)
+"#,
+);
+
+testcase!(
     test_splat_kwargs_subclass,
     r#"
 class Counter[T](dict[T, int]): ...

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -730,6 +730,23 @@ def test(m: Mapping[str, int]) -> None:
 );
 
 testcase!(
+    test_dict_unpack_descriptor_attribute,
+    r#"
+from typing import Any
+
+class Column[T]:
+    def __get__(self, obj: Any, objtype: Any = None) -> T: ...
+    def __set__(self, obj: Any, value: T) -> None: ...
+
+class CallbackModel:
+    data: Column[dict[str, Any]]
+
+def test(model: CallbackModel) -> None:
+    tags: dict[str, Any] = {"result": "success", **model.data}
+"#,
+);
+
+testcase!(
     test_dict_unpack_subclass,
     r#"
 from typing import assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2751

`**expr` mapping checks now look through a descriptor getter when expr is an attribute access whose raw field type
  defines `__get__`, but only for unpacking contexts.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test