### PR TITLE
fix Support star-unpacking in except clause #2749

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -3468,7 +3468,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Expr::Tuple(tup) => tup
                 .elts
                 .iter()
-                .map(|e| check_exception_type(self.expr_infer(e, errors), e.range()))
+                .flat_map(|e| match e {
+                    Expr::Starred(starred) => self.decompose_except_types(
+                        self.expr_infer(&starred.value, errors),
+                        e.range(),
+                        &check_exception_type,
+                    ),
+                    _ => vec![check_exception_type(self.expr_infer(e, errors), e.range())],
+                })
                 .collect(),
             _ => {
                 let exception_types = self.expr_infer(ann, errors);

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -349,6 +349,21 @@ def handle(
 );
 
 testcase!(
+    test_exception_handler_star_unpacking,
+    r#"
+import sys
+from typing import assert_type
+
+EXTRA_ERRORS: tuple[type[Exception], ...] = (RuntimeError,) if sys.version_info < (3, 13) else ()
+
+try:
+    pass
+except (ValueError, *EXTRA_ERRORS) as e:
+    assert_type(e, ValueError | Exception)
+"#,
+);
+
+testcase!(
     test_exception_group_handler,
     r#"
 from typing import reveal_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2749

teaching exception-handler tuple processing to flatten starred entries instead of validating the *expr node as an exception class.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test