### PR TITLE
Fix overloaded __get__ on descriptor with type[T] where T is bounded (#2881)

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1401,7 +1401,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 self.heap.mk_class_def(classtype.class_object().dupe()),
                 self.heap.mk_class_type(classtype),
             ),
-            DescriptorBase::ClassDef(class) => (self.heap.mk_class_def(class), self.heap.mk_none()),
+            DescriptorBase::ClassDef(class_base) => {
+                (class_base.to_type(self.heap), self.heap.mk_none())
+            }
         };
         let args = [CallArg::ty(&obj, range), CallArg::ty(&objtype, range)];
         let call_target = self.as_call_target_or_error(

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -207,7 +207,7 @@ pub struct Descriptor {
 #[derive(Clone, Debug)]
 pub enum DescriptorBase {
     Instance(ClassType),
-    ClassDef(Class),
+    ClassDef(ClassBase),
 }
 
 /// Correctly analyzing which attributes are visible on class objects, as well
@@ -2740,10 +2740,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // When accessing a property on a class (not instance), you get the property object itself
                 bind_class_attribute(self.heap, cls, ty, None)
             }
-            ClassFieldInner::Descriptor { descriptor, .. } => ClassAttribute::descriptor(
-                descriptor,
-                DescriptorBase::ClassDef(cls.class_object().dupe()),
-            ),
+            ClassFieldInner::Descriptor { descriptor, .. } => {
+                ClassAttribute::descriptor(descriptor, DescriptorBase::ClassDef(cls.clone()))
+            }
             ClassFieldInner::Method { mut ty, .. } => {
                 // When accessing a method on a class (not instance), you get the unbound function
                 if let Some(quantified) = self_quantified {

--- a/pyrefly/lib/test/descriptors.rs
+++ b/pyrefly/lib/test/descriptors.rs
@@ -648,7 +648,6 @@ class User(Base):
 );
 
 testcase!(
-    bug = "Overloaded __get__ on descriptor fails with type[T] where T is bounded; https://github.com/facebook/pyrefly/issues/1083",
     test_overloaded_descriptor_get_with_bounded_typevar,
     r#"
 from typing import Callable, overload
@@ -675,7 +674,7 @@ class B[T: A]:
         self.a = a
 
     def f(self):
-        for k in self.a.x:  # E: No matching overload found for function `MyDescriptor.__get__`
+        for k in self.a.x:
             print(k)
     "#,
 );

--- a/pyrefly/lib/test/pydantic/field.rs
+++ b/pyrefly/lib/test/pydantic/field.rs
@@ -307,3 +307,24 @@ house = House(
 )
     "#,
 );
+
+pydantic_testcase!(
+    test_model_fields_with_bounded_typevar,
+    r#"
+from pydantic import BaseModel
+
+class MyModel(BaseModel):
+    field: int
+
+class A[T: BaseModel]:
+    def __init__(self, model_type: type[T]) -> None:
+        self._model_type = model_type
+
+    def print_model_fields(self) -> None:
+        for field in self._model_type.model_fields:
+            print(field)
+
+a = A(MyModel)
+a.print_model_fields()
+    "#,
+);


### PR DESCRIPTION
Summary:

When accessing a descriptor with overloaded `__get__` through `type[T]` where `T: A`, pyrefly reports "No matching overload found". This affects real-world code like Pydantic's `model_fields` accessed through generic type parameters.

The root cause is that `DescriptorBase::ClassDef(Class)` discards the `ClassBase` wrapper (which carries TypeVar info), so `call_descriptor_getter` always constructs `objtype = type[A]` (concrete) even when the descriptor's overloads expect `type[T]`. Since `A <: T` does not hold (only `T <: A` from the bound), both overloads fail.

The fix changes `DescriptorBase::ClassDef` to hold a `ClassBase` instead of a bare `Class`, preserving the Quantified variant so `to_type()` correctly produces `type[T]` instead of `type[A]`.

Fixes https://github.com/facebook/pyrefly/issues/1083

Reviewed By: rchen152

Differential Revision: D97821022
