### PR TITLE
Do not allow calling NotImplemented

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -366,9 +366,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     // If the class has an unknown base (e.g. inherits from an
                     // unresolved name), it might have inherited `__call__` from
                     // that base, so treat it as callable with implicit Any.
+                    //
+                    // `NotImplemented` is a singleton instance of `NotImplementedType`; it must
+                    // never be treated as callable even when stubs use `NotImplementedType(Any)`,
+                    // which would otherwise set `has_base_any` and hit this branch.
                     None if self
                         .get_metadata_for_class(cls.class_object())
-                        .has_base_any() =>
+                        .has_base_any()
+                        && !cls.has_qname("types", "NotImplementedType")
+                        && !cls.has_qname("builtins", "_NotImplementedType") =>
                     {
                         CallTargetLookup::Ok(Box::new(CallTarget::Any(AnyStyle::Implicit)))
                     }

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -1449,3 +1449,13 @@ def after_func() -> None: ...
 schedule(1000, after_func)
 "#,
 );
+
+// Regression test for https://github.com/facebook/pyrefly/issues/2918
+testcase!(
+    test_notimplemented_not_callable,
+    r#"
+NotImplemented()  # E: Expected a callable
+NotImplemented("not yet done")  # E: Expected a callable
+raise NotImplementedError()
+"#,
+);

--- a/pyrefly/lib/test/calls.rs
+++ b/pyrefly/lib/test/calls.rs
@@ -408,16 +408,15 @@ def get_flow_version(run_id: str | None) -> str | None:
 
 // https://github.com/facebook/pyrefly/issues/2918
 testcase!(
-    bug = "Should error when calling NotImplemented (a constant, not a class)",
     test_call_not_implemented_constant,
     r#"
 # NotImplemented is a singleton constant, not a callable class.
 # Using NotImplemented() is always a mistake; they mean NotImplementedError().
 def broken():
-    raise NotImplemented()
+    raise NotImplemented()  # E: Expected a callable
 
 def also_broken():
-    raise NotImplemented("not yet done")
+    raise NotImplemented("not yet done")  # E: Expected a callable
 "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

NotImplemented is a singleton, not callable, but bundled stdlib stubs declare NotImplementedType with an Any base. Pyrefly then treated instances as implicitly callable when no __call__ was found (has_base_any → implicit Any call target). This change skips that implicit-call path for types.NotImplementedType and builtins._NotImplementedType, so NotImplemented(...) is reported as not callable. Adds a regression test in pyrefly/lib/test/callable.rs.

Fixes #2918

# Test Plan

cargo test -p pyrefly test_notimplemented_not_callable
cargo test -p pyrefly test_return_notimplemented (ensure return NotImplemented behavior unchanged)
cargo test -p pyrefly test_no_missing_return_for_stubs
python3 test.py --no-test --no-conformance (no generated conformance files touched for this change)
