### PR TITLE
Resolve bare module names in __all__ = foo.__all__ to fully qualified names

### DIFF
--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -485,6 +485,38 @@ impl DefinitionsBuilder {
         });
     }
 
+    /// Resolve bare module names in `DunderAllEntry::Module` entries to their
+    /// fully qualified names using import definitions in scope.
+    ///
+    /// When `as_list` sees `foo.__all__`, it creates `ModuleName::from_name("foo")`
+    /// which is a bare unqualified name. If `foo` was imported via a relative import
+    /// (e.g. `from . import foo`), the actual module is fully qualified (e.g. `pkg.foo`).
+    /// This method resolves such bare names using the definitions already collected.
+    fn resolve_module_entries(&self, entries: &mut [DunderAllEntry]) {
+        for entry in entries.iter_mut() {
+            if let DunderAllEntry::Module(_, module_name) = entry {
+                let key = Name::new(module_name.as_str());
+                if let Some(def) = self.inner.definitions.get(&key) {
+                    match &def.style {
+                        DefinitionStyle::Import(base) | DefinitionStyle::ImportAsEq(base) => {
+                            *module_name = base.append(&key);
+                        }
+                        DefinitionStyle::ImportAs(base, original) => {
+                            if ModuleName::from_name(original) == *base {
+                                // `import X as Y` — base is already the full module path
+                                *module_name = *base;
+                            } else {
+                                // `from X import Y as Z` — base is the source module
+                                *module_name = base.append(original);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
     fn stmt(&mut self, x: &Stmt) {
         match x {
             Stmt::Import(x) => {
@@ -600,7 +632,8 @@ impl DefinitionsBuilder {
                     self.expr_lvalue(t);
                     if DunderAllEntry::is_all(t) {
                         match DunderAllEntry::as_list(&x.value) {
-                            Some(entries) => {
+                            Some(mut entries) => {
+                                self.resolve_module_entries(&mut entries);
                                 self.inner.dunder_all = DunderAll {
                                     kind: DunderAllKind::Specified,
                                     entries,
@@ -624,7 +657,8 @@ impl DefinitionsBuilder {
                     && DunderAllEntry::is_all(&x.target)
                 {
                     match DunderAllEntry::as_list(v.as_ref()) {
-                        Some(entries) => {
+                        Some(mut entries) => {
+                            self.resolve_module_entries(&mut entries);
                             self.inner.dunder_all = DunderAll {
                                 kind: DunderAllKind::Specified,
                                 entries,
@@ -660,7 +694,8 @@ impl DefinitionsBuilder {
                 self.named_in_expr(&x.value);
                 if DunderAllEntry::is_all(&x.target) && x.op == Operator::Add {
                     match DunderAllEntry::as_list(&x.value) {
-                        Some(entries) => {
+                        Some(mut entries) => {
+                            self.resolve_module_entries(&mut entries);
                             self.inner.dunder_all.kind = DunderAllKind::Specified;
                             self.inner.dunder_all.entries.extend(entries);
                         }
@@ -704,7 +739,10 @@ impl DefinitionsBuilder {
                     self.inner.dunder_all.kind = DunderAllKind::Specified;
                     match attr.as_str() {
                         "extend" => match DunderAllEntry::as_list(&arguments.args[0]) {
-                            Some(entries) => self.inner.dunder_all.entries.extend(entries),
+                            Some(mut entries) => {
+                                self.resolve_module_entries(&mut entries);
+                                self.inner.dunder_all.entries.extend(entries);
+                            }
                             None => {
                                 self.inner.dunder_all = DunderAll {
                                     kind: DunderAllKind::Unresolvable(arguments.args[0].range()),

--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -659,11 +659,18 @@ impl DefinitionsBuilder {
             Stmt::AugAssign(x) => {
                 self.named_in_expr(&x.value);
                 if DunderAllEntry::is_all(&x.target) && x.op == Operator::Add {
-                    self.inner.dunder_all.kind = DunderAllKind::Specified;
-                    self.inner
-                        .dunder_all
-                        .entries
-                        .extend(DunderAllEntry::as_list(&x.value).unwrap_or_default());
+                    match DunderAllEntry::as_list(&x.value) {
+                        Some(entries) => {
+                            self.inner.dunder_all.kind = DunderAllKind::Specified;
+                            self.inner.dunder_all.entries.extend(entries);
+                        }
+                        None => {
+                            self.inner.dunder_all = DunderAll {
+                                kind: DunderAllKind::Unresolvable(x.value.range()),
+                                entries: Vec::new(),
+                            };
+                        }
+                    }
                 }
                 if let Expr::Name(name) = &*x.target {
                     self.add_name(
@@ -696,14 +703,24 @@ impl DefinitionsBuilder {
                 {
                     self.inner.dunder_all.kind = DunderAllKind::Specified;
                     match attr.as_str() {
-                        "extend" => self.inner.dunder_all.entries.extend(
-                            DunderAllEntry::as_list(&arguments.args[0]).unwrap_or_default(),
-                        ),
-                        "append" => self
-                            .inner
-                            .dunder_all
-                            .entries
-                            .extend(DunderAllEntry::as_item(&arguments.args[0])),
+                        "extend" => match DunderAllEntry::as_list(&arguments.args[0]) {
+                            Some(entries) => self.inner.dunder_all.entries.extend(entries),
+                            None => {
+                                self.inner.dunder_all = DunderAll {
+                                    kind: DunderAllKind::Unresolvable(arguments.args[0].range()),
+                                    entries: Vec::new(),
+                                };
+                            }
+                        },
+                        "append" => match DunderAllEntry::as_item(&arguments.args[0]) {
+                            Some(entry) => self.inner.dunder_all.entries.push(entry),
+                            None => {
+                                self.inner.dunder_all = DunderAll {
+                                    kind: DunderAllKind::Unresolvable(arguments.args[0].range()),
+                                    entries: Vec::new(),
+                                };
+                            }
+                        },
                         "remove" => {
                             if let Some(DunderAllEntry::Name(range, remove)) =
                                 DunderAllEntry::as_item(&arguments.args[0])

--- a/pyrefly/lib/test/imports.rs
+++ b/pyrefly/lib/test/imports.rs
@@ -1343,6 +1343,48 @@ assert_type(y, str)
 "#,
 );
 
+fn env_all_relative_module_ref() -> TestEnv {
+    let mut t = TestEnv::new();
+    t.add_with_path(
+        "pkg",
+        "pkg/__init__.py",
+        r#"
+from .sub import *
+"#,
+    );
+    t.add_with_path(
+        "pkg.sub",
+        "pkg/sub/__init__.py",
+        r#"
+from . import _api
+from ._api import *
+__all__ = _api.__all__
+"#,
+    );
+    t.add_with_path(
+        "pkg.sub._api",
+        "pkg/sub/_api.py",
+        r#"
+__all__ = ["convolve", "medfilt"]
+def convolve(x: list[float]) -> list[float]: return x
+def medfilt(x: list[float]) -> list[float]: return x
+"#,
+    );
+    t
+}
+
+testcase!(
+    test_all_relative_module_ref,
+    env_all_relative_module_ref(),
+    r#"
+from typing import assert_type
+import pkg
+# __all__ = _api.__all__ should resolve _api to pkg.sub._api
+assert_type(pkg.convolve([1.0]), list[float])
+assert_type(pkg.medfilt([1.0]), list[float])
+"#,
+);
+
 fn env_relative_import_in_subdirectory() -> TestEnv {
     let mut t = TestEnv::new();
     t.add_with_path("test.foo", "test/foo.py", "from .foo2 import bar");

--- a/pyrefly/lib/test/imports.rs
+++ b/pyrefly/lib/test/imports.rs
@@ -1273,6 +1273,76 @@ assert_type(y, str)
 "#,
 );
 
+fn env_all_augassign_unresolvable() -> TestEnv {
+    let mut t = TestEnv::new();
+    t.add_with_path(
+        "pkg",
+        "pkg/__init__.py",
+        r#"
+from .sub import *
+"#,
+    );
+    t.add_with_path(
+        "pkg.sub",
+        "pkg/sub/__init__.py",
+        r#"
+from ._impl import *
+
+_extra_names = ["x"]
+__all__ = ["Base"]
+__all__ += _extra_names  # E: `__all__` could not be statically analyzed
+"#,
+    );
+    t.add_with_path(
+        "pkg.sub._impl",
+        "pkg/sub/_impl.py",
+        r#"
+class Base: ...
+x: int = 1
+y: str = "hello"
+"#,
+    );
+    t
+}
+
+testcase!(
+    test_all_augassign_unresolvable,
+    env_all_augassign_unresolvable(),
+    r#"
+from typing import assert_type
+import pkg
+# Since __all__ += variable is unresolvable, falls back to all public names,
+# which includes names from `from ._impl import *`.
+assert_type(pkg.x, int)
+assert_type(pkg.y, str)
+"#,
+);
+
+fn env_all_append_unresolvable() -> TestEnv {
+    TestEnv::one(
+        "foo",
+        r#"
+x: int = 1
+y: str = "hello"
+_name = "x"
+__all__ = ["y"]
+__all__.append(_name)  # E: `__all__` could not be statically analyzed
+"#,
+    )
+}
+
+testcase!(
+    test_all_append_unresolvable,
+    env_all_append_unresolvable(),
+    r#"
+from typing import assert_type
+from foo import *
+# Since __all__.append(variable) is unresolvable, falls back to all public names.
+assert_type(x, int)
+assert_type(y, str)
+"#,
+);
+
 fn env_relative_import_in_subdirectory() -> TestEnv {
     let mut t = TestEnv::new();
     t.add_with_path("test.foo", "test/foo.py", "from .foo2 import bar");


### PR DESCRIPTION
Summary:
When a module re-exports another module's `__all__` via a relative import:

```python
from . import _api
__all__ = _api.__all__
```

Pyrefly was creating an unqualified module reference `_api` instead of the fully qualified `pkg.sub._api`. The wildcard lookup then searched for a non-existent top-level module `_api` and found nothing, causing all re-exported names to be missing.

Now, after parsing `foo.__all__` references, Pyrefly resolves the bare name `foo` through the import definitions already in scope to recover the fully qualified module name. This handles `from . import foo`, `import X as foo`, and `from X import foo as foo` patterns.

This fixes false positive `missing-attribute` errors on packages that use `__all__ = submod.__all__` with relative imports (e.g. `scipy.signal`, `scipy.ndimage`).

Differential Revision: D95857420


