### PR TITLE
fix Closure narrowing loss after reassignment #2739

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -1120,9 +1120,10 @@ impl<'a> BindingsBuilder<'a> {
     /// For names that are read but not locally-defined (implicit captures),
     /// this method creates flow entries pointing to the outer scope's binding.
     ///
-    /// When the outer scope has an active narrow for the captured variable and
-    /// the variable is not reassigned after this function definition, we use
-    /// the narrowed type in the nested scope.
+    /// When the outer scope has a current value binding for the captured
+    /// variable and the variable is not reassigned after this function
+    /// definition, we seed the nested scope from that value. If the outer scope
+    /// also has an active type-guard narrow, we layer that narrow on top.
     pub fn seed_captured_variables(&mut self) {
         let captures = self.scopes.implicit_capture_names();
         let inner_fn_range = self.scopes.current_scope_range();
@@ -1132,7 +1133,10 @@ impl<'a> BindingsBuilder<'a> {
                 .scopes
                 .look_up_name_for_read(hashed_name, &Usage::Narrowing(None));
             if let NameReadInfo::Anywhere { key, .. } = name_read_info {
-                let idx = self.idx_for_promise(key);
+                let idx = self
+                    .scopes
+                    .outer_capture_value_idx(hashed_name, inner_fn_range)
+                    .unwrap_or_else(|| self.idx_for_promise(key));
                 let style = self
                     .scopes
                     .flow_style_for_name(&name)

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -1309,6 +1309,52 @@ impl Scopes {
         self.current().range
     }
 
+    fn outer_capture_not_reassigned_after(
+        scope: &Scope,
+        name: Hashed<&Name>,
+        inner_fn_range: TextRange,
+    ) -> bool {
+        scope
+            .stat
+            .0
+            .get_hashed(name)
+            .map(|s| s.last_range.start() < inner_fn_range.start())
+            .unwrap_or(true)
+    }
+
+    /// Get the outer local scope's current value idx for a captured variable,
+    /// if the variable is not reassigned after the function definition.
+    ///
+    /// This preserves value rebindings like `x = x.clone()` that happen before
+    /// a nested function definition, while still refusing to propagate values
+    /// when a later assignment could change what the closure observes. Module
+    /// scopes continue to use the static binding so conditional top-level
+    /// shadowing keeps its existing behavior.
+    pub fn outer_capture_value_idx(
+        &self,
+        name: Hashed<&Name>,
+        inner_fn_range: TextRange,
+    ) -> Option<Idx<Key>> {
+        for scope in self.iter_rev().skip(1) {
+            match scope.kind {
+                ScopeKind::Class(_) => continue,
+                ScopeKind::Module => return None,
+                _ => {}
+            }
+            if let Some(flow_info) = scope.flow.get_info_hashed(name) {
+                if Self::outer_capture_not_reassigned_after(scope, name, inner_fn_range) {
+                    return flow_info.value().map(|value| value.idx);
+                }
+                return None;
+            }
+            // Name is in stat but not flow — possibly uninitialized, don't propagate.
+            if scope.stat.0.get_hashed(name).is_some() {
+                return None;
+            }
+        }
+        None
+    }
+
     /// Get the outer scope's narrow idx for a captured variable, if the outer
     /// scope has an active narrow and the variable is not reassigned after the
     /// function definition.
@@ -1333,13 +1379,7 @@ impl Scopes {
             if let Some(flow_info) = scope.flow.get_info_hashed(name) {
                 // Only propagate when the outer scope has an active narrow.
                 flow_info.narrow.as_ref()?;
-                let not_reassigned_after = scope
-                    .stat
-                    .0
-                    .get_hashed(name)
-                    .map(|s| s.last_range.start() < inner_fn_range.start())
-                    .unwrap_or(true);
-                if not_reassigned_after {
+                if Self::outer_capture_not_reassigned_after(scope, name, inner_fn_range) {
                     return Some(flow_info.idx());
                 }
                 return None;

--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -1181,6 +1181,37 @@ def f(rows: list[int]) -> int:
 );
 
 testcase!(
+    // #2739: reassignment before nested function definition should preserve the reassigned type
+    test_narrow_capture_reassigned_before_nested_def,
+    r#"
+from typing import Callable
+from typing_extensions import assert_type
+
+class Connection:
+    def __init__(self, host: str) -> None:
+        self.host = host
+
+    def clone(self) -> "Connection":
+        return Connection(self.host)
+
+def get_connection() -> Connection | None:
+    return Connection("localhost")
+
+def make_query_func() -> Callable[[], str]:
+    conn = get_connection()
+    assert conn is not None
+    conn = conn.clone()
+    assert_type(conn, Connection)
+
+    def query() -> str:
+        assert_type(conn, Connection)
+        return conn.host
+
+    return query
+"#,
+);
+
+testcase!(
     // #2408: isinstance narrowing with derived variable
     test_narrow_capture_isinstance_derived,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2739

changed capture seeding to prefer the outer flow’s current value binding when that value is fixed before the nested function definition, while keeping the existing “do not propagate if reassigned after the inner def” rule.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test