### PR TITLE
Fix ParamSpec forwarding between generic helpers (#823) - minimal fix (#2801)

### DIFF
--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -575,6 +575,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     let ps = ParamList::everything();
                     ps.prepend_types(&prefix).into_owned()
                 }
+                // The ParamSpec Var resolved to another quantified ParamSpec (e.g.,
+                // one generic helper forwarding `*args: P.args, **kwargs: P.kwargs`
+                // to another). There are no concrete parameters to contribute;
+                // treat it permissively like `...` so the forwarded args pass through.
+                Type::Quantified(q) if q.is_param_spec() => ParamList::everything(),
                 t => {
                     error(
                         call_errors,

--- a/pyrefly/lib/test/paramspec.rs
+++ b/pyrefly/lib/test/paramspec.rs
@@ -521,6 +521,36 @@ def wrap(f: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
 );
 
 testcase!(
+    test_paramspec_forwarding_between_generic_helpers,
+    r#"
+from typing import Callable, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def run_and_get_code(fn: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R: ...
+
+def run_and_get_kernels(fn: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+    return run_and_get_code(fn, *args, **kwargs)
+"#,
+);
+
+testcase!(
+    test_paramspec_forwarding_extra_concrete_arg,
+    r#"
+from typing import Callable, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def inner(fn: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R: ...
+
+def outer(fn: Callable[P, R], extra: int, *args: P.args, **kwargs: P.kwargs) -> R:
+    return inner(fn, *args, **kwargs)
+"#,
+);
+
+testcase!(
     test_param_spec_ellipsis,
     r#"
 from typing import Callable


### PR DESCRIPTION
Summary:

When one generic helper forwards `*args: P.args, **kwargs: P.kwargs` to another generic helper that also takes `Callable[P, R]`, the solver binds the callee's ParamSpec Var to the caller's still-quantified `P`. The `var_to_rparams` closure didn't handle `Type::Quantified` and fell through to the error branch, producing a bogus "Expected `P` to be a ParamSpec value" error.

Fix: recognize `Type::Quantified(q) if q.is_param_spec()` and treat it permissively (like `...`), since a forwarded ParamSpec contributes no concrete parameters to expand.

Reviewed By: migeed-z

Differential Revision: D96510930
