### PR TITLE
fix Pydantic lax-mode rewrites Pattern[str] to Pattern[LaxStr] and rejects re.Pattern[str] #2991

### DIFF
--- a/pyrefly/lib/alt/class/pydantic_lax.rs
+++ b/pyrefly/lib/alt/class/pydantic_lax.rs
@@ -161,6 +161,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         None
     }
 
+    fn get_regex_pattern_lax_conversion(
+        &self,
+        class_obj: &Class,
+        ty: &Type,
+        targs: &[Type],
+    ) -> Option<Type> {
+        if class_obj.has_toplevel_qname(ModuleName::from_str("re").as_str(), "Pattern")
+            || class_obj.has_toplevel_qname(ModuleName::typing().as_str(), "Pattern")
+        {
+            let pattern_input = targs
+                .first()
+                .cloned()
+                .unwrap_or_else(|| self.heap.mk_any_implicit());
+            return Some(self.union(ty.clone(), pattern_input));
+        }
+        None
+    }
+
     fn get_tuple_element_type(&self, tuple: &Tuple) -> Type {
         match tuple {
             Tuple::Unbounded(elem) => self.expand_type_for_lax_mode(elem),
@@ -207,6 +225,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     return self
                         .heap
                         .mk_class_type(self.stdlib.mapping(key_ty, expanded_val));
+                }
+
+                if let Some(converted) = self.get_regex_pattern_lax_conversion(class_obj, ty, targs)
+                {
+                    return converted;
                 }
 
                 let expanded_targs = self.expand_types(targs);

--- a/pyrefly/lib/test/pydantic/strictness.rs
+++ b/pyrefly/lib/test/pydantic/strictness.rs
@@ -340,6 +340,23 @@ Model(parameters=d)
 );
 
 pydantic_testcase!(
+    test_lax_mode_pattern_field,
+    r#"
+import re
+from typing import reveal_type
+from pydantic import BaseModel
+
+class RegexSignature(BaseModel):
+    signature: re.Pattern[str]
+
+reveal_type(RegexSignature.__init__)  # E: revealed type: (self: RegexSignature, *, signature: Pattern[str] | str, **Unknown) -> None
+RegexSignature(signature=re.compile(r"needle"))
+RegexSignature(signature="needle")
+RegexSignature(signature=b"needle")  # E: Argument `Literal[b'needle']` is not assignable to parameter `signature`
+    "#,
+);
+
+pydantic_testcase!(
     test_lax_mode_other,
     r#"
 from pydantic import BaseModel


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2991

Pydantic lax conversion now special-cases regex patterns so `re.Pattern[T]` expands to `re.Pattern[T] | T` instead of recursively widening the inner type to LaxStr.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test