### PR TITLE
fix False positive with overloaded async iterators #2873

### DIFF
--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -366,6 +366,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         defs,
                         errors,
                     );
+                    let sigs = if let [impl_sig] = def.ty.callable_signatures().as_slice() {
+                        self.normalize_async_generator_overloads(sigs, impl_sig)
+                    } else {
+                        sigs
+                    };
                     self.check_signature_consistency(&sigs, &def, errors);
                     Type::Overload(Overload {
                         signatures: sigs.mapped(|(_, sig)| sig),
@@ -1857,6 +1862,49 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 .find_map(|(_, _, metadata)| metadata.flags.dataclass_transform_metadata.clone());
         }
         metadata
+    }
+
+    fn normalize_async_generator_overload_signature(&self, sig: &Callable) -> Callable {
+        if let Some((_, _, ret)) = self.unwrap_coroutine(&sig.ret)
+            && self.decompose_async_generator(&ret).is_some()
+        {
+            let mut sig = sig.clone();
+            sig.ret = ret;
+            sig
+        } else {
+            sig.clone()
+        }
+    }
+
+    fn normalize_async_generator_overloads(
+        &self,
+        overloads: Vec1<(TextRange, OverloadType)>,
+        impl_sig: &Callable,
+    ) -> Vec1<(TextRange, OverloadType)> {
+        if self.decompose_async_generator(&impl_sig.ret).is_none() {
+            return overloads;
+        }
+        overloads.mapped(|(range, overload)| {
+            (
+                range,
+                match overload {
+                    OverloadType::Function(func) => OverloadType::Function(Function {
+                        signature: self
+                            .normalize_async_generator_overload_signature(&func.signature),
+                        metadata: func.metadata,
+                    }),
+                    OverloadType::Forall(forall) => OverloadType::Forall(Forall {
+                        tparams: forall.tparams,
+                        body: Function {
+                            signature: self.normalize_async_generator_overload_signature(
+                                &forall.body.signature,
+                            ),
+                            metadata: forall.body.metadata,
+                        },
+                    }),
+                },
+            )
+        })
     }
 
     /// Substitute each type parameter with its upper bound, for overload consistency checking.

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -414,6 +414,11 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                         defs,
                         errors,
                     );
+                    let sigs = if let [impl_sig] = def_ty.callable_signatures().as_slice() {
+                        self.normalize_async_generator_overloads(sigs, impl_sig)
+                    } else {
+                        sigs
+                    };
                     self.check_signature_consistency(&sigs, def_ty, undecorated, errors);
                     Type::Overload(Overload {
                         signatures: sigs.mapped(|(_, sig)| sig),
@@ -2202,6 +2207,49 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 .find_map(|(_, _, metadata)| metadata.flags.dataclass_transform_metadata.clone());
         }
         metadata
+    }
+
+    fn normalize_async_generator_overload_signature(&self, sig: &Callable) -> Callable {
+        if let Some((_, _, ret)) = self.unwrap_coroutine(&sig.ret)
+            && self.decompose_async_generator(&ret).is_some()
+        {
+            let mut sig = sig.clone();
+            sig.ret = ret;
+            sig
+        } else {
+            sig.clone()
+        }
+    }
+
+    fn normalize_async_generator_overloads(
+        &self,
+        overloads: Vec1<(TextRange, OverloadType)>,
+        impl_sig: &Callable,
+    ) -> Vec1<(TextRange, OverloadType)> {
+        if self.decompose_async_generator(&impl_sig.ret).is_none() {
+            return overloads;
+        }
+        overloads.mapped(|(range, overload)| {
+            (
+                range,
+                match overload {
+                    OverloadType::Function(func) => OverloadType::Function(Function {
+                        signature: self
+                            .normalize_async_generator_overload_signature(&func.signature),
+                        metadata: func.metadata,
+                    }),
+                    OverloadType::Forall(forall) => OverloadType::Forall(Forall {
+                        tparams: forall.tparams,
+                        body: Function {
+                            signature: self.normalize_async_generator_overload_signature(
+                                &forall.body.signature,
+                            ),
+                            metadata: forall.body.metadata,
+                        },
+                    }),
+                },
+            )
+        })
     }
 
     /// Substitute each type parameter with its upper bound, for overload consistency checking.

--- a/pyrefly/lib/alt/unwrap.rs
+++ b/pyrefly/lib/alt/unwrap.rs
@@ -19,6 +19,7 @@ use crate::types::callable::Required;
 use crate::types::class::ClassType;
 use crate::types::tuple::Tuple;
 use crate::types::types::Type;
+use crate::types::types::Union;
 use crate::types::types::Var;
 
 /// Maximum size for a union hint to a function call. Hints wider than this are ignored.

--- a/pyrefly/lib/alt/unwrap.rs
+++ b/pyrefly/lib/alt/unwrap.rs
@@ -356,22 +356,35 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     }
 
     pub fn decompose_async_generator(&self, ty: &Type) -> Option<(Type, Type)> {
-        let yield_ty = self.fresh_var();
-        let send_ty = self.fresh_var();
-        let async_generator_ty = self.heap.mk_class_type(
-            self.stdlib
-                .async_generator(yield_ty.to_type(self.heap), send_ty.to_type(self.heap)),
-        );
-        if self.is_subset_eq(&async_generator_ty, ty) {
-            let yield_ty: Type = self.resolve_var_opt(ty, yield_ty)?;
-            let send_ty = self
-                .resolve_var_opt(ty, send_ty)
-                .unwrap_or_else(|| self.heap.mk_none());
-            Some((yield_ty, send_ty))
-        } else if ty.is_any() {
-            Some((self.heap.mk_any_explicit(), self.heap.mk_any_explicit()))
-        } else {
-            None
+        match ty {
+            Type::Union(u) => {
+                let results: Option<Vec<_>> = u
+                    .members
+                    .iter()
+                    .map(|member| self.decompose_async_generator(member))
+                    .collect();
+                let (yield_tys, send_tys) = results?.into_iter().unzip();
+                Some((self.unions(yield_tys), self.unions(send_tys)))
+            }
+            _ => {
+                let yield_ty = self.fresh_var();
+                let send_ty = self.fresh_var();
+                let async_generator_ty = self.heap.mk_class_type(
+                    self.stdlib
+                        .async_generator(yield_ty.to_type(self.heap), send_ty.to_type(self.heap)),
+                );
+                if self.is_subset_eq(&async_generator_ty, ty) {
+                    let yield_ty: Type = self.resolve_var_opt(ty, yield_ty)?;
+                    let send_ty = self
+                        .resolve_var_opt(ty, send_ty)
+                        .unwrap_or_else(|| self.heap.mk_none());
+                    Some((yield_ty, send_ty))
+                } else if ty.is_any() {
+                    Some((self.heap.mk_any_explicit(), self.heap.mk_any_explicit()))
+                } else {
+                    None
+                }
+            }
         }
     }
 

--- a/pyrefly/lib/alt/unwrap.rs
+++ b/pyrefly/lib/alt/unwrap.rs
@@ -403,22 +403,35 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     }
 
     pub fn decompose_async_generator(&self, ty: &Type) -> Option<(Type, Type)> {
-        let yield_ty = self.fresh_var();
-        let send_ty = self.fresh_var();
-        let async_generator_ty = self.heap.mk_class_type(
-            self.stdlib
-                .async_generator(yield_ty.to_type(self.heap), send_ty.to_type(self.heap)),
-        );
-        if self.is_subset_eq(&async_generator_ty, ty) {
-            let yield_ty: Type = self.resolve_var_opt(ty, yield_ty)?;
-            let send_ty = self
-                .resolve_var_opt(ty, send_ty)
-                .unwrap_or_else(|| self.heap.mk_none());
-            Some((yield_ty, send_ty))
-        } else if ty.is_any() {
-            Some((self.heap.mk_any_explicit(), self.heap.mk_any_explicit()))
-        } else {
-            None
+        match ty {
+            Type::Union(u) => {
+                let results: Option<Vec<_>> = u
+                    .members
+                    .iter()
+                    .map(|member| self.decompose_async_generator(member))
+                    .collect();
+                let (yield_tys, send_tys) = results?.into_iter().unzip();
+                Some((self.unions(yield_tys), self.unions(send_tys)))
+            }
+            _ => {
+                let yield_ty = self.fresh_var();
+                let send_ty = self.fresh_var();
+                let async_generator_ty = self.heap.mk_class_type(
+                    self.stdlib
+                        .async_generator(yield_ty.to_type(self.heap), send_ty.to_type(self.heap)),
+                );
+                if self.is_subset_eq(&async_generator_ty, ty) {
+                    let yield_ty: Type = self.resolve_var_opt(ty, yield_ty)?;
+                    let send_ty = self
+                        .resolve_var_opt(ty, send_ty)
+                        .unwrap_or_else(|| self.heap.mk_none());
+                    Some((yield_ty, send_ty))
+                } else if ty.is_any() {
+                    Some((self.heap.mk_any_explicit(), self.heap.mk_any_explicit()))
+                } else {
+                    None
+                }
+            }
         }
     }
 

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -851,6 +851,34 @@ def f[T](x: T) -> T:
 );
 
 testcase!(
+    test_overloaded_async_iterator_impl,
+    r#"
+from collections.abc import AsyncIterator
+from typing import Literal, assert_type, overload
+
+class Patch:
+    pass
+
+class FullState(Patch):
+    pass
+
+@overload
+async def astream(*, diff: Literal[True] = ...) -> AsyncIterator[Patch]: ...
+@overload
+async def astream(*, diff: Literal[False]) -> AsyncIterator[FullState]: ...
+async def astream(*, diff: bool = True) -> AsyncIterator[Patch] | AsyncIterator[FullState]:
+    if diff:
+        yield Patch()
+    else:
+        yield FullState()
+
+assert_type(astream(), AsyncIterator[Patch])
+assert_type(astream(diff=True), AsyncIterator[Patch])
+assert_type(astream(diff=False), AsyncIterator[FullState])
+    "#,
+);
+
+testcase!(
     test_param_consistency,
     r#"
 from typing import overload

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -1037,6 +1037,34 @@ def f[T](x: T) -> T:
 );
 
 testcase!(
+    test_overloaded_async_iterator_impl,
+    r#"
+from collections.abc import AsyncIterator
+from typing import Literal, assert_type, overload
+
+class Patch:
+    pass
+
+class FullState(Patch):
+    pass
+
+@overload
+async def astream(*, diff: Literal[True] = ...) -> AsyncIterator[Patch]: ...
+@overload
+async def astream(*, diff: Literal[False]) -> AsyncIterator[FullState]: ...
+async def astream(*, diff: bool = True) -> AsyncIterator[Patch] | AsyncIterator[FullState]:
+    if diff:
+        yield Patch()
+    else:
+        yield FullState()
+
+assert_type(astream(), AsyncIterator[Patch])
+assert_type(astream(diff=True), AsyncIterator[Patch])
+assert_type(astream(diff=False), AsyncIterator[FullState])
+    "#,
+);
+
+testcase!(
     test_param_consistency,
     r#"
 from typing import overload


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2873

The change has two parts.

overload signatures are normalized when the implementation is an async generator, so async def overload stubs returning `AsyncIterator[...]` no longer stay wrapped as `Coroutine[..., AsyncIterator[...]]`.

generator decomposition now handles unions member-by-member, which fixes the bogus yield Patch() vs FullState error from `AsyncIterator[Patch] | AsyncIterator[FullState]`.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test