### PR TITLE
fix vararg unpacking bug in overload context #3161

### DIFF
--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -874,7 +874,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 &unpacked_args_ty,
                 &unpacked_param_tuple,
                 arguments_range,
-                arg_errors,
+                call_errors,
                 &|| {
                     TypeCheckContext::of_kind(TypeCheckKind::CallVarArgs(
                         true,

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -1863,3 +1863,21 @@ def test(value: int | float | None) -> str:
     return str(i)
     "#,
 );
+
+// Regression test for https://github.com/facebook/pyrefly/issues/3161
+testcase!(
+    test_overload_unpacked_tuple_varargs,
+    r#"
+from typing import overload, assert_type
+
+@overload
+def f(*args: *tuple[int]) -> int: ...
+@overload
+def f(*args: *tuple[int, int]) -> tuple[int, int]: ...
+def f(*args) -> int | tuple[int, int]:
+    return 1
+
+assert_type(f(1), int)
+assert_type(f(1, 2), tuple[int, int])
+    "#,
+);


### PR DESCRIPTION
# Summary

The type check for unpacked varargs was sending errors to `arg_errors` rather than to `call_errors`, which lead to false positives in an overload context.

Fixes #3161

# Test Plan

Regression test added