### PR TITLE
check non-callable __bool__ on in operator result

### DIFF
--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -767,7 +767,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                     errors,
                                     Some(&context),
                                 ) {
-                                    ret
+                                    self.check_dunder_bool_is_callable(&ret, x.range, errors);
+                                    self.heap.mk_class_type(self.stdlib.bool().clone())
                                 } else {
                                     let iteration_errors = self.error_collector();
                                     let iterables = self.iterate(

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -1068,3 +1068,20 @@ class Container:
 10 in Container()  # E: The `__bool__` attribute of `BadBool` has type `int`, which is not callable
 "#,
 );
+
+testcase!(
+    test_in_operator_returns_bool,
+    r#"
+from typing import assert_type
+
+class Truthy:
+    def __contains__(self, item: object) -> int:
+        return 1
+
+assert_type(10 in Truthy(), bool)
+assert_type(10 not in Truthy(), bool)
+
+x: bool = 10 in Truthy()
+y: int = 10 in Truthy()
+"#,
+);

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -1056,7 +1056,6 @@ assert BadBool()
 
 // https://github.com/facebook/pyrefly/issues/2913
 testcase!(
-    bug = "Should detect unsupported-bool-conversion in membership tests",
     test_bool_conversion_in_contains,
     r#"
 class BadBool:
@@ -1066,6 +1065,6 @@ class Container:
     def __contains__(self, item: object) -> BadBool:
         return BadBool()
 
-10 in Container()
+10 in Container()  # E: The `__bool__` attribute of `BadBool` has type `int`, which is not callable
 "#,
 );


### PR DESCRIPTION
## summary
- in/not in operator now checks that __bool__ is callable on the __contains__ return type
- also returns bool instead of the raw __contains__ return type, matching python semantics

## test plan
- updated existing bug test case to expect the error
- all 4678 tests pass

fixes #2913