### PR TITLE
fix Namedtuple with *-unpacked fields #2734

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -768,12 +768,19 @@ impl<'a> BindingsBuilder<'a> {
         self.table.get::<K>().0.idx_to_key(idx)
     }
 
-    fn idx_to_binding<K>(&self, idx: Idx<K>) -> Option<&K::Value>
+    pub(crate) fn idx_to_binding<K>(&self, idx: Idx<K>) -> Option<&K::Value>
     where
         K: Keyed,
         BindingTable: TableKeyed<K, Value = BindingEntry<K>>,
     {
         self.table.get::<K>().1.get(idx)
+    }
+
+    pub(crate) fn key_to_idx_opt<K: Keyed>(&self, key: &K) -> Option<Idx<K>>
+    where
+        BindingTable: TableKeyed<K, Value = BindingEntry<K>>,
+    {
+        self.table.get::<K>().0.key_to_idx(key)
     }
 
     fn idx_to_binding_mut<K>(&mut self, idx: Idx<K>) -> Option<&mut K::Value>

--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -615,6 +615,23 @@ impl<'a> BindingsBuilder<'a> {
             {
                 Vec::new()
             }
+            // namedtuple('Point', [*BasePoint._fields, 'z'])
+            [Expr::List(ExprList { elts, .. }) | Expr::Tuple(ExprTuple { elts, .. })]
+                if elts.iter().any(|elt| matches!(elt, Expr::Starred(_))) =>
+            {
+                match self.extract_namedtuple_fields_with_unpacking(elts) {
+                    Some(fields) => fields,
+                    None => {
+                        self.error(
+                            error_range,
+                            ErrorInfo::Kind(ErrorKind::BadClassDefinition),
+                            "Expected valid functional named tuple definition".to_owned(),
+                        );
+                        has_dynamic_fields = true;
+                        Vec::new()
+                    }
+                }
+            }
             // namedtuple('Point', ['x', 'y'])
             [Expr::List(ExprList { elts, .. })]
                 if matches!(elts.as_slice(), [Expr::StringLiteral(_), ..]) =>
@@ -638,6 +655,76 @@ impl<'a> BindingsBuilder<'a> {
             }
         };
         (fields, has_dynamic_fields)
+    }
+
+    fn extract_namedtuple_fields_with_unpacking(
+        &self,
+        items: &[Expr],
+    ) -> Option<Vec<(String, TextRange, Option<Expr>)>> {
+        let mut fields = Vec::new();
+        for item in items {
+            match item {
+                Expr::StringLiteral(x) => fields.push((x.value.to_string(), x.range(), None)),
+                Expr::Starred(starred) => fields
+                    .extend(self.resolve_namedtuple_field_unpacking(&starred.value, item.range())?),
+                _ => return None,
+            }
+        }
+        Some(fields)
+    }
+
+    fn resolve_namedtuple_field_unpacking(
+        &self,
+        expr: &Expr,
+        range: TextRange,
+    ) -> Option<Vec<(String, TextRange, Option<Expr>)>> {
+        let Expr::Attribute(attr) = expr else {
+            return None;
+        };
+        if attr.attr.as_str() != "_fields" {
+            return None;
+        }
+        let Expr::Name(base_name) = attr.value.as_ref() else {
+            return None;
+        };
+        let (mut binding_idx, _) = self.scopes.binding_idx_for_name(&base_name.id)?;
+        for _ in 0..16 {
+            match self.idx_to_binding(binding_idx)? {
+                Binding::Forward(inner) | Binding::ForwardToFirstUse(inner) => binding_idx = *inner,
+                Binding::ClassDef(class_idx, _) => {
+                    return self.namedtuple_fields_for_class(*class_idx, range);
+                }
+                _ => return None,
+            }
+        }
+        None
+    }
+
+    fn namedtuple_fields_for_class(
+        &self,
+        class_idx: Idx<KeyClass>,
+        range: TextRange,
+    ) -> Option<Vec<(String, TextRange, Option<Expr>)>> {
+        let BindingClass::FunctionalClassDef(def_index, _, _, fields) =
+            self.idx_to_binding(class_idx)?
+        else {
+            return None;
+        };
+        let metadata_idx = self.key_to_idx_opt(&KeyClassMetadata(*def_index))?;
+        let metadata = self.idx_to_binding(metadata_idx)?;
+        if !metadata
+            .bases
+            .iter()
+            .any(|base| matches!(base, BaseClass::NamedTuple(_, _)))
+        {
+            return None;
+        }
+        Some(
+            fields
+                .keys()
+                .map(|name| (name.as_str().to_owned(), range, None))
+                .collect(),
+        )
     }
 
     /// Parse fields for `typing.NamedTuple`: list/tuple of (name, type) pairs.

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -80,6 +80,22 @@ Point3(1)  # E: Missing argument `y` in function `Point3.__new__`
     "#,
 );
 
+// Regression test for https://github.com/facebook/pyrefly/issues/2734
+testcase!(
+    test_named_tuple_spread_fields_from_namedtuple,
+    r#"
+import collections
+
+BaseFieldInfo = collections.namedtuple("BaseFieldInfo", ["name", "type_code", "size"])
+ExtendedFieldInfo = collections.namedtuple(
+    "ExtendedFieldInfo",
+    [*BaseFieldInfo._fields, "extra", "comment"],
+)
+
+info = ExtendedFieldInfo("col1", 1, 100, "extra_val", "a comment")
+    "#,
+);
+
 testcase!(
     test_named_tuple_functional_rename,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2734

teaching the binding-phase collections.namedtuple parser to flatten a narrow starred form: `*SomeNamedTuple._fields` inside list/tuple field specs.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test