### PR TITLE
Preserve decorated function type through @wraps-style unions

### DIFF
--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -39,6 +39,7 @@ use crate::equality::TypeEq;
 use crate::equality::TypeEqCtx;
 use crate::keywords::DataclassTransformMetadata;
 use crate::type_output::TypeOutput;
+use crate::types::AnyStyle;
 use crate::types::Type;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -46,6 +47,34 @@ use crate::types::Type;
 pub struct Callable {
     pub params: Params,
     pub ret: Type,
+}
+
+impl Callable {
+    /// Returns true if this callable has only *args and **kwargs parameters
+    /// (plus an optional unannotated self/cls at index 0) and no return type
+    /// annotation. Used as a heuristic in decorator type resolution: when a
+    /// decorator returns a union containing such a wrapper, the decorator is
+    /// treated as preserving the original function's signature.
+    pub fn is_args_kwargs_wrapper(&self) -> bool {
+        if !matches!(&self.ret, Type::Any(AnyStyle::Implicit)) {
+            return false;
+        }
+        match &self.params {
+            Params::List(params) => {
+                let items = params.items();
+                items.iter().any(|p| matches!(p, Param::Varargs(..)))
+                    && items.iter().any(|p| matches!(p, Param::Kwargs(..)))
+                    && items.iter().enumerate().all(|(i, p)| match p {
+                        Param::Varargs(..) | Param::Kwargs(..) => true,
+                        Param::Pos(_, ty, _) | Param::PosOnly(Some(_), ty, _) if i == 0 => {
+                            matches!(ty, Type::Any(AnyStyle::Implicit))
+                        }
+                        _ => false,
+                    })
+            }
+            _ => false,
+        }
+    }
 }
 
 impl Display for Callable {

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -1427,6 +1427,21 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             {
                 original_decoratee.clone()
             }
+            // A "dual-use" decorator can be applied with or without parentheses
+            // (e.g., @my_decorator or @my_decorator(flag)). Its return type is a union of
+            // the wrapper result and the inner decorator function. If any member
+            // is a *args/**kwargs wrapper or a functools._Wrapped, treat the
+            // whole decorator as a passthrough that preserves the original signature.
+            Type::Union(ref u)
+                if u.members.iter().any(|m| match m {
+                    Type::Function(f) => f.signature.is_args_kwargs_wrapper(),
+                    Type::Callable(c) => c.is_args_kwargs_wrapper(),
+                    Type::ClassType(cls) => cls.has_qname("functools", "_Wrapped"),
+                    _ => false,
+                }) =>
+            {
+                original_decoratee.clone()
+            }
             returned_ty => returned_ty,
         }
     }

--- a/pyrefly/lib/test/decorators.rs
+++ b/pyrefly/lib/test/decorators.rs
@@ -680,7 +680,6 @@ reveal_type(my_func)  # E: revealed type: (object) -> None
 );
 
 testcase!(
-    bug = "FP in Dual-use decorators https://github.com/facebook/pyrefly/issues/2621",
     test_dual_use_decorator,
     r#"
 from typing import assert_type
@@ -696,12 +695,21 @@ def optional_debug(func_or_flag=None):
         return decorator(func_or_flag)
     return decorator
 
+# Used without parentheses — func_or_flag receives the function directly.
 @optional_debug
 def compute(x: int, y: int, z: int) -> int:
     return x + y + z
 
-r1 = compute(1, 2, 3)  # E: Expected 1 positional argument, got 3 in function `decorator`
-assert_type(r1, int)  # E: assert_type(((*args: Unknown, **kwargs: Unknown) -> Unknown) | Unknown, int) failed
+r1 = compute(1, 2, 3)
+assert_type(r1, int)
+
+# Used with parentheses — func_or_flag receives the flag, returns decorator.
+@optional_debug(True)
+def compute2(x: int, y: int, z: int) -> int:
+    return x + y + z
+
+r2 = compute2(1, 2, 3)
+assert_type(r2, int)
     "#,
 );
 


### PR DESCRIPTION
Summary:
When a decorator returns a union where one branch is an unannotated
*args/**kwargs wrapper, return the original function's type. 

The heuristic: if a decorator's inferred return type is a union, and any
member of that union is a function with only *args/**kwargs parameters
(plus optional self) and no return type annotation, it's recognized as a
functools.wraps-style passthrough wrapper. In that case the decorated
function keeps its original signature instead of getting the union type.

The fix adds `Callable::is_args_kwargs_wrapper()` to detect wrapper
functions, and uses it in `decorate_returned_callable` to handle unions
containing such wrappers.


for issue https://github.com/facebook/pyrefly/issues/2621

Reviewed By: stroxler

Differential Revision: D100251940


