### PR TITLE
Fix raw JSON rendering in classifier verdict display

### DIFF
--- a/scripts/primer_classifier/formatter.py
+++ b/scripts/primer_classifier/formatter.py
@@ -111,6 +111,42 @@ def _linkify_files_in_text(text: str) -> str:
     return result
 
 
+def _format_reason(reason: str) -> str:
+    """Format a reason string for display, handling raw JSON dicts.
+
+    When the LLM returns a JSON dict as the reason (with fields like
+    spec_check, runtime_behavior, etc.), format it into readable text
+    instead of dumping raw JSON.
+    """
+    if not reason or not reason.strip().startswith("{"):
+        return reason
+    try:
+        parsed = json.loads(reason)
+        if not isinstance(parsed, dict):
+            return reason
+    except (json.JSONDecodeError, ValueError):
+        return reason
+
+    # Format known analysis fields into readable text
+    _FIELD_LABELS = {
+        "spec_check": "Spec check",
+        "runtime_behavior": "Runtime behavior",
+        "mypy_pyright": "Mypy/pyright comparison",
+        "removal_assessment": "Removal assessment",
+        "pr_attribution": "PR attribution",
+        "reason": "Reasoning",
+    }
+    parts = []
+    for key, label in _FIELD_LABELS.items():
+        val = parsed.get(key)
+        if val and val != "N/A":
+            parts.append(f"**{label}:** {val}")
+    # Fall back to the "reason" field if nothing else was formatted
+    if not parts:
+        return parsed.get("reason", reason)
+    return "\n> ".join(parts)
+
+
 def _extract_root_cause(c) -> str:
     """Extract a linkified root cause string from a classification's pr_attribution.
 
@@ -292,7 +328,7 @@ def format_markdown(result: ClassificationResult) -> str:
                     )
                 lines.append("")
             else:
-                lines.append(f"> {c.reason}")
+                lines.append(f"> {_format_reason(c.reason)}")
                 if c.pr_attribution and c.pr_attribution != "N/A":
                     lines.append(
                         f"> **Attribution:** "

--- a/scripts/primer_classifier/llm_client.py
+++ b/scripts/primer_classifier/llm_client.py
@@ -335,7 +335,10 @@ def classify_with_llm(
             raw_response=result,
         )
 
-    reason = classification.get("reason", "No reason provided")
+    reason_val = classification.get("reason", "No reason provided")
+    # The LLM sometimes returns a dict for "reason" instead of a string.
+    # If so, serialize it so downstream code always sees a string.
+    reason = json.dumps(reason_val) if isinstance(reason_val, dict) else str(reason_val)
 
     # Parse per-category reasoning (no verdicts in pass 1)
     categories: list[CategoryVerdict] = []


### PR DESCRIPTION
Summary:
I noticed when looking at the classifier output for https://github.com/facebook/pyrefly/pull/2764 that the "verdict" formatting needed to be fixed.

Two fixes:
1. formatter.py: Add _format_reason() to render JSON reason dicts as
   labeled readable sections (e.g. "**Spec check:** ...", "**Reasoning:** ...")
2. llm_client.py: Ensure reason is always a string by serializing dict
   values, so downstream code handles it consistently.

Reviewed By: grievejia

Differential Revision: D97422229


