### PR TITLE
Explicitly declare VS Code extension workspace trust capabilities

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -36,6 +36,12 @@
         "onLanguage:python",
         "onNotebook:jupyter-notebook"
     ],
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": false,
+            "description": "Pyrefly can be configured to execute binaries. A malicious actor could exploit this to run arbitrary code on your machine."
+        }
+    },
     "contributes": {
         "languages": [
             {
@@ -98,7 +104,8 @@
                 "pyrefly.lspPath": {
                     "type": "string",
                     "default": "",
-                    "description": "The path to the binary used for the lsp"
+                    "description": "The path to the binary used for the lsp",
+                    "scope": "machine-overridable"
                 },
                 "pyrefly.lspArguments": {
                     "type": "array",
@@ -108,7 +115,8 @@
                     "default": [
                         "lsp"
                     ],
-                    "description": "Additional arguments that should be passed to the binary at pyrefly.lspPath"
+                    "description": "Additional arguments that should be passed to the binary at pyrefly.lspPath",
+                    "scope": "machine-overridable"
                 },
                 "python.pyrefly.disableLanguageServices": {
                     "type": "boolean",


### PR DESCRIPTION
The extension already does not run in untrusted workspaces and lspPath can already be overridden in trusted workspaces. These changes make that behavior explicit by declaring untrustedWorkspaces support as disabled via the capabilities API and adding machine-overridable scope to the lspPath and lspArguments settings.

# Test Plan

Confirmed that we get a dialog when opening an untrusted workspace:
<img width="1495" height="1056" alt="Screenshot 2026-04-09 at 11 04 00 AM" src="https://github.com/user-attachments/assets/61a6cfa3-b6b7-4dd4-86f2-f81825d6ada1" />

In an untrusted workspace, the settings.json is not used (Pyrefly is not enabled at all), no PWNED file:
<img width="1495" height="1056" alt="Screenshot 2026-04-09 at 11 22 49 AM" src="https://github.com/user-attachments/assets/1bca758f-80e9-4c18-8aa7-bb375721e91f" />

The Extension summary includes the description of why restricted mode is not supported:
<img width="1495" height="1056" alt="Screenshot 2026-04-09 at 11 34 14 AM" src="https://github.com/user-attachments/assets/0e0bc1d1-3f5f-4266-8ec3-b8d4af51862c" />

In trusted mode, a malicious actor can still cause point lspPath to a malicious binary. This is the same as rust-analyzer and TypeScript extensions.
<img width="1495" height="1056" alt="Screenshot 2026-04-09 at 11 43 05 AM" src="https://github.com/user-attachments/assets/cfdb864c-0f94-4483-b343-20c56b785f39" />
