### PR TITLE
Avoid pinning solver variables too early when RHS is a union (#2839)

### DIFF
--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -1268,9 +1268,23 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
             }
             (Type::Quantified(q), u)
                 if let Restriction::Constraints(constraints) = q.restriction()
-                    && constraints
-                        .iter()
-                        .all(|constraint| self.is_subset_eq(constraint, u).is_ok()) =>
+                    && constraints.iter().all(|constraint| {
+                        // When u is a union containing solver variables, check each
+                        // constraint only against concrete (non-var) members. The
+                        // `.all()` iterator can partially pin vars: e.g. for AnyStr
+                        // <: Var(T) | None, `str <: Var(T)` pins T=str, then `bytes
+                        // <: str|None` fails, leaving T irreversibly pinned to str.
+                        if let Type::Union(box Union { members, .. }) = u
+                            && u.may_contain_quantified_var()
+                        {
+                            members
+                                .iter()
+                                .filter(|m| !m.may_contain_quantified_var())
+                                .any(|m| self.is_subset_eq(constraint, m).is_ok())
+                        } else {
+                            self.is_subset_eq(constraint, u).is_ok()
+                        }
+                    }) =>
             {
                 Ok(())
             }

--- a/pyrefly/lib/test/generic_restrictions.rs
+++ b/pyrefly/lib/test/generic_restrictions.rs
@@ -1213,7 +1213,6 @@ assert_type(f(b"hi"), bytes)
 );
 
 testcase!(
-    bug = "Should not produce a type error; https://github.com/facebook/pyrefly/issues/2644",
     test_anystr_none_passthrough_classmethod,
     r#"
 from typing import AnyStr
@@ -1223,7 +1222,7 @@ class A:
     def create(cls, x: AnyStr | None): ...
 
 def test(x: AnyStr | None):
-    A.create(x)  # E: Argument `AnyStr | None` is not assignable to parameter `x` with type `str | None` in function `A.create`
+    A.create(x)
     "#,
 );
 


### PR DESCRIPTION
Summary:

During the constraint resolution, when solving a constraint of the form:

`Quantified(AnyStr) <: x | None` we expand the union and end up pinning `str` to `x` which causes a false positive since it pins the type var.

This diff works around the issue by skipping the the subset check which pins the type var. Instread, we directly check `Quantified(AnyStr)  <: x`

RFC: I suspect this is related to typevar pinning and that fixing that is the right solution so I am not sure if we should be adding a workaround.

For issue https://github.com/facebook/pyrefly/issues/2644

Differential Revision: D97522732
