### PR TITLE
fix Object of class _lru_cache_wrapper has no attribute get when using lru-cached property #2979

### DIFF
--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -1412,7 +1412,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     self.heap.mk_class_type(cls)
                 }
             }
-            Type::ClassType(cls) if cls.has_qname("functools", "_Wrapped") => {
+            Type::ClassType(cls)
+                if cls.has_qname("functools", "_Wrapped")
+                    || (original_decoratee.property_metadata().is_some()
+                        && cls.has_qname("functools", "_lru_cache_wrapper")) =>
+            {
                 original_decoratee.clone()
             }
             returned_ty => returned_ty,

--- a/pyrefly/lib/test/descriptors.rs
+++ b/pyrefly/lib/test/descriptors.rs
@@ -178,6 +178,23 @@ def f(c: C) -> None:
 );
 
 testcase!(
+    test_property_decorated_with_lru_cache,
+    r#"
+import functools
+
+class Foo:
+    @property
+    @functools.lru_cache
+    def foo(self) -> dict[str, str]:
+        return {"a": "b"}
+
+def main() -> None:
+    Foo.foo.get("a")
+    Foo().foo.get("a")
+    "#,
+);
+
+testcase!(
     bug = "cached_property's __name__ should not exist and attrname should be a str",
     test_cached_property_attrname,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2979

preserving `@property` semantics when the inner decorator is functools.lru_cache.

The change in unwraps _lru_cache_wrapper back to the original decorated function only when the original already carried property metadata, so ordinary lru_cache wrappers are unchanged.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test