### PR TITLE
fix hover over tuple element shows type of whole tuple #2973

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -815,7 +815,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                 }
                 _ => {
-                    let ty = self.expr_infer_type_no_trace(
+                    let ty = self.expr_infer_with_hint(
                         elt,
                         if unbounded.is_empty() {
                             hint_ts_iter.next().or(default_hint)

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -560,6 +560,27 @@ lhs @ rhs
 }
 
 #[test]
+fn hover_over_tuple_element_literal_uses_element_type() {
+    let code = r#"
+tup = (1, +2)
+#      ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert_eq!(
+        r#"
+# main.py
+2 | tup = (1, +2)
+           ^
+```python
+Literal[1]
+```
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn hover_over_getitem_operator_shows_dunder_name() {
     let code = r#"
 class Container:

--- a/pyrefly/lib/test/lsp/hover_type.rs
+++ b/pyrefly/lib/test/lsp/hover_type.rs
@@ -199,6 +199,33 @@ Hover Result: `(self: My, other: object) -> bool`
 }
 
 #[test]
+fn tuple_element_hover_prefers_element_type() {
+    let code = r#"
+tup = (1, +2)
+#      ^  ^ ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert_eq!(
+        r#"
+# main.py
+2 | tup = (1, +2)
+           ^
+Hover Result: `Literal[1]`
+
+2 | tup = (1, +2)
+              ^
+Hover Result: `Literal[2]`
+
+2 | tup = (1, +2)
+                ^
+Hover Result: `Literal[2]`
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn import_test() {
     let code = r#"
 import typing


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2973

non-starred tuple elements were inferred with the no-trace path, so hover on 1 or the operand in +2 had no child expression trace and fell back to the enclosing tuple type.

changed to use the trace-recording inference path for tuple elements.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test