### PR TITLE
strip "-stubs" suffix from FQN in `pyrefly report` #3094

### DIFF
--- a/crates/pyrefly_python/src/module_name.rs
+++ b/crates/pyrefly_python/src/module_name.rs
@@ -493,6 +493,12 @@ impl ModuleName {
                     out.push(x.to_string_lossy());
                 }
             }
+            // strip `-stubs` from the top-level directory (e.g. `scipy-stubs/` -> `scipy`)
+            if let Some(first) = out.first_mut()
+                && let Some(stripped) = first.strip_suffix("-stubs")
+            {
+                *first = stripped.to_owned().into();
+            }
             if out.is_empty() {
                 None
             } else {
@@ -702,5 +708,26 @@ mod tests {
             ),
             Some(ModuleName::from_str("service.types.cinc"))
         );
+    }
+
+    #[test]
+    fn test_module_from_path_stubs_suffix() {
+        // PEP 561: `-stubs` suffix on the top-level directory should be stripped.
+        let includes = [PathBuf::from("/sp")];
+        let assert_module_name = |path: &str, expected: &str| {
+            assert_eq!(
+                ModuleName::from_path(Path::new(path), includes.iter(), &[]),
+                Some(ModuleName::from_str(expected))
+            );
+        };
+
+        assert_module_name("/sp/scipy-stubs/stats/foo.pyi", "scipy.stats.foo");
+        assert_module_name("/sp/scipy-stubs/__init__.pyi", "scipy");
+
+        // Non-top-level `-stubs` should not be stripped.
+        assert_module_name("/sp/pkg/nested-stubs/foo.py", "pkg.nested-stubs.foo");
+
+        // Plain package without `-stubs` is unchanged.
+        assert_module_name("/sp/scipy/stats/foo.py", "scipy.stats.foo");
     }
 }


### PR DESCRIPTION
# Summary

This fixes the fully-qualified names reported with `pyrefly report` for stubs-only packages according to [PEP 561](https://peps.python.org/pep-0561/) by removing the top-level `-stubs` suffix.

Fixes #3094

# Test Plan

added a unit test