### PR TITLE
Assume unannotated `__new__` returns `Self`

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -4089,7 +4089,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             } else {
                 Instance::of_class(cls)
             };
-            Arc::unwrap_or_clone(new_member.value).as_raw_special_method_type(self.heap, &instance)
+            let assume_self_return = new_member.value.is_function_without_return_annotation();
+            let mut new_ty = Arc::unwrap_or_clone(new_member.value)
+                .as_raw_special_method_type(self.heap, &instance)?;
+            if assume_self_return {
+                // Per the constructor typing spec, unannotated `__new__` may be assumed to
+                // return `Self` for constructor analysis.
+                let ret = if preserve_self {
+                    self.heap.mk_self_type(cls.clone())
+                } else {
+                    self.heap.mk_class_type(cls.clone())
+                };
+                new_ty.transform_toplevel_callable(&mut |callable: &mut Callable| {
+                    callable.ret = ret.clone();
+                });
+            }
+            Some(new_ty)
         }
     }
 

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -1189,7 +1189,7 @@ class C:
         if orig_func is None:
             return super().__new__(cls)
 def f():
-    with C():  # E: `NoneType` has no attribute `__enter__`  # E: `NoneType` has no attribute `__exit__`
+    with C():
         pass
     "#,
 );

--- a/pyrefly/lib/test/constructors.rs
+++ b/pyrefly/lib/test/constructors.rs
@@ -989,6 +989,28 @@ C("5")  # E: Argument `Literal['5']` is not assignable to parameter `x` with typ
     "#,
 );
 
+// Regression test for a problem in networkx: https://github.com/facebook/pyrefly/issues/3121
+testcase!(
+    bug = "Following the typing spec, we may assume unannotated `__new__` returns Self, which would avoid bad behaviors in some complex, dynamically-typed codebases",
+    test_return_type_inference_for_constructors,
+    r#"
+from typing import assert_type
+
+class A:
+    def __new__(cls, x: int | None = None):
+        if x is None:
+            return cls.__new__(cls, 5)
+        else:
+            return object.__new__(cls)
+    
+    def __init__(cls):
+        return "x"
+
+a = A()
+assert_type(a, A)  # E: assert_type(A | Unknown, A)
+"#,
+);
+
 testcase!(
     test_redundant_dict_constructor_call_ok,
     r#"

--- a/pyrefly/lib/test/constructors.rs
+++ b/pyrefly/lib/test/constructors.rs
@@ -991,7 +991,6 @@ C("5")  # E: Argument `Literal['5']` is not assignable to parameter `x` with typ
 
 // Regression test for a problem in networkx: https://github.com/facebook/pyrefly/issues/3121
 testcase!(
-    bug = "Following the typing spec, we may assume unannotated `__new__` returns Self, which would avoid bad behaviors in some complex, dynamically-typed codebases",
     test_return_type_inference_for_constructors,
     r#"
 from typing import assert_type
@@ -1006,8 +1005,12 @@ class A:
     def __init__(cls):
         return "x"
 
+class B(A): ...
+
 a = A()
-assert_type(a, A)  # E: assert_type(A | Unknown, A)
+assert_type(a, A)
+b = B()
+assert_type(b, B)
 "#,
 );
 


### PR DESCRIPTION
Summary:
This fixes some pretty bad behaviors when dealing with return type
inference on complex code that is really dynamically typed, but can
be approximated by normal static typing (specifically, the
networkx `_dispatch` class).

In general, getting bad return type inference on constructors can
fan out to a lot of errors, so this is a nice way to reduce FPs
against untyped dependencies that might do complicated, dynamic things.

It is consistent with the typing spec to do this. Note that `networkx` isn't
in mypy primer, but we actually get a significant error reduction on `sympy` which
is a good sign that this is a real improvement in practice on untyped code
beyond just the one motivating example.

Fixes https://github.com/facebook/pyrefly/issues/3120

Differential Revision: D100686394


