### PR TITLE
fix Unexpected Never type in arm of the match #2826

### DIFF
--- a/pyrefly/lib/binding/pattern.rs
+++ b/pyrefly/lib/binding/pattern.rs
@@ -149,11 +149,10 @@ impl<'a> BindingsBuilder<'a> {
                     // Add the combined narrow op to the returned narrow_ops.
                     // We insert directly instead of using and_all twice to avoid
                     // Placeholder issues when starting from an empty NarrowOps.
-                    let name = match subject {
-                        NarrowingSubject::Name(name) => name.clone(),
-                        NarrowingSubject::Facets(name, _) => name.clone(),
-                    };
-                    narrow_ops.0.insert(name, (combined_narrow_op, x.range));
+                    let name = subject.name().clone();
+                    narrow_ops
+                        .0
+                        .insert(name, (combined_narrow_op.for_subject(subject), x.range));
                 }
                 let mut seen_star = false;
                 for (i, x) in x.patterns.into_iter().enumerate() {

--- a/pyrefly/lib/test/pattern_match.rs
+++ b/pyrefly/lib/test/pattern_match.rs
@@ -431,6 +431,26 @@ def test_list_pattern(x: list[int]) -> None:
 );
 
 testcase!(
+    test_sequence_pattern_facet_subject_preserves_base_type,
+    r#"
+from __future__ import annotations
+from typing import assert_type
+
+class C:
+    items: list[C]
+
+    def __init__(self, items: list[C]) -> None:
+        self.items = items
+
+def handle(c: C) -> None:
+    match c.items:
+        case [_]:
+            assert_type(c, C)
+    assert_type(c, C)
+"#,
+);
+
+testcase!(
     test_sequence_pattern_tuple,
     r#"
 from typing import assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2826

The bug was in sequence-pattern narrowing for facet subjects.

When matching on something like c.items, the IsSequence/length narrow was being recorded on the base name c without reattaching the .items facet, so the checker tried to narrow C itself as a sequence and collapsed it to Never.

where the combined narrow op is now rebound to the original subject before being stored.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test