### PR TITLE
Preserve original type for unannotated passthrough decorators (#2825)

### DIFF
--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -46,6 +46,29 @@ pub struct Callable {
     pub ret: Type,
 }
 
+impl Callable {
+    /// Returns `true` if this callable looks like an unannotated passthrough wrapper,
+    /// i.e. it has only `*args` and/or `**kwargs` parameters with implicit `Any` types
+    /// and an implicit `Any` return type. This pattern arises from unannotated decorators
+    /// like `def wrapper(*args, **kwargs): return func(*args, **kwargs)`.
+    pub fn is_unannotated_passthrough(&self) -> bool {
+        if !self.ret.is_any() {
+            return false;
+        }
+        match &self.params {
+            Params::List(params) => {
+                let items = params.items();
+                !items.is_empty()
+                    && items.iter().all(|p| match p {
+                        Param::VarArg(_, ty) | Param::Kwargs(_, ty) => ty.is_any(),
+                        _ => false,
+                    })
+            }
+            _ => false,
+        }
+    }
+}
+
 impl Display for Callable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use crate::display::TypeDisplayContext;

--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -1043,6 +1043,17 @@ impl Type {
         matches!(self, Type::Any(_))
     }
 
+    /// Returns `true` if this type is an unannotated passthrough wrapper callable,
+    /// i.e. a function/callable with only `*args`/`**kwargs` params and all implicit
+    /// `Any` types. See `Callable::is_unannotated_passthrough`.
+    pub fn is_unannotated_passthrough(&self) -> bool {
+        match self {
+            Type::Function(f) => f.signature.is_unannotated_passthrough(),
+            Type::Callable(c) => c.is_unannotated_passthrough(),
+            _ => false,
+        }
+    }
+
     pub fn is_typed_dict(&self) -> bool {
         matches!(self, Type::TypedDict(_) | Type::PartialTypedDict(_))
     }

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -1324,6 +1324,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                 }
                 Type::ClassType(cls) if cls.has_qname("functools", "_Wrapped") => decoratee.clone(),
+                // Unannotated decorator passthrough: if the decorator returns a type that
+                // looks like an unannotated wrapper (only *args/**kwargs with implicit Any
+                // types), or a union containing such a wrapper, preserve the original
+                // function's type. This handles common patterns like dual-use decorators
+                // (usable as @deco or @deco(flag)) where the inferred return type is a
+                // union of the wrapper and the decorator factory, but the wrapper branch
+                // is just an unannotated passthrough.
+                returned_ty if returned_ty.is_unannotated_passthrough() => decoratee.clone(),
+                Type::Union(box Union { ref members, .. })
+                    if members.iter().any(|m| m.is_unannotated_passthrough()) =>
+                {
+                    decoratee.clone()
+                }
                 returned_ty => returned_ty,
             };
 

--- a/pyrefly/lib/test/decorators.rs
+++ b/pyrefly/lib/test/decorators.rs
@@ -717,3 +717,50 @@ assert_type(test1(1, 2), int)
 assert_type(test2(1, 2), int)
 "#,
 );
+
+// Dual-use decorator: can be used as @decorator or @decorator(flag).
+// The decorator function returns a union of the wrapper and the decorator factory,
+// but since the wrapper is an unannotated passthrough, we should preserve the
+// original function's type.
+testcase!(
+    test_dual_use_decorator,
+    r#"
+from functools import wraps
+from typing import assert_type
+
+def optional_debug(func_or_flag=None):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+        return wrapper
+    if callable(func_or_flag):
+        return decorator(func_or_flag)
+    return decorator
+
+@optional_debug
+def compute(x: int, y: int, z: int) -> int:
+    return x + y + z
+
+assert_type(compute(1, 2, 3), int)
+"#,
+);
+
+// Simple unannotated passthrough decorator should preserve the original function's type.
+testcase!(
+    test_unannotated_passthrough_decorator,
+    r#"
+from typing import assert_type
+
+def simple_decorator(func):
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
+@simple_decorator
+def compute(x: int, y: int, z: int) -> int:
+    return x + y + z
+
+assert_type(compute(1, 2, 3), int)
+"#,
+);


### PR DESCRIPTION
Summary:

Pyrefly was emitting a false positive `bad-argument-count` error when a function was decorated with a "dual-use" decorator — one that can be used as both `decs` and `decs(flag)`. This pattern is common in libraries like click, celery, and flask, as well as in application code.

The root cause is that Pyrefly infers the return type of such decorators as a union of all return paths. For example, a decorator like `optional_debug` that returns either `decorator(func_or_flag)` (a passthrough wrapper) or `decorator` (the factory function) gets a union type of `wrapper | decorator`. When the decorated function is called, the `decorator` branch of the union rejects the arguments (wrong arity), producing a spurious error even though the `wrapper` branch accepts them.

The fix adapts pyright's unannotated decorator passthrough heuristic: when a decorator call returns a callable (or a union containing one) that has only `*args`/`**kwargs` parameters with all implicit `Any` types and an implicit `Any` return — the hallmark of an unannotated passthrough wrapper — we preserve the original decorated function's type instead. This is sound because such a wrapper provides no type information; preserving the original signature is strictly more informative.

Changes:
- Add `Callable::is_unannotated_passthrough()` to detect the `(*args, **kwargs) -> Unknown` pattern
- Add `Type::is_unannotated_passthrough()` as a convenience wrapper for Function/Callable variants
- Add two match arms in `apply_function_decorator` to handle direct passthrough and union-containing-passthrough cases
- Add test cases for dual-use decorators and simple unannotated passthrough decorators

Fixes https://github.com/facebook/pyrefly/issues/2621

Differential Revision: D96672235


