### PR TITLE
Fix support for inmemory files in `did_open`

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -3496,7 +3496,7 @@ impl Server {
         let path = url
             .to_file_path()
             .or_else(|_| {
-                if url.scheme() == "untitled" {
+                if url.scheme() == "untitled" || url.scheme() == "inmemory" {
                     Ok(self
                         .unsaved_file_tracker
                         .ensure_path_for_open(&url, "python"))

--- a/pyrefly/lib/test/lsp/lsp_interaction/unsaved_file.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/unsaved_file.rs
@@ -67,3 +67,57 @@ math.
 
     interaction.shutdown().unwrap();
 }
+
+#[test]
+fn test_semantic_tokens_for_inmemory_file() {
+    let interaction = LspInteraction::new();
+    interaction
+        .initialize(InitializeSettings::default())
+        .unwrap();
+
+    let uri = Url::parse("inmemory:/repl-python-00000000-0000-0000-0000-000000000001").unwrap();
+    let text = r#"def foo():
+    return 1
+
+foo()
+"#;
+    interaction.client.did_open_uri(&uri, "python", text);
+
+    interaction
+        .client
+        .send_request::<SemanticTokensFullRequest>(json!({
+            "textDocument": { "uri": uri.to_string() }
+        }))
+        .expect_response_with(|response| match response {
+            Some(SemanticTokensResult::Tokens(xs)) => !xs.data.is_empty(),
+            _ => false,
+        })
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_completion_for_inmemory_file() {
+    let interaction = LspInteraction::new();
+    interaction
+        .initialize(InitializeSettings::default())
+        .unwrap();
+
+    let uri = Url::parse("inmemory:/repl-python-00000000-0000-0000-0000-000000000002").unwrap();
+    let text = r#"import math
+math.
+"#;
+    interaction.client.did_open_uri(&uri, "python", text);
+
+    interaction
+        .client
+        .send_request::<Completion>(json!({
+            "textDocument": {"uri": uri.to_string()},
+            "position": {"line": 1, "character": 5}
+        }))
+        .expect_completion_response_with(|list| !list.items.is_empty())
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}


### PR DESCRIPTION
I didn't make an issue for this, but I can first if you'd like!

# Summary

One-line change to fix `inmemory` documents (e.g. the [Positron](https://positron.posit.co/blog/posts/2026-03-31-python-type-checkers/) Console) failing to be registered with the server on Windows.

This is a follow-up to #1637, which added `inmemory` to the extension's `documentSelector`. That change works on Mac/Linux but not on Windows because the LSP server's `did_open` rejects `inmemory` URIs on that platform.

### Root cause

When `did_open` receives an `inmemory` URI like `inmemory:/repl-python-<uuid>`, it calls `Url::to_file_path()`. That method doesn't check the URI scheme, it just converts path segments into a platform path. On Mac/Linux this happens to succeed (producing `/repl-python-<uuid>`), but on Windows it fails because `file_url_segments_to_pathbuf_windows` requires the first path segment to be a drive letter like `C:`.

After `to_file_path()` fails, the fallback in `did_open` only accepts `untitled`, so `inmemory` documents are silently rejected on Windows and never registered. But the fallback should work for both schemes.

### Fix

Extend the scheme check in `did_open` to also accept `inmemory`, routing it through the `UnsavedFileTracker`. This makes the behavior consistent across platforms instead of relying on `to_file_path()` accidentally succeeding on Unix.

I added tests for semantic tokens and completions on `inmemory` documents, mirroring the existing `untitled` tests, so regressions here will be caught going forward.

# Test Plan

- [x] Existing `unsaved_file` tests still pass
- [x] New tests pass
- [x] Verified completions and semantic highlighting work in Positron Console on Windows
- [x] Verified they still work in Positron Console on Mac
- [x] Ran `test.py` (no changes)