### PR TITLE
Fix Windows test failure in thrift_go_to_def_navigates_to_thrift_source

### DIFF
--- a/pyrefly/lib/test/lsp/lsp_interaction/definition.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/definition.rs
@@ -700,10 +700,7 @@ fn thrift_go_to_def_navigates_to_thrift_source() {
     let remap_root = root_path.clone();
     let thrift_remapper = Arc::new(move |location: &Location| {
         let stub_path = location.uri.to_file_path().ok()?;
-        if !stub_path
-            .to_string_lossy()
-            .ends_with("my_thrift/ttypes.pyi")
-        {
+        if !stub_path.ends_with(PathBuf::from("my_thrift").join("ttypes.pyi")) {
             return None;
         }
         let thrift_path = remap_root.join("my_service.thrift");


### PR DESCRIPTION
Summary:
The test's thrift remapper used `to_string_lossy().ends_with("my_thrift/ttypes.pyi")`
to check stub paths, which fails on Windows where path separators are backslashes.
Replaced with `Path::ends_with` which is OS-aware.

Differential Revision: D98409653


