### PR TITLE
Preserve Literal types through TypeVar solving for unions

### DIFF
--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -1956,9 +1956,16 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                     }
                     | Variable::PartialQuantified(q) => {
                         let is_partial = matches!(&*v2_ref, Variable::PartialQuantified(_));
-                        let t1_p = t1
-                            .clone()
-                            .promote_implicit_literals(self.type_order.stdlib());
+                        // Don't promote unions of implicit literals (e.g., Literal["a"] | Literal["b"]
+                        // from tuple element types) — they represent structured type information
+                        // that should be preserved through TypeVar solving.
+                        let t1_p = if matches!(t1, Type::Union(u) if u.members.iter().all(|t| t.is_implicit_literal()))
+                        {
+                            t1.clone()
+                        } else {
+                            t1.clone()
+                                .promote_implicit_literals(self.type_order.stdlib())
+                        };
                         let name = q.name.clone();
                         let kind = q.kind();
                         let restriction = q.restriction().clone();

--- a/pyrefly/lib/test/literal.rs
+++ b/pyrefly/lib/test/literal.rs
@@ -437,7 +437,6 @@ Spam: TypeAlias = Literal[OneOrTwo]
 );
 
 testcase!(
-    bug = "enumerate promotes Literal types to their base type",
     test_enumerate_preserves_literal_type,
     r#"
 from typing import Literal
@@ -447,12 +446,10 @@ def test(x: Literal["a", "b"]) -> None:
 
 c = ("a", "b")
 
-# Direct iteration preserves Literal types
 for i in c:
     test(i)
 
-# enumerate loses Literal types due to TypeVar promotion
 for i, j in enumerate(c):
-    test(j) # E: Argument `str` is not assignable to parameter `x` with type `Literal['a', 'b']` in function `test`
+    test(j)
     "#,
 );


### PR DESCRIPTION
Summary:
When solving a TypeVar from a union of implicit literals (e.g.,
Literal["a"] | Literal["b"] from tuple element types), skip literal
promotion. Previously, enumerate(("a", "b")) would promote the literals
to str when solving enumerate[T], losing type information.

The fix: when the type being checked against a TypeVar is a union where
all members are implicit literals, preserve them as-is instead of promoting
to the base type.

Fixes https://github.com/facebook/pyrefly/issues/1323

Differential Revision: D97844612
