### PR TITLE
fix LSP - typing.NamedTuple tooltip is not informative #2844

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -698,10 +698,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         };
         let hint = None; // discard hint
         let class_metadata = self.get_metadata_for_class(cls.class_object());
+        let metaclass_dunder_call = self.get_metaclass_dunder_call(&cls);
         if let Some(ret) =
             self.call_metaclass(&cls, arguments_range, args, keywords, errors, context, hint)
         {
-            if let Some(metaclass_dunder_call) = self.get_metaclass_dunder_call(&cls) {
+            if let Some(metaclass_dunder_call) = metaclass_dunder_call.clone() {
                 if let Some(callee_range) = callee_range
                     && let Some(metaclass) = class_metadata.custom_metaclass()
                 {
@@ -774,7 +775,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         callee_range,
                     );
                 }
-                self.record_resolved_trace(arguments_range, new_method);
+                if metaclass_dunder_call.is_none() {
+                    self.record_resolved_trace(arguments_range, new_method);
+                }
                 if self.is_compatible_constructor_return(&ret, cls.class_object()) {
                     dunder_new_ret = Some(ret);
                 } else if !matches!(ret, Type::Any(AnyStyle::Error | AnyStyle::Implicit)) {
@@ -829,7 +832,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     callee_range,
                 );
             }
-            self.record_resolved_trace(arguments_range, init_method);
+            if !overrides_new && metaclass_dunder_call.is_none() {
+                self.record_resolved_trace(arguments_range, init_method);
+            }
         }
         if class_metadata.is_pydantic_model()
             && let Some(dataclass) = class_metadata.dataclass_metadata()

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -1072,6 +1072,29 @@ Person("Alice", 25)
 }
 
 #[test]
+fn hover_on_namedtuple_constructor_shows_field_signature() {
+    let code = r#"
+from typing import NamedTuple
+
+class Test(NamedTuple):
+    a: str
+    b: int
+
+Test()
+#^
+"#;
+    let report = get_batched_lsp_operations_report_allow_error(&[("main", code)], get_test_report);
+    assert!(
+        report.contains("a: str") && report.contains("b: int") && report.contains("-> Test"),
+        "Expected NamedTuple constructor hover to show field parameters, got: {report}"
+    );
+    assert!(
+        !report.contains("*Unknown") && !report.contains("**Unknown"),
+        "NamedTuple constructor hover should not fall back to variadic Unknown params, got: {report}"
+    );
+}
+
+#[test]
 fn hover_over_in_keyword_in_for_loop() {
     let code = r#"
 for x in [1, 2, 3]:

--- a/pyrefly/lib/test/lsp/signature_help.rs
+++ b/pyrefly/lib/test/lsp/signature_help.rs
@@ -935,6 +935,31 @@ Signature Help Result: active=0
 }
 
 #[test]
+fn namedtuple_constructor_signature_shows_namedtuple_fields() {
+    let code = r#"
+from typing import NamedTuple
+
+class Test(NamedTuple):
+    a: str
+    b: int
+
+Test()
+#    ^
+Test(a="", )
+#          ^
+"#;
+    let report = get_batched_lsp_operations_report_allow_error(&[("main", code)], get_test_report);
+    assert!(
+        report.contains("a: str") && report.contains("b: int") && report.contains("-> Test"),
+        "Expected NamedTuple signature help to show field parameters, got: {report}"
+    );
+    assert!(
+        !report.contains("*Unknown") && !report.contains("**Unknown"),
+        "NamedTuple signature help should not fall back to variadic Unknown params, got: {report}"
+    );
+}
+
+#[test]
 fn direct_init_call_shows_none() {
     let code = r#"
 class Person:


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2844

The checker was still analyzing both `__new__` and `__init__`, but the LSP trace for a constructor call was getting overwritten by __init__, which is why NamedTuple showed the useless `*Unknown, **Unknown` tooltip.

I changed the trace priority so IDE features keep metaclass `__call__` first, otherwise overridden `__new__`, otherwise `__init__`.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test