### PR TITLE
fix Type aliases are expanded in the hover text #2707

### DIFF
--- a/crates/pyrefly_types/src/annotation.rs
+++ b/crates/pyrefly_types/src/annotation.rs
@@ -25,6 +25,8 @@ use crate::types::Type;
 pub struct Annotation {
     pub qualifiers: Vec<Qualifier>,
     pub ty: Option<Type>,
+    /// A semantically equivalent type that retains alias names for presentation.
+    pub display_ty: Option<Type>,
 }
 
 impl Display for Annotation {
@@ -49,6 +51,15 @@ impl Annotation {
         Self {
             qualifiers: Vec::new(),
             ty: Some(ty),
+            display_ty: None,
+        }
+    }
+
+    pub fn new_type_with_display(ty: Type, display_ty: Type) -> Self {
+        Self {
+            qualifiers: Vec::new(),
+            ty: Some(ty),
+            display_ty: Some(display_ty),
         }
     }
 
@@ -76,6 +87,7 @@ impl Annotation {
         Self {
             qualifiers: self.qualifiers,
             ty: self.ty.map(|ty| substitution.substitute_into(ty)),
+            display_ty: self.display_ty.map(|ty| substitution.substitute_into(ty)),
         }
     }
 }
@@ -102,7 +114,8 @@ mod tests {
         assert_eq!(
             Annotation {
                 qualifiers: Vec::new(),
-                ty: Some(Type::None)
+                ty: Some(Type::None),
+                display_ty: None,
             }
             .to_string(),
             "None"
@@ -110,7 +123,8 @@ mod tests {
         assert_eq!(
             Annotation {
                 qualifiers: vec![Qualifier::Required, Qualifier::ReadOnly],
-                ty: None
+                ty: None,
+                display_ty: None,
             }
             .to_string(),
             "Required[ReadOnly]"
@@ -119,6 +133,7 @@ mod tests {
             Annotation {
                 qualifiers: vec![Qualifier::Required, Qualifier::ReadOnly],
                 ty: Some(Type::LiteralString(LitStyle::Implicit)),
+                display_ty: None,
             }
             .to_string(),
             "Required[ReadOnly[LiteralString]]"

--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -92,6 +92,48 @@ impl<T> Deref for IdentityIgnored<T> {
     }
 }
 
+/// Auxiliary display data that is ignored by type identity but follows type transformations.
+#[derive(Debug, Clone, Default, Visit, VisitMut)]
+pub struct DisplayOnly<T>(pub T);
+
+impl<T> PartialEq for DisplayOnly<T> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl<T> Eq for DisplayOnly<T> {}
+
+impl<T> Hash for DisplayOnly<T> {
+    fn hash<H: Hasher>(&self, _state: &mut H) {}
+}
+
+impl<T> PartialOrd for DisplayOnly<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Ord for DisplayOnly<T> {
+    fn cmp(&self, _other: &Self) -> Ordering {
+        Ordering::Equal
+    }
+}
+
+impl<T> TypeEq for DisplayOnly<T> {
+    fn type_eq(&self, _other: &Self, _ctx: &mut TypeEqCtx) -> bool {
+        true
+    }
+}
+
+impl<T> Deref for DisplayOnly<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[derive(Visit, VisitMut, TypeEq)]
 pub struct Callable {

--- a/crates/pyrefly_types/src/callable_residual.rs
+++ b/crates/pyrefly_types/src/callable_residual.rs
@@ -279,10 +279,7 @@ impl Type {
     fn try_combine_reconstructed_overload(&self, reconstructed: &[Type]) -> Option<Type> {
         let metadata = self
             .visit_toplevel_func_metadata(&|metadata| Some(metadata.clone()))
-            .unwrap_or(FuncMetadata {
-                kind: FunctionKind::Overload,
-                flags: FuncFlags::default(),
-            });
+            .unwrap_or_else(|| FuncMetadata::new(FunctionKind::Overload, FuncFlags::default()));
         let signatures = reconstructed
             .iter()
             .cloned()

--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -32,6 +32,7 @@ use crate::callable::Required;
 use crate::callable_residual::CallableResidualKind;
 use crate::class::Class;
 use crate::data_frame::SchemaCompleteness;
+use crate::function::FuncMetadata;
 use crate::function::Function;
 use crate::function::FunctionKind;
 use crate::heap::TypeHeap;
@@ -845,6 +846,18 @@ impl<'a> TypeDisplayContext<'a> {
         self.fmt_helper_generic(&value_type, false, output)
     }
 
+    fn function_signature_for_display<'b>(
+        &self,
+        signature: &'b Callable,
+        metadata: &'b FuncMetadata,
+    ) -> &'b Callable {
+        if self.lsp_display_mode == LspDisplayMode::Hover {
+            metadata.display_signature.as_deref().unwrap_or(signature)
+        } else {
+            signature
+        }
+    }
+
     fn fmt_hover_type<O: TypeOutput>(
         &self,
         t: &Type,
@@ -1090,6 +1103,7 @@ impl<'a> TypeDisplayContext<'a> {
                     signature,
                     metadata,
                 } = &**func;
+                let signature = self.function_signature_for_display(signature, metadata);
                 // A singledispatch dispatcher is modeled as a callback protocol over the fallback
                 // signature, but should still reveal as `_SingleDispatchCallable[T]`.
                 if let FunctionKind::CallbackProtocol(cls) = &metadata.kind
@@ -1211,6 +1225,8 @@ impl<'a> TypeDisplayContext<'a> {
                                 metadata,
                             }) => {
                                 let func_name = metadata.kind.function_name();
+                                let signature =
+                                    self.function_signature_for_display(signature, metadata);
                                 output.write_str("def ")?;
                                 self.write_func_fqn(output, &func_name, &metadata.kind)?;
                                 // Strip the `self` parameter only in ProvideType mode;
@@ -1247,6 +1263,8 @@ impl<'a> TypeDisplayContext<'a> {
                                         metadata,
                                     },
                             }) => {
+                                let signature =
+                                    self.function_signature_for_display(signature, metadata);
                                 let func_name = metadata.kind.function_name();
                                 output.write_str("def ")?;
                                 self.write_func_fqn(output, &func_name, &metadata.kind)?;
@@ -1472,6 +1490,8 @@ impl<'a> TypeDisplayContext<'a> {
                         | LspDisplayMode::ProvideType
                             if is_toplevel =>
                         {
+                            let signature =
+                                self.function_signature_for_display(signature, metadata);
                             let func_name = metadata.kind.function_name();
                             output.write_str("def ")?;
                             self.write_func_fqn(output, &func_name, &metadata.kind)?;
@@ -1658,7 +1678,29 @@ impl<'a> TypeDisplayContext<'a> {
             Type::UntypedAlias(ta) if let TypeAliasData::Ref(r) = &**ta => {
                 self.fmt_helper_type_alias_ref(r, output)
             }
-            Type::UntypedAlias(ta) => output.write_str(ta.name().as_str()),
+            Type::UntypedAlias(ta) => {
+                let TypeAliasData::Value(alias) = &**ta else {
+                    unreachable!("type alias references are handled above")
+                };
+                if self.always_display_expanded_unions
+                    && let Type::Type(inner) = alias.as_type_ref()
+                    && matches!(&**inner, Type::Union(_))
+                {
+                    return self.fmt_helper_generic(inner, false, output);
+                }
+                output.write_str(alias.name.as_str())?;
+                if let Some(args) = alias.display_args() {
+                    output.write_str("[")?;
+                    for (index, arg) in args.iter().enumerate() {
+                        if index > 0 {
+                            output.write_str(", ")?;
+                        }
+                        self.fmt_helper_generic(arg, false, output)?;
+                    }
+                    output.write_str("]")?;
+                }
+                Ok(())
+            }
             Type::SuperInstance(s) => {
                 let (cls, obj) = &**s;
                 if self.always_display_builtins_module_name {

--- a/crates/pyrefly_types/src/equality.rs
+++ b/crates/pyrefly_types/src/equality.rs
@@ -446,10 +446,7 @@ mod tests {
 
             Forallable::Function(Function {
                 signature: Callable::list(ParamList::everything(), q.clone().to_type(heap)),
-                metadata: FuncMetadata {
-                    kind: FunctionKind::Overload,
-                    flags: FuncFlags::default(),
-                },
+                metadata: FuncMetadata::new(FunctionKind::Overload, FuncFlags::default()),
             })
             .forall(Arc::new(tparams))
         }

--- a/crates/pyrefly_types/src/function.rs
+++ b/crates/pyrefly_types/src/function.rs
@@ -27,6 +27,7 @@ use pyrefly_util::visit::VisitMut;
 use ruff_python_ast::name::Name;
 
 use crate::callable::Callable;
+use crate::callable::DisplayOnly;
 use crate::callable::IdentityIgnored;
 use crate::class::Class;
 use crate::class::ClassType;
@@ -49,18 +50,28 @@ pub struct Function {
 pub struct FuncMetadata {
     pub kind: FunctionKind,
     pub flags: FuncFlags,
+    /// The source annotation spelling used only when rendering function hover.
+    pub display_signature: DisplayOnly<Option<Box<Callable>>>,
 }
 
 impl FuncMetadata {
-    pub fn synthesized(module: &Module, cls: Option<&Class>, name: Name) -> Self {
+    pub fn new(kind: FunctionKind, flags: FuncFlags) -> Self {
         Self {
-            kind: FunctionKind::Synthesized(Arc::new(FuncSymbol {
+            kind,
+            flags,
+            display_signature: DisplayOnly(None),
+        }
+    }
+
+    pub fn synthesized(module: &Module, cls: Option<&Class>, name: Name) -> Self {
+        Self::new(
+            FunctionKind::Synthesized(Arc::new(FuncSymbol {
                 module: module.dupe(),
                 cls: cls.map(Dupe::dupe),
                 name,
             })),
-            flags: FuncFlags::default(),
-        }
+            FuncFlags::default(),
+        )
     }
 
     pub fn method(cls: &Class, name: Name) -> Self {

--- a/crates/pyrefly_types/src/type_alias.rs
+++ b/crates/pyrefly_types/src/type_alias.rs
@@ -18,6 +18,7 @@ use pyrefly_python::module_path::ModulePath;
 use pyrefly_util::display::commas_iter;
 use ruff_python_ast::name::Name;
 
+use crate::callable::DisplayOnly;
 use crate::display::TypeDisplayContext;
 use crate::stdlib::Stdlib;
 use crate::type_output::DisplayOutput;
@@ -45,6 +46,8 @@ pub struct TypeAlias {
     pub name: Box<Name>,
     ty: Box<Type>,
     pub style: TypeAliasStyle,
+    /// Specialized arguments retained only for displaying an alias reference.
+    display_args: DisplayOnly<Option<Box<[Type]>>>,
 }
 
 impl TypeAlias {
@@ -53,6 +56,7 @@ impl TypeAlias {
             name: Box::new(name),
             ty: Box::new(ty),
             style,
+            display_args: DisplayOnly(None),
         }
     }
 
@@ -77,6 +81,27 @@ impl TypeAlias {
 
     pub fn as_type_mut(&mut self) -> &mut Type {
         &mut self.ty
+    }
+
+    /// Borrows the type form stored by the alias.
+    pub fn as_type_ref(&self) -> &Type {
+        &self.ty
+    }
+
+    /// Replaces the stored type form while retaining presentation metadata.
+    pub fn with_type(mut self, ty: Type) -> Self {
+        self.ty = Box::new(ty);
+        self
+    }
+
+    /// Records the arguments from a specialized alias reference for display.
+    pub fn set_display_args(&mut self, args: Box<[Type]>) {
+        self.display_args.0 = Some(args);
+    }
+
+    /// Returns the arguments from a specialized alias reference.
+    pub fn display_args(&self) -> Option<&[Type]> {
+        self.display_args.as_deref()
     }
 
     pub fn fmt_with_type<O: TypeOutput>(

--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -617,7 +617,16 @@ pub struct Forall<T> {
 
 impl Forall<Forallable> {
     pub fn apply_targs(self, targs: TArgs) -> Type {
-        targs.substitute_into(self.body.as_type())
+        match self.body {
+            Forallable::TypeAlias(TypeAliasData::Value(mut alias)) => {
+                alias.set_display_args(targs.as_slice().to_vec().into_boxed_slice());
+                targs
+                    .substitution()
+                    .substitute_into_mut(alias.as_type_mut());
+                Type::TypeAlias(Box::new(TypeAliasData::Value(alias)))
+            }
+            body => targs.substitute_into(body.as_type()),
+        }
     }
 }
 

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -934,6 +934,7 @@ impl ClassField {
                     Some(Annotation {
                         ty: Some(ty),
                         qualifiers,
+                        ..
                     }),
                 ..
             } => Some(TypedDictField {
@@ -956,6 +957,7 @@ impl ClassField {
                     Some(Annotation {
                         ty: Some(ty),
                         qualifiers,
+                        ..
                     }),
                 ..
             } => Some(TypedDictField {
@@ -1689,6 +1691,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             direct_annotation = Some(Annotation {
                                 qualifiers: Vec::new(),
                                 ty: Some(ty),
+                                display_ty: None,
                             });
                         }
                     }
@@ -3010,10 +3013,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         direct_qualifiers: Option<&Vec<Qualifier>>,
     ) -> Option<Annotation> {
         match (inherited, direct_qualifiers) {
-            (inherited, Some(qualifiers)) => Some(Annotation {
-                ty: inherited.and_then(|ann| ann.ty),
-                qualifiers: qualifiers.clone(),
-            }),
+            (inherited, Some(qualifiers)) => {
+                let (ty, display_ty) = inherited
+                    .map(|annotation| (annotation.ty, annotation.display_ty))
+                    .unwrap_or_default();
+                Some(Annotation {
+                    ty,
+                    qualifiers: qualifiers.clone(),
+                    display_ty,
+                })
+            }
             (ann, None) => ann,
         }
     }

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -66,6 +66,7 @@ use crate::binding::binding::Binding;
 use crate::binding::binding::FunctionDefData;
 use crate::binding::binding::FunctionParameter;
 use crate::binding::binding::Key;
+use crate::binding::binding::KeyAnnotation;
 use crate::binding::binding::KeyClass;
 use crate::binding::binding::KeyDecoratedFunction;
 use crate::binding::binding::KeyDecorator;
@@ -135,6 +136,8 @@ struct PreparedDecoratorApplication {
 struct ParamTypeResult {
     /// The resolved type of the parameter.
     ty: Type,
+    /// The annotation type with source alias names retained for display.
+    display_ty: Type,
     /// Whether the parameter is required or optional.
     required: Required,
     /// Whether the parameter lacked a type annotation (was unannotated).
@@ -145,6 +148,8 @@ struct ParamTypeResult {
 struct FunctionParamsResult {
     /// The resolved function parameters.
     params: Vec<Param>,
+    /// Display-only replacements for annotated parameter types.
+    display_param_types: SmallMap<Name, Type>,
     /// The paramspec quantified type, if any.
     paramspec: Option<Quantified>,
     /// Maps parameter names to their resolved types for unannotated parameters.
@@ -622,6 +627,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
         let FunctionParamsResult {
             params,
+            display_param_types,
             paramspec,
             resolved_param_types,
         } = self.get_params_and_paramspec(
@@ -691,7 +697,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
 
         flags.has_gradual_variadic_params = params_are_gradual_variadic(&params);
-        let metadata = FuncMetadata { kind, flags };
+        let metadata = FuncMetadata::new(kind, flags);
 
         Arc::new(UndecoratedFunction {
             def_index,
@@ -700,6 +706,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             decorators,
             tparams,
             params,
+            display_param_types,
             paramspec,
             defining_cls,
             type_shape_dsl_def,
@@ -718,6 +725,20 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .arc_clone_ty();
         // `stmt.returns` is always set to None because the binding step calls `mem::take` on it
         let has_return_annotation = self.bindings().function_has_return_annotation(&stmt.name);
+        let display_ret = has_return_annotation
+            .then(|| {
+                let key = KeyAnnotation::ReturnAnnotation(ShortIdentifier::new(&stmt.name));
+                let annotation = self.get_idx(self.bindings().key_to_idx(&key));
+                annotation.annotation.display_ty.clone()
+            })
+            .flatten()
+            .map(|display_ret| {
+                if stmt.is_async && self.unwrap_coroutine(&ret).is_some() {
+                    self.return_type_from_annotation(display_ret, true, false)
+                } else {
+                    display_ret
+                }
+            });
         if !has_return_annotation && !def.metadata.flags.has_no_type_check {
             self.error(
                 errors,
@@ -849,26 +870,45 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         }
 
-        let callable = if let Some(q) = &def.paramspec {
-            Callable::concatenate(
-                def.params
-                    .iter()
-                    .filter_map(|p| match p {
-                        Param::PosOnly(name, ty, req) => {
-                            Some(PrefixParam::PosOnly(name.clone(), ty.clone(), req.clone()))
-                        }
-                        Param::Pos(name, ty, req) => {
-                            Some(PrefixParam::Pos(name.clone(), ty.clone(), req.clone()))
-                        }
-                        _ => None,
-                    })
-                    .collect(),
-                self.heap.mk_quantified(q.clone()),
-                ret,
-            )
-        } else {
-            Callable::list(ParamList::new(def.params.clone()), ret)
+        let make_callable = |params: Vec<Param>, ret: Type| {
+            if let Some(q) = &def.paramspec {
+                Callable::concatenate(
+                    params
+                        .iter()
+                        .filter_map(|p| match p {
+                            Param::PosOnly(name, ty, req) => {
+                                Some(PrefixParam::PosOnly(name.clone(), ty.clone(), req.clone()))
+                            }
+                            Param::Pos(name, ty, req) => {
+                                Some(PrefixParam::Pos(name.clone(), ty.clone(), req.clone()))
+                            }
+                            _ => None,
+                        })
+                        .collect(),
+                    self.heap.mk_quantified(q.clone()),
+                    ret,
+                )
+            } else {
+                Callable::list(ParamList::new(params), ret)
+            }
         };
+        let display_signature = if def.display_param_types.is_empty() && display_ret.is_none() {
+            None
+        } else {
+            let mut params = def.params.clone();
+            for param in &mut params {
+                if let Some(name) = param.name()
+                    && let Some(display_ty) = def.display_param_types.get(name)
+                {
+                    *param.as_type_mut() = display_ty.clone();
+                }
+            }
+            Some(make_callable(
+                params,
+                display_ret.unwrap_or_else(|| ret.clone()),
+            ))
+        };
+        let callable = make_callable(def.params.clone(), ret);
         if let Some(cls) = &def.defining_cls {
             // Constructors are always validated per spec. For other methods,
             // skip overload variants because self/cls annotations in overloads
@@ -901,6 +941,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             self.collect_jaxtyping_tparams(&callable, &def.tparams, stmt.name.range, errors);
 
         let mut metadata = def.metadata.clone();
+        metadata.display_signature.0 = display_signature.map(Box::new);
         if let Some(dsl) = &def.type_shape_dsl_def
             && let Some(kind) = self.validate_type_shape_dsl_declaration(
                 dsl,
@@ -1175,63 +1216,70 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> ParamTypeResult {
         // We only want to use self for the first param, so take & replace with None
         let self_type = std::mem::take(self_type);
-        let (ty, required, is_unannotated) = match self.bindings().get_function_param(name) {
-            FunctionParameter::Annotated(idx) => {
-                let param_ty = self.get_idx(*idx).annotation.get_type().clone();
-                let annot_range = self.annotation_range(*idx);
-                let make_context = || {
-                    TypeCheckContext::of_kind(TypeCheckKind::FunctionParameterDefault(
-                        name.id.clone(),
-                    ))
-                    .with_annotation(annot_range, "declared type".to_owned())
-                };
-                // Integer literal defaults are valid for symbolic integer parameters: at
-                // call time the dimension variable is bound from that default value.
-                let skip_check = matches!(
-                    (&param_ty, default),
-                    (
-                        Type::Int(Int::Symbolic(inner)),
-                        Some(Expr::NumberLiteral(ruff_python_ast::ExprNumberLiteral {
-                            value: ruff_python_ast::Number::Int(i),
-                            ..
-                        }))
-                    ) if i.as_i64().is_some() && matches!(inner.as_ref(), Type::Quantified(_))
-                );
-                let check: Option<(&Type, &dyn Fn() -> TypeCheckContext)> = if skip_check {
-                    None
-                } else {
-                    Some((&param_ty, &make_context))
-                };
-                let required = self.get_requiredness(default, check, is_stub, errors);
-                (param_ty, required, false)
-            }
-            FunctionParameter::Unannotated(_, _, _) => {
-                let required = self.get_requiredness(default, None, is_stub, errors);
-                // If this is the first parameter and there is a self type, resolve to `Self`.
-                // We only try to resolve the first param for now. Other unannotated params
-                // resolve to Any. If a default value of type T is provided, it will resolve to Any | T.
-                // Otherwise, it will be Any.
-                let ty = if let Some(ty) = self_type {
-                    ty.clone()
-                } else if let Some(hint) = hint {
-                    hint.clone()
-                } else if let Required::Optional(Some(default_val)) = &required {
-                    self.union(
-                        self.heap.mk_any_implicit(),
-                        default_val
-                            .ty
-                            .clone()
-                            .with_literal_style(LitStyle::Implicit)
-                            .promote_implicit_literals(self.stdlib),
-                    )
-                } else {
-                    self.heap.mk_any_implicit()
-                };
-                (ty, required, true)
-            }
-        };
+        let (ty, display_ty, required, is_unannotated) =
+            match self.bindings().get_function_param(name) {
+                FunctionParameter::Annotated(idx) => {
+                    let annotation = &self.get_idx(*idx).annotation;
+                    let param_ty = annotation.get_type().clone();
+                    let display_ty = annotation
+                        .display_ty
+                        .clone()
+                        .unwrap_or_else(|| param_ty.clone());
+                    let annot_range = self.annotation_range(*idx);
+                    let make_context = || {
+                        TypeCheckContext::of_kind(TypeCheckKind::FunctionParameterDefault(
+                            name.id.clone(),
+                        ))
+                        .with_annotation(annot_range, "declared type".to_owned())
+                    };
+                    // Integer literal defaults are valid for symbolic integer parameters: at
+                    // call time the dimension variable is bound from that default value.
+                    let skip_check = matches!(
+                        (&param_ty, default),
+                        (
+                            Type::Int(Int::Symbolic(inner)),
+                            Some(Expr::NumberLiteral(ruff_python_ast::ExprNumberLiteral {
+                                value: ruff_python_ast::Number::Int(i),
+                                ..
+                            }))
+                        ) if i.as_i64().is_some() && matches!(inner.as_ref(), Type::Quantified(_))
+                    );
+                    let check: Option<(&Type, &dyn Fn() -> TypeCheckContext)> = if skip_check {
+                        None
+                    } else {
+                        Some((&param_ty, &make_context))
+                    };
+                    let required = self.get_requiredness(default, check, is_stub, errors);
+                    (param_ty, display_ty, required, false)
+                }
+                FunctionParameter::Unannotated(_, _, _) => {
+                    let required = self.get_requiredness(default, None, is_stub, errors);
+                    // If this is the first parameter and there is a self type, resolve to `Self`.
+                    // We only try to resolve the first param for now. Other unannotated params
+                    // resolve to Any. If a default value of type T is provided, it will resolve to Any | T.
+                    // Otherwise, it will be Any.
+                    let ty = if let Some(ty) = self_type {
+                        ty.clone()
+                    } else if let Some(hint) = hint {
+                        hint.clone()
+                    } else if let Required::Optional(Some(default_val)) = &required {
+                        self.union(
+                            self.heap.mk_any_implicit(),
+                            default_val
+                                .ty
+                                .clone()
+                                .with_literal_style(LitStyle::Implicit)
+                                .promote_implicit_literals(self.stdlib),
+                        )
+                    } else {
+                        self.heap.mk_any_implicit()
+                    };
+                    (ty.clone(), ty, required, true)
+                }
+            };
         ParamTypeResult {
             ty,
+            display_ty,
             required,
             is_unannotated,
         }
@@ -1252,6 +1300,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let mut paramspec_args = None;
         let mut paramspec_kwargs = None;
         let mut resolved_param_types = SmallMap::new();
+        let mut display_param_types = SmallMap::new();
         let mut params = Vec::with_capacity(def.parameters.len());
         params.extend(def.parameters.posonlyargs.iter().map(|x| {
             let decorator_hint = decorator_param_hints
@@ -1266,6 +1315,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             };
             let ParamTypeResult {
                 ty,
+                display_ty,
                 required,
                 is_unannotated,
             } = self.get_param_type_and_requiredness(
@@ -1278,6 +1328,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             );
             if is_unannotated {
                 resolved_param_types.insert(x.parameter.name.id.clone(), ty.clone());
+            }
+            if display_ty != ty {
+                display_param_types.insert(x.parameter.name.id.clone(), display_ty);
             }
             Param::PosOnly(Some(x.parameter.name.id.clone()), ty, required)
         }));
@@ -1300,6 +1353,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             };
             let ParamTypeResult {
                 ty,
+                display_ty,
                 required,
                 is_unannotated,
             } = self.get_param_type_and_requiredness(
@@ -1312,6 +1366,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             );
             if is_unannotated {
                 resolved_param_types.insert(x.parameter.name.id.clone(), ty.clone());
+            }
+            if display_ty != ty {
+                display_param_types.insert(x.parameter.name.id.clone(), display_ty);
             }
 
             // If the parameter begins but does not end with "__", it is a positional-only parameter.
@@ -1345,7 +1402,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             // will need to have the same type as self/cls
             let _ = std::mem::take(self_type);
             let ParamTypeResult {
-                ty, is_unannotated, ..
+                ty,
+                display_ty,
+                is_unannotated,
+                ..
             } = self.get_param_type_and_requiredness(
                 &x.name,
                 None,
@@ -1356,6 +1416,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             );
             if is_unannotated {
                 resolved_param_types.insert(x.name.id.clone(), ty.clone());
+            }
+            if display_ty != ty {
+                display_param_types.insert(x.name.id.clone(), display_ty);
             }
             if let Type::Args(q) = &ty {
                 paramspec_args = Some(q.clone());
@@ -1381,6 +1444,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 .and_then(|hint| hint.take_kwonly(&x.parameter.name));
             let ParamTypeResult {
                 ty,
+                display_ty,
                 required,
                 is_unannotated,
             } = self.get_param_type_and_requiredness(
@@ -1394,6 +1458,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             if is_unannotated {
                 resolved_param_types.insert(x.parameter.name.id.clone(), ty.clone());
             }
+            if display_ty != ty {
+                display_param_types.insert(x.parameter.name.id.clone(), display_ty);
+            }
             Param::KwOnly(x.parameter.name.id.clone(), ty, required)
         }));
         if let Some(x) = &def.parameters.kwarg {
@@ -1401,7 +1468,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 .as_mut()
                 .and_then(|hint| hint.take_kwargs());
             let ParamTypeResult {
-                ty, is_unannotated, ..
+                ty,
+                display_ty,
+                is_unannotated,
+                ..
             } = self.get_param_type_and_requiredness(
                 &x.name,
                 None,
@@ -1412,6 +1482,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             );
             if is_unannotated {
                 resolved_param_types.insert(x.name.id.clone(), ty.clone());
+            }
+            if display_ty != ty {
+                display_param_types.insert(x.name.id.clone(), display_ty);
             }
             if let Type::Kwargs(q) = &ty {
                 paramspec_kwargs = Some(q.clone());
@@ -1489,6 +1562,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         };
         FunctionParamsResult {
             params,
+            display_param_types,
             paramspec,
             resolved_param_types,
         }
@@ -1744,10 +1818,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 });
                 if let Some(mut call_attr) = call_attr {
                     call_attr.transform_toplevel_func_metadata(|m| {
-                        *m = FuncMetadata {
-                            kind: FunctionKind::CallbackProtocol(Box::new(cls.clone())),
-                            flags: metadata.flags.clone(),
-                        };
+                        *m = FuncMetadata::new(
+                            FunctionKind::CallbackProtocol(Box::new(cls.clone())),
+                            metadata.flags.clone(),
+                        );
                     });
                     call_attr
                 } else {

--- a/pyrefly/lib/alt/singledispatch.rs
+++ b/pyrefly/lib/alt/singledispatch.rs
@@ -92,10 +92,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             };
             let func = Function {
                 signature,
-                metadata: FuncMetadata {
-                    kind: FunctionKind::CallbackProtocol(Box::new(ct.clone())),
-                    flags: FuncFlags::default(),
-                },
+                metadata: FuncMetadata::new(
+                    FunctionKind::CallbackProtocol(Box::new(ct.clone())),
+                    FuncFlags::default(),
+                ),
             };
             return Forallable::Function(func).forall(forall.tparams.clone());
         }
@@ -107,10 +107,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             return self.heap.mk_function(Function {
                 signature,
-                metadata: FuncMetadata {
-                    kind: FunctionKind::CallbackProtocol(Box::new(ct.clone())),
-                    flags: FuncFlags::default(),
-                },
+                metadata: FuncMetadata::new(
+                    FunctionKind::CallbackProtocol(Box::new(ct.clone())),
+                    FuncFlags::default(),
+                ),
             });
         }
         ty
@@ -340,10 +340,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         );
         if dispatch_class.is_some() && !has_func {
             self.heap.mk_kw_call(KwCall {
-                func_metadata: FuncMetadata {
-                    kind: FunctionKind::SingleDispatchRegister(Box::new(fallback_first)),
-                    flags: FuncFlags::default(),
-                },
+                func_metadata: FuncMetadata::new(
+                    FunctionKind::SingleDispatchRegister(Box::new(fallback_first)),
+                    FuncFlags::default(),
+                ),
                 keywords: TypeMap::new(),
                 return_ty,
             })

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -671,6 +671,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 Annotation {
                     qualifiers: vec![qualifier],
                     ty: Some(self.expr_infer(&x.slice, errors)),
+                    display_ty: None,
                 }
             }
             _ => Annotation::new_type(self.expr_infer(x, errors)),
@@ -830,6 +831,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 Annotation {
                     qualifiers: vec![qualifier],
                     ty: None,
+                    display_ty: None,
                 }
             }
             Expr::Subscript(x)
@@ -908,7 +910,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
                 ann
             }
-            _ => Annotation::new_type(self.expr_untype(x, type_form_context, errors)),
+            _ => {
+                let (ty, display_ty) = self.expr_untype_with_display(x, type_form_context, errors);
+                match display_ty {
+                    Some(display_ty) => Annotation::new_type_with_display(ty, display_ty),
+                    None => Annotation::new_type(ty),
+                }
+            }
         }
     }
 
@@ -2810,11 +2818,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     if let Some(k) = annotation
                         && let AnnotationWithTarget {
                             target,
-                            annotation:
-                                Annotation {
-                                    ty: Some(want),
-                                    qualifiers: _,
-                                },
+                            annotation: Annotation { ty: Some(want), .. },
                         } = &*self.get_idx(*k)
                     {
                         ty = self.check_and_return_type(ty, want, expr.range(), errors, &|| {
@@ -4762,11 +4766,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if let Some(k) = ann
             && let AnnotationWithTarget {
                 target,
-                annotation:
-                    Annotation {
-                        ty: Some(want),
-                        qualifiers: _,
-                    },
+                annotation: Annotation { ty: Some(want), .. },
             } = &*self.get_idx(k)
         {
             // Validate the annotation but always preserve the special TypeVarTuple type,
@@ -5845,7 +5845,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
-    fn return_type_from_annotation(
+    pub(crate) fn return_type_from_annotation(
         &self,
         annotated_ty: Type,
         is_async: bool,
@@ -5961,11 +5961,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if let Some(k) = ann
                     && let AnnotationWithTarget {
                         target,
-                        annotation:
-                            Annotation {
-                                ty: Some(want),
-                                qualifiers: _,
-                            },
+                        annotation: Annotation { ty: Some(want), .. },
                     } = &*self.get_idx(*k)
                 {
                     // Validate the annotation but always preserve the special TypeVar type,
@@ -5984,11 +5980,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if let Some(k) = ann
                     && let AnnotationWithTarget {
                         target,
-                        annotation:
-                            Annotation {
-                                ty: Some(want),
-                                qualifiers: _,
-                            },
+                        annotation: Annotation { ty: Some(want), .. },
                     } = &*self.get_idx(*k)
                 {
                     // Validate the annotation but always preserve the special ParamSpec type,
@@ -6173,11 +6165,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if let Some(k) = ann
                     && let AnnotationWithTarget {
                         target,
-                        annotation:
-                            Annotation {
-                                ty: Some(want),
-                                qualifiers: _,
-                            },
+                        annotation: Annotation { ty: Some(want), .. },
                     } = &*self.get_idx(*k)
                 {
                     // Validate the annotation already on assigned name
@@ -6496,10 +6484,21 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
     pub(crate) fn untype_opt_with_context(
         &self,
+        ty: Type,
+        range: TextRange,
+        errors: &ErrorCollector,
+        context: UntypeContext,
+    ) -> Option<Type> {
+        self.untype_opt_with_context_impl(ty, range, errors, context, false)
+    }
+
+    fn untype_opt_with_context_impl(
+        &self,
         mut ty: Type,
         range: TextRange,
         errors: &ErrorCollector,
         context: UntypeContext,
+        preserve_aliases: bool,
     ) -> Option<Type> {
         if let Type::Forall(forall) = ty {
             ty = self.promote_forall(*forall, range, errors);
@@ -6508,14 +6507,25 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::Union(f) if !f.members.is_empty() => {
                 let mut ts = Vec::new();
                 for x in f.members {
-                    let t = self.untype_opt_with_context(x, range, errors, context)?;
+                    let t = self.untype_opt_with_context_impl(
+                        x,
+                        range,
+                        errors,
+                        context,
+                        preserve_aliases,
+                    )?;
                     ts.push(t);
                 }
                 Some(self.unions(ts))
             }
-            Type::Var(v) if let Some(_guard) = self.recurse(v) => {
-                self.untype_opt_with_context(self.solver().force_var(v), range, errors, context)
-            }
+            Type::Var(v) if let Some(_guard) = self.recurse(v) => self
+                .untype_opt_with_context_impl(
+                    self.solver().force_var(v),
+                    range,
+                    errors,
+                    context,
+                    preserve_aliases,
+                ),
             // These are all legal type forms, so we accept them (return `Some`).
             // Only the quantified kinds get a kind check from the validator;
             // `TypeForm`/`Args`/`Kwargs` pass through unchanged but must be listed
@@ -6568,12 +6578,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 let TypeAliasData::Value(ta) = *ta else {
                     unreachable!("guarded by matches! above")
                 };
-                let mut aliased_type =
-                    self.untype_opt_with_context(ta.as_type(), range, errors, context)?;
+                let mut aliased_type = self.untype_opt_with_context_impl(
+                    ta.as_type(),
+                    range,
+                    errors,
+                    context,
+                    preserve_aliases,
+                )?;
                 if let Type::Union(f) = &mut aliased_type {
                     f.display_name = Some((self.module().name(), (*ta.name).clone()));
                 }
-                Some(aliased_type)
+                if preserve_aliases {
+                    let alias = ta.with_type(self.heap.mk_type(aliased_type));
+                    Some(Type::UntypedAlias(Box::new(TypeAliasData::Value(alias))))
+                } else {
+                    Some(aliased_type)
+                }
             }
             // `as_type_alias` untypes a type alias in order to validate that it is a legal type.
             // If we hit a recursive reference to the alias while untyping it, delay the untyping
@@ -6593,11 +6613,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if let Type::Var(v) = &**inner
                     && let Some(_guard) = self.recurse(*v) =>
             {
-                self.untype_opt_with_context(
+                self.untype_opt_with_context_impl(
                     self.heap.mk_unpack(self.solver().force_var(*v)),
                     range,
                     errors,
                     context,
+                    preserve_aliases,
                 )
             }
             // A quantified *value* (e.g. an `IntVar` used in value position) is
@@ -6621,7 +6642,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::ClassDef(cls) => {
                 let canonicalized =
                     self.canonicalize_all_class_types(Type::ClassDef(cls), range, errors);
-                self.untype_opt_with_context(canonicalized, range, errors, context)
+                self.untype_opt_with_context_impl(
+                    canonicalized,
+                    range,
+                    errors,
+                    context,
+                    preserve_aliases,
+                )
             }
             // Annotated[T, meta] in annotation/type-alias context unwraps to T
             Type::Annotated(t, _) => {
@@ -6987,13 +7014,25 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         type_form_context: TypeFormContext<'_>,
         errors: &ErrorCollector,
     ) -> Type {
-        let result = match x {
+        self.expr_untype_with_display(x, type_form_context, errors)
+            .0
+    }
+
+    fn expr_untype_with_display(
+        &self,
+        x: &Expr,
+        type_form_context: TypeFormContext<'_>,
+        errors: &ErrorCollector,
+    ) -> (Type, Option<Type>) {
+        let (result, display_ty) = match x {
             // A `IntVar`'s default (e.g. `N = 3`) is a dimension expression, not
             // an ordinary type, so route it through the dimension parser.
-            _ if type_form_context == TypeFormContext::IntVarDefault => self
-                .parse_dimension_list(slice::from_ref(x), type_form_context, errors)
-                .and_then(|dims| dims.into_iter().next())
-                .unwrap_or_else(Type::any_error),
+            _ if type_form_context == TypeFormContext::IntVarDefault => (
+                self.parse_dimension_list(slice::from_ref(x), type_form_context, errors)
+                    .and_then(|dims| dims.into_iter().next())
+                    .unwrap_or_else(Type::any_error),
+                None,
+            ),
             Expr::List(x)
                 if matches!(
                     type_form_context,
@@ -7008,20 +7047,38 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         Param::PosOnly(None, ty, Required::Required)
                     })
                     .collect();
-                Type::ParamSpecValue(ParamList::new(elts))
+                (Type::ParamSpecValue(ParamList::new(elts)), None)
             }
             _ => {
                 let inferred_ty = self
                     .expr_infer_impl(x, None, errors, Some(type_form_context))
                     .into_ty();
-                self.untype_runtime_type(inferred_ty, x.range(), type_form_context, errors)
+                let result = self.untype_runtime_type(
+                    inferred_ty.clone(),
+                    x.range(),
+                    type_form_context,
+                    errors,
+                );
+                let display_ty = if inferred_ty.any(|ty| matches!(ty, Type::TypeAlias(_))) {
+                    self.untype_opt_with_context_impl(
+                        inferred_ty,
+                        x.range(),
+                        &self.error_swallower(),
+                        type_form_context.untype_context(),
+                        true,
+                    )
+                } else {
+                    None
+                };
+                (result, display_ty)
             }
         };
         let result = self.validate_type_form(result, x.range(), type_form_context, errors);
         if type_form_context.can_report_explicit_any() {
             self.check_explicit_any(&result, x.range(), errors);
         }
-        result
+        let display_ty = display_ty.filter(|display_ty| display_ty != &result);
+        (result, display_ty)
     }
 
     fn untype_runtime_type(

--- a/pyrefly/lib/alt/types/decorated_function.rs
+++ b/pyrefly/lib/alt/types/decorated_function.rs
@@ -45,6 +45,8 @@ pub struct UndecoratedFunction {
     pub decorators: Box<[(Type, TextRange)]>,
     pub tparams: Arc<TParams>,
     pub params: Vec<Param>,
+    /// Alias-preserving parameter types used to construct the hover signature.
+    pub display_param_types: SmallMap<Name, Type>,
     pub paramspec: Option<Quantified>,
     pub defining_cls: Option<Class>,
     pub type_shape_dsl_def: Option<Arc<ParsedTypeShapeDslFunction>>,
@@ -108,6 +110,7 @@ impl UndecoratedFunction {
             decorators: Box::from([]),
             tparams: Arc::new(TParams::default()),
             params: Vec::new(),
+            display_param_types: SmallMap::new(),
             paramspec: None,
             defining_cls: None,
             type_shape_dsl_def: None,

--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -842,7 +842,7 @@ fn resolve_hovered_type(
     handle: &Handle,
     ast: Option<&ModModule>,
     position: TextSize,
-) -> Option<Type> {
+) -> Option<(Type, bool)> {
     let mut type_ = transaction
         .subscript_operator_type_at(handle, position)
         .or_else(|| transaction.get_type_at_for_display(handle, position))
@@ -894,7 +894,7 @@ fn resolve_hovered_type(
             type_ = transaction.coerce_type_to_callable(handle, type_);
         }
     }
-    Some(type_)
+    Some((type_, callee_range_opt.is_none()))
 }
 
 /// Resolve parameter documentation for the symbol under the cursor: keyword-argument docs
@@ -971,7 +971,8 @@ pub fn get_hover_with_verbosity(
         return Some(result);
     }
 
-    let type_ = resolve_hovered_type(transaction, handle, ast.as_deref(), position)?;
+    let (type_, use_declared_function_display) =
+        resolve_hovered_type(transaction, handle, ast.as_deref(), position)?;
 
     // `a and b and c` is a single flat BoolOp, so hovering any operator in the
     // chain highlights the whole expression.
@@ -1014,11 +1015,11 @@ pub fn get_hover_with_verbosity(
         });
     let (kind, name, definition_range, docstring_range, module) =
         if let Some(FindDefinitionItemWithDocstring {
-        metadata,
-        definition_range: definition_location,
-        module,
-        docstring_range,
-        display_name,
+            metadata,
+            definition_range: definition_location,
+            module,
+            docstring_range,
+            display_name,
         }) = definition
         {
             let kind = metadata.symbol_kind();
@@ -1049,7 +1050,7 @@ pub fn get_hover_with_verbosity(
         && hover_identifier
             .as_ref()
             .is_some_and(|id| !matches!(id.context, IdentifierContext::ClassDef { .. }));
-    let declared_function_display = if callee_range_opt.is_none() {
+    let declared_function_display = if use_declared_function_display {
         match (&type_, module.as_ref(), definition_range) {
             (Type::Function(_), Some(module), Some(definition_range)) => {
                 transaction.get_ast(handle).and_then(|ast| {
@@ -1097,15 +1098,14 @@ pub fn get_hover_with_verbosity(
             (rendered, can_increase_verbosity)
         }
     });
-    let (type_display, can_increase_verbosity) =
-        match (declared_function_display, solved_display) {
-            (Some(display), Some((_, can_increase))) if options.verbosity_level == 0 => {
-                (Some(display), can_increase)
-            }
-            (_, Some((display, can_increase))) => (Some(display), can_increase),
-            (Some(display), None) => (Some(display), false),
-            (None, None) => (None, false),
-        };
+    let (type_display, can_increase_verbosity) = match (declared_function_display, solved_display) {
+        (Some(display), Some((_, can_increase))) if options.verbosity_level == 0 => {
+            (Some(display), can_increase)
+        }
+        (_, Some((display, can_increase))) => (Some(display), can_increase),
+        (Some(display), None) => (Some(display), false),
+        (None, None) => (None, false),
+    };
 
     let docstring = if let (Some(docstring), Some(module)) = (docstring_range, module) {
         Some(Docstring(docstring, module))

--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -720,34 +720,6 @@ fn keyword_argument_identifier(
         .then_some(identifier.identifier)
 }
 
-fn declared_function_hover_display(
-    ast: &ModModule,
-    module: &Module,
-    definition_range: TextRange,
-) -> Option<String> {
-    let function_def = Ast::locate_node(ast, definition_range.start())
-        .into_iter()
-        .find_map(|node| match node {
-            AnyNodeRef::StmtFunctionDef(function_def)
-                if function_def.name.range() == definition_range =>
-            {
-                Some(function_def)
-            }
-            _ => None,
-        })?;
-    let signature_end = function_def
-        .returns
-        .as_ref()
-        .map(|returns| returns.range().end())
-        .unwrap_or_else(|| function_def.parameters.end());
-    let contents = module.contents();
-    let colon_offset =
-        contents[signature_end.to_usize()..function_def.range.end().to_usize()].find(':')?;
-    let colon = signature_end + TextSize::try_from(colon_offset + 1).ok()?;
-    let header = module.code_at(TextRange::new(function_def.range.start(), colon));
-    Some(format!("{header} ..."))
-}
-
 /// Check if the cursor position is on the `in` keyword within a for loop or comprehension.
 /// Returns Some(iterable_range) if found, None otherwise.
 fn in_keyword_in_iteration_at(ast: Option<&ModModule>, position: TextSize) -> Option<TextRange> {
@@ -832,7 +804,7 @@ fn resolve_hovered_type(
     handle: &Handle,
     ast: Option<&ModModule>,
     position: TextSize,
-) -> Option<(Type, bool)> {
+) -> Option<Type> {
     let mut type_ = transaction
         .subscript_operator_type_at(handle, position)
         .or_else(|| transaction.get_type_at_for_display(handle, position))
@@ -884,7 +856,7 @@ fn resolve_hovered_type(
             type_ = transaction.coerce_type_to_callable(handle, type_);
         }
     }
-    Some((type_, callee_range_opt.is_none()))
+    Some(type_)
 }
 
 /// Resolve parameter documentation for the symbol under the cursor: keyword-argument docs
@@ -961,8 +933,7 @@ pub fn get_hover_with_verbosity(
         return Some(result);
     }
 
-    let (type_, use_declared_function_display) =
-        resolve_hovered_type(transaction, handle, ast.as_deref(), position)?;
+    let type_ = resolve_hovered_type(transaction, handle, ast.as_deref(), position)?;
 
     // `a and b and c` is a single flat BoolOp, so hovering any operator in the
     // chain highlights the whole expression. `not` highlights its unary expression.
@@ -1006,31 +977,24 @@ pub fn get_hover_with_verbosity(
                     item.module.code_at(item.definition_range) == identifier.id.as_str()
                 })
         });
-    let (kind, name, definition_range, docstring_range, module) =
-        if let Some(FindDefinitionItemWithDocstring {
-            metadata,
-            definition_range: definition_location,
-            module,
-            docstring_range,
-            display_name,
-        }) = definition
-        {
-            let kind = metadata.symbol_kind();
-            let name = hover_name_from_definition_snippet(
-                module.code_at(definition_location),
-                display_name.as_deref(),
-                fallback_name_from_type,
-            );
-            (
-                kind,
-                name,
-                Some(definition_location),
-                docstring_range,
-                Some(module),
-            )
-        } else {
-            (None, fallback_name_from_type, None, None, None)
-        };
+    let (kind, name, docstring_range, module) = if let Some(FindDefinitionItemWithDocstring {
+        metadata,
+        definition_range: definition_location,
+        module,
+        docstring_range,
+        display_name,
+    }) = definition
+    {
+        let kind = metadata.symbol_kind();
+        let name = hover_name_from_definition_snippet(
+            module.code_at(definition_location),
+            display_name.as_deref(),
+            fallback_name_from_type,
+        );
+        (kind, name, docstring_range, Some(module))
+    } else {
+        (None, fallback_name_from_type, None, None)
+    };
 
     let name = name.or_else(|| identifier_text_at(transaction, handle, position));
 
@@ -1043,62 +1007,47 @@ pub fn get_hover_with_verbosity(
         && hover_identifier
             .as_ref()
             .is_some_and(|id| !matches!(id.context, IdentifierContext::ClassDef { .. }));
-    let declared_function_display = if use_declared_function_display {
-        match (&type_, module.as_ref(), definition_range) {
-            (Type::Function(_), Some(module), Some(definition_range)) => {
-                transaction.get_ast(handle).and_then(|ast| {
-                    declared_function_hover_display(ast.as_ref(), module, definition_range)
-                })
+    let (type_display, can_increase_verbosity) =
+        match transaction.ad_hoc_solve(handle, "hover_display", {
+            let mut cloned = type_.clone();
+            move |solver| {
+                let unions_expanded = options.verbosity_level > 0;
+                if let Some(owner) = &type_parameter_owner_class
+                    && let Some(display) = type_parameter_hover_display(&solver, &cloned, owner)
+                {
+                    // Type parameter displays (e.g. `T@Foo (covariant)`) never contain unions.
+                    return (display, false);
+                }
+                // Named unions can be surfaced by the class/kwargs transforms, so pick the
+                // type we're about to render first.
+                let display_type = if show_constructor
+                    && let Some(class_type) = class_display_type(&solver, &cloned)
+                {
+                    class_type
+                } else {
+                    cloned.transform_toplevel_callable(|c| {
+                        expand_callable_kwargs_for_hover(&solver, c)
+                    });
+                    cloned
+                };
+                let render = |expand| {
+                    display_type.as_lsp_string_with_fallback_name_and_expanded_unions(
+                        name_for_display.as_deref(),
+                        LspDisplayMode::Hover,
+                        expand,
+                    )
+                };
+                let rendered = render(unions_expanded);
+                // Offer "+" only when expanding actually changes the rendered type. Deriving
+                // this from the renderer itself (rather than a structural type walk) means the
+                // affordance can never advertise an expansion that produces identical output.
+                let can_increase_verbosity = !unions_expanded && rendered != render(true);
+                (rendered, can_increase_verbosity)
             }
-            _ => None,
-        }
-    } else {
-        None
-    };
-    let solved_display = transaction.ad_hoc_solve(handle, "hover_display", {
-        let mut cloned = type_.clone();
-        move |solver| {
-            let unions_expanded = options.verbosity_level > 0;
-            if let Some(owner) = &type_parameter_owner_class
-                && let Some(display) = type_parameter_hover_display(&solver, &cloned, owner)
-            {
-                // Type parameter displays (e.g. `T@Foo (covariant)`) never contain unions.
-                return (display, false);
-            }
-            // Named unions can be surfaced by the class/kwargs transforms, so pick the
-            // type we're about to render first.
-            let display_type = if show_constructor
-                && let Some(class_type) = class_display_type(&solver, &cloned)
-            {
-                class_type
-            } else {
-                cloned
-                    .transform_toplevel_callable(|c| expand_callable_kwargs_for_hover(&solver, c));
-                cloned
-            };
-            let render = |expand| {
-                display_type.as_lsp_string_with_fallback_name_and_expanded_unions(
-                    name_for_display.as_deref(),
-                    LspDisplayMode::Hover,
-                    expand,
-                )
-            };
-            let rendered = render(unions_expanded);
-            // Offer "+" only when expanding actually changes the rendered type. Deriving
-            // this from the renderer itself (rather than a structural type walk) means the
-            // affordance can never advertise an expansion that produces identical output.
-            let can_increase_verbosity = !unions_expanded && rendered != render(true);
-            (rendered, can_increase_verbosity)
-        }
-    });
-    let (type_display, can_increase_verbosity) = match (declared_function_display, solved_display) {
-        (Some(display), Some((_, can_increase))) if options.verbosity_level == 0 => {
-            (Some(display), can_increase)
-        }
-        (_, Some((display, can_increase))) => (Some(display), can_increase),
-        (Some(display), None) => (Some(display), false),
-        (None, None) => (None, false),
-    };
+        }) {
+            Some((display, can_increase)) => (Some(display), can_increase),
+            None => (None, false),
+        };
 
     let docstring = if let (Some(docstring), Some(module)) = (docstring_range, module) {
         Some(Docstring(docstring, module))

--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -730,9 +730,12 @@ fn keyword_argument_identifier(
         .then_some(identifier.identifier)
 }
 
-fn declared_function_hover_display(module: &Module, definition_range: TextRange) -> Option<String> {
-    let (ast, _, _) = Ast::parse(module.contents(), module.source_type());
-    let function_def = Ast::locate_node(&ast, definition_range.start())
+fn declared_function_hover_display(
+    ast: &ModModule,
+    module: &Module,
+    definition_range: TextRange,
+) -> Option<String> {
+    let function_def = Ast::locate_node(ast, definition_range.start())
         .into_iter()
         .find_map(|node| match node {
             AnyNodeRef::StmtFunctionDef(function_def)
@@ -742,16 +745,17 @@ fn declared_function_hover_display(module: &Module, definition_range: TextRange)
             }
             _ => None,
         })?;
-    let body_start = function_def
-        .body
-        .first()
-        .map(Ranged::range)
-        .map(|range| range.start())
-        .unwrap_or(function_def.range.end());
-    let header = module
-        .code_at(TextRange::new(function_def.range.start(), body_start))
-        .trim_end();
-    header.ends_with(':').then(|| format!("{header} ..."))
+    let signature_end = function_def
+        .returns
+        .as_ref()
+        .map(|returns| returns.range().end())
+        .unwrap_or_else(|| function_def.parameters.end());
+    let contents = module.contents();
+    let colon_offset =
+        contents[signature_end.to_usize()..function_def.range.end().to_usize()].find(':')?;
+    let colon = signature_end + TextSize::try_from(colon_offset + 1).ok()?;
+    let header = module.code_at(TextRange::new(function_def.range.start(), colon));
+    Some(format!("{header} ..."))
 }
 
 /// Check if the cursor position is on the `in` keyword within a for loop or comprehension.
@@ -1048,7 +1052,9 @@ pub fn get_hover_with_verbosity(
     let declared_function_display = if callee_range_opt.is_none() {
         match (&type_, module.as_ref(), definition_range) {
             (Type::Function(_), Some(module), Some(definition_range)) => {
-                declared_function_hover_display(module, definition_range)
+                transaction.get_ast(handle).and_then(|ast| {
+                    declared_function_hover_display(ast.as_ref(), module, definition_range)
+                })
             }
             _ => None,
         }

--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -720,6 +720,30 @@ fn keyword_argument_identifier(
         .then_some(identifier.identifier)
 }
 
+fn declared_function_hover_display(module: &Module, definition_range: TextRange) -> Option<String> {
+    let (ast, _, _) = Ast::parse(module.contents(), module.source_type());
+    let function_def = Ast::locate_node(&ast, definition_range.start())
+        .into_iter()
+        .find_map(|node| match node {
+            AnyNodeRef::StmtFunctionDef(function_def)
+                if function_def.name.range() == definition_range =>
+            {
+                Some(function_def)
+            }
+            _ => None,
+        })?;
+    let body_start = function_def
+        .body
+        .first()
+        .map(Ranged::range)
+        .map(|range| range.start())
+        .unwrap_or(function_def.range.end());
+    let header = module
+        .code_at(TextRange::new(function_def.range.start(), body_start))
+        .trim_end();
+    header.ends_with(':').then(|| format!("{header} ..."))
+}
+
 /// Check if the cursor position is on the `in` keyword within a for loop or comprehension.
 /// Returns Some(iterable_range) if found, None otherwise.
 fn in_keyword_in_iteration_at(ast: Option<&ModModule>, position: TextSize) -> Option<TextRange> {
@@ -977,24 +1001,31 @@ pub fn get_hover_with_verbosity(
                     item.module.code_at(item.definition_range) == identifier.id.as_str()
                 })
         });
-    let (kind, name, docstring_range, module) = if let Some(FindDefinitionItemWithDocstring {
+    let (kind, name, definition_range, docstring_range, module) =
+        if let Some(FindDefinitionItemWithDocstring {
         metadata,
         definition_range: definition_location,
         module,
         docstring_range,
         display_name,
-    }) = definition
-    {
-        let kind = metadata.symbol_kind();
-        let name = hover_name_from_definition_snippet(
-            module.code_at(definition_location),
-            display_name.as_deref(),
-            fallback_name_from_type,
-        );
-        (kind, name, docstring_range, Some(module))
-    } else {
-        (None, fallback_name_from_type, None, None)
-    };
+        }) = definition
+        {
+            let kind = metadata.symbol_kind();
+            let name = hover_name_from_definition_snippet(
+                module.code_at(definition_location),
+                display_name.as_deref(),
+                fallback_name_from_type,
+            );
+            (
+                kind,
+                name,
+                Some(definition_location),
+                docstring_range,
+                Some(module),
+            )
+        } else {
+            (None, fallback_name_from_type, None, None, None)
+        };
 
     let name = name.or_else(|| identifier_text_at(transaction, handle, position));
 
@@ -1007,46 +1038,60 @@ pub fn get_hover_with_verbosity(
         && hover_identifier
             .as_ref()
             .is_some_and(|id| !matches!(id.context, IdentifierContext::ClassDef { .. }));
-    let (type_display, can_increase_verbosity) =
-        match transaction.ad_hoc_solve(handle, "hover_display", {
-            let mut cloned = type_.clone();
-            move |solver| {
-                let unions_expanded = options.verbosity_level > 0;
-                if let Some(owner) = &type_parameter_owner_class
-                    && let Some(display) = type_parameter_hover_display(&solver, &cloned, owner)
-                {
-                    // Type parameter displays (e.g. `T@Foo (covariant)`) never contain unions.
-                    return (display, false);
-                }
-                // Named unions can be surfaced by the class/kwargs transforms, so pick the
-                // type we're about to render first.
-                let display_type = if show_constructor
-                    && let Some(class_type) = class_display_type(&solver, &cloned)
-                {
-                    class_type
-                } else {
-                    cloned.transform_toplevel_callable(|c| {
-                        expand_callable_kwargs_for_hover(&solver, c)
-                    });
-                    cloned
-                };
-                let render = |expand| {
-                    display_type.as_lsp_string_with_fallback_name_and_expanded_unions(
-                        name_for_display.as_deref(),
-                        LspDisplayMode::Hover,
-                        expand,
-                    )
-                };
-                let rendered = render(unions_expanded);
-                // Offer "+" only when expanding actually changes the rendered type. Deriving
-                // this from the renderer itself (rather than a structural type walk) means the
-                // affordance can never advertise an expansion that produces identical output.
-                let can_increase_verbosity = !unions_expanded && rendered != render(true);
-                (rendered, can_increase_verbosity)
+    let declared_function_display = if callee_range_opt.is_none() {
+        match (&type_, module.as_ref(), definition_range) {
+            (Type::Function(_), Some(module), Some(definition_range)) => {
+                declared_function_hover_display(module, definition_range)
             }
-        }) {
-            Some((display, can_increase)) => (Some(display), can_increase),
-            None => (None, false),
+            _ => None,
+        }
+    } else {
+        None
+    };
+    let solved_display = transaction.ad_hoc_solve(handle, "hover_display", {
+        let mut cloned = type_.clone();
+        move |solver| {
+            let unions_expanded = options.verbosity_level > 0;
+            if let Some(owner) = &type_parameter_owner_class
+                && let Some(display) = type_parameter_hover_display(&solver, &cloned, owner)
+            {
+                // Type parameter displays (e.g. `T@Foo (covariant)`) never contain unions.
+                return (display, false);
+            }
+            // Named unions can be surfaced by the class/kwargs transforms, so pick the
+            // type we're about to render first.
+            let display_type = if show_constructor
+                && let Some(class_type) = class_display_type(&solver, &cloned)
+            {
+                class_type
+            } else {
+                cloned
+                    .transform_toplevel_callable(|c| expand_callable_kwargs_for_hover(&solver, c));
+                cloned
+            };
+            let render = |expand| {
+                display_type.as_lsp_string_with_fallback_name_and_expanded_unions(
+                    name_for_display.as_deref(),
+                    LspDisplayMode::Hover,
+                    expand,
+                )
+            };
+            let rendered = render(unions_expanded);
+            // Offer "+" only when expanding actually changes the rendered type. Deriving
+            // this from the renderer itself (rather than a structural type walk) means the
+            // affordance can never advertise an expansion that produces identical output.
+            let can_increase_verbosity = !unions_expanded && rendered != render(true);
+            (rendered, can_increase_verbosity)
+        }
+    });
+    let (type_display, can_increase_verbosity) =
+        match (declared_function_display, solved_display) {
+            (Some(display), Some((_, can_increase))) if options.verbosity_level == 0 => {
+                (Some(display), can_increase)
+            }
+            (_, Some((display, can_increase))) => (Some(display), can_increase),
+            (Some(display), None) => (Some(display), false),
+            (None, None) => (None, false),
         };
 
     let docstring = if let (Some(docstring), Some(module)) = (docstring_range, module) {

--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -720,9 +720,12 @@ fn keyword_argument_identifier(
         .then_some(identifier.identifier)
 }
 
-fn declared_function_hover_display(module: &Module, definition_range: TextRange) -> Option<String> {
-    let (ast, _, _) = Ast::parse(module.contents(), module.source_type());
-    let function_def = Ast::locate_node(&ast, definition_range.start())
+fn declared_function_hover_display(
+    ast: &ModModule,
+    module: &Module,
+    definition_range: TextRange,
+) -> Option<String> {
+    let function_def = Ast::locate_node(ast, definition_range.start())
         .into_iter()
         .find_map(|node| match node {
             AnyNodeRef::StmtFunctionDef(function_def)
@@ -732,16 +735,17 @@ fn declared_function_hover_display(module: &Module, definition_range: TextRange)
             }
             _ => None,
         })?;
-    let body_start = function_def
-        .body
-        .first()
-        .map(Ranged::range)
-        .map(|range| range.start())
-        .unwrap_or(function_def.range.end());
-    let header = module
-        .code_at(TextRange::new(function_def.range.start(), body_start))
-        .trim_end();
-    header.ends_with(':').then(|| format!("{header} ..."))
+    let signature_end = function_def
+        .returns
+        .as_ref()
+        .map(|returns| returns.range().end())
+        .unwrap_or_else(|| function_def.parameters.end());
+    let contents = module.contents();
+    let colon_offset =
+        contents[signature_end.to_usize()..function_def.range.end().to_usize()].find(':')?;
+    let colon = signature_end + TextSize::try_from(colon_offset + 1).ok()?;
+    let header = module.code_at(TextRange::new(function_def.range.start(), colon));
+    Some(format!("{header} ..."))
 }
 
 /// Check if the cursor position is on the `in` keyword within a for loop or comprehension.
@@ -828,7 +832,7 @@ fn resolve_hovered_type(
     handle: &Handle,
     ast: Option<&ModModule>,
     position: TextSize,
-) -> Option<Type> {
+) -> Option<(Type, bool)> {
     let mut type_ = transaction
         .subscript_operator_type_at(handle, position)
         .or_else(|| transaction.get_type_at_for_display(handle, position))
@@ -880,7 +884,7 @@ fn resolve_hovered_type(
             type_ = transaction.coerce_type_to_callable(handle, type_);
         }
     }
-    Some(type_)
+    Some((type_, callee_range_opt.is_none()))
 }
 
 /// Resolve parameter documentation for the symbol under the cursor: keyword-argument docs
@@ -957,7 +961,8 @@ pub fn get_hover_with_verbosity(
         return Some(result);
     }
 
-    let type_ = resolve_hovered_type(transaction, handle, ast.as_deref(), position)?;
+    let (type_, use_declared_function_display) =
+        resolve_hovered_type(transaction, handle, ast.as_deref(), position)?;
 
     // `a and b and c` is a single flat BoolOp, so hovering any operator in the
     // chain highlights the whole expression. `not` highlights its unary expression.
@@ -1003,11 +1008,11 @@ pub fn get_hover_with_verbosity(
         });
     let (kind, name, definition_range, docstring_range, module) =
         if let Some(FindDefinitionItemWithDocstring {
-        metadata,
-        definition_range: definition_location,
-        module,
-        docstring_range,
-        display_name,
+            metadata,
+            definition_range: definition_location,
+            module,
+            docstring_range,
+            display_name,
         }) = definition
         {
             let kind = metadata.symbol_kind();
@@ -1038,10 +1043,12 @@ pub fn get_hover_with_verbosity(
         && hover_identifier
             .as_ref()
             .is_some_and(|id| !matches!(id.context, IdentifierContext::ClassDef { .. }));
-    let declared_function_display = if callee_range_opt.is_none() {
+    let declared_function_display = if use_declared_function_display {
         match (&type_, module.as_ref(), definition_range) {
             (Type::Function(_), Some(module), Some(definition_range)) => {
-                declared_function_hover_display(module, definition_range)
+                transaction.get_ast(handle).and_then(|ast| {
+                    declared_function_hover_display(ast.as_ref(), module, definition_range)
+                })
             }
             _ => None,
         }
@@ -1084,15 +1091,14 @@ pub fn get_hover_with_verbosity(
             (rendered, can_increase_verbosity)
         }
     });
-    let (type_display, can_increase_verbosity) =
-        match (declared_function_display, solved_display) {
-            (Some(display), Some((_, can_increase))) if options.verbosity_level == 0 => {
-                (Some(display), can_increase)
-            }
-            (_, Some((display, can_increase))) => (Some(display), can_increase),
-            (Some(display), None) => (Some(display), false),
-            (None, None) => (None, false),
-        };
+    let (type_display, can_increase_verbosity) = match (declared_function_display, solved_display) {
+        (Some(display), Some((_, can_increase))) if options.verbosity_level == 0 => {
+            (Some(display), can_increase)
+        }
+        (_, Some((display, can_increase))) => (Some(display), can_increase),
+        (Some(display), None) => (Some(display), false),
+        (None, None) => (None, false),
+    };
 
     let docstring = if let (Some(docstring), Some(module)) = (docstring_range, module) {
         Some(Docstring(docstring, module))

--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -730,6 +730,30 @@ fn keyword_argument_identifier(
         .then_some(identifier.identifier)
 }
 
+fn declared_function_hover_display(module: &Module, definition_range: TextRange) -> Option<String> {
+    let (ast, _, _) = Ast::parse(module.contents(), module.source_type());
+    let function_def = Ast::locate_node(&ast, definition_range.start())
+        .into_iter()
+        .find_map(|node| match node {
+            AnyNodeRef::StmtFunctionDef(function_def)
+                if function_def.name.range() == definition_range =>
+            {
+                Some(function_def)
+            }
+            _ => None,
+        })?;
+    let body_start = function_def
+        .body
+        .first()
+        .map(Ranged::range)
+        .map(|range| range.start())
+        .unwrap_or(function_def.range.end());
+    let header = module
+        .code_at(TextRange::new(function_def.range.start(), body_start))
+        .trim_end();
+    header.ends_with(':').then(|| format!("{header} ..."))
+}
+
 /// Check if the cursor position is on the `in` keyword within a for loop or comprehension.
 /// Returns Some(iterable_range) if found, None otherwise.
 fn in_keyword_in_iteration_at(ast: Option<&ModModule>, position: TextSize) -> Option<TextRange> {
@@ -984,24 +1008,31 @@ pub fn get_hover_with_verbosity(
                     item.module.code_at(item.definition_range) == identifier.id.as_str()
                 })
         });
-    let (kind, name, docstring_range, module) = if let Some(FindDefinitionItemWithDocstring {
+    let (kind, name, definition_range, docstring_range, module) =
+        if let Some(FindDefinitionItemWithDocstring {
         metadata,
         definition_range: definition_location,
         module,
         docstring_range,
         display_name,
-    }) = definition
-    {
-        let kind = metadata.symbol_kind();
-        let name = hover_name_from_definition_snippet(
-            module.code_at(definition_location),
-            display_name.as_deref(),
-            fallback_name_from_type,
-        );
-        (kind, name, docstring_range, Some(module))
-    } else {
-        (None, fallback_name_from_type, None, None)
-    };
+        }) = definition
+        {
+            let kind = metadata.symbol_kind();
+            let name = hover_name_from_definition_snippet(
+                module.code_at(definition_location),
+                display_name.as_deref(),
+                fallback_name_from_type,
+            );
+            (
+                kind,
+                name,
+                Some(definition_location),
+                docstring_range,
+                Some(module),
+            )
+        } else {
+            (None, fallback_name_from_type, None, None, None)
+        };
 
     let name = name.or_else(|| identifier_text_at(transaction, handle, position));
 
@@ -1014,46 +1045,60 @@ pub fn get_hover_with_verbosity(
         && hover_identifier
             .as_ref()
             .is_some_and(|id| !matches!(id.context, IdentifierContext::ClassDef { .. }));
-    let (type_display, can_increase_verbosity) =
-        match transaction.ad_hoc_solve(handle, "hover_display", {
-            let mut cloned = type_.clone();
-            move |solver| {
-                let unions_expanded = options.verbosity_level > 0;
-                if let Some(owner) = &type_parameter_owner_class
-                    && let Some(display) = type_parameter_hover_display(&solver, &cloned, owner)
-                {
-                    // Type parameter displays (e.g. `T@Foo (covariant)`) never contain unions.
-                    return (display, false);
-                }
-                // Named unions can be surfaced by the class/kwargs transforms, so pick the
-                // type we're about to render first.
-                let display_type = if show_constructor
-                    && let Some(class_type) = class_display_type(&solver, &cloned)
-                {
-                    class_type
-                } else {
-                    cloned.transform_toplevel_callable(|c| {
-                        expand_callable_kwargs_for_hover(&solver, c)
-                    });
-                    cloned
-                };
-                let render = |expand| {
-                    display_type.as_lsp_string_with_fallback_name_and_expanded_unions(
-                        name_for_display.as_deref(),
-                        LspDisplayMode::Hover,
-                        expand,
-                    )
-                };
-                let rendered = render(unions_expanded);
-                // Offer "+" only when expanding actually changes the rendered type. Deriving
-                // this from the renderer itself (rather than a structural type walk) means the
-                // affordance can never advertise an expansion that produces identical output.
-                let can_increase_verbosity = !unions_expanded && rendered != render(true);
-                (rendered, can_increase_verbosity)
+    let declared_function_display = if callee_range_opt.is_none() {
+        match (&type_, module.as_ref(), definition_range) {
+            (Type::Function(_), Some(module), Some(definition_range)) => {
+                declared_function_hover_display(module, definition_range)
             }
-        }) {
-            Some((display, can_increase)) => (Some(display), can_increase),
-            None => (None, false),
+            _ => None,
+        }
+    } else {
+        None
+    };
+    let solved_display = transaction.ad_hoc_solve(handle, "hover_display", {
+        let mut cloned = type_.clone();
+        move |solver| {
+            let unions_expanded = options.verbosity_level > 0;
+            if let Some(owner) = &type_parameter_owner_class
+                && let Some(display) = type_parameter_hover_display(&solver, &cloned, owner)
+            {
+                // Type parameter displays (e.g. `T@Foo (covariant)`) never contain unions.
+                return (display, false);
+            }
+            // Named unions can be surfaced by the class/kwargs transforms, so pick the
+            // type we're about to render first.
+            let display_type = if show_constructor
+                && let Some(class_type) = class_display_type(&solver, &cloned)
+            {
+                class_type
+            } else {
+                cloned
+                    .transform_toplevel_callable(|c| expand_callable_kwargs_for_hover(&solver, c));
+                cloned
+            };
+            let render = |expand| {
+                display_type.as_lsp_string_with_fallback_name_and_expanded_unions(
+                    name_for_display.as_deref(),
+                    LspDisplayMode::Hover,
+                    expand,
+                )
+            };
+            let rendered = render(unions_expanded);
+            // Offer "+" only when expanding actually changes the rendered type. Deriving
+            // this from the renderer itself (rather than a structural type walk) means the
+            // affordance can never advertise an expansion that produces identical output.
+            let can_increase_verbosity = !unions_expanded && rendered != render(true);
+            (rendered, can_increase_verbosity)
+        }
+    });
+    let (type_display, can_increase_verbosity) =
+        match (declared_function_display, solved_display) {
+            (Some(display), Some((_, can_increase))) if options.verbosity_level == 0 => {
+                (Some(display), can_increase)
+            }
+            (_, Some((display, can_increase))) => (Some(display), can_increase),
+            (Some(display), None) => (Some(display), false),
+            (None, None) => (None, false),
         };
 
     let docstring = if let (Some(docstring), Some(module)) = (docstring_range, module) {

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -508,6 +508,38 @@ def f(c: C) -> None:
 }
 
 #[test]
+fn hover_preserves_type_aliases_in_function_signatures() {
+    let code = r#"
+from typing import TypeAlias
+
+Messages: TypeAlias = list[str]
+
+def func(msgs: Messages) -> None:
+    pass
+
+func
+#^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], |state, handle, position| {
+        match get_hover(&state.transaction(), handle, position, false) {
+            Some(Hover {
+                contents: HoverContents::Markup(markup),
+                ..
+            }) => markup.value,
+            _ => "None".to_owned(),
+        }
+    });
+    assert!(
+        report.contains("def func(msgs: Messages) -> None: ..."),
+        "Expected hover to preserve the alias name, got: {report}"
+    );
+    assert!(
+        !report.contains("def func(msgs: list[str]) -> None: ..."),
+        "Expected hover not to expand the alias, got: {report}"
+    );
+}
+
+#[test]
 fn hover_over_inline_ignore_comment() {
     let code = r#"
 a: int = "test"  # pyrefly: ignore

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -516,7 +516,6 @@ Messages: TypeAlias = list[str]
 type Payloads = list[str]
 
 def func(msgs: Messages) -> None:
-    # Leading body trivia must not make hover fall back to resolved types.
     pass
 
 def handle(payloads: Payloads) -> None:
@@ -548,6 +547,29 @@ handle
         !report.contains("def func(msgs: list[str]) -> None: ..."),
         "Expected hover not to expand the alias, got: {report}"
     );
+}
+
+#[test]
+fn hover_preserves_type_aliases_in_imported_function_signatures() {
+    let main = r#"
+from lib import handle
+
+handle
+#^
+"#;
+    let lib = r#"
+from typing import TypeAlias
+
+Messages: TypeAlias = list[str]
+type Payload[T] = list[T]
+
+def handle(messages: Messages, payload: Payload[str]) -> Payload[int]: ...
+"#;
+    let report =
+        get_batched_lsp_operations_report(&[("main", main), ("lib", lib)], get_test_report);
+    assert!(report.contains("messages: Messages"), "got: {report}");
+    assert!(report.contains("payload: Payload[str]"), "got: {report}");
+    assert!(report.contains(") -> Payload[int]: ..."), "got: {report}");
 }
 
 #[test]

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -513,11 +513,18 @@ fn hover_preserves_type_aliases_in_function_signatures() {
 from typing import TypeAlias
 
 Messages: TypeAlias = list[str]
+type Payloads = list[str]
 
 def func(msgs: Messages) -> None:
+    # Leading body trivia must not make hover fall back to resolved types.
+    pass
+
+def handle(payloads: Payloads) -> None:
     pass
 
 func
+#^
+handle
 #^
 "#;
     let report = get_batched_lsp_operations_report(&[("main", code)], |state, handle, position| {
@@ -531,7 +538,11 @@ func
     });
     assert!(
         report.contains("def func(msgs: Messages) -> None: ..."),
-        "Expected hover to preserve the alias name, got: {report}"
+        "Expected hover to preserve the legacy alias name, got: {report}"
+    );
+    assert!(
+        report.contains("def handle(payloads: Payloads) -> None: ..."),
+        "Expected hover to preserve the scoped alias name, got: {report}"
     );
     assert!(
         !report.contains("def func(msgs: list[str]) -> None: ..."),

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -1955,10 +1955,7 @@ mod tests {
         );
         let func = Function {
             signature: callable,
-            metadata: FuncMetadata {
-                kind: FunctionKind::Overload,
-                flags: FuncFlags::default(),
-            },
+            metadata: FuncMetadata::new(FunctionKind::Overload, FuncFlags::default()),
         };
         let ty = PyreflyType::Function(Box::new(func));
         match convert_type(&ty) {
@@ -2037,10 +2034,7 @@ mod tests {
         let callable = Callable::list(ParamList::new(vec![]), PyreflyType::None);
         let func = Function {
             signature: callable,
-            metadata: FuncMetadata {
-                kind: FunctionKind::Overload,
-                flags: FuncFlags::default(),
-            },
+            metadata: FuncMetadata::new(FunctionKind::Overload, FuncFlags::default()),
         };
         let ty = PyreflyType::Function(Box::new(func));
         let range = lsp_types::Range {


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2707

non-call hovers on plain functions render the declared source header instead of the normalized solved signature.

That preserves aliases like Messages in hover text while leaving call-site hover behavior unchanged for constructors, `__call__`, and expanded `**kwargs`.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test