### PR TITLE
fix Narrowing inside try is preserved into finally, ignoring type outside of try #2845

### DIFF
--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -917,7 +917,8 @@ impl FlowStyle {
                         MergeStyle::Loop
                         | MergeStyle::LoopDefinitelyRuns
                         | MergeStyle::Exclusive
-                        | MergeStyle::Inclusive => FlowStyle::PossiblyUninitialized,
+                        | MergeStyle::Inclusive
+                        | MergeStyle::Finally => FlowStyle::PossiblyUninitialized,
                     }
                 }
             }
@@ -3336,6 +3337,10 @@ enum MergeStyle {
     /// Distinct from [Branching] because we have to be more lax about
     /// uninitialized locals (see `FlowStyle::merge` for details).
     BoolOp,
+    /// This is the merge immediately before analyzing a `finally` block.
+    /// Terminating branches still contribute because `finally` executes before
+    /// their control-flow effect is observed outside the statement.
+    Finally,
 }
 
 impl MergeStyle {
@@ -3688,17 +3693,20 @@ impl<'a> BindingsBuilder<'a> {
             return;
         }
 
+        let use_all_branches = matches!(merge_style, MergeStyle::Finally);
         // We normally only merge the live branches (where control flow is not
         // known to terminate), but if nothing is live we still need to fill in
         // the Phi keys and potentially analyze downstream code, so in that case
         // we'll use the terminated branches.
-        let (terminated_branches, live_branches): (Vec<_>, Vec<_>) =
-            branches.into_iter().partition(|flow| flow.has_terminated);
-        let has_terminated = live_branches.is_empty() && !merge_style.is_loop();
-        let flows = if has_terminated {
-            terminated_branches
+        let n_live_branches = branches.iter().filter(|flow| !flow.has_terminated).count();
+        let has_terminated = n_live_branches == 0 && !merge_style.is_loop();
+        let flows = if use_all_branches || has_terminated {
+            branches
         } else {
-            live_branches
+            branches
+                .into_iter()
+                .filter(|flow| !flow.has_terminated)
+                .collect()
         };
         // Determine reachability of the merged flow.
         // For Loop style with empty flows (all branches terminated), the loop body might
@@ -3710,6 +3718,11 @@ impl<'a> BindingsBuilder<'a> {
                 MergeStyle::Loop => base.is_definitely_unreachable,
                 _ => true,
             }
+        } else if use_all_branches && n_live_branches > 0 {
+            flows
+                .iter()
+                .filter(|f| !f.has_terminated)
+                .all(|f| f.is_definitely_unreachable)
         } else {
             flows.iter().all(|f| f.is_definitely_unreachable)
         };
@@ -4010,6 +4023,18 @@ impl<'a> BindingsBuilder<'a> {
     /// means the caller forgot to call `finish_branch` and is always a bug).
     pub fn finish_exhaustive_fork(&mut self) {
         self.finish_fork_impl(None, false, None)
+    }
+
+    /// Finish an exhaustive fork for a `finally` block. Unlike a normal merge,
+    /// branches that have already terminated still contribute to the merged type
+    /// state because they will execute the `finally` body first.
+    pub fn finish_finally_fork(&mut self) {
+        let fork = self.scopes.current_mut().forks.pop().unwrap();
+        assert!(
+            !fork.branch_started,
+            "A branch is started - did you forget to call `finish_branch`?"
+        );
+        self.merge_flow(fork.base, fork.branches, fork.range, MergeStyle::Finally);
     }
 
     /// Finish a non-exhaustive fork in which the base flow is part of the merge. It negates

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -941,7 +941,8 @@ impl FlowStyle {
                         MergeStyle::Loop
                         | MergeStyle::LoopDefinitelyRuns
                         | MergeStyle::Exclusive
-                        | MergeStyle::Inclusive => FlowStyle::PossiblyUninitialized,
+                        | MergeStyle::Inclusive
+                        | MergeStyle::Finally => FlowStyle::PossiblyUninitialized,
                     }
                 }
             }
@@ -3549,6 +3550,10 @@ enum MergeStyle {
     /// Distinct from [Branching] because we have to be more lax about
     /// uninitialized locals (see `FlowStyle::merge` for details).
     BoolOp,
+    /// This is the merge immediately before analyzing a `finally` block.
+    /// Terminating branches still contribute because `finally` executes before
+    /// their control-flow effect is observed outside the statement.
+    Finally,
 }
 
 impl MergeStyle {
@@ -3904,20 +3909,25 @@ impl<'a> BindingsBuilder<'a> {
             return;
         }
 
+        let use_all_branches = matches!(merge_style, MergeStyle::Finally);
         // We normally only merge the live branches (where control flow is not
         // known to terminate), but if nothing is live we still need to fill in
         // the Phi keys and potentially analyze downstream code, so in that case
         // we'll use the terminated branches.
-        let (terminated_branches, live_branches): (Vec<_>, Vec<_>) =
-            branches.into_iter().partition(|flow| flow.has_terminated);
-        let has_terminated = live_branches.is_empty() && !merge_style.is_loop();
+        let n_live_branches = branches.iter().filter(|flow| !flow.has_terminated).count();
+        let has_terminated = n_live_branches == 0 && !merge_style.is_loop();
         // An enclosing `with` can only resume the merged flow if at least one of the
         // paths that terminated it raised.
-        let any_terminated_by_raise = terminated_branches.iter().any(|f| f.terminated_by_raise);
-        let flows = if has_terminated {
-            terminated_branches
+        let any_terminated_by_raise = branches
+            .iter()
+            .any(|flow| flow.has_terminated && flow.terminated_by_raise);
+        let flows = if use_all_branches || has_terminated {
+            branches
         } else {
-            live_branches
+            branches
+                .into_iter()
+                .filter(|flow| !flow.has_terminated)
+                .collect()
         };
         // Determine reachability of the merged flow.
         // For Loop style with empty flows (all branches terminated), the loop body might
@@ -3929,6 +3939,11 @@ impl<'a> BindingsBuilder<'a> {
                 MergeStyle::Loop => base.is_definitely_unreachable,
                 _ => true,
             }
+        } else if use_all_branches && n_live_branches > 0 {
+            flows
+                .iter()
+                .filter(|f| !f.has_terminated)
+                .all(|f| f.is_definitely_unreachable)
         } else {
             flows.iter().all(|f| f.is_definitely_unreachable)
         };
@@ -4230,6 +4245,18 @@ impl<'a> BindingsBuilder<'a> {
     /// means the caller forgot to call `finish_branch` and is always a bug).
     pub fn finish_exhaustive_fork(&mut self) {
         self.finish_fork_impl(None, false, None)
+    }
+
+    /// Finish an exhaustive fork for a `finally` block. Unlike a normal merge,
+    /// branches that have already terminated still contribute to the merged type
+    /// state because they will execute the `finally` body first.
+    pub fn finish_finally_fork(&mut self) {
+        let fork = self.scopes.current_mut().forks.pop().unwrap();
+        assert!(
+            !fork.branch_started,
+            "A branch is started - did you forget to call `finish_branch`?"
+        );
+        self.merge_flow(fork.base, fork.branches, fork.range, MergeStyle::Finally);
     }
 
     /// Finish a non-exhaustive fork in which the base flow is part of the merge. It negates

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -1426,11 +1426,10 @@ impl<'a> BindingsBuilder<'a> {
                         // https://docs.python.org/3/reference/compound_stmts.html#except-clause
                         self.scopes.mark_as_deleted(&name.id);
                     }
-
                     self.finish_branch();
                 }
 
-                self.finish_exhaustive_fork();
+                self.finish_finally_fork();
                 self.scopes.enter_finally();
                 self.stmts(x.finalbody, parent);
                 self.scopes.exit_finally();

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -1527,11 +1527,10 @@ impl<'a> BindingsBuilder<'a> {
                         // https://docs.python.org/3/reference/compound_stmts.html#except-clause
                         self.scopes.mark_as_deleted(&name.id);
                     }
-
                     self.finish_branch();
                 }
 
-                self.finish_exhaustive_fork();
+                self.finish_finally_fork();
                 self.scopes.enter_finally();
                 self.stmts(x.finalbody, parent);
                 self.scopes.exit_finally();

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -2414,6 +2414,33 @@ def main(resolve: bool) -> None:
 "#,
 );
 
+// Issue #2845: `finally` must see both the successful `try` state and terminating `except` state.
+testcase!(
+    test_try_finally_preserves_pre_try_possibility_from_terminating_except,
+    r#"
+from typing import assert_type
+
+def something_that_might_throw() -> None:
+    raise Exception()
+
+class Thing:
+    def something(self) -> None:
+        pass
+
+def blah() -> None:
+    x = None
+    try:
+        something_that_might_throw()
+        if x is None:
+            x = Thing()
+    except Exception:
+        raise
+    finally:
+        assert_type(x, Thing | None)
+        x.something()  # E: Object of class `NoneType` has no attribute `something`
+"#,
+);
+
 // for https://github.com/facebook/pyrefly/issues/1840
 testcase!(
     test_exhaustive_flow_no_fall_through,

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -2549,6 +2549,33 @@ def main(resolve: bool) -> None:
 "#,
 );
 
+// Issue #2845: `finally` must see both the successful `try` state and terminating `except` state.
+testcase!(
+    test_try_finally_preserves_pre_try_possibility_from_terminating_except,
+    r#"
+from typing import assert_type
+
+def something_that_might_throw() -> None:
+    raise Exception()
+
+class Thing:
+    def something(self) -> None:
+        pass
+
+def blah() -> None:
+    x = None
+    try:
+        something_that_might_throw()
+        if x is None:
+            x = Thing()
+    except Exception:
+        raise
+    finally:
+        assert_type(x, Thing | None)
+        x.something()  # E: Object of class `NoneType` has no attribute `something`
+"#,
+);
+
 // for https://github.com/facebook/pyrefly/issues/1840
 testcase!(
     test_exhaustive_flow_no_fall_through,


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2845

try statements now use a dedicated pre-finally merge so branches that have already terminated still contribute type state while the finally body is analyzed, instead of being dropped too early.

but mypy primer seems not so good.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
