### PR TITLE
Fix double-counting cls with __class_getitem__ and @classmethod (#2765)

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -2044,13 +2044,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         // TODO(stroxler): Add a new API, similar to `type_of_attr_get` but returning a
                         // LookupResult or an Optional type, that we could use here to avoid the double lookup.
                         if self.has_attr(&class_ty, &dunder::CLASS_GETITEM) {
-                            let cls_value = self.promote_silently(&cls);
-                            let call_args = [CallArg::ty(&cls_value, range), CallArg::expr(slice)];
                             Some(self.call_method_or_error(
                                 &class_ty,
                                 &dunder::CLASS_GETITEM,
                                 range,
-                                &call_args,
+                                &[CallArg::expr(slice)],
                                 &[],
                                 errors,
                                 Some(&|| ErrorContext::Index(self.for_display(class_ty.clone()))),

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -415,11 +415,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .as_ref()
             .map(|cls| self.heap.mk_self_type(self.as_class_type_unchecked(cls)));
 
-        // __new__ is an implicit staticmethod, __init_subclass__ is an implicit classmethod
-        // __new__, unlike decorated staticmethods, uses Self
+        // __new__ is an implicit staticmethod; __init_subclass__ and __class_getitem__ are
+        // implicit classmethods. __new__, unlike decorated staticmethods, uses Self.
         let is_dunder_new = defining_cls.is_some() && def.name.as_str() == dunder::NEW;
-        let is_dunder_init_subclass =
-            defining_cls.is_some() && def.name.as_str() == dunder::INIT_SUBCLASS;
+        let is_dunder_init_subclass = defining_cls.is_some()
+            && (def.name.as_str() == dunder::INIT_SUBCLASS
+                || def.name.as_str() == dunder::CLASS_GETITEM);
 
         let mut flags = FuncFlags {
             is_staticmethod: is_dunder_new,

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -2004,6 +2004,24 @@ assert_type(Foo[0], str)
 );
 
 testcase!(
+    test_class_getitem_classmethod_does_not_double_bind_cls,
+    r#"
+from types import GenericAlias
+from typing import assert_type
+
+class SparseBase:
+    @classmethod
+    def __class_getitem__(cls, arg: object, /) -> GenericAlias:
+        return GenericAlias(cls, arg)
+
+class SparseMatrix(SparseBase):
+    pass
+
+assert_type(SparseMatrix[int], GenericAlias)
+"#,
+);
+
+testcase!(
     test_class_metaclass_getitem,
     r#"
 from typing import assert_type


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/pyrefly/issues/2740

When `__class_getitem__` is decorated with `classmethod`, the old call site in `expr.rs` explicitly passed `cls` as the first argument while the descriptor protocol had already bound it, resulting in `cls` being passed twice.

D95972179 (the original PR fix) addressed this by inspecting the resolved callee type at the call site: if it was a `BoundMethod`, only the subscript was passed; otherwise `cls` was passed explicitly. This works but is fragile — it requires the call site to reason about binding, introduces a `BoundMethod` match that couples the calling convention to a specific type variant, and needed a visibility change to `make_call_target_and_call`.

The root cause is that CPython's `type.__new__()` implicitly wraps `__class_getitem__` as a classmethod — the same treatment it gives `__init_subclass__`. Pyrefly already models the `__init_subclass__` case via an implicit `is_classmethod` flag in `function.rs`, but `__class_getitem__` was missing from the list. Adding it there means the descriptor protocol always binds `cls` for `__class_getitem__`, regardless of whether the user wrote `classmethod`. The call site then simplifies to just passing the subscript — no type inspection, no conditional args, no visibility changes needed.


Differential Revision: D96042004


