### PR TITLE
consider partially unknown types as typed in `pyrefly report` #3096

### DIFF
--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -505,9 +505,7 @@ impl ReportArgs {
                     let is_type_known = annotation_text.is_some()
                         && answers
                             .get_idx(*annot_idx)
-                            .and_then(|awt| {
-                                awt.annotation.ty.as_ref().map(Self::is_type_fully_known)
-                            })
+                            .and_then(|awt| awt.annotation.ty.as_ref().map(Self::is_type_known))
                             .unwrap_or(false);
                     let slots = Self::classify_slot(annotation_text.is_some(), is_type_known);
                     variables.push(Variable {
@@ -699,9 +697,9 @@ impl ReportArgs {
             let is_type_known = annotation_text.is_some()
                 && annotation_idx
                     .and_then(|idx| {
-                        answers.get_idx(idx).and_then(|awt| {
-                            awt.annotation.ty.as_ref().map(Self::is_type_fully_known)
-                        })
+                        answers
+                            .get_idx(idx)
+                            .and_then(|awt| awt.annotation.ty.as_ref().map(Self::is_type_known))
                     })
                     .unwrap_or(false);
             let slots = Self::classify_slot(annotation_text.is_some(), is_type_known);
@@ -811,7 +809,7 @@ impl ReportArgs {
                 let is_return_type_known = return_annotation.is_some()
                     && answers
                         .get_type_at(return_idx)
-                        .is_some_and(|t| Self::is_type_fully_known(&t));
+                        .is_some_and(|t| Self::is_type_known(&t));
 
                 let mut parameters = Vec::new();
                 let all_params = Self::extract_parameters(&fun.def.parameters);
@@ -848,9 +846,7 @@ impl ReportArgs {
                         let annot_idx = bindings.key_to_idx(&annot_key);
                         answers
                             .get_idx(annot_idx)
-                            .and_then(|awt| {
-                                awt.annotation.ty.as_ref().map(Self::is_type_fully_known)
-                            })
+                            .and_then(|awt| awt.annotation.ty.as_ref().map(Self::is_type_known))
                             .unwrap_or(false)
                     } else {
                         false
@@ -985,9 +981,9 @@ impl ReportArgs {
         true
     }
 
-    /// Returns true if the type contains no `Any` anywhere in its structure.
-    fn is_type_fully_known(ty: &Type) -> bool {
-        !ty.any(|t| t.is_any())
+    /// Only a bare `Any` counts as unknown; container types like `list[Any]` are known.
+    fn is_type_known(ty: &Type) -> bool {
+        !ty.is_any()
     }
 
     /// Dunder methods whose return type is fully determined by the protocol
@@ -2211,5 +2207,12 @@ mod tests {
     fn test_report_inherited_attrs() {
         let report = build_module_report_for_test("inherited_attrs.py");
         compare_snapshot("inherited_attrs.expected.json", &report);
+    }
+
+    /// `list[Any]` etc. count as typed; only bare `Any` is "any".
+    #[test]
+    fn test_report_partial_any() {
+        let report = build_module_report_for_test("partial_any.py");
+        compare_snapshot("partial_any.expected.json", &report);
     }
 }

--- a/pyrefly/lib/test/report/test_files/partial_any.expected.json
+++ b/pyrefly/lib/test/report/test_files/partial_any.expected.json
@@ -1,0 +1,127 @@
+{
+  "name": "test",
+  "names": [
+    "test.x",
+    "test.y",
+    "test.z",
+    "test.w",
+    "test.v",
+    "test.container_any",
+    "test.pure_any",
+    "test.concrete"
+  ],
+  "line_count": 31,
+  "symbol_reports": [
+    {
+      "kind": "attr",
+      "name": "test.x",
+      "n_typable": 1,
+      "n_typed": 1,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 10,
+        "column": 1
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.y",
+      "n_typable": 1,
+      "n_typed": 1,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 11,
+        "column": 1
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.z",
+      "n_typable": 1,
+      "n_typed": 1,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 12,
+        "column": 1
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.w",
+      "n_typable": 1,
+      "n_typed": 0,
+      "n_any": 1,
+      "n_untyped": 0,
+      "location": {
+        "line": 15,
+        "column": 1
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.v",
+      "n_typable": 1,
+      "n_typed": 1,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 18,
+        "column": 1
+      }
+    },
+    {
+      "kind": "function",
+      "name": "test.container_any",
+      "n_typable": 2,
+      "n_typed": 2,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 21,
+        "column": 1
+      }
+    },
+    {
+      "kind": "function",
+      "name": "test.pure_any",
+      "n_typable": 2,
+      "n_typed": 0,
+      "n_any": 2,
+      "n_untyped": 0,
+      "location": {
+        "line": 25,
+        "column": 1
+      }
+    },
+    {
+      "kind": "function",
+      "name": "test.concrete",
+      "n_typable": 2,
+      "n_typed": 2,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 29,
+        "column": 1
+      }
+    }
+  ],
+  "type_ignores": [],
+  "n_typable": 11,
+  "n_typed": 8,
+  "n_any": 3,
+  "n_untyped": 0,
+  "coverage": 100.0,
+  "strict_coverage": 72.72727272727273,
+  "n_functions": 3,
+  "n_methods": 0,
+  "n_function_params": 3,
+  "n_method_params": 0,
+  "n_classes": 0,
+  "n_attrs": 5,
+  "n_properties": 0,
+  "n_type_ignores": 0
+}

--- a/pyrefly/lib/test/report/test_files/partial_any.py
+++ b/pyrefly/lib/test/report/test_files/partial_any.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any
+
+# Container types with Any type args should count as typed (not any).
+# Only a bare `Any` annotation is "100% any".
+x: list[Any] = []
+y: dict[str, Any] = {}
+z: tuple[int, Any] = (1, None)
+
+# Bare Any annotation: should count as any
+w: Any = None
+
+# Concrete annotation: should count as typed
+v: int = 0
+
+
+def container_any(a: list[Any]) -> dict[str, Any]:
+    return {}
+
+
+def pure_any(a: Any) -> Any:
+    return a
+
+
+def concrete(a: int) -> str:
+    return ""


### PR DESCRIPTION
# Summary

This ensures that annotations like `_: numpy.floating[Any]` are now treated as "typed" rather than "any".

Fixes #3096 (and #3102)

# Test Plan

Added a unit test and integration tests