### PR TITLE
support non-standard "self" and "cls" param names in `pyrefly report` #3095

### DIFF
--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -15,6 +15,7 @@ use pyrefly_build::handle::Handle;
 use pyrefly_config::args::ConfigOverrideArgs;
 use pyrefly_config::finder::ConfigFinder;
 use pyrefly_graph::index::Idx;
+use pyrefly_python::dunder;
 use pyrefly_python::ignore::Ignore;
 use pyrefly_python::ignore::Tool;
 use pyrefly_python::module::Module;
@@ -41,9 +42,9 @@ use crate::binding::binding::BindingAnnotation;
 use crate::binding::binding::BindingClass;
 use crate::binding::binding::BindingClassField;
 use crate::binding::binding::BindingExport;
+use crate::binding::binding::BindingUndecoratedFunction;
 use crate::binding::binding::ClassBinding;
 use crate::binding::binding::ClassFieldDefinition;
-use crate::binding::binding::FunctionDefData;
 use crate::binding::binding::Key;
 use crate::binding::binding::KeyAnnotation;
 use crate::binding::binding::KeyClass;
@@ -52,6 +53,7 @@ use crate::binding::binding::KeyClassMetadata;
 use crate::binding::binding::KeyClassMro;
 use crate::binding::binding::KeyDecorator;
 use crate::binding::binding::KeyExport;
+use crate::binding::binding::KeyUndecoratedFunction;
 use crate::binding::binding::ReturnTypeKind;
 use crate::binding::bindings::Bindings;
 use crate::commands::check::Handles;
@@ -424,9 +426,19 @@ impl ReportArgs {
     const EXCLUDED_MODULE_DUNDERS: &'static [&'static str] =
         &["__all__", "__dir__", "__doc__", "__getattr__"];
 
-    /// Returns true if the first parameter is self/cls (implicit, excluded from slot counting).
-    fn is_self_or_cls(index: usize, name: &str) -> bool {
-        index == 0 && (name == "self" || name == "cls")
+    /// True if the first parameter is the implicit receiver (`self`/`cls`),
+    /// excluded from slot counting. `__new__` is a staticmethod but still takes cls.
+    fn has_implicit_receiver(
+        fun: &BindingUndecoratedFunction,
+        answers: &Answers,
+        undecorated_idx: Idx<KeyUndecoratedFunction>,
+    ) -> bool {
+        fun.class_key.is_some() && {
+            let is_staticmethod = answers
+                .get_idx(undecorated_idx)
+                .is_some_and(|u| u.metadata.flags.is_staticmethod);
+            !is_staticmethod || fun.def.name.as_str() == dunder::NEW
+        }
     }
 
     /// Returns the ClassBinding if the class owning this field is a schema class (dataclass, enum,
@@ -832,15 +844,19 @@ impl ReportArgs {
                 };
                 let mut func_slots = return_slot;
                 let mut n_params = 0usize;
+                let fn_name = fun.def.name.as_str();
+                let implicit_receiver =
+                    Self::has_implicit_receiver(fun, answers, decorated.undecorated_idx);
 
                 for (i, param) in all_params.iter().enumerate() {
                     let param_name = param.name.as_str();
+                    let is_self = i == 0 && implicit_receiver;
                     let param_annotation = param
                         .annotation
                         .as_ref()
                         .map(|ann| module.code_at(ann.range()).to_owned());
 
-                    let is_param_type_known = if Self::is_self_or_cls(i, param_name) {
+                    let is_param_type_known = if is_self {
                         true
                     } else if param.annotation.is_some() {
                         let annot_key =
@@ -858,22 +874,16 @@ impl ReportArgs {
 
                     // Check if this non-self param has an implicit type for a dunder method.
                     // Like implicit returns, only applies when annotation is absent.
-                    let is_implicit_param = !Self::is_self_or_cls(i, param_name)
+                    let is_implicit_param = !is_self
                         && fun.class_key.is_some()
                         && param_annotation.is_none()
-                        && Self::is_implicit_dunder_param(
-                            fun.def.name.as_str(),
-                            i.saturating_sub(1),
-                        );
+                        && Self::is_implicit_dunder_param(fn_name, i.saturating_sub(1));
 
-                    if !is_param_type_known
-                        && !Self::is_self_or_cls(i, param_name)
-                        && !is_implicit_param
-                    {
+                    if !is_param_type_known && !is_self && !is_implicit_param {
                         all_params_type_known = false;
                     }
 
-                    if !Self::is_self_or_cls(i, param_name) && !is_implicit_param {
+                    if !is_self && !is_implicit_param {
                         let param_slot =
                             Self::classify_slot(param_annotation.is_some(), is_param_type_known);
                         func_slots = func_slots.merge(param_slot);
@@ -892,7 +902,7 @@ impl ReportArgs {
                     && parameters
                         .iter()
                         .enumerate()
-                        .all(|(i, p)| Self::is_self_or_cls(i, &p.name) || p.annotation.is_some());
+                        .all(|(i, p)| (i == 0 && implicit_receiver) || p.annotation.is_some());
                 let is_type_known =
                     is_fully_annotated && is_return_type_known && all_params_type_known;
                 let is_property = answers
@@ -954,8 +964,13 @@ impl ReportArgs {
     }
 
     /// Only the first parameter (`self`/`cls`) is allowed to be unannotated.
-    fn is_function_completely_annotated(bindings: &Bindings, func_def: &FunctionDefData) -> bool {
-        let return_key = Key::ReturnType(ShortIdentifier::new(&func_def.name));
+    fn is_function_completely_annotated(
+        bindings: &Bindings,
+        answers: &Answers,
+        undecorated_idx: Idx<KeyUndecoratedFunction>,
+    ) -> bool {
+        let fun = bindings.get(undecorated_idx);
+        let return_key = Key::ReturnType(ShortIdentifier::new(&fun.def.name));
         let return_idx = bindings.key_to_idx(&return_key);
         let has_return_annotation = if let Binding::ReturnType(ret) = bindings.get(return_idx) {
             matches!(
@@ -971,10 +986,10 @@ impl ReportArgs {
             return false;
         }
 
-        // Check all parameters. Only the first parameter named self/cls may be unannotated.
-        let all_params = Self::extract_parameters(&func_def.parameters);
+        let all_params = Self::extract_parameters(&fun.def.parameters);
+        let implicit_receiver = Self::has_implicit_receiver(fun, answers, undecorated_idx);
         for (i, param) in all_params.iter().enumerate() {
-            if Self::is_self_or_cls(i, param.name.as_str()) {
+            if i == 0 && implicit_receiver {
                 continue;
             }
             if param.annotation.is_none() {
@@ -1202,13 +1217,19 @@ impl ReportArgs {
                 if let Key::Definition(_id) = bindings.idx_to_key(idx)
                     && let Binding::Function(x, _pred, _class_meta) = bindings.get(idx)
                 {
-                    let fun = bindings.get(bindings.get(*x).undecorated_idx);
+                    let decorated = bindings.get(*x);
+                    let undecorated_idx = decorated.undecorated_idx;
+                    let fun = bindings.get(undecorated_idx);
                     if let Some(func_class_key) = fun.class_key {
                         if func_class_key != class_idx {
                             continue;
                         }
                         let method_name = fun.def.name.to_string();
-                        if !Self::is_function_completely_annotated(bindings, &fun.def) {
+                        if !Self::is_function_completely_annotated(
+                            bindings,
+                            answers,
+                            undecorated_idx,
+                        ) {
                             incomplete_attributes.push(IncompleteAttribute {
                                 name: method_name.clone(),
                                 declared_in: class_name.clone(),
@@ -2011,18 +2032,16 @@ mod tests {
             }
         }
 
-        /// Check if a function is fully annotated. A function is fully annotated if
-        /// it has a return annotation and all parameters have annotations. Only the
-        /// first parameter named `self`/`cls` is exempt.
+        /// Name-based approximation of `has_implicit_receiver` for test convenience.
         fn is_fully_annotated(function: &Function) -> bool {
             if function.return_annotation.is_none() {
                 return false;
             }
-            function
-                .parameters
-                .iter()
-                .enumerate()
-                .all(|(i, p)| ReportArgs::is_self_or_cls(i, &p.name) || p.annotation.is_some())
+            let implicit_receiver = function.name == "__new__";
+            function.parameters.iter().enumerate().all(|(i, p)| {
+                (i == 0 && (p.name == "self" || p.name == "cls" || implicit_receiver))
+                    || p.annotation.is_some()
+            })
         }
 
         // Fully annotated function
@@ -2072,6 +2091,20 @@ mod tests {
             "bad_cls",
             true,
             vec![("x", true), ("cls", false)]
+        )));
+
+        // __new__ first param is exempt regardless of name
+        assert!(is_fully_annotated(&make_function(
+            "__new__",
+            true,
+            vec![("_cls", false), ("x", true)]
+        )));
+
+        // __new__ with standard "cls" name is also exempt
+        assert!(is_fully_annotated(&make_function(
+            "__new__",
+            true,
+            vec![("cls", false), ("x", true)]
         )));
     }
 

--- a/pyrefly/lib/test/report/test_files/decorators.expected.json
+++ b/pyrefly/lib/test/report/test_files/decorators.expected.json
@@ -4,9 +4,12 @@
     "test.WithDecorators.static_method",
     "test.WithDecorators.class_method",
     "test.WithDecorators.regular_method",
+    "test.RenamedReceiver.regular_method",
+    "test.RenamedReceiver.class_method",
+    "test.RenamedReceiver",
     "test.WithDecorators"
   ],
-  "line_count": 22,
+  "line_count": 31,
   "symbol_reports": [
     {
       "kind": "function",
@@ -45,6 +48,42 @@
       }
     },
     {
+      "kind": "function",
+      "name": "test.RenamedReceiver.regular_method",
+      "n_typable": 2,
+      "n_typed": 2,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 25,
+        "column": 5
+      }
+    },
+    {
+      "kind": "function",
+      "name": "test.RenamedReceiver.class_method",
+      "n_typable": 2,
+      "n_typed": 2,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 28,
+        "column": 5
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.RenamedReceiver",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 24,
+        "column": 1
+      }
+    },
+    {
       "kind": "class",
       "name": "test.WithDecorators",
       "n_typable": 0,
@@ -58,17 +97,17 @@
     }
   ],
   "type_ignores": [],
-  "n_typable": 6,
-  "n_typed": 6,
+  "n_typable": 10,
+  "n_typed": 10,
   "n_any": 0,
   "n_untyped": 0,
   "coverage": 100.0,
   "strict_coverage": 100.0,
   "n_functions": 0,
-  "n_methods": 3,
+  "n_methods": 5,
   "n_function_params": 0,
-  "n_method_params": 3,
-  "n_classes": 1,
+  "n_method_params": 5,
+  "n_classes": 2,
   "n_attrs": 0,
   "n_properties": 0,
   "n_type_ignores": 0

--- a/pyrefly/lib/test/report/test_files/decorators.py
+++ b/pyrefly/lib/test/report/test_files/decorators.py
@@ -19,3 +19,12 @@ class WithDecorators:
 
     def regular_method(self, a: int) -> str:
         return ""
+
+
+class RenamedReceiver:
+    def regular_method(_self, x: int) -> str:
+        return ""
+
+    @classmethod
+    def class_method(_cls, s: str) -> None:
+        pass

--- a/pyrefly/lib/test/report/test_files/dunder_params.expected.json
+++ b/pyrefly/lib/test/report/test_files/dunder_params.expected.json
@@ -5,12 +5,14 @@
     "test.WithGetattr.__getattr__",
     "test.WithSetattr.__setattr__",
     "test.AnnotatedExit.__exit__",
+    "test.WithNewRenamed.__new__",
     "test.AnnotatedExit",
     "test.WithExit",
     "test.WithGetattr",
+    "test.WithNewRenamed",
     "test.WithSetattr"
   ],
-  "line_count": 31,
+  "line_count": 36,
   "symbol_reports": [
     {
       "kind": "function",
@@ -61,6 +63,18 @@
       }
     },
     {
+      "kind": "function",
+      "name": "test.WithNewRenamed.__new__",
+      "n_typable": 2,
+      "n_typed": 2,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 34,
+        "column": 5
+      }
+    },
+    {
       "kind": "class",
       "name": "test.AnnotatedExit",
       "n_typable": 0,
@@ -98,6 +112,18 @@
     },
     {
       "kind": "class",
+      "name": "test.WithNewRenamed",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 33,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
       "name": "test.WithSetattr",
       "n_typable": 0,
       "n_typed": 0,
@@ -110,17 +136,17 @@
     }
   ],
   "type_ignores": [],
-  "n_typable": 7,
-  "n_typed": 4,
+  "n_typable": 9,
+  "n_typed": 6,
   "n_any": 0,
   "n_untyped": 3,
-  "coverage": 57.14285714285714,
-  "strict_coverage": 57.14285714285714,
+  "coverage": 66.66666666666666,
+  "strict_coverage": 66.66666666666666,
   "n_functions": 0,
-  "n_methods": 4,
+  "n_methods": 5,
   "n_function_params": 0,
-  "n_method_params": 4,
-  "n_classes": 4,
+  "n_method_params": 5,
+  "n_classes": 5,
   "n_attrs": 0,
   "n_properties": 0,
   "n_type_ignores": 0

--- a/pyrefly/lib/test/report/test_files/dunder_params.py
+++ b/pyrefly/lib/test/report/test_files/dunder_params.py
@@ -28,3 +28,8 @@ class WithSetattr:
 class AnnotatedExit:
     def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> bool:
         return False
+
+
+class WithNewRenamed:
+    def __new__(_cls, x: int) -> "WithNewRenamed":
+        return super().__new__(_cls)


### PR DESCRIPTION
# Summary

This adds support for detecting instance/class-bound method (first) parameters that aren't named `self` or `cls`. It will, for example, now correctly count `__new__(_cls) -> Self` as annotated. 

Fixes #3095

# Test Plan

Added unit tests and integration tests