### PR TITLE
Mark __all__ as unresolvable when augmented assignment or .extend() RHS can't be statically analyzed

### DIFF
--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -659,11 +659,18 @@ impl DefinitionsBuilder {
             Stmt::AugAssign(x) => {
                 self.named_in_expr(&x.value);
                 if DunderAllEntry::is_all(&x.target) && x.op == Operator::Add {
-                    self.inner.dunder_all.kind = DunderAllKind::Specified;
-                    self.inner
-                        .dunder_all
-                        .entries
-                        .extend(DunderAllEntry::as_list(&x.value).unwrap_or_default());
+                    match DunderAllEntry::as_list(&x.value) {
+                        Some(entries) => {
+                            self.inner.dunder_all.kind = DunderAllKind::Specified;
+                            self.inner.dunder_all.entries.extend(entries);
+                        }
+                        None => {
+                            self.inner.dunder_all = DunderAll {
+                                kind: DunderAllKind::Unresolvable(x.value.range()),
+                                entries: Vec::new(),
+                            };
+                        }
+                    }
                 }
                 if let Expr::Name(name) = &*x.target {
                     self.add_name(
@@ -696,14 +703,24 @@ impl DefinitionsBuilder {
                 {
                     self.inner.dunder_all.kind = DunderAllKind::Specified;
                     match attr.as_str() {
-                        "extend" => self.inner.dunder_all.entries.extend(
-                            DunderAllEntry::as_list(&arguments.args[0]).unwrap_or_default(),
-                        ),
-                        "append" => self
-                            .inner
-                            .dunder_all
-                            .entries
-                            .extend(DunderAllEntry::as_item(&arguments.args[0])),
+                        "extend" => match DunderAllEntry::as_list(&arguments.args[0]) {
+                            Some(entries) => self.inner.dunder_all.entries.extend(entries),
+                            None => {
+                                self.inner.dunder_all = DunderAll {
+                                    kind: DunderAllKind::Unresolvable(arguments.args[0].range()),
+                                    entries: Vec::new(),
+                                };
+                            }
+                        },
+                        "append" => match DunderAllEntry::as_item(&arguments.args[0]) {
+                            Some(entry) => self.inner.dunder_all.entries.push(entry),
+                            None => {
+                                self.inner.dunder_all = DunderAll {
+                                    kind: DunderAllKind::Unresolvable(arguments.args[0].range()),
+                                    entries: Vec::new(),
+                                };
+                            }
+                        },
                         "remove" => {
                             if let Some(DunderAllEntry::Name(range, remove)) =
                                 DunderAllEntry::as_item(&arguments.args[0])

--- a/pyrefly/lib/test/imports.rs
+++ b/pyrefly/lib/test/imports.rs
@@ -1273,6 +1273,76 @@ assert_type(y, str)
 "#,
 );
 
+fn env_all_augassign_unresolvable() -> TestEnv {
+    let mut t = TestEnv::new();
+    t.add_with_path(
+        "pkg",
+        "pkg/__init__.py",
+        r#"
+from .sub import *
+"#,
+    );
+    t.add_with_path(
+        "pkg.sub",
+        "pkg/sub/__init__.py",
+        r#"
+from ._impl import *
+
+_extra_names = ["x"]
+__all__ = ["Base"]
+__all__ += _extra_names  # E: `__all__` could not be statically analyzed
+"#,
+    );
+    t.add_with_path(
+        "pkg.sub._impl",
+        "pkg/sub/_impl.py",
+        r#"
+class Base: ...
+x: int = 1
+y: str = "hello"
+"#,
+    );
+    t
+}
+
+testcase!(
+    test_all_augassign_unresolvable,
+    env_all_augassign_unresolvable(),
+    r#"
+from typing import assert_type
+import pkg
+# Since __all__ += variable is unresolvable, falls back to all public names,
+# which includes names from `from ._impl import *`.
+assert_type(pkg.x, int)
+assert_type(pkg.y, str)
+"#,
+);
+
+fn env_all_append_unresolvable() -> TestEnv {
+    TestEnv::one(
+        "foo",
+        r#"
+x: int = 1
+y: str = "hello"
+_name = "x"
+__all__ = ["y"]
+__all__.append(_name)  # E: `__all__` could not be statically analyzed
+"#,
+    )
+}
+
+testcase!(
+    test_all_append_unresolvable,
+    env_all_append_unresolvable(),
+    r#"
+from typing import assert_type
+from foo import *
+# Since __all__.append(variable) is unresolvable, falls back to all public names.
+assert_type(x, int)
+assert_type(y, str)
+"#,
+);
+
 fn env_relative_import_in_subdirectory() -> TestEnv {
     let mut t = TestEnv::new();
     t.add_with_path("test.foo", "test/foo.py", "from .foo2 import bar");


### PR DESCRIPTION
Summary:
Pyrefly statically analyzes `__all__` to determine which names a module exports via `from mod import *`. When it encounters patterns like:

```python
__all__ = ["Base"]
__all__ += _impl._distn_names  # computed at runtime
```

it was silently ignoring the unresolvable `+=` while still treating `__all__` as fully resolved. This meant only `["Base"]` was exported, even though `_distn_names` contained additional names at runtime.

With this diff, when the RHS of `__all__ +=` or `__all__.extend()`/`__all__.append()` can't be statically analyzed, the entire `__all__` is marked as unresolvable, falling back to exporting all public module-level names. This matches the existing behavior for `__all__ = generate_all()`.

Differential Revision: D95857423


