### PR TITLE
Preserve function signatures through unannotated decorators (#3135)

### DIFF
--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -74,6 +74,22 @@ impl Callable {
             _ => false,
         }
     }
+
+    /// Returns true if this callable carries no real type information: all
+    /// parameters and the return type are `Any(Implicit)` (i.e. Unknown).
+    pub fn is_fully_unknown(&self) -> bool {
+        if !matches!(&self.ret, Type::Any(AnyStyle::Implicit)) {
+            return false;
+        }
+        match &self.params {
+            Params::List(params) => params
+                .items()
+                .iter()
+                .all(|p| matches!(p.as_type(), Type::Any(AnyStyle::Implicit))),
+            Params::Ellipsis => true,
+            _ => false,
+        }
+    }
 }
 
 impl Display for Callable {

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -20,6 +20,7 @@ use pyrefly_types::class::Class;
 use pyrefly_types::class::ClassType;
 use pyrefly_types::dimension::SizeExpr;
 use pyrefly_types::quantified::Quantified;
+use pyrefly_types::types::AnyStyle;
 use pyrefly_types::types::BoundMethod;
 use pyrefly_types::types::BoundMethodType;
 use pyrefly_types::types::TParams;
@@ -1441,6 +1442,21 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     Type::Function(f) => f.signature.is_args_kwargs_wrapper(),
                     Type::Callable(c) => c.is_args_kwargs_wrapper(),
                     Type::ClassType(cls) => cls.has_qname("functools", "_Wrapped"),
+                    _ => false,
+                }) =>
+            {
+                original_decoratee.clone()
+            }
+            // If the decorator's return type is a union where every member is
+            // fully unknown (either Unknown itself or a callable with all-Unknown
+            // params and return), the decorator is completely unannotated and its
+            // return carries no useful type information. Preserve the original
+            // function signature rather than replacing it with a useless union.
+            Type::Union(ref u)
+                if u.members.iter().all(|m| match m {
+                    Type::Function(f) => f.signature.is_fully_unknown(),
+                    Type::Callable(c) => c.is_fully_unknown(),
+                    Type::Any(AnyStyle::Implicit) => true,
                     _ => false,
                 }) =>
             {

--- a/pyrefly/lib/test/decorators.rs
+++ b/pyrefly/lib/test/decorators.rs
@@ -713,6 +713,34 @@ assert_type(r2, int)
     "#,
 );
 
+testcase!(
+    test_unannotated_decorator_preserves_signature,
+    r#"
+from typing import assert_type
+
+def make_decorator(target, decorator_func):
+    decorator_func.__name__ = target.__name__
+    return decorator_func
+
+def add_dispatch_support(target=None):
+    def decorator(dispatch_target):
+        def op_dispatch_handler(*args, **kwargs):
+            return dispatch_target(*args, **kwargs)
+        op_dispatch_handler = make_decorator(dispatch_target, op_dispatch_handler)
+        return op_dispatch_handler
+    if target is None:
+        return decorator
+    return decorator(target)
+
+@add_dispatch_support
+def matmul(a: int, b: int, name: str | None = None) -> int:
+    return a + b
+
+r = matmul(1, 2, name="test")
+assert_type(r, int)
+    "#,
+);
+
 fn env_numba() -> TestEnv {
     let mut env = TestEnv::one_with_path(
         "numba",


### PR DESCRIPTION
Summary:

When a decorator is fully unannotated, Pyrefly infers Unknown for all return paths, producing a union like ((dispatch_target: Unknown) -> Unknown) | Unknown. This union carries no useful type information but replaces the original function's signature, causing cascading false positives.

In this diff, we extend the heuristic as follows: if every member of the decorator's return union is "fully unknown" (either Unknown itself, or a callable where all parameters and the return type are Unknown), preserve the original function signature.

Reduces TensorFlow errors from 21,007 to 16,213 (~23% reduction, ~4,794 fewer false positives).

Differential Revision:
D100840454

https://github.com/facebook/pyrefly/issues/2621

D100840454

Reviewed By: grievejia
