### PR TITLE
Add faling test for overloads for returning Self

### DIFF
--- a/pyrefly/lib/test/typing_self.rs
+++ b/pyrefly/lib/test/typing_self.rs
@@ -564,3 +564,18 @@ class Base:
         self.field = "hello"
 "#,
 );
+
+testcase!(
+    bug = "Should raise error in the overloads when returning concrete class instead of Self",
+    test_overload_returning_self,
+    r#"
+from typing import Self, overload
+
+class C:
+    @overload
+    def clone(self, x: int) -> C: ...
+    @overload
+    def clone(self, x: str) -> C: ...
+    def clone(self, x) -> Self: ...
+    "#,
+);


### PR DESCRIPTION
Summary:
If a method returns `Self`, then an overload returning the current class should not be accepted as an overload.

This is on par with Pyright: https://pyright-play.net/?code=GYJw9gtgBALgngBwJYDsDmUkQWEMoDKApgDbAA0UYAbkSCWAIYAmAUKwMYmMDOPUAYQBcrKGKgABGnQYtR45kWBQuYFEQAUPUhSgAPIZhQwAlFAC0APkGGAdPfliptekzbioi5avVadlAygeGBAzKxsoe1tHTyUVBl9tMgCw62IyO3sgA

Differential Revision: D100428648


