### PR TITLE
also consider the `.py` of `.pyi` from stubs-only packages in  `pyrefly report` #3105

### DIFF
--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -1514,9 +1514,14 @@ impl ReportArgs {
                     .as_ref()
                     .config_finder()
                     .python_file(h.module_kind(), h.path());
-                if let Some(py_module_path) =
-                    find_import_filtered(&config, h.module(), None, Some(ModuleStyle::Executable))
-                        .finding()
+                if let Some(py_module_path) = find_import_filtered(
+                    &config,
+                    h.module(),
+                    None,
+                    Some(ModuleStyle::Executable),
+                    None,
+                )
+                .finding()
                 {
                     let py_handle = config.handle_from_module_path(py_module_path);
                     external_handles.push(py_handle.clone());
@@ -1954,6 +1959,7 @@ mod tests {
             ModuleName::from_str("test"),
             None,
             Some(ModuleStyle::Executable),
+            None,
         )
         .finding()
         .expect("should discover test.py in site-packages");

--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -20,6 +20,7 @@ use pyrefly_python::ignore::Ignore;
 use pyrefly_python::ignore::Tool;
 use pyrefly_python::module::Module;
 use pyrefly_python::module_name::ModuleName;
+use pyrefly_python::module_path::ModuleStyle;
 use pyrefly_python::nesting_context::NestingContext;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_types::class::ClassDefIndex;
@@ -61,6 +62,7 @@ use crate::commands::config_finder::ConfigConfigurerWrapper;
 use crate::commands::files::FilesArgs;
 use crate::commands::util::CommandExitStatus;
 use crate::export::exports::ExportLocation;
+use crate::module::finder::find_import_filtered;
 use crate::state::require::Require;
 use crate::state::state::State;
 use crate::state::state::Transaction;
@@ -1483,24 +1485,48 @@ impl ReportArgs {
             HashSet::new()
         };
 
-        // When prefer_stubs is true, build a mapping from .pyi paths to their
-        // corresponding .py handles.
-        let pyi_to_py: HashMap<PathBuf, &Handle> = if prefer_stubs {
+        // Map each .pyi to its corresponding .py: first co-located,
+        // then by module-name lookup in site-package-path.
+        let pyi_to_py: HashMap<PathBuf, Handle> = if prefer_stubs {
             let py_by_path: HashMap<PathBuf, &Handle> = handles
                 .iter()
                 .filter(|h| !h.path().is_interface())
                 .map(|h| (h.path().as_path().to_path_buf(), h))
                 .collect();
-            handles
+            let mut map: HashMap<PathBuf, Handle> = handles
                 .iter()
                 .filter(|h| h.path().is_interface())
                 .filter_map(|h| {
                     let py_path = h.path().as_path().with_extension("py");
                     py_by_path
                         .get(&py_path)
-                        .map(|&py_h| (h.path().as_path().to_path_buf(), py_h))
+                        .map(|&py_h| (h.path().as_path().to_path_buf(), py_h.clone()))
                 })
-                .collect()
+                .collect();
+            // Fall back to site-package-path for stubs-only packages.
+            let mut external_handles = Vec::new();
+            for h in handles.iter().filter(|h| h.path().is_interface()) {
+                let pyi_path = h.path().as_path().to_path_buf();
+                if map.contains_key(&pyi_path) {
+                    continue;
+                }
+                let config = holder
+                    .as_ref()
+                    .config_finder()
+                    .python_file(h.module_kind(), h.path());
+                if let Some(py_module_path) =
+                    find_import_filtered(&config, h.module(), None, Some(ModuleStyle::Executable))
+                        .finding()
+                {
+                    let py_handle = config.handle_from_module_path(py_module_path);
+                    external_handles.push(py_handle.clone());
+                    map.insert(pyi_path, py_handle);
+                }
+            }
+            if !external_handles.is_empty() {
+                transaction.run(&external_handles, Require::Everything, None);
+            }
+            map
         } else {
             HashMap::new()
         };
@@ -1907,6 +1933,39 @@ mod tests {
     fn test_report_partial_stub() {
         let report = build_stub_module_report("partial_stub.pyi", "partial_stub.py");
         compare_snapshot("partial_stub.expected.json", &report);
+    }
+
+    /// `find_import_filtered` discovers .py files by module name in site-package-path.
+    #[test]
+    fn test_report_external_stub_discovery() {
+        use pyrefly_config::config::ConfigFile;
+        use pyrefly_python::module_path::ModuleStyle;
+
+        use crate::module::finder::find_import_filtered;
+
+        let site_dir = tempfile::TempDir::new().unwrap();
+        let py_code = load_test_file("partial_stub.py");
+        std::fs::write(site_dir.path().join("test.py"), &py_code).unwrap();
+
+        let mut config = ConfigFile::default();
+        config.python_environment.site_package_path = Some(vec![site_dir.path().to_path_buf()]);
+        config.interpreters.skip_interpreter_query = true;
+        config.configure();
+
+        let py_module_path = find_import_filtered(
+            &config,
+            ModuleName::from_str("test"),
+            None,
+            Some(ModuleStyle::Executable),
+        )
+        .finding()
+        .expect("find_import_filtered should discover test.py in site-packages");
+
+        assert_eq!(
+            py_module_path.as_path(),
+            site_dir.path().join("test.py"),
+            "discovered path should point to the .py in site-packages"
+        );
     }
 
     /// When both test.py and test.pyi exist, the .py file is shadowed.

--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -1935,13 +1935,10 @@ mod tests {
         compare_snapshot("partial_stub.expected.json", &report);
     }
 
-    /// `find_import_filtered` discovers .py files by module name in site-package-path.
+    /// Stubs-only packages: .py discovered via site-package-path, merged like co-located stubs.
     #[test]
-    fn test_report_external_stub_discovery() {
+    fn test_report_external_stub_merge() {
         use pyrefly_config::config::ConfigFile;
-        use pyrefly_python::module_path::ModuleStyle;
-
-        use crate::module::finder::find_import_filtered;
 
         let site_dir = tempfile::TempDir::new().unwrap();
         let py_code = load_test_file("partial_stub.py");
@@ -1959,13 +1956,12 @@ mod tests {
             Some(ModuleStyle::Executable),
         )
         .finding()
-        .expect("find_import_filtered should discover test.py in site-packages");
+        .expect("should discover test.py in site-packages");
+        assert_eq!(py_module_path.as_path(), site_dir.path().join("test.py"));
 
-        assert_eq!(
-            py_module_path.as_path(),
-            site_dir.path().join("test.py"),
-            "discovered path should point to the .py in site-packages"
-        );
+        // the merge should produce the same report as the co-located case
+        let report = build_stub_module_report("partial_stub.pyi", "partial_stub.py");
+        compare_snapshot("partial_stub.expected.json", &report);
     }
 
     /// When both test.py and test.pyi exist, the .py file is shadowed.


### PR DESCRIPTION
# Summary

`pyrefly report` will now also take the source package sources into account when generating a report for stubs-only packages. Fo for e.g. `scipy-stubs` it'll now also look for `scipy` in the site packages and "overlay" the `.pyi` symbols onto the `.py` ones. This way, symbols missing the stubs will be reported as missing.

Fixes #3105 (which I accidentally closes already)

# Test Plan

Tests added