### PR TITLE
fix unsafe-overlap reported for checking if Iterable is Generator #2978

### DIFF
--- a/pyrefly/lib/alt/special_calls.rs
+++ b/pyrefly/lib/alt/special_calls.rs
@@ -356,12 +356,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             && let (vs, Type::ClassType(protocol_class_type)) =
                                 self.instantiate_fresh_class(cls)
                         {
+                            let mut all_members_present = true;
                             let mut unsafe_overlap_errors = vec![];
                             for field_name in &protocol_metadata.members {
                                 if !self.has_attr(object_type, field_name) {
-                                    // It's okay if the field is missing, since
-                                    // we only care about unsafe overlaps
-                                    continue;
+                                    all_members_present = false;
+                                    break;
                                 }
                                 if let Err(subset_err) = self.is_protocol_subset_at_attr(
                                     object_type,
@@ -379,25 +379,27 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                     ));
                                 }
                             }
-                            if let Err(specialization_errors) =
-                                self.solver().finish_quantified(vs, false)
-                            {
-                                for e in specialization_errors {
-                                    unsafe_overlap_errors.push(e.to_error_msg(self))
+                            if all_members_present {
+                                if let Err(specialization_errors) =
+                                    self.solver().finish_quantified(vs, false)
+                                {
+                                    for e in specialization_errors {
+                                        unsafe_overlap_errors.push(e.to_error_msg(self))
+                                    }
                                 }
-                            }
-                            if !unsafe_overlap_errors.is_empty() {
-                                let mut full_msg = vec1![format!(
-                                    "Runtime checkable protocol `{}` has an unsafe overlap with type `{}`",
-                                    cls.name(),
-                                    self.for_display(object_type.clone())
-                                )];
-                                full_msg.extend(unsafe_overlap_errors);
-                                errors.add(
-                                    range,
-                                    ErrorInfo::Kind(ErrorKind::UnsafeOverlap),
-                                    full_msg,
-                                );
+                                if !unsafe_overlap_errors.is_empty() {
+                                    let mut full_msg = vec1![format!(
+                                        "Runtime checkable protocol `{}` has an unsafe overlap with type `{}`",
+                                        cls.name(),
+                                        self.for_display(object_type.clone())
+                                    )];
+                                    full_msg.extend(unsafe_overlap_errors);
+                                    errors.add(
+                                        range,
+                                        ErrorInfo::Kind(ErrorKind::UnsafeOverlap),
+                                        full_msg,
+                                    );
+                                }
                             }
                         }
                     }

--- a/pyrefly/lib/test/protocol.rs
+++ b/pyrefly/lib/test/protocol.rs
@@ -714,6 +714,17 @@ issubclass(X, Sized) # E: Runtime checkable protocol `Sized` has an unsafe overl
 );
 
 testcase!(
+    test_runtime_checkable_missing_members_do_not_overlap,
+    r#"
+from typing import Any, Generator, Iterable
+
+def main(a: Iterable[Any]) -> None:
+    if isinstance(a, Generator):
+        pass
+"#,
+);
+
+testcase!(
     test_runtime_checkable_generics_no_error,
     r#"
 from typing import Protocol, runtime_checkable, TypeVar


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2978

the runtime-checkable protocol overlap check now only reports unsafe-overlap when the checked type has all protocol members.

matches the intended erased-runtime-shape test and avoids flagging partial matches like `Iterable[Any]`, which shares `__iter__` with Generator but lacks the rest of Generator’s runtime API.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test