### PR TITLE
fix Support inline namedtuple definition #2811

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -3039,6 +3039,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let mut parent_attr_found = false;
         let mut parent_has_any = false;
         let is_typed_dict_field = self.is_typed_dict_field(metadata.as_ref(), field_name);
+        let is_named_tuple_element = metadata
+            .named_tuple_metadata()
+            .is_some_and(|named_tuple| named_tuple.elements.contains(field_name));
 
         let bases_to_check: Box<dyn Iterator<Item = &ClassType>> = if bases.is_empty() {
             // If the class doesn't have any base type, we should just use `object` as base to ensure
@@ -3062,6 +3065,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     ErrorInfo::Kind(ErrorKind::BadOverride),
                     format!("Cannot override named tuple element `{field_name}`"),
                 );
+            }
+            if is_named_tuple_element {
+                continue;
             }
             let Some(want_field) = self.get_class_member(parent_cls, field_name) else {
                 continue;

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -72,6 +72,7 @@ use crate::alt::nn_module_specials::is_nn_module_dict;
 use crate::alt::solve::TypeFormContext;
 use crate::alt::unwrap::Hint;
 use crate::alt::unwrap::HintRef;
+use crate::binding::binding::Binding;
 use crate::binding::binding::Key;
 use crate::binding::binding::KeyYield;
 use crate::binding::binding::KeyYieldFrom;
@@ -221,6 +222,18 @@ impl Display for ConditionRedundantReason {
 static MAX_TUPLE_LENGTH: usize = 256;
 
 impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
+    fn synthesized_functional_class_type(&self, call: &ExprCall) -> Option<Type> {
+        let anon_key = match call.arguments.args.first()? {
+            Expr::StringLiteral(name) => Key::Anon(name.range()),
+            _ => Key::Anon(call.range),
+        };
+        let idx = self
+            .bindings()
+            .key_to_idx_hashed_opt(Hashed::new(&anon_key))?;
+        matches!(self.bindings().get(idx), Binding::ClassDef(..))
+            .then(|| self.get_hashed(Hashed::new(&anon_key)).ty().clone())
+    }
+
     /// Infer a type for an expression, with an optional type hint that influences the inferred type.
     /// The inferred type is also checked against the hint.
     pub fn expr(
@@ -578,6 +591,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Expr::YieldFrom(x) => self.get(&KeyYieldFrom(x.range)).return_ty.clone(),
             Expr::Compare(x) => self.compare_infer(x, errors),
             Expr::Call(x) => {
+                if let Some(ty) = self.synthesized_functional_class_type(x) {
+                    return ty;
+                }
                 let callee_ty = self.expr_infer(&x.func, errors);
                 if let Some(d) = self.call_to_dict(&callee_ty, &x.arguments) {
                     self.dict_infer(&d, hint, x.range, errors)

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -8,6 +8,7 @@
 use pyrefly_graph::index::Idx;
 use pyrefly_python::ast::Ast;
 use pyrefly_python::module_path::ModuleStyle;
+use pyrefly_python::nesting_context::NestingContext;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_util::visit::VisitMut;
 use ruff_python_ast::Arguments;
@@ -30,6 +31,7 @@ use ruff_python_ast::ExprYieldFrom;
 use ruff_python_ast::Identifier;
 use ruff_python_ast::Operator;
 use ruff_python_ast::StringLiteral;
+use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use starlark_map::Hashed;
@@ -549,6 +551,49 @@ impl<'a> BindingsBuilder<'a> {
         }
     }
 
+    fn bind_inline_functional_named_tuple(&mut self, call: &mut ExprCall) {
+        let Some(kind) = self.as_special_export(&call.func) else {
+            return;
+        };
+        let Some(Expr::StringLiteral(name)) = call.arguments.args.first() else {
+            return;
+        };
+        let class_name = Identifier::new(Name::new(name.value.to_str()), name.range());
+        let parent = NestingContext::toplevel();
+        let class_idx = match kind {
+            SpecialExport::CollectionsNamedTuple => {
+                let Some((_arg_name, members)) = call.arguments.args.split_first_mut() else {
+                    return;
+                };
+                self.synthesize_collections_named_tuple_def(
+                    class_name,
+                    &parent,
+                    &mut call.func,
+                    members,
+                    &mut call.arguments.keywords,
+                    false,
+                )
+            }
+            SpecialExport::TypingNamedTuple => {
+                let Some((_arg_name, members)) = call.arguments.args.split_first_mut() else {
+                    return;
+                };
+                self.synthesize_typing_named_tuple_def(
+                    class_name,
+                    &parent,
+                    &mut call.func,
+                    members,
+                    false,
+                )
+            }
+            _ => return,
+        };
+        self.insert_binding(
+            Key::Anon(call.range),
+            Binding::ClassDef(class_idx, Box::new([])),
+        );
+    }
+
     fn record_yield(&mut self, mut x: ExprYield) {
         let mut yield_link = self.declare_current_idx(Key::YieldLink(x.range));
         let idx = self.idx_for_promise(KeyYield(x.range));
@@ -660,6 +705,14 @@ impl<'a> BindingsBuilder<'a> {
                     self.finish_branch();
                     self.finish_bool_op_fork();
                 }
+            }
+            Expr::Call(call)
+                if matches!(
+                    self.as_special_export(&call.func),
+                    Some(SpecialExport::CollectionsNamedTuple | SpecialExport::TypingNamedTuple)
+                ) && matches!(call.arguments.args.first(), Some(Expr::StringLiteral(_))) =>
+            {
+                self.bind_inline_functional_named_tuple(call);
             }
             Expr::Call(ExprCall {
                 node_index: _,

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -80,6 +80,19 @@ Point3(1)  # E: Missing argument `y` in function `Point3.__new__`
     "#,
 );
 
+// Regression test for https://github.com/facebook/pyrefly/issues/2811
+testcase!(
+    test_inline_collections_namedtuple_constructor,
+    r#"
+import collections
+from typing import Any, assert_type
+
+device = collections.namedtuple("FakeDevice", ["type", "index"])("lazy-caster", 0)
+assert_type(device.type, Any)
+assert_type(device.index, Any)
+    "#,
+);
+
 // Regression test for https://github.com/facebook/pyrefly/issues/2734
 // Starred expressions in field lists can't be fully resolved statically,
 // so the namedtuple has dynamic fields. String literals alongside the


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2811

now synthesizes anonymous functional namedtuple classes when collections.namedtuple(...) or typing.NamedTuple(...) appears inline in expression position, instead of only when bound to a name or used as a base class.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test