### PR TITLE
fix Autocomplete parameters of class pattern in match-case situation #2830

### DIFF
--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -49,6 +49,7 @@ use crate::state::lsp::IdentifierContext;
 use crate::state::lsp::IdentifierWithContext;
 use crate::state::lsp::ImportFormat;
 use crate::state::lsp::MIN_CHARACTERS_TYPED_AUTOIMPORT;
+use crate::state::lsp::PatternMatchParameterKind;
 use crate::state::state::Transaction;
 use crate::types::callable::Param;
 use crate::types::types::Type;
@@ -945,6 +946,55 @@ impl Transaction<'_> {
         });
     }
 
+    /// Suggest `attr=` completions inside a class pattern like `case Point(x=...)`.
+    pub(crate) fn add_match_class_keyword_completions(
+        &self,
+        handle: &Handle,
+        covering_nodes: &[AnyNodeRef],
+        completions: &mut Vec<RankedCompletion>,
+    ) {
+        let Some(pattern_class) = covering_nodes.iter().find_map(|node| match node {
+            AnyNodeRef::PatternMatchClass(pattern_class) => Some(pattern_class),
+            _ => None,
+        }) else {
+            return;
+        };
+        let Some(class_ty) = self.get_type_trace(handle, pattern_class.cls.range()) else {
+            return;
+        };
+        let Some(items) = self.ad_hoc_solve(handle, "completion_match_class_keywords", |solver| {
+            let instance_ty = match class_ty {
+                Type::ClassDef(cls) => solver.instantiate(&cls),
+                Type::ClassType(cls) => Type::ClassType(cls),
+                Type::Type(inner) => match *inner {
+                    Type::ClassType(cls) => Type::ClassType(cls),
+                    _ => return Vec::new(),
+                },
+                _ => return Vec::new(),
+            };
+            solver
+                .completions(instance_ty, None, true)
+                .into_iter()
+                .map(|attr| {
+                    RankedCompletion::new(CompletionItem {
+                        label: format!("{}=", attr.name.as_str()),
+                        detail: attr.ty.map(|ty| ty.to_string()),
+                        kind: Some(CompletionItemKind::VARIABLE),
+                        tags: if attr.is_deprecated {
+                            Some(vec![CompletionItemTag::DEPRECATED])
+                        } else {
+                            None
+                        },
+                        ..Default::default()
+                    })
+                })
+                .collect::<Vec<_>>()
+        }) else {
+            return;
+        };
+        completions.extend(items);
+    }
+
     /// Core completion implementation returning items and incomplete flag.
     pub(crate) fn completion_sorted_opt_with_incomplete<F>(
         &self,
@@ -1120,6 +1170,13 @@ impl Transaction<'_> {
                         }
                     }
                 }
+                if matches!(
+                    context,
+                    IdentifierContext::PatternMatch(PatternMatchParameterKind::KeywordArgName)
+                ) && let Some(covering_nodes) = covering_nodes.as_deref()
+                {
+                    self.add_match_class_keyword_completions(handle, covering_nodes, &mut result);
+                }
                 self.add_kwargs_completions(handle, position, &mut result);
                 Self::add_keyword_completions(handle, &mut result);
                 let has_local_completions = self.add_local_variable_completions(
@@ -1191,6 +1248,7 @@ impl Transaction<'_> {
                             &mut result,
                             in_string_literal,
                         );
+                        self.add_match_class_keyword_completions(handle, &nodes, &mut result);
                         // `dict_key_claimed` was computed up front; when a dict key was
                         // offered we skip the overload literal completions.
                         if !dict_key_claimed {

--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -53,6 +53,7 @@ use crate::state::lsp::IdentifierContext;
 use crate::state::lsp::IdentifierWithContext;
 use crate::state::lsp::ImportFormat;
 use crate::state::lsp::MIN_CHARACTERS_TYPED_AUTOIMPORT;
+use crate::state::lsp::PatternMatchParameterKind;
 use crate::state::state::Transaction;
 use crate::types::callable::Param;
 use crate::types::types::Type;
@@ -1036,6 +1037,55 @@ impl Transaction<'_> {
         });
     }
 
+    /// Suggest `attr=` completions inside a class pattern like `case Point(x=...)`.
+    pub(crate) fn add_match_class_keyword_completions(
+        &self,
+        handle: &Handle,
+        covering_nodes: &[AnyNodeRef],
+        completions: &mut Vec<RankedCompletion>,
+    ) {
+        let Some(pattern_class) = covering_nodes.iter().find_map(|node| match node {
+            AnyNodeRef::PatternMatchClass(pattern_class) => Some(pattern_class),
+            _ => None,
+        }) else {
+            return;
+        };
+        let Some(class_ty) = self.get_type_trace(handle, pattern_class.cls.range()) else {
+            return;
+        };
+        let Some(items) = self.ad_hoc_solve(handle, "completion_match_class_keywords", |solver| {
+            let instance_ty = match class_ty {
+                Type::ClassDef(cls) => solver.instantiate(&cls),
+                Type::ClassType(cls) => Type::ClassType(cls),
+                Type::Type(inner) => match *inner {
+                    Type::ClassType(cls) => Type::ClassType(cls),
+                    _ => return Vec::new(),
+                },
+                _ => return Vec::new(),
+            };
+            solver
+                .completions(instance_ty, None, true)
+                .into_iter()
+                .map(|attr| {
+                    RankedCompletion::new(CompletionItem {
+                        label: format!("{}=", attr.name.as_str()),
+                        detail: attr.ty.map(|ty| ty.to_string()),
+                        kind: Some(CompletionItemKind::VARIABLE),
+                        tags: if attr.is_deprecated {
+                            Some(vec![CompletionItemTag::DEPRECATED])
+                        } else {
+                            None
+                        },
+                        ..Default::default()
+                    })
+                })
+                .collect::<Vec<_>>()
+        }) else {
+            return;
+        };
+        completions.extend(items);
+    }
+
     /// Core completion implementation returning items and incomplete flag.
     pub(crate) fn completion_sorted_opt_with_incomplete<F>(
         &self,
@@ -1216,6 +1266,13 @@ impl Transaction<'_> {
                         }
                     }
                 }
+                if matches!(
+                    context,
+                    IdentifierContext::PatternMatch(PatternMatchParameterKind::KeywordArgName)
+                ) && let Some(covering_nodes) = covering_nodes.as_deref()
+                {
+                    self.add_match_class_keyword_completions(handle, covering_nodes, &mut result);
+                }
                 self.add_kwargs_completions(handle, position, &mut result);
                 // In `func(foo=1, ba|` the cursor can only be a keyword-argument
                 // name, so suppress unrelated completions.
@@ -1325,6 +1382,7 @@ impl Transaction<'_> {
                             position,
                             &mut result,
                         );
+                        self.add_match_class_keyword_completions(handle, &nodes, &mut result);
                         // `dict_key_claimed` was computed up front; when a dict key was
                         // offered we skip the overload literal completions.
                         if !dict_key_claimed {

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -1537,6 +1537,37 @@ Completion Results:
 }
 
 #[test]
+fn completion_match_class_keyword_dataclass() {
+    let code = r#"
+from dataclasses import dataclass
+
+@dataclass
+class A:
+    a: int
+    b: int
+
+x = object()
+match x:
+    case A(  ): ...
+#           ^
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, false);
+    let handle = handles.get("main").unwrap();
+    let position = extract_cursors_for_test(code)[0];
+    let txn = state.transaction();
+    let completions = txn.completion(handle, position, ImportFormat::Absolute, true, None);
+    let completion_labels: Vec<_> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    for expected in ["a=", "b="] {
+        assert!(
+            completion_labels.contains(&expected),
+            "missing {expected} in completions: {:?}",
+            completion_labels
+        );
+    }
+}
+
+#[test]
 fn completion_literal_union_alias() {
     let code = r#"
 from typing import Literal, Union

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -2077,6 +2077,37 @@ Completion Results:
 }
 
 #[test]
+fn completion_match_class_keyword_dataclass() {
+    let code = r#"
+from dataclasses import dataclass
+
+@dataclass
+class A:
+    a: int
+    b: int
+
+x = object()
+match x:
+    case A(  ): ...
+#           ^
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, false);
+    let handle = handles.get("main").unwrap();
+    let position = extract_cursors_for_test(code)[0];
+    let txn = state.transaction();
+    let completions = txn.completion(handle, position, ImportFormat::Absolute, true, None);
+    let completion_labels: Vec<_> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    for expected in ["a=", "b="] {
+        assert!(
+            completion_labels.contains(&expected),
+            "missing {expected} in completions: {:?}",
+            completion_labels
+        );
+    }
+}
+
+#[test]
 fn completion_literal_union_alias() {
     let code = r#"
 from typing import Literal, Union


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2830

adds class-pattern keyword completions from the matched class’s instance attributes, so case A(...): now suggests a= / b= for dataclass fields.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test