### PR TITLE
fix Tuple expansion/equivalence for return type & subset check #1556

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -719,6 +719,41 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         hint: Option<HintRefOld>,
         errors: &ErrorCollector,
     ) -> Type {
+        if let Some(hint) = hint
+            && let Some(ty) = self.tuple_infer_matching_union_branch(x, hint)
+        {
+            return ty;
+        }
+        self.tuple_infer_with_hint(x, hint, errors)
+    }
+
+    fn tuple_infer_matching_union_branch(&self, x: &ExprTuple, hint: HintRefOld) -> Option<Type> {
+        let (tuples, _) = self.split_tuple_hint(hint.ty());
+        if tuples.len() <= 1 {
+            return None;
+        }
+        let mut matching = Vec::new();
+        for tuple in tuples {
+            let branch_errors = self.error_collector();
+            let branch_hint = Type::Tuple(tuple.clone());
+            let inferred = self.tuple_infer_with_hint(
+                x,
+                Some(HintRefOld::new(&branch_hint, Some(&branch_errors))),
+                &branch_errors,
+            );
+            if branch_errors.is_empty() && self.is_subset_eq(&inferred, &branch_hint) {
+                matching.push(inferred);
+            }
+        }
+        (!matching.is_empty()).then(|| self.unions(matching))
+    }
+
+    fn tuple_infer_with_hint(
+        &self,
+        x: &ExprTuple,
+        hint: Option<HintRefOld>,
+        errors: &ErrorCollector,
+    ) -> Type {
         let owner = Owner::new();
         let has_hint = hint.is_some();
         let (hint_ts, default_hint) = if let Some(hint) = &hint {

--- a/pyrefly/lib/test/tuple.rs
+++ b/pyrefly/lib/test/tuple.rs
@@ -683,6 +683,23 @@ x: tuple[Literal["a", "b"], ...] = tuple(CONSTS)
 );
 
 testcase!(
+    test_tuple_return_contextual_union_hint,
+    r#"
+def check_type[T](
+    value: object,
+    expected_type: type[T],
+) -> T: ...
+
+def login(username: str | int) -> tuple[bool, int] | tuple[bool, str]:
+    return True, check_type(username, int)
+
+def login_via_local(username: str | int) -> tuple[bool, int] | tuple[bool, str]:
+    result = True, check_type(username, int)
+    return result
+    "#,
+);
+
+testcase!(
     test_callable_tuple_mismatch,
     r#"
 from typing import Callable


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1556

tuple literals with a union tuple hint now try each tuple branch independently and keep the branches whose fully inferred tuple matches, instead of immediately unioning element hints and losing the int/str correlation.

preserves the correct direct-return behavior for cases like `tuple[bool, int] | tuple[bool, str]`.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test