### PR TITLE
fix False positive with @dataclass(frozen=True) and a ClassVar #2789

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -2118,9 +2118,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         {
             return Some(ReadOnlyReason::NamedTuple);
         }
+        // ClassVars in dataclasses are class attributes rather than frozen instance fields.
+        let is_classvar = annotation.is_some_and(|ann| ann.has_qualifier(&Qualifier::ClassVar));
         // Frozen dataclass fields (not methods) are read-only
         if let Some(dm) = metadata.dataclass_metadata()
             && dm.kws.frozen
+            && !is_classvar
             && dm.fields.contains(name)
         {
             let reason = if metadata.is_pydantic_model() {

--- a/pyrefly/lib/test/dataclasses.rs
+++ b/pyrefly/lib/test/dataclasses.rs
@@ -793,6 +793,21 @@ C()
 );
 
 testcase!(
+    test_frozen_classvar_class_assignment,
+    r#"
+import dataclasses
+from typing import ClassVar
+
+@dataclasses.dataclass(frozen=True)
+class C:
+    x: ClassVar[bool] = True
+
+    def set_x(self) -> None:
+        self.__class__.x = False
+    "#,
+);
+
+testcase!(
     test_hashable,
     r#"
 from typing import Hashable


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2789

stops ClassVar members from being classified as frozen dataclass fields.

preserves the existing ClassVar write restriction on instances, but no longer incorrectly rejects writes through a class object like `self.__class__.x = False` in a frozen dataclass.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test