### PR TITLE
Collect lower bounds on Variable::Quantified and Variable::Unwrap (#2795)

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -7456,45 +7456,12 @@
     {
       "code": -2,
       "column": 16,
-      "concise_description": "assert_type(list[int], list[int] | set[int]) failed",
-      "description": "assert_type(list[int], list[int] | set[int]) failed",
-      "line": 43,
-      "name": "assert-type",
-      "severity": "error",
-      "stop_column": 59,
-      "stop_line": 43
-    },
-    {
-      "code": -2,
-      "column": 31,
-      "concise_description": "Argument `set[int]` is not assignable to parameter `y` with type `list[int]` in function `longer`",
-      "description": "Argument `set[int]` is not assignable to parameter `y` with type `list[int]` in function `longer`",
-      "line": 43,
-      "name": "bad-argument-type",
-      "severity": "error",
-      "stop_column": 35,
-      "stop_line": 43
-    },
-    {
-      "code": -2,
-      "column": 16,
-      "concise_description": "assert_type(list[int], Collection[int]) failed",
-      "description": "assert_type(list[int], Collection[int]) failed",
+      "concise_description": "assert_type(list[int] | set[int], Collection[int]) failed",
+      "description": "assert_type(list[int] | set[int], Collection[int]) failed",
       "line": 44,
       "name": "assert-type",
       "severity": "error",
       "stop_column": 54,
-      "stop_line": 44
-    },
-    {
-      "code": -2,
-      "column": 31,
-      "concise_description": "Argument `set[int]` is not assignable to parameter `y` with type `list[int]` in function `longer`",
-      "description": "Argument `set[int]` is not assignable to parameter `y` with type `list[int]` in function `longer`",
-      "line": 44,
-      "name": "bad-argument-type",
-      "severity": "error",
-      "stop_column": 35,
       "stop_line": 44
     },
     {

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -17,6 +17,7 @@ use pyrefly_types::dimension::ShapeError;
 use pyrefly_types::dimension::canonicalize;
 use pyrefly_types::heap::TypeHeap;
 use pyrefly_types::quantified::Quantified;
+use pyrefly_types::quantified::QuantifiedKind;
 use pyrefly_types::simplify::intersect;
 use pyrefly_types::special_form::SpecialForm;
 use pyrefly_types::tensor::TensorShape;
@@ -406,8 +407,12 @@ impl Solver {
                 Some(PinError::ImplicitPartialContained(range))
             }
             Variable::PartialContained(_) => None,
-            Variable::Unwrap(_lower_bounds) => {
-                *variable = Variable::Answer(self.heap.mk_any_implicit());
+            Variable::Unwrap(lower_bounds) => {
+                *variable = Variable::Answer(if lower_bounds.is_empty() {
+                    Type::any_implicit()
+                } else {
+                    self.solve_lower_bounds(mem::take(lower_bounds))
+                });
                 None
             }
         }
@@ -454,7 +459,6 @@ impl Solver {
 
     /// Expand, but if the resulting type will be greater than limit levels deep, return an `Any`.
     /// Avoids producing things that stack overflow later in the process.
-    #[expect(clippy::only_used_in_recursion)]
     fn expand_with_limit(
         &self,
         t: &mut Type,
@@ -473,6 +477,31 @@ impl Solver {
                 match &*variable {
                     Variable::Answer(ty) | Variable::LoopRecursive(ty, LoopBound::Prior) => {
                         *t = ty.clone();
+                        drop(variable);
+                        drop(lock);
+                        self.expand_with_limit(
+                            t,
+                            limit - 1,
+                            recurser,
+                            expand_unfinished_quantified,
+                        );
+                    }
+                    Variable::Quantified {
+                        quantified: _,
+                        lower_bounds,
+                    } if expand_unfinished_quantified && !lower_bounds.is_empty() => {
+                        *t = self.solve_lower_bounds(lower_bounds.clone());
+                        drop(variable);
+                        drop(lock);
+                        self.expand_with_limit(
+                            t,
+                            limit - 1,
+                            recurser,
+                            expand_unfinished_quantified,
+                        );
+                    }
+                    Variable::Unwrap(lower_bounds) if !lower_bounds.is_empty() => {
+                        *t = self.solve_lower_bounds(lower_bounds.clone());
                         drop(variable);
                         drop(lock);
                         self.expand_with_limit(
@@ -519,6 +548,9 @@ impl Solver {
                         lower_bounds: _,
                     } => q.as_gradual_type(),
                     Variable::PartialQuantified(q) => q.as_gradual_type(),
+                    Variable::Unwrap(lower_bounds) if !lower_bounds.is_empty() => {
+                        self.solve_lower_bounds(mem::take(lower_bounds))
+                    }
                     _ => self.heap.mk_any_implicit(),
                 };
                 *e = Variable::Answer(ty.clone());
@@ -943,7 +975,6 @@ impl Solver {
         }
     }
 
-    #[expect(dead_code)]
     fn solve_lower_bounds(&self, mut lower_bounds: Vec<Type>) -> Type {
         // Keeping `Any` bounds causes `Any` to propagate to too many places,
         // so we filter them out unless `Any` is the only solution.
@@ -976,17 +1007,23 @@ impl Solver {
                     }
                 }
                 Variable::Quantified {
-                    quantified: q,
+                    quantified: _,
                     lower_bounds,
-                } if infer_with_first_use && lower_bounds.is_empty() => {
-                    *e = Variable::finished(q);
+                } if !lower_bounds.is_empty() => {
+                    if let Some(e) = self.instantiation_errors.read().get(&v) {
+                        err.push(e.clone());
+                    }
+                    *e = Variable::Answer(self.solve_lower_bounds(mem::take(lower_bounds)));
                 }
                 Variable::Quantified {
                     quantified: q,
                     lower_bounds: _,
                 } => {
-                    // Either `infer_with_first_use` is false or the variable has already been solved.
-                    *e = Variable::Answer(q.as_gradual_type());
+                    *e = if infer_with_first_use {
+                        Variable::finished(q)
+                    } else {
+                        Variable::Answer(q.as_gradual_type())
+                    };
                 }
                 _ => {}
             }
@@ -1897,6 +1934,18 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                         self.is_subset_eq(&t1, t2)
                     }
                     Variable::Quantified {
+                        quantified: _,
+                        lower_bounds,
+                    }
+                    | Variable::Unwrap(lower_bounds)
+                        if !lower_bounds.is_empty() =>
+                    {
+                        let lower_bound = self.solver.solve_lower_bounds(lower_bounds.clone());
+                        drop(v1_ref);
+                        drop(variables);
+                        self.is_subset_eq(&lower_bound, t2)
+                    }
+                    Variable::Quantified {
                         quantified: q,
                         lower_bounds: _,
                     }
@@ -2060,6 +2109,7 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                             .clone()
                             .promote_implicit_literals(self.type_order.stdlib());
                         let name = q.name.clone();
+                        let kind = q.kind();
                         let restriction = q.restriction().clone();
                         let bound =
                             restriction.as_type(self.type_order.stdlib(), &self.solver.heap);
@@ -2134,11 +2184,22 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                             } else {
                                 variables.update(*v2, Variable::Answer(answer));
                             }
-                        } else {
+                        } else if kind != QuantifiedKind::TypeVar
+                            || matches!(restriction, Restriction::Constraints(_))
+                        {
+                            // If the TypeVar has constraints, we write the answer immediately to
+                            // enforce that we always match the same constraint.
+                            //
+                            // TODO(https://github.com/facebook/pyrefly/issues/105): figure out
+                            // what to do with ParamSpec and TypeVarTuple.
                             self.solver
                                 .variables
                                 .lock()
                                 .update(*v2, Variable::Answer(answer));
+                        } else {
+                            self.solver.add_lower_bound(*v2, answer, &mut |got, want| {
+                                self.is_subset_eq(got, want).is_ok()
+                            });
                         }
                         Ok(())
                     }
@@ -2157,7 +2218,17 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                         variables.update(*v2, Variable::Answer(answer));
                         Ok(())
                     }
-                    Variable::Unwrap(_) | Variable::Recursive => {
+                    Variable::Unwrap(_) => {
+                        drop(v2_ref);
+                        match &mut *variables.get_mut(*v2) {
+                            Variable::Unwrap(lower_bounds) => {
+                                lower_bounds.push(t1.clone());
+                            }
+                            _ => {}
+                        }
+                        Ok(())
+                    }
+                    Variable::Recursive => {
                         drop(v2_ref);
                         variables.update(*v2, Variable::Answer(t1.clone()));
                         Ok(())

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -320,7 +320,6 @@ def foo(x: Callable[[int], str], c: C, c2: C2, c3: C3):
 );
 
 testcase!(
-    bug = "classmethod bound object w/o targs is default-instantiated, solves T to Any",
     test_bound_classmethod_explicit_targs,
     r#"
 from typing import assert_type
@@ -333,7 +332,7 @@ class A[T]:
         return cls(x)
 
 assert_type(A[int].m(0), A[int])
-assert_type(A.m(0), A[int]) # TODO # E: assert_type(A[Unknown], A[int]) failed
+assert_type(A.m(0), A[int])
 
 def test_typevar_bounds[T: A[int]](x: type[T]):
     assert_type(x.m(0), A[int])

--- a/pyrefly/lib/test/constructors.rs
+++ b/pyrefly/lib/test/constructors.rs
@@ -103,7 +103,7 @@ class Box[T]:
         if x:
             return Box(self, self)  # E: `Box[Box[Box[T]]]` is not assignable to parameter `self`
         else:
-            return Box(self, 42)  # E: `Box[Box[Box[T]]]` is not assignable to parameter `self`  # E: Argument `Literal[42]` is not assignable to parameter `y` with type `Self@Box`
+            return Box(self, 42)  # E: `Box[Box[Box[T]]]` is not assignable to parameter `self`
 b = Box[int]("hello", "world")
 assert_type(b, Box[int])
 assert_type(b.wrap(True), Box[Box[int]])

--- a/pyrefly/lib/test/flow_looping.rs
+++ b/pyrefly/lib/test/flow_looping.rs
@@ -11,12 +11,23 @@ use crate::testcase;
 testcase!(
     test_loop_with_generic_pin,
     r#"
+from typing import assert_type, Sequence
+
 def condition() -> bool: ...
+
 def f[T](x: T, y: list[T]) -> T: ...
 x = 5
 y: list[str] = []
 while condition():
-    x = f(x, y)  # E: Argument `list[str]` is not assignable to parameter `y` with type `list[int]` in function `f`
+    x = f(x, y)  # E: Argument `list[str]` is not assignable to parameter `y` with type `list[int | str]` in function `f`
+assert_type(x, int | str)
+
+def g[T](x: T, y: Sequence[T]) -> T: ...
+z = 5
+w: list[str] = []
+while condition():
+    z = g(z, w)
+assert_type(z, int | str)
 "#,
 );
 
@@ -665,7 +676,7 @@ assert_type(good, list[int])
 bad = [1]
 while condition():
     if condition():
-        bad = [f(bad)]  # E: Argument `list[int] | list[str]` is not assignable to parameter `x` with type `list[int]` in function `f`
+        bad = [f(bad)]  # E: Argument `list[int | str] | list[int] | list[str]` is not assignable to parameter `x` with type `list[int | str]` in function `f`
     else:
         bad = [""]
 "#,

--- a/pyrefly/lib/test/generic_basic.rs
+++ b/pyrefly/lib/test/generic_basic.rs
@@ -110,7 +110,6 @@ assert_type(C2[int], type[C2[int, *tuple[()]]])
 );
 
 testcase!(
-    bug = "T is pinned prematurely due to https://github.com/facebook/pyrefly/issues/105",
     test_generics,
     r#"
 from typing import Literal
@@ -118,7 +117,7 @@ class C[T]: ...
 def append[T](x: C[T], y: T):
     pass
 v: C[int] = C()
-append(v, "test")  # E: `Literal['test']` is not assignable to parameter `y` with type `int`
+append(v, "test")
 "#,
 );
 testcase!(
@@ -706,5 +705,31 @@ T = TypeVar("T")
 def f(x: TypeVar):
     pass
 f(T)
+    "#,
+);
+
+testcase!(
+    test_list_or_sequence_of_typevar,
+    r#"
+from typing import assert_type, Sequence
+
+def f[T](x: T, y: list[T]) -> T: ...
+def g[T](x: T, y: Sequence[T]) -> T: ...
+
+assert_type(f(0, [""]), int | str)  # E: Argument `list[str]` is not assignable to parameter `y` with type `list[int | str]`
+assert_type(g(0, [""]), int | str)
+    "#,
+);
+
+testcase!(
+    test_any_absorption,
+    r#"
+from typing import Any, assert_type
+
+def f[T](x: T, y: T) -> T: ...
+
+def g(x: Any):
+    # `list[Any]` absorbs `list[int]`
+    assert_type(f([x], [1]), list[Any])
     "#,
 );

--- a/pyrefly/lib/test/generic_legacy.rs
+++ b/pyrefly/lib/test/generic_legacy.rs
@@ -576,6 +576,7 @@ reveal_type(TypeForm)  # E: revealed type: type[type[T]]
 );
 
 testcase!(
+    bug = "TODO(https://github.com/facebook/pyrefly/issues/105): collect upper bounds on typevars",
     test_generics_legacy_unqualified,
     r#"
 from typing import TypeVar, Generic
@@ -584,11 +585,12 @@ class C(Generic[T]): ...
 def append(x: C[T], y: T):
     pass
 v: C[int] = C()
-append(v, "test")  # E: Argument `Literal['test']` is not assignable to parameter `y` with type `int`
+append(v, "test")  # should error
 "#,
 );
 
 testcase!(
+    bug = "TODO(https://github.com/facebook/pyrefly/issues/105): collect upper bounds on typevars",
     test_generics_legacy_qualified,
     r#"
 import typing
@@ -597,7 +599,7 @@ class C(typing.Generic[T]): ...
 def append(x: C[T], y: T):
     pass
 v: C[int] = C()
-append(v, "test")  # E: Argument `Literal['test']` is not assignable to parameter `y` with type `int`
+append(v, "test")  # should error
 "#,
 );
 

--- a/pyrefly/lib/test/generic_restrictions.rs
+++ b/pyrefly/lib/test/generic_restrictions.rs
@@ -636,19 +636,17 @@ def add2[T: int | float](x: T, y: T) -> T:
 );
 
 testcase!(
-    bug = "This should succeed with no errors. Pyrefly pins the types too early due to https://github.com/facebook/pyrefly/issues/105",
     test_multiple_args_upper_bound,
     r#"
 from typing import assert_type
 
 def f[T: int | str](x: T, y: T): ...
-f(0, "1") # E: `Literal['1']` is not assignable to parameter `y` with type `int`
+f(0, "1")
 
 class A[T]:
     def __init__(self, x: T, y: T): ...
-# Note: pyright says the type is A[int | str]; mypy says A[object].
-# Either is okay, but A[int] is definitely wrong and we shouldn't emit the not assignable error.
-assert_type(A(0, "1"), A[int | str]) # E: assert_type(A[int], A[int | str]) # E: `Literal['1']` is not assignable to parameter `y` with type `int`
+# Note: pyright says the type is A[int | str]; mypy says A[object]. Either is ok.
+assert_type(A(0, "1"), A[int | str])
     "#,
 );
 
@@ -1194,5 +1192,22 @@ def g(x: AnyStr) -> AnyStr:
 # Concrete calls still promote correctly.
 assert_type(f("hi"), str)
 assert_type(f(b"hi"), bytes)
+    "#,
+);
+
+testcase!(
+    test_do_not_match_multiple_constraints,
+    r#"
+def f[T: (int, str)](x: T, y: T): ...
+f(0, "wrong")  # E: `Literal['wrong']` is not assignable to parameter `y` with type `int`
+    "#,
+);
+
+testcase!(
+    bug = "TODO(https://github.com/facebook/pyrefly/issues/105): error message should also flag `Literal['oops']`",
+    test_multiple_bad_specialization,
+    r#"
+def f[T: int](x: T, y: T): ...
+f("oops", None)  # E: `None` is not assignable to upper bound `int`
     "#,
 );

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -2258,3 +2258,16 @@ takes_Type_any(Callable) # E: is not assignable to parameter `x` with type `type
 takes_Type_any(Callable[..., int]) # E: is not assignable to parameter `x` with type `type[Any]` in function
 "#,
 );
+
+testcase!(
+    test_min_max_int_and_float,
+    r#"
+from typing import reveal_type
+def f(x: float):
+    # We use reveal_type rather than assert_type here to verify that the type is exactly float, not
+    # int | float. Even though the two are equivalent, pyrefly doesn't eagerly simplify the union,
+    # so producing the union would cause spurious downstream errors.
+    reveal_type(min(0, x))  # E: revealed type: float
+    reveal_type(max(0, x))  # E: revealed type: float
+    "#,
+);


### PR DESCRIPTION
Summary:

Changes Variable::Quantified and Variable::Unwrap to collect lower bounds rather than solving immediately to the first encountered type. Because a Quantified can be solved to an Unwrap and vice versa, I had to update their behavior together to keep tests passing.

This fixes a group of bugs related to eager pinning of type parameters. I left TODOs for remaining work.

Note that we appear to regress on a couple of generics tests, but what's actually happening is that we stop reporting a false positive, but we still don't report the error that we're supposed to (pre-existing). The false positive previously fooled us into thinking the tests were passing.

Fixes https://github.com/facebook/pyrefly/issues/345.
Fixes https://github.com/facebook/pyrefly/issues/924.
Fixes https://github.com/facebook/pyrefly/issues/2515.
Fixes https://github.com/facebook/pyrefly/issues/2519.
Fixes https://github.com/facebook/pyrefly/issues/2616.
Ref https://github.com/facebook/pyrefly/issues/105.

Differential Revision: D96439545
