### PR TITLE
LSP `unused-ignore` support #3167

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -2963,10 +2963,10 @@ impl Server {
                 diags.insert(handle_path_buf, Vec::new());
             }
         }
-        let collected = transaction.get_errors(handles).collect_errors();
-        let mut output_errors = collected.ordinary;
-        output_errors.extend(collected.directives);
-        for e in output_errors {
+        for e in transaction
+            .get_errors(handles)
+            .collect_display_errors_with_unused_ignores()
+        {
             if let Some((path, diag)) = self.get_diag_if_shown(&e, &open_files, None) {
                 diags.entry(path.to_owned()).or_default().push(diag);
             }
@@ -5410,10 +5410,10 @@ impl Server {
         let handle = make_open_handle(&self.state, &path);
         let mut items = Vec::new();
         let open_files = &self.open_files.read();
-        let collected = transaction.get_errors(once(&handle)).collect_errors();
-        let mut output_errors = collected.ordinary;
-        output_errors.extend(collected.directives);
-        for e in output_errors {
+        for e in transaction
+            .get_errors(once(&handle))
+            .collect_display_errors_with_unused_ignores()
+        {
             if let Some((_, diag)) = self.get_diag_if_shown(&e, open_files, cell_uri) {
                 items.push(diag);
             }

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -217,6 +217,14 @@ impl Errors {
         Self::merge_display_errors(errors.ordinary, errors.directives)
     }
 
+    pub fn collect_display_errors_with_unused_ignores(&self) -> Vec<Error> {
+        let collected = self.collect_errors();
+        let unused = self.collect_unused_ignore_errors_for_display(&collected);
+        let mut ordinary = collected.ordinary;
+        ordinary.extend(unused.ordinary);
+        Self::merge_display_errors(ordinary, collected.directives)
+    }
+
     pub fn collect_ignores(&self) -> SmallMap<&ModulePath, &Ignore> {
         let mut ignore_collection: SmallMap<&ModulePath, &Ignore> = SmallMap::new();
         for (load, _, _) in &self.loads {

--- a/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
@@ -1769,3 +1769,31 @@ fn test_unused_ignore_diagnostic() {
 
     interaction.shutdown().unwrap();
 }
+
+#[test]
+fn test_unused_ignore_diagnostic_default_severity() {
+    let test_files_root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(test_files_root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(None),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open("unused_ignore_no_config.py");
+
+    // Without `unused-ignore = "error"` in config, the default severity is "ignore", so no
+    // `unused-ignore` diagnostic should appear.
+    interaction
+        .client
+        .diagnostic("unused_ignore_no_config.py")
+        .expect_response(json!({
+            "items": [],
+            "kind": "full"
+        }))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}

--- a/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
@@ -1726,3 +1726,46 @@ fn test_deprecated_diagnostic_tag() {
 
     interaction.shutdown().unwrap();
 }
+
+#[test]
+fn test_unused_ignore_diagnostic() {
+    let root = get_test_files_root();
+    let test_files_root = root.path().join("unused_ignore");
+    let scope_uri = Url::from_file_path(test_files_root.as_path()).unwrap();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(test_files_root.clone());
+    interaction
+        .initialize(InitializeSettings {
+            workspace_folders: Some(vec![("test".to_owned(), scope_uri)]),
+            configuration: Some(None),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open("example.py");
+
+    interaction
+        .client
+        .diagnostic("example.py")
+        .expect_response(json!({
+            "items": [
+                {
+                    "code": "unused-ignore",
+                    "codeDescription": {
+                        "href": "https://pyrefly.org/en/docs/error-kinds/#unused-ignore"
+                    },
+                    "message": "Unused `# pyrefly: ignore` comment",
+                    "range": {
+                        "start": {"line": 5, "character": 0},
+                        "end": {"line": 5, "character": 1}
+                    },
+                    "severity": 1,
+                    "source": "Pyrefly"
+                }
+            ],
+            "kind": "full"
+        }))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/unused_ignore/example.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/unused_ignore/example.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyrefly: ignore
+x: int = 1

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/unused_ignore/pyrefly.toml
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/unused_ignore/pyrefly.toml
@@ -1,0 +1,2 @@
+[errors]
+unused-ignore = "error"

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/unused_ignore_no_config.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/unused_ignore_no_config.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyrefly: ignore
+x: int = 1


### PR DESCRIPTION
# Summary

The Pyrefly LSP will now report `unused-ignore` diagnostics when configured to do so.

Fixes #3167

# Test Plan

Tests added