### PR TITLE
[LSP] use source.fixAll.pyrefly for fix-all code actions

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -4174,9 +4174,7 @@ impl Server {
         let allow_fix_all = only_kinds.is_none_or(|kinds| {
             kinds.iter().any(|kind| {
                 kind == &CodeActionKind::SOURCE_FIX_ALL
-                    || kind
-                        .as_str()
-                        .starts_with(CodeActionKind::SOURCE_FIX_ALL.as_str())
+                    || kind.as_str().starts_with(SOURCE_FIX_ALL_PYREFLY)
             })
         });
         let allow_refactor = only_kinds.is_none_or(|kinds| {

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -681,7 +681,11 @@ fn format_diagnostic_message_for_markdown(message: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use lsp_types::CodeActionKind;
+
+    use super::SOURCE_FIX_ALL_PYREFLY;
     use super::format_diagnostic_message_for_markdown;
+    use super::is_fix_all_code_action_kind_requested;
 
     #[test]
     fn test_format_diagnostic_message_for_markdown() {
@@ -721,6 +725,26 @@ mod tests {
     #[test]
     fn test_format_only_special_characters() {
         assert_eq!(format_diagnostic_message_for_markdown("***"), "\\*\\*\\*");
+    }
+
+    #[test]
+    fn test_fix_all_kind_filter_matches_supported_kinds() {
+        assert!(is_fix_all_code_action_kind_requested(
+            &CodeActionKind::SOURCE_FIX_ALL
+        ));
+        assert!(is_fix_all_code_action_kind_requested(&CodeActionKind::new(
+            SOURCE_FIX_ALL_PYREFLY,
+        )));
+    }
+
+    #[test]
+    fn test_fix_all_kind_filter_rejects_pyrefly_suffix_kinds() {
+        assert!(!is_fix_all_code_action_kind_requested(
+            &CodeActionKind::new("source.fixAll.pyrefly.foo",)
+        ));
+        assert!(!is_fix_all_code_action_kind_requested(
+            &CodeActionKind::new("source.fixAll.pyreflyyyyyy",)
+        ));
     }
 }
 
@@ -1253,6 +1277,10 @@ pub enum ProcessEvent {
 
 const PYTHON_SECTION: &str = "python";
 const SOURCE_FIX_ALL_PYREFLY: &str = "source.fixAll.pyrefly";
+
+fn is_fix_all_code_action_kind_requested(kind: &CodeActionKind) -> bool {
+    kind == &CodeActionKind::SOURCE_FIX_ALL || kind.as_str() == SOURCE_FIX_ALL_PYREFLY
+}
 
 struct TypeHierarchyTarget {
     def_index: ClassDefIndex,
@@ -4171,12 +4199,8 @@ impl Server {
         let only_kinds = params.context.only.as_ref();
         let allow_quickfix = only_kinds
             .is_none_or(|kinds| kinds.iter().any(|kind| kind == &CodeActionKind::QUICKFIX));
-        let allow_fix_all = only_kinds.is_none_or(|kinds| {
-            kinds.iter().any(|kind| {
-                kind == &CodeActionKind::SOURCE_FIX_ALL
-                    || kind.as_str().starts_with(SOURCE_FIX_ALL_PYREFLY)
-            })
-        });
+        let allow_fix_all =
+            only_kinds.is_none_or(|kinds| kinds.iter().any(is_fix_all_code_action_kind_requested));
         let allow_refactor = only_kinds.is_none_or(|kinds| {
             kinds
                 .iter()

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -1142,7 +1142,7 @@ pub fn capabilities(
                 CodeActionKind::new("refactor.delete"),
                 CodeActionKind::new("refactor.move"),
                 CodeActionKind::REFACTOR_INLINE,
-                CodeActionKind::SOURCE_FIX_ALL,
+                CodeActionKind::new(SOURCE_FIX_ALL_PYREFLY),
             ]),
             ..Default::default()
         })),
@@ -1252,6 +1252,7 @@ pub enum ProcessEvent {
 }
 
 const PYTHON_SECTION: &str = "python";
+const SOURCE_FIX_ALL_PYREFLY: &str = "source.fixAll.pyrefly";
 
 struct TypeHierarchyTarget {
     def_index: ClassDefIndex,
@@ -4171,9 +4172,12 @@ impl Server {
         let allow_quickfix = only_kinds
             .is_none_or(|kinds| kinds.iter().any(|kind| kind == &CodeActionKind::QUICKFIX));
         let allow_fix_all = only_kinds.is_none_or(|kinds| {
-            kinds
-                .iter()
-                .any(|kind| kind == &CodeActionKind::SOURCE_FIX_ALL)
+            kinds.iter().any(|kind| {
+                kind == &CodeActionKind::SOURCE_FIX_ALL
+                    || kind
+                        .as_str()
+                        .starts_with(CodeActionKind::SOURCE_FIX_ALL.as_str())
+            })
         });
         let allow_refactor = only_kinds.is_none_or(|kinds| {
             kinds
@@ -4276,7 +4280,7 @@ impl Server {
                 if !changes.is_empty() {
                     actions.push(CodeActionOrCommand::CodeAction(CodeAction {
                         title: "Remove all redundant casts".to_owned(),
-                        kind: Some(CodeActionKind::SOURCE_FIX_ALL),
+                        kind: Some(CodeActionKind::new(SOURCE_FIX_ALL_PYREFLY)),
                         edit: Some(WorkspaceEdit {
                             changes: Some(changes),
                             ..Default::default()

--- a/pyrefly/lib/test/lsp/lsp_interaction/basic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/basic.rs
@@ -36,7 +36,7 @@ fn test_initialize_basic() {
             "definitionProvider": true,
             "typeDefinitionProvider": true,
             "codeActionProvider": {
-                "codeActionKinds": ["quickfix", "refactor.extract", "refactor.rewrite", "refactor.delete", "refactor.move", "refactor.inline", "source.fixAll"]
+                "codeActionKinds": ["quickfix", "refactor.extract", "refactor.rewrite", "refactor.delete", "refactor.move", "refactor.inline", "source.fixAll.pyrefly"]
             },
             "codeLensProvider": {
                 "resolveProvider": false,


### PR DESCRIPTION
## Summary
- advertise `source.fixAll.pyrefly` in server capabilities instead of generic `source.fixAll`
- emit fix-all actions with the pyrefly-specific kind
- for `context.only`, run pyrefly fix-all only when the request includes either `source.fixAll` or a `source.fixAll.pyrefly...` kind

Fixes #3024.