### PR TITLE
fix False positive [missing-attribute] for dict.setdefault(key, []).append(val) on unannotated dict #2799

### DIFF
--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -825,6 +825,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let mut overload_ctor_targs = ctor_targs.as_ref().map(|x| (**x).clone());
         let tparams = callable.0.as_deref();
 
+        let checkpoint = self.solver().checkpoint();
         let call_errors = self.error_collector();
         let (res, specialization_errors, expected_types) = self.callable_infer(
             callable.1.signature.clone(),
@@ -843,6 +844,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             hint,
             overload_ctor_targs.as_mut(),
         );
+        if !call_errors.is_empty() {
+            self.solver().restore_checkpoint(checkpoint);
+        }
 
         CalledOverload {
             func: callable,

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -336,7 +336,7 @@ impl QuantifiedHandle {
 /// Note that RefCell means we need to be careful about how we access
 /// variables. Access is "mutable xor shared" like ordinary references,
 /// except with runtime instead of static enforcement.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 struct Variables(SmallMap<Var, RefCell<VariableNode>>);
 
 /// A union-find node. We store the parent pointer in a Cell so that we
@@ -500,6 +500,12 @@ pub struct Solver {
     pub spec_compliant_overloads: bool,
 }
 
+#[derive(Clone)]
+pub(crate) struct SolverCheckpoint {
+    variables: Variables,
+    instantiation_errors: SmallMap<Var, TypeVarSpecializationError>,
+}
+
 impl Display for Solver {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (x, y) in self.variables.lock().iter() {
@@ -591,6 +597,18 @@ impl Solver {
         result: Result<(), SubsetError>,
     ) {
         self.typed_dict_cache.lock().insert((got, want), result);
+    }
+
+    pub(crate) fn checkpoint(&self) -> SolverCheckpoint {
+        SolverCheckpoint {
+            variables: self.variables.lock().clone(),
+            instantiation_errors: self.instantiation_errors.read().clone(),
+        }
+    }
+
+    pub(crate) fn restore_checkpoint(&self, checkpoint: SolverCheckpoint) {
+        *self.variables.lock() = checkpoint.variables;
+        *self.instantiation_errors.write() = checkpoint.instantiation_errors;
     }
 
     /// Force all non-recursive Vars in `vars`.

--- a/pyrefly/lib/test/delayed_inference.rs
+++ b/pyrefly/lib/test/delayed_inference.rs
@@ -414,6 +414,18 @@ assert_type(z, dict[str, int])
     "#,
 );
 
+// Regression test for https://github.com/facebook/pyrefly/issues/2799
+testcase!(
+    test_dict_setdefault_with_empty_list_default,
+    r#"
+d = {}
+items = [("news", "token1"), ("sports", "token2"), ("news", "token3")]
+
+for topic, token in items:
+    d.setdefault(topic, []).append(token)
+    "#,
+);
+
 testcase!(
     test_redundant_empty_container_constructor_call,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2799

isolating failed overload attempts so they can’t mutate solver state and leak None into later matches.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test