### PR TITLE
Add linux ppc64le wheel build to CI

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -138,6 +138,7 @@ jobs:
           - x86_64-unknown-linux-gnu
           - i686-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
+          - powerpc64le-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v6
         with:
@@ -148,7 +149,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - name: Build wheels
-        if: ${{ !startsWith(matrix.target, 'aarch64') }}
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'i686-unknown-linux-gnu' }}
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
@@ -166,6 +167,18 @@ jobs:
         env:
           # aarch64-linux builds need JEMALLOC_SYS_WITH_LG_PAGE=16, or they segfault.
           # See https://github.com/facebook/pyrefly/issues/380
+          JEMALLOC_SYS_WITH_LG_PAGE: 16
+      - name: Build wheels ppc64le
+        if: ${{ startsWith(matrix.target, 'powerpc64le') }}
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: auto
+          args: --release --out dist
+          working-directory: pyrefly
+        env:
+          # ppc64le-linux uses 64KB pages (2^16 bytes). JEMALLOC_SYS_WITH_LG_PAGE is
+          # log2 of the page size, same as aarch64-linux.
           JEMALLOC_SYS_WITH_LG_PAGE: 16
       - name: Test wheel (unactivated venv)
         if: ${{ startsWith(matrix.target, 'x86_64') }}


### PR DESCRIPTION
# Summary

To add wheel build for Linux ppc64le target.

Why? The PPC community has been building pyrefly wheel manually for a while when working with projects that happen to leverage pyrefly for example servo project. It would be a big win in term of convenience/time-saving if there is an official wheel build.
