### PR TITLE
fix while...else return not recognized as exhaustive #2868

### DIFF
--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -783,15 +783,19 @@ fn function_last_expressions<'a>(
                 f(sys_info, &x.body, res)?;
             }
             Stmt::While(x) => {
-                // Infinite loops with no breaks cannot fall through
-                if sys_info.evaluate_bool(&x.test) != Some(true) {
-                    return None;
-                }
                 let mut has_break = false;
                 x.body
                     .visit(&mut |stmt| loop_body_has_break_statement(stmt, &mut has_break));
-                if has_break {
-                    return None;
+                if sys_info.evaluate_bool(&x.test) == Some(true) {
+                    // Infinite loops with no breaks cannot fall through.
+                    if has_break {
+                        return None;
+                    }
+                } else {
+                    if has_break || x.orelse.is_empty() {
+                        return None;
+                    }
+                    f(sys_info, &x.orelse, res)?;
                 }
             }
             Stmt::For(x) => {

--- a/pyrefly/lib/test/returns.rs
+++ b/pyrefly/lib/test/returns.rs
@@ -237,6 +237,21 @@ def f(b: bool) -> None:
 "#,
 );
 
+// Regression test for https://github.com/facebook/pyrefly/issues/2868
+testcase!(
+    test_return_while_else,
+    r#"
+def find_match(items: list[int], target: int) -> int:
+    i = 0
+    while i < len(items):
+        if items[i] == target:
+            return i
+        i += 1
+    else:
+        return -1
+"#,
+);
+
 testcase!(
     test_return_then_dead_code,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2868

teaching implicit-return analysis to treat while ... else like a normal-termination branch instead of an unconditional fallthrough.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test