### PR TITLE
Skip self/cls in overload consistency checks (#3112)

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -8918,17 +8918,6 @@
     {
       "code": -2,
       "column": 9,
-      "concise_description": "Implementation signature `(cls: type[Self@C], *args: int | str) -> int | str` does not accept all arguments that overload signature `(self: Self@C, x: str, /) -> str` accepts",
-      "description": "Implementation signature `(cls: type[Self@C], *args: int | str) -> int | str` does not accept all arguments that overload signature `(self: Self@C, x: str, /) -> str` accepts",
-      "line": 90,
-      "name": "inconsistent-overload",
-      "severity": "error",
-      "stop_column": 14,
-      "stop_line": 90
-    },
-    {
-      "code": -2,
-      "column": 9,
       "concise_description": "`@final` should only be applied to the implementation of an overloaded function.",
       "description": "`@final` should only be applied to the implementation of an overloaded function.",
       "line": 124,

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -1784,14 +1784,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 Some(Arc::new(all_tparams))
             }
         };
+        let has_self_param = def.defining_cls().is_some() && !def.metadata().flags.is_staticmethod;
         let sig_for_input_check = |sig: &Callable| {
             let mut sig = sig.clone();
             // Set the return type to `Any` so that we check just the input signature.
             sig.ret = self.heap.mk_any_implicit();
+            // Skip self/cls to avoid false positive overload errors on narrowed self types.
+            if has_self_param {
+                let mut owner = Owner::new();
+                if let Some((_, rest)) = sig.split_first_param(&mut owner) {
+                    sig = rest;
+                }
+            }
             sig
         };
         // Collect param name -> default map from implementation so we can check for
         // inconsistencies between the default and the param type in overloads.
+        // This uses the original parameter lists instead of `sig_for_input_check`:
+        // self/cls never has a default, so stripping the receiver is unnecessary here.
         let mut defaults = match &impl_sig.params {
             Params::List(params) => params
                 .items()

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -1307,16 +1307,16 @@ class MyString(str):
 );
 
 testcase!(
-    bug = "We raise 4 inconsistent-overload errors where pyright raises 1. We should investigate this.",
+    bug = "We raise 2 inconsistent-overload errors where pyright raises 1. We should investigate this.",
     test_override_all_parent_overloads_inapplicable,
     r#"
 from typing import overload, LiteralString
 
 class Base(str):
     @overload
-    def method(self: LiteralString) -> LiteralString: ...  # E: Implementation signature `(self: Self@Base, x: Unknown | None = None) -> Self@Base` does not accept all arguments that overload signature `(self: LiteralString) -> LiteralString` accepts  # E: Overload return type `LiteralString` is not assignable to implementation return type `Self@Base`
+    def method(self: LiteralString) -> LiteralString: ...  # E: Overload return type `LiteralString` is not assignable to implementation return type `Self@Base`
     @overload
-    def method(self: LiteralString, x: int) -> LiteralString: ...  # E: Implementation signature `(self: Self@Base, x: Unknown | None = None) -> Self@Base` does not accept all arguments that overload signature `(self: LiteralString, x: int) -> LiteralString` accepts  # E: Overload return type `LiteralString` is not assignable to implementation return type `Self@Base`
+    def method(self: LiteralString, x: int) -> LiteralString: ...  # E: Overload return type `LiteralString` is not assignable to implementation return type `Self@Base`
     def method(self, x=None):
         return self
 
@@ -1344,6 +1344,32 @@ class Narrow(Parent):
 
 class Child(Parent):
     def method(self, x: int) -> int:
+        return x
+    "#,
+);
+
+testcase!(
+    test_override_generic_overload_with_inapplicable_cls,
+    r#"
+from typing import overload
+
+class Parent[T]:
+    @classmethod
+    @overload
+    def make(cls: type["Narrow"], x: T) -> T: ...
+    @classmethod
+    @overload
+    def make(cls, x: int) -> int: ...
+    @classmethod
+    def make(cls, x):
+        return x
+
+class Narrow(Parent[int]):
+    pass
+
+class Child(Parent[int]):
+    @classmethod
+    def make(cls, x: int) -> int:
         return x
     "#,
 );

--- a/pyrefly/lib/test/constructors.rs
+++ b/pyrefly/lib/test/constructors.rs
@@ -668,9 +668,9 @@ class E(A):
 
 class C[T]:
     @overload
-    def __init__(self: A, x: Literal[True]) -> None: ...  # E: `__init__` method self type `A` is not a superclass of class `C`  # E: Implementation signature `(self: Self@C, x: Unknown) -> None` does not accept all arguments that overload signature `(self: A, x: Literal[True]) -> None` accepts
+    def __init__(self: A, x: Literal[True]) -> None: ...  # E: `__init__` method self type `A` is not a superclass of class `C`
     @overload
-    def __init__(self: B, x: Literal[False]) -> None: ...  # E: `__init__` method self type `B` is not a superclass of class `C`  # E: Implementation signature `(self: Self@C, x: Unknown) -> None` does not accept all arguments that overload signature `(self: B, x: Literal[False]) -> None` accepts
+    def __init__(self: B, x: Literal[False]) -> None: ...  # E: `__init__` method self type `B` is not a superclass of class `C`
     def __init__(self, x):
         pass
 


### PR DESCRIPTION
Summary:

Skip the self/cls parameter when checking overload input signature consistency.
Without this, overloads with narrowed self types (e.g. `self: C[int]`) produce
false positive `inconsistent-overload` errors because `C[int] <: Self@C` fails
after removing the unsound `ClassType <: SelfType` subtyping rule.

This is a deliberate relaxation: stripping self loses type variable constraints
that flow through the self parameter, but in practice the self type is validated
separately (must be a superclass of the defining class, D97390197), and callers don't pass
self explicitly.

This is preparatory work for removing the unsound `ClassType <: SelfType`
subtyping rule.

Reviewed By: grievejia

Differential Revision: D99748452
