### PR TITLE
added override check for init method

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -2970,11 +2970,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         &self,
         field_name: &Name,
         class_metadata: &Arc<ClassMetadata>,
+        is_override: bool,
     ) -> bool {
-        // Object construction (`__new__`, `__init__`, `__init_subclass__`) should not participate in override checks
-        if field_name == &dunder::NEW
-            || field_name == &dunder::INIT
-            || field_name == &dunder::INIT_SUBCLASS
+        // Object construction (`__new__`, `__init__`, `__init_subclass__`) should not participate
+        // in override checks unless the user explicitly opts in with `@override`.
+        if !is_override
+            && (field_name == &dunder::NEW
+                || field_name == &dunder::INIT
+                || field_name == &dunder::INIT_SUBCLASS)
         {
             return false;
         }
@@ -3041,7 +3044,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             return;
         }
         let metadata = self.get_metadata_for_class(cls);
-        if !self.should_check_field_for_override_consistency(field_name, &metadata) {
+        if !self.should_check_field_for_override_consistency(field_name, &metadata, is_override) {
             return;
         }
 
@@ -3371,6 +3374,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if !self.should_check_field_for_override_consistency(
                     parent_field_name,
                     &current_class_metadata,
+                    false,
                 ) {
                     continue;
                 }

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -1347,3 +1347,48 @@ class Child(Parent):
         return x
     "#,
 );
+
+testcase!(
+    test_override_init_with_decorator,
+    r#"
+from typing import override
+
+class Parent:
+    def __init__(self, x: int) -> None:
+        pass
+
+class Child(Parent):
+    @override
+    def __init__(self, x: str) -> None: # E: Class member `Child.__init__` overrides parent class `Parent` in an inconsistent manner
+        pass
+    "#,
+);
+
+testcase!(
+    test_override_init_without_decorator,
+    r#"
+class Parent:
+    def __init__(self, x: int) -> None:
+        pass
+
+class Child(Parent):
+    def __init__(self, x: str) -> None:
+        pass
+    "#,
+);
+
+testcase!(
+    test_override_init_compatible,
+    r#"
+from typing import override
+
+class Parent:
+    def __init__(self, x: int) -> None:
+        pass
+
+class Child(Parent):
+    @override
+    def __init__(self, x: int) -> None:
+        pass
+    "#,
+);


### PR DESCRIPTION

- Previously, pyrefly unconditionally skipped override consistency checks for __init__, __new__, and
  __init_subclass__. This is correct by default, but the typing spec requires that when @override is explicitly
  applied, the type checker must verify the overriding method's type is assignable to the overridden method's
  type.
  - Added an is_override parameter to should_check_field_for_override_consistency so that the skip is only
  applied when @override is not present.

  Test plan

  - Added test_override_init_with_decorator: @override + incompatible signature produces error
  - Added test_override_init_without_decorator: no decorator + incompatible signature produces no error (existing
   behavior preserved)
  - Added test_override_init_compatible: @override + compatible signature produces no error
  - All existing class_overrides tests pass (84 total)