### PR TITLE
check non-callable __bool__ in assert statements

### DIFF
--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -120,7 +120,9 @@ impl<'a> BindingsBuilder<'a> {
         self.ensure_expr(&mut test, &mut Usage::Narrowing(None));
         let narrow_ops = NarrowOps::from_expr(self, Some(&test));
         let static_test = self.sys_info.evaluate_bool(&test);
+        let test_clone = test.clone();
         self.insert_binding(Key::Anon(test_range), Binding::Expr(None, Box::new(test)));
+        self.insert_binding(KeyExpect::Bool(test_range), BindingExpect::Bool(test_clone));
         if let Some(mut msg_expr) = msg {
             let mut base = self.scopes.clone_current_flow();
             // Negate the narrowing of the test expression when typechecking

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -1044,13 +1044,12 @@ p += 1  # E: `+=` is not supported
 
 // https://github.com/facebook/pyrefly/issues/2914
 testcase!(
-    bug = "Should detect unsupported-bool-conversion when __bool__ is not callable",
     test_bool_conversion_non_callable,
     r#"
 class BadBool:
     __bool__: int = 3
 
-assert BadBool()
+assert BadBool()  # E: The `__bool__` attribute of `BadBool` has type `int`, which is not callable
 "#,
 );
 


### PR DESCRIPTION
## summary
- assert statements now check that __bool__ is callable on the test expression
- previously only if/while/ternary checked this, assert was missing the check
- matches behavior of pyright and mypy which flag this

## test plan
- updated existing bug test case to expect the error
- all 4678 tests pass

fixes #2914