### PR TITLE
Skip inapplicable parent overloads during override checking (#2880)

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -3165,6 +3165,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
                 attr
             };
+            let Some(want_attribute) = self.filter_overloads_for_override(want_attribute, cls)
+            else {
+                // All parent overloads have a `self` type incompatible with the child class;
+                // skip the override check.
+                continue;
+            };
             if got_attribute.is_none() {
                 // Optimisation: Only compute the `got_attr` once, and only if we actually need it.
                 got_attribute = Some(self.as_instance_attribute(
@@ -4246,6 +4252,58 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             | ClassAttribute::Descriptor(..) => {
                 // Allow deleting most attributes for now, for compatibility with mypy.
             }
+        }
+    }
+
+    /// Filter out overloads from a parent's attribute whose `self` parameter type is
+    /// incompatible with the child class. This prevents false positive `bad-override` errors.
+    fn filter_overloads_for_override(
+        &self,
+        attr: ClassAttribute,
+        child_cls: &Class,
+    ) -> Option<ClassAttribute> {
+        let child_type = self
+            .heap
+            .mk_class_type(self.as_class_type_unchecked(child_cls));
+        let filter_type = |ty: Type| -> Option<Type> {
+            match ty {
+                Type::BoundMethod(box BoundMethod {
+                    obj,
+                    func: BoundMethodType::Overload(overload),
+                }) => {
+                    let self_param = |sig: &OverloadType| match sig {
+                        OverloadType::Function(f) => f.signature.get_first_param(),
+                        OverloadType::Forall(forall) => forall.body.signature.get_first_param(),
+                    };
+                    let applicable: Vec<_> = overload
+                        .signatures
+                        .into_iter()
+                        .filter(|sig| {
+                            self_param(sig)
+                                .is_none_or(|param| self.is_subset_eq(&child_type, &param))
+                        })
+                        .collect();
+                    let signatures = vec1::Vec1::try_from_vec(applicable).ok()?;
+                    Some(
+                        BoundMethod {
+                            obj,
+                            func: BoundMethodType::Overload(Overload {
+                                signatures,
+                                metadata: overload.metadata,
+                            }),
+                        }
+                        .as_type(),
+                    )
+                }
+                other => Some(other),
+            }
+        };
+        match attr {
+            ClassAttribute::ReadWrite(ty) => Some(ClassAttribute::ReadWrite(filter_type(ty)?)),
+            ClassAttribute::ReadOnly(ty, reason) => {
+                Some(ClassAttribute::ReadOnly(filter_type(ty)?, reason))
+            }
+            other => Some(other),
         }
     }
 

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -1298,11 +1298,52 @@ class B(A):
 );
 
 testcase!(
-    bug = "False positive bad-override when subclassing str with LiteralString overloads",
     test_override_str_subclass_with_optional_param,
     r#"
 class MyString(str):
-    def upper(self, locale: str = "en") -> str: # E: Class member `MyString.upper` overrides parent class `str` in an inconsistent manner
+    def upper(self, locale: str = "en") -> str:
         return super().upper()
+    "#,
+);
+
+testcase!(
+    bug = "We raise 4 inconsistent-overload errors where pyright raises 1. We should investigate this.",
+    test_override_all_parent_overloads_inapplicable,
+    r#"
+from typing import overload, LiteralString
+
+class Base(str):
+    @overload
+    def method(self: LiteralString) -> LiteralString: ...  # E: Implementation signature `(self: Self@Base, x: Unknown | None = None) -> Self@Base` does not accept all arguments that overload signature `(self: LiteralString) -> LiteralString` accepts  # E: Overload return type `LiteralString` is not assignable to implementation return type `Self@Base`
+    @overload
+    def method(self: LiteralString, x: int) -> LiteralString: ...  # E: Implementation signature `(self: Self@Base, x: Unknown | None = None) -> Self@Base` does not accept all arguments that overload signature `(self: LiteralString, x: int) -> LiteralString` accepts  # E: Overload return type `LiteralString` is not assignable to implementation return type `Self@Base`
+    def method(self, x=None):
+        return self
+
+class Child(Base):
+    def method(self, x: int = 0) -> str:
+        return str(self)
+    "#,
+);
+
+testcase!(
+    test_override_generic_overload_with_inapplicable_self,
+    r#"
+from typing import overload
+
+class Parent:
+    @overload
+    def method[T](self: "Narrow", x: T) -> T: ...
+    @overload
+    def method(self, x: int) -> int: ...
+    def method(self, x):
+        return x
+
+class Narrow(Parent):
+    pass
+
+class Child(Parent):
+    def method(self, x: int) -> int:
+        return x
     "#,
 );


### PR DESCRIPTION
Summary:

When binding an overloaded method to an object, filter out overloads whose
`self` parameter type is incompatible with the object type. This fixes false
positive `bad-override` errors when subclassing `str` (and similar classes
with `LiteralString` overloads) and adding optional parameters to overridden
methods.

For example, `str.upper()` has two overloads:
1. `(self: LiteralString) -> LiteralString`
2. `(self) -> str`

When `MyString(str)` overrides `upper()`, the override check previously
required the child to satisfy ALL parent overloads, including the
`LiteralString` one. Since `MyString` is not `LiteralString`, the check
failed with a false positive. Now, inapplicable overloads are filtered out
during method binding.

Fixes https://github.com/facebook/pyrefly/issues/2309

Reviewed By: rchen152

Differential Revision: D97805178
