### PR TITLE
Do not exclude explicit any from decorator heuristic

### DIFF
--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -51,12 +51,12 @@ pub struct Callable {
 
 impl Callable {
     /// Returns true if this callable has only *args and **kwargs parameters
-    /// (plus an optional unannotated self/cls at index 0) and no return type
-    /// annotation. Used as a heuristic in decorator type resolution: when a
-    /// decorator returns a union containing such a wrapper, the decorator is
-    /// treated as preserving the original function's signature.
+    /// (plus an optional unannotated self/cls at index 0) and an `Any` return
+    /// type (implicit or explicit). Used as a heuristic in decorator type
+    /// resolution: when a decorator returns a union containing such a wrapper,
+    /// the decorator is treated as preserving the original function's signature.
     pub fn is_args_kwargs_wrapper(&self) -> bool {
-        if !matches!(&self.ret, Type::Any(AnyStyle::Implicit)) {
+        if !matches!(&self.ret, Type::Any(_)) {
             return false;
         }
         match &self.params {

--- a/pyrefly/lib/test/decorators.rs
+++ b/pyrefly/lib/test/decorators.rs
@@ -713,6 +713,43 @@ assert_type(r2, int)
     "#,
 );
 
+testcase!(
+    test_dual_use_decorator_explicit_any,
+    r#"
+import functools  # noqa: E402
+from typing import Any
+
+
+def add_dispatch_support(target=None, iterable_parameters=None):  # type: ignore[no-untyped-def]
+    """Decorator with optional args. Can be used as @deco or @deco()."""
+
+    def decorator(dispatch_target):  # type: ignore[no-untyped-def]
+        @functools.wraps(dispatch_target)
+        def op_dispatch_handler(*args: Any, **kwargs: Any) -> Any:
+            return dispatch_target(*args, **kwargs)
+
+        return op_dispatch_handler
+
+    if target is not None:
+        return decorator(target)
+    return decorator
+
+
+@add_dispatch_support
+def matmul(
+    a: list[list[float]],
+    b: list[list[float]],
+    name: str | None = None,
+) -> list[list[float]]:
+    return a
+
+
+result = matmul(
+    [[1.0]], [[2.0]], name="test"
+)  # FP: Unexpected keyword argument `name` in function `decorator`
+    "#,
+);
+
 fn env_numba() -> TestEnv {
     let mut env = TestEnv::one_with_path(
         "numba",


### PR DESCRIPTION
Summary: The heuristic should also apply to explicit any.

Differential Revision: D100837079


