### PR TITLE
fix: ensure all diagnostic paths in baseline are relative

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,6 +2424,7 @@ dependencies = [
  "notify",
  "parse-display",
  "path-absolutize",
+ "pathdiff",
  "pyrefly_derive",
  "rayon",
  "ruff_notebook",
@@ -2859,6 +2860,7 @@ dependencies = [
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"

--- a/crates/pyrefly_util/Cargo.toml
+++ b/crates/pyrefly_util/Cargo.toml
@@ -30,6 +30,7 @@ memory-stats = "1.2.0"
 notify = "8.2.0"
 parse-display = "0.8.2"
 path-absolutize = { version = "3.1.1", features = ["use_unix_paths_on_wasm"] }
+pathdiff = "0.2"
 rayon = "1.11.0"
 ruff_notebook = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff/", rev = "474b00568ad78f02ad8e19b8166cbeb6d69f8511" }

--- a/crates/pyrefly_util/src/absolutize.rs
+++ b/crates/pyrefly_util/src/absolutize.rs
@@ -10,6 +10,16 @@ use std::path::PathBuf;
 
 use path_absolutize::Absolutize as PathAbsolutize;
 
+pub trait Relativize {
+    fn relativize_from(&self, base: &Path) -> PathBuf;
+}
+
+impl Relativize for Path {
+    fn relativize_from(&self, base: &Path) -> PathBuf {
+        pathdiff::diff_paths(self, base).unwrap_or_else(|| self.to_path_buf())
+    }
+}
+
 pub trait Absolutize {
     fn absolutize(&self) -> PathBuf;
     fn absolutize_from(&self, base: &Path) -> PathBuf;

--- a/crates/pyrefly_util/src/absolutize.rs
+++ b/crates/pyrefly_util/src/absolutize.rs
@@ -10,16 +10,6 @@ use std::path::PathBuf;
 
 use path_absolutize::Absolutize as PathAbsolutize;
 
-pub trait Relativize {
-    fn relativize_from(&self, base: &Path) -> PathBuf;
-}
-
-impl Relativize for Path {
-    fn relativize_from(&self, base: &Path) -> PathBuf {
-        pathdiff::diff_paths(self, base).unwrap_or_else(|| self.to_path_buf())
-    }
-}
-
 pub trait Absolutize {
     fn absolutize(&self) -> PathBuf;
     fn absolutize_from(&self, base: &Path) -> PathBuf;

--- a/crates/pyrefly_util/src/lib.rs
+++ b/crates/pyrefly_util/src/lib.rs
@@ -47,6 +47,7 @@ pub mod owner;
 pub mod panic;
 pub mod prelude;
 pub mod recurser;
+pub mod relativize;
 pub mod ruff_visitors;
 pub mod small_map1;
 pub mod small_set1;

--- a/crates/pyrefly_util/src/relativize.rs
+++ b/crates/pyrefly_util/src/relativize.rs
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::path::Path;
+use std::path::PathBuf;
+
+pub trait Relativize {
+    fn relativize_from(&self, base: &Path) -> PathBuf;
+}
+
+impl Relativize for Path {
+    fn relativize_from(&self, base: &Path) -> PathBuf {
+        pathdiff::diff_paths(self, base).unwrap_or_else(|| self.to_path_buf())
+    }
+}

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -1103,11 +1103,7 @@ impl CheckArgs {
         let collected = loads.collect_errors();
         // Pass pre-collected errors to avoid redundant error collection.
         let unused_ignore_errors = loads.collect_unused_ignore_errors_for_display(&collected);
-        let errors = loads.apply_baseline(
-            collected,
-            self.output.baseline.as_deref(),
-            relative_to.as_path(),
-        );
+        let errors = loads.apply_baseline(collected, self.output.baseline.as_deref());
         let (directives, ordinary_errors) = if let Some(only) = &self.output.only {
             let only = only.iter().collect::<SmallSet<_>>();
             (

--- a/pyrefly/lib/error/baseline.rs
+++ b/pyrefly/lib/error/baseline.rs
@@ -128,25 +128,21 @@ mod tests {
 
     #[test]
     fn test_baseline_matching() {
-        let baseline_json = r#"
-        {
-            "errors": [
-                {
-                    "line": 1,
-                    "column": 3,
-                    "stop_line": 1,
-                    "stop_column": 5,
-                    "path": "/workspace/test.py",
-                    "code": -2,
-                    "name": "bad-return",
-                    "description": "Test error",
-                    "concise_description": "Test error"
-                }
-            ]
-        }
-        "#;
+        let baseline_json = serde_json::json!({
+            "errors": [{
+                "line": 1,
+                "column": 3,
+                "stop_line": 1,
+                "stop_column": 5,
+                "path": "/workspace/test.py",
+                "code": -2,
+                "name": "bad-return",
+                "description": "Test error",
+                "concise_description": "Test error"
+            }]
+        });
 
-        let baseline_file: LegacyErrors = serde_json::from_str(baseline_json).unwrap();
+        let baseline_file: LegacyErrors = serde_json::from_value(baseline_json).unwrap();
         let baseline_keys: HashSet<BaselineKey> =
             baseline_file.errors.iter().map(BaselineKey::from).collect();
 
@@ -209,18 +205,16 @@ mod tests {
         let cwd = std::env::current_dir().unwrap();
         let abs_path = cwd.join("src/foo.py");
 
-        let baseline_json = format!(
-            r#"{{
-                "errors": [{{
-                    "line": 1, "column": 5, "stop_line": 1, "stop_column": 10,
-                    "path": "{baseline_path}",
-                    "code": -2, "name": "bad-return",
-                    "description": "test", "concise_description": "test"
-                }}]
-            }}"#
-        );
+        let baseline_json = serde_json::json!({
+            "errors": [{
+                "line": 1, "column": 5, "stop_line": 1, "stop_column": 10,
+                "path": baseline_path,
+                "code": -2, "name": "bad-return",
+                "description": "test", "concise_description": "test"
+            }]
+        });
 
-        let baseline_file: LegacyErrors = serde_json::from_str(&baseline_json).unwrap();
+        let baseline_file: LegacyErrors = serde_json::from_value(baseline_json).unwrap();
         let baseline_keys: HashSet<BaselineKey> =
             baseline_file.errors.iter().map(BaselineKey::from).collect();
         let processor = BaselineProcessor { baseline_keys };

--- a/pyrefly/lib/error/baseline.rs
+++ b/pyrefly/lib/error/baseline.rs
@@ -227,7 +227,8 @@ mod tests {
         let error = Error::new(
             module,
             TextRange::new(TextSize::new(4), TextSize::new(10)),
-            vec1!["err".to_owned()],
+            "err".to_owned(),
+            Vec::new(),
             ErrorKind::BadReturn,
         );
         assert!(processor.matches_baseline(&error));

--- a/pyrefly/lib/error/baseline.rs
+++ b/pyrefly/lib/error/baseline.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use anyhow::Result;
+use pyrefly_util::absolutize::Absolutize;
 use pyrefly_util::fs_anyhow;
 
 use crate::error::error::Error;
@@ -16,6 +17,7 @@ use crate::error::legacy::LegacyError;
 use crate::error::legacy::LegacyErrors;
 
 /// If an error with an exactly matching path, error slug, and starting column exist in the baseline, we ignore it.
+/// Keys always use absolute paths internally so that comparison is decoupled from path format in baseline file.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct BaselineKey {
     path: String,
@@ -25,8 +27,9 @@ struct BaselineKey {
 
 impl From<&LegacyError> for BaselineKey {
     fn from(baseline_error: &LegacyError) -> Self {
+        let path = Path::new(&baseline_error.path);
         Self {
-            path: baseline_error.path.clone(),
+            path: path.absolutize().to_string_lossy().into_owned(),
             name: baseline_error.name.clone(),
             column: baseline_error.column,
         }
@@ -34,12 +37,12 @@ impl From<&LegacyError> for BaselineKey {
 }
 
 impl BaselineKey {
-    fn from_error(error: &Error, relative_to: &Path) -> Self {
-        let error_path = error.path().as_path();
+    fn from_error(error: &Error) -> Self {
         Self {
-            path: error_path
-                .strip_prefix(relative_to)
-                .unwrap_or(error_path)
+            path: error
+                .path()
+                .as_path()
+                .absolutize()
                 .to_string_lossy()
                 .into_owned(),
             name: error.error_kind().to_name().to_owned(),
@@ -62,22 +65,17 @@ impl BaselineProcessor {
         Ok(Self { baseline_keys })
     }
 
-    pub fn matches_baseline(&self, error: &Error, relative_to: &Path) -> bool {
-        let key = BaselineKey::from_error(error, relative_to);
+    pub fn matches_baseline(&self, error: &Error) -> bool {
+        let key = BaselineKey::from_error(error);
         self.baseline_keys.contains(&key)
     }
 
     /// Baseline suppressions are processed last, after inline and config suppressions
-    pub fn process_errors(
-        &self,
-        shown_errors: &mut Vec<Error>,
-        baseline_errors: &mut Vec<Error>,
-        relative_to: &Path,
-    ) {
+    pub fn process_errors(&self, shown_errors: &mut Vec<Error>, baseline_errors: &mut Vec<Error>) {
         let mut remaining_errors = Vec::new();
 
         for error in shown_errors.drain(..) {
-            if self.matches_baseline(&error, relative_to) {
+            if self.matches_baseline(&error) {
                 baseline_errors.push(error);
             } else {
                 remaining_errors.push(error);
@@ -106,7 +104,7 @@ mod tests {
     fn test_baseline_key_generation() {
         let module = Module::new(
             ModuleName::from_str("test_module"),
-            ModulePath::filesystem(PathBuf::from("test/path.py")),
+            ModulePath::filesystem(PathBuf::from("/workspace/test/path.py")),
             Arc::new("test content".to_owned()),
         );
 
@@ -118,9 +116,9 @@ mod tests {
             ErrorKind::BadReturn,
         );
 
-        let key = BaselineKey::from_error(&error, Path::new("/root"));
+        let key = BaselineKey::from_error(&error);
 
-        assert_eq!(key.path, "test/path.py");
+        assert_eq!(key.path, "/workspace/test/path.py");
         assert_eq!(key.name, "bad-return");
         assert_eq!(key.column, 1);
     }
@@ -135,7 +133,7 @@ mod tests {
                     "column": 3,
                     "stop_line": 1,
                     "stop_column": 5,
-                    "path": "test.py",
+                    "path": "/workspace/test.py",
                     "code": -2,
                     "name": "bad-return",
                     "description": "Test error",
@@ -153,12 +151,12 @@ mod tests {
 
         let module = Module::new(
             ModuleName::from_str("test_module"),
-            ModulePath::filesystem(PathBuf::from("test.py")),
+            ModulePath::filesystem(PathBuf::from("/workspace/test.py")),
             Arc::new("test content 123456789".to_owned()),
         );
         let module2 = Module::new(
             ModuleName::from_str("test_module2"),
-            ModulePath::filesystem(PathBuf::from("test2.py")),
+            ModulePath::filesystem(PathBuf::from("/workspace/test2.py")),
             Arc::new("test content 123456789".to_owned()),
         );
 
@@ -170,7 +168,7 @@ mod tests {
             Vec::new(),
             ErrorKind::BadReturn,
         );
-        assert!(processor.matches_baseline(&error1, Path::new("/")));
+        assert!(processor.matches_baseline(&error1));
 
         // This error should not match (different column)
         let error2 = Error::new(
@@ -180,7 +178,7 @@ mod tests {
             Vec::new(),
             ErrorKind::BadReturn,
         );
-        assert!(!processor.matches_baseline(&error2, Path::new("/")));
+        assert!(!processor.matches_baseline(&error2));
 
         // This error should not match (different error code)
         let error3 = Error::new(
@@ -190,7 +188,7 @@ mod tests {
             Vec::new(),
             ErrorKind::AssertType,
         );
-        assert!(!processor.matches_baseline(&error3, Path::new("/")));
+        assert!(!processor.matches_baseline(&error3));
 
         // This error should not match (different module)
         let error4 = Error::new(
@@ -200,6 +198,6 @@ mod tests {
             Vec::new(),
             ErrorKind::BadReturn,
         );
-        assert!(!processor.matches_baseline(&error4, Path::new("/")));
+        assert!(!processor.matches_baseline(&error4));
     }
 }

--- a/pyrefly/lib/error/baseline.rs
+++ b/pyrefly/lib/error/baseline.rs
@@ -200,4 +200,51 @@ mod tests {
         );
         assert!(!processor.matches_baseline(&error4));
     }
+
+    /// Check that an error matches a baseline entry regardless of how the path is stored.
+    fn assert_baseline_path_matches(baseline_path: &str) {
+        let cwd = std::env::current_dir().unwrap();
+        let abs_path = cwd.join("src/foo.py");
+
+        let baseline_json = format!(
+            r#"{{
+                "errors": [{{
+                    "line": 1, "column": 5, "stop_line": 1, "stop_column": 10,
+                    "path": "{baseline_path}",
+                    "code": -2, "name": "bad-return",
+                    "description": "test", "concise_description": "test"
+                }}]
+            }}"#
+        );
+
+        let baseline_file: LegacyErrors = serde_json::from_str(&baseline_json).unwrap();
+        let baseline_keys: HashSet<BaselineKey> =
+            baseline_file.errors.iter().map(BaselineKey::from).collect();
+        let processor = BaselineProcessor { baseline_keys };
+
+        let module = Module::new(
+            ModuleName::from_str("foo"),
+            ModulePath::filesystem(abs_path),
+            Arc::new("test content 123456789".to_owned()),
+        );
+        let error = Error::new(
+            module,
+            TextRange::new(TextSize::new(4), TextSize::new(10)),
+            vec1!["err".to_owned()],
+            ErrorKind::BadReturn,
+        );
+        assert!(processor.matches_baseline(&error));
+    }
+
+    #[test]
+    fn test_baseline_matches_absolute_path() {
+        let cwd = std::env::current_dir().unwrap();
+        let abs_path = cwd.join("src/foo.py");
+        assert_baseline_path_matches(&abs_path.to_string_lossy());
+    }
+
+    #[test]
+    fn test_baseline_matches_relative_path() {
+        assert_baseline_path_matches("src/foo.py");
+    }
 }

--- a/pyrefly/lib/error/baseline.rs
+++ b/pyrefly/lib/error/baseline.rs
@@ -243,9 +243,7 @@ mod tests {
     fn test_baseline_matches_absolute_path() {
         let cwd = std::env::current_dir().unwrap();
         let abs_path = cwd.join("src/foo.py");
-        // Baseline files will always store forward-slash paths
-        let path_str = abs_path.to_string_lossy().replace('\\', "/");
-        assert_baseline_path_matches(&path_str);
+        assert_baseline_path_matches(&abs_path.to_string_lossy());
     }
 
     #[test]

--- a/pyrefly/lib/error/baseline.rs
+++ b/pyrefly/lib/error/baseline.rs
@@ -25,28 +25,27 @@ struct BaselineKey {
     column: usize,
 }
 
-impl From<&LegacyError> for BaselineKey {
-    fn from(baseline_error: &LegacyError) -> Self {
-        let path = Path::new(&baseline_error.path);
+impl BaselineKey {
+    fn normalize_path(path: &Path) -> String {
+        path.absolutize().to_string_lossy().replace('\\', "/")
+    }
+
+    fn from_error(error: &Error) -> Self {
         Self {
-            path: path.absolutize().to_string_lossy().into_owned(),
-            name: baseline_error.name.clone(),
-            column: baseline_error.column,
+            path: Self::normalize_path(error.path().as_path()),
+            name: error.error_kind().to_name().to_owned(),
+            column: error.display_range().start.column().get() as usize,
         }
     }
 }
 
-impl BaselineKey {
-    fn from_error(error: &Error) -> Self {
+impl From<&LegacyError> for BaselineKey {
+    fn from(baseline_error: &LegacyError) -> Self {
+        let path = Path::new(&baseline_error.path);
         Self {
-            path: error
-                .path()
-                .as_path()
-                .absolutize()
-                .to_string_lossy()
-                .into_owned(),
-            name: error.error_kind().to_name().to_owned(),
-            column: error.display_range().start.column().get() as usize,
+            path: BaselineKey::normalize_path(path),
+            name: baseline_error.name.clone(),
+            column: baseline_error.column,
         }
     }
 }
@@ -118,7 +117,11 @@ mod tests {
 
         let key = BaselineKey::from_error(&error);
 
-        assert_eq!(key.path, "/workspace/test/path.py");
+        let expected_path = Path::new("/workspace/test/path.py")
+            .absolutize()
+            .to_string_lossy()
+            .replace('\\', "/");
+        assert_eq!(key.path, expected_path);
         assert_eq!(key.name, "bad-return");
         assert_eq!(key.column, 1);
     }
@@ -240,7 +243,9 @@ mod tests {
     fn test_baseline_matches_absolute_path() {
         let cwd = std::env::current_dir().unwrap();
         let abs_path = cwd.join("src/foo.py");
-        assert_baseline_path_matches(&abs_path.to_string_lossy());
+        // Baseline files will always store forward-slash paths
+        let path_str = abs_path.to_string_lossy().replace('\\', "/");
+        assert_baseline_path_matches(&path_str);
     }
 
     #[test]

--- a/pyrefly/lib/error/legacy.rs
+++ b/pyrefly/lib/error/legacy.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use pyrefly_config::error_kind::Severity;
 use pyrefly_util::prelude::SliceExt;
+use pyrefly_util::relativize::Relativize;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -63,8 +64,7 @@ impl LegacyError {
             stop_column: error_range.end.column().get() as usize,
             cell: error_range.start.cell().map(|cell| cell.get() as usize),
             path: error_path
-                .strip_prefix(relative_to)
-                .unwrap_or(error_path)
+                .relativize_from(relative_to)
                 .to_string_lossy()
                 .into_owned(),
             // -2 is chosen because it's an unused error code in Pyre1

--- a/pyrefly/lib/error/legacy.rs
+++ b/pyrefly/lib/error/legacy.rs
@@ -66,7 +66,7 @@ impl LegacyError {
             path: error_path
                 .relativize_from(relative_to)
                 .to_string_lossy()
-                .into_owned(),
+                .replace('\\', "/"), // Normalize Windows backslashes so baseline files are consistent across platforms
             // -2 is chosen because it's an unused error code in Pyre1
             code: -2, // TODO: replace this dummy value
             name: error.error_kind().to_name().to_owned(),

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -225,13 +225,9 @@ impl Errors {
         errors
     }
 
-    pub fn collect_errors_with_baseline(
-        &self,
-        baseline_path: Option<&Path>,
-        relative_to: &Path,
-    ) -> CollectedErrors {
+    pub fn collect_errors_with_baseline(&self, baseline_path: Option<&Path>) -> CollectedErrors {
         let errors = self.collect_errors();
-        self.apply_baseline(errors, baseline_path, relative_to)
+        self.apply_baseline(errors, baseline_path)
     }
 
     /// Apply baseline filtering to already-collected errors.
@@ -239,12 +235,11 @@ impl Errors {
         &self,
         mut errors: CollectedErrors,
         baseline_path: Option<&Path>,
-        relative_to: &Path,
     ) -> CollectedErrors {
         if let Some(baseline_path) = baseline_path
             && let Ok(processor) = BaselineProcessor::from_file(baseline_path)
         {
-            processor.process_errors(&mut errors.ordinary, &mut errors.baseline, relative_to);
+            processor.process_errors(&mut errors.ordinary, &mut errors.baseline);
         }
         errors
     }


### PR DESCRIPTION
# Summary

Fixes #2547

When pyrefly writes `baseline.json`, files located outside the current working directory (e.g. referenced via `../../libs/foo` in `search-path`) were stored with absolute paths. This breaks baseline matching in CI where the checkout path differs from a local dev environment.

Changes:
- Internally `BaselineKey` now always contains absolute paths. This decouples key comparison from the path format (relative or absolute) in the baseline file on disk.
- Added tests to make sure baseline parsing is backwards compatible with old absolute path format.
- Paths in baseline are always stored with forward slashes for cross-platform compatibility of a baseline file, i.e. if some devs use windows and some linux.

# Test Plan
- [x] Ran all tests manually.
- [x] Tested manually to make sure `pyrefly check` still works with an older absolute path baseline, and that regenerating the baseline creates one with relative paths. Then tested to make sure `pyrefly check` works on the new baseline.