### PR TITLE
Add minimal reproduction for stub overlay issue #2859

### DIFF
--- a/test/repro/stub_overlay_2859/README.md
+++ b/test/repro/stub_overlay_2859/README.md
@@ -1,0 +1,49 @@
+# Pyrefly Issue #2859 - Minimal Reproduction
+
+This directory contains a minimal reproduction for issue #2859: **Generated typestubs are not found for untyped modules**.
+
+**Issue:** https://github.com/facebook/pyrefly/issues/2859
+
+## The Bug
+
+When a Python module has no type hints (common for compiled extensions like `.so`/`.pyd` files), Pyrefly should look for companion `.pyi` stub files and use them for type checking. Currently, it doesn't.
+
+## Directory Structure
+
+```
+stub_overlay_2859/
+├── mypackage/
+│   ├── __init__.py      # Re-exports add(), defines typed sub()
+│   └── _core.py         # NO type hints (simulates compiled extension)
+├── stubs/
+│   └── mypackage/
+│       └── _core.pyi    # Type stub: add(a: int, b: int) -> int
+├── test_script.py       # Test that calls add("hello", "world")
+├── pyrefly.toml         # Config with search-path = ["stubs"]
+└── README.md
+```
+
+## How to Reproduce
+
+```bash
+cd test/repro/stub_overlay_2859
+pyrefly check test_script.py
+```
+
+### Expected Output (when fixed): 4 errors
+```
+ERROR ... add("hello", "world") ... [bad-argument-type]
+ERROR ... add("hello", "world") ... [bad-argument-type]
+ERROR ... sub("foo", "bar") ... [bad-argument-type]
+ERROR ... sub("foo", "bar") ... [bad-argument-type]
+INFO 4 errors
+```
+
+### Actual Output (buggy): 2 errors
+```
+ERROR ... sub("foo", "bar") ... [bad-argument-type]
+ERROR ... sub("foo", "bar") ... [bad-argument-type]
+INFO 2 errors
+```
+
+The `add("hello", "world")` call does NOT produce an error because Pyrefly doesn't find `stubs/mypackage/_core.pyi`.

--- a/test/repro/stub_overlay_2859/mypackage/__init__.py
+++ b/test/repro/stub_overlay_2859/mypackage/__init__.py
@@ -1,0 +1,9 @@
+from mypackage._core import add
+
+
+def sub(a: int, b: int) -> int:
+    """Subtract two integers. This function HAS type hints."""
+    return add(a, -b)
+
+
+__all__ = ["add", "sub"]

--- a/test/repro/stub_overlay_2859/mypackage/_core.py
+++ b/test/repro/stub_overlay_2859/mypackage/_core.py
@@ -1,0 +1,6 @@
+# Simulates a compiled extension module (like a .so/.pyd file)
+# This module has NO type hints - the types only exist in _core.pyi
+
+def add(a, b):
+    """Add two values. No type hints here!"""
+    return a + b

--- a/test/repro/stub_overlay_2859/pyrefly.toml
+++ b/test/repro/stub_overlay_2859/pyrefly.toml
@@ -1,0 +1,3 @@
+# Pyrefly configuration with stub path
+# This SHOULD make Pyrefly find stubs/mypackage/_core.pyi, but it doesn't (bug)
+search-path = ["stubs"]

--- a/test/repro/stub_overlay_2859/stubs/mypackage/_core.pyi
+++ b/test/repro/stub_overlay_2859/stubs/mypackage/_core.pyi
@@ -1,0 +1,6 @@
+# Type stub for _core module
+# This file should provide type hints for the untyped _core.py module
+
+def add(a: int, b: int) -> int:
+    """Add two integers."""
+    ...

--- a/test/repro/stub_overlay_2859/test_script.py
+++ b/test/repro/stub_overlay_2859/test_script.py
@@ -1,0 +1,18 @@
+from mypackage import add, sub
+
+# =============================================================================
+# BUG REPRODUCTION: Issue #2859
+# https://github.com/facebook/pyrefly/issues/2859
+# =============================================================================
+
+# This call SHOULD error because stubs/mypackage/_core.pyi defines:
+#   add(a: int, b: int) -> int
+# But Pyrefly doesn't find the stub, so NO ERROR is reported.
+result1 = add("hello", "world")  # BUG: No error! Should be "expected int, got str"
+
+# This call DOES error correctly because sub() has inline type hints
+# in mypackage/__init__.py
+result2 = sub("foo", "bar")  # ERROR: Argument `Literal['foo']` is not assignable...
+
+print(f"result1 = {result1}")
+print(f"result2 = {result2}")


### PR DESCRIPTION
## Summary

This PR adds a minimal reproduction test for issue #2859: Generated typestubs are not found for untyped modules.

## The Problem

When a module has no inline type hints (common for compiled extensions like `.so`/`.pyd` files), Pyrefly doesn't use companion `.pyi` stub files to supplement type information, even when the stub directory is configured in `search-path`.

## Test Description

The test creates:
- `mypackage/_core.py` - module with NO type hints (simulates compiled extension)
- `mypackage/__init__.py` - re-exports `add()` and defines typed `sub()` function
- `stubs/mypackage/_core.pyi` - stub file with type hints for `add(a: int, b: int) -> int`
- `test_script.py` - calls both `add("hello", "world")` and `sub("foo", "bar")`

**Current (buggy) behavior:**
- Only 2 errors reported (for `sub()` calls which has inline type hints)
- `add("hello", "world")` does NOT error even with `search-path = ["stubs"]`

**Expected behavior when fixed:**
- 4 errors reported (2 for `add()` using stub types + 2 for `sub()` using inline types)

## Test Plan

```bash
PYREFLY=./target/release/pyrefly scrut test test/stub_overlay.md
