### PR TITLE
fix Incorrect overload selection for itertools.accumulate #2876

### DIFF
--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -221,6 +221,20 @@ impl Display for VariableNode {
 }
 
 impl Variables {
+    fn snapshot(&self) -> SmallMap<Var, VariableNode> {
+        self.0
+            .iter()
+            .map(|(var, node)| (*var, node.borrow().clone()))
+            .collect()
+    }
+
+    fn restore(&mut self, snapshot: SmallMap<Var, VariableNode>) {
+        self.0 = snapshot
+            .into_iter()
+            .map(|(var, node)| (var, RefCell::new(node)))
+            .collect();
+    }
+
     fn get<'a>(&'a self, x: Var) -> Ref<'a, Variable> {
         let root = self.get_root(x);
         let variable = self.get_node(root).borrow();

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -221,20 +221,6 @@ impl Display for VariableNode {
 }
 
 impl Variables {
-    fn snapshot(&self) -> SmallMap<Var, VariableNode> {
-        self.0
-            .iter()
-            .map(|(var, node)| (*var, node.borrow().clone()))
-            .collect()
-    }
-
-    fn restore(&mut self, snapshot: SmallMap<Var, VariableNode>) {
-        self.0 = snapshot
-            .into_iter()
-            .map(|(var, node)| (var, RefCell::new(node)))
-            .collect();
-    }
-
     fn get<'a>(&'a self, x: Var) -> Ref<'a, Variable> {
         let root = self.get_root(x);
         let variable = self.get_node(root).borrow();

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -149,6 +149,26 @@ impl SubsetWithSnapshotResult {
 }
 
 impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
+    fn is_subset_overload_candidate(
+        &mut self,
+        got: &Type,
+        want: &Type,
+    ) -> Result<(), SubsetError> {
+        let vars = got
+            .collect_maybe_placeholder_vars()
+            .into_iter()
+            .chain(want.collect_maybe_placeholder_vars())
+            .collect::<Vec<_>>();
+        match self.with_snapshot(&vars, |me| me.is_subset_eq(got, want)) {
+            SubsetWithSnapshotResult::Ok => Ok(()),
+            SubsetWithSnapshotResult::InstantiationErrors(snapshot) => {
+                self.solver.restore_vars(snapshot);
+                Ok(())
+            }
+            SubsetWithSnapshotResult::Err(e) => Err(e),
+        }
+    }
+
     /// Can a function with l_args be called as a function with u_args?
     fn is_subset_param_list(
         &mut self,
@@ -1135,7 +1155,11 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
     }
 
     fn is_subset_overload(&mut self, overload: &Overload, want: &Type) -> Result<(), SubsetError> {
-        if any(overload.signatures.iter(), |l| self.is_subset_eq(&l.as_type(), want)).is_ok() {
+        if any(overload.signatures.iter(), |l| {
+            self.is_subset_overload_candidate(&l.as_type(), want)
+        })
+        .is_ok()
+        {
             return Ok(());
         }
         if let Type::Callable(box Callable {
@@ -1183,7 +1207,9 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                         ParamList::new_types(ts),
                         ret.clone(),
                     )));
-                    any(overload.signatures.iter(), |l| self.is_subset_eq(&l.as_type(), &callable))
+                    any(overload.signatures.iter(), |l| {
+                        self.is_subset_overload_candidate(&l.as_type(), &callable)
+                    })
                 })
                 .is_ok()
                 {
@@ -1635,7 +1661,7 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                 }),
             ) => {
                 let want_has_vars =
-                    Type::Callable(Box::new(u.clone())).may_contain_quantified_var();
+                    Type::Callable(Box::new(u.clone())).may_contain_placeholder_var();
                 if want_has_vars {
                     self.is_subset_eq(&l.ret, &u.ret)?;
                     self.is_subset_params(&l.params, &u.params)

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -1135,11 +1135,7 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
     }
 
     fn is_subset_overload(&mut self, overload: &Overload, want: &Type) -> Result<(), SubsetError> {
-        if any(overload.signatures.iter(), |l| {
-            self.is_subset_eq(&l.as_type(), want)
-        })
-        .is_ok()
-        {
+        if any(overload.signatures.iter(), |l| self.is_subset_eq(&l.as_type(), want)).is_ok() {
             return Ok(());
         }
         if let Type::Callable(box Callable {
@@ -1187,9 +1183,7 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                         ParamList::new_types(ts),
                         ret.clone(),
                     )));
-                    any(overload.signatures.iter(), |l| {
-                        self.is_subset_eq(&l.as_type(), &callable)
-                    })
+                    any(overload.signatures.iter(), |l| self.is_subset_eq(&l.as_type(), &callable))
                 })
                 .is_ok()
                 {
@@ -1640,8 +1634,15 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                     metadata: _,
                 }),
             ) => {
-                self.is_subset_params(&l.params, &u.params)?;
-                self.is_subset_eq(&l.ret, &u.ret)
+                let want_has_vars =
+                    Type::Callable(Box::new(u.clone())).may_contain_quantified_var();
+                if want_has_vars {
+                    self.is_subset_eq(&l.ret, &u.ret)?;
+                    self.is_subset_params(&l.params, &u.params)
+                } else {
+                    self.is_subset_params(&l.params, &u.params)?;
+                    self.is_subset_eq(&l.ret, &u.ret)
+                }
             }
             (Type::TypedDict(TypedDict::Anonymous(got)), Type::TypedDict(want)) => {
                 self.is_subset_anonymous_typed_dict(got, want)

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -442,6 +442,23 @@ bar: Callable[[int, bytes | str], int] = foo
 );
 
 testcase!(
+    test_bound_method_overload_assignable_to_callable,
+    r#"
+from typing import Callable, assert_type
+import itertools
+
+_FORMAT_PATH = "{}/{}".format
+_DIRECT: Callable[[str, str], str] = _FORMAT_PATH
+
+def get_paths(path: str) -> list[str]:
+    parts = path.split("/")
+    result = list(itertools.accumulate(parts, _FORMAT_PATH))
+    assert_type(result, list[str])
+    return result
+    "#,
+);
+
+testcase!(
     test_overload_assignable_to_callable_return_supertype,
     r#"
 from typing import Callable, overload


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2876

when matching a generic callable target that still has inference vars, Pyrefly now checks the return type before the parameter list

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test