### PR TITLE
fix Unary operator for int not applicable for Literal of bool #2750

### DIFF
--- a/crates/pyrefly_types/src/literal.rs
+++ b/crates/pyrefly_types/src/literal.rs
@@ -102,6 +102,8 @@ impl Lit {
     pub fn negate(&self) -> Option<Type> {
         match self {
             Lit::Int(x) => Some(Lit::Int(x.negate()).to_implicit_type()),
+            Lit::Bool(true) => Some(LitInt::new(-1).to_implicit_type()),
+            Lit::Bool(false) => Some(LitInt::new(0).to_implicit_type()),
             _ => None,
         }
     }
@@ -123,6 +125,8 @@ impl Lit {
                 let x = x.invert();
                 Some(Lit::Int(x).to_implicit_type())
             }
+            Lit::Bool(true) => Some(LitInt::new(-2).to_implicit_type()),
+            Lit::Bool(false) => Some(LitInt::new(-1).to_implicit_type()),
             _ => None,
         }
     }

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -287,6 +287,25 @@ assert_type(y6, Literal[True])
 );
 
 testcase!(
+    test_unary_bool_literals,
+    r#"
+from typing import Literal, assert_type
+
+def invert_literal_false(x: Literal[False]) -> None:
+    assert_type(~x, Literal[-1])
+
+def invert_literal_true(x: Literal[True]) -> None:
+    assert_type(~x, Literal[-2])
+
+def negate_literal_false(x: Literal[False]) -> None:
+    assert_type(-x, Literal[0])
+
+def negate_literal_true(x: Literal[True]) -> None:
+    assert_type(-x, Literal[-1])
+    "#,
+);
+
+testcase!(
     test_unary_dunders,
     r#"
 from typing import Literal, assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2750 

`Lit::negate` and `Lit::invert` now map bool literals to the correct integer literals

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test