### PR TITLE
Fix GitHub build

### DIFF
--- a/pyrefly/lib/test/lsp/lsp_interaction/pytorch_benchmark.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/pytorch_benchmark.rs
@@ -48,7 +48,7 @@ fn test_pytorch_error_propagation_latency() {
     };
     // Use all available cores for realistic benchmarking
     let mut interaction =
-        LspInteraction::new_with_args(args, NoTelemetry, Some(ThreadCount::AllThreads));
+        LspInteraction::new_with_args(args, NoTelemetry, Some(ThreadCount::AllThreads), None);
     interaction.set_root(pytorch_root.clone());
 
     interaction


### PR DESCRIPTION
Summary:
pytorch_benchmark.rs is gated with #[cfg(not(fbcode_build))] (line 14), so it's only compiled on GitHub/cargo builds, never internally.

When the thrift_remapper parameter was added to LspInteraction::new_with_args, this call site was missed because it doesn't compile in the internal build.

Fix: Added None as the 4th argument (thrift_remapper) to match the updated function signature, consistent with all other callers.

Differential Revision: D98568416


