### PR TITLE
fix ENH: Allow setting default output-format in pyproject.toml / pyrefly.toml #2688

### DIFF
--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -19,6 +19,7 @@ use std::time::Instant;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
+use clap::ValueEnum;
 use derivative::Derivative;
 use dupe::Dupe as _;
 use itertools::Itertools;
@@ -103,6 +104,32 @@ pub enum ConfigSource {
     Marker(PathBuf),
     #[default]
     Synthetic,
+}
+
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    Clone,
+    Copy,
+    Default,
+    ValueEnum
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum OutputFormat {
+    /// Minimal text output, one line per error
+    MinText,
+    #[default]
+    /// Full, verbose text output
+    FullText,
+    /// JSON output
+    Json,
+    /// Emit GitHub Actions workflow commands
+    Github,
+    /// Only show error count, omitting individual errors
+    OmitErrors,
 }
 
 impl ConfigSource {
@@ -479,6 +506,10 @@ pub struct ConfigFile {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub baseline: Option<PathBuf>,
 
+    /// Default error output format for CLI checks when `--output-format` is not set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_format: Option<OutputFormat>,
+
     /// Pyrefly's configurations around interpreter querying/finding.
     #[serde(flatten)]
     pub interpreters: Interpreters,
@@ -563,6 +594,7 @@ impl Default for ConfigFile {
             typeshed_path: None,
             baseline: None,
             min_severity: None,
+            output_format: None,
             skip_lsp_config_indexing: false,
         }
     }
@@ -1407,6 +1439,7 @@ mod tests {
              python-version = "1.2.3"
              site-package-path = ["venv/lib/python1.2.3/site-packages"]
              python-interpreter = "venv/my/python"
+             output-format = "min-text"
              replace-imports-with-any = ["fibonacci"]
              ignore-missing-imports = ["sprout"]
              ignore-errors-in-generated-code = true
@@ -1448,6 +1481,7 @@ mod tests {
                 import_root: None,
                 build_system: Default::default(),
                 use_ignore_files: true,
+                output_format: Some(OutputFormat::MinText),
                 fallback_search_path: Default::default(),
                 python_environment: PythonEnvironment {
                     python_platform: Some(PythonPlatform::mac()),
@@ -1599,10 +1633,11 @@ mod tests {
     #[test]
     fn deserialize_pyproject_toml() {
         let config_str = r#"
-             [tool.pyrefly]
+            [tool.pyrefly]
              project_includes = ["./tests", "./implementation"]
                  python_platform = "darwin"
                  python_version = "1.2.3"
+                 output-format = "json"
                  "#;
         let config = ConfigFile::parse_pyproject_toml(config_str)
             .unwrap()
@@ -1629,6 +1664,7 @@ mod tests {
                         .interpreter_stdlib_path
                         .clone(),
                 },
+                output_format: Some(OutputFormat::Json),
                 ..Default::default()
             }
         );
@@ -1737,6 +1773,7 @@ mod tests {
             disable_project_excludes_heuristics: false,
             import_root: None,
             use_ignore_files: true,
+            output_format: Some(OutputFormat::Json),
             fallback_search_path: Default::default(),
             python_environment: python_environment.clone(),
             interpreters: Interpreters {
@@ -1804,6 +1841,7 @@ mod tests {
             disable_search_path_heuristics: false,
             disable_project_excludes_heuristics: false,
             use_ignore_files: true,
+            output_format: Some(OutputFormat::Json),
             import_root: None,
             fallback_search_path: Default::default(),
             python_environment,
@@ -1851,6 +1889,15 @@ baseline = "baseline.json"
 "#;
         let config = ConfigFile::parse_config(config_str).unwrap();
         assert_eq!(config.baseline, Some(PathBuf::from("baseline.json")));
+    }
+
+    #[test]
+    fn test_output_format_config_parsing() {
+        let config_str = r#"
+output-format = "omit-errors"
+"#;
+        let config = ConfigFile::parse_config(config_str).unwrap();
+        assert_eq!(config.output_format, Some(OutputFormat::OmitErrors));
     }
 
     #[test]

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -30,6 +30,7 @@ use percent_encoding::utf8_percent_encode;
 use pyrefly_build::handle::Handle;
 use pyrefly_config::args::ConfigOverrideArgs;
 use pyrefly_config::config::ConfigFile;
+use pyrefly_config::config::OutputFormat as ConfigOutputFormat;
 use pyrefly_config::error_kind::ErrorKind;
 use pyrefly_config::finder::ConfigError;
 use pyrefly_python::module_name::ModuleName;
@@ -173,6 +174,18 @@ enum OutputFormat {
     OmitErrors,
 }
 
+impl From<ConfigOutputFormat> for OutputFormat {
+    fn from(value: ConfigOutputFormat) -> Self {
+        match value {
+            ConfigOutputFormat::MinText => Self::MinText,
+            ConfigOutputFormat::FullText => Self::FullText,
+            ConfigOutputFormat::Json => Self::Json,
+            ConfigOutputFormat::Github => Self::Github,
+            ConfigOutputFormat::OmitErrors => Self::OmitErrors,
+        }
+    }
+}
+
 /// Main arguments for Pyrefly type checker
 #[deny(clippy::missing_docs_in_private_items)]
 #[derive(Debug, Parser, Clone)]
@@ -236,8 +249,8 @@ struct OutputArgs {
     #[arg(long, short = 'o', value_name = "OUTPUT_FILE")]
     output: Option<PathBuf>,
     /// Set the error output format.
-    #[arg(long, value_enum, default_value_t)]
-    output_format: OutputFormat,
+    #[arg(long, value_enum)]
+    output_format: Option<OutputFormat>,
     /// Produce debugging information about the type checking process.
     #[arg(long, value_name = "OUTPUT_FILE")]
     debug_info: Option<PathBuf>,
@@ -328,6 +341,24 @@ struct OutputArgs {
     /// Errors below this severity will not be shown. Defaults to "error".
     #[arg(long, value_enum)]
     min_severity: Option<Severity>,
+}
+
+impl OutputArgs {
+    fn inherit_defaults_from_config(&mut self, config: &ConfigFile) {
+        if self.baseline.is_none() {
+            self.baseline = config.baseline.clone();
+        }
+        if self.output_format.is_none() {
+            self.output_format = config.output_format.map(OutputFormat::from);
+        }
+        if self.min_severity.is_none() {
+            self.min_severity = config.min_severity;
+        }
+    }
+
+    fn output_format(&self) -> OutputFormat {
+        self.output_format.clone().unwrap_or_default()
+    }
 }
 
 #[derive(Clone, Debug, ValueEnum, Default, PartialEq, Eq)]
@@ -700,20 +731,17 @@ impl CheckArgs {
         );
         let (loaded_handles, _, sourcedb_errors) = handles.all(holder.as_ref().config_finder());
 
-        // If CLI doesn't provide baseline or min-severity, get from config
-        if (self.output.baseline.is_none() || self.output.min_severity.is_none())
+        // Project-level output settings can come from config when CLI flags are absent.
+        if (self.output.baseline.is_none()
+            || self.output.output_format.is_none()
+            || self.output.min_severity.is_none())
             && let Some(handle) = loaded_handles.first()
         {
             let config = holder.as_ref().config_finder().python_file(
                 ModuleNameWithKind::guaranteed(handle.module()),
                 handle.path(),
             );
-            if self.output.baseline.is_none() {
-                self.output.baseline = config.baseline.clone();
-            }
-            if self.output.min_severity.is_none() {
-                self.output.min_severity = config.min_severity;
-            }
+            self.output.inherit_defaults_from_config(&config);
         }
 
         let checked_file_count = loaded_handles.len();
@@ -749,12 +777,12 @@ impl CheckArgs {
         let sys_info = config.get_sys_info();
         let handle = Handle::new(module_name, module_path.clone(), sys_info);
 
-        // If CLI doesn't provide baseline or min-severity, get from config
-        if self.output.baseline.is_none() {
-            self.output.baseline = config.baseline.clone();
-        }
-        if self.output.min_severity.is_none() {
-            self.output.min_severity = config.min_severity;
+        // Project-level output settings can come from config when CLI flags are absent.
+        if self.output.baseline.is_none()
+            || self.output.output_format.is_none()
+            || self.output.min_severity.is_none()
+        {
+            self.output.inherit_defaults_from_config(&config);
         }
 
         let require_levels = self.get_required_levels();
@@ -795,9 +823,10 @@ impl CheckArgs {
         let mut handles = Handles::new(expanded_file_list);
         let state = State::new(config_finder);
 
-        // Track if CLI provided values - if so, never override them with config values
+        // Track which output settings were explicitly set on the CLI.
         let cli_provided_baseline = self.output.baseline.is_some();
         let cli_provided_min_severity = self.output.min_severity.is_some();
+        let cli_provided_output_format = self.output.output_format.is_some();
 
         let mut transaction = state.new_committable_transaction(require_levels.default, None);
         loop {
@@ -805,21 +834,16 @@ impl CheckArgs {
             let (loaded_handles, reloaded_configs, sourcedb_errors) =
                 handles.all(state.config_finder());
 
-            // If CLI didn't provide these values, get from config on every iteration
-            // to pick up config file changes
-            if (!cli_provided_baseline || !cli_provided_min_severity)
+            // Inherit project-level output settings from config on every iteration
+            // to pick up config file changes when the CLI did not override them.
+            if (!cli_provided_baseline || !cli_provided_output_format || !cli_provided_min_severity)
                 && let Some(handle) = loaded_handles.first()
             {
                 let config = state.config_finder().python_file(
                     ModuleNameWithKind::guaranteed(handle.module()),
                     handle.path(),
                 );
-                if !cli_provided_baseline {
-                    self.output.baseline = config.baseline.clone();
-                }
-                if !cli_provided_min_severity {
-                    self.output.min_severity = config.min_severity;
-                }
+                self.output.inherit_defaults_from_config(&config);
             }
             let mut_transaction = transaction.as_mut();
             mut_transaction.invalidate_find_for_configs(reloaded_configs);
@@ -923,6 +947,7 @@ impl CheckArgs {
             || std::env::current_dir().ok().unwrap_or_default(),
             |x| PathBuf::from_str(x.as_str()).unwrap(),
         );
+        let output_format = self.output.output_format();
 
         let errors = loads
             .collect_errors_with_baseline(self.output.baseline.as_deref(), relative_to.as_path());
@@ -1036,15 +1061,9 @@ impl CheckArgs {
         });
 
         if let Some(path) = &self.output.output {
-            self.output.output_format.write_errors_to_file(
-                path,
-                relative_to.as_path(),
-                &output_errors,
-            )?;
+            output_format.write_errors_to_file(path, relative_to.as_path(), &output_errors)?;
         } else {
-            self.output
-                .output_format
-                .write_errors_to_console(relative_to.as_path(), &output_errors)?;
+            output_format.write_errors_to_console(relative_to.as_path(), &output_errors)?;
         }
         memory_trace.stop();
         if let Some(limit) = self.output.count_errors {
@@ -1219,5 +1238,31 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
         assert!(output.contains("::error file=/repo/foo.py"));
         assert!(output.ends_with("::bad\n"));
+    }
+
+    #[test]
+    fn output_args_inherit_output_format_from_config() {
+        let mut output = OutputArgs::parse_from(["pyrefly-check"]);
+        let config = ConfigFile {
+            output_format: Some(ConfigOutputFormat::MinText),
+            ..Default::default()
+        };
+
+        output.inherit_defaults_from_config(&config);
+
+        assert_eq!(output.output_format(), OutputFormat::MinText);
+    }
+
+    #[test]
+    fn cli_output_format_overrides_config_output_format() {
+        let mut output = OutputArgs::parse_from(["pyrefly-check", "--output-format", "json"]);
+        let config = ConfigFile {
+            output_format: Some(ConfigOutputFormat::MinText),
+            ..Default::default()
+        };
+
+        output.inherit_defaults_from_config(&config);
+
+        assert_eq!(output.output_format(), OutputFormat::Json);
     }
 }

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -481,6 +481,18 @@ min-severity = "warn"
       are currently open in the editor, regardless of this setting.
     - Directives such as [`reveal_type`](../error-kinds#reveal-type) are always
       shown regardless of this threshold.
+### `output-format`
+
+Default format for `pyrefly check` error output when `--output-format` is not
+set on the CLI.
+
+- Type: `"min-text" | "full-text" | "json" | "github" | "omit-errors"`
+- Default: `full-text`
+- Flag equivalent: `--output-format`
+- Notes:
+    - `output-format` is a **project-level setting** and cannot be overridden in
+      [`sub-config`](#sub-configs) sections.
+    - A CLI `--output-format` flag still takes precedence over the config value.
 
 ### `errors`
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2688

output-format is now a recognized project-level config option in both `pyrefly.toml` and `[tool.pyrefly]` in `pyproject.toml`, and pyrefly check will inherit it only when `--output-format` is not set on the CLI.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test