### PR TITLE
public symbol filtering with `pyrefly report --public-only` #3104

### DIFF
--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -291,6 +291,35 @@ enum SymbolReport {
     },
 }
 
+impl SymbolReport {
+    fn name(&self) -> &str {
+        match self {
+            Self::Attr { name, .. }
+            | Self::Function { name, .. }
+            | Self::Class { name, .. }
+            | Self::Property { name, .. } => name,
+        }
+    }
+
+    fn name_mut(&mut self) -> &mut String {
+        match self {
+            Self::Attr { name, .. }
+            | Self::Function { name, .. }
+            | Self::Class { name, .. }
+            | Self::Property { name, .. } => name,
+        }
+    }
+
+    fn slots(&self) -> &SlotCounts {
+        match self {
+            Self::Attr { slots, .. }
+            | Self::Function { slots, .. }
+            | Self::Class { slots, .. }
+            | Self::Property { slots, .. } => slots,
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 struct ModuleReport {
     /// Fully-qualified module name (e.g. "mypackage.submodule").
@@ -361,6 +390,10 @@ pub struct ReportArgs {
     /// from its filesystem layout.
     #[clap(long)]
     module: Option<String>,
+
+    /// Only report symbols reachable from public modules via re-export chains.
+    #[clap(long)]
+    public_only: bool,
 }
 
 impl ReportArgs {
@@ -376,6 +409,7 @@ impl ReportArgs {
             config_finder,
             self.prefer_stubs,
             self.module,
+            self.public_only,
             thread_count,
         )
     }
@@ -543,9 +577,122 @@ impl ReportArgs {
         !name.starts_with('_') || name.ends_with("__")
     }
 
+    /// A module is public when every dotted-path component is public.
+    fn is_public_module(module: ModuleName) -> bool {
+        module.as_str().split('.').all(Self::is_public_name)
+    }
+
+    /// True if `fqn` or any class-level prefix of it is in the public set.
+    fn is_public_fqn(fqn: &str, module_prefix: &str, public_fqns: &HashSet<String>) -> bool {
+        let start = module_prefix.len();
+        public_fqns.contains(fqn)
+            || fqn[start..]
+                .match_indices('.')
+                .any(|(i, _)| public_fqns.contains(&fqn[..start + i]))
+    }
+
     /// Module-level dunders that typestats always excludes from the report.
     const EXCLUDED_MODULE_DUNDERS: &'static [&'static str] =
         &["__all__", "__dir__", "__doc__", "__getattr__"];
+
+    /// Collect origin FQNs of all publicly exported names across public modules.
+    fn compute_public_fqns(handles: &[Handle], transaction: &Transaction) -> HashSet<String> {
+        handles
+            .iter()
+            .filter(|h| Self::is_public_module(h.module()))
+            .flat_map(|handle| {
+                let exports_data = transaction.get_exports_data(handle);
+                let exports = transaction.get_exports(handle);
+
+                // prioritize `__all__` if present, otherwise local defs + `import x as x`
+                let names: Vec<Name> =
+                    if let Some(all_iter) = exports_data.get_explicit_dunder_all_names_iter() {
+                        all_iter.cloned().collect()
+                    } else {
+                        exports
+                            .iter()
+                            .filter_map(|(name, loc)| {
+                                let is_local = matches!(loc, ExportLocation::ThisModule(_));
+                                let is_reexport = exports_data.is_explicit_reexport(name);
+                                (Self::is_public_name(name.as_str()) && (is_local || is_reexport))
+                                    .then_some(name.clone())
+                            })
+                            .collect()
+                    };
+
+                // follow re-export chains to the origin FQN
+                names
+                    .into_iter()
+                    .filter(|n| !Self::EXCLUDED_MODULE_DUNDERS.contains(&n.as_str()))
+                    .filter_map(move |mut cur_name| {
+                        let mut seen = HashSet::new();
+                        let mut cur_handle = handle.clone();
+                        loop {
+                            let module_name = cur_handle.module();
+                            if !seen.insert((module_name, cur_name.clone())) {
+                                return None;
+                            }
+                            let cur_exports = transaction.get_exports(&cur_handle);
+                            match cur_exports.get(&cur_name) {
+                                Some(ExportLocation::ThisModule(_)) | None => {
+                                    return Some(format!("{module_name}.{cur_name}"));
+                                }
+                                Some(ExportLocation::OtherModule(other_module, alias)) => {
+                                    if let Some(alias) = alias {
+                                        cur_name = alias.clone();
+                                    }
+                                    cur_handle = transaction
+                                        .import_handle(&cur_handle, *other_module, None)
+                                        .finding()?;
+                                }
+                            }
+                        }
+                    })
+            })
+            .collect()
+    }
+
+    /// Retain only publicly reachable symbols and recalculate aggregates.
+    fn filter_module_report_to_public(report: &mut ModuleReport, public_fqns: &HashSet<String>) {
+        let module_prefix = format!("{}.", report.name);
+
+        report
+            .symbol_reports
+            .retain(|sym| Self::is_public_fqn(sym.name(), &module_prefix, public_fqns));
+        report
+            .names
+            .retain(|n| Self::is_public_fqn(n, &module_prefix, public_fqns));
+
+        // recompute all aggregates in a single pass
+        let (slots, meth, fun, cls, attr, prop) = report.symbol_reports.iter().fold(
+            (SlotCounts::default(), 0, 0, 0, 0, 0),
+            |(slots, meth, fun, cls, attr, prop), sym| match sym {
+                SymbolReport::Function { name, .. } if Self::is_method(name, &module_prefix) => {
+                    (slots.merge(*sym.slots()), meth + 1, fun, cls, attr, prop)
+                }
+                SymbolReport::Function { .. } => {
+                    (slots.merge(*sym.slots()), meth, fun + 1, cls, attr, prop)
+                }
+                SymbolReport::Class { .. } => {
+                    (slots.merge(*sym.slots()), meth, fun, cls + 1, attr, prop)
+                }
+                SymbolReport::Attr { .. } => {
+                    (slots.merge(*sym.slots()), meth, fun, cls, attr + 1, prop)
+                }
+                SymbolReport::Property { .. } => {
+                    (slots.merge(*sym.slots()), meth, fun, cls, attr, prop + 1)
+                }
+            },
+        );
+        report.slots = slots;
+        report.coverage = slots.coverage();
+        report.strict_coverage = slots.strict_coverage();
+        report.n_methods = meth;
+        report.n_functions = fun;
+        report.n_classes = cls;
+        report.n_attrs = attr;
+        report.n_properties = prop;
+    }
 
     /// True if the first parameter is the implicit receiver (`self`/`cls`),
     /// excluded from slot counting. `__new__` is a staticmethod but still takes cls.
@@ -1615,6 +1762,7 @@ impl ReportArgs {
         config_finder: ConfigFinder,
         prefer_stubs: bool,
         module_name_override: Option<String>,
+        public_only: bool,
         thread_count: ThreadCount,
     ) -> anyhow::Result<CommandExitStatus> {
         let expanded_file_list = config_finder.checkpoint(files_to_check.files())?;
@@ -1769,12 +1917,7 @@ impl ReportArgs {
                         }
                     }
                     for sym in &mut module_report.symbol_reports {
-                        let sym_name = match sym {
-                            SymbolReport::Attr { name, .. }
-                            | SymbolReport::Function { name, .. }
-                            | SymbolReport::Class { name, .. }
-                            | SymbolReport::Property { name, .. } => name,
-                        };
+                        let sym_name = sym.name_mut();
                         if let Some(rest) = sym_name.strip_prefix(&old_prefix) {
                             *sym_name = format!("{new_prefix}{rest}");
                         }
@@ -1782,6 +1925,14 @@ impl ReportArgs {
                 }
                 module_reports.push(module_report);
             }
+        }
+
+        if public_only {
+            let public_fqns = Self::compute_public_fqns(&handles, transaction);
+            for report in &mut module_reports {
+                Self::filter_module_report_to_public(report, &public_fqns);
+            }
+            module_reports.retain(|r| !r.symbol_reports.is_empty());
         }
 
         let summary = Self::calculate_summary(&module_reports);
@@ -1907,12 +2058,7 @@ mod tests {
             }
         }
         for sym in &mut report.symbol_reports {
-            let sym_name = match sym {
-                SymbolReport::Attr { name, .. }
-                | SymbolReport::Function { name, .. }
-                | SymbolReport::Class { name, .. }
-                | SymbolReport::Property { name, .. } => name,
-            };
+            let sym_name = sym.name_mut();
             if let Some(rest) = sym_name.strip_prefix(&old_prefix) {
                 *sym_name = format!("{new_prefix}{rest}");
             }
@@ -2453,5 +2599,197 @@ mod tests {
     fn test_report_type_aliases() {
         let report = build_module_report_for_test("type_aliases.py");
         compare_snapshot("type_aliases.expected.json", &report);
+    }
+
+    // ──── --public-only tests ────
+
+    #[test]
+    fn test_is_public_module() {
+        let public = |s| ReportArgs::is_public_module(ModuleName::from_str(s));
+        assert!(public("pkg"));
+        assert!(public("pkg.sub"));
+        assert!(!public("pkg._internal"));
+        assert!(!public("_pkg"));
+        assert!(!public("pkg._internal.sub"));
+    }
+
+    #[test]
+    fn test_is_fqn_public() {
+        let fqns: HashSet<String> = ["pkg.Foo", "pkg.bar"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let public = |s| ReportArgs::is_public_fqn(s, "pkg.", &fqns);
+        assert!(public("pkg.Foo"));
+        assert!(public("pkg.bar"));
+        assert!(public("pkg.Foo.method")); // class member of a public class
+        assert!(public("pkg.Foo.Inner.attr"));
+        assert!(!public("pkg.Baz"));
+        assert!(!public("pkg.Baz.method"));
+    }
+
+    #[test]
+    fn test_filter_module_report_to_public() {
+        let loc = |line| Location { line, column: 1 };
+        let mut report = ModuleReport {
+            name: "pkg".to_owned(),
+            names: vec!["pkg.Foo".into(), "pkg.bar".into(), "pkg._private".into()],
+            line_count: 10,
+            symbol_reports: vec![
+                SymbolReport::Class {
+                    name: "pkg.Foo".into(),
+                    slots: SlotCounts::default(),
+                    location: loc(1),
+                },
+                SymbolReport::Function {
+                    name: "pkg.Foo.method".into(),
+                    slots: SlotCounts::typed(),
+                    location: loc(2),
+                },
+                SymbolReport::Function {
+                    name: "pkg.bar".into(),
+                    slots: SlotCounts::untyped(),
+                    location: loc(3),
+                },
+                SymbolReport::Attr {
+                    name: "pkg._private".into(),
+                    slots: SlotCounts::typed(),
+                    location: loc(4),
+                },
+            ],
+            type_ignores: vec![],
+            slots: SlotCounts::default(),
+            coverage: 100.0,
+            strict_coverage: 100.0,
+            n_functions: 2,
+            n_methods: 0,
+            n_function_params: 0,
+            n_method_params: 0,
+            n_classes: 1,
+            n_attrs: 1,
+            n_properties: 0,
+            n_type_ignores: 0,
+        };
+
+        let public_fqns: HashSet<String> = ["pkg.Foo", "pkg.bar"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        ReportArgs::filter_module_report_to_public(&mut report, &public_fqns);
+
+        assert_eq!(report.names, vec!["pkg.Foo", "pkg.bar"]);
+        assert_eq!(report.symbol_reports.len(), 3); // Foo, Foo.method, bar
+        assert_eq!(report.n_functions, 1);
+        assert_eq!(report.n_methods, 1);
+        assert_eq!(report.n_classes, 1);
+        assert_eq!(report.n_attrs, 0);
+    }
+
+    #[test]
+    fn test_compute_public_fqns() {
+        let compute = |modules: &[(&str, &str, &str)], handle_names: &[&str]| -> HashSet<String> {
+            let mut env = TestEnv::new();
+            for &(name, path, source) in modules {
+                env.add_with_path(name, path, source);
+            }
+            let env = env.with_default_require_level(Require::Everything);
+            let (state, handle_fn) = env.to_state();
+            let transaction = state.transaction();
+            let handles: Vec<_> = handle_names.iter().map(|n| handle_fn(n)).collect();
+            ReportArgs::compute_public_fqns(&handles, &transaction)
+        };
+
+        // Re-export from a private module traces to its origin FQN
+        let fqns = compute(
+            &[
+                (
+                    "pkg",
+                    "pkg/__init__.py",
+                    "from pkg._internal import Foo\n__all__ = [\"Foo\"]\n",
+                ),
+                (
+                    "pkg._internal",
+                    "pkg/_internal.py",
+                    "class Foo:\n    x: int = 1\n",
+                ),
+            ],
+            &["pkg", "pkg._internal"],
+        );
+        assert!(fqns.contains("pkg._internal.Foo"));
+        assert!(!fqns.contains("pkg.Foo"));
+
+        // Without __all__, non-underscore local names are exported
+        let fqns = compute(
+            &[(
+                "pkg",
+                "pkg/__init__.py",
+                "def foo() -> int: ...\ndef _private(): ...\n",
+            )],
+            &["pkg"],
+        );
+        assert!(fqns.contains("pkg.foo"));
+        assert!(!fqns.contains("pkg._private"));
+
+        // Regular imports (not `import x as x`) are not re-exports
+        let fqns = compute(
+            &[
+                (
+                    "pkg",
+                    "pkg/__init__.py",
+                    "from pkg._internal import helper\ndef local_fn() -> int: ...\n",
+                ),
+                (
+                    "pkg._internal",
+                    "pkg/_internal.py",
+                    "def helper() -> int: ...\n",
+                ),
+            ],
+            &["pkg", "pkg._internal"],
+        );
+        assert!(fqns.contains("pkg.local_fn"));
+        assert!(!fqns.contains("pkg._internal.helper"));
+
+        // `import x as x` is an implicit re-export when there is no __all__
+        let fqns = compute(
+            &[
+                (
+                    "pkg",
+                    "pkg/__init__.py",
+                    "from pkg._internal import helper as helper\n",
+                ),
+                (
+                    "pkg._internal",
+                    "pkg/_internal.py",
+                    "def helper() -> int: ...\n",
+                ),
+            ],
+            &["pkg", "pkg._internal"],
+        );
+        assert!(fqns.contains("pkg._internal.helper"));
+
+        // __all__ takes precedence over `import x as x`
+        let fqns = compute(
+            &[
+                (
+                    "pkg",
+                    "pkg/__init__.py",
+                    concat!(
+                        "from pkg._internal import foo as foo\n",
+                        "from pkg._internal import bar\n",
+                        "baz: int = 1\n",
+                        "__all__ = [\"bar\"]\n",
+                    ),
+                ),
+                (
+                    "pkg._internal",
+                    "pkg/_internal.py",
+                    "def foo() -> int: ...\ndef bar() -> int: ...\n",
+                ),
+            ],
+            &["pkg", "pkg._internal"],
+        );
+        assert!(fqns.contains("pkg._internal.bar"));
+        assert!(!fqns.contains("pkg._internal.foo"));
+        assert!(!fqns.contains("pkg.baz"));
     }
 }

--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -675,6 +675,9 @@ impl ReportArgs {
         report.n_classes = 0;
         report.n_attrs = 0;
         report.n_properties = 0;
+        // `n_type_ignores` is not affected by public filtering since type ignores are always
+        // attached to the module itself, not individual symbols, so we don't need to recalculate
+        // it here.
 
         for sym in &report.symbol_reports {
             report.slots = report.slots.merge(*sym.slots());

--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -6,6 +6,7 @@
  */
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -1984,6 +1985,7 @@ impl ReportArgs {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::path::PathBuf;
 
     use dupe::Dupe;

--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -405,6 +405,11 @@ impl ReportArgs {
         thread_count: ThreadCount,
     ) -> anyhow::Result<CommandExitStatus> {
         self.config_override.validate()?;
+
+        if self.public_only && self.module.is_some() {
+            anyhow::bail!("--module and --public-only cannot be combined");
+        }
+
         let (files_to_check, config_finder) = self.files.resolve(self.config_override, wrapper)?;
         Self::run_inner(
             files_to_check,
@@ -584,8 +589,15 @@ impl ReportArgs {
         module.as_str().split('.').all(Self::is_public_name)
     }
 
-    /// True if `fqn` or any class-level prefix of it is in the public set.
+    /// True if `fqn` or a class-level prefix is public, and every segment below the module is
+    /// itself a public name (no private nested leaks).
     fn is_public_fqn(fqn: &str, module_prefix: &str, public_fqns: &HashSet<String>) -> bool {
+        if let Some(relative) = fqn.strip_prefix(module_prefix)
+            && !relative.split('.').all(Self::is_public_name)
+        {
+            return false;
+        }
+
         public_fqns.contains(fqn)
             || std::iter::successors(fqn.rsplit_once('.').map(|(prefix, _)| prefix), |prefix| {
                 prefix.rsplit_once('.').map(|(parent, _)| parent)
@@ -597,6 +609,37 @@ impl ReportArgs {
     /// Module-level dunders that typestats always excludes from the report.
     const EXCLUDED_MODULE_DUNDERS: &'static [&'static str] =
         &["__all__", "__dir__", "__doc__", "__getattr__"];
+
+    /// Walk re-exports to the defining module's FQN, `None` on cycle/miss.
+    fn trace_export_origin(
+        handle: &Handle,
+        mut cur_name: Name,
+        transaction: &Transaction,
+    ) -> Option<String> {
+        let mut seen = SmallSet::new();
+        let mut cur_handle = handle.clone();
+
+        loop {
+            let module_name = cur_handle.module();
+            if !seen.insert((module_name, cur_name.clone())) {
+                return None;
+            }
+
+            match transaction.get_exports(&cur_handle).get(&cur_name) {
+                Some(ExportLocation::ThisModule(_)) | None => {
+                    return Some(format!("{module_name}.{cur_name}"));
+                }
+                Some(ExportLocation::OtherModule(other_module, alias)) => {
+                    if let Some(alias) = alias {
+                        cur_name = alias.clone();
+                    }
+                    cur_handle = transaction
+                        .import_handle(&cur_handle, *other_module, None)
+                        .finding()?;
+                }
+            }
+        }
+    }
 
     /// Collect origin FQNs of all publicly exported names across public modules.
     fn compute_public_fqns(handles: &[Handle], transaction: &Transaction) -> HashSet<String> {
@@ -623,33 +666,15 @@ impl ReportArgs {
                             .collect()
                     };
 
-                // follow re-export chains to the origin FQN
+                // emit both the local FQN and the traced origin FQN so a file-scoped run matches
+                // whichever module was requested
                 names
                     .into_iter()
                     .filter(|n| !Self::EXCLUDED_MODULE_DUNDERS.contains(&n.as_str()))
-                    .filter_map(move |mut cur_name| {
-                        let mut seen = HashSet::new();
-                        let mut cur_handle = handle.clone();
-                        loop {
-                            let module_name = cur_handle.module();
-                            if !seen.insert((module_name, cur_name.clone())) {
-                                return None;
-                            }
-                            let cur_exports = transaction.get_exports(&cur_handle);
-                            match cur_exports.get(&cur_name) {
-                                Some(ExportLocation::ThisModule(_)) | None => {
-                                    return Some(format!("{module_name}.{cur_name}"));
-                                }
-                                Some(ExportLocation::OtherModule(other_module, alias)) => {
-                                    if let Some(alias) = alias {
-                                        cur_name = alias.clone();
-                                    }
-                                    cur_handle = transaction
-                                        .import_handle(&cur_handle, *other_module, None)
-                                        .finding()?;
-                                }
-                            }
-                        }
+                    .flat_map(move |name| {
+                        let local = format!("{}.{}", handle.module(), name);
+                        let origin = Self::trace_export_origin(handle, name, transaction);
+                        std::iter::once(local).chain(origin)
                     })
             })
             .collect()
@@ -2636,6 +2661,10 @@ mod tests {
         assert!(!public("other.Foo"));
         assert!(!public("pkg.Baz"));
         assert!(!public("pkg.Baz.method"));
+        // Private nested members do not leak through a public parent.
+        assert!(!public("pkg.Foo._private"));
+        assert!(!public("pkg.Foo._Inner.attr"));
+        assert!(!public("pkg._Hidden.Foo"));
     }
 
     #[test]
@@ -2713,7 +2742,8 @@ mod tests {
             ReportArgs::compute_public_fqns(&handles, &transaction)
         };
 
-        // Re-export from a private module traces to its origin FQN
+        // Re-export from a private module keeps both the local alias and the
+        // traced origin, so reports covering either module stay non-empty.
         let fqns = compute(
             &[
                 (
@@ -2729,8 +2759,8 @@ mod tests {
             ],
             &["pkg", "pkg._internal"],
         );
+        assert!(fqns.contains("pkg.Foo"));
         assert!(fqns.contains("pkg._internal.Foo"));
-        assert!(!fqns.contains("pkg.Foo"));
 
         // Without __all__, non-underscore local names are exported
         let fqns = compute(

--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -273,6 +273,8 @@ enum SymbolReport {
         name: String,
         #[serde(flatten)]
         slots: SlotCounts,
+        #[serde(skip)]
+        n_params: usize,
         location: Location,
     },
     #[serde(rename = "class")]
@@ -584,11 +586,12 @@ impl ReportArgs {
 
     /// True if `fqn` or any class-level prefix of it is in the public set.
     fn is_public_fqn(fqn: &str, module_prefix: &str, public_fqns: &HashSet<String>) -> bool {
-        let start = module_prefix.len();
         public_fqns.contains(fqn)
-            || fqn[start..]
-                .match_indices('.')
-                .any(|(i, _)| public_fqns.contains(&fqn[..start + i]))
+            || std::iter::successors(fqn.rsplit_once('.').map(|(prefix, _)| prefix), |prefix| {
+                prefix.rsplit_once('.').map(|(parent, _)| parent)
+            })
+            .take_while(|prefix| prefix.starts_with(module_prefix))
+            .any(|prefix| public_fqns.contains(prefix))
     }
 
     /// Module-level dunders that typestats always excludes from the report.
@@ -664,34 +667,36 @@ impl ReportArgs {
             .retain(|n| Self::is_public_fqn(n, &module_prefix, public_fqns));
 
         // recompute all aggregates in a single pass
-        let (slots, meth, fun, cls, attr, prop) = report.symbol_reports.iter().fold(
-            (SlotCounts::default(), 0, 0, 0, 0, 0),
-            |(slots, meth, fun, cls, attr, prop), sym| match sym {
-                SymbolReport::Function { name, .. } if Self::is_method(name, &module_prefix) => {
-                    (slots.merge(*sym.slots()), meth + 1, fun, cls, attr, prop)
+        report.slots = SlotCounts::default();
+        report.n_methods = 0;
+        report.n_functions = 0;
+        report.n_method_params = 0;
+        report.n_function_params = 0;
+        report.n_classes = 0;
+        report.n_attrs = 0;
+        report.n_properties = 0;
+
+        for sym in &report.symbol_reports {
+            report.slots = report.slots.merge(*sym.slots());
+            match sym {
+                SymbolReport::Function { name, n_params, .. }
+                    if Self::is_method(name, &module_prefix) =>
+                {
+                    report.n_methods += 1;
+                    report.n_method_params += *n_params;
                 }
-                SymbolReport::Function { .. } => {
-                    (slots.merge(*sym.slots()), meth, fun + 1, cls, attr, prop)
+                SymbolReport::Function { n_params, .. } => {
+                    report.n_functions += 1;
+                    report.n_function_params += *n_params;
                 }
-                SymbolReport::Class { .. } => {
-                    (slots.merge(*sym.slots()), meth, fun, cls + 1, attr, prop)
-                }
-                SymbolReport::Attr { .. } => {
-                    (slots.merge(*sym.slots()), meth, fun, cls, attr + 1, prop)
-                }
-                SymbolReport::Property { .. } => {
-                    (slots.merge(*sym.slots()), meth, fun, cls, attr, prop + 1)
-                }
-            },
-        );
-        report.slots = slots;
-        report.coverage = slots.coverage();
-        report.strict_coverage = slots.strict_coverage();
-        report.n_methods = meth;
-        report.n_functions = fun;
-        report.n_classes = cls;
-        report.n_attrs = attr;
-        report.n_properties = prop;
+                SymbolReport::Class { .. } => report.n_classes += 1,
+                SymbolReport::Attr { .. } => report.n_attrs += 1,
+                SymbolReport::Property { .. } => report.n_properties += 1,
+            }
+        }
+
+        report.coverage = report.slots.coverage();
+        report.strict_coverage = report.slots.strict_coverage();
     }
 
     /// True if the first parameter is the implicit receiver (`self`/`cls`),
@@ -1678,6 +1683,7 @@ impl ReportArgs {
                 symbol_reports.push(SymbolReport::Function {
                     name: func.name.clone(),
                     slots: func.slots,
+                    n_params: func.n_params,
                     location: func.location,
                 });
             }
@@ -2624,6 +2630,7 @@ mod tests {
         assert!(public("pkg.bar"));
         assert!(public("pkg.Foo.method")); // class member of a public class
         assert!(public("pkg.Foo.Inner.attr"));
+        assert!(!public("other.Foo"));
         assert!(!public("pkg.Baz"));
         assert!(!public("pkg.Baz.method"));
     }
@@ -2644,11 +2651,13 @@ mod tests {
                 SymbolReport::Function {
                     name: "pkg.Foo.method".into(),
                     slots: SlotCounts::typed(),
+                    n_params: 2,
                     location: loc(2),
                 },
                 SymbolReport::Function {
                     name: "pkg.bar".into(),
                     slots: SlotCounts::untyped(),
+                    n_params: 1,
                     location: loc(3),
                 },
                 SymbolReport::Attr {
@@ -2663,8 +2672,8 @@ mod tests {
             strict_coverage: 100.0,
             n_functions: 2,
             n_methods: 0,
-            n_function_params: 0,
-            n_method_params: 0,
+            n_function_params: 123,
+            n_method_params: 456,
             n_classes: 1,
             n_attrs: 1,
             n_properties: 0,
@@ -2681,6 +2690,8 @@ mod tests {
         assert_eq!(report.symbol_reports.len(), 3); // Foo, Foo.method, bar
         assert_eq!(report.n_functions, 1);
         assert_eq!(report.n_methods, 1);
+        assert_eq!(report.n_function_params, 1);
+        assert_eq!(report.n_method_params, 2);
         assert_eq!(report.n_classes, 1);
         assert_eq!(report.n_attrs, 0);
     }


### PR DESCRIPTION
# Summary

In #3104 I proposed that `pyrefly report` also includes an export graph so we'd be able to figure out in `typestats` what the public symbols are as post-processing step.

With this change, that is no longer needed. Because now, `pyrefly report --public-only` will report only the public symbols, using the cross-module tracing algorithm from typestats. 

Right now this is opt-in. But we could also make this the default, and instead add a `--include-private` flag or something. Thoughts?

Fixes #3104

# Test Plan

Tests added