### PR TITLE
fix Render callable protocols in hover as the signature of __call__ rather than by name #2832

### DIFF
--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -542,6 +542,7 @@ pub fn get_hover(
         .get_callables_from_call(handle, position)
         .map(|info| info.callee_range)
         .or_else(find_callee_range_at_position);
+    let hovering_over_callee = callee_range_opt.is_some_and(|range| range.contains(position));
 
     if let Some(callee_range) = callee_range_opt {
         let is_constructor = transaction
@@ -550,6 +551,8 @@ pub fn get_hover(
             .is_some_and(is_constructor_call);
         if is_constructor && let Some(new_type) = override_constructor_return_type(type_.clone()) {
             type_ = new_type;
+        } else if hovering_over_callee {
+            type_ = transaction.coerce_type_to_callable(handle, type_);
         }
     }
 

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -178,6 +178,36 @@ greeter("hi")
 }
 
 #[test]
+fn hover_on_callable_protocol_attribute_uses_dunder_call_signature() {
+    let code = r#"
+from typing import Protocol, cast
+
+class Parametrize(Protocol):
+    def __call__(self, argnames: str, *, ids: list[str] | None = None) -> int: ...
+
+class Mark:
+    parametrize: Parametrize
+
+mark = cast(Mark, ...)
+mark.parametrize("role", ids=["owner"])
+#    ^^^^^^^^^^^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert!(
+        report.contains("__call__"),
+        "Expected hover to refer to __call__, got: {report}"
+    );
+    assert!(
+        report.contains("argnames: str"),
+        "Expected hover to show the positional parameter, got: {report}"
+    );
+    assert!(
+        report.contains("ids: list[str] | None = None"),
+        "Expected hover to show the keyword-only parameter, got: {report}"
+    );
+}
+
+#[test]
 fn hover_over_inline_ignore_comment() {
     let code = r#"
 a: int = "test"  # pyrefly: ignore


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2832

coercing the hovered type to its callable form only when the cursor is actually on the callee.

preserves the existing constructor special case and avoids changing plain attribute hovers.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test