### PR TITLE
Fix noisy label timeline events in V1 ranking workflow

### DIFF
--- a/scripts/issue_ranker/tests/test_issue_ranker.py
+++ b/scripts/issue_ranker/tests/test_issue_ranker.py
@@ -47,8 +47,8 @@ from relationship_resolver import (
 from report_formatter import format_json, format_markdown
 from status_classifier import _format_errors, _heuristic_classify
 from v1_analysis import (
-    _cleanup_managed_labels,
     _ensure_labels_exist,
+    _get_current_managed_labels,
     _github_api,
     apply_labels,
     format_v1_report,
@@ -1185,11 +1185,11 @@ class TestEnsureLabelsExist(unittest.TestCase):
         self.assertEqual(len(post_calls), 0)
 
 
-class TestCleanupManagedLabels(unittest.TestCase):
-    """Test _cleanup_managed_labels only removes our labels."""
+class TestGetCurrentManagedLabels(unittest.TestCase):
+    """Test _get_current_managed_labels fetches current label state."""
 
     @patch("v1_analysis._github_api")
-    def test_removes_labels_from_issues(self, mock_api):
+    def test_fetches_labels_from_issues(self, mock_api):
         def side_effect(method, url, token, body=None):
             if method == "GET" and "v1-verified" in url and "page=1" in url:
                 return [{"number": 10}, {"number": 20}]
@@ -1198,21 +1198,16 @@ class TestCleanupManagedLabels(unittest.TestCase):
             return None
 
         mock_api.side_effect = side_effect
-        removed = _cleanup_managed_labels("facebook/pyrefly", "tok")
+        result = _get_current_managed_labels("facebook/pyrefly", "tok")
 
-        # 2 issues had v1-verified, so 2 DELETEs for that label
-        delete_calls = [c for c in mock_api.call_args_list if c[0][0] == "DELETE"]
-        self.assertEqual(len(delete_calls), 2)
-        self.assertEqual(removed, 2)
-        # Verify DELETE URLs target only managed labels
-        for call in delete_calls:
-            self.assertIn("v1-verified", call[0][1])
+        self.assertEqual(result[10], {"v1-verified"})
+        self.assertEqual(result[20], {"v1-verified"})
 
     @patch("v1_analysis._github_api")
-    def test_no_issues_to_clean(self, mock_api):
+    def test_no_issues(self, mock_api):
         mock_api.return_value = []
-        removed = _cleanup_managed_labels("facebook/pyrefly", "tok")
-        self.assertEqual(removed, 0)
+        result = _get_current_managed_labels("facebook/pyrefly", "tok")
+        self.assertEqual(result, {})
 
     @patch("v1_analysis._github_api")
     def test_paginates(self, mock_api):
@@ -1220,15 +1215,11 @@ class TestCleanupManagedLabels(unittest.TestCase):
         page1 = [{"number": i} for i in range(100)]
         page2 = [{"number": 100}]
 
-        # Track which page we're on for v1-verified GET requests
         verified_gets = {"count": 0}
 
         def side_effect(method, url, token, body=None):
-            if method == "DELETE":
-                return None
             if method != "GET":
                 return None
-            # Only v1-verified has issues; other labels return empty
             if "v1-verified" not in url:
                 return []
             verified_gets["count"] += 1
@@ -1239,18 +1230,18 @@ class TestCleanupManagedLabels(unittest.TestCase):
             return []
 
         mock_api.side_effect = side_effect
-        removed = _cleanup_managed_labels("facebook/pyrefly", "tok")
-        # 100 from page 1 + 1 from page 2
-        self.assertEqual(removed, 101)
+        result = _get_current_managed_labels("facebook/pyrefly", "tok")
+        # 100 from page 1 + 1 from page 2 = 101 issues
+        self.assertEqual(len(result), 101)
 
 
 class TestApplyLabels(unittest.TestCase):
-    """Test apply_labels orchestration."""
+    """Test apply_labels diff-based orchestration."""
 
-    @patch("v1_analysis._cleanup_managed_labels", return_value=0)
+    @patch("v1_analysis._get_current_managed_labels", return_value={})
     @patch("v1_analysis._ensure_labels_exist")
     @patch("v1_analysis._github_api")
-    def test_applies_correct_labels(self, mock_api, mock_ensure, mock_cleanup):
+    def test_adds_labels_when_none_exist(self, mock_api, mock_ensure, mock_get):
         analysis = {
             "overlap_issues": [1, 2],
             "in_v1_not_top_ranked": [3],
@@ -1258,20 +1249,45 @@ class TestApplyLabels(unittest.TestCase):
         }
         result = apply_labels("facebook/pyrefly", analysis, "tok")
 
-        self.assertEqual(result["verified"], 2)
-        self.assertEqual(result["consider_removing"], 1)
-        self.assertEqual(result["consider_adding"], 2)
-        # Total POST calls: 2 + 1 + 2 = 5
-        self.assertEqual(mock_api.call_count, 5)
+        self.assertEqual(result["added"], 5)
+        self.assertEqual(result["removed"], 0)
+        self.assertEqual(result["unchanged"], 0)
 
-    @patch("v1_analysis._cleanup_managed_labels", return_value=5)
+    @patch("v1_analysis._get_current_managed_labels")
     @patch("v1_analysis._ensure_labels_exist")
     @patch("v1_analysis._github_api")
-    def test_cleans_before_applying(self, mock_api, mock_ensure, mock_cleanup):
-        apply_labels("facebook/pyrefly", {}, "tok")
-        # Ensure + cleanup called before any label application
-        mock_ensure.assert_called_once()
-        mock_cleanup.assert_called_once()
+    def test_skips_already_correct_labels(self, mock_api, mock_ensure, mock_get):
+        # Issue 1 already has v1-verified — should not be touched
+        mock_get.return_value = {1: {"v1-verified"}}
+        analysis = {
+            "overlap_issues": [1],
+            "in_v1_not_top_ranked": [],
+            "in_top_ranked_not_v1": [],
+        }
+        result = apply_labels("facebook/pyrefly", analysis, "tok")
+
+        self.assertEqual(result["added"], 0)
+        self.assertEqual(result["removed"], 0)
+        self.assertEqual(result["unchanged"], 1)
+        # No API calls for label changes (only _ensure + _get)
+        self.assertEqual(mock_api.call_count, 0)
+
+    @patch("v1_analysis._get_current_managed_labels")
+    @patch("v1_analysis._ensure_labels_exist")
+    @patch("v1_analysis._github_api")
+    def test_removes_stale_and_adds_new(self, mock_api, mock_ensure, mock_get):
+        # Issue 1 had v1-verified but should now have v1-consider-removing
+        mock_get.return_value = {1: {"v1-verified"}}
+        analysis = {
+            "overlap_issues": [],
+            "in_v1_not_top_ranked": [1],
+            "in_top_ranked_not_v1": [],
+        }
+        result = apply_labels("facebook/pyrefly", analysis, "tok")
+
+        self.assertEqual(result["added"], 1)
+        self.assertEqual(result["removed"], 1)
+        self.assertEqual(result["unchanged"], 0)
 
 
 class TestGenerateReasons(unittest.TestCase):
@@ -1369,7 +1385,7 @@ class TestRunV1Analysis(unittest.TestCase):
         finally:
             os.unlink(ranking_file.name)
 
-    @patch("v1_analysis.apply_labels", return_value={"verified": 1})
+    @patch("v1_analysis.apply_labels", return_value={"added": 1, "removed": 0, "unchanged": 0})
     @patch("v1_analysis.generate_reasons")
     def test_applies_labels_with_token(self, mock_reasons, mock_labels):
         mock_reasons.return_value = {"q2_reasons": {}, "q3_reasons": {}}
@@ -1390,7 +1406,7 @@ class TestRunV1Analysis(unittest.TestCase):
                 apply=True,
             )
             mock_labels.assert_called_once()
-            self.assertEqual(result["labels_applied"], {"verified": 1})
+            self.assertEqual(result["labels_applied"], {"added": 1, "removed": 0, "unchanged": 0})
         finally:
             os.unlink(ranking_file.name)
 

--- a/scripts/issue_ranker/v1_analysis.py
+++ b/scripts/issue_ranker/v1_analysis.py
@@ -195,17 +195,11 @@ def _ensure_labels_exist(repo: str, token: str) -> None:
             logging.debug(f"Label '{name}' already exists")
 
 
-def _cleanup_managed_labels(repo: str, token: str) -> int:
-    """Remove all managed labels from all issues. Returns count of labels removed.
-
-    IMPORTANT: This ONLY removes labels that our workflow introduced
-    (v1-verified, v1-consider-adding, v1-consider-removing). No other
-    labels on any issue are ever touched.
-    """
+def _get_current_managed_labels(repo: str, token: str) -> dict[int, set[str]]:
+    """Fetch current managed labels for all open issues. Returns {issue_num: {label_names}}."""
     api = f"https://api.github.com/repos/{repo}"
-    removed = 0
+    current: dict[int, set[str]] = {}
     for label_name in _MANAGED_LABELS:
-        # Fetch all issues that have this specific managed label
         page = 1
         while True:
             url = (
@@ -217,85 +211,82 @@ def _cleanup_managed_labels(repo: str, token: str) -> int:
                 break
             for issue in issues:
                 num = issue["number"]
-                # Remove ONLY this specific managed label from the issue
-                delete_url = (
-                    f"{api}/issues/{num}/labels/{urllib.parse.quote(label_name)}"
-                )
-                _github_api("DELETE", delete_url, token)
-                removed += 1
-                logging.debug(f"Removed '{label_name}' from #{num}")
+                current.setdefault(num, set()).add(label_name)
             if len(issues) < 100:
                 break
             page += 1
-    return removed
+    return current
 
 
 def apply_labels(repo: str, analysis: dict, github_token: str) -> dict:
-    """Apply V1 analysis labels to GitHub issues.
+    """Apply V1 analysis labels to GitHub issues using diff-based updates.
 
     IMPORTANT: Only manages labels introduced by this workflow:
     v1-verified, v1-consider-adding, v1-consider-removing.
     No other labels are ever created, modified, or removed.
 
-    Steps:
-    1. Ensure the three managed labels exist on the repo
-    2. Remove managed labels from all issues (clean slate)
-    3. Apply fresh labels based on current analysis
+    Computes the difference between current and desired label state,
+    then only adds/removes labels that actually changed. This avoids
+    generating redundant timeline events on issues.
     """
     logging.info("Ensuring managed labels exist on repo")
     _ensure_labels_exist(repo, github_token)
 
+    # Build desired label state: {issue_num: {label_names}}
+    desired: dict[int, set[str]] = {}
+    for num in analysis.get("overlap_issues", []):
+        desired.setdefault(num, set()).add(LABEL_VERIFIED)
+    for num in analysis.get("in_v1_not_top_ranked", []):
+        desired.setdefault(num, set()).add(LABEL_CONSIDER_REMOVING)
+    for num in analysis.get("in_top_ranked_not_v1", []):
+        desired.setdefault(num, set()).add(LABEL_CONSIDER_ADDING)
+
+    # Fetch current label state
+    current = _get_current_managed_labels(repo, github_token)
     logging.info(
-        "Cleaning up old managed labels (only v1-verified/consider-adding/removing)"
+        f"Current state: {sum(len(v) for v in current.values())} managed labels "
+        f"across {len(current)} issues"
     )
-    removed = _cleanup_managed_labels(repo, github_token)
-    logging.info(f"Removed {removed} stale managed labels")
 
     api = f"https://api.github.com/repos/{repo}/issues"
-    applied = {"verified": 0, "consider_adding": 0, "consider_removing": 0}
+    added = 0
+    removed = 0
 
-    # Apply v1-verified to overlap issues
-    for num in analysis.get("overlap_issues", []):
-        _github_api(
-            "POST",
-            f"{api}/{num}/labels",
-            github_token,
-            {
-                "labels": [LABEL_VERIFIED],
-            },
-        )
-        applied["verified"] += 1
+    # All issues that have or should have managed labels
+    all_issues = set(current.keys()) | set(desired.keys())
 
-    # Apply v1-consider-removing to Q2 issues
-    for num in analysis.get("in_v1_not_top_ranked", []):
-        _github_api(
-            "POST",
-            f"{api}/{num}/labels",
-            github_token,
-            {
-                "labels": [LABEL_CONSIDER_REMOVING],
-            },
-        )
-        applied["consider_removing"] += 1
+    for num in all_issues:
+        current_labels = current.get(num, set())
+        desired_labels = desired.get(num, set())
 
-    # Apply v1-consider-adding to Q3 issues
-    for num in analysis.get("in_top_ranked_not_v1", []):
-        _github_api(
-            "POST",
-            f"{api}/{num}/labels",
-            github_token,
-            {
-                "labels": [LABEL_CONSIDER_ADDING],
-            },
-        )
-        applied["consider_adding"] += 1
+        # Remove labels that should no longer be present
+        for label in current_labels - desired_labels:
+            delete_url = (
+                f"{api}/{num}/labels/{urllib.parse.quote(label)}"
+            )
+            _github_api("DELETE", delete_url, github_token)
+            removed += 1
+            logging.debug(f"Removed '{label}' from #{num}")
 
-    logging.info(
-        f"Applied labels: {applied['verified']} verified, "
-        f"{applied['consider_adding']} consider-adding, "
-        f"{applied['consider_removing']} consider-removing"
+        # Add labels that are missing
+        for label in desired_labels - current_labels:
+            _github_api(
+                "POST",
+                f"{api}/{num}/labels",
+                github_token,
+                {"labels": [label]},
+            )
+            added += 1
+            logging.debug(f"Added '{label}' to #{num}")
+
+    skipped = sum(
+        len(current.get(num, set()) & desired.get(num, set()))
+        for num in all_issues
     )
-    return applied
+    logging.info(
+        f"Label sync: {added} added, {removed} removed, {skipped} unchanged"
+    )
+    return {"added": added, "removed": removed, "unchanged": skipped}
 
 
 def _escape_md_table(text: str) -> str:


### PR DESCRIPTION
## Summary

The V1 analysis workflow (`issue_ranking.yml`) was using a "clean slate" approach for label management: remove ALL managed labels from ALL issues, then re-apply them from scratch. This generated redundant add/remove timeline events on **every run**, even when labels hadn't changed, cluttering issue timelines with noise like:

> github-actions added `v1-verified`
> github-actions removed `v1-verified`  
> github-actions added `v1-verified`

See https://github.com/facebook/pyrefly/issues/1422 for an example of the clutter.

**Fix:** Replace the clean-slate approach with diff-based label updates. The workflow now:
1. Fetches the current managed label state across all issues
2. Computes the desired label state from the analysis
3. Only adds/removes labels where the state actually differs
4. Leaves already-correct labels untouched (no API calls = no timeline events)

## Changes

- `v1_analysis.py`: Replaced `_cleanup_managed_labels()` with `_get_current_managed_labels()` that fetches current state. Rewrote `apply_labels()` to compute the diff and only touch labels that need to change.
- `test_issue_ranker.py`: Updated tests to match the new diff-based approach, including a test that verifies no API calls are made when labels are already correct.

## Test Plan

- All existing tests updated and passing (`pytest -k "TestGetCurrentManagedLabels or TestApplyLabels or TestRunV1Analysis"` — 10/10 pass)
- Key new test: `test_skips_already_correct_labels` verifies zero API calls when labels match desired state