### PR TITLE
fix empty case and dict case of key autocompletion #1886 #2838

### DIFF
--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -345,6 +345,14 @@ impl Transaction<'_> {
         position: TextSize,
         completions: &mut Vec<RankedCompletion>,
     ) {
+        if let Some(mod_module) = self.get_ast(handle) {
+            self.add_typed_dict_constructor_kwargs_completions(
+                handle,
+                mod_module.as_ref(),
+                position,
+                completions,
+            );
+        }
         if let Some(CallInfo {
             callables,
             provided_arg_ranges,
@@ -482,6 +490,24 @@ impl Transaction<'_> {
                 }));
             }
         }
+    }
+
+    pub(crate) fn expected_call_argument_type(
+        &self,
+        handle: &Handle,
+        position: TextSize,
+    ) -> Option<Type> {
+        let CallInfo {
+            callables,
+            chosen_overload_index,
+            active_argument,
+            ..
+        } = self.get_callables_from_call(handle, position)?;
+        let callable = callables.get(chosen_overload_index.unwrap_or(0))?.clone();
+        let params = Self::normalize_singleton_function_type_into_params(callable)?;
+        let arg_index = Self::active_parameter_index(&params, &active_argument)?;
+        let param = params.get(arg_index)?;
+        Some(param.as_type().clone())
     }
 
     fn is_incompatible_with_expected_type(

--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -373,6 +373,14 @@ impl Transaction<'_> {
         position: TextSize,
         completions: &mut Vec<RankedCompletion>,
     ) {
+        if let Some(mod_module) = self.get_ast(handle) {
+            self.add_typed_dict_constructor_kwargs_completions(
+                handle,
+                mod_module.as_ref(),
+                position,
+                completions,
+            );
+        }
         if let Some(CallInfo {
             callables,
             provided_arg_ranges,
@@ -518,6 +526,24 @@ impl Transaction<'_> {
                 }));
             }
         }
+    }
+
+    pub(crate) fn expected_call_argument_type(
+        &self,
+        handle: &Handle,
+        position: TextSize,
+    ) -> Option<Type> {
+        let CallInfo {
+            callables,
+            chosen_overload_index,
+            active_argument,
+            ..
+        } = self.get_callables_from_call(handle, position)?;
+        let callable = callables.get(chosen_overload_index.unwrap_or(0))?.clone();
+        let params = Self::normalize_singleton_function_type_into_params(callable)?;
+        let arg_index = Self::active_parameter_index(&params, &active_argument)?;
+        let param = params.get(arg_index)?;
+        Some(param.as_type().clone())
     }
 
     fn is_incompatible_with_expected_type(

--- a/pyrefly/lib/state/lsp/dict_completions.rs
+++ b/pyrefly/lib/state/lsp/dict_completions.rs
@@ -18,6 +18,7 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprCall;
 use ruff_python_ast::ExprDict;
+use ruff_python_ast::ExprSet;
 use ruff_python_ast::ExprStringLiteral;
 use ruff_python_ast::Identifier;
 use ruff_python_ast::ModModule;
@@ -49,7 +50,7 @@ enum DictKeyLiteralContext {
     /// A key literal inside a dict literal being constructed.
     /// Example: `{"na|": 1}`.
     DictLiteral {
-        dict: ExprDict,
+        range: TextRange,
         literal: ExprStringLiteral,
     },
     /// An empty subscript slot, before any key string has been typed.
@@ -217,9 +218,10 @@ impl<'a> Transaction<'a> {
             self.dict_key_string_literal_at(handle, module, position)
         {
             Some(DictKeyLiteralContext::KeyAccess { base_expr, literal })
-        } else if let Some((dict, literal)) = Self::dict_literal_string_literal_at(module, position)
+        } else if let Some((range, literal)) =
+            Self::dict_literal_string_literal_at(module, position)
         {
-            Some(DictKeyLiteralContext::DictLiteral { dict, literal })
+            Some(DictKeyLiteralContext::DictLiteral { range, literal })
         } else if let Some((source_expr, literal)) =
             self.dataframe_call_argument_string_literal_at(handle, module, position)
         {
@@ -279,36 +281,18 @@ impl<'a> Transaction<'a> {
     fn dict_literal_string_literal_at(
         module: &ModModule,
         position: TextSize,
-    ) -> Option<(ExprDict, ExprStringLiteral)> {
+    ) -> Option<(TextRange, ExprStringLiteral)> {
         let nodes = Ast::locate_node(module, position);
-        let mut best: Option<(u8, TextSize, ExprDict, ExprStringLiteral)> = None;
+        let mut best: Option<(u8, TextSize, TextRange, ExprStringLiteral)> = None;
         for node in nodes {
-            let AnyNodeRef::ExprDict(dict) = node else {
-                continue;
+            let best_in_expr = match node {
+                // Ruff recovers `{""}` as a set until a `:` turns it into a dict item.
+                // Treat that shape like a dict-key placeholder so completion can recover.
+                AnyNodeRef::ExprSet(set) => Self::best_string_literal_in_set(set, position),
+                AnyNodeRef::ExprDict(dict) => Self::best_string_literal_in_dict(dict, position),
+                _ => None,
             };
-            let mut best_in_dict: Option<(u8, TextSize, ExprStringLiteral)> = None;
-            for item in &dict.items {
-                let Some(key_expr) = item.key.as_ref() else {
-                    continue;
-                };
-                let Expr::StringLiteral(literal) = key_expr else {
-                    continue;
-                };
-                let (priority, dist) = Self::string_literal_priority(position, literal.range());
-                let should_update = match &best_in_dict {
-                    Some((best_prio, best_dist, _)) => {
-                        priority < *best_prio || (priority == *best_prio && dist < *best_dist)
-                    }
-                    None => true,
-                };
-                if should_update {
-                    best_in_dict = Some((priority, dist, literal.clone()));
-                    if priority == 0 && dist == TextSize::from(0) {
-                        break;
-                    }
-                }
-            }
-            let Some((priority, dist, literal)) = best_in_dict else {
+            let Some((priority, dist, range, literal)) = best_in_expr else {
                 continue;
             };
             let should_update = match &best {
@@ -318,13 +302,68 @@ impl<'a> Transaction<'a> {
                 None => true,
             };
             if should_update {
-                best = Some((priority, dist, dict.clone(), literal));
+                best = Some((priority, dist, range, literal));
                 if priority == 0 && dist == TextSize::from(0) {
                     break;
                 }
             }
         }
-        best.map(|(_, _, dict, literal)| (dict, literal))
+        best.map(|(_, _, range, literal)| (range, literal))
+    }
+
+    fn best_string_literal_in_dict(
+        dict: &ExprDict,
+        position: TextSize,
+    ) -> Option<(u8, TextSize, TextRange, ExprStringLiteral)> {
+        let mut best = None;
+        for item in &dict.items {
+            let Some(key_expr) = item.key.as_ref() else {
+                continue;
+            };
+            let Expr::StringLiteral(literal) = key_expr else {
+                continue;
+            };
+            let (priority, dist) = Self::string_literal_priority(position, literal.range());
+            let should_update = match &best {
+                Some((best_prio, best_dist, _, _)) => {
+                    priority < *best_prio || (priority == *best_prio && dist < *best_dist)
+                }
+                None => true,
+            };
+            if should_update {
+                best = Some((priority, dist, dict.range(), literal.clone()));
+                if priority == 0 && dist == TextSize::from(0) {
+                    break;
+                }
+            }
+        }
+        best
+    }
+
+    fn best_string_literal_in_set(
+        set: &ExprSet,
+        position: TextSize,
+    ) -> Option<(u8, TextSize, TextRange, ExprStringLiteral)> {
+        let mut best = None;
+        for elt in &set.elts {
+            let Expr::StringLiteral(literal) = elt else {
+                continue;
+            };
+            let (priority, dist) = Self::string_literal_priority(position, literal.range());
+            let should_update = match &best {
+                Some((best_prio, best_dist, _, _)) => {
+                    priority < *best_prio || (priority == *best_prio && dist < *best_dist)
+                }
+                None => true,
+            };
+            if should_update {
+                best = Some((priority, dist, set.range(), literal.clone()));
+                if priority == 0 && dist == TextSize::from(0) {
+                    break;
+                }
+            }
+        }
+        best
     }
 
     fn expression_facets(expr: &Expr) -> Option<(Identifier, Vec<FacetKind>)> {
@@ -406,6 +445,62 @@ impl<'a> Transaction<'a> {
         }
     }
 
+    fn type_for_assignment_target(
+        &self,
+        handle: &Handle,
+        module: &ModModule,
+        position: TextSize,
+    ) -> Option<Type> {
+        let bindings = self.get_bindings(handle)?;
+        let nodes = Ast::locate_node(module, position);
+        for node in nodes {
+            let target = match node {
+                AnyNodeRef::StmtAnnAssign(ann_assign) => Some(ann_assign.target.as_ref()),
+                AnyNodeRef::StmtAssign(assign) if assign.targets.len() == 1 => {
+                    assign.targets.first()
+                }
+                _ => None,
+            };
+            let Some(Expr::Name(name)) = target else {
+                continue;
+            };
+            let identifier = Ast::expr_name_identifier(name.clone());
+            let bound_key = Key::BoundName(ShortIdentifier::new(&identifier));
+            let key = if bindings.is_valid_key(&bound_key) {
+                bound_key
+            } else {
+                let def_key = Key::Definition(ShortIdentifier::new(&identifier));
+                if bindings.is_valid_key(&def_key) {
+                    def_key
+                } else {
+                    continue;
+                }
+            };
+            if let Some(ty) = self.get_type(handle, &key)
+                && Self::type_contains_typed_dict(&ty)
+            {
+                return Some(ty);
+            }
+        }
+        None
+    }
+
+    fn contextual_typed_dict_type(
+        &self,
+        handle: &Handle,
+        module: &ModModule,
+        position: TextSize,
+        range: TextRange,
+    ) -> Option<Type> {
+        self.get_type_trace(handle, range)
+            .filter(Self::type_contains_typed_dict)
+            .or_else(|| {
+                self.expected_call_argument_type(handle, position)
+                    .filter(Self::type_contains_typed_dict)
+            })
+            .or_else(|| self.type_for_assignment_target(handle, module, position))
+    }
+
     /// Adds dict key completions for the given position. Handles a key string being
     /// typed (`d["k|"]`, `{"k|": …}`) as well as an empty subscript slot (`d[|]`),
     /// where the inserted key is quoted. Returns `true` if this function claimed the
@@ -440,6 +535,8 @@ impl<'a> Transaction<'a> {
             | DictKeyLiteralContext::BareSubscript { base_expr } => self
                 .extend_dict_key_suggestions(
                     handle,
+                    module,
+                    position,
                     Some(base_expr),
                     base_expr.range(),
                     &mut suggestions,
@@ -447,13 +544,20 @@ impl<'a> Transaction<'a> {
             DictKeyLiteralContext::CallArgument { source_expr, .. } => self
                 .extend_dict_key_suggestions(
                     handle,
+                    module,
+                    position,
                     Some(source_expr),
                     source_expr.range(),
                     &mut suggestions,
                 ),
-            DictKeyLiteralContext::DictLiteral { dict, .. } => {
-                self.extend_dict_key_suggestions(handle, None, dict.range(), &mut suggestions)
-            }
+            DictKeyLiteralContext::DictLiteral { range, .. } => self.extend_dict_key_suggestions(
+                handle,
+                module,
+                position,
+                None,
+                *range,
+                &mut suggestions,
+            ),
         }
         if suggestions.is_empty() {
             return false;
@@ -480,6 +584,8 @@ impl<'a> Transaction<'a> {
     fn extend_dict_key_suggestions(
         &self,
         handle: &Handle,
+        module: &ModModule,
+        position: TextSize,
         base_expr: Option<&Expr>,
         base_range: TextRange,
         suggestions: &mut BTreeMap<String, Option<Type>>,
@@ -527,19 +633,22 @@ impl<'a> Transaction<'a> {
 
         // For key access we query the container expression; for literals we query the
         // literal itself to pick up contextual TypedDict typing from assignments.
-        if let Some(base_type) = self.get_type_trace(handle, base_range) {
-            if let Some(typed_keys) = self.collect_typed_dict_keys(handle, base_type.clone()) {
-                for (key, ty) in typed_keys {
-                    let entry = suggestions.entry(key).or_insert(None);
-                    if entry.is_none() {
-                        *entry = Some(ty);
-                    }
+        if let Some(base_type) =
+            self.contextual_typed_dict_type(handle, module, position, base_range)
+            && let Some(typed_keys) = self.collect_typed_dict_keys(handle, base_type)
+        {
+            for (key, ty) in typed_keys {
+                let entry = suggestions.entry(key).or_insert(None);
+                if entry.is_none() {
+                    *entry = Some(ty);
                 }
             }
-            if let Some(columns) = Self::collect_dataframe_columns(&base_type) {
-                for column in columns {
-                    suggestions.entry(column).or_insert(None);
-                }
+        }
+        if let Some(base_type) = self.get_type_trace(handle, base_range)
+            && let Some(columns) = Self::collect_dataframe_columns(&base_type)
+        {
+            for column in columns {
+                suggestions.entry(column).or_insert(None);
             }
         }
     }
@@ -557,6 +666,49 @@ impl<'a> Transaction<'a> {
                 detail,
                 kind: Some(CompletionItemKind::FIELD),
                 insert_text,
+                ..Default::default()
+            }));
+        }
+    }
+
+    pub(crate) fn add_typed_dict_constructor_kwargs_completions(
+        &self,
+        handle: &Handle,
+        module: &ModModule,
+        position: TextSize,
+        completions: &mut Vec<RankedCompletion>,
+    ) {
+        let Some(call) =
+            Ast::locate_node(module, position)
+                .into_iter()
+                .find_map(|node| match node {
+                    AnyNodeRef::ExprCall(call)
+                        if call.arguments.range.contains_inclusive(position)
+                            && matches!(
+                                call.func.as_ref(),
+                                Expr::Name(name) if name.id.as_str() == "dict"
+                            ) =>
+                    {
+                        Some(call.clone())
+                    }
+                    _ => None,
+                })
+        else {
+            return;
+        };
+        let Some(base_type) =
+            self.contextual_typed_dict_type(handle, module, position, call.range())
+        else {
+            return;
+        };
+        let Some(typed_keys) = self.collect_typed_dict_keys(handle, base_type) else {
+            return;
+        };
+        for (label, ty) in typed_keys {
+            completions.push(RankedCompletion::new(CompletionItem {
+                label: format!("{label}="),
+                detail: Some(ty.to_string()),
+                kind: Some(CompletionItemKind::VARIABLE),
                 ..Default::default()
             }));
         }

--- a/pyrefly/lib/state/lsp/dict_completions.rs
+++ b/pyrefly/lib/state/lsp/dict_completions.rs
@@ -19,6 +19,7 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprCall;
 use ruff_python_ast::ExprDict;
+use ruff_python_ast::ExprSet;
 use ruff_python_ast::ExprStringLiteral;
 use ruff_python_ast::Identifier;
 use ruff_python_ast::ModModule;
@@ -55,6 +56,11 @@ enum DictKeyLiteralContext {
         dict: ExprDict,
         literal: ExprStringLiteral,
     },
+    /// Ruff parses an empty string in braces as a set until a colon is typed.
+    RecoveredSetLiteral {
+        range: TextRange,
+        literal: ExprStringLiteral,
+    },
     /// An empty subscript slot, before any key string has been typed.
     /// Example: `cfg[|]`. Completions insert a quoted key since there is no
     /// surrounding string.
@@ -75,7 +81,8 @@ impl DictKeyLiteralContext {
         match self {
             Self::KeyAccess { literal, .. }
             | Self::CallArgument { literal, .. }
-            | Self::DictLiteral { literal, .. } => Some(literal.range()),
+            | Self::DictLiteral { literal, .. }
+            | Self::RecoveredSetLiteral { literal, .. } => Some(literal.range()),
             Self::BareSubscript { .. } => None,
         }
     }
@@ -452,9 +459,8 @@ impl<'a> Transaction<'a> {
             self.dict_key_string_literal_at(handle, module, position)
         {
             Some(DictKeyLiteralContext::KeyAccess { base_expr, literal })
-        } else if let Some((dict, literal)) = Self::dict_literal_string_literal_at(module, position)
-        {
-            Some(DictKeyLiteralContext::DictLiteral { dict, literal })
+        } else if let Some(context) = Self::dict_literal_string_literal_at(module, position) {
+            Some(context)
         } else if let Some((source_expr, literal)) =
             self.dataframe_call_argument_string_literal_at(handle, module, position)
         {
@@ -543,45 +549,71 @@ impl<'a> Transaction<'a> {
     fn dict_literal_string_literal_at(
         module: &ModModule,
         position: TextSize,
-    ) -> Option<(ExprDict, ExprStringLiteral)> {
+    ) -> Option<DictKeyLiteralContext> {
         let nodes = Ast::locate_node(module, position);
-        let mut best: Option<(u8, TextSize, ExprDict, ExprStringLiteral)> = None;
+        let mut best: Option<(u8, TextSize, DictKeyLiteralContext)> = None;
         for node in nodes {
-            let AnyNodeRef::ExprDict(dict) = node else {
+            let best_in_expr = match node {
+                // Ruff recovers `{""}` as a set until a `:` turns it into a dict item.
+                // Treat that shape like a dict-key placeholder so completion can recover.
+                AnyNodeRef::ExprSet(set) => Self::best_string_literal_in_set(set, position).map(
+                    |(priority, dist, range, literal)| {
+                        (
+                            priority,
+                            dist,
+                            DictKeyLiteralContext::RecoveredSetLiteral { range, literal },
+                        )
+                    },
+                ),
+                AnyNodeRef::ExprDict(dict) => Self::best_string_literal_in_dict(dict, position)
+                    .map(|(priority, dist, dict, literal)| {
+                        (
+                            priority,
+                            dist,
+                            DictKeyLiteralContext::DictLiteral { dict, literal },
+                        )
+                    }),
+                _ => None,
+            };
+            let Some((priority, dist, context)) = best_in_expr else {
                 continue;
             };
-            if dict
-                .items
-                .iter()
-                .any(|item| item.value.range().contains(position))
-            {
-                continue;
-            }
-            let mut best_in_dict: Option<(u8, TextSize, ExprStringLiteral)> = None;
-            for item in &dict.items {
-                let Some(key_expr) = item.key.as_ref() else {
-                    continue;
-                };
-                let Expr::StringLiteral(literal) = key_expr else {
-                    continue;
-                };
-                let (priority, dist) = Self::string_literal_priority(position, literal.range());
-                let should_update = match &best_in_dict {
-                    Some((best_prio, best_dist, _)) => {
-                        priority < *best_prio || (priority == *best_prio && dist < *best_dist)
-                    }
-                    None => true,
-                };
-                if should_update {
-                    best_in_dict = Some((priority, dist, literal.clone()));
-                    if priority == 0 && dist == TextSize::from(0) {
-                        break;
-                    }
+            let should_update = match &best {
+                Some((best_prio, best_dist, _)) => {
+                    priority < *best_prio || (priority == *best_prio && dist < *best_dist)
+                }
+                None => true,
+            };
+            if should_update {
+                best = Some((priority, dist, context));
+                if priority == 0 && dist == TextSize::from(0) {
+                    break;
                 }
             }
-            let Some((priority, dist, literal)) = best_in_dict else {
+        }
+        best.map(|(_, _, context)| context)
+    }
+
+    fn best_string_literal_in_dict(
+        dict: &ExprDict,
+        position: TextSize,
+    ) -> Option<(u8, TextSize, ExprDict, ExprStringLiteral)> {
+        if dict
+            .items
+            .iter()
+            .any(|item| item.value.range().contains(position))
+        {
+            return None;
+        }
+        let mut best = None;
+        for item in &dict.items {
+            let Some(key_expr) = item.key.as_ref() else {
                 continue;
             };
+            let Expr::StringLiteral(literal) = key_expr else {
+                continue;
+            };
+            let (priority, dist) = Self::string_literal_priority(position, literal.range());
             let should_update = match &best {
                 Some((best_prio, best_dist, _, _)) => {
                     priority < *best_prio || (priority == *best_prio && dist < *best_dist)
@@ -589,13 +621,39 @@ impl<'a> Transaction<'a> {
                 None => true,
             };
             if should_update {
-                best = Some((priority, dist, dict.clone(), literal));
+                best = Some((priority, dist, dict.clone(), literal.clone()));
                 if priority == 0 && dist == TextSize::from(0) {
                     break;
                 }
             }
         }
-        best.map(|(_, _, dict, literal)| (dict, literal))
+        best
+    }
+
+    fn best_string_literal_in_set(
+        set: &ExprSet,
+        position: TextSize,
+    ) -> Option<(u8, TextSize, TextRange, ExprStringLiteral)> {
+        let mut best = None;
+        for elt in &set.elts {
+            let Expr::StringLiteral(literal) = elt else {
+                continue;
+            };
+            let (priority, dist) = Self::string_literal_priority(position, literal.range());
+            let should_update = match &best {
+                Some((best_prio, best_dist, _, _)) => {
+                    priority < *best_prio || (priority == *best_prio && dist < *best_dist)
+                }
+                None => true,
+            };
+            if should_update {
+                best = Some((priority, dist, set.range(), literal.clone()));
+                if priority == 0 && dist == TextSize::from(0) {
+                    break;
+                }
+            }
+        }
+        best
     }
 
     fn dict_literal_value_string_literal_at(
@@ -756,6 +814,56 @@ impl<'a> Transaction<'a> {
         }
     }
 
+    fn assignment_expected_type(
+        &self,
+        handle: &Handle,
+        module: &ModModule,
+        position: TextSize,
+        range: TextRange,
+    ) -> Option<Type> {
+        for node in Ast::locate_node(module, position) {
+            let target = match node {
+                AnyNodeRef::StmtAnnAssign(assign)
+                    if assign
+                        .value
+                        .as_ref()
+                        .is_some_and(|value| value.range() == range) =>
+                {
+                    Some(assign.target.as_ref())
+                }
+                AnyNodeRef::StmtAssign(assign)
+                    if assign.value.range() == range && assign.targets.len() == 1 =>
+                {
+                    assign.targets.first()
+                }
+                _ => None,
+            };
+            if let Some(ty) = target.and_then(|target| self.named_target_type(handle, target)) {
+                return Some(ty);
+            }
+        }
+        None
+    }
+
+    fn contextual_typed_dict_type(
+        &self,
+        handle: &Handle,
+        module: &ModModule,
+        position: TextSize,
+        range: TextRange,
+    ) -> Option<Type> {
+        self.get_type_trace(handle, range)
+            .filter(Self::type_contains_typed_dict)
+            .or_else(|| {
+                self.expected_call_argument_type(handle, position)
+                    .filter(Self::type_contains_typed_dict)
+            })
+            .or_else(|| {
+                self.assignment_expected_type(handle, module, position, range)
+                    .filter(Self::type_contains_typed_dict)
+            })
+    }
+
     /// Adds dict key completions for the given position. Handles a key string being
     /// typed (`d["k|"]`, `{"k|": …}`) as well as an empty subscript slot (`d[|]`),
     /// where the inserted key is quoted. Returns `true` if this function claimed the
@@ -790,6 +898,8 @@ impl<'a> Transaction<'a> {
             | DictKeyLiteralContext::BareSubscript { base_expr } => self
                 .extend_dict_key_suggestions(
                     handle,
+                    module,
+                    position,
                     Some(base_expr),
                     base_expr.range(),
                     &mut suggestions,
@@ -797,6 +907,8 @@ impl<'a> Transaction<'a> {
             DictKeyLiteralContext::CallArgument { source_expr, .. } => self
                 .extend_dict_key_suggestions(
                     handle,
+                    module,
+                    position,
                     Some(source_expr),
                     source_expr.range(),
                     &mut suggestions,
@@ -829,9 +941,25 @@ impl<'a> Transaction<'a> {
                         }
                     }
                 } else {
-                    self.extend_dict_key_suggestions(handle, None, dict.range(), &mut suggestions);
+                    self.extend_dict_key_suggestions(
+                        handle,
+                        module,
+                        position,
+                        None,
+                        dict.range(),
+                        &mut suggestions,
+                    );
                 }
             }
+            DictKeyLiteralContext::RecoveredSetLiteral { range, .. } => self
+                .extend_dict_key_suggestions(
+                    handle,
+                    module,
+                    position,
+                    None,
+                    *range,
+                    &mut suggestions,
+                ),
         }
         if suggestions.is_empty() {
             return false;
@@ -858,6 +986,8 @@ impl<'a> Transaction<'a> {
     fn extend_dict_key_suggestions(
         &self,
         handle: &Handle,
+        module: &ModModule,
+        position: TextSize,
         base_expr: Option<&Expr>,
         base_range: TextRange,
         suggestions: &mut BTreeMap<String, Option<Type>>,
@@ -905,19 +1035,22 @@ impl<'a> Transaction<'a> {
 
         // For key access we query the container expression; for literals we query the
         // literal itself to pick up contextual TypedDict typing from assignments.
-        if let Some(base_type) = self.get_type_trace(handle, base_range) {
-            if let Some(typed_keys) = self.collect_typed_dict_keys(handle, base_type.clone()) {
-                for (key, ty) in typed_keys {
-                    let entry = suggestions.entry(key).or_insert(None);
-                    if entry.is_none() {
-                        *entry = Some(ty);
-                    }
+        if let Some(base_type) =
+            self.contextual_typed_dict_type(handle, module, position, base_range)
+            && let Some(typed_keys) = self.collect_typed_dict_keys(handle, base_type)
+        {
+            for (key, ty) in typed_keys {
+                let entry = suggestions.entry(key).or_insert(None);
+                if entry.is_none() {
+                    *entry = Some(ty);
                 }
             }
-            if let Some(columns) = Self::collect_dataframe_columns(&base_type) {
-                for column in columns {
-                    suggestions.entry(column).or_insert(None);
-                }
+        }
+        if let Some(base_type) = self.get_type_trace(handle, base_range)
+            && let Some(columns) = Self::collect_dataframe_columns(&base_type)
+        {
+            for column in columns {
+                suggestions.entry(column).or_insert(None);
             }
         }
     }
@@ -935,6 +1068,49 @@ impl<'a> Transaction<'a> {
                 detail,
                 kind: Some(CompletionItemKind::FIELD),
                 insert_text,
+                ..Default::default()
+            }));
+        }
+    }
+
+    pub(crate) fn add_typed_dict_constructor_kwargs_completions(
+        &self,
+        handle: &Handle,
+        module: &ModModule,
+        position: TextSize,
+        completions: &mut Vec<RankedCompletion>,
+    ) {
+        let Some(call) =
+            Ast::locate_node(module, position)
+                .into_iter()
+                .find_map(|node| match node {
+                    AnyNodeRef::ExprCall(call)
+                        if call.arguments.range.contains_inclusive(position)
+                            && matches!(
+                                call.func.as_ref(),
+                                Expr::Name(name) if name.id.as_str() == "dict"
+                            ) =>
+                    {
+                        Some(call.clone())
+                    }
+                    _ => None,
+                })
+        else {
+            return;
+        };
+        let Some(base_type) =
+            self.contextual_typed_dict_type(handle, module, position, call.range())
+        else {
+            return;
+        };
+        let Some(typed_keys) = self.collect_typed_dict_keys(handle, base_type) else {
+            return;
+        };
+        for (label, ty) in typed_keys {
+            completions.push(RankedCompletion::new(CompletionItem {
+                label: format!("{label}="),
+                detail: Some(ty.to_string()),
+                kind: Some(CompletionItemKind::VARIABLE),
                 ..Default::default()
             }));
         }

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -482,6 +482,68 @@ def f(cond: bool) -> None:
 }
 
 #[test]
+fn dict_key_completion_from_incomplete_typed_dict_literal() {
+    let code = r#"
+from typing import TypedDict
+
+class Config(TypedDict):
+    name: str
+    age: int
+
+cfg: Config = {""}
+#              ^
+"#;
+    let report =
+        get_batched_lsp_operations_report_allow_error(&[("main", code)], get_default_test_report());
+    let report = strip_ansi(&report);
+    assert!(report.contains("- (Field) age: int"), "{report}");
+    assert!(report.contains("- (Field) name: str"), "{report}");
+}
+
+#[test]
+fn kwargs_completion_from_typed_dict_dict_constructor() {
+    let code = r#"
+from typing import TypedDict
+
+class Config(TypedDict):
+    name: str
+    age: int
+
+cfg: Config = dict(
+#                 ^
+"#;
+    let report =
+        get_batched_lsp_operations_report_allow_error(&[("main", code)], get_default_test_report());
+    let report = strip_ansi(&report);
+    assert!(report.contains("- (Variable) age=: int"), "{report}");
+    assert!(report.contains("- (Variable) name=: str"), "{report}");
+}
+
+#[test]
+fn dict_key_completion_from_incomplete_typed_dict_call_argument() {
+    let code = r#"
+from typing import TypedDict
+
+class Box(TypedDict):
+    x: float
+    y: float
+    z: float
+
+def take(box: Box):
+    return
+
+take({""})
+#      ^
+"#;
+    let report =
+        get_batched_lsp_operations_report_allow_error(&[("main", code)], get_default_test_report());
+    let report = strip_ansi(&report);
+    assert!(report.contains("- (Field) x: float"), "{report}");
+    assert!(report.contains("- (Field) y: float"), "{report}");
+    assert!(report.contains("- (Field) z: float"), "{report}");
+}
+
+#[test]
 fn dot_complete_with_deprecated_method() {
     let code = r#"
 from warnings import deprecated

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -874,6 +874,68 @@ def f(cond: bool) -> None:
 }
 
 #[test]
+fn dict_key_completion_from_incomplete_typed_dict_literal() {
+    let code = r#"
+from typing import TypedDict
+
+class Config(TypedDict):
+    name: str
+    age: int
+
+cfg: Config = {""}
+#              ^
+"#;
+    let report =
+        get_batched_lsp_operations_report_allow_error(&[("main", code)], get_default_test_report());
+    let report = strip_ansi(&report);
+    assert!(report.contains("- (Field) age: int"), "{report}");
+    assert!(report.contains("- (Field) name: str"), "{report}");
+}
+
+#[test]
+fn kwargs_completion_from_typed_dict_dict_constructor() {
+    let code = r#"
+from typing import TypedDict
+
+class Config(TypedDict):
+    name: str
+    age: int
+
+cfg: Config = dict(
+#                 ^
+"#;
+    let report =
+        get_batched_lsp_operations_report_allow_error(&[("main", code)], get_default_test_report());
+    let report = strip_ansi(&report);
+    assert!(report.contains("- (Variable) age=: int"), "{report}");
+    assert!(report.contains("- (Variable) name=: str"), "{report}");
+}
+
+#[test]
+fn dict_key_completion_from_incomplete_typed_dict_call_argument() {
+    let code = r#"
+from typing import TypedDict
+
+class Box(TypedDict):
+    x: float
+    y: float
+    z: float
+
+def take(box: Box):
+    return
+
+take({""})
+#      ^
+"#;
+    let report =
+        get_batched_lsp_operations_report_allow_error(&[("main", code)], get_default_test_report());
+    let report = strip_ansi(&report);
+    assert!(report.contains("- (Field) x: float"), "{report}");
+    assert!(report.contains("- (Field) y: float"), "{report}");
+    assert!(report.contains("- (Field) z: float"), "{report}");
+}
+
+#[test]
 fn dot_complete_with_deprecated_method() {
     let code = r#"
 from warnings import deprecated


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1886 
fixes #2838

The dict-key matcher now treats Ruff’s error-recovery {""} shape as a placeholder key position, then recovers the contextual TypedDict from the enclosing assignment/call when the literal itself only infers as set[str].

also added a specialized dict(...) kwargs path so contextual TypedDict fields show up as name= / age= completions in the existing kwargs flow.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test
