### PR TITLE
fix urlunparse returns Literal[b''] instead of str #2867

### DIFF
--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -285,7 +285,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
         let named_tuple_metadata =
             self.named_tuple_metadata(cls, bases, &bases_with_metadata, errors);
-        if named_tuple_metadata.is_some() && bases_with_metadata.len() > 1 {
+        if named_tuple_metadata.is_some()
+            && bases_with_metadata.len() > 1
+            && !cls.module().path().is_interface()
+        {
+            // Typeshed models some stdlib namedtuple result objects, such as urllib.parse.ParseResult,
+            // by mixing methods into a NamedTuple subclass inside a `.pyi`. Keep rejecting this in
+            // user code, but allow it in stubs so we can type-check those result objects precisely.
             self.error(
                 errors,
                 cls.range(),

--- a/pyrefly/lib/alt/class/classdef.rs
+++ b/pyrefly/lib/alt/class/classdef.rs
@@ -199,6 +199,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     pub fn as_superclass(&self, class: &ClassType, want: &Class) -> Option<ClassType> {
         if class.class_object() == want {
             Some(class.clone())
+        } else if !class.class_object().is_builtin("tuple")
+            && let Some(tuple) = self.as_tuple(class)
+            && self.has_superclass(
+                self.stdlib
+                    .tuple(self.heap.mk_any_implicit())
+                    .class_object(),
+                want,
+            )
+        {
+            // NamedTuple subclasses support precise tuple operations via `as_tuple`, but their
+            // nominal base-class hierarchy still flows through `NamedTupleFallback`, whose tuple
+            // ancestor is `tuple[Any, ...]`. Route tuple-related superclass lookups through an
+            // erased tuple class so assignability to Sequence/Iterable/etc. uses the actual
+            // element types instead of `Any`.
+            let tuple_class = self.erase_tuple_type(tuple);
+            self.as_superclass(&tuple_class, want)
         } else {
             self.get_ancestor(class.class_object(), want)
                 .map(|ancestor| ancestor.substitute_with(&class.substitution()))

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use crate::test::util::TestEnv;
 use crate::testcase;
 
 testcase!(
@@ -270,7 +271,6 @@ def test(p: Pair, p2: Pair2[bytes]):
 );
 
 testcase!(
-    bug = "NamedTuple extends tuple[Any, ...], making it a subtype of too many things",
     test_named_tuple_subclass,
     r#"
 from typing import NamedTuple, Sequence, Never
@@ -278,8 +278,46 @@ class Pair(NamedTuple):
     x: int
     y: str
 p: Pair = Pair(1, "")
-x1: Sequence[int|str] = p # should succeed
-x2: Sequence[Never] = p # should fail
+x1: Sequence[int|str] = p
+def f(x: Sequence[Never]) -> None: ...
+f(p)  # E: Argument `Pair` is not assignable to parameter `x` with type `Sequence[Never]` in function `f`
+    "#,
+);
+
+fn env_named_tuple_stub_mixins() -> TestEnv {
+    let mut t = TestEnv::new();
+    t.add_with_path(
+        "foo",
+        "foo.pyi",
+        r#"
+from typing import Generic, NamedTuple, TypeVar
+
+T = TypeVar("T")
+
+class Base(NamedTuple, Generic[T]):
+    x: T
+
+class Mixin: ...
+
+class Derived(Base[str], Mixin): ...
+        "#,
+    );
+    t
+}
+
+testcase!(
+    test_named_tuple_stub_mixins_preserve_tuple_subtyping,
+    env_named_tuple_stub_mixins(),
+    r#"
+from typing import Iterable
+from foo import Derived
+
+def takes_none(xs: Iterable[None]) -> None: ...
+def takes_str(xs: Iterable[str]) -> None: ...
+
+def f(d: Derived) -> None:
+    takes_str(d)
+    takes_none(d)  # E: Argument `Derived` is not assignable to parameter `xs` with type `Iterable[None]` in function `takes_none`
     "#,
 );
 

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -31,6 +31,22 @@ def anywhere():
     "#,
 );
 
+// Regression test for https://github.com/facebook/pyrefly/issues/2867
+testcase!(
+    test_urlunparse_prefers_string_overload_for_parse_result,
+    r#"
+from typing import assert_type
+from urllib.parse import urlparse, urlunparse
+
+def sanitize_url(url: str) -> str:
+    parsed = urlparse(url)
+    assert_type(urlunparse(parsed), str)
+    sanitized = parsed._replace(netloc="example.com")
+    assert_type(urlunparse(sanitized), str)
+    return urlunparse(sanitized)
+    "#,
+);
+
 testcase!(
     test_branches,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2867

changed `as_superclass` so tuple-like NamedTuple subclasses are upcast through their erased tuple element types instead of the old `tuple[Any, ...]` fallback.

stops `ParseResult` from matching `Iterable[None]`, which was why urlunparse incorrectly chose the Literal[b""] overload.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test