### PR TITLE
fix invalid-argument "Expected first argument to super" false positives #3065

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -4256,11 +4256,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     if let Some(reason) = self.super_method_needs_impl_reason(&member) {
                         ClassAttribute::no_access(reason)
                     } else {
-                        self.as_class_attribute(
-                            name,
-                            &member.value,
-                            &ClassBase::SelfType(obj.clone()),
-                        )
+                        let cls = if name == &dunder::NEW {
+                            ClassBase::ClassDef(obj.clone())
+                        } else {
+                            ClassBase::SelfType(obj.clone())
+                        };
+                        self.as_class_attribute(name, &member.value, &cls)
                     }
                 }),
         }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -2955,64 +2955,83 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Type {
         match style {
             SuperStyle::ExplicitArgs(cls_binding, obj_binding) => {
-                match self.get_idx(*cls_binding).ty() {
-                    Type::Any(style) => style.propagate(),
-                    cls_type @ Type::ClassDef(cls) => {
-                        let heap = self.heap;
-                        let make_super_instance = |obj_cls, super_obj: &dyn Fn() -> SuperObj| {
-                            let lookup_cls = self.get_super_lookup_class(cls, obj_cls);
-                            lookup_cls.map_or_else (
-                                || {
-                                    let cls_type = self.for_display(cls_type.clone());
-                                    self.error(
-                                        errors,
-                                        range,
-                                        ErrorKind::InvalidSuperCall,
-                                        format!(
-                                            "Illegal `super({cls_type}, {obj_cls})` call: `{obj_cls}` is not an instance or subclass of `{cls_type}`"
-                                        ),
-                                    )
-                                },
-                                |lookup_cls| {
-                                    heap.mk_super_instance(lookup_cls, super_obj())
-                                }
-                            )
-                        };
-                        match self.get_idx(*obj_binding).ty() {
-                            Type::Any(style) => style.propagate(),
-                            Type::ClassType(obj_cls) => make_super_instance(obj_cls, &|| SuperObj::Instance(obj_cls.clone())),
-                            Type::Type(f) if let Type::ClassType(obj_cls) = &**f => {
-                                make_super_instance(obj_cls, &|| SuperObj::Class(obj_cls.clone()))
-                            }
-                            Type::ClassDef(obj_cls) => {
-                                let obj_type = self.type_order().as_class_type_unchecked(obj_cls);
-                                make_super_instance(&obj_type, &|| SuperObj::Class(obj_type.clone()))
-                            }
-                            Type::SelfType(obj_cls) => {
-                                make_super_instance(obj_cls, &|| SuperObj::Instance(obj_cls.clone()))
-                            }
-                            Type::Type(f) if let Type::SelfType(obj_cls) = &**f => {
-                                make_super_instance(obj_cls, &|| SuperObj::Class(obj_cls.clone()))
-                            }
-                            t => {
-                                self.error(
-                                    errors,
-                                    range,
-                                    ErrorKind::InvalidArgument,
-                                    format!("Expected second argument to `super` to be a class object or instance, got `{}`", self.for_display(t.clone())),
-                                )
-                            }
+                let cls_type = self.get_idx(*cls_binding).ty().clone();
+                let cls = match &cls_type {
+                    Type::Any(style) => return style.propagate(),
+                    Type::ClassDef(cls) => cls,
+                    Type::Type(f) => match &**f {
+                        Type::ClassType(cls) | Type::SelfType(cls) => cls.class_object(),
+                        t => {
+                            return self.error(
+                                errors,
+                                range,
+                                ErrorKind::InvalidArgument,
+                                format!(
+                                    "Expected first argument to `super` to be a class object, got `{}`",
+                                    self.for_display(t.clone())
+                                ),
+                            );
                         }
+                    },
+                    t => {
+                        return self.error(
+                            errors,
+                            range,
+                            ErrorKind::InvalidArgument,
+                            format!(
+                                "Expected first argument to `super` to be a class object, got `{}`",
+                                self.for_display(t.clone())
+                            ),
+                        );
                     }
-                    t => self.error(
-                        errors,
-                        range,
-                        ErrorKind::InvalidArgument,
-                        format!(
-                            "Expected first argument to `super` to be a class object, got `{}`",
-                            self.for_display(t.clone())
-                        ),
-                    ),
+                };
+                let heap = self.heap;
+                let make_super_instance = |obj_cls, super_obj: &dyn Fn() -> SuperObj| {
+                    let lookup_cls = self.get_super_lookup_class(cls, obj_cls);
+                    lookup_cls.map_or_else(
+                        || {
+                            let cls_type = self.for_display(cls_type.clone());
+                            self.error(
+                                errors,
+                                range,
+                                ErrorKind::InvalidSuperCall,
+                                format!(
+                                    "Illegal `super({cls_type}, {obj_cls})` call: `{obj_cls}` is not an instance or subclass of `{cls_type}`"
+                                ),
+                            )
+                        },
+                        |lookup_cls| heap.mk_super_instance(lookup_cls, super_obj()),
+                    )
+                };
+                match self.get_idx(*obj_binding).ty() {
+                    Type::Any(style) => style.propagate(),
+                    Type::ClassType(obj_cls) => {
+                        make_super_instance(obj_cls, &|| SuperObj::Instance(obj_cls.clone()))
+                    }
+                    Type::Type(f) if let Type::ClassType(obj_cls) = &**f => {
+                        make_super_instance(obj_cls, &|| SuperObj::Class(obj_cls.clone()))
+                    }
+                    Type::ClassDef(obj_cls) => {
+                        let obj_type = self.type_order().as_class_type_unchecked(obj_cls);
+                        make_super_instance(&obj_type, &|| SuperObj::Class(obj_type.clone()))
+                    }
+                    Type::SelfType(obj_cls) => {
+                        make_super_instance(obj_cls, &|| SuperObj::Instance(obj_cls.clone()))
+                    }
+                    Type::Type(f) if let Type::SelfType(obj_cls) = &**f => {
+                        make_super_instance(obj_cls, &|| SuperObj::Class(obj_cls.clone()))
+                    }
+                    t => {
+                        self.error(
+                            errors,
+                            range,
+                            ErrorKind::InvalidArgument,
+                            format!(
+                                "Expected second argument to `super` to be a class object or instance, got `{}`",
+                                self.for_display(t.clone())
+                            ),
+                        )
+                    }
                 }
             }
             SuperStyle::ImplicitArgs(self_binding, method) => {

--- a/pyrefly/lib/test/class_super.rs
+++ b/pyrefly/lib/test/class_super.rs
@@ -321,6 +321,30 @@ class B(A):
 );
 
 testcase!(
+    test_super_explicit_dynamic_first_arg,
+    r#"
+from typing import Any
+
+class YearMonthDay(list[int]):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super(self.__class__, self).__init__(*args, **kwargs)
+        self.century_specified = False
+
+class Distribution:
+    def fit(self, data: list[float]) -> float:
+        return sum(data) / len(data)
+
+class NormalDist(Distribution):
+    def fit(self, data: list[float]) -> float:
+        return super(type(self), self).fit(data)
+
+class PlatformDispatch:
+    def __new__(cls, *args, **kwargs):
+        return super(cls, PlatformDispatch).__new__(PlatformDispatch)
+    "#,
+);
+
+testcase!(
     test_call_instance_method_from_classmethod,
     r#"
 class A:


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3065

relaxing the explicit super(cls, obj) first-argument check.

now accepts not just literal class defs, but also class-object values typed as type[C] and type[Self], which covers patterns like `self.__class__`, `type(self)`, and cls in `__new__`. 

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test