### PR TITLE
Fix panic on duplicate names in __all__ augmented assignment

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -616,7 +616,7 @@ impl Bindings {
         // already handled by the exportables loop (e.g., a name from builtins
         // can appear in both exportables and invalid_dunder_all_entries).
         for (name, key) in invalid_all_exports {
-            if !exported_names.contains(&name) {
+            if exported_names.insert(name.clone()) {
                 builder
                     .table
                     .insert(KeyExport(name), BindingExport::Forward(key));

--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -809,6 +809,14 @@ __all__ += []  # E: `__all__` is uninitialized
 );
 
 testcase!(
+    test_dunder_all_duplicate_invalid_name,
+    r#"
+__all__ += ["A"]  # E: `__all__` is uninitialized  # E: Name `A` is listed in `__all__` but is not defined in the module
+__all__ += ["A"]  # E: Name `A` is listed in `__all__` but is not defined in the module
+"#,
+);
+
+testcase!(
     test_aug_assign_lookup_inconsistencies,
     r#"
 from typing import assert_type, Any


### PR DESCRIPTION
When `__all__ += ["A"]` appears multiple times with the same undefined name, the name gets added to `invalid_all_exports` once per occurrence. The loop then tries to insert `KeyExport(Name("A"))` multiple times, hitting a panic in the binding table.

Fix: use `exported_names.insert()` instead of `!exported_names.contains()` so duplicate names are tracked and skipped after the first insertion.

# Summary

  Fixes a panic when `__all__ += ["A"]` appears multiple times with the same undefined name. The duplicate caused `KeyExport(Name("A"))` to
   be inserted twice into the binding table, triggering a panic.

  Fix: use `exported_names.insert()` instead of `!exported_names.contains()` so duplicate names are tracked and skipped after the first
  insertion.

Fixes #2900 

# Test Plan

  - Added `test_dunder_all_duplicate_invalid_name` test reproducing the exact crash scenario
  - `cargo test test_dunder_all_duplicate` passes
  - Ran `python3 test.py --no-test --no-conformance` — no new lint or formatting issues
