### PR TITLE
fix TypeVar bound to type[X] resolves as object #3066

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -2075,6 +2075,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     fn quantified_bound_class(&self, base: AttributeBase1) -> Option<ClassType> {
         match base {
             AttributeBase1::ClassInstance(cls) => Some(cls),
+            // Bounds like `type[C]` become class-object bases; keep their underlying class
+            // instead of falling back to `object`.
+            AttributeBase1::ClassObject(class) => Some(class.class_type().clone()),
             // Handle `type[Any]`, which happens for TypeVars w/ `bound=type`
             AttributeBase1::TypeAny(_) => Some(self.stdlib.builtins_type().clone()),
             _ => None,

--- a/pyrefly/lib/test/generic_restrictions.rs
+++ b/pyrefly/lib/test/generic_restrictions.rs
@@ -259,6 +259,24 @@ def get_class_name(cls: T) -> str:
 );
 
 testcase!(
+    test_bounded_typevar_specific_type_attribute_access,
+    r#"
+from typing import TypeVar, assert_type
+
+class ShellComplete:
+    name: str = "base"
+
+T = TypeVar("T", bound=type[ShellComplete])
+
+def add_completion_class(cls: T, label: str | None = None) -> T:
+    if label is None:
+        assert_type(cls.name, str)
+        label = cls.name
+    return cls
+ "#,
+);
+
+testcase!(
     test_instantiate_default_typevar,
     r#"
 from typing import assert_type, reveal_type, Callable, Self


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3066

The bug was in quantified attribute lookup: a TypeVar bound like type[ShellComplete] was converted into a class-object base, but the helper only recognized instance-style bases and fell back to object. 

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test