### PR TITLE
Fix CharField primary key lost when inheriting from multiple abstract Django mixins

### DIFF
--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -197,7 +197,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
 
             if let Some(dm) = metadata.django_model_metadata() {
-                inherited_django_metadata = Some(dm);
+                // Prefer the base that has a custom primary key field,
+                // so a later base without one doesn't overwrite it.
+                if inherited_django_metadata
+                    .is_none_or(|prev| prev.custom_primary_key_field.is_none())
+                {
+                    inherited_django_metadata = Some(dm);
+                }
             }
         }
 

--- a/pyrefly/lib/test/django/auto_generated_fields.rs
+++ b/pyrefly/lib/test/django/auto_generated_fields.rs
@@ -19,7 +19,7 @@ class Reporter(models.Model):
 
 reporter = Reporter()
 assert_type(reporter.id, int)
-assert_type(reporter.pk, int) 
+assert_type(reporter.pk, int)
 "#,
 );
 
@@ -53,12 +53,59 @@ class B(Article):
 
 article = Article()
 article.id # E: Object of class `Article` has no attribute `id`
-assert_type(article.uuid, UUID) 
-assert_type(article.pk, UUID) 
+assert_type(article.uuid, UUID)
+assert_type(article.pk, UUID)
 
 article2 = B()
-article2.id # E: Object of class `B` has no attribute `id` 
+article2.id # E: Object of class `B` has no attribute `id`
 assert_type(article2.uuid, UUID)
-assert_type(article2.pk, UUID) 
+assert_type(article2.pk, UUID)
+"#,
+);
+
+django_testcase!(
+    test_abstract_model_charfield_pk,
+    r#"
+from typing import assert_type
+from django.db import models
+
+class StrIdMixin(models.Model):
+    id = models.CharField(max_length=36, primary_key=True)
+    class Meta:
+        abstract = True
+
+class StrIdChildModel(StrIdMixin):
+    name = models.CharField(max_length=100)
+
+child = StrIdChildModel()
+assert_type(child.id, str)
+assert_type(child.pk, str)
+"#,
+);
+
+// Multiple abstract mixins: the one with primary_key=True must win,
+// even if a later base has no custom PK (regression test for #2218).
+django_testcase!(
+    test_abstract_model_charfield_pk_multiple_mixins,
+    r#"
+from typing import assert_type
+from django.db import models
+
+class StrIdMixin(models.Model):
+    id = models.CharField(max_length=36, primary_key=True)
+    class Meta:
+        abstract = True
+
+class AuditMixin(models.Model):
+    created_by = models.CharField(max_length=100)
+    class Meta:
+        abstract = True
+
+class ConcreteModel(StrIdMixin, AuditMixin):
+    name = models.CharField(max_length=100)
+
+obj = ConcreteModel()
+assert_type(obj.id, str)
+assert_type(obj.pk, str)
 "#,
 );


### PR DESCRIPTION
# Summary

Fixes #2218

When a Django model inherits from multiple abstract mixins (e.g. `class Concrete(StrIdMixin, AuditMixin)`), the metadata inheritance loop in `class_metadata.rs` unconditionally overwrites `inherited_django_metadata` with each base. If a later base has no custom primary key, it clobbers the one that did — causing the child to synthesize `id: int` instead of using the inherited `CharField`.

The fix: only overwrite `inherited_django_metadata` if the current value has no custom primary key field yet.

# Test Plan

- Added `test_abstract_model_charfield_pk` — single abstract mixin with `CharField(primary_key=True)`
- Added `test_abstract_model_charfield_pk_multiple_mixins` — the failing case: multiple abstract mixins where only the first defines a custom PK
- All 56 existing Django tests continue to pass
- Full `test.py` suite passes