### PR TITLE
Fix duplicate Protocol base class detection (#2919)

### DIFF
--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -323,15 +323,26 @@ impl<'a> BindingsBuilder<'a> {
             base_class
         });
 
-        let has_protocol_base = bases.iter().any(|base| {
-            matches!(
-                base,
-                BaseClass::Generic(BaseClassGeneric {
-                    kind: BaseClassGenericKind::Protocol,
-                    ..
-                })
-            )
-        });
+        let mut has_protocol_base = false;
+        let mut seen_protocol = false;
+        for base in bases.iter() {
+            if let BaseClass::Generic(BaseClassGeneric {
+                kind: BaseClassGenericKind::Protocol,
+                range,
+                ..
+            }) = base
+            {
+                if seen_protocol {
+                    self.error(
+                        *range,
+                        ErrorInfo::Kind(ErrorKind::InvalidInheritance),
+                        "Duplicate base class `Protocol`".to_owned(),
+                    );
+                }
+                seen_protocol = true;
+                has_protocol_base = true;
+            }
+        }
 
         let mut keywords = Vec::new();
         if let Some(args) = &mut x.arguments {

--- a/pyrefly/lib/test/mro.rs
+++ b/pyrefly/lib/test/mro.rs
@@ -242,11 +242,10 @@ f(A[int])
 
 // https://github.com/facebook/pyrefly/issues/2919
 testcase!(
-    bug = "Should detect duplicate Protocol base class",
     test_duplicate_protocol_base,
     r#"
 from typing import Protocol
 
-class P(Protocol, Protocol): ...
+class P(Protocol, Protocol): ...  # E: Duplicate base class `Protocol`
 "#,
 );


### PR DESCRIPTION
Fixes #2919 

Summary
This PR addresses an issue where defining a class with duplicate `Protocol` bases (e.g., `class P(Protocol, Protocol): ...`) failed to produce a diagnostic error.

Changes Made
* Updated the semantic analysis logic in `pyrefly/lib/binding/class.rs` within `class_def_inner`.
* Replaced the `.any()` short-circuiting logic with a full iteration over the `bases` array to accurately track if `Protocol` has been seen.
* Added a boolean flag (`seen_protocol`) to correctly emit an `InvalidInheritance` diagnostic when multiple `Protocol` bases are detected, avoiding issues with unique `TextRange` positions.
* Added a new test case `test_duplicate_protocol_base` in `mro.rs` to prevent regressions.

Testing
* `cargo test test_duplicate_protocol_base --lib` passes successfully.
* `python test.py` passes without formatting, linting, or integration errors.