### PR TITLE
fix Double-counting cls with __class_getitem__ and @classmethod #2740

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -500,7 +500,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
-    fn make_call_target_and_call(
+    pub(crate) fn make_call_target_and_call(
         &self,
         callee_ty: Type,
         method_name: &Name,

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -2044,10 +2044,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         // TODO(stroxler): Add a new API, similar to `type_of_attr_get` but returning a
                         // LookupResult or an Optional type, that we could use here to avoid the double lookup.
                         if self.has_attr(&class_ty, &dunder::CLASS_GETITEM) {
-                            let cls_value = self.promote_silently(&cls);
-                            let call_args = [CallArg::ty(&cls_value, range), CallArg::expr(slice)];
-                            Some(self.call_method_or_error(
+                            let callee_ty = self.type_of_attr_get(
                                 &class_ty,
+                                &dunder::CLASS_GETITEM,
+                                range,
+                                errors,
+                                Some(&|| ErrorContext::Index(self.for_display(class_ty.clone()))),
+                                "Expr::call_method",
+                            );
+                            self.record_resolved_trace(range, callee_ty.clone());
+                            let cls_value = self.promote_silently(&cls);
+                            let call_args = match callee_ty {
+                                Type::BoundMethod(_) => vec![CallArg::expr(slice)],
+                                _ => vec![CallArg::ty(&cls_value, range), CallArg::expr(slice)],
+                            };
+                            Some(self.make_call_target_and_call(
+                                callee_ty,
                                 &dunder::CLASS_GETITEM,
                                 range,
                                 &call_args,

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -2004,6 +2004,24 @@ assert_type(Foo[0], str)
 );
 
 testcase!(
+    test_class_getitem_classmethod_does_not_double_bind_cls,
+    r#"
+from types import GenericAlias
+from typing import assert_type
+
+class SparseBase:
+    @classmethod
+    def __class_getitem__(cls, arg: object, /) -> GenericAlias:
+        return GenericAlias(cls, arg)
+
+class SparseMatrix(SparseBase):
+    pass
+
+assert_type(SparseMatrix[int], GenericAlias)
+"#,
+);
+
+testcase!(
     test_class_metaclass_getitem,
     r#"
 from typing import assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2740

Adjusted the `__class_getitem__` class-subscript path so it only injects an explicit cls when the looked-up callee is still unbound.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
add test