### PR TITLE
Fix race condition causing false primer deltas (#2823)

### DIFF
--- a/scripts/pyrefly_primer_wrapper.sh
+++ b/scripts/pyrefly_primer_wrapper.sh
@@ -18,35 +18,47 @@
 # The real pyrefly binary sits alongside this script with a "-real" suffix.
 REAL_PYREFLY="$(dirname "$0")/pyrefly-real"
 
-# Run init on the current working directory (mypy_primer sets cwd to the project dir).
-# --non-interactive ensures no stdin prompts; exit code is ignored since init may
-# legitimately fail (e.g., existing config) and we still want to proceed with check.
-"$REAL_PYREFLY" init --non-interactive . >/dev/null 2>&1 || true
+# mypy_primer runs old and new pyrefly concurrently (asyncio.gather) in the
+# same project directory.  Without serialization the two wrapper instances race
+# on pyrefly init (writes pyrefly.toml) and venv creation, producing false
+# primer deltas.  We use mkdir as a portable atomic lock to ensure only one
+# instance performs setup; the second waits, then reuses the results.
 
-# When PYREFLY_SCRIPTS_DIR is set, set up project deps and extract site-package
-# paths so pyrefly can resolve third-party imports.
-#
-# setup_primer_deps.py outputs one --site-package-path=... flag per line.
-# We use readarray to safely handle paths containing spaces.
-SITE_PATH_ARGS=()
-if [ -n "$PYREFLY_SCRIPTS_DIR" ]; then
-    PROJECT_NAME=$(basename "$(pwd)")
-    if [ ! -d ".venv" ]; then
-        readarray -t SITE_PATH_ARGS < <(
+
+# TODO/BE: cleaner solution is to run the setup/initialization steps once before running both old/new pyrefly binaries
+LOCKDIR=".pyrefly_primer.lock"
+
+if mkdir "$LOCKDIR" 2>/dev/null; then
+    # We won the lock — perform init + deps setup.
+    "$REAL_PYREFLY" init --non-interactive . >/dev/null 2>&1 || true
+
+    if [ -n "$PYREFLY_SCRIPTS_DIR" ]; then
+        PROJECT_NAME=$(basename "$(pwd)")
+        if [ ! -d ".venv" ]; then
             PYTHONPATH="$PYREFLY_SCRIPTS_DIR" python3 \
-                "$PYREFLY_SCRIPTS_DIR/setup_primer_deps.py" "$PROJECT_NAME" 2>/dev/null
-        )
-    else
-        if [ -f ".venv/bin/python" ]; then
-            readarray -t SITE_PATH_ARGS < <(
-                .venv/bin/python -c "
+                "$PYREFLY_SCRIPTS_DIR/setup_primer_deps.py" "$PROJECT_NAME" >/dev/null 2>&1 || true
+        fi
+    fi
+
+    # Signal that setup is complete.
+    touch "$LOCKDIR/done"
+else
+    # Another instance is running setup — wait for it to finish.
+    while [ ! -f "$LOCKDIR/done" ]; do
+        sleep 0.2
+    done
+fi
+
+# Extract site-package paths (read-only, safe to run after setup is complete).
+SITE_PATH_ARGS=()
+if [ -n "$PYREFLY_SCRIPTS_DIR" ] && [ -f ".venv/bin/python" ]; then
+    readarray -t SITE_PATH_ARGS < <(
+        .venv/bin/python -c "
 import site
 for p in site.getsitepackages():
     print('--site-package-path=' + p)
 "
-            )
-        fi
-    fi
+    )
 fi
 
 # Forward all original arguments to the real pyrefly binary


### PR DESCRIPTION
Summary:

mypy_primer runs old and new pyrefly concurrently via `asyncio.gather` in
the same project directory. The wrapper script (which runs `pyrefly init`
and installs deps via `setup_primer_deps.py`) was not safe for concurrent
execution: both instances would race on writing `pyrefly.toml` and
creating `.venv`, causing one run to get deps and the other to not, which produced massive deltas. We fix the race condition by adding a lock to the wrapper script.

Reviewed By: yangdanny97

Differential Revision: D97007184
