### PR TITLE
fix Metaclass instance in issubclass after isinstance narrowing #3064

### DIFF
--- a/pyrefly/lib/alt/class/classdef.rs
+++ b/pyrefly/lib/alt/class/classdef.rs
@@ -163,7 +163,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::None | Type::Type(box Type::None) => {
                 Some((TParams::empty(), self.heap.mk_none()))
             }
-            Type::ClassType(cls) if cls.is_builtin("type") => {
+            // Instances of `type` subclasses are class objects too, so metaclass-narrowed
+            // values remain valid inputs to isinstance()/issubclass().
+            Type::ClassType(cls)
+                if self.has_superclass(
+                    cls.class_object(),
+                    self.stdlib.builtins_type().class_object(),
+                ) =>
+            {
                 Some((TParams::empty(), self.heap.mk_any_implicit()))
             }
             Type::Any(_) => Some((TParams::empty(), ty.clone())),

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -1393,6 +1393,24 @@ def test_isinstance_then_issubclass(x: object) -> None:
 );
 
 testcase!(
+    test_issubclass_with_metaclass_instance,
+    r#"
+class ModelBase(type):
+    pass
+
+class Model(metaclass=ModelBase):
+    pass
+
+def validate_force_insert(cls: type, force_insert: tuple[object, ...]) -> None:
+    for member in force_insert:
+        if not isinstance(member, ModelBase):
+            raise TypeError("not a model class")
+        if not issubclass(cls, member):
+            raise TypeError("not a base")
+    "#,
+);
+
+testcase!(
     test_issubclass_typevar_object,
     r#"
 from typing import TypeVar


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3064

reason: only treated bare type as a valid class object for isinstance/issubclass unwrapping, so a value narrowed to a custom metaclass instance like ModelBase was rejected.

broadened that logic to accept any subtype of type, which keeps metaclass-narrowed values valid for issubclass.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test