### PR TITLE
Fix(#2918): `NotImplemented` being incorrectly accepted as a callable

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1748,7 +1748,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 kws = x.arguments.keywords.map(CallKeyword::new);
             }
 
-            let result = self.distribute_over_union(&callee_ty, |ty| match ty.callee_kind() {
+            let result = self.distribute_over_union(&callee_ty, |ty| {
+                // NotImplemented is a singleton constant, not a callable class.
+                if matches!(ty, Type::ClassType(cls) if cls.is_builtin("_NotImplementedType") || cls.has_qname("types", "NotImplementedType"))
+                {
+                    return self.error(
+                        errors,
+                        x.func.range(),
+                        ErrorInfo::Kind(ErrorKind::NotCallable),
+                        "`NotImplemented` is not callable. Did you mean `NotImplementedError`?".to_owned(),
+                    );
+                }
+                match ty.callee_kind() {
                 Some(CalleeKind::Function(FunctionKind::AssertType)) => self
                     .call_assert_type(
                         &x.arguments.args,
@@ -1844,7 +1855,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // Check if this call applies a decorator with known typing effects to a function.
                 _ if let Some(ret) = self.maybe_apply_function_decorator(ty, &args, &kws, errors) => ret,
                 _ => self.freeform_call_infer(ty.clone(), &args, &kws, x.func.range(), x.arguments.range(), hint, errors),
-            });
+            }});
             // TypeIs and TypeGuard functions return bool at runtime
             match result {
                 Type::TypeIs(_) | Type::TypeGuard(_) => {

--- a/pyrefly/lib/test/calls.rs
+++ b/pyrefly/lib/test/calls.rs
@@ -406,18 +406,30 @@ def get_flow_version(run_id: str | None) -> str | None:
     "#,
 );
 
-// https://github.com/facebook/pyrefly/issues/2918
+// https://github.com/facebook/pyrefly/issues/2918 (solved)
 testcase!(
-    bug = "Should error when calling NotImplemented (a constant, not a class)",
     test_call_not_implemented_constant,
     r#"
 # NotImplemented is a singleton constant, not a callable class.
 # Using NotImplemented() is always a mistake; they mean NotImplementedError().
 def broken():
-    raise NotImplemented()
+    raise NotImplemented()  # E: `NotImplemented` is not callable. Did you mean `NotImplementedError`?
 
 def also_broken():
-    raise NotImplemented("not yet done")
+    raise NotImplemented("not yet done")  # E: `NotImplemented` is not callable. Did you mean `NotImplementedError`?
+"#,
+);
+
+testcase!(
+    test_call_not_implemented_in_union,
+    r#"
+def f(condition: bool):
+    def g(): ...
+    if condition:
+        x = g
+    else:
+        x = NotImplemented
+    x()  # E: `NotImplemented` is not callable. Did you mean `NotImplementedError`?
 "#,
 );
 


### PR DESCRIPTION
Fixes [#2918 ](https://github.com/facebook/pyrefly/issues/2918)

# Summary 
Resolves the issue by showing a helpful NotCallable error when users mistakenly try to call the NotImplemented singleton constant as a function.

# Changes
- pyrefly/lib/alt/call.rs: Added the has_qname match checks for builtins._NotImplementedType and types.NotImplementedType inside expr_call_infer to return an early NotCallable error.
- pyrefly/lib/test/calls.rs: Removed the bug marker from test_call_not_implemented_constant and updated the standard test framework expectations to assert our new error cleanly.

# Tests
`cargo test test_call_not_implemented_constant -p pyrefly --lib` - Passed
`python test.py --no-test --no-conformance --no-jsonschema` - Passed