### PR TITLE
Rank __init__.py results lower in workspace symbol search

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/workspace_symbols.rs
+++ b/pyrefly/lib/lsp/non_wasm/workspace_symbols.rs
@@ -37,6 +37,8 @@ impl Transaction<'_> {
                 result.push((name, kind, location));
             }
         }
+        // Keep shared fuzzy ordering intact while preferring non-`__init__.py` matches here.
+        result.sort_by_key(|(_, _, location)| location.module.path().is_init());
         Some(result)
     }
 }

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/tests_requiring_config/workspace_symbol_prefer_non_init/__init__.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/tests_requiring_config/workspace_symbol_prefer_non_init/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .implementation import workspace_symbol_prefers_non_init_over_init_reexport

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/tests_requiring_config/workspace_symbol_prefer_non_init/implementation.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/tests_requiring_config/workspace_symbol_prefer_non_init/implementation.py
@@ -1,0 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+def workspace_symbol_prefers_non_init_over_init_reexport() -> None:
+    return

--- a/pyrefly/lib/test/lsp/lsp_interaction/workspace_symbol.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/workspace_symbol.rs
@@ -6,6 +6,7 @@
  */
 
 use lsp_types::Url;
+use lsp_types::WorkspaceSymbolResponse;
 use lsp_types::request::WorkspaceSymbolRequest;
 use serde_json::json;
 
@@ -50,6 +51,65 @@ fn test_workspace_symbol() {
                 "name": "this_is_a_very_long_function_name_so_we_can_deterministically_test_autoimport_with_fuzzy_search"
             }
         ]))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_workspace_symbol_prefers_non_init_result() {
+    let root = get_test_files_root();
+    let root_path = root.path().join("tests_requiring_config");
+    let scope_uri = Url::from_file_path(root_path.clone()).unwrap();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root_path.clone());
+    interaction
+        .initialize(InitializeSettings {
+            workspace_folders: Some(vec![("test".to_owned(), scope_uri)]),
+            configuration: Some(Some(json!([{ "indexing_mode": "lazy_blocking"}]))),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction
+        .client
+        .did_open("workspace_symbol_prefer_non_init/implementation.py");
+    interaction
+        .client
+        .did_open("workspace_symbol_prefer_non_init/__init__.py");
+
+    let implementation_uri =
+        Url::from_file_path(root_path.join("workspace_symbol_prefer_non_init/implementation.py"))
+            .unwrap();
+    let init_uri =
+        Url::from_file_path(root_path.join("workspace_symbol_prefer_non_init/__init__.py"))
+            .unwrap();
+    let symbol_name = "workspace_symbol_prefers_non_init_over_init_reexport";
+
+    interaction
+        .client
+        .send_request::<WorkspaceSymbolRequest>(json!({ "query": symbol_name }))
+        .expect_response_with(|result| {
+            let Some(WorkspaceSymbolResponse::Flat(symbols)) = result else {
+                panic!("Unexpected workspace symbol response: {result:?}");
+            };
+            assert!(symbols.iter().all(|symbol| symbol.name == symbol_name));
+            assert!(symbols.iter().all(|symbol| {
+                symbol.location.uri == implementation_uri || symbol.location.uri == init_uri
+            }));
+
+            let first_init_index = symbols
+                .iter()
+                .position(|symbol| symbol.location.uri == init_uri)
+                .expect("expected at least one __init__.py result");
+            let last_non_init_index = symbols
+                .iter()
+                .rposition(|symbol| symbol.location.uri == implementation_uri)
+                .expect("expected at least one non-__init__.py result");
+
+            assert!(last_non_init_index < first_init_index);
+            true
+        })
         .unwrap();
 
     interaction.shutdown().unwrap();


### PR DESCRIPTION
## Summary

Fixes #2465

When a symbol is re-exported from `__init__.py`, workspace symbol search currently surfaces both the `__init__.py` re-export and the original definition at equal priority. This means users often land on the re-export rather than the actual definition.

This PR applies a single stable sort pass at the workspace symbol response site to push `__init__.py` results after non-`__init__.py` results, while keeping both visible. The fuzzy relevance ordering within each group is preserved (Rust's `sort_by_key` is a stable sort).

**Scope:** workspace symbol response path only (`workspace_symbols.rs`). No changes to fuzzy matching, go-to-definition, shared export search logic, dedup behavior, or any other LSP feature.

## Changes

- `pyrefly/lib/lsp/non_wasm/workspace_symbols.rs`: add a stable sort by `is_init()` after assembling the result list, with a single comment explaining the invariant.
- `pyrefly/lib/test/lsp/lsp_interaction/workspace_symbol.rs`: add regression test `test_workspace_symbol_prefers_non_init_result` that opens both an implementation module and its package `__init__.py`, queries for the shared symbol, and asserts the ordering invariant holds.
- `pyrefly/lib/test/lsp/lsp_interaction/test_files/tests_requiring_config/workspace_symbol_prefer_non_init/`: minimal fixture package with one definition in `implementation.py` and one re-export in `__init__.py`.

## Test Plan

- New LSP interaction test covers the ordering invariant end-to-end.
- `python3 test.py --no-test --no-conformance` (fmt + lint) passes with no new errors introduced.
- Targeted test: `cargo test workspace_symbol`
