### PR TITLE
Reject @dataclass on TypedDict classes

### DIFF
--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -371,7 +371,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let is_attrs_class =
             self.is_attrs_class(&dataclass_from_dataclass_transform, &bases_with_metadata);
         let is_from_dataclass_transform = dataclass_from_dataclass_transform.is_some();
-        let dataclass_metadata = self.dataclass_metadata(
+        let mut dataclass_metadata = self.dataclass_metadata(
             cls,
             &decorators,
             &bases_with_metadata,
@@ -379,6 +379,21 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             pydantic_config.as_ref(),
             is_attrs_class,
         );
+        let has_dataclass_decorator = decorators.iter().any(|(decorator, _)| {
+            matches!(
+                decorator.ty.callee_kind(),
+                Some(CalleeKind::Function(FunctionKind::Dataclass))
+            ) || matches!(&decorator.ty, Type::KwCall(call) if call.has_function_kind(FunctionKind::Dataclass))
+        });
+        if is_typed_dict && dataclass_metadata.is_some() && has_dataclass_decorator {
+            self.error(
+                errors,
+                cls.range(),
+                ErrorInfo::Kind(ErrorKind::BadClassDefinition),
+                format!("Cannot apply @dataclass to TypedDict class `{}`", cls.name()),
+            );
+            dataclass_metadata = None;
+        }
         if let Some(dm) = dataclass_metadata.as_ref()
             && pydantic_config.is_none()
         {

--- a/pyrefly/lib/test/typed_dict.rs
+++ b/pyrefly/lib/test/typed_dict.rs
@@ -97,6 +97,62 @@ class Coord(TypedDict, object):  # E: Typed dictionary definitions may only exte
 );
 
 testcase!(
+    test_typeddict_dataclass_rejected,
+    r#"
+from dataclasses import dataclass
+import dataclasses
+from typing import TypedDict
+
+class Good(TypedDict):
+    x: int
+
+@dataclass
+class Bad1(TypedDict):  # E: Cannot apply @dataclass to TypedDict class `Bad1`
+    x: int
+
+@dataclasses.dataclass
+class Bad2(TypedDict):  # E: Cannot apply @dataclass to TypedDict class `Bad2`
+    x: int
+
+@dataclass()
+class Bad3(TypedDict):  # E: Cannot apply @dataclass to TypedDict class `Bad3`
+    x: int
+"#,
+);
+
+testcase!(
+    test_typeddict_dataclass_transform_not_rejected,
+    r#"
+from typing import TypedDict, dataclass_transform
+
+@dataclass_transform()
+def my_transform(cls):
+    return cls
+
+@my_transform
+class TD(TypedDict):
+    x: int
+"#,
+);
+
+testcase!(
+    test_typeddict_child_of_rejected_dataclass_base,
+    r#"
+from dataclasses import dataclass
+from typing import TypedDict
+
+@dataclass
+class Bad(TypedDict):  # E: Cannot apply @dataclass to TypedDict class `Bad`
+    x: int
+
+class Child(Bad):
+    y: int
+
+c: Child = {"x": 1, "y": 2}
+"#,
+);
+
+testcase!(
     test_typed_dict_literal,
     r#"
 from typing import TypedDict, NotRequired


### PR DESCRIPTION
## Summary
- Fixes #2923 by rejecting explicit `@dataclass` usage on `TypedDict` classes in the canonical `class_metadata_of` path.
- Clears `dataclass_metadata` after reporting the class-definition error so downstream phases do not apply dataclass synthesis to invalid classes.
- Adds regression tests for `@dataclass`, `@dataclasses.dataclass`, `@dataclass()`, a `@dataclass_transform` case (intentionally not rejected), and inheritance from a rejected base.

## Test plan
- `cargo test typed_dict` *(fails in this environment due stable toolchain vs dependency requiring nightly `#![feature(offset_of)]`)*
- `cargo test dataclass` *(same environment/toolchain failure)*
- IDE lints on touched files report no new diagnostics.

Made with [Cursor](https://cursor.com)