### PR TITLE
fix Incorrect invalid-type-var check when persisting get method of a fully-annotated dict #2812

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -2466,6 +2466,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // (e.g. generic functions assigned to attributes have their own
         // type parameters that should not trigger invalid-type-var errors).
         let mut forall_bound: SmallSet<&Quantified> = SmallSet::new();
+        fn collect_overload_tparams<'a>(
+            overload: &'a Overload,
+            acc: &mut SmallSet<&'a Quantified>,
+        ) {
+            for sig in overload.signatures.iter() {
+                if let OverloadType::Forall(forall) = sig {
+                    for q in forall.tparams.iter() {
+                        acc.insert(q);
+                    }
+                }
+            }
+        }
         fn collect_forall_tparams<'a>(ty: &'a Type, acc: &mut SmallSet<&'a Quantified>) {
             match ty {
                 Type::Forall(forall) => {
@@ -2473,13 +2485,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         acc.insert(q);
                     }
                 }
-                Type::BoundMethod(bm) => {
-                    if let BoundMethodType::Forall(forall) = &bm.func {
+                Type::Overload(overload) => collect_overload_tparams(overload, acc),
+                Type::BoundMethod(bm) => match &bm.func {
+                    BoundMethodType::Forall(forall) => {
                         for q in forall.tparams.iter() {
                             acc.insert(q);
                         }
                     }
-                }
+                    BoundMethodType::Overload(overload) => collect_overload_tparams(overload, acc),
+                    BoundMethodType::Function(_) => {}
+                },
                 _ => {}
             }
             ty.recurse(&mut |inner| collect_forall_tparams(inner, acc));

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -1143,6 +1143,23 @@ def test(o: D):
 "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/2812
+testcase!(
+    test_bound_overload_assigned_to_attribute,
+    r#"
+from typing import assert_type
+
+class ThemeStack:
+    def __init__(self) -> None:
+        self._entries: list[dict[str, str]] = [{}]
+        self.get = self._entries[-1].get
+
+def test(stack: ThemeStack) -> None:
+    assert_type(stack.get("theme"), str | None)
+    assert_type(stack.get("theme", "fallback"), str)
+"#,
+);
+
 testcase!(
     test_attr_unknown,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2812

The cause was: invalid-type-var sanitization already exempted generic Forall methods, but it was not exempting generic overload signatures carried inside Overload and bound-method overloads. I added that handling there, so storing `dict[str, str].get` on an instance attribute no longer falsely reports leaked `_T`.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test