### PR TITLE
Do not stop extension publish job if version already exists for a platform

### DIFF
--- a/.github/workflows/deploy_extension.yml
+++ b/.github/workflows/deploy_extension.yml
@@ -23,7 +23,7 @@ jobs:
             - name: upload
               uses: actions/download-artifact@v7
             - name: publish
-              run: npx vsce publish --packagePath $(find . -iname *.vsix)
+              run: npx @vscode/vsce publish --skip-duplicate --packagePath $(find . -iname '*.vsix')
               env:
                 VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
@@ -37,4 +37,4 @@ jobs:
             - name: upload
               uses: actions/download-artifact@v7
             - name: publish
-              run: npx ovsx publish --packagePath $(find . -iname *.vsix) --pat ${{ secrets.OPENVSX_TOKEN }}
+              run: npx ovsx publish --skip-duplicate --packagePath $(find . -iname '*.vsix') --pat ${{ secrets.OPENVSX_TOKEN }}


### PR DESCRIPTION
Summary:
Sometimes the extension publish fails due to "version already published". This can happen if the previous extension publish failed halfway through (each platform is updated one-at-a-time). in this case, the rest of the platforms will never update since the job fails early. we should succeed on an extension bump if the version already exists on the marketplace letting us push for every version.

Questions:

will this mean bugs in versioning get unnoticed? if we have a v100 and all of our v1-100 fail?

I don't think so. The documentation says `Fail silently if version already exists on the marketplace`, not `if the version is less than the released version`

Differential Revision: D98143442


