### PR TITLE
fix autocomplete for discriminated unions #1442

### DIFF
--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -220,7 +220,7 @@ impl Transaction<'_> {
     }
 
     /// Adds completion items for literal types (e.g., `Literal["foo", "bar"]`).
-    fn add_literal_completions_from_type(
+    pub(crate) fn add_literal_completions_from_type(
         param_type: &Type,
         completions: &mut Vec<RankedCompletion>,
         in_string_literal: bool,
@@ -1270,6 +1270,12 @@ impl Transaction<'_> {
                             &nodes,
                             &mut result,
                             in_string_literal,
+                        );
+                        self.add_dict_value_literal_completions(
+                            handle,
+                            mod_module.as_ref(),
+                            position,
+                            &mut result,
                         );
                         // `dict_key_claimed` was computed up front; when a dict key was
                         // offered we skip the overload literal completions.

--- a/pyrefly/lib/state/lsp/dict_completions.rs
+++ b/pyrefly/lib/state/lsp/dict_completions.rs
@@ -25,10 +25,12 @@ use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
 
+use crate::alt::answers_solver::AnswersSolver;
 use crate::alt::polars_specials::is_dataframe_column_method;
 use crate::binding::binding::Key;
 use crate::binding::narrow::int_from_slice;
 use crate::lsp::wasm::completion::RankedCompletion;
+use crate::state::lsp::TransactionHandle;
 use crate::state::state::Transaction;
 use crate::types::types::Type;
 
@@ -78,12 +80,190 @@ impl DictKeyLiteralContext {
 }
 
 impl<'a> Transaction<'a> {
+    fn named_target_type(&self, handle: &Handle, expr: &Expr) -> Option<Type> {
+        let Expr::Name(name) = expr else {
+            return None;
+        };
+        let short_id = ShortIdentifier::expr_name(name);
+        let bindings = self.get_bindings(handle)?;
+        let bound_key = Key::BoundName(short_id);
+        if bindings.is_valid_key(&bound_key) {
+            return self.get_type(handle, &bound_key);
+        }
+        let def_key = Key::Definition(short_id);
+        if bindings.is_valid_key(&def_key) {
+            self.get_type(handle, &def_key)
+        } else {
+            None
+        }
+    }
+
+    fn dict_literal_expected_type(
+        &self,
+        handle: &Handle,
+        module: &ModModule,
+        dict: &ExprDict,
+    ) -> Option<Type> {
+        for node in Ast::locate_node(module, dict.range().start()) {
+            match node {
+                AnyNodeRef::StmtAnnAssign(assign)
+                    if assign
+                        .value
+                        .as_ref()
+                        .is_some_and(|value| value.range() == dict.range()) =>
+                {
+                    return self.named_target_type(handle, assign.target.as_ref());
+                }
+                AnyNodeRef::StmtAssign(assign)
+                    if assign.value.range() == dict.range() && assign.targets.len() == 1 =>
+                {
+                    return self.named_target_type(handle, &assign.targets[0]);
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    fn dict_literal_contextual_type(
+        &self,
+        handle: &Handle,
+        module: &ModModule,
+        dict: &ExprDict,
+    ) -> Option<Type> {
+        self.dict_literal_expected_type(handle, module, dict)
+            .or_else(|| self.get_type_trace(handle, dict.range()))
+    }
+
     fn type_contains_typed_dict(ty: &Type) -> bool {
         match ty {
             Type::TypedDict(_) | Type::PartialTypedDict(_) => true,
             Type::Union(u) => u.members.iter().any(Self::type_contains_typed_dict),
             _ => false,
         }
+    }
+
+    fn typed_dict_members(base_type: Type) -> Vec<Type> {
+        let mut members = Vec::new();
+        let mut stack = vec![base_type];
+        while let Some(ty) = stack.pop() {
+            match ty {
+                Type::TypedDict(_) | Type::PartialTypedDict(_) => members.push(ty),
+                Type::Union(u) => stack.extend(u.members),
+                _ => {}
+            }
+        }
+        members
+    }
+
+    fn typed_dict_member_field_maps<'b>(
+        solver: &AnswersSolver<TransactionHandle<'b>>,
+        members: Vec<Type>,
+    ) -> Vec<(Type, BTreeMap<String, Type>)> {
+        members
+            .into_iter()
+            .filter_map(|member| {
+                let typed_dict = match &member {
+                    Type::TypedDict(td) | Type::PartialTypedDict(td) => td,
+                    _ => return None,
+                };
+                let fields = solver
+                    .type_order()
+                    .typed_dict_fields(typed_dict)
+                    .into_iter()
+                    .map(|(name, field)| (name.to_string(), field.ty))
+                    .collect();
+                Some((member, fields))
+            })
+            .collect()
+    }
+
+    fn narrowed_typed_dict_members_for_dict_literal(
+        &self,
+        handle: &Handle,
+        module: &ModModule,
+        dict: &ExprDict,
+        skip_key_range: Option<TextRange>,
+        skip_value_range: Option<TextRange>,
+    ) -> Option<Vec<Type>> {
+        let base_type = self.dict_literal_contextual_type(handle, module, dict)?;
+        self.ad_hoc_solve(handle, "dict_literal_typed_dict_members", |solver| {
+            let members = Self::typed_dict_members(base_type);
+            if members.is_empty() {
+                return Vec::new();
+            }
+            let member_fields = Self::typed_dict_member_field_maps(&solver, members);
+            let narrowed = member_fields
+                .iter()
+                .filter(|(_, fields)| {
+                    dict.items.iter().all(|item| {
+                        let Some(key_expr) = item.key.as_ref() else {
+                            return true;
+                        };
+                        let value_expr = &item.value;
+                        let Expr::StringLiteral(key_lit) = key_expr else {
+                            return true;
+                        };
+                        if skip_key_range == Some(key_lit.range())
+                            || skip_value_range == Some(value_expr.range())
+                        {
+                            return true;
+                        }
+                        let Some(field_ty) = fields.get(key_lit.value.to_str()) else {
+                            return false;
+                        };
+                        let Some(value_ty) = self.get_type_trace(handle, value_expr.range()) else {
+                            return true;
+                        };
+                        solver.is_subset_eq(&value_ty, field_ty)
+                    })
+                })
+                .map(|(member, _)| member.clone())
+                .collect::<Vec<_>>();
+            if narrowed.is_empty() {
+                member_fields
+                    .into_iter()
+                    .map(|(member, _)| member)
+                    .collect()
+            } else {
+                narrowed
+            }
+        })
+    }
+
+    fn typed_dict_field_type_from_members(
+        &self,
+        handle: &Handle,
+        members: Vec<Type>,
+        key: &str,
+    ) -> Option<Type> {
+        self.ad_hoc_solve(handle, "typed_dict_field_type", |solver| {
+            let field_types = Self::typed_dict_member_field_maps(&solver, members)
+                .into_iter()
+                .filter_map(|(_, fields)| fields.get(key).cloned())
+                .collect::<Vec<_>>();
+            match field_types.len() {
+                0 => None,
+                1 => field_types.into_iter().next(),
+                _ => Some(solver.unions(field_types)),
+            }
+        })
+        .flatten()
+    }
+
+    fn dict_literal_present_keys(
+        dict: &ExprDict,
+        skip_key_range: Option<TextRange>,
+    ) -> BTreeSet<String> {
+        dict.items
+            .iter()
+            .filter_map(|item| {
+                let Expr::StringLiteral(lit) = item.key.as_ref()? else {
+                    return None;
+                };
+                (skip_key_range != Some(lit.range())).then(|| lit.value.to_string())
+            })
+            .collect()
     }
 
     fn type_is_dataframe(ty: &Type) -> bool {
@@ -327,6 +507,58 @@ impl<'a> Transaction<'a> {
         best.map(|(_, _, dict, literal)| (dict, literal))
     }
 
+    fn dict_literal_value_string_literal_at(
+        module: &ModModule,
+        position: TextSize,
+    ) -> Option<(ExprDict, ExprStringLiteral, ExprStringLiteral)> {
+        let nodes = Ast::locate_node(module, position);
+        let mut best: Option<(u8, TextSize, ExprDict, ExprStringLiteral, ExprStringLiteral)> = None;
+        for node in nodes {
+            let AnyNodeRef::ExprDict(dict) = node else {
+                continue;
+            };
+            let mut best_in_dict: Option<(u8, TextSize, ExprStringLiteral, ExprStringLiteral)> =
+                None;
+            for item in &dict.items {
+                let Some(Expr::StringLiteral(key_lit)) = item.key.as_ref() else {
+                    continue;
+                };
+                let Expr::StringLiteral(value_lit) = &item.value else {
+                    continue;
+                };
+                let (priority, dist) = Self::string_literal_priority(position, value_lit.range());
+                let should_update = match &best_in_dict {
+                    Some((best_prio, best_dist, _, _)) => {
+                        priority < *best_prio || (priority == *best_prio && dist < *best_dist)
+                    }
+                    None => true,
+                };
+                if should_update {
+                    best_in_dict = Some((priority, dist, key_lit.clone(), value_lit.clone()));
+                    if priority == 0 && dist == TextSize::from(0) {
+                        break;
+                    }
+                }
+            }
+            let Some((priority, dist, key_lit, value_lit)) = best_in_dict else {
+                continue;
+            };
+            let should_update = match &best {
+                Some((best_prio, best_dist, _, _, _)) => {
+                    priority < *best_prio || (priority == *best_prio && dist < *best_dist)
+                }
+                None => true,
+            };
+            if should_update {
+                best = Some((priority, dist, dict.clone(), key_lit, value_lit));
+                if priority == 0 && dist == TextSize::from(0) {
+                    break;
+                }
+            }
+        }
+        best.map(|(_, _, dict, key_lit, value_lit)| (dict, key_lit, value_lit))
+    }
+
     fn expression_facets(expr: &Expr) -> Option<(Identifier, Vec<FacetKind>)> {
         let mut facets = Vec::new();
         let mut current = expr;
@@ -362,23 +594,50 @@ impl<'a> Transaction<'a> {
     ) -> Option<BTreeMap<String, Type>> {
         self.ad_hoc_solve(handle, "typed_dict_keys", |solver| {
             let mut map = BTreeMap::new();
-            let mut stack = vec![base_type];
-            while let Some(ty) = stack.pop() {
-                match ty {
-                    Type::TypedDict(td) | Type::PartialTypedDict(td) => {
-                        for (name, field) in solver.type_order().typed_dict_fields(&td) {
-                            map.entry(name.to_string())
-                                .or_insert_with(|| field.ty.clone());
-                        }
-                    }
-                    Type::Union(u) => {
-                        stack.extend(u.members);
-                    }
-                    _ => {}
+            for member in Self::typed_dict_members(base_type) {
+                let typed_dict = match member {
+                    Type::TypedDict(td) | Type::PartialTypedDict(td) => td,
+                    _ => continue,
+                };
+                for (name, field) in solver.type_order().typed_dict_fields(&typed_dict) {
+                    map.entry(name.to_string())
+                        .or_insert_with(|| field.ty.clone());
                 }
             }
             map
         })
+    }
+
+    pub(crate) fn add_dict_value_literal_completions(
+        &self,
+        handle: &Handle,
+        module: &ModModule,
+        position: TextSize,
+        completions: &mut Vec<RankedCompletion>,
+    ) {
+        let Some((dict, key_lit, value_lit)) =
+            Self::dict_literal_value_string_literal_at(module, position)
+        else {
+            return;
+        };
+        if position < value_lit.range().start() || position > value_lit.range().end() {
+            return;
+        }
+        let Some(members) = self.narrowed_typed_dict_members_for_dict_literal(
+            handle,
+            module,
+            &dict,
+            Some(key_lit.range()),
+            Some(value_lit.range()),
+        ) else {
+            return;
+        };
+        let Some(field_ty) =
+            self.typed_dict_field_type_from_members(handle, members, key_lit.value.to_str())
+        else {
+            return;
+        };
+        Self::add_literal_completions_from_type(&field_ty, completions, true);
     }
 
     fn collect_dataframe_columns(ty: &Type) -> Option<BTreeSet<String>> {
@@ -451,8 +710,36 @@ impl<'a> Transaction<'a> {
                     source_expr.range(),
                     &mut suggestions,
                 ),
-            DictKeyLiteralContext::DictLiteral { dict, .. } => {
-                self.extend_dict_key_suggestions(handle, None, dict.range(), &mut suggestions)
+            DictKeyLiteralContext::DictLiteral { dict, literal } => {
+                let members = self.narrowed_typed_dict_members_for_dict_literal(
+                    handle,
+                    module,
+                    dict,
+                    Some(literal.range()),
+                    None,
+                );
+                let narrowed_type = members.as_ref().and_then(|members| {
+                    self.ad_hoc_solve(handle, "dict_literal_typed_dict_union", |solver| {
+                        match members.len() {
+                            0 => None,
+                            1 => members.first().cloned(),
+                            _ => Some(solver.unions(members.clone())),
+                        }
+                    })
+                    .flatten()
+                });
+                if let Some(base_type) = narrowed_type
+                    && let Some(typed_keys) = self.collect_typed_dict_keys(handle, base_type)
+                {
+                    let present_keys = Self::dict_literal_present_keys(dict, Some(literal.range()));
+                    for (key, ty) in typed_keys {
+                        if !present_keys.contains(&key) {
+                            suggestions.insert(key, Some(ty));
+                        }
+                    }
+                } else {
+                    self.extend_dict_key_suggestions(handle, None, dict.range(), &mut suggestions);
+                }
             }
         }
         if suggestions.is_empty() {

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -403,6 +403,68 @@ cfg: Config = {"": 1}
 }
 
 #[test]
+fn dict_value_completion_from_discriminated_typed_dict_union_literal() {
+    let code = r#"
+from typing import Literal, TypedDict
+
+class Foo(TypedDict):
+    kind: Literal["foo"]
+    foo_value: int
+
+class Bar(TypedDict):
+    kind: Literal["bar"]
+    bar_value: str
+
+type FooBar = Foo | Bar
+
+item: FooBar = {
+    "kind": "|",
+#            ^
+}
+"#;
+    let report =
+        get_batched_lsp_operations_report_allow_error(&[("main", code)], get_default_test_report());
+    let report = strip_ansi(&report);
+    assert!(
+        report.contains("- (Value) 'bar': Literal['bar']"),
+        "{report}"
+    );
+    assert!(
+        report.contains("- (Value) 'foo': Literal['foo']"),
+        "{report}"
+    );
+}
+
+#[test]
+fn dict_key_completion_from_discriminated_typed_dict_union_literal() {
+    let code = r#"
+from typing import Literal, TypedDict
+
+class Foo(TypedDict):
+    kind: Literal["foo"]
+    foo_value: int
+
+class Bar(TypedDict):
+    kind: Literal["bar"]
+    bar_value: str
+
+type FooBar = Foo | Bar
+
+item: FooBar = {
+    "kind": "foo",
+    "": 0,
+#    ^
+}
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, false);
+    let handle = handles.get("main").unwrap();
+    let position = extract_cursors_for_test(code)[0];
+    let txn = state.transaction();
+    let labels = dict_field_labels(&txn, handle, position);
+    assert_eq!(labels, vec!["foo_value".to_owned()]);
+}
+
+#[test]
 fn dataframe_column_completion_from_method_argument() {
     let code = r#"
 import polars as pl


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1442

The completion engine now recovers the enclosing expected type for incomplete dict literals, narrows union members from already-entered literal fields like "kind": "foo", and uses that narrowed set for both key suggestions and literal value suggestions.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test