### PR TITLE
Reject stdlib dataclass on Enum subclasses

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1025,6 +1025,44 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 format!("Cannot call abstract method `{method_name}`"),
             );
         }
+        if let Some(meta) = metadata
+            && meta.kind == FunctionKind::Dataclass
+            && let Some(first_ty) = self.first_arg_type(args, errors)
+        {
+            let first_arg_range = args
+                .first()
+                .map(|a| a.range())
+                .unwrap_or(arguments_range);
+            self.map_over_union(&first_ty, |ty| {
+                if let Some((_, inner)) = self.unwrap_class_object_silently(ty) {
+                    if let Type::ClassType(ct) = inner
+                        && self.get_metadata_for_class(ct.class_object()).is_enum()
+                    {
+                        self.error(
+                            errors,
+                            first_arg_range,
+                            ErrorInfo::Kind(ErrorKind::BadClassDefinition),
+                            format!(
+                                "Cannot apply dataclasses.dataclass to Enum class `{}`",
+                                ct.class_object().name()
+                            ),
+                        );
+                    }
+                } else if let Type::ClassType(ct) = ty
+                    && self.get_metadata_for_class(ct.class_object()).is_enum()
+                {
+                    self.error(
+                        errors,
+                        first_arg_range,
+                        ErrorInfo::Kind(ErrorKind::BadClassDefinition),
+                        format!(
+                            "Cannot apply dataclasses.dataclass to Enum class `{}`",
+                            ct.class_object().name()
+                        ),
+                    );
+                }
+            });
+        }
         // Does this call target correspond to a function whose keyword arguments we should save?
         let kw_metadata = {
             if let Some(m) = metadata

--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -371,7 +371,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let is_attrs_class =
             self.is_attrs_class(&dataclass_from_dataclass_transform, &bases_with_metadata);
         let is_from_dataclass_transform = dataclass_from_dataclass_transform.is_some();
-        let dataclass_metadata = self.dataclass_metadata(
+        let mut dataclass_metadata = self.dataclass_metadata(
             cls,
             &decorators,
             &bases_with_metadata,
@@ -379,6 +379,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             pydantic_config.as_ref(),
             is_attrs_class,
         );
+        let has_dataclass_decorator = decorators.iter().any(|(decorator, _)| {
+            matches!(
+                decorator.ty.callee_kind(),
+                Some(CalleeKind::Function(FunctionKind::Dataclass))
+            ) || matches!(&decorator.ty, Type::KwCall(call) if call.has_function_kind(FunctionKind::Dataclass))
+        });
+        if enum_metadata.is_some() && dataclass_metadata.is_some() && has_dataclass_decorator {
+            self.error(
+                errors,
+                cls.range(),
+                ErrorInfo::Kind(ErrorKind::BadClassDefinition),
+                format!(
+                    "Cannot apply @dataclass to Enum class `{}`",
+                    cls.name()
+                ),
+            );
+            dataclass_metadata = None;
+        }
         if let Some(dm) = dataclass_metadata.as_ref()
             && pydantic_config.is_none()
         {

--- a/pyrefly/lib/test/dataclasses.rs
+++ b/pyrefly/lib/test/dataclasses.rs
@@ -24,6 +24,32 @@ assert_type(Data, type[Data])
 );
 
 testcase!(
+    test_enum_dataclass_rejected,
+    r#"
+from dataclasses import dataclass
+import dataclasses
+from enum import Enum
+
+class Good(Enum):
+    RED = 1
+
+@dataclass
+class Bad1(Enum):  # E: Cannot apply @dataclass to Enum class `Bad1`
+    RED = 1
+
+@dataclasses.dataclass
+class Bad2(Enum):  # E: Cannot apply @dataclass to Enum class `Bad2`
+    RED = 1
+
+@dataclass()
+class Bad3(Enum):  # E: Cannot apply @dataclass to Enum class `Bad3`
+    RED = 1
+
+dataclass(Good)  # E: Cannot apply dataclasses.dataclass to Enum class `Good`
+    "#,
+);
+
+testcase!(
     test_kw_only_sentinel_deep_inheritance,
     r#"
 from dataclasses import dataclass, KW_ONLY


### PR DESCRIPTION
Fixes #2922.

Python's `dataclasses` module does not support Enum subclasses (runtime `TypeError`). Pyrefly now emits `BadClassDefinition` when:

- An Enum class is decorated with stdlib `@dataclass` / `@dataclasses.dataclass`, or
- `dataclasses.dataclass` is called with an Enum class as the first positional argument (e.g. `dataclass(Color)`).

Adds `test_enum_dataclass_rejected` in `lib/test/dataclasses.rs`.

Made with [Cursor](https://cursor.com)