### PR TITLE
docs(configuration): fix closing punctuation for matches in examples

### DIFF
--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -1057,7 +1057,7 @@ assert-type = true
 
 [[sub-config]]
 # apply this config to all files in `sub`
-matches = "sub/**`
+matches = "sub/**"
 
 # disable `assert-type` errors in `sub`
 [sub-config.errors]
@@ -1254,7 +1254,7 @@ assert-type = true
 
 [[tool.pyrefly.sub-config]]
 # apply this config to all files in `sub`
-matches = "sub/**`
+matches = "sub/**"
 
 # disable `assert-type` errors in `sub/project`
 [tool.pyrefly.sub-config.errors]


### PR DESCRIPTION
# Summary

Changed two instances of: `` matches = "sub/**` `` to fix unterminated string errors in config examples.

```
error: Failed to parse: `pyproject.toml`
  Caused by: TOML parse error at line 33, column 19
   |
33 | matches = "sub/**`
   |                   ^
invalid basic string, expected `"`
```
