### PR TITLE
fix Cannot infer set type from usage #2693

### DIFF
--- a/pyrefly/lib/test/delayed_inference.rs
+++ b/pyrefly/lib/test/delayed_inference.rs
@@ -415,6 +415,27 @@ assert_type(z, dict[str, int])
 );
 
 testcase!(
+    test_empty_set_constructor_call_inside_loop,
+    r#"
+from typing import assert_type
+
+rows: list[dict[str, str]] = []
+seen = set()
+deduped = []
+
+for r in rows:
+    key = r['a']
+    if key not in seen:
+        seen.add(key)
+        deduped.append(r)
+
+assert_type(seen, set[str])
+assert_type(deduped, list[dict[str, str]])
+    "#,
+);
+
+testcase!(
+    bug = "Container contents should be promoted",
     test_redundant_empty_container_constructor_call,
     r#"
 from typing import assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2693

Adjusted first-use binding so an initial narrowing read no longer permanently disables deferred inference. In practice, if key not in seen: no longer forces seen off the first-use path, so the later seen.add(key) can infer set[str] as intended.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test