### PR TITLE
fix(typing): resolve invalid Self to Any during annotation solving to prevent internal-error

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -399,6 +399,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         ));
                     }
                 }
+                if let Some(ty) = &mut ann.ty
+                    && ty.any(|t| matches!(t, Type::SpecialForm(SpecialForm::SelfType)))
+                {
+                    // The binding phase reports invalid uses of `Self` (for example, outside a class).
+                    // Replace any unresolved `Self` special forms with `Any` so they do not leak into
+                    // later phases as internal errors.
+                    ty.subst_self_special_form_mut(&self.heap.mk_any_error());
+                }
                 if let Some(ty) = &ann.ty {
                     self.check_legacy_typevar_scoping(ty, x.range(), errors);
                 }

--- a/pyrefly/lib/test/typing_self.rs
+++ b/pyrefly/lib/test/typing_self.rs
@@ -241,6 +241,31 @@ tupleSelf = tuple[Self] # E: `Self` must appear within a class
     "#,
 );
 
+// Regression test for https://github.com/facebook/pyrefly/issues/3008
+testcase!(
+    test_self_outside_class_no_internal_error_via_classmethod_trampoline,
+    r#"
+from typing import Callable, Self, TypeVar
+
+TReturn = TypeVar("TReturn")
+
+def trampoline(orig: Callable[..., TReturn]) -> TReturn:
+    ...
+
+def person_create_with_name_trampoline(cls, *args, **kwargs):
+    return trampoline(person_create_with_name_orig)
+
+class Person:
+    name: str
+    create_with_name = classmethod(person_create_with_name_trampoline)
+
+def person_create_with_name_orig(cls, name: str) -> Self:  # E: `Self` must appear within a class
+    return cls()
+
+Person.create_with_name("foo").name
+    "#,
+);
+
 testcase!(
     test_self_inside_class,
     r#"


### PR DESCRIPTION
This PR resolves Issue #3008, which reported a TODO internal error in Expr::attr_infer_for_type. The root cause was that typing.Self, when used invalidly outside of a class context, was being reported by the binding phase but was still "leaking" as an unresolved special form into the inference engine.

When the engine attempted an attribute lookup on this raw Self form, it hit an undefined state. This patch ensures that any Self forms remaining after class-context substitution are collapsed to Any (Error type), allowing the type-checker to proceed gracefully using the already-emitted diagnostic.

**Changes**

-     pyrefly/lib/alt/solve.rs: Added logic in the annotation solver to detect and normalize dangling Self special forms to Any.

-     pyrefly/lib/test/typing_self.rs: Added a regression test test_self_outside_class_no_internal_error_via_classmethod_trampoline which specifically targets the classmethod trampoline pattern identified in the issue.


**Validation Results**


-     **Targeted Test**: test_self_outside_class_no_internal_error_via_classmethod_trampoline → **PASSED**

-     **Subsystem Suite**: cargo test typing_self (31 tests) → **PASSED**

-     **Regression Suite**: cargo test test::attributes:: (161 tests) → **PASSED**

-     **Formatting**: cargo fmt → **Clean**

-     **Linting**: cargo clippy was run. Note that current workspace failures in protocol_types.rs and tsp_types are pre-existing technical debt and unrelated to these changes.
This pull request addresses a regression related to the handling of the `Self` special form in type annotations, particularly when it appears outside of a class context. The main fix ensures that invalid uses of `Self` are replaced with `Any` to prevent internal errors in later phases. Additionally, a regression test is added to verify the fix.

Type system robustness:

* Updated `AnswersSolver` in `solve.rs` to replace unresolved `Self` special forms with `Any` during annotation processing, preventing internal errors when `Self` is used outside a class.

Testing:

* Added a regression test in `typing_self.rs` to ensure that using `Self` outside a class (e.g., via a classmethod trampoline) does not cause internal errors, referencing issue #3008.