### PR TITLE
fix go-to definition / hover includes the lhs in operators #1517

### DIFF
--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2235,13 +2235,6 @@ impl<'a> Transaction<'a> {
                     }))
                 }
                 AnyNodeRef::ExprSubscript(subscript) => {
-                    if !Self::position_is_between(
-                        position,
-                        subscript.value.range().end(),
-                        subscript.slice.range().start(),
-                    ) {
-                        return None;
-                    }
                     let dunder_name = match subscript.ctx {
                         ExprContext::Load => Some(dunder::GETITEM),
                         ExprContext::Store => Some(dunder::SETITEM),

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2110,9 +2110,14 @@ impl<'a> Transaction<'a> {
     /// - `Err(NotAnIdentifier)` — operator without a dunder (`not`, `is`, `is not`)
     /// - `Err(AnswersNotFound)` — operator found but answers unavailable
     /// - `Err(TypeTraceNotFound)` — operator found but base expression has no type trace
+    fn position_is_between(position: TextSize, left_end: TextSize, right_start: TextSize) -> bool {
+        TextRange::new(left_end, right_start).contains(position)
+    }
+
     fn find_operator_dunder(
         &self,
         handle: &Handle,
+        position: TextSize,
         covering_nodes: &[AnyNodeRef],
     ) -> Result<Option<OperatorDunder>, EmptyResponseReason> {
         // Look up the type of an expression, distinguishing "no answers"
@@ -2130,17 +2135,23 @@ impl<'a> Transaction<'a> {
             .iter()
             .find_map(|node| match node {
                 AnyNodeRef::ExprCompare(compare) => {
-                    for op in &compare.ops {
+                    let mut left = compare.left.as_ref();
+                    for (op, right) in compare.ops.iter().zip(compare.comparators.iter()) {
+                        if !Self::position_is_between(
+                            position,
+                            left.range().end(),
+                            right.range().start(),
+                        ) {
+                            left = right;
+                            continue;
+                        }
                         // Handle membership test operators (in/not in) - uses __contains__ on the right operand
                         if matches!(op, CmpOp::In | CmpOp::NotIn) {
-                            let result =
-                                type_at(compare.comparators.first()?.range()).map(|right_type| {
-                                    OperatorDunder {
-                                        base_type: right_type,
-                                        dunder_name: dunder::CONTAINS,
-                                        range: compare.range(),
-                                    }
-                                });
+                            let result = type_at(right.range()).map(|right_type| OperatorDunder {
+                                base_type: right_type,
+                                dunder_name: dunder::CONTAINS,
+                                range: compare.range(),
+                            });
                             return Some(result);
                         }
                         // is / is not — no dunder
@@ -2156,18 +2167,25 @@ impl<'a> Transaction<'a> {
                         }
                         // Handle rich comparison operators
                         if let Some(dunder_name) = dunder::rich_comparison_dunder(*op) {
-                            let result =
-                                type_at(compare.left.range()).map(|left_type| OperatorDunder {
-                                    base_type: left_type,
-                                    dunder_name,
-                                    range: compare.range(),
-                                });
+                            let result = type_at(left.range()).map(|left_type| OperatorDunder {
+                                base_type: left_type,
+                                dunder_name,
+                                range: compare.range(),
+                            });
                             return Some(result);
                         }
+                        left = right;
                     }
                     None
                 }
                 AnyNodeRef::ExprBinOp(binop) => {
+                    if !Self::position_is_between(
+                        position,
+                        binop.left.range().end(),
+                        binop.right.range().start(),
+                    ) {
+                        return None;
+                    }
                     let dunder_name = Name::new_static(binop.op.dunder());
                     Some(type_at(binop.left.range()).map(|left_type| OperatorDunder {
                         base_type: left_type,
@@ -2176,6 +2194,13 @@ impl<'a> Transaction<'a> {
                     }))
                 }
                 AnyNodeRef::StmtAugAssign(augassign) => {
+                    if !Self::position_is_between(
+                        position,
+                        augassign.target.range().end(),
+                        augassign.value.range().start(),
+                    ) {
+                        return None;
+                    }
                     let dunder_name = Name::new_static(augassign.op.in_place_dunder());
                     Some(
                         type_at(augassign.target.range()).map(|left_type| OperatorDunder {
@@ -2186,6 +2211,13 @@ impl<'a> Transaction<'a> {
                     )
                 }
                 AnyNodeRef::ExprUnaryOp(unaryop) => {
+                    if !Self::position_is_between(
+                        position,
+                        unaryop.range.start(),
+                        unaryop.operand.range().start(),
+                    ) {
+                        return None;
+                    }
                     let dunder_name = match unaryop.op {
                         UnaryOp::Invert => Ok(dunder::INVERT),
                         UnaryOp::UAdd => Ok(dunder::POS),
@@ -2203,6 +2235,13 @@ impl<'a> Transaction<'a> {
                     }))
                 }
                 AnyNodeRef::ExprSubscript(subscript) => {
+                    if !Self::position_is_between(
+                        position,
+                        subscript.value.range().end(),
+                        subscript.slice.range().start(),
+                    ) {
+                        return None;
+                    }
                     let dunder_name = match subscript.ctx {
                         ExprContext::Load => Some(dunder::GETITEM),
                         ExprContext::Store => Some(dunder::SETITEM),
@@ -2218,15 +2257,31 @@ impl<'a> Transaction<'a> {
                     )
                 }
                 // Handle iteration `in` keyword in for loops
-                AnyNodeRef::StmtFor(stmt_for) => Some(type_at(stmt_for.iter.range()).map(
-                    |iter_type| OperatorDunder {
-                        base_type: iter_type,
-                        dunder_name: dunder::ITER,
-                        range: stmt_for.iter.range(),
-                    },
-                )),
+                AnyNodeRef::StmtFor(stmt_for) => {
+                    if !Self::position_is_between(
+                        position,
+                        stmt_for.target.range().end(),
+                        stmt_for.iter.range().start(),
+                    ) {
+                        return None;
+                    }
+                    Some(
+                        type_at(stmt_for.iter.range()).map(|iter_type| OperatorDunder {
+                            base_type: iter_type,
+                            dunder_name: dunder::ITER,
+                            range: stmt_for.iter.range(),
+                        }),
+                    )
+                }
                 // Handle iteration `in` keyword in comprehensions
                 AnyNodeRef::Comprehension(comp) => {
+                    if !Self::position_is_between(
+                        position,
+                        comp.target.range().end(),
+                        comp.iter.range().start(),
+                    ) {
+                        return None;
+                    }
                     Some(type_at(comp.iter.range()).map(|iter_type| OperatorDunder {
                         base_type: iter_type,
                         dunder_name: dunder::ITER,
@@ -2272,7 +2327,9 @@ impl<'a> Transaction<'a> {
         }
         let module = self.get_ast(handle)?;
         let covering_nodes = Ast::locate_node(&module, position);
-        let dunder = self.find_operator_dunder(handle, &covering_nodes).ok()??;
+        let dunder = self
+            .find_operator_dunder(handle, position, &covering_nodes)
+            .ok()??;
         self.get_chosen_overload_trace_for_surface(handle, dunder.range, true)
     }
 
@@ -2282,10 +2339,11 @@ impl<'a> Transaction<'a> {
     fn find_definition_for_operator(
         &self,
         handle: &Handle,
+        position: TextSize,
         covering_nodes: &[AnyNodeRef],
         preference: FindPreference,
     ) -> Result<Option<Vec1<FindDefinitionItemWithDocstring>>, EmptyResponseReason> {
-        let Some(dunder) = self.find_operator_dunder(handle, covering_nodes)? else {
+        let Some(dunder) = self.find_operator_dunder(handle, position, covering_nodes)? else {
             return Ok(None);
         };
         let OperatorDunder {
@@ -2842,9 +2900,12 @@ impl<'a> Transaction<'a> {
                     };
                 }
                 // Fall back to operator handling
-                if let Some(defs) =
-                    self.find_definition_for_operator(handle, &covering_nodes, preference)?
-                {
+                if let Some(defs) = self.find_definition_for_operator(
+                    handle,
+                    position,
+                    &covering_nodes,
+                    preference,
+                )? {
                     return Ok(defs);
                 }
                 let found = covering_nodes

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2287,6 +2287,10 @@ impl<'a> Transaction<'a> {
         })
     }
 
+    fn position_is_between(position: TextSize, left_end: TextSize, right_start: TextSize) -> bool {
+        TextRange::new(left_end, right_start).contains(position)
+    }
+
     /// Try to find the dunder method associated with an operator at the cursor.
     ///
     /// Returns:
@@ -2295,10 +2299,6 @@ impl<'a> Transaction<'a> {
     /// - `Err(NotAnIdentifier)` — operator without a dunder (`not`, `is`, `is not`)
     /// - `Err(AnswersNotFound)` — operator found but answers unavailable
     /// - `Err(TypeTraceNotFound)` — operator found but base expression has no type trace
-    fn position_is_between(position: TextSize, left_end: TextSize, right_start: TextSize) -> bool {
-        TextRange::new(left_end, right_start).contains(position)
-    }
-
     fn find_operator_dunder(
         &self,
         handle: &Handle,
@@ -2420,13 +2420,6 @@ impl<'a> Transaction<'a> {
                     }))
                 }
                 AnyNodeRef::ExprSubscript(subscript) => {
-                    if !Self::position_is_between(
-                        position,
-                        subscript.value.range().end(),
-                        subscript.slice.range().start(),
-                    ) {
-                        return None;
-                    }
                     let dunder_name = match subscript.ctx {
                         ExprContext::Load => Some(dunder::GETITEM),
                         ExprContext::Store => Some(dunder::SETITEM),

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2295,9 +2295,14 @@ impl<'a> Transaction<'a> {
     /// - `Err(NotAnIdentifier)` — operator without a dunder (`not`, `is`, `is not`)
     /// - `Err(AnswersNotFound)` — operator found but answers unavailable
     /// - `Err(TypeTraceNotFound)` — operator found but base expression has no type trace
+    fn position_is_between(position: TextSize, left_end: TextSize, right_start: TextSize) -> bool {
+        TextRange::new(left_end, right_start).contains(position)
+    }
+
     fn find_operator_dunder(
         &self,
         handle: &Handle,
+        position: TextSize,
         covering_nodes: &[AnyNodeRef],
     ) -> Result<Option<OperatorDunder>, EmptyResponseReason> {
         // Look up the type of an expression, distinguishing "no answers"
@@ -2315,17 +2320,23 @@ impl<'a> Transaction<'a> {
             .iter()
             .find_map(|node| match node {
                 AnyNodeRef::ExprCompare(compare) => {
-                    for op in &compare.ops {
+                    let mut left = compare.left.as_ref();
+                    for (op, right) in compare.ops.iter().zip(compare.comparators.iter()) {
+                        if !Self::position_is_between(
+                            position,
+                            left.range().end(),
+                            right.range().start(),
+                        ) {
+                            left = right;
+                            continue;
+                        }
                         // Handle membership test operators (in/not in) - uses __contains__ on the right operand
                         if matches!(op, CmpOp::In | CmpOp::NotIn) {
-                            let result =
-                                type_at(compare.comparators.first()?.range()).map(|right_type| {
-                                    OperatorDunder {
-                                        base_type: right_type,
-                                        dunder_name: dunder::CONTAINS,
-                                        range: compare.range(),
-                                    }
-                                });
+                            let result = type_at(right.range()).map(|right_type| OperatorDunder {
+                                base_type: right_type,
+                                dunder_name: dunder::CONTAINS,
+                                range: compare.range(),
+                            });
                             return Some(result);
                         }
                         // is / is not — no dunder
@@ -2341,18 +2352,25 @@ impl<'a> Transaction<'a> {
                         }
                         // Handle rich comparison operators
                         if let Some(dunder_name) = dunder::rich_comparison_dunder(*op) {
-                            let result =
-                                type_at(compare.left.range()).map(|left_type| OperatorDunder {
-                                    base_type: left_type,
-                                    dunder_name,
-                                    range: compare.range(),
-                                });
+                            let result = type_at(left.range()).map(|left_type| OperatorDunder {
+                                base_type: left_type,
+                                dunder_name,
+                                range: compare.range(),
+                            });
                             return Some(result);
                         }
+                        left = right;
                     }
                     None
                 }
                 AnyNodeRef::ExprBinOp(binop) => {
+                    if !Self::position_is_between(
+                        position,
+                        binop.left.range().end(),
+                        binop.right.range().start(),
+                    ) {
+                        return None;
+                    }
                     let dunder_name = Name::new_static(binop.op.dunder());
                     Some(type_at(binop.left.range()).map(|left_type| OperatorDunder {
                         base_type: left_type,
@@ -2361,6 +2379,13 @@ impl<'a> Transaction<'a> {
                     }))
                 }
                 AnyNodeRef::StmtAugAssign(augassign) => {
+                    if !Self::position_is_between(
+                        position,
+                        augassign.target.range().end(),
+                        augassign.value.range().start(),
+                    ) {
+                        return None;
+                    }
                     let dunder_name = Name::new_static(augassign.op.in_place_dunder());
                     Some(
                         type_at(augassign.target.range()).map(|left_type| OperatorDunder {
@@ -2371,6 +2396,13 @@ impl<'a> Transaction<'a> {
                     )
                 }
                 AnyNodeRef::ExprUnaryOp(unaryop) => {
+                    if !Self::position_is_between(
+                        position,
+                        unaryop.range.start(),
+                        unaryop.operand.range().start(),
+                    ) {
+                        return None;
+                    }
                     let dunder_name = match unaryop.op {
                         UnaryOp::Invert => Ok(dunder::INVERT),
                         UnaryOp::UAdd => Ok(dunder::POS),
@@ -2388,6 +2420,13 @@ impl<'a> Transaction<'a> {
                     }))
                 }
                 AnyNodeRef::ExprSubscript(subscript) => {
+                    if !Self::position_is_between(
+                        position,
+                        subscript.value.range().end(),
+                        subscript.slice.range().start(),
+                    ) {
+                        return None;
+                    }
                     let dunder_name = match subscript.ctx {
                         ExprContext::Load => Some(dunder::GETITEM),
                         ExprContext::Store => Some(dunder::SETITEM),
@@ -2403,15 +2442,31 @@ impl<'a> Transaction<'a> {
                     )
                 }
                 // Handle iteration `in` keyword in for loops
-                AnyNodeRef::StmtFor(stmt_for) => Some(type_at(stmt_for.iter.range()).map(
-                    |iter_type| OperatorDunder {
-                        base_type: iter_type,
-                        dunder_name: dunder::ITER,
-                        range: stmt_for.iter.range(),
-                    },
-                )),
+                AnyNodeRef::StmtFor(stmt_for) => {
+                    if !Self::position_is_between(
+                        position,
+                        stmt_for.target.range().end(),
+                        stmt_for.iter.range().start(),
+                    ) {
+                        return None;
+                    }
+                    Some(
+                        type_at(stmt_for.iter.range()).map(|iter_type| OperatorDunder {
+                            base_type: iter_type,
+                            dunder_name: dunder::ITER,
+                            range: stmt_for.iter.range(),
+                        }),
+                    )
+                }
                 // Handle iteration `in` keyword in comprehensions
                 AnyNodeRef::Comprehension(comp) => {
+                    if !Self::position_is_between(
+                        position,
+                        comp.target.range().end(),
+                        comp.iter.range().start(),
+                    ) {
+                        return None;
+                    }
                     Some(type_at(comp.iter.range()).map(|iter_type| OperatorDunder {
                         base_type: iter_type,
                         dunder_name: dunder::ITER,
@@ -2457,7 +2512,9 @@ impl<'a> Transaction<'a> {
         }
         let module = self.get_ast(handle)?;
         let covering_nodes = Ast::locate_node(&module, position);
-        let dunder = self.find_operator_dunder(handle, &covering_nodes).ok()??;
+        let dunder = self
+            .find_operator_dunder(handle, position, &covering_nodes)
+            .ok()??;
         self.get_chosen_overload_trace_for_surface(handle, dunder.range, true)
     }
 
@@ -2467,10 +2524,11 @@ impl<'a> Transaction<'a> {
     fn find_definition_for_operator(
         &self,
         handle: &Handle,
+        position: TextSize,
         covering_nodes: &[AnyNodeRef],
         preference: FindPreference,
     ) -> Result<Option<Vec1<FindDefinitionItemWithDocstring>>, EmptyResponseReason> {
-        let Some(dunder) = self.find_operator_dunder(handle, covering_nodes)? else {
+        let Some(dunder) = self.find_operator_dunder(handle, position, covering_nodes)? else {
             return Ok(None);
         };
         let OperatorDunder {
@@ -3031,9 +3089,12 @@ impl<'a> Transaction<'a> {
                     };
                 }
                 // Fall back to operator handling
-                if let Some(defs) =
-                    self.find_definition_for_operator(handle, &covering_nodes, preference)?
-                {
+                if let Some(defs) = self.find_definition_for_operator(
+                    handle,
+                    position,
+                    &covering_nodes,
+                    preference,
+                )? {
                     return Ok(defs);
                 }
                 let found = covering_nodes

--- a/pyrefly/lib/test/lsp/definition.rs
+++ b/pyrefly/lib/test/lsp/definition.rs
@@ -85,6 +85,25 @@ Definition Result: None
 }
 
 #[test]
+fn operator_does_not_include_binop_lhs_literal() {
+    let code = r#"
+x = 1 + 1
+#   ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert_eq!(
+        r#"
+# main.py
+2 | x = 1 + 1
+        ^
+Definition Result: None
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn no_crash_on_dead_branch_test() {
     let code = r#"
 from typing import TYPE_CHECKING

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -1306,6 +1306,27 @@ c += 1
 }
 
 #[test]
+fn hover_over_binop_lhs_literal_does_not_show_operator_dunder() {
+    let code = r#"
+x = 1 + 1
+#   ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert_eq!(
+        r#"
+# main.py
+2 | x = 1 + 1
+        ^
+```python
+Literal[1]
+```
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn hover_over_tuple_element_literal_uses_element_type() {
     let code = r#"
 tup = (1, +2)

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -1067,6 +1067,27 @@ c += 1
 }
 
 #[test]
+fn hover_over_binop_lhs_literal_does_not_show_operator_dunder() {
+    let code = r#"
+x = 1 + 1
+#   ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert_eq!(
+        r#"
+# main.py
+2 | x = 1 + 1
+        ^
+```python
+Literal[1]
+```
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn hover_over_tuple_element_literal_uses_element_type() {
     let code = r#"
 tup = (1, +2)


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1517

The operator-definition path now only activates when the cursor is actually in the operator gap, instead of anywhere inside the enclosing expression, so hovering or go-to-def on the left 1 in 1 + 1 no longer resolves `int.__add__`. 

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

update test