### PR TITLE
Add snapshot changed notification to TSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,6 +3559,7 @@ dependencies = [
  "lsp-server",
  "serde",
  "serde_json",
+ "serde_repr",
 ]
 
 [[package]]

--- a/crates/tsp_types/Cargo.toml
+++ b/crates/tsp_types/Cargo.toml
@@ -12,3 +12,4 @@ license = "MIT"
 lsp-server = "0.7.9"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
+serde_repr = "0.1"

--- a/crates/tsp_types/protocol_generator/generate_protocol.py
+++ b/crates/tsp_types/protocol_generator/generate_protocol.py
@@ -544,26 +544,28 @@ def fixup_request_in_content(content: str, request: model.Request) -> str:
         return content[:offset] + request_text + content[end_offset + 1 :]
 
 
+def find_block_end(content: str, idx: int) -> Optional[int]:
+    """Find the end of a brace-delimited block starting at the opening brace at `idx`."""
+    if idx < 0:
+        return None
+    depth = 0
+    i = idx
+    while i < len(content):
+        c = content[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return None
+
+
 # Helper to replace enum flags with newtype bitflag style
 
 
 def replace_flag_enum(content: str, name: str, mapping: Dict[str, int]) -> str:
-    def find_block_end(idx: int) -> Optional[int]:
-        if idx < 0:
-            return None
-        depth = 0
-        i = idx
-        while i < len(content):
-            c = content[i]
-            if c == "{":
-                depth += 1
-            elif c == "}":
-                depth -= 1
-                if depth == 0:
-                    return i + 1
-            i += 1
-        return None
-
     enum_marker = f"pub enum {name} "
     enum_start = content.find(enum_marker)
     if enum_start == -1:
@@ -572,7 +574,7 @@ def replace_flag_enum(content: str, name: str, mapping: Dict[str, int]) -> str:
         )
         return content
     enum_brace = content.find("{", enum_start)
-    enum_end = find_block_end(enum_brace)
+    enum_end = find_block_end(content, enum_brace)
     if enum_end is None:
         print(
             f"Warning: Could not find end of enum {name}, skipping flag enum replacement"
@@ -586,7 +588,7 @@ def replace_flag_enum(content: str, name: str, mapping: Dict[str, int]) -> str:
         )
         return content
     ser_brace = content.find("{", ser_start)
-    ser_end = find_block_end(ser_brace)
+    ser_end = find_block_end(content, ser_brace)
     if ser_end is None:
         print(
             f"Warning: Could not find end of Serialize impl for {name}, skipping flag enum replacement"
@@ -600,7 +602,7 @@ def replace_flag_enum(content: str, name: str, mapping: Dict[str, int]) -> str:
         )
         return content
     de_brace = content.find("{", de_start)
-    de_end = find_block_end(de_brace)
+    de_end = find_block_end(content, de_brace)
     if de_end is None:
         print(
             f"Warning: Could not find end of Deserialize impl for {name}, skipping flag enum replacement"
@@ -676,56 +678,141 @@ def replace_flag_enum(content: str, name: str, mapping: Dict[str, int]) -> str:
 
 
 def extract_flag_enums_from_tsp(tsp_json: Dict[str, Any]) -> Dict[str, Dict[str, int]]:
-    """
-    Extract flag enums from TSP JSON file.
+    """Extract flag enums from TSP JSON file.
 
-    A flag enum is identified by:
-    1. Having integer values
-    2. Having "Flags" in the name, OR
-    3. Having values that are powers of 2 (or 0), suggesting bitflag usage
+    A flag enum is identified by having `"isFlags": true` in its definition.
     """
     flag_enums = {}
 
     for enum_def in tsp_json.get("enumerations", []):
         enum_name = enum_def["name"]
 
-        # Check if this enum has integer values
-
         if enum_def.get("type", {}).get("name") != "integer":
             continue
-        # Extract value mappings
+        if not enum_def.get("isFlags", False):
+            continue
 
         mapping = {}
-        power_of_two_count = 0
-        zero_count = 0
-
         for value_def in enum_def["values"]:
-            name = value_def["name"]
-            value = value_def["value"]
-            mapping[name] = value
-
-            if value == 0:
-                zero_count += 1
-            elif value > 0 and (value & (value - 1)) == 0:
-                # This is a power of 2
-
-                power_of_two_count += 1
-        total_values = len(mapping)
-
-        # Determine if this is likely a flag enum:
-
-        is_flag_enum = False
-
-        # Strong indicator: name contains "Flags"
-
-        if "Flags" in enum_name:
-            is_flag_enum = True
-        # Special case: all values are powers of 2 or 0
-        elif total_values > 1 and (power_of_two_count + zero_count) == total_values:
-            is_flag_enum = True
-        if is_flag_enum:
-            flag_enums[enum_name] = mapping
+            mapping[value_def["name"]] = value_def["value"]
+        flag_enums[enum_name] = mapping
     return flag_enums
+
+
+def extract_integer_enums_from_tsp(
+    tsp_json: Dict[str, Any],
+) -> Dict[str, Dict[str, int]]:
+    """Extract non-flag integer enums from TSP JSON file.
+
+    These are integer enums with sequential (non-power-of-2) values,
+    used as discriminators (e.g., DeclarationCategory, TypeKind, DeclarationKind).
+    """
+    flag_enums = extract_flag_enums_from_tsp(tsp_json)
+    integer_enums = {}
+
+    for enum_def in tsp_json.get("enumerations", []):
+        enum_name = enum_def["name"]
+        if enum_def.get("type", {}).get("name") != "integer":
+            continue
+        if enum_name in flag_enums:
+            continue
+        mapping = {}
+        for value_def in enum_def["values"]:
+            mapping[value_def["name"]] = value_def["value"]
+        integer_enums[enum_name] = mapping
+    return integer_enums
+
+
+def replace_integer_enum(
+    content: str, name: str, mapping: Dict[str, int], tsp_json: Dict[str, Any]
+) -> str:
+    """Replace lsprotocol-generated integer enum with #[repr(u8)] + serde_repr.
+
+    The lsprotocol generator emits integer enums with custom Serialize/Deserialize
+    impls. We replace them with simpler #[repr(u8)] enums using serde_repr.
+    """
+
+    enum_marker = f"pub enum {name} "
+    enum_start = content.find(enum_marker)
+    if enum_start == -1:
+        print(
+            f"Warning: Enum {name} not found in content, skipping integer enum replacement"
+        )
+        return content
+    enum_brace = content.find("{", enum_start)
+    enum_end = find_block_end(content, enum_brace)
+    if enum_end is None:
+        print(
+            f"Warning: Could not find end of enum {name}, skipping integer enum replacement"
+        )
+        return content
+
+    # Find and remove Serialize/Deserialize impls generated by lsprotocol
+    ser_marker = f"impl Serialize for {name}"
+    ser_start = content.find(ser_marker, enum_end)
+    de_marker = f"impl<'de> Deserialize<'de> for {name}"
+
+    removal_end = enum_end
+    if ser_start != -1:
+        ser_brace = content.find("{", ser_start)
+        ser_end = find_block_end(content, ser_brace)
+        if ser_end is not None:
+            de_start = content.find(de_marker, ser_end)
+            if de_start != -1:
+                de_brace = content.find("{", de_start)
+                de_end = find_block_end(content, de_brace)
+                if de_end is not None:
+                    removal_end = de_end
+
+    # Capture doc comments preceding enum
+    doc_start = enum_start
+    line_start = content.rfind("\n", 0, enum_start) + 1
+    while line_start >= 0:
+        line = content[line_start:enum_start]
+        stripped = line.strip()
+        if (
+            stripped.startswith("///")
+            or stripped.startswith("#[derive")
+            or stripped == ""
+        ):
+            doc_start = line_start
+            if line_start == 0:
+                break
+            prev_line_end = content.rfind("\n", 0, line_start - 1)
+            if prev_line_end == -1:
+                line_start = 0
+            else:
+                line_start = prev_line_end + 1
+        else:
+            break
+
+    # Look up documentation from tsp.json
+    enum_doc = None
+    value_docs = {}
+    for enum_def in tsp_json.get("enumerations", []):
+        if enum_def["name"] == name:
+            enum_doc = enum_def.get("documentation")
+            for value_def in enum_def.get("values", []):
+                value_docs[value_def["name"]] = value_def.get("documentation")
+            break
+
+    lines: list[str] = []
+    if enum_doc:
+        lines.append(f"/// {enum_doc}")
+    lines.append(
+        "#[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug, Eq, Clone, Copy)]"
+    )
+    lines.append(f"#[repr(u8)]")
+    lines.append(f"pub enum {name} {{")
+    for variant_name, val in mapping.items():
+        doc = value_docs.get(variant_name)
+        rust_name = value_to_rust_identifier(variant_name)
+        if doc:
+            lines.append(f"    /// {doc}")
+        lines.append(f"    {rust_name} = {val},")
+    lines.append("}")
+    replacement = "\n" + "\n".join(lines) + "\n"
+    return content[:doc_start] + replacement + content[removal_end:]
 
 
 def generate_rust_protocol(tsp_json_path: str, output_dir: str) -> None:
@@ -830,13 +917,36 @@ def generate_rust_protocol(tsp_json_path: str, output_dir: str) -> None:
         for enum_name, mapping in flag_enums.items():
             content = replace_flag_enum(content, enum_name, mapping)
 
+        # Fixup integer enums (non-flag) - use #[repr(u8)] + serde_repr
+
+        integer_enums = extract_integer_enums_from_tsp(tsp_json)
+        if integer_enums:
+            # Add serde_repr imports after the allow directives
+            allow_marker = "#![allow(dead_code)]\n\n"
+            content = content.replace(
+                allow_marker,
+                allow_marker
+                + "use serde_repr::Deserialize_repr;\nuse serde_repr::Serialize_repr;\n\n",
+                1,
+            )
+            for enum_name, mapping in integer_enums.items():
+                content = replace_integer_enum(
+                    content, enum_name, mapping, tsp_json
+                )
+
         # Fix recursive types by adding Box indirection
         # The Type enum is recursive through BuiltInType.possible_type and others
         content = fix_recursive_types(content)
 
         target_protocol.write_text(content, encoding="utf-8")
         print(f"Successfully generated: {target_protocol}")
-        subprocess.run(["cargo", "fmt", "--", str(target_protocol)], check=False)
+        # Run cargo fmt from the crate root directory
+        crate_root = output_path
+        subprocess.run(
+            ["cargo", "fmt", "--", str(target_protocol)],
+            cwd=str(crate_root),
+            check=False,
+        )
     else:
         print(f"Warning: Generated lib.rs not found at {generated_lib}")
 

--- a/crates/tsp_types/protocol_generator/tsp.json
+++ b/crates/tsp_types/protocol_generator/tsp.json
@@ -6,6 +6,7 @@
         {
             "name": "TypeFlags",
             "type": {"kind": "base", "name": "integer"},
+            "isFlags": true,
             "documentation": "Flags that describe the characteristics of a type. These flags can be combined using bitwise operations.",
             "values": [
                 {"name": "None", "value": 0, "documentation": "No flags set."},
@@ -19,6 +20,47 @@
                 {"name": "Unpacked", "value": 128, "documentation": "Indicates if the type is unpacked (used with TypeVarTuple)."},
                 {"name": "Optional", "value": 256, "documentation": "Indicates if the type is optional (used with Tuple type arguments)."},
                 {"name": "Unbound", "value": 512, "documentation": "Indicates if the type is unbound (used with *args in tuple type arguments)."}
+            ]
+        },
+        {
+            "name": "DeclarationCategory",
+            "type": {"kind": "base", "name": "integer"},
+            "documentation": "Represents the category of a declaration in the type system. This is used to classify declarations such as variables, functions, classes, etc.",
+            "values": [
+                {"name": "Intrinsic", "value": 0, "documentation": "An intrinsic refers to a symbol that has no actual declaration in the source code, such as built-in types or functions. One such example is a '__class__' declaration."},
+                {"name": "Variable", "value": 1, "documentation": "A variable is a named storage location that can hold a value."},
+                {"name": "Param", "value": 2, "documentation": "A parameter is a variable that is passed to a function or method."},
+                {"name": "TypeParam", "value": 3, "documentation": "This is for PEP 695 type parameters."},
+                {"name": "TypeAlias", "value": 4, "documentation": "This is for PEP 695 type aliases."},
+                {"name": "Function", "value": 5, "documentation": "A function is any construct that begins with the `def` keyword and has a body, which can be called with arguments."},
+                {"name": "Class", "value": 6, "documentation": "A class is any construct that begins with the `class` keyword and has a body, which can be instantiated."},
+                {"name": "Import", "value": 7, "documentation": "An import declaration, which is a reference to another module."}
+            ]
+        },
+        {
+            "name": "TypeKind",
+            "type": {"kind": "base", "name": "integer"},
+            "documentation": "Discriminator for the Type union, identifying which variant a type is.",
+            "values": [
+                {"name": "BuiltIn", "value": 0, "documentation": "unknown, any, never, etc."},
+                {"name": "Declared", "value": 1, "documentation": "Base for source-declared types (rarely used directly)"},
+                {"name": "Function", "value": 2, "documentation": "Functions and methods from def statements"},
+                {"name": "Class", "value": 3, "documentation": "Classes from class statements"},
+                {"name": "Union", "value": 4, "documentation": "int | str | None"},
+                {"name": "Module", "value": 5, "documentation": "import os -> os is ModuleType"},
+                {"name": "TypeVar", "value": 6, "documentation": "T, P, Ts in generics"},
+                {"name": "Overloaded", "value": 7, "documentation": "Functions with multiple @overload signatures"},
+                {"name": "Synthesized", "value": 8, "documentation": "Types that are synthesized by the type checker"},
+                {"name": "TypeReference", "value": 9, "documentation": "Reference by ID for deduplication"}
+            ]
+        },
+        {
+            "name": "DeclarationKind",
+            "type": {"kind": "base", "name": "integer"},
+            "documentation": "Discriminator for Declaration variants.",
+            "values": [
+                {"name": "Regular", "value": 0, "documentation": "Declaration exists in source code with AST node"},
+                {"name": "Synthesized", "value": 1, "documentation": "Declaration created by type checker (no source node)"}
             ]
         }
     ],
@@ -266,56 +308,6 @@
                 "v0_2_0": "Added new request types and fields",
                 "v0_3_0": "Switch to more complex types",
                 "current": "Switch to Type union and using stubs"
-            }
-        },
-        "DeclarationCategory": {
-            "kind": "stringLiteral",
-            "value": ["Intrinsic", "Variable", "Param", "TypeParam", "TypeAlias", "Function", "Class", "Import"],
-            "documentation": "Represents the category of a declaration in the type system. This is used to classify declarations such as variables, functions, classes, etc.",
-            "valueDocumentation": {
-                "Intrinsic": "An intrinsic refers to a symbol that has no actual declaration in the source code, such as built-in types or functions. One such example is a '__class__' declaration.",
-                "Variable": "A variable is a named storage location that can hold a value.",
-                "Param": "A parameter is a variable that is passed to a function or method.",
-                "TypeParam": "This is for PEP 695 type parameters.",
-                "TypeAlias": "This is for PEP 695 type aliases.",
-                "Function": "A function is any construct that begins with the `def` keyword and has a body, which can be called with arguments.",
-                "Class": "A class is any construct that begins with the `class` keyword and has a body, which can be instantiated.",
-                "Import": "An import declaration, which is a reference to another module."
-            }
-        },
-        "TypeKind": {
-            "kind": "stringLiteral",
-            "value": [
-                "BuiltIn",
-                "Declared",
-                "Function",
-                "Class",
-                "Union",
-                "Module",
-                "TypeVar",
-                "Overloaded",
-                "Synthesized",
-                "TypeReference"
-            ],
-            "valueDocumentation": {
-                "BuiltIn": "unknown, any, never, etc.",
-                "Declared": "Base for source-declared types (rarely used directly)",
-                "Function": "Functions and methods from def statements",
-                "Class": "Classes from class statements",
-                "Union": "int | str | None",
-                "Module": "import os -> os is ModuleType",
-                "TypeVar": "T, P, Ts in generics",
-                "Overloaded": "Functions with multiple @overload signatures",
-                "Synthesized": "Types that are synthesized by the type checker",
-                "TypeReference": "Reference by ID for deduplication"
-            }
-        },
-        "DeclarationKind": {
-            "kind": "stringLiteral",
-            "value": ["Regular", "Synthesized"],
-            "valueDocumentation": {
-                "Regular": "Declaration exists in source code with AST node",
-                "Synthesized": "Declaration created by type checker (no source node)"
             }
         },
         "Variance": {
@@ -591,13 +583,13 @@
                     "name": "kind",
                     "type": {
                         "kind": "reference",
-                        "name": "T"
+                        "name": "DeclarationKind"
                     },
                     "optional": false,
                     "documentation": "Discriminator field that determines which declaration variant this is. Regular: Has source code and AST node Synthesized: Created by type checker, no source node"
                 }
             ],
-            "documentation": "Base interface for all declaration types. Provides the discriminator field for the Declaration union. This is a generic interface that is extended by: - RegularDeclaration (kind = Regular) - SynthesizedDeclaration (kind = Synthesized) The type parameter T ensures that the kind field matches the implementing interface. Used for type-safe discrimination: ```typescript if (declaration.kind === DeclarationKind.Regular) { // TypeScript knows this is RegularDeclaration const node = declaration.node; } ```"
+            "documentation": "Base interface for all declaration types. Provides the discriminator field for the Declaration union."
         },
         "RegularDeclaration": {
             "kind": "interface",
@@ -771,7 +763,7 @@
                     "name": "kind",
                     "type": {
                         "kind": "reference",
-                        "name": "T"
+                        "name": "TypeKind"
                     },
                     "optional": false,
                     "documentation": "Discriminator field that determines which Type variant this is. Used for type narrowing when processing Type unions. Example: `if (type.kind === TypeKind.BuiltIn) { ... }`"

--- a/crates/tsp_types/src/protocol.rs
+++ b/crates/tsp_types/src/protocol.rs
@@ -13,9 +13,10 @@
 // 1. Create tsp.json and tsp.schema.json from typeServerProtocol.ts
 // 2. Install lsprotocol generator: `pip install git+https://github.com/microsoft/lsprotocol.git`
 // 3. Run: `python generate_protocol.py`
-
 use serde::Deserialize;
 use serde::Serialize;
+use serde_repr::Deserialize_repr;
+use serde_repr::Serialize_repr;
 
 /// This type allows extending any string enum to support custom values.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
@@ -173,25 +174,6 @@ pub enum MessageDirection {
     ServerToClient,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
-pub enum TypeServerVersion {
-    /// Initial protocol version
-    #[serde(rename = "0.1.0")]
-    V010,
-
-    /// Added new request types and fields
-    #[serde(rename = "0.2.0")]
-    V020,
-
-    /// Switch to more complex types
-    #[serde(rename = "0.3.0")]
-    V030,
-
-    /// Switch to Type union and using stubs
-    #[serde(rename = "0.4.0")]
-    Current,
-}
-
 /// Flags that describe the characteristics of a type. These flags can be combined using bitwise operations.
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct TypeFlags(pub i32);
@@ -292,93 +274,80 @@ impl std::ops::BitAnd for TypeFlags {
 }
 
 /// Represents the category of a declaration in the type system. This is used to classify declarations such as variables, functions, classes, etc.
-#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug, Eq, Clone, Copy)]
+#[repr(u8)]
 pub enum DeclarationCategory {
     /// An intrinsic refers to a symbol that has no actual declaration in the source code, such as built-in types or functions. One such example is a '__class__' declaration.
-    #[serde(rename = "Intrinsic")]
-    Intrinsic,
-
+    Intrinsic = 0,
     /// A variable is a named storage location that can hold a value.
-    #[serde(rename = "Variable")]
-    Variable,
-
+    Variable = 1,
     /// A parameter is a variable that is passed to a function or method.
-    #[serde(rename = "Param")]
-    Param,
-
+    Param = 2,
     /// This is for PEP 695 type parameters.
-    #[serde(rename = "TypeParam")]
-    Typeparam,
-
+    Typeparam = 3,
     /// This is for PEP 695 type aliases.
-    #[serde(rename = "TypeAlias")]
-    Typealias,
-
+    Typealias = 4,
     /// A function is any construct that begins with the `def` keyword and has a body, which can be called with arguments.
-    #[serde(rename = "Function")]
-    Function,
-
+    Function = 5,
     /// A class is any construct that begins with the `class` keyword and has a body, which can be instantiated.
-    #[serde(rename = "Class")]
-    Class,
-
+    Class = 6,
     /// An import declaration, which is a reference to another module.
-    #[serde(rename = "Import")]
-    Import,
+    Import = 7,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+/// Discriminator for the Type union, identifying which variant a type is.
+#[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug, Eq, Clone, Copy)]
+#[repr(u8)]
 pub enum TypeKind {
     /// unknown, any, never, etc.
-    #[serde(rename = "BuiltIn")]
-    Builtin,
-
+    Builtin = 0,
     /// Base for source-declared types (rarely used directly)
-    #[serde(rename = "Declared")]
-    Declared,
-
+    Declared = 1,
     /// Functions and methods from def statements
-    #[serde(rename = "Function")]
-    Function,
-
+    Function = 2,
     /// Classes from class statements
-    #[serde(rename = "Class")]
-    Class,
-
+    Class = 3,
     /// int | str | None
-    #[serde(rename = "Union")]
-    Union,
-
+    Union = 4,
     /// import os -> os is ModuleType
-    #[serde(rename = "Module")]
-    Module,
-
+    Module = 5,
     /// T, P, Ts in generics
-    #[serde(rename = "TypeVar")]
-    Typevar,
-
+    Typevar = 6,
     /// Functions with multiple @overload signatures
-    #[serde(rename = "Overloaded")]
-    Overloaded,
-
+    Overloaded = 7,
     /// Types that are synthesized by the type checker
-    #[serde(rename = "Synthesized")]
-    Synthesized,
-
+    Synthesized = 8,
     /// Reference by ID for deduplication
-    #[serde(rename = "TypeReference")]
-    Typereference,
+    Typereference = 9,
+}
+
+/// Discriminator for Declaration variants.
+#[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug, Eq, Clone, Copy)]
+#[repr(u8)]
+pub enum DeclarationKind {
+    /// Declaration exists in source code with AST node
+    Regular = 0,
+    /// Declaration created by type checker (no source node)
+    Synthesized = 1,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
-pub enum DeclarationKind {
-    /// Declaration exists in source code with AST node
-    #[serde(rename = "Regular")]
-    Regular,
+pub enum TypeServerVersion {
+    /// Initial protocol version
+    #[serde(rename = "0.1.0")]
+    V010,
 
-    /// Declaration created by type checker (no source node)
-    #[serde(rename = "Synthesized")]
-    Synthesized,
+    /// Added new request types and fields
+    #[serde(rename = "0.2.0")]
+    V020,
+
+    /// Switch to more complex types
+    #[serde(rename = "0.3.0")]
+    V030,
+
+    /// Switch to Type union and using stubs
+    #[serde(rename = "0.4.0")]
+    Current,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
@@ -541,12 +510,12 @@ pub struct SentinelLiteral {
     pub module_name: String,
 }
 
-/// Base interface for all declaration types. Provides the discriminator field for the Declaration union. This is a generic interface that is extended by: - RegularDeclaration (kind = Regular) - SynthesizedDeclaration (kind = Synthesized) The type parameter T ensures that the kind field matches the implementing interface. Used for type-safe discrimination: ```typescript if (declaration.kind === DeclarationKind.Regular) { // TypeScript knows this is RegularDeclaration const node = declaration.node; } ```
+/// Base interface for all declaration types. Provides the discriminator field for the Declaration union.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DeclarationBase {
     /// Discriminator field that determines which declaration variant this is. Regular: Has source code and AST node Synthesized: Created by type checker, no source node
-    pub kind: String,
+    pub kind: DeclarationKind,
 }
 
 /// Represents a declaration that exists in source code. Points to the actual AST node where a symbol is declared. Fields: - category: Type of declaration (Variable, Function, Class, etc.) - node: AST node pointing to the declaration location - name: Name of the declared symbol (undefined for anonymous/implicit declarations) Examples: ```python def my_function(x: int) -> str:  # Function declaration return str(x) class MyClass:  # Class declaration x: int      # Variable declaration T = TypeVar('T')  # TypeParam declaration ```
@@ -557,7 +526,7 @@ pub struct RegularDeclaration {
     pub category: DeclarationCategory,
 
     /// Discriminator field that determines which declaration variant this is. Regular: Has source code and AST node Synthesized: Created by type checker, no source node
-    pub kind: String,
+    pub kind: DeclarationKind,
 
     /// Name of the declared symbol, or undefined for anonymous declarations. Example: "foo" for `def foo():`, undefined for lambda functions.
     pub name: Option<String>,
@@ -571,7 +540,7 @@ pub struct RegularDeclaration {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SynthesizedDeclaration {
     /// Discriminator field that determines which declaration variant this is. Regular: Has source code and AST node Synthesized: Created by type checker, no source node
-    pub kind: String,
+    pub kind: DeclarationKind,
 
     /// URI of the file where this symbol is conceptually declared. For built-ins, this might be a special URI; for decorator-generated code, it's the file containing the decorator. Example: File URI of a @dataclass-decorated class for synthesized __init__.
     pub uri: String,
@@ -620,7 +589,7 @@ pub struct TypeBase {
     pub id: i32,
 
     /// Discriminator field that determines which Type variant this is. Used for type narrowing when processing Type unions. Example: `if (type.kind === TypeKind.BuiltIn) { ... }`
-    pub kind: String,
+    pub kind: TypeKind,
 
     /// Information about type aliases. Present when this type was created from a type alias. Contains the alias name, module, file location, type parameters, and type arguments. Example: `type MyList = list[int]` - typeAliasInfo contains name="MyList", typeArgs=[int]
     pub type_alias_info: Option<TypeAliasInfo>,
@@ -640,7 +609,7 @@ pub struct BuiltInType {
     pub id: i32,
 
     /// Discriminator field that determines which Type variant this is. Used for type narrowing when processing Type unions. Example: `if (type.kind === TypeKind.BuiltIn) { ... }`
-    pub kind: String,
+    pub kind: TypeKind,
 
     /// The name of the built-in type. Limited to specific known built-in types. 'unknown': Type cannot be determined 'any': Accepts any value (gradual typing) 'unbound': Variable not yet bound to a value 'ellipsis': The ... literal 'never': Type that never occurs (e.g., function that always raises) 'noreturn': Function that doesn't return (alias for never)
     pub name: String,
@@ -666,7 +635,7 @@ pub struct DeclaredType {
     pub id: i32,
 
     /// Discriminator field that determines which Type variant this is. Used for type narrowing when processing Type unions. Example: `if (type.kind === TypeKind.BuiltIn) { ... }`
-    pub kind: String,
+    pub kind: TypeKind,
 
     /// Information about type aliases. Present when this type was created from a type alias. Contains the alias name, module, file location, type parameters, and type arguments. Example: `type MyList = list[int]` - typeAliasInfo contains name="MyList", typeArgs=[int]
     pub type_alias_info: Option<TypeAliasInfo>,
@@ -689,7 +658,7 @@ pub struct FunctionType {
     pub id: i32,
 
     /// Discriminator field that determines which Type variant this is. Used for type narrowing when processing Type unions. Example: `if (type.kind === TypeKind.BuiltIn) { ... }`
-    pub kind: String,
+    pub kind: TypeKind,
 
     /// The return type annotation of the function. Example: In `def foo() -> int:`, returnType is the int type.
     pub return_type: Option<Box<Type>>,
@@ -715,7 +684,7 @@ pub struct ClassType {
     pub id: i32,
 
     /// Discriminator field that determines which Type variant this is. Used for type narrowing when processing Type unions. Example: `if (type.kind === TypeKind.BuiltIn) { ... }`
-    pub kind: String,
+    pub kind: TypeKind,
 
     /// The literal value if this class represents a literal (e.g., int literal 42, str literal "hello"). Can be a primitive value, enum member, or sentinel object. Example: For the literal `42`, literalValue = 42.
     pub literal_value: Option<LiteralValue>,
@@ -738,7 +707,7 @@ pub struct UnionType {
     pub id: i32,
 
     /// Discriminator field that determines which Type variant this is. Used for type narrowing when processing Type unions. Example: `if (type.kind === TypeKind.BuiltIn) { ... }`
-    pub kind: String,
+    pub kind: TypeKind,
 
     /// Array of types that make up this union. Example: For `int | str | None`, subTypes = [int, str, None].
     pub sub_types: Vec<Type>,
@@ -758,7 +727,7 @@ pub struct ModuleType {
     pub id: i32,
 
     /// Discriminator field that determines which Type variant this is. Used for type narrowing when processing Type unions. Example: `if (type.kind === TypeKind.BuiltIn) { ... }`
-    pub kind: String,
+    pub kind: TypeKind,
 
     /// Fully qualified name of the module. Example: "os.path" for the os.path module.
     pub module_name: String,
@@ -784,7 +753,7 @@ pub struct OverloadedType {
     pub implementation: Option<Box<Type>>,
 
     /// Discriminator field that determines which Type variant this is. Used for type narrowing when processing Type unions. Example: `if (type.kind === TypeKind.BuiltIn) { ... }`
-    pub kind: String,
+    pub kind: TypeKind,
 
     /// List of overload signatures for this overloaded function. Each overload represents a different way the function can be called. Example: For a function with @overload decorators, each overload is in this array.
     pub overloads: Vec<Type>,
@@ -813,7 +782,7 @@ pub struct SynthesizedType {
     pub id: i32,
 
     /// Discriminator field that determines which Type variant this is. Used for type narrowing when processing Type unions. Example: `if (type.kind === TypeKind.BuiltIn) { ... }`
-    pub kind: String,
+    pub kind: TypeKind,
 
     pub metadata: SynthesizedTypeMetadata,
 
@@ -834,7 +803,7 @@ pub struct TypeReferenceType {
     pub id: i32,
 
     /// Discriminator field that determines which Type variant this is. Used for type narrowing when processing Type unions. Example: `if (type.kind === TypeKind.BuiltIn) { ... }`
-    pub kind: String,
+    pub kind: TypeKind,
 
     /// Information about type aliases. Present when this type was created from a type alias. Contains the alias name, module, file location, type parameters, and type arguments. Example: `type MyList = list[int]` - typeAliasInfo contains name="MyList", typeArgs=[int]
     pub type_alias_info: Option<TypeAliasInfo>,

--- a/crates/tsp_types/tests/protocol_types.rs
+++ b/crates/tsp_types/tests/protocol_types.rs
@@ -18,19 +18,19 @@ use tsp_types::*;
 fn test_type_kind_serialization() {
     let kind = TypeKind::Builtin;
     let json = serde_json::to_value(&kind).unwrap();
-    assert_eq!(json, serde_json::json!("BuiltIn"));
+    assert_eq!(json, serde_json::json!(0));
 
     let kind = TypeKind::Function;
     let json = serde_json::to_value(&kind).unwrap();
-    assert_eq!(json, serde_json::json!("Function"));
+    assert_eq!(json, serde_json::json!(2));
 }
 
 #[test]
 fn test_type_kind_deserialization() {
-    let kind: TypeKind = serde_json::from_str(r#""Class""#).unwrap();
+    let kind: TypeKind = serde_json::from_str("3").unwrap();
     assert_eq!(kind, TypeKind::Class);
 
-    let kind: TypeKind = serde_json::from_str(r#""Union""#).unwrap();
+    let kind: TypeKind = serde_json::from_str("4").unwrap();
     assert_eq!(kind, TypeKind::Union);
 }
 
@@ -47,7 +47,7 @@ fn test_declaration_kind_round_trip() {
 fn test_declaration_category_serialization() {
     let cat = DeclarationCategory::Function;
     let json = serde_json::to_value(&cat).unwrap();
-    assert_eq!(json, serde_json::json!("Function"));
+    assert_eq!(json, serde_json::json!(5));
 }
 
 #[test]
@@ -113,7 +113,7 @@ fn regular_decl(
     uri: &str,
 ) -> RegularDeclaration {
     RegularDeclaration {
-        kind: "Regular".to_owned(),
+        kind: DeclarationKind::Regular,
         category,
         name: name.map(|s| s.to_owned()),
         node: node(uri, 0, 0, 0, 10),
@@ -213,7 +213,7 @@ fn test_resolve_import_params_serialization() {
 #[test]
 fn test_regular_declaration_has_base_kind() {
     let decl = regular_decl(DeclarationCategory::Function, Some("foo"), "file:///a.py");
-    assert_eq!(decl.kind, "Regular");
+    assert_eq!(decl.kind, DeclarationKind::Regular);
     assert_eq!(decl.category, DeclarationCategory::Function);
     assert_eq!(decl.name, Some("foo".to_owned()));
 }
@@ -222,8 +222,8 @@ fn test_regular_declaration_has_base_kind() {
 fn test_regular_declaration_serialization() {
     let decl = regular_decl(DeclarationCategory::Variable, Some("x"), "file:///a.py");
     let json = serde_json::to_value(&decl).unwrap();
-    assert_eq!(json["kind"], "Regular");
-    assert_eq!(json["category"], "Variable");
+    assert_eq!(json["kind"], 0);
+    assert_eq!(json["category"], 1);
     assert_eq!(json["name"], "x");
     assert!(json["node"].is_object());
 
@@ -234,13 +234,13 @@ fn test_regular_declaration_serialization() {
 #[test]
 fn test_synthesized_declaration_has_base_kind() {
     let decl = SynthesizedDeclaration {
-        kind: "Synthesized".to_owned(),
+        kind: DeclarationKind::Synthesized,
         uri: "file:///builtins.pyi".to_owned(),
     };
-    assert_eq!(decl.kind, "Synthesized");
+    assert_eq!(decl.kind, DeclarationKind::Synthesized);
 
     let json = serde_json::to_value(&decl).unwrap();
-    assert_eq!(json["kind"], "Synthesized");
+    assert_eq!(json["kind"], 1);
     assert_eq!(json["uri"], "file:///builtins.pyi");
 }
 
@@ -252,7 +252,7 @@ fn test_synthesized_declaration_has_base_kind() {
 fn test_builtin_type_has_base_fields() {
     let t = BuiltInType {
         id: 1,
-        kind: "BuiltIn".to_owned(),
+        kind: TypeKind::Builtin,
         flags: TypeFlags::INSTANCE,
         type_alias_info: None,
         name: "int".to_owned(),
@@ -261,7 +261,7 @@ fn test_builtin_type_has_base_fields() {
     };
     // TypeBase fields are present
     assert_eq!(t.id, 1);
-    assert_eq!(t.kind, "BuiltIn");
+    assert_eq!(t.kind, TypeKind::Builtin);
     assert_eq!(t.flags, TypeFlags::INSTANCE);
     assert!(t.type_alias_info.is_none());
     // Own fields
@@ -272,7 +272,7 @@ fn test_builtin_type_has_base_fields() {
 fn test_builtin_type_serialization_round_trip() {
     let t = BuiltInType {
         id: 42,
-        kind: "BuiltIn".to_owned(),
+        kind: TypeKind::Builtin,
         flags: TypeFlags::NONE,
         type_alias_info: None,
         name: "unknown".to_owned(),
@@ -281,7 +281,7 @@ fn test_builtin_type_serialization_round_trip() {
     };
     let json = serde_json::to_value(&t).unwrap();
     assert_eq!(json["id"], 42);
-    assert_eq!(json["kind"], "BuiltIn");
+    assert_eq!(json["kind"], 0);
     assert_eq!(json["flags"], 0);
     assert_eq!(json["name"], "unknown");
 
@@ -294,7 +294,7 @@ fn test_union_type_serialization() {
     // Build a union of two built-in types
     let int_type = Type::BuiltInType(BuiltInType {
         id: 1,
-        kind: "BuiltIn".to_owned(),
+        kind: TypeKind::Builtin,
         flags: TypeFlags::INSTANCE,
         type_alias_info: None,
         name: "int".to_owned(),
@@ -303,7 +303,7 @@ fn test_union_type_serialization() {
     });
     let str_type = Type::BuiltInType(BuiltInType {
         id: 2,
-        kind: "BuiltIn".to_owned(),
+        kind: TypeKind::Builtin,
         flags: TypeFlags::INSTANCE,
         type_alias_info: None,
         name: "str".to_owned(),
@@ -312,13 +312,13 @@ fn test_union_type_serialization() {
     });
     let union = UnionType {
         id: 3,
-        kind: "Union".to_owned(),
+        kind: TypeKind::Union,
         flags: TypeFlags::INSTANCE,
         type_alias_info: None,
         sub_types: vec![int_type, str_type],
     };
     let json = serde_json::to_value(&union).unwrap();
-    assert_eq!(json["kind"], "Union");
+    assert_eq!(json["kind"], 4);
     assert_eq!(json["subTypes"].as_array().unwrap().len(), 2);
 
     let back: UnionType = serde_json::from_value(json).unwrap();
@@ -329,7 +329,7 @@ fn test_union_type_serialization() {
 fn test_module_type_serialization() {
     let m = ModuleType {
         id: 10,
-        kind: "Module".to_owned(),
+        kind: TypeKind::Module,
         flags: TypeFlags::NONE,
         type_alias_info: None,
         module_name: "os.path".to_owned(),
@@ -337,7 +337,7 @@ fn test_module_type_serialization() {
     };
     let json = serde_json::to_value(&m).unwrap();
     assert_eq!(json["moduleName"], "os.path");
-    assert_eq!(json["kind"], "Module");
+    assert_eq!(json["kind"], 5);
 
     let back: ModuleType = serde_json::from_value(json).unwrap();
     assert_eq!(back, m);
@@ -347,7 +347,7 @@ fn test_module_type_serialization() {
 fn test_type_reference_type_serialization() {
     let r = TypeReferenceType {
         id: 99,
-        kind: "TypeReference".to_owned(),
+        kind: TypeKind::Typereference,
         flags: TypeFlags::NONE,
         type_alias_info: None,
         type_reference_id: 1,
@@ -459,7 +459,7 @@ fn test_literal_value_bool() {
 fn test_enum_literal_serialization() {
     let int_type = Type::BuiltInType(BuiltInType {
         id: 1,
-        kind: "BuiltIn".to_owned(),
+        kind: TypeKind::Builtin,
         flags: TypeFlags::INSTANCE,
         type_alias_info: None,
         name: "int".to_owned(),

--- a/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
@@ -10,6 +10,7 @@
 
 use lsp_types::Url;
 use tempfile::TempDir;
+use tsp_types::TypeKind;
 
 use crate::test::tsp::tsp_interaction::object_model::TspInteraction;
 use crate::test::tsp::tsp_interaction::object_model::get_current_snapshot;
@@ -37,14 +38,15 @@ fn setup_project(file_content: &str) -> (TspInteraction, String, i32) {
 }
 
 /// Helper to extract the "kind" field from a type query result.
-fn assert_kind(result: &serde_json::Value, expected_kind: &str) {
+fn assert_kind(result: &serde_json::Value, expected_kind: TypeKind) {
     let kind = result
         .get("kind")
-        .and_then(|v| v.as_str())
-        .unwrap_or_else(|| panic!("Expected 'kind' field in type result: {result}"));
+        .and_then(|v| v.as_u64())
+        .unwrap_or_else(|| panic!("Expected 'kind' field (integer) in type result: {result}"));
+    let expected = expected_kind as u64;
     assert_eq!(
-        kind, expected_kind,
-        "Expected kind={expected_kind}, got kind={kind} in: {result}"
+        kind, expected,
+        "Expected kind={expected_kind:?} ({expected}), got kind={kind} in: {result}"
     );
 }
 
@@ -87,7 +89,7 @@ fn test_get_declared_type_int_annotation() {
     );
     let result = resp.result.expect("Expected result");
     assert!(!result.is_null(), "Expected non-null type");
-    assert_kind(&result, "Class");
+    assert_kind(&result, TypeKind::Class);
 
     tsp.shutdown();
 }
@@ -141,7 +143,7 @@ fn test_get_computed_type_int_is_class() {
     let (mut tsp, file_uri, snapshot) = setup_project("x = 42\n");
 
     let result = get_computed_type_ok(&mut tsp, &file_uri, 0, 0, snapshot);
-    assert_kind(&result, "Class");
+    assert_kind(&result, TypeKind::Class);
 
     // Literal types carry a literalValue field
     let literal_value = result.get("literalValue");
@@ -164,7 +166,7 @@ fn test_get_computed_type_string_is_class() {
     let (mut tsp, file_uri, snapshot) = setup_project("s = \"hello\"\n");
 
     let result = get_computed_type_ok(&mut tsp, &file_uri, 0, 0, snapshot);
-    assert_kind(&result, "Class");
+    assert_kind(&result, TypeKind::Class);
 
     let literal_value = result.get("literalValue");
     assert!(
@@ -185,7 +187,7 @@ fn test_get_computed_type_none_is_builtin() {
     let (mut tsp, file_uri, snapshot) = setup_project("x = None\n");
 
     let result = get_computed_type_ok(&mut tsp, &file_uri, 0, 0, snapshot);
-    assert_kind(&result, "BuiltIn");
+    assert_kind(&result, TypeKind::Builtin);
 
     let name = result.get("name").and_then(|v| v.as_str());
     assert_eq!(name, Some("none"), "Expected builtin name 'none'");
@@ -198,7 +200,7 @@ fn test_get_computed_type_bool_is_class() {
     let (mut tsp, file_uri, snapshot) = setup_project("b = True\n");
 
     let result = get_computed_type_ok(&mut tsp, &file_uri, 0, 0, snapshot);
-    assert_kind(&result, "Class");
+    assert_kind(&result, TypeKind::Class);
 
     tsp.shutdown();
 }
@@ -208,7 +210,7 @@ fn test_get_computed_type_list_is_class() {
     let (mut tsp, file_uri, snapshot) = setup_project("xs = [1, 2, 3]\n");
 
     let result = get_computed_type_ok(&mut tsp, &file_uri, 0, 0, snapshot);
-    assert_kind(&result, "Class");
+    assert_kind(&result, TypeKind::Class);
 
     let decl = result.get("declaration").expect("Expected declaration");
     let name = decl.get("name").and_then(|v| v.as_str());
@@ -225,7 +227,7 @@ fn test_get_computed_type_function_is_synthesized() {
 
     let result = get_computed_type_ok(&mut tsp, &file_uri, 0, 4, snapshot);
     // Function types are emitted as SynthesizedType with CALLABLE flag
-    assert_kind(&result, "Synthesized");
+    assert_kind(&result, TypeKind::Synthesized);
 
     let flags = result.get("flags").and_then(|v| v.as_i64());
     // CALLABLE = 4
@@ -248,10 +250,10 @@ fn test_get_computed_type_union_annotation() {
     // is a valid type with a known kind.
     let kind = result
         .get("kind")
-        .and_then(|v| v.as_str())
+        .and_then(|v| v.as_u64())
         .expect("Expected kind");
     assert!(
-        kind == "Class" || kind == "Union",
+        kind == TypeKind::Class as u64 || kind == TypeKind::Union as u64,
         "Expected Class or Union for union-annotated var, got {kind}"
     );
 
@@ -264,7 +266,7 @@ fn test_get_computed_type_class_definition() {
     let (mut tsp, file_uri, snapshot) = setup_project("class MyClass:\n    pass\n");
 
     let result = get_computed_type_ok(&mut tsp, &file_uri, 0, 6, snapshot);
-    assert_kind(&result, "Class");
+    assert_kind(&result, TypeKind::Class);
 
     // INSTANTIABLE = 1
     let flags = result.get("flags").and_then(|v| v.as_i64());
@@ -310,7 +312,7 @@ fn test_get_expected_type_str_annotation() {
     let result = resp.result.expect("Expected result");
     assert!(!result.is_null(), "Expected non-null type");
     // The variable `y` should have a Class kind
-    assert_kind(&result, "Class");
+    assert_kind(&result, TypeKind::Class);
 
     tsp.shutdown();
 }
@@ -349,9 +351,9 @@ fn test_all_three_methods_return_same_kind_for_simple_var() {
     let r3 = resp3.result.expect("expected result");
 
     // All should have the same kind
-    let kind1 = r1.get("kind").and_then(|v| v.as_str()).unwrap();
-    let kind2 = r2.get("kind").and_then(|v| v.as_str()).unwrap();
-    let kind3 = r3.get("kind").and_then(|v| v.as_str()).unwrap();
+    let kind1 = r1.get("kind").and_then(|v| v.as_u64()).unwrap();
+    let kind2 = r2.get("kind").and_then(|v| v.as_u64()).unwrap();
+    let kind3 = r3.get("kind").and_then(|v| v.as_u64()).unwrap();
     assert_eq!(kind1, kind2, "declared vs computed kind mismatch");
     assert_eq!(kind2, kind3, "computed vs expected kind mismatch");
 

--- a/pyrefly/lib/test/tsp/tsp_interaction/mod.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/mod.rs
@@ -13,3 +13,4 @@ pub mod get_supported_protocol_version;
 pub mod get_type_queries;
 pub mod object_model;
 pub mod resolve_import;
+pub mod snapshot_changed;

--- a/pyrefly/lib/test/tsp/tsp_interaction/object_model.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/object_model.rs
@@ -435,6 +435,33 @@ impl TestTspClient {
             }
         }
     }
+
+    /// Receive messages until a Notification with the given method is found,
+    /// skipping any other messages. Returns the notification params.
+    pub fn expect_notification(&self, method: &str) -> serde_json::Value {
+        loop {
+            match self.receiver.recv_timeout(self.timeout) {
+                Ok(msg) => {
+                    eprintln!(
+                        "client<---server {}",
+                        serde_json::to_string(&JsonRpcMessage::from_message(msg.clone())).unwrap()
+                    );
+                    if let Message::Notification(ref n) = msg {
+                        if n.method == method {
+                            return n.params.clone();
+                        }
+                    }
+                    // Skip non-matching messages
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    panic!("Timeout waiting for notification '{method}'");
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    panic!("Channel disconnected waiting for notification '{method}'");
+                }
+            }
+        }
+    }
 }
 
 pub struct TspInteraction {

--- a/pyrefly/lib/test/tsp/tsp_interaction/snapshot_changed.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/snapshot_changed.rs
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Tests for TSP snapshotChanged notification
+
+use tempfile::TempDir;
+
+use crate::test::tsp::tsp_interaction::object_model::TspInteraction;
+
+#[test]
+fn test_tsp_snapshot_changed_notification_on_recheck() {
+    // After opening a file and triggering an initial recheck, the client
+    // should receive a snapshotChanged notification.
+    let temp_dir = TempDir::new().unwrap();
+    let test_file_path = temp_dir.path().join("test.py");
+    std::fs::write(&test_file_path, "x = 1\n").unwrap();
+
+    let pyproject = "[project]\nname = \"test-project\"\nversion = \"1.0.0\"\n";
+    std::fs::write(temp_dir.path().join("pyproject.toml"), pyproject).unwrap();
+
+    let mut tsp = TspInteraction::new();
+    tsp.set_root(temp_dir.path().to_path_buf());
+    tsp.initialize(Default::default());
+
+    // Opening a file eventually triggers RecheckFinished which increments the
+    // snapshot and sends snapshotChanged.
+    tsp.server.did_open("test.py");
+
+    let params = tsp.client.expect_notification("typeServer/snapshotChanged");
+    // The notification params should contain old and new snapshot values.
+    let old_snapshot = params["old"].as_i64().expect("old should be an integer");
+    let new_snapshot = params["new"].as_i64().expect("new should be an integer");
+    // Snapshot starts at 0 in TspServer::new and this is the first event that
+    // triggers an increment, so old must be 0.
+    assert_eq!(old_snapshot, 0, "old snapshot should be 0 for first change");
+    assert!(
+        new_snapshot > 0,
+        "new snapshot should be positive after recheck"
+    );
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_tsp_snapshot_changed_notification_on_did_change() {
+    // A didChange notification should also trigger snapshotChanged.
+    let temp_dir = TempDir::new().unwrap();
+    let test_file_path = temp_dir.path().join("change.py");
+    std::fs::write(&test_file_path, "x = 1\n").unwrap();
+
+    let pyproject = "[project]\nname = \"test-project\"\nversion = \"1.0.0\"\n";
+    std::fs::write(temp_dir.path().join("pyproject.toml"), pyproject).unwrap();
+
+    let mut tsp = TspInteraction::new();
+    tsp.set_root(temp_dir.path().to_path_buf());
+    tsp.initialize(Default::default());
+
+    tsp.server.did_open("change.py");
+
+    // Consume the first snapshotChanged from the open/recheck
+    tsp.client.expect_notification("typeServer/snapshotChanged");
+
+    // Now send a didChange and expect another snapshotChanged
+    tsp.server.did_change("change.py", "x = 2\n", 2);
+
+    let params = tsp.client.expect_notification("typeServer/snapshotChanged");
+    let new_snapshot = params["new"].as_i64().expect("new should be an integer");
+    assert!(
+        new_snapshot > 1,
+        "new snapshot should be > 1 after second change"
+    );
+
+    tsp.shutdown();
+}

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -16,10 +16,14 @@ use pyrefly_util::telemetry::Telemetry;
 use pyrefly_util::telemetry::TelemetryEvent;
 use pyrefly_util::telemetry::TelemetryEventKind;
 use tracing::info;
+use tracing::warn;
 use tsp_types::GetTypeParams;
+use tsp_types::TSPNotificationMethods;
 use tsp_types::TSPRequests;
 
 use crate::commands::lsp::IndexingMode;
+use crate::lsp::non_wasm::protocol::Message;
+use crate::lsp::non_wasm::protocol::Notification;
 use crate::lsp::non_wasm::protocol::Request;
 use crate::lsp::non_wasm::protocol::Response;
 use crate::lsp::non_wasm::queue::LspEvent;
@@ -93,10 +97,39 @@ impl<T: TspInterface> TspServer<T> {
 
         // Increment snapshot after the inner server has processed the event
         if should_increment_snapshot && let Ok(mut current) = self.current_snapshot.lock() {
+            let old_snapshot = *current;
             *current += 1;
+            let new_snapshot = *current;
+            drop(current); // Release the lock before sending the notification
+            self.send_snapshot_changed_notification(old_snapshot, new_snapshot);
         }
 
         Ok(result)
+    }
+
+    /// Send a `typeServer/snapshotChanged` notification to the client.
+    ///
+    /// Called whenever the snapshot counter increments, so the client knows
+    /// any previously-returned types are stale.
+    fn send_snapshot_changed_notification(&self, old_snapshot: i32, new_snapshot: i32) {
+        let method = serde_json::to_value(TSPNotificationMethods::TypeServerSnapshotChanged)
+            .expect("TSPNotificationMethods serialization is infallible");
+        let method_str = method
+            .as_str()
+            .expect("TSPNotificationMethods serializes to a string")
+            .to_owned();
+
+        if let Err(e) = self
+            .inner
+            .sender()
+            .send(Message::Notification(Notification {
+                method: method_str,
+                params: serde_json::json!({ "old": old_snapshot, "new": new_snapshot }),
+                activity_key: None,
+            }))
+        {
+            warn!("Failed to send snapshotChanged notification: {e}");
+        }
     }
 
     fn handle_tsp_request<'a>(

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -36,6 +36,7 @@ use tsp_types::BuiltInType;
 use tsp_types::ClassType as TspClassType;
 use tsp_types::Declaration;
 use tsp_types::DeclarationCategory;
+use tsp_types::DeclarationKind;
 use tsp_types::LiteralValue;
 use tsp_types::ModuleType as TspModuleType;
 use tsp_types::Node;
@@ -47,23 +48,10 @@ use tsp_types::SynthesizedType;
 use tsp_types::SynthesizedTypeMetadata;
 use tsp_types::Type as TspType;
 use tsp_types::TypeFlags;
+use tsp_types::TypeKind;
 use tsp_types::UnionType;
 
 use crate::lsp::module_helpers::to_real_path;
-
-// ---------------------------------------------------------------------------
-// Wire-protocol discriminator values for the `kind` field.
-// These must match the serde rename values in the generated protocol types.
-// ---------------------------------------------------------------------------
-const KIND_BUILTIN: &str = "BuiltIn";
-const KIND_CLASS: &str = "Class";
-const KIND_UNION: &str = "Union";
-const KIND_MODULE: &str = "Module";
-const KIND_OVERLOADED: &str = "Overloaded";
-const KIND_SYNTHESIZED: &str = "Synthesized";
-
-/// Declaration kind for source-level declarations.
-const DECL_KIND_REGULAR: &str = "Regular";
 
 /// Monotonic counter used to assign unique ids to converted types.
 static NEXT_TYPE_ID: AtomicI32 = AtomicI32::new(1);
@@ -109,7 +97,7 @@ pub fn convert_type(ty: &PyreflyType) -> TspType {
             TspType::Union(UnionType {
                 flags: TypeFlags::NONE,
                 id: next_id(),
-                kind: KIND_UNION.to_owned(),
+                kind: TypeKind::Union,
                 sub_types,
                 type_alias_info: None,
             })
@@ -119,7 +107,7 @@ pub fn convert_type(ty: &PyreflyType) -> TspType {
         PyreflyType::Module(m) => TspType::Module(TspModuleType {
             flags: TypeFlags::NONE,
             id: next_id(),
-            kind: KIND_MODULE.to_owned(),
+            kind: TypeKind::Module,
             module_name: m.to_string(),
             type_alias_info: None,
             uri: String::new(),
@@ -134,7 +122,7 @@ pub fn convert_type(ty: &PyreflyType) -> TspType {
                     declaration: Declaration::Regular(declaration),
                     flags: TypeFlags::INSTANCE,
                     id: next_id(),
-                    kind: KIND_CLASS.to_owned(),
+                    kind: TypeKind::Class,
                     literal_value: None,
                     type_alias_info: None,
                     type_args: None,
@@ -162,7 +150,7 @@ pub fn convert_type(ty: &PyreflyType) -> TspType {
                 flags: TypeFlags::CALLABLE,
                 id: next_id(),
                 implementation: None,
-                kind: KIND_OVERLOADED.to_owned(),
+                kind: TypeKind::Overloaded,
                 overloads,
                 type_alias_info: None,
             })
@@ -210,7 +198,7 @@ fn convert_class_type(ct: &PyreflyClassType, flags: TypeFlags) -> TspType {
         declaration: Declaration::Regular(declaration),
         flags,
         id: next_id(),
-        kind: KIND_CLASS.to_owned(),
+        kind: TypeKind::Class,
         literal_value: None,
         type_alias_info: None,
         type_args,
@@ -226,7 +214,7 @@ fn convert_class_def(cls: &Class) -> TspType {
         declaration: Declaration::Regular(declaration),
         flags: TypeFlags::INSTANTIABLE,
         id: next_id(),
-        kind: KIND_CLASS.to_owned(),
+        kind: TypeKind::Class,
         literal_value: None,
         type_alias_info: None,
         type_args: None,
@@ -244,7 +232,7 @@ fn convert_literal(lit: &pyrefly_types::literal::Literal) -> TspType {
                 declaration: Declaration::Regular(declaration),
                 flags: TypeFlags::LITERAL,
                 id: next_id(),
-                kind: KIND_CLASS.to_owned(),
+                kind: TypeKind::Class,
                 literal_value: None,
                 type_alias_info: None,
                 type_args: None,
@@ -275,14 +263,14 @@ fn convert_literal(lit: &pyrefly_types::literal::Literal) -> TspType {
                 };
                 TspType::Class(TspClassType {
                     declaration: Declaration::Regular(RegularDeclaration {
-                        kind: DECL_KIND_REGULAR.to_owned(),
+                        kind: DeclarationKind::Regular,
                         category: DeclarationCategory::Variable,
                         name: None,
                         node: dummy_node,
                     }),
                     flags: TypeFlags::INSTANCE,
                     id: next_id(),
-                    kind: KIND_CLASS.to_owned(),
+                    kind: TypeKind::Class,
                     literal_value: Some(lv),
                     type_alias_info: None,
                     type_args: None,
@@ -314,12 +302,12 @@ fn convert_function(callable: &Callable, kind: &FunctionKind) -> TspType {
         TspType::Synthesized(SynthesizedType {
             flags: TypeFlags::CALLABLE,
             id: next_id(),
-            kind: KIND_SYNTHESIZED.to_owned(),
+            kind: TypeKind::Synthesized,
             metadata: SynthesizedTypeMetadata {
                 module: TspModuleType {
                     flags: TypeFlags::NONE,
                     id: next_id(),
-                    kind: KIND_MODULE.to_owned(),
+                    kind: TypeKind::Module,
                     module_name,
                     type_alias_info: None,
                     uri: module_uri,
@@ -334,7 +322,7 @@ fn convert_function(callable: &Callable, kind: &FunctionKind) -> TspType {
         TspType::Synthesized(SynthesizedType {
             flags: TypeFlags::CALLABLE,
             id: next_id(),
-            kind: KIND_SYNTHESIZED.to_owned(),
+            kind: TypeKind::Synthesized,
             metadata: empty_synthesized_metadata(),
             stub_content: format!("{kind:?}"),
             type_alias_info: None,
@@ -453,7 +441,7 @@ fn make_class_declaration(cls: &Class) -> RegularDeclaration {
 
     RegularDeclaration {
         category: DeclarationCategory::Class,
-        kind: DECL_KIND_REGULAR.to_owned(),
+        kind: DeclarationKind::Regular,
         name: Some(cls.name().to_string()),
         node: Node {
             range: lsp_range_to_tsp(lsp_range),
@@ -495,7 +483,7 @@ fn builtin(name: &str) -> TspType {
         declaration: None,
         flags: TypeFlags::NONE,
         id: next_id(),
-        kind: KIND_BUILTIN.to_owned(),
+        kind: TypeKind::Builtin,
         name: name.to_owned(),
         possible_type: None,
         type_alias_info: None,
@@ -509,7 +497,7 @@ fn synthesized(ty: &PyreflyType) -> TspType {
     TspType::Synthesized(SynthesizedType {
         flags: TypeFlags::INSTANCE,
         id: next_id(),
-        kind: KIND_SYNTHESIZED.to_owned(),
+        kind: TypeKind::Synthesized,
         metadata: empty_synthesized_metadata(),
         stub_content: display,
         type_alias_info: None,
@@ -522,7 +510,7 @@ fn empty_synthesized_metadata() -> SynthesizedTypeMetadata {
         module: TspModuleType {
             flags: TypeFlags::NONE,
             id: 0,
-            kind: KIND_MODULE.to_owned(),
+            kind: TypeKind::Module,
             module_name: String::new(),
             type_alias_info: None,
             uri: String::new(),
@@ -547,7 +535,7 @@ mod tests {
             TspType::BuiltInType(b) => {
                 assert_eq!(b.name, "any");
                 assert_eq!(b.flags, TypeFlags::NONE);
-                assert_eq!(b.kind, KIND_BUILTIN);
+                assert_eq!(b.kind, TypeKind::Builtin);
             }
             other => panic!("expected BuiltInType, got {other:?}"),
         }
@@ -647,7 +635,7 @@ mod tests {
         match tsp {
             TspType::Synthesized(s) => {
                 assert_eq!(s.flags, TypeFlags::INSTANCE);
-                assert_eq!(s.kind, KIND_SYNTHESIZED);
+                assert_eq!(s.kind, TypeKind::Synthesized);
             }
             other => panic!("expected SynthesizedType, got {other:?}"),
         }
@@ -663,7 +651,7 @@ mod tests {
         let tsp = convert_type(&union_ty);
         match tsp {
             TspType::Union(u) => {
-                assert_eq!(u.kind, KIND_UNION);
+                assert_eq!(u.kind, TypeKind::Union);
                 assert_eq!(u.flags, TypeFlags::NONE);
                 assert_eq!(u.sub_types.len(), 2);
                 // First member should be BuiltIn "none"
@@ -762,7 +750,10 @@ mod tests {
         let tsp = builtin("any");
         let json = serde_json::to_value(&tsp).unwrap();
         let obj = json.as_object().expect("expected JSON object");
-        assert_eq!(obj.get("kind").and_then(|v| v.as_str()), Some("BuiltIn"));
+        assert_eq!(
+            obj.get("kind").and_then(|v| v.as_u64()),
+            Some(TypeKind::Builtin as u64)
+        );
         assert_eq!(obj.get("name").and_then(|v| v.as_str()), Some("any"));
         assert!(obj.contains_key("id"));
         assert!(obj.contains_key("flags"));
@@ -775,7 +766,10 @@ mod tests {
         let tsp = convert_type(&union_ty);
         let json = serde_json::to_value(&tsp).unwrap();
         let obj = json.as_object().expect("expected JSON object");
-        assert_eq!(obj.get("kind").and_then(|v| v.as_str()), Some("Union"));
+        assert_eq!(
+            obj.get("kind").and_then(|v| v.as_u64()),
+            Some(TypeKind::Union as u64)
+        );
         let sub_types = obj
             .get("subTypes")
             .and_then(|v| v.as_array())
@@ -790,8 +784,8 @@ mod tests {
         let json = serde_json::to_value(&tsp).unwrap();
         let obj = json.as_object().expect("expected JSON object");
         assert_eq!(
-            obj.get("kind").and_then(|v| v.as_str()),
-            Some("Synthesized")
+            obj.get("kind").and_then(|v| v.as_u64()),
+            Some(TypeKind::Synthesized as u64)
         );
         assert!(
             obj.contains_key("stubContent"),


### PR DESCRIPTION
# Summary

Add a snapshot changed notification to the TSP implementation in Pyrefly. Also fix some of the kind fields to be integers instead of strings as that matches typescript.

I believe this is the last change for Pyrefly to work inside of Pylance as a TSP provider. I ran a bunch of TSP tests using Pylance and it seems to work for all of them.

# Test Plan

Added a bunch of unit and integration tests.

/cc @kinto0 