### PR TITLE
fix Conformance: Missing type alias validation #2451

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,6 +2859,7 @@ dependencies = [
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"

--- a/crates/pyrefly_types/src/type_info.rs
+++ b/crates/pyrefly_types/src/type_info.rs
@@ -90,7 +90,7 @@ pub struct TypeInfo {
 #[derive(Debug, Clone, PartialEq, Eq, Visit, VisitMut, TypeEq)]
 pub enum NameAssignTypeForm {
     RuntimeTypeValue,
-    InvalidImplicitAlias(String),
+    InvalidImplicitAlias(Box<str>),
 }
 
 impl TypeInfo {

--- a/crates/pyrefly_types/src/type_info.rs
+++ b/crates/pyrefly_types/src/type_info.rs
@@ -25,7 +25,7 @@ use crate::facet::FacetKind;
 use crate::types::AnyStyle;
 use crate::types::Type;
 
-assert_bytes!(TypeInfo, 40);
+assert_bytes!(TypeInfo, 64);
 
 /// The style of a phi.
 ///
@@ -84,17 +84,29 @@ impl<T> JoinStyle<T> {
 pub struct TypeInfo {
     ty: Type,
     facets: Option<Box<NarrowedFacets>>,
+    name_assign_type_form: Option<NameAssignTypeForm>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Visit, VisitMut, TypeEq)]
+pub enum NameAssignTypeForm {
+    RuntimeTypeValue,
+    InvalidImplicitAlias(String),
 }
 
 impl TypeInfo {
     pub fn of_ty(ty: Type) -> Self {
-        Self { ty, facets: None }
+        Self {
+            ty,
+            facets: None,
+            name_assign_type_form: None,
+        }
     }
 
     pub fn with_ty(self, ty: Type) -> Self {
         Self {
             ty,
             facets: self.facets,
+            name_assign_type_form: self.name_assign_type_form,
         }
     }
 
@@ -102,7 +114,17 @@ impl TypeInfo {
         Self {
             ty: f(self.ty),
             facets: self.facets,
+            name_assign_type_form: self.name_assign_type_form,
         }
+    }
+
+    pub fn with_name_assign_type_form(mut self, x: NameAssignTypeForm) -> Self {
+        self.name_assign_type_form = Some(x);
+        self
+    }
+
+    pub fn name_assign_type_form(&self) -> Option<&NameAssignTypeForm> {
+        self.name_assign_type_form.as_ref()
     }
 
     pub fn record_key_completion(&mut self, facets: &Vec1<FacetKind>, ty: Option<Type>) {
@@ -128,10 +150,12 @@ impl TypeInfo {
             Some(NarrowedFacet::WithoutRoot { facets, .. }) => Self {
                 ty: fallback(),
                 facets: Some(Box::new(facets.clone())),
+                name_assign_type_form: self.name_assign_type_form.clone(),
             },
             Some(NarrowedFacet::WithRoot(ty, narrowed_facets)) => Self {
                 ty: ty.clone(),
                 facets: Some(Box::new(narrowed_facets.clone())),
+                name_assign_type_form: self.name_assign_type_form.clone(),
             },
         }
     }
@@ -160,7 +184,7 @@ impl TypeInfo {
             n => {
                 let (tys, facets_branches): (Vec<Type>, Vec<Option<NarrowedFacets>>) = branches
                     .into_iter()
-                    .map(|TypeInfo { ty, facets }| (ty, facets.map(|x| *x)))
+                    .map(|TypeInfo { ty, facets, .. }| (ty, facets.map(|x| *x)))
                     .unzip();
                 let ty = join_types(
                     tys,
@@ -185,6 +209,7 @@ impl TypeInfo {
                 Self {
                     ty,
                     facets: facets.map(Box::new),
+                    name_assign_type_form: None,
                 }
             }
         }

--- a/crates/pyrefly_types/src/type_info.rs
+++ b/crates/pyrefly_types/src/type_info.rs
@@ -25,7 +25,7 @@ use crate::facet::FacetKind;
 use crate::types::AnyStyle;
 use crate::types::Type;
 
-assert_bytes!(TypeInfo, 64);
+assert_bytes!(TypeInfo, 40);
 
 /// The style of a phi.
 ///
@@ -40,6 +40,35 @@ pub enum JoinStyle<T> {
     ReassignmentOf(T),
     // A merge where the name was already defined in the base flow, and was only narrowed.
     NarrowOf(T),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Visit, VisitMut, TypeEq)]
+pub enum NameAssignTypeForm {
+    InvalidImplicitAlias(Box<str>),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Visit, VisitMut, TypeEq)]
+pub struct NameAssignTypeFormInfo(Option<NameAssignTypeForm>);
+
+impl NameAssignTypeFormInfo {
+    pub fn invalid_implicit_alias(problem: Box<str>) -> Self {
+        Self(Some(NameAssignTypeForm::InvalidImplicitAlias(problem)))
+    }
+
+    pub fn as_ref(&self) -> Option<&NameAssignTypeForm> {
+        self.0.as_ref()
+    }
+}
+
+impl Display for NameAssignTypeFormInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            Some(NameAssignTypeForm::InvalidImplicitAlias(problem)) => {
+                write!(f, "InvalidImplicitAlias({problem})")
+            }
+            None => write!(f, "None"),
+        }
+    }
 }
 
 impl<T> JoinStyle<T> {
@@ -84,29 +113,17 @@ impl<T> JoinStyle<T> {
 pub struct TypeInfo {
     ty: Type,
     facets: Option<Box<NarrowedFacets>>,
-    name_assign_type_form: Option<NameAssignTypeForm>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Visit, VisitMut, TypeEq)]
-pub enum NameAssignTypeForm {
-    RuntimeTypeValue,
-    InvalidImplicitAlias(Box<str>),
 }
 
 impl TypeInfo {
     pub fn of_ty(ty: Type) -> Self {
-        Self {
-            ty,
-            facets: None,
-            name_assign_type_form: None,
-        }
+        Self { ty, facets: None }
     }
 
     pub fn with_ty(self, ty: Type) -> Self {
         Self {
             ty,
             facets: self.facets,
-            name_assign_type_form: self.name_assign_type_form,
         }
     }
 
@@ -114,17 +131,7 @@ impl TypeInfo {
         Self {
             ty: f(self.ty),
             facets: self.facets,
-            name_assign_type_form: self.name_assign_type_form,
         }
-    }
-
-    pub fn with_name_assign_type_form(mut self, x: NameAssignTypeForm) -> Self {
-        self.name_assign_type_form = Some(x);
-        self
-    }
-
-    pub fn name_assign_type_form(&self) -> Option<&NameAssignTypeForm> {
-        self.name_assign_type_form.as_ref()
     }
 
     pub fn record_key_completion(&mut self, facets: &Vec1<FacetKind>, ty: Option<Type>) {
@@ -150,12 +157,10 @@ impl TypeInfo {
             Some(NarrowedFacet::WithoutRoot { facets, .. }) => Self {
                 ty: fallback(),
                 facets: Some(Box::new(facets.clone())),
-                name_assign_type_form: self.name_assign_type_form.clone(),
             },
             Some(NarrowedFacet::WithRoot(ty, narrowed_facets)) => Self {
                 ty: ty.clone(),
                 facets: Some(Box::new(narrowed_facets.clone())),
-                name_assign_type_form: self.name_assign_type_form.clone(),
             },
         }
     }
@@ -184,7 +189,7 @@ impl TypeInfo {
             n => {
                 let (tys, facets_branches): (Vec<Type>, Vec<Option<NarrowedFacets>>) = branches
                     .into_iter()
-                    .map(|TypeInfo { ty, facets, .. }| (ty, facets.map(|x| *x)))
+                    .map(|TypeInfo { ty, facets }| (ty, facets.map(|x| *x)))
                     .unzip();
                 let ty = join_types(
                     tys,
@@ -209,7 +214,6 @@ impl TypeInfo {
                 Self {
                     ty,
                     facets: facets.map(Box::new),
-                    name_assign_type_form: None,
                 }
             }
         }

--- a/pyrefly/lib/alt/answers.rs
+++ b/pyrefly/lib/alt/answers.rs
@@ -37,6 +37,7 @@ use crate::alt::traits::Solve;
 use crate::binding::binding::AnyIdx;
 use crate::binding::binding::Exported;
 use crate::binding::binding::Key;
+use crate::binding::binding::KeyExportNameAssignTypeForm;
 use crate::binding::binding::Keyed;
 use crate::binding::bindings::BindingEntry;
 use crate::binding::bindings::BindingTable;
@@ -68,6 +69,7 @@ use crate::types::equality::TypeEq;
 use crate::types::equality::TypeEqCtx;
 use crate::types::heap::TypeHeap;
 use crate::types::stdlib::Stdlib;
+use crate::types::type_info::NameAssignTypeFormInfo;
 use crate::types::types::Forall;
 use crate::types::types::Forallable;
 use crate::types::types::TParams;
@@ -573,6 +575,14 @@ pub trait LookupAnswer: Sized {
         AnswerTable: TableKeyed<K, Value = AnswerEntry<K>>,
         BindingTable: TableKeyed<K, Value = BindingEntry<K>>,
         SolutionsTable: TableKeyed<K, Value = SolutionsEntry<K>>;
+
+    fn get_name_assign_type_form(
+        &self,
+        module: ModuleName,
+        path: Option<&ModulePath>,
+        k: &KeyExportNameAssignTypeForm,
+        stack: &ThreadState,
+    ) -> Option<Arc<NameAssignTypeFormInfo>>;
 
     /// Commit a preliminary answer to a specific module's Calculation cell.
     /// Used for cross-module batch commit when an SCC spans module boundaries.

--- a/pyrefly/lib/alt/answers_solver.rs
+++ b/pyrefly/lib/alt/answers_solver.rs
@@ -60,6 +60,7 @@ use crate::binding::binding::Binding;
 use crate::binding::binding::Exported;
 use crate::binding::binding::Key;
 use crate::binding::binding::KeyExport;
+use crate::binding::binding::KeyExportNameAssignTypeForm;
 use crate::binding::binding::KeyTypeAlias;
 use crate::binding::binding::LambdaParamId;
 use crate::binding::bindings::BindingEntry;
@@ -88,6 +89,7 @@ use crate::types::class::ClassFields;
 use crate::types::equality::TypeEq;
 use crate::types::equality::TypeEqCtx;
 use crate::types::stdlib::Stdlib;
+use crate::types::type_info::NameAssignTypeFormInfo;
 use crate::types::type_info::TypeInfo;
 use crate::types::types::Type;
 use crate::types::types::Var;
@@ -2922,15 +2924,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         path: Option<&ModulePath>,
         k: &KeyExport,
     ) -> Arc<Type> {
-        Arc::new(self.get_from_export_type_info(module, path, k).ty().clone())
+        self.get_from_module(module, path, k).unwrap_or_else(|| {
+            panic!("We should have checked Exports before calling this, {module} {k:?}")
+        })
     }
 
-    pub fn get_from_export_type_info(
+    pub fn get_from_export_name_assign_type_form(
         &self,
         module: ModuleName,
         path: Option<&ModulePath>,
-        k: &KeyExport,
-    ) -> Arc<TypeInfo> {
+        k: &KeyExportNameAssignTypeForm,
+    ) -> Arc<NameAssignTypeFormInfo> {
         self.get_from_module(module, path, k).unwrap_or_else(|| {
             panic!("We should have checked Exports before calling this, {module} {k:?}")
         })

--- a/pyrefly/lib/alt/answers_solver.rs
+++ b/pyrefly/lib/alt/answers_solver.rs
@@ -2935,9 +2935,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         path: Option<&ModulePath>,
         k: &KeyExportNameAssignTypeForm,
     ) -> Arc<NameAssignTypeFormInfo> {
-        self.get_from_module(module, path, k).unwrap_or_else(|| {
-            panic!("We should have checked Exports before calling this, {module} {k:?}")
-        })
+        self.answers
+            .get_name_assign_type_form(module, path, k, self.thread_state)
+            .unwrap_or_else(|| Arc::new(NameAssignTypeFormInfo::default()))
     }
 
     /// Might return None if the class is no longer present on the underlying module.

--- a/pyrefly/lib/alt/answers_solver.rs
+++ b/pyrefly/lib/alt/answers_solver.rs
@@ -2922,6 +2922,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         path: Option<&ModulePath>,
         k: &KeyExport,
     ) -> Arc<Type> {
+        Arc::new(self.get_from_export_type_info(module, path, k).ty().clone())
+    }
+
+    pub fn get_from_export_type_info(
+        &self,
+        module: ModuleName,
+        path: Option<&ModulePath>,
+        k: &KeyExport,
+    ) -> Arc<TypeInfo> {
         self.get_from_module(module, path, k).unwrap_or_else(|| {
             panic!("We should have checked Exports before calling this, {module} {k:?}")
         })

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -251,7 +251,7 @@ impl TypeFormContext {
                 | TypeFormContext::TypeArgument
                 | TypeFormContext::TypeArgumentCallableReturn
                 | TypeFormContext::TypeArgumentForType
-            )
+        )
     }
 
     fn reports_implicit_alias_syntax_at_use_site(self) -> bool {
@@ -742,36 +742,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         self.name_assign_type_form_for_idx(idx, &self.error_swallower())
             .as_ref()
             .cloned()
-    }
-
-    fn annotation_name_resolves_to_import(&self, name: &ruff_python_ast::ExprName) -> bool {
-        let key = Key::BoundName(ShortIdentifier::expr_name(name));
-        let Some(mut idx) = self.bindings().key_to_idx_hashed_opt(Hashed::new(&key)) else {
-            return false;
-        };
-        let mut visited = SmallSet::new();
-        loop {
-            if !visited.insert(idx) {
-                unreachable!("cycle in binding chain while checking annotation import origin");
-            }
-            match self.bindings().get(idx) {
-                Binding::Forward(next)
-                | Binding::PromoteForward(next)
-                | Binding::ForwardToFirstUse(next)
-                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
-                Binding::Import(_) => return true,
-                Binding::PossibleLegacyTParam(key, _) => {
-                    match (self.bindings().get(*key), &*self.get_idx(*key)) {
-                        (
-                            BindingLegacyTypeParam::ParamKeyed(next),
-                            LegacyTypeParameterLookup::NotParameter(_),
-                        ) => idx = *next,
-                        _ => return false,
-                    }
-                }
-                _ => return false,
-            }
-        }
     }
 
     pub fn name_assign_type_form_for_export(
@@ -2364,7 +2334,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     pub fn solve_expectation(
         &self,
         binding: &BindingExpect,
-        range: TextRange,
+        _range: TextRange,
         errors: &ErrorCollector,
     ) -> Arc<EmptyAnswer> {
         match binding {
@@ -2563,35 +2533,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
             }
             BindingExpect::ImplicitAliasCheck {
-                name,
-                expr,
-                problem,
+                name: _,
+                expr: _,
+                problem: _,
             } => {
-                // A call expression is exempt if its result is a type-like
-                // value (TypeVar, class metatype) or its callable is a class
-                // constructor. Non-call expressions are never exempt.
-                let is_exempt = if let Expr::Call(call) = expr.as_ref() {
-                    let swallower = self.error_swallower();
-                    let result_ty = self.expr_infer(expr, &swallower);
-                    (matches!(
-                        &result_ty,
-                        Type::TypeVar(_) | Type::ParamSpec(_) | Type::TypeVarTuple(_)
-                    ) || matches!(&result_ty, Type::Type(f) if matches!(&**f, Type::ClassType(_))))
-                        || {
-                            let callable_ty = self.expr_infer(&call.func, &swallower);
-                            matches!(&callable_ty, Type::ClassDef(_))
-                        }
-                } else {
-                    false
-                };
-                if !is_exempt {
-                    self.error(
-                        errors,
-                        range,
-                        ErrorKind::InvalidAnnotation,
-                        format!("`{name}` is not a valid type alias: {problem} cannot be used in annotations"),
-                    );
-                }
+                // Handled by `expr_untype`, which can classify both local and
+                // imported implicit aliases using solved definition-site info.
             }
         }
         Arc::new(EmptyAnswer)
@@ -6191,7 +6138,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Type {
         if type_form_context.reports_implicit_alias_syntax_at_use_site()
             && let Expr::Name(name) = x
-            && !self.annotation_name_resolves_to_import(name)
             && let Some(NameAssignTypeForm::InvalidImplicitAlias(problem)) =
                 self.annotation_name_assign_type_form(name)
         {
@@ -6199,7 +6145,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 errors,
                 x.range(),
                 ErrorKind::InvalidAnnotation,
-                format!("{problem} cannot be used in annotations"),
+                format!(
+                    "`{}` is not a valid type alias: {problem} cannot be used in annotations",
+                    name.id
+                ),
             );
         }
         let result = match x {
@@ -6248,19 +6197,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             _ => {
                 let inferred_ty = self.expr_infer(x, errors);
-                if type_form_context.reports_implicit_alias_syntax_at_use_site()
-                    && let Expr::Name(name) = x
-                    && self.annotation_name_resolves_to_import(name)
-                    && let Some(NameAssignTypeForm::InvalidImplicitAlias(problem)) =
-                        self.annotation_name_assign_type_form(name)
-                {
-                    return self.error(
-                        errors,
-                        x.range(),
-                        ErrorKind::InvalidAnnotation,
-                        format!("{problem} cannot be used in annotations"),
-                    );
-                }
                 // Check if this is a scoped type alias in base class context
                 // We do this check here instead of `validate_type_form` because it
                 // substitutes type aliases with the aliased type

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -635,43 +635,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             true
         }
     }
-<<<<<<< HEAD
-    fn implicit_alias_call_uses_runtime_type(&self, call: &ExprCall) -> bool {
-        if matches!(
-            self.call_targets_special_export(&call.func),
-            Some(
-                SpecialExport::TypeVar
-                    | SpecialExport::ParamSpec
-                    | SpecialExport::TypeVarTuple
-                    | SpecialExport::TypedDict
-                    | SpecialExport::TypingNamedTuple
-                    | SpecialExport::CollectionsNamedTuple
-                    | SpecialExport::BuiltinsType
-            )
-        ) {
-            return true;
-        }
-||||||| parent of d1be9bab0 (clean)
-
-    fn implicit_alias_call_uses_runtime_type(&self, call: &ExprCall) -> bool {
-        if matches!(
-            self.call_targets_special_export(&call.func),
-            Some(
-                SpecialExport::TypeVar
-                    | SpecialExport::ParamSpec
-                    | SpecialExport::TypeVarTuple
-                    | SpecialExport::TypedDict
-                    | SpecialExport::TypingNamedTuple
-                    | SpecialExport::CollectionsNamedTuple
-                    | SpecialExport::BuiltinsType
-            )
-        ) {
-            return true;
-        }
-=======
-
     fn call_has_synthesized_runtime_type(&self, call: &ExprCall) -> bool {
->>>>>>> d1be9bab0 (clean)
         let anon_key = Key::Anon(call.range);
         self.bindings()
             .key_to_idx_hashed_opt(Hashed::new(&anon_key))
@@ -697,243 +661,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if annotation.is_some() || is_in_function_scope {
             return None;
         }
-        let problem = self.annotation_syntax_problem(expr)?;
+        let problem = Ast::annotation_syntax_problem(expr)?;
         if matches!(
             ty,
             Type::TypeVar(_) | Type::ParamSpec(_) | Type::TypeVarTuple(_)
         ) {
             return Some(NameAssignTypeForm::RuntimeTypeValue);
         }
-<<<<<<< HEAD
-        Ast::annotation_syntax_problem(expr)
-            .map(str::to_owned)
-            .map(NameAssignTypeForm::InvalidImplicitAlias)
-    }
-
-    fn call_targets_special_export(&self, expr: &Expr) -> Option<SpecialExport> {
-        let mut visited_names = SmallSet::new();
-        let mut visited_keys = SmallSet::new();
-        self.call_targets_special_export_inner(expr, &mut visited_names, &mut visited_keys)
-    }
-
-    fn call_targets_special_export_inner(
-        &self,
-        expr: &Expr,
-        visited_names: &mut SmallSet<Name>,
-        visited_keys: &mut SmallSet<Idx<Key>>,
-    ) -> Option<SpecialExport> {
-        match expr {
-            Expr::Name(name) => {
-                if !visited_names.insert(name.id.clone()) {
-                    return None;
-                }
-                let key = Key::BoundName(ShortIdentifier::expr_name(name));
-                self.bindings()
-                    .key_to_idx_hashed_opt(Hashed::new(&key))
-                    .and_then(|idx| {
-                        self.special_export_from_binding_idx(idx, visited_names, visited_keys)
-                    })
-                    .or_else(|| {
-                        SpecialExport::new(&name.id)
-                            .filter(|export| *export == SpecialExport::BuiltinsType)
-                    })
-            }
-            Expr::Attribute(attr) if let Expr::Name(base) = attr.value.as_ref() => {
-                let module = self.bound_name_module(base)?;
-                let export = SpecialExport::new(&attr.attr.id)?;
-                if export.defined_in(module)
-                    || matches!(
-                        export,
-                        SpecialExport::TypeVar
-                            | SpecialExport::ParamSpec
-                            | SpecialExport::TypeVarTuple
-                    )
-                {
-                    Some(export)
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        }
-    }
-
-    fn special_export_from_binding_idx(
-        &self,
-        mut idx: Idx<Key>,
-        visited_names: &mut SmallSet<Name>,
-        visited_keys: &mut SmallSet<Idx<Key>>,
-    ) -> Option<SpecialExport> {
-        loop {
-            if !visited_keys.insert(idx) {
-                return None;
-            }
-            match self.bindings().get(idx) {
-                Binding::Forward(next)
-                | Binding::PromoteForward(next)
-                | Binding::ForwardToFirstUse(next)
-                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
-                Binding::NameAssign(name_assign) => {
-                    return self.call_targets_special_export_inner(
-                        &name_assign.expr,
-                        visited_names,
-                        visited_keys,
-                    );
-                }
-                Binding::Import(import) => {
-                    return SpecialExport::new(&import.name)
-                        .filter(|export| export.defined_in(import.module));
-                }
-                Binding::ClassDef(class_idx, _) => {
-                    let Some(cls) = &self.get_idx(*class_idx).0 else {
-                        return None;
-                    };
-                    return SpecialExport::new(cls.name());
-                }
-                _ => return None,
-            }
-        }
-    }
-
-    fn bound_name_module(&self, name: &ruff_python_ast::ExprName) -> Option<ModuleName> {
-        let key = Key::BoundName(ShortIdentifier::expr_name(name));
-        let mut idx = self.bindings().key_to_idx_hashed_opt(Hashed::new(&key))?;
-        let mut visited = SmallSet::new();
-        loop {
-            if !visited.insert(idx) {
-                return None;
-            }
-            match self.bindings().get(idx) {
-                Binding::Forward(next)
-                | Binding::PromoteForward(next)
-                | Binding::ForwardToFirstUse(next)
-                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
-                Binding::Module(module) => return Some(module.0),
-                Binding::NameAssign(name_assign)
-                    if let Expr::Name(alias) = name_assign.expr.as_ref() =>
-                {
-                    let alias_key = Key::BoundName(ShortIdentifier::expr_name(alias));
-                    idx = self
-                        .bindings()
-                        .key_to_idx_hashed_opt(Hashed::new(&alias_key))?;
-                }
-                _ => return None,
-            }
-||||||| parent of d1be9bab0 (clean)
-        self.annotation_syntax_problem(expr)
-            .map(NameAssignTypeForm::InvalidImplicitAlias)
-    }
-
-    fn call_targets_special_export(&self, expr: &Expr) -> Option<SpecialExport> {
-        let mut visited_names = SmallSet::new();
-        let mut visited_keys = SmallSet::new();
-        self.call_targets_special_export_inner(expr, &mut visited_names, &mut visited_keys)
-    }
-
-    fn call_targets_special_export_inner(
-        &self,
-        expr: &Expr,
-        visited_names: &mut SmallSet<Name>,
-        visited_keys: &mut SmallSet<Idx<Key>>,
-    ) -> Option<SpecialExport> {
-        match expr {
-            Expr::Name(name) => {
-                if !visited_names.insert(name.id.clone()) {
-                    return None;
-                }
-                let key = Key::BoundName(ShortIdentifier::expr_name(name));
-                self.bindings()
-                    .key_to_idx_hashed_opt(Hashed::new(&key))
-                    .and_then(|idx| {
-                        self.special_export_from_binding_idx(idx, visited_names, visited_keys)
-                    })
-                    .or_else(|| {
-                        SpecialExport::new(&name.id)
-                            .filter(|export| *export == SpecialExport::BuiltinsType)
-                    })
-            }
-            Expr::Attribute(attr) if let Expr::Name(base) = attr.value.as_ref() => {
-                let module = self.bound_name_module(base)?;
-                let export = SpecialExport::new(&attr.attr.id)?;
-                if export.defined_in(module)
-                    || matches!(
-                        export,
-                        SpecialExport::TypeVar
-                            | SpecialExport::ParamSpec
-                            | SpecialExport::TypeVarTuple
-                    )
-                {
-                    Some(export)
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        }
-    }
-
-    fn special_export_from_binding_idx(
-        &self,
-        mut idx: Idx<Key>,
-        visited_names: &mut SmallSet<Name>,
-        visited_keys: &mut SmallSet<Idx<Key>>,
-    ) -> Option<SpecialExport> {
-        loop {
-            if !visited_keys.insert(idx) {
-                return None;
-            }
-            match self.bindings().get(idx) {
-                Binding::Forward(next)
-                | Binding::PromoteForward(next)
-                | Binding::ForwardToFirstUse(next)
-                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
-                Binding::NameAssign(name_assign) => {
-                    return self.call_targets_special_export_inner(
-                        &name_assign.expr,
-                        visited_names,
-                        visited_keys,
-                    );
-                }
-                Binding::Import(import) => {
-                    return SpecialExport::new(&import.name)
-                        .filter(|export| export.defined_in(import.module));
-                }
-                Binding::ClassDef(class_idx, _) => {
-                    let Some(cls) = &self.get_idx(*class_idx).0 else {
-                        return None;
-                    };
-                    return SpecialExport::new(cls.name());
-                }
-                _ => return None,
-            }
-        }
-    }
-
-    fn bound_name_module(&self, name: &ruff_python_ast::ExprName) -> Option<ModuleName> {
-        let key = Key::BoundName(ShortIdentifier::expr_name(name));
-        let mut idx = self.bindings().key_to_idx_hashed_opt(Hashed::new(&key))?;
-        let mut visited = SmallSet::new();
-        loop {
-            if !visited.insert(idx) {
-                return None;
-            }
-            match self.bindings().get(idx) {
-                Binding::Forward(next)
-                | Binding::PromoteForward(next)
-                | Binding::ForwardToFirstUse(next)
-                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
-                Binding::Module(module) => return Some(module.0),
-                Binding::NameAssign(name_assign)
-                    if let Expr::Name(alias) = name_assign.expr.as_ref() =>
-                {
-                    let alias_key = Key::BoundName(ShortIdentifier::expr_name(alias));
-                    idx = self
-                        .bindings()
-                        .key_to_idx_hashed_opt(Hashed::new(&alias_key))?;
-                }
-                _ => return None,
-            }
-=======
         if let Expr::Call(call) = expr
             && (self.call_has_synthesized_runtime_type(call)
                 || self.callable_is_builtin_type(
@@ -941,9 +675,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 ))
         {
             return Some(NameAssignTypeForm::RuntimeTypeValue);
->>>>>>> d1be9bab0 (clean)
         }
         Some(NameAssignTypeForm::InvalidImplicitAlias(problem.into()))
+    }
+
+    fn annotation_name_assign_type_form(
+        &self,
+        name: &ruff_python_ast::ExprName,
+    ) -> Option<NameAssignTypeForm> {
+        let key = Key::BoundName(ShortIdentifier::expr_name(name));
+        self.get(&key).name_assign_type_form().cloned()
     }
 
     fn expr_annotation(
@@ -4856,7 +4597,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         range_if_scoped_params_exist: &Option<TextRange>,
         errors: &ErrorCollector,
     ) -> TypeInfo {
-        let ty = match &*self.get_idx(key) {
+        let lookup = self.get_idx(key);
+        let ty = match &*lookup {
             LegacyTypeParameterLookup::Parameter(p) => {
                 // This class or function has scoped (PEP 695) type parameters. Mixing legacy-style parameters is an error.
                 if let Some(r) = range_if_scoped_params_exist {
@@ -4888,7 +4630,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     module
                 }
             }
-            BindingLegacyTypeParam::ParamKeyed(_) => TypeInfo::of_ty(ty),
+            BindingLegacyTypeParam::ParamKeyed(idx) => match &*lookup {
+                LegacyTypeParameterLookup::NotParameter(_) => self.get_idx(*idx).arc_clone(),
+                LegacyTypeParameterLookup::Parameter(_) => TypeInfo::of_ty(ty),
+            },
         }
     }
 
@@ -4969,6 +4714,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     range_if_scoped_params_exist,
                     errors,
                 ),
+            Binding::Import(x) => self
+                .get_from_export_type_info(x.0, None, &KeyExport(x.1.clone()))
+                .as_ref()
+                .clone(),
             _ => {
                 // All other Bindings model `Type` level operations where we do not
                 // propagate any attribute narrows.
@@ -6359,9 +6108,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Type {
         if type_form_context.reports_implicit_alias_syntax_at_use_site()
             && let Expr::Name(name) = x
-            && let Some(NameAssignTypeForm::InvalidImplicitAlias(problem)) = self
-                .get(&Key::BoundName(ShortIdentifier::expr_name(name)))
-                .name_assign_type_form()
+            && let Some(NameAssignTypeForm::InvalidImplicitAlias(problem)) =
+                self.annotation_name_assign_type_form(name)
         {
             return self.error(
                 errors,

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -635,6 +635,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             true
         }
     }
+<<<<<<< HEAD
     fn implicit_alias_call_uses_runtime_type(&self, call: &ExprCall) -> bool {
         if matches!(
             self.call_targets_special_export(&call.func),
@@ -650,15 +651,31 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         ) {
             return true;
         }
-        let anon_key = Key::Anon(call.range);
-        if let Some(idx) = self
-            .bindings()
-            .key_to_idx_hashed_opt(Hashed::new(&anon_key))
-            && matches!(self.bindings().get(idx), Binding::ClassDef(..))
-        {
+||||||| parent of d1be9bab0 (clean)
+
+    fn implicit_alias_call_uses_runtime_type(&self, call: &ExprCall) -> bool {
+        if matches!(
+            self.call_targets_special_export(&call.func),
+            Some(
+                SpecialExport::TypeVar
+                    | SpecialExport::ParamSpec
+                    | SpecialExport::TypeVarTuple
+                    | SpecialExport::TypedDict
+                    | SpecialExport::TypingNamedTuple
+                    | SpecialExport::CollectionsNamedTuple
+                    | SpecialExport::BuiltinsType
+            )
+        ) {
             return true;
         }
-        self.callable_is_builtin_type(&self.expr_infer(&call.func, &self.error_swallower()))
+=======
+
+    fn call_has_synthesized_runtime_type(&self, call: &ExprCall) -> bool {
+>>>>>>> d1be9bab0 (clean)
+        let anon_key = Key::Anon(call.range);
+        self.bindings()
+            .key_to_idx_hashed_opt(Hashed::new(&anon_key))
+            .is_some_and(|idx| matches!(self.bindings().get(idx), Binding::ClassDef(..)))
     }
 
     fn callable_is_builtin_type(&self, ty: &Type) -> bool {
@@ -680,17 +697,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if annotation.is_some() || is_in_function_scope {
             return None;
         }
-        if let Expr::Call(call) = expr
-            && self.implicit_alias_call_uses_runtime_type(call)
-        {
-            return Some(NameAssignTypeForm::RuntimeTypeValue);
-        }
+        let problem = self.annotation_syntax_problem(expr)?;
         if matches!(
             ty,
             Type::TypeVar(_) | Type::ParamSpec(_) | Type::TypeVarTuple(_)
         ) {
             return Some(NameAssignTypeForm::RuntimeTypeValue);
         }
+<<<<<<< HEAD
         Ast::annotation_syntax_problem(expr)
             .map(str::to_owned)
             .map(NameAssignTypeForm::InvalidImplicitAlias)
@@ -805,7 +819,131 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
                 _ => return None,
             }
+||||||| parent of d1be9bab0 (clean)
+        self.annotation_syntax_problem(expr)
+            .map(NameAssignTypeForm::InvalidImplicitAlias)
+    }
+
+    fn call_targets_special_export(&self, expr: &Expr) -> Option<SpecialExport> {
+        let mut visited_names = SmallSet::new();
+        let mut visited_keys = SmallSet::new();
+        self.call_targets_special_export_inner(expr, &mut visited_names, &mut visited_keys)
+    }
+
+    fn call_targets_special_export_inner(
+        &self,
+        expr: &Expr,
+        visited_names: &mut SmallSet<Name>,
+        visited_keys: &mut SmallSet<Idx<Key>>,
+    ) -> Option<SpecialExport> {
+        match expr {
+            Expr::Name(name) => {
+                if !visited_names.insert(name.id.clone()) {
+                    return None;
+                }
+                let key = Key::BoundName(ShortIdentifier::expr_name(name));
+                self.bindings()
+                    .key_to_idx_hashed_opt(Hashed::new(&key))
+                    .and_then(|idx| {
+                        self.special_export_from_binding_idx(idx, visited_names, visited_keys)
+                    })
+                    .or_else(|| {
+                        SpecialExport::new(&name.id)
+                            .filter(|export| *export == SpecialExport::BuiltinsType)
+                    })
+            }
+            Expr::Attribute(attr) if let Expr::Name(base) = attr.value.as_ref() => {
+                let module = self.bound_name_module(base)?;
+                let export = SpecialExport::new(&attr.attr.id)?;
+                if export.defined_in(module)
+                    || matches!(
+                        export,
+                        SpecialExport::TypeVar
+                            | SpecialExport::ParamSpec
+                            | SpecialExport::TypeVarTuple
+                    )
+                {
+                    Some(export)
+                } else {
+                    None
+                }
+            }
+            _ => None,
         }
+    }
+
+    fn special_export_from_binding_idx(
+        &self,
+        mut idx: Idx<Key>,
+        visited_names: &mut SmallSet<Name>,
+        visited_keys: &mut SmallSet<Idx<Key>>,
+    ) -> Option<SpecialExport> {
+        loop {
+            if !visited_keys.insert(idx) {
+                return None;
+            }
+            match self.bindings().get(idx) {
+                Binding::Forward(next)
+                | Binding::PromoteForward(next)
+                | Binding::ForwardToFirstUse(next)
+                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
+                Binding::NameAssign(name_assign) => {
+                    return self.call_targets_special_export_inner(
+                        &name_assign.expr,
+                        visited_names,
+                        visited_keys,
+                    );
+                }
+                Binding::Import(import) => {
+                    return SpecialExport::new(&import.name)
+                        .filter(|export| export.defined_in(import.module));
+                }
+                Binding::ClassDef(class_idx, _) => {
+                    let Some(cls) = &self.get_idx(*class_idx).0 else {
+                        return None;
+                    };
+                    return SpecialExport::new(cls.name());
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    fn bound_name_module(&self, name: &ruff_python_ast::ExprName) -> Option<ModuleName> {
+        let key = Key::BoundName(ShortIdentifier::expr_name(name));
+        let mut idx = self.bindings().key_to_idx_hashed_opt(Hashed::new(&key))?;
+        let mut visited = SmallSet::new();
+        loop {
+            if !visited.insert(idx) {
+                return None;
+            }
+            match self.bindings().get(idx) {
+                Binding::Forward(next)
+                | Binding::PromoteForward(next)
+                | Binding::ForwardToFirstUse(next)
+                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
+                Binding::Module(module) => return Some(module.0),
+                Binding::NameAssign(name_assign)
+                    if let Expr::Name(alias) = name_assign.expr.as_ref() =>
+                {
+                    let alias_key = Key::BoundName(ShortIdentifier::expr_name(alias));
+                    idx = self
+                        .bindings()
+                        .key_to_idx_hashed_opt(Hashed::new(&alias_key))?;
+                }
+                _ => return None,
+            }
+=======
+        if let Expr::Call(call) = expr
+            && (self.call_has_synthesized_runtime_type(call)
+                || self.callable_is_builtin_type(
+                    &self.expr_infer(&call.func, &self.error_swallower()),
+                ))
+        {
+            return Some(NameAssignTypeForm::RuntimeTypeValue);
+>>>>>>> d1be9bab0 (clean)
+        }
+        Some(NameAssignTypeForm::InvalidImplicitAlias(problem))
     }
 
     fn expr_annotation(

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -716,6 +716,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     }
 
     fn implicit_alias_call_uses_runtime_type(&self, call: &ExprCall) -> bool {
+        if matches!(
+            self.call_targets_special_export(&call.func),
+            Some(
+                SpecialExport::TypeVar
+                    | SpecialExport::ParamSpec
+                    | SpecialExport::TypeVarTuple
+                    | SpecialExport::BuiltinsType
+            )
+        ) {
+            return true;
+        }
         let anon_key = Key::Anon(call.range);
         if let Some(idx) = self
             .bindings()
@@ -733,6 +744,112 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::ClassType(cls) | Type::SelfType(cls) => cls.has_qname("builtins", "type"),
             Type::Type(inner) => self.callable_is_builtin_type(inner),
             _ => false,
+        }
+    }
+
+    fn call_targets_special_export(&self, expr: &Expr) -> Option<SpecialExport> {
+        let mut visited_names = SmallSet::new();
+        let mut visited_keys = SmallSet::new();
+        self.call_targets_special_export_inner(expr, &mut visited_names, &mut visited_keys)
+    }
+
+    fn call_targets_special_export_inner(
+        &self,
+        expr: &Expr,
+        visited_names: &mut SmallSet<Name>,
+        visited_keys: &mut SmallSet<Idx<Key>>,
+    ) -> Option<SpecialExport> {
+        match expr {
+            Expr::Name(name) => {
+                if !visited_names.insert(name.id.clone()) {
+                    return None;
+                }
+                let key = Key::BoundName(ShortIdentifier::expr_name(name));
+                self.bindings()
+                    .key_to_idx_hashed_opt(Hashed::new(&key))
+                    .and_then(|idx| {
+                        self.special_export_from_binding_idx(idx, visited_names, visited_keys)
+                    })
+                    .or_else(|| {
+                        SpecialExport::new(&name.id)
+                            .filter(|export| *export == SpecialExport::BuiltinsType)
+                    })
+            }
+            Expr::Attribute(attr) if let Expr::Name(base) = attr.value.as_ref() => {
+                let module = self.bound_name_module(base)?;
+                let export = SpecialExport::new(&attr.attr.id)?;
+                if export.defined_in(module)
+                    || matches!(
+                        export,
+                        SpecialExport::TypeVar
+                            | SpecialExport::ParamSpec
+                            | SpecialExport::TypeVarTuple
+                    )
+                {
+                    Some(export)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn special_export_from_binding_idx(
+        &self,
+        mut idx: Idx<Key>,
+        visited_names: &mut SmallSet<Name>,
+        visited_keys: &mut SmallSet<Idx<Key>>,
+    ) -> Option<SpecialExport> {
+        loop {
+            if !visited_keys.insert(idx) {
+                return None;
+            }
+            match self.bindings().get(idx) {
+                Binding::Forward(next)
+                | Binding::PromoteForward(next)
+                | Binding::ForwardToFirstUse(next)
+                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
+                Binding::NameAssign(name_assign) => {
+                    return self.call_targets_special_export_inner(
+                        &name_assign.expr,
+                        visited_names,
+                        visited_keys,
+                    );
+                }
+                Binding::Import(import) => {
+                    return SpecialExport::new(&import.1)
+                        .filter(|export| export.defined_in(import.0));
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    fn bound_name_module(&self, name: &ruff_python_ast::ExprName) -> Option<ModuleName> {
+        let key = Key::BoundName(ShortIdentifier::expr_name(name));
+        let mut idx = self.bindings().key_to_idx_hashed_opt(Hashed::new(&key))?;
+        let mut visited = SmallSet::new();
+        loop {
+            if !visited.insert(idx) {
+                return None;
+            }
+            match self.bindings().get(idx) {
+                Binding::Forward(next)
+                | Binding::PromoteForward(next)
+                | Binding::ForwardToFirstUse(next)
+                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
+                Binding::Module(module) => return Some(module.0),
+                Binding::NameAssign(name_assign)
+                    if let Expr::Name(alias) = name_assign.expr.as_ref() =>
+                {
+                    let alias_key = Key::BoundName(ShortIdentifier::expr_name(alias));
+                    idx = self
+                        .bindings()
+                        .key_to_idx_hashed_opt(Hashed::new(&alias_key))?;
+                }
+                _ => return None,
+            }
         }
     }
 

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -606,6 +606,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     }
 
     pub(crate) fn has_valid_annotation_syntax(&self, x: &Expr, errors: &ErrorCollector) -> bool {
+<<<<<<< HEAD
         if let Some(problem) = Ast::annotation_syntax_problem(x) {
             let message = if let Expr::BinOp(ExprBinOp { op, .. }) = x {
                 format!(
@@ -619,6 +620,119 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             false
         } else {
             true
+||||||| parent of 60c6a145e (type())
+        let Some(problem) = self.annotation_syntax_problem(x) else {
+            return true;
+        };
+        self.error(
+            errors,
+            x.range(),
+            ErrorInfo::Kind(ErrorKind::InvalidAnnotation),
+            format!("{problem} cannot be used in annotations"),
+        );
+        false
+    }
+
+    fn implicit_type_alias_syntax_problem(&self, x: &Expr) -> Option<String> {
+        let Expr::Name(name) = x else {
+            return None;
+        };
+        let key = Key::BoundName(ShortIdentifier::expr_name(name));
+        let mut idx = self.bindings().key_to_idx_hashed_opt(Hashed::new(&key))?;
+        let mut visited = SmallSet::new();
+        loop {
+            if !visited.insert(idx) {
+                return None;
+            }
+            match self.bindings().get(idx) {
+                Binding::Forward(next)
+                | Binding::PromoteForward(next)
+                | Binding::ForwardToFirstUse(next)
+                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
+                Binding::NameAssign(name_assign) => {
+                    if name_assign.annotation.is_some() || name_assign.is_in_function_scope {
+                        return None;
+                    }
+                    if matches!(
+                        self.expr_infer(&name_assign.expr, &self.error_swallower()),
+                        Type::TypeVar(_) | Type::ParamSpec(_) | Type::TypeVarTuple(_)
+                    ) {
+                        return None;
+                    }
+                    return self.annotation_syntax_problem(&name_assign.expr);
+                }
+                _ => return None,
+            }
+=======
+        let Some(problem) = self.annotation_syntax_problem(x) else {
+            return true;
+        };
+        self.error(
+            errors,
+            x.range(),
+            ErrorInfo::Kind(ErrorKind::InvalidAnnotation),
+            format!("{problem} cannot be used in annotations"),
+        );
+        false
+    }
+
+    fn implicit_type_alias_syntax_problem(&self, x: &Expr) -> Option<String> {
+        let Expr::Name(name) = x else {
+            return None;
+        };
+        let key = Key::BoundName(ShortIdentifier::expr_name(name));
+        let mut idx = self.bindings().key_to_idx_hashed_opt(Hashed::new(&key))?;
+        let mut visited = SmallSet::new();
+        loop {
+            if !visited.insert(idx) {
+                return None;
+            }
+            match self.bindings().get(idx) {
+                Binding::Forward(next)
+                | Binding::PromoteForward(next)
+                | Binding::ForwardToFirstUse(next)
+                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
+                Binding::NameAssign(name_assign) => {
+                    if name_assign.annotation.is_some() || name_assign.is_in_function_scope {
+                        return None;
+                    }
+                    if let Expr::Call(call) = name_assign.expr.as_ref()
+                        && self.implicit_alias_call_uses_runtime_type(call)
+                    {
+                        return None;
+                    }
+                    if matches!(
+                        self.expr_infer(&name_assign.expr, &self.error_swallower()),
+                        Type::TypeVar(_) | Type::ParamSpec(_) | Type::TypeVarTuple(_)
+                    ) {
+                        return None;
+                    }
+                    return self.annotation_syntax_problem(&name_assign.expr);
+                }
+                _ => return None,
+            }
+>>>>>>> 60c6a145e (type())
+        }
+    }
+
+    fn implicit_alias_call_uses_runtime_type(&self, call: &ExprCall) -> bool {
+        let anon_key = Key::Anon(call.range);
+        if let Some(idx) = self
+            .bindings()
+            .key_to_idx_hashed_opt(Hashed::new(&anon_key))
+            && matches!(self.bindings().get(idx), Binding::ClassDef(..))
+        {
+            return true;
+        }
+        self.callable_is_builtin_type(&self.expr_infer(&call.func, &self.error_swallower()))
+    }
+
+    fn callable_is_builtin_type(&self, ty: &Type) -> bool {
+        match ty {
+            Type::ClassDef(cls) => cls.is_builtin("type"),
+            Type::ClassType(cls) | Type::SelfType(cls) => cls.has_qname("builtins", "type"),
+            Type::Type(inner) => self.callable_is_builtin_type(inner),
+            _ => false,
         }
     }
 

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -23,6 +23,7 @@ use pyrefly_types::type_alias::TypeAliasIndex;
 use pyrefly_types::type_alias::TypeAliasRef;
 use pyrefly_types::type_info::JoinStyle;
 use pyrefly_types::type_info::NameAssignTypeForm;
+use pyrefly_types::type_info::NameAssignTypeFormInfo;
 use pyrefly_types::typed_dict::ExtraItems;
 use pyrefly_types::typed_dict::TypedDict;
 use pyrefly_util::display::pluralize;
@@ -80,6 +81,7 @@ use crate::binding::binding::BindingConsistentOverrideCheck;
 use crate::binding::binding::BindingDecoratedFunction;
 use crate::binding::binding::BindingDecorator;
 use crate::binding::binding::BindingExpect;
+use crate::binding::binding::BindingExport;
 use crate::binding::binding::BindingLegacyTypeParam;
 use crate::binding::binding::BindingTParams;
 use crate::binding::binding::BindingTypeAlias;
@@ -100,6 +102,7 @@ use crate::binding::binding::Key;
 use crate::binding::binding::KeyAnnotation;
 use crate::binding::binding::KeyClass;
 use crate::binding::binding::KeyExport;
+use crate::binding::binding::KeyExportNameAssignTypeForm;
 use crate::binding::binding::KeyLegacyTypeParam;
 use crate::binding::binding::KeyTypeAlias;
 use crate::binding::binding::KeyUndecoratedFunction;
@@ -657,16 +660,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         expr: &Expr,
         ty: &Type,
         is_in_function_scope: bool,
-    ) -> Option<NameAssignTypeForm> {
+    ) -> NameAssignTypeFormInfo {
         if annotation.is_some() || is_in_function_scope {
-            return None;
+            return NameAssignTypeFormInfo::default();
         }
-        let problem = Ast::annotation_syntax_problem(expr)?;
+        let Some(problem) = Ast::annotation_syntax_problem(expr) else {
+            return NameAssignTypeFormInfo::default();
+        };
         if matches!(
             ty,
             Type::TypeVar(_) | Type::ParamSpec(_) | Type::TypeVarTuple(_)
         ) {
-            return Some(NameAssignTypeForm::RuntimeTypeValue);
+            return NameAssignTypeFormInfo::default();
         }
         if let Expr::Call(call) = expr
             && (self.call_has_synthesized_runtime_type(call)
@@ -674,9 +679,58 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     &self.expr_infer(&call.func, &self.error_swallower()),
                 ))
         {
-            return Some(NameAssignTypeForm::RuntimeTypeValue);
+            return NameAssignTypeFormInfo::default();
         }
-        Some(NameAssignTypeForm::InvalidImplicitAlias(problem.into()))
+        NameAssignTypeFormInfo::invalid_implicit_alias(problem.into())
+    }
+
+    fn name_assign_type_form_for_idx(
+        &self,
+        mut idx: Idx<Key>,
+        _errors: &ErrorCollector,
+    ) -> NameAssignTypeFormInfo {
+        let mut visited = SmallSet::new();
+        loop {
+            if !visited.insert(idx) {
+                unreachable!("cycle in binding chain while classifying implicit type alias syntax");
+            }
+            match self.bindings().get(idx) {
+                Binding::Forward(next)
+                | Binding::PromoteForward(next)
+                | Binding::ForwardToFirstUse(next)
+                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
+                Binding::NameAssign(name_assign) => {
+                    let ty =
+                        self.binding_to_type(self.bindings().get(idx), &self.error_swallower());
+                    return self.classify_name_assign_type_form(
+                        name_assign.annotation,
+                        &name_assign.expr,
+                        &ty,
+                        name_assign.is_in_function_scope,
+                    );
+                }
+                Binding::Import(import) => {
+                    return self
+                        .get_from_export_name_assign_type_form(
+                            import.module,
+                            None,
+                            &KeyExportNameAssignTypeForm(import.name.clone()),
+                        )
+                        .as_ref()
+                        .clone();
+                }
+                Binding::PossibleLegacyTParam(key, _) => {
+                    match (self.bindings().get(*key), &*self.get_idx(*key)) {
+                        (
+                            BindingLegacyTypeParam::ParamKeyed(next),
+                            LegacyTypeParameterLookup::NotParameter(_),
+                        ) => idx = *next,
+                        _ => return NameAssignTypeFormInfo::default(),
+                    }
+                }
+                _ => return NameAssignTypeFormInfo::default(),
+            }
+        }
     }
 
     fn annotation_name_assign_type_form(
@@ -684,7 +738,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         name: &ruff_python_ast::ExprName,
     ) -> Option<NameAssignTypeForm> {
         let key = Key::BoundName(ShortIdentifier::expr_name(name));
-        self.get(&key).name_assign_type_form().cloned()
+        let idx = self.bindings().key_to_idx_hashed_opt(Hashed::new(&key))?;
+        self.name_assign_type_form_for_idx(idx, &self.error_swallower())
+            .as_ref()
+            .cloned()
+    }
+
+    pub fn name_assign_type_form_for_export(
+        &self,
+        binding: &BindingExport,
+        errors: &ErrorCollector,
+    ) -> NameAssignTypeFormInfo {
+        self.name_assign_type_form_for_idx(binding.key_idx(), errors)
     }
 
     fn expr_annotation(
@@ -4647,15 +4712,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         errors: &ErrorCollector,
     ) -> TypeInfo {
         let ty = self.binding_to_type(binding, errors);
-        let mut type_info = TypeInfo::of_ty(ty.clone());
-        if let Some(name_assign_type_form) = self.classify_name_assign_type_form(
-            name_assign.annotation,
-            name_assign.expr.as_ref(),
-            &ty,
-            name_assign.is_in_function_scope,
-        ) {
-            type_info = type_info.with_name_assign_type_form(name_assign_type_form);
-        }
+        let mut type_info = TypeInfo::of_ty(ty);
         let mut prefix = Vec::new();
         self.populate_dict_literal_facets(&mut type_info, &mut prefix, name_assign.expr.as_ref());
         type_info
@@ -4714,10 +4771,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     range_if_scoped_params_exist,
                     errors,
                 ),
-            Binding::Import(x) => self
-                .get_from_export_type_info(x.0, None, &KeyExport(x.1.clone()))
-                .as_ref()
-                .clone(),
             _ => {
                 // All other Bindings model `Type` level operations where we do not
                 // propagate any attribute narrows.

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -22,6 +22,7 @@ use pyrefly_types::type_alias::TypeAliasData;
 use pyrefly_types::type_alias::TypeAliasIndex;
 use pyrefly_types::type_alias::TypeAliasRef;
 use pyrefly_types::type_info::JoinStyle;
+use pyrefly_types::type_info::NameAssignTypeForm;
 use pyrefly_types::typed_dict::ExtraItems;
 use pyrefly_types::typed_dict::TypedDict;
 use pyrefly_util::display::pluralize;
@@ -105,6 +106,7 @@ use crate::binding::binding::KeyUndecoratedFunction;
 use crate::binding::binding::Keyed;
 use crate::binding::binding::LastStmt;
 use crate::binding::binding::LinkedKey;
+use crate::binding::binding::NameAssign;
 use crate::binding::binding::NoneIfRecursive;
 use crate::binding::binding::PrivateAttributeAccessCheck;
 use crate::binding::binding::RaisedException;
@@ -246,6 +248,18 @@ impl TypeFormContext {
                 | TypeFormContext::TypeArgument
                 | TypeFormContext::TypeArgumentCallableReturn
                 | TypeFormContext::TypeArgumentForType
+            )
+    }
+
+    fn reports_implicit_alias_syntax_at_use_site(self) -> bool {
+        matches!(
+            self,
+            TypeFormContext::ClassVarAnnotation
+                | TypeFormContext::ParameterAnnotation
+                | TypeFormContext::ParameterArgsAnnotation
+                | TypeFormContext::ParameterKwargsAnnotation
+                | TypeFormContext::ReturnAnnotation
+                | TypeFormContext::VarAnnotation(_)
         )
     }
 }
@@ -606,7 +620,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     }
 
     pub(crate) fn has_valid_annotation_syntax(&self, x: &Expr, errors: &ErrorCollector) -> bool {
-<<<<<<< HEAD
         if let Some(problem) = Ast::annotation_syntax_problem(x) {
             let message = if let Expr::BinOp(ExprBinOp { op, .. }) = x {
                 format!(
@@ -620,101 +633,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             false
         } else {
             true
-||||||| parent of 60c6a145e (type())
-        let Some(problem) = self.annotation_syntax_problem(x) else {
-            return true;
-        };
-        self.error(
-            errors,
-            x.range(),
-            ErrorInfo::Kind(ErrorKind::InvalidAnnotation),
-            format!("{problem} cannot be used in annotations"),
-        );
-        false
-    }
-
-    fn implicit_type_alias_syntax_problem(&self, x: &Expr) -> Option<String> {
-        let Expr::Name(name) = x else {
-            return None;
-        };
-        let key = Key::BoundName(ShortIdentifier::expr_name(name));
-        let mut idx = self.bindings().key_to_idx_hashed_opt(Hashed::new(&key))?;
-        let mut visited = SmallSet::new();
-        loop {
-            if !visited.insert(idx) {
-                return None;
-            }
-            match self.bindings().get(idx) {
-                Binding::Forward(next)
-                | Binding::PromoteForward(next)
-                | Binding::ForwardToFirstUse(next)
-                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
-                Binding::NameAssign(name_assign) => {
-                    if name_assign.annotation.is_some() || name_assign.is_in_function_scope {
-                        return None;
-                    }
-                    if matches!(
-                        self.expr_infer(&name_assign.expr, &self.error_swallower()),
-                        Type::TypeVar(_) | Type::ParamSpec(_) | Type::TypeVarTuple(_)
-                    ) {
-                        return None;
-                    }
-                    return self.annotation_syntax_problem(&name_assign.expr);
-                }
-                _ => return None,
-            }
-=======
-        let Some(problem) = self.annotation_syntax_problem(x) else {
-            return true;
-        };
-        self.error(
-            errors,
-            x.range(),
-            ErrorInfo::Kind(ErrorKind::InvalidAnnotation),
-            format!("{problem} cannot be used in annotations"),
-        );
-        false
-    }
-
-    fn implicit_type_alias_syntax_problem(&self, x: &Expr) -> Option<String> {
-        let Expr::Name(name) = x else {
-            return None;
-        };
-        let key = Key::BoundName(ShortIdentifier::expr_name(name));
-        let mut idx = self.bindings().key_to_idx_hashed_opt(Hashed::new(&key))?;
-        let mut visited = SmallSet::new();
-        loop {
-            if !visited.insert(idx) {
-                return None;
-            }
-            match self.bindings().get(idx) {
-                Binding::Forward(next)
-                | Binding::PromoteForward(next)
-                | Binding::ForwardToFirstUse(next)
-                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
-                Binding::NameAssign(name_assign) => {
-                    if name_assign.annotation.is_some() || name_assign.is_in_function_scope {
-                        return None;
-                    }
-                    if let Expr::Call(call) = name_assign.expr.as_ref()
-                        && self.implicit_alias_call_uses_runtime_type(call)
-                    {
-                        return None;
-                    }
-                    if matches!(
-                        self.expr_infer(&name_assign.expr, &self.error_swallower()),
-                        Type::TypeVar(_) | Type::ParamSpec(_) | Type::TypeVarTuple(_)
-                    ) {
-                        return None;
-                    }
-                    return self.annotation_syntax_problem(&name_assign.expr);
-                }
-                _ => return None,
-            }
->>>>>>> 60c6a145e (type())
         }
     }
-
     fn implicit_alias_call_uses_runtime_type(&self, call: &ExprCall) -> bool {
         if matches!(
             self.call_targets_special_export(&call.func),
@@ -748,6 +668,32 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::Type(inner) => self.callable_is_builtin_type(inner),
             _ => false,
         }
+    }
+
+    fn classify_name_assign_type_form(
+        &self,
+        annotation: Option<(AnnotationStyle, Idx<KeyAnnotation>)>,
+        expr: &Expr,
+        ty: &Type,
+        is_in_function_scope: bool,
+    ) -> Option<NameAssignTypeForm> {
+        if annotation.is_some() || is_in_function_scope {
+            return None;
+        }
+        if let Expr::Call(call) = expr
+            && self.implicit_alias_call_uses_runtime_type(call)
+        {
+            return Some(NameAssignTypeForm::RuntimeTypeValue);
+        }
+        if matches!(
+            ty,
+            Type::TypeVar(_) | Type::ParamSpec(_) | Type::TypeVarTuple(_)
+        ) {
+            return Some(NameAssignTypeForm::RuntimeTypeValue);
+        }
+        Ast::annotation_syntax_problem(expr)
+            .map(str::to_owned)
+            .map(NameAssignTypeForm::InvalidImplicitAlias)
     }
 
     fn call_targets_special_export(&self, expr: &Expr) -> Option<SpecialExport> {
@@ -821,8 +767,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     );
                 }
                 Binding::Import(import) => {
-                    return SpecialExport::new(&import.1)
-                        .filter(|export| export.defined_in(import.0));
+                    return SpecialExport::new(&import.name)
+                        .filter(|export| export.defined_in(import.module));
                 }
                 Binding::ClassDef(class_idx, _) => {
                     let Some(cls) = &self.get_idx(*class_idx).0 else {
@@ -4813,14 +4759,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     #[inline(never)]
     fn binding_to_type_info_name_assign(
         &self,
+        name_assign: &NameAssign,
         binding: &Binding,
-        expr: &Expr,
         errors: &ErrorCollector,
     ) -> TypeInfo {
         let ty = self.binding_to_type(binding, errors);
-        let mut type_info = TypeInfo::of_ty(ty);
+        let mut type_info = TypeInfo::of_ty(ty.clone());
+        if let Some(name_assign_type_form) = self.classify_name_assign_type_form(
+            name_assign.annotation,
+            name_assign.expr.as_ref(),
+            &ty,
+            name_assign.is_in_function_scope,
+        ) {
+            type_info = type_info.with_name_assign_type_form(name_assign_type_form);
+        }
         let mut prefix = Vec::new();
-        self.populate_dict_literal_facets(&mut type_info, &mut prefix, expr);
+        self.populate_dict_literal_facets(&mut type_info, &mut prefix, name_assign.expr.as_ref());
         type_info
     }
 
@@ -4859,7 +4813,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if x.receiver_idx.is_some() {
                     TypeInfo::of_ty(self.binding_to_type(binding, errors))
                 } else {
-                    self.binding_to_type_info_name_assign(binding, x.expr.as_ref(), errors)
+                    self.binding_to_type_info_name_assign(x, binding, errors)
                 }
             }
             Binding::AssignToAttribute(x) => self.binding_to_type_info_assign_to_attribute(
@@ -6265,6 +6219,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         type_form_context: TypeFormContext,
         errors: &ErrorCollector,
     ) -> Type {
+        if type_form_context.reports_implicit_alias_syntax_at_use_site()
+            && let Expr::Name(name) = x
+            && let Some(NameAssignTypeForm::InvalidImplicitAlias(problem)) = self
+                .get(&Key::BoundName(ShortIdentifier::expr_name(name)))
+                .name_assign_type_form()
+        {
+            return self.error(
+                errors,
+                x.range(),
+                ErrorKind::InvalidAnnotation,
+                format!("{problem} cannot be used in annotations"),
+            );
+        }
         let result = match x {
             Expr::List(x)
                 if matches!(

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -6257,7 +6257,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     return self.error(
                         errors,
                         x.range(),
-                        ErrorInfo::Kind(ErrorKind::InvalidAnnotation),
+                        ErrorKind::InvalidAnnotation,
                         format!("{problem} cannot be used in annotations"),
                     );
                 }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -722,6 +722,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 SpecialExport::TypeVar
                     | SpecialExport::ParamSpec
                     | SpecialExport::TypeVarTuple
+                    | SpecialExport::TypedDict
+                    | SpecialExport::TypingNamedTuple
+                    | SpecialExport::CollectionsNamedTuple
                     | SpecialExport::BuiltinsType
             )
         ) {
@@ -820,6 +823,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 Binding::Import(import) => {
                     return SpecialExport::new(&import.1)
                         .filter(|export| export.defined_in(import.0));
+                }
+                Binding::ClassDef(class_idx, _) => {
+                    let Some(cls) = &self.get_idx(*class_idx).0 else {
+                        return None;
+                    };
+                    return SpecialExport::new(cls.name());
                 }
                 _ => return None,
             }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -943,7 +943,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             return Some(NameAssignTypeForm::RuntimeTypeValue);
 >>>>>>> d1be9bab0 (clean)
         }
-        Some(NameAssignTypeForm::InvalidImplicitAlias(problem))
+        Some(NameAssignTypeForm::InvalidImplicitAlias(problem.into()))
     }
 
     fn expr_annotation(

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -710,6 +710,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     );
                 }
                 Binding::Import(import) => {
+                    if !self.exports.export_exists(import.module, &import.name) {
+                        return NameAssignTypeFormInfo::default();
+                    }
                     return self
                         .get_from_export_name_assign_type_form(
                             import.module,

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -710,9 +710,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     );
                 }
                 Binding::Import(import) => {
-                    if !self.exports.export_exists(import.module, &import.name) {
-                        return NameAssignTypeFormInfo::default();
-                    }
                     return self
                         .get_from_export_name_assign_type_form(
                             import.module,
@@ -745,6 +742,36 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         self.name_assign_type_form_for_idx(idx, &self.error_swallower())
             .as_ref()
             .cloned()
+    }
+
+    fn annotation_name_resolves_to_import(&self, name: &ruff_python_ast::ExprName) -> bool {
+        let key = Key::BoundName(ShortIdentifier::expr_name(name));
+        let Some(mut idx) = self.bindings().key_to_idx_hashed_opt(Hashed::new(&key)) else {
+            return false;
+        };
+        let mut visited = SmallSet::new();
+        loop {
+            if !visited.insert(idx) {
+                unreachable!("cycle in binding chain while checking annotation import origin");
+            }
+            match self.bindings().get(idx) {
+                Binding::Forward(next)
+                | Binding::PromoteForward(next)
+                | Binding::ForwardToFirstUse(next)
+                | Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
+                Binding::Import(_) => return true,
+                Binding::PossibleLegacyTParam(key, _) => {
+                    match (self.bindings().get(*key), &*self.get_idx(*key)) {
+                        (
+                            BindingLegacyTypeParam::ParamKeyed(next),
+                            LegacyTypeParameterLookup::NotParameter(_),
+                        ) => idx = *next,
+                        _ => return false,
+                    }
+                }
+                _ => return false,
+            }
+        }
     }
 
     pub fn name_assign_type_form_for_export(
@@ -6164,6 +6191,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Type {
         if type_form_context.reports_implicit_alias_syntax_at_use_site()
             && let Expr::Name(name) = x
+            && !self.annotation_name_resolves_to_import(name)
             && let Some(NameAssignTypeForm::InvalidImplicitAlias(problem)) =
                 self.annotation_name_assign_type_form(name)
         {
@@ -6220,6 +6248,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             _ => {
                 let inferred_ty = self.expr_infer(x, errors);
+                if type_form_context.reports_implicit_alias_syntax_at_use_site()
+                    && let Expr::Name(name) = x
+                    && self.annotation_name_resolves_to_import(name)
+                    && let Some(NameAssignTypeForm::InvalidImplicitAlias(problem)) =
+                        self.annotation_name_assign_type_form(name)
+                {
+                    return self.error(
+                        errors,
+                        x.range(),
+                        ErrorInfo::Kind(ErrorKind::InvalidAnnotation),
+                        format!("{problem} cannot be used in annotations"),
+                    );
+                }
                 // Check if this is a scoped type alias in base class context
                 // We do this check here instead of `validate_type_form` because it
                 // substitutes type aliases with the aliased type

--- a/pyrefly/lib/alt/traits.rs
+++ b/pyrefly/lib/alt/traits.rs
@@ -69,6 +69,7 @@ use crate::binding::binding::KeyDecoratedFunction;
 use crate::binding::binding::KeyDecorator;
 use crate::binding::binding::KeyExpect;
 use crate::binding::binding::KeyExport;
+use crate::binding::binding::KeyExportNameAssignTypeForm;
 use crate::binding::binding::KeyLegacyTypeParam;
 use crate::binding::binding::KeyTParams;
 use crate::binding::binding::KeyTypeAlias;
@@ -84,6 +85,7 @@ use crate::binding::binding::UndecoratedFunctionRangeAnswer;
 use crate::error::collector::ErrorCollector;
 use crate::types::annotation::Annotation;
 use crate::types::class::Class;
+use crate::types::type_info::NameAssignTypeFormInfo;
 use crate::types::type_info::TypeInfo;
 use crate::types::types::AnyStyle;
 use crate::types::types::TParams;
@@ -234,7 +236,7 @@ impl<Ans: LookupAnswer> Solve<Ans> for KeyExport {
         binding: &BindingExport,
         range: TextRange,
         errors: &ErrorCollector,
-    ) -> Arc<TypeInfo> {
+    ) -> Arc<Type> {
         let inner = match binding {
             BindingExport::Forward(idx) => Binding::Forward(*idx),
             BindingExport::PromoteForward(idx) => Binding::PromoteForward(*idx),
@@ -242,7 +244,7 @@ impl<Ans: LookupAnswer> Solve<Ans> for KeyExport {
                 Binding::AnnotatedType(*ann, Box::new(Binding::Forward(*idx)))
             }
         };
-        answers.solve_binding(&inner, range, errors)
+        Arc::new(answers.solve_binding(&inner, range, errors).arc_clone_ty())
     }
 
     fn promote_recursive(_heap: &TypeHeap, _: Var) -> Self::Answer {
@@ -252,7 +254,22 @@ impl<Ans: LookupAnswer> Solve<Ans> for KeyExport {
         // returning Unknown here avoids leaking a Var across module boundaries
         // in iterative-fixpoint SCC solving (where cross-module back-edges on
         // KeyExport would otherwise return a Type::Var from a foreign solver).
-        TypeInfo::of_ty(Type::Any(AnyStyle::Implicit))
+        Type::Any(AnyStyle::Implicit)
+    }
+}
+
+impl<Ans: LookupAnswer> Solve<Ans> for KeyExportNameAssignTypeForm {
+    fn solve(
+        answers: &AnswersSolver<Ans>,
+        binding: &BindingExport,
+        _range: TextRange,
+        errors: &ErrorCollector,
+    ) -> Arc<NameAssignTypeFormInfo> {
+        Arc::new(answers.name_assign_type_form_for_export(binding, errors))
+    }
+
+    fn promote_recursive(_heap: &TypeHeap, _: Var) -> Self::Answer {
+        NameAssignTypeFormInfo::default()
     }
 }
 

--- a/pyrefly/lib/alt/traits.rs
+++ b/pyrefly/lib/alt/traits.rs
@@ -234,7 +234,7 @@ impl<Ans: LookupAnswer> Solve<Ans> for KeyExport {
         binding: &BindingExport,
         range: TextRange,
         errors: &ErrorCollector,
-    ) -> Arc<Type> {
+    ) -> Arc<TypeInfo> {
         let inner = match binding {
             BindingExport::Forward(idx) => Binding::Forward(*idx),
             BindingExport::PromoteForward(idx) => Binding::PromoteForward(*idx),
@@ -242,7 +242,7 @@ impl<Ans: LookupAnswer> Solve<Ans> for KeyExport {
                 Binding::AnnotatedType(*ann, Box::new(Binding::Forward(*idx)))
             }
         };
-        Arc::new(answers.solve_binding(&inner, range, errors).arc_clone_ty())
+        answers.solve_binding(&inner, range, errors)
     }
 
     fn promote_recursive(_heap: &TypeHeap, _: Var) -> Self::Answer {
@@ -252,7 +252,7 @@ impl<Ans: LookupAnswer> Solve<Ans> for KeyExport {
         // returning Unknown here avoids leaking a Var across module boundaries
         // in iterative-fixpoint SCC solving (where cross-module back-edges on
         // KeyExport would otherwise return a Type::Var from a foreign solver).
-        Type::Any(AnyStyle::Implicit)
+        TypeInfo::of_ty(Type::Any(AnyStyle::Implicit))
     }
 }
 

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -84,6 +84,7 @@ use crate::types::quantified::QuantifiedIdentity;
 use crate::types::quantified::QuantifiedKind;
 use crate::types::stdlib::Stdlib;
 use crate::types::type_info::JoinStyle;
+use crate::types::type_info::NameAssignTypeFormInfo;
 use crate::types::type_info::TypeInfo;
 use crate::types::types::AnyStyle;
 use crate::types::types::TParams;
@@ -93,6 +94,7 @@ assert_words!(Key, 2);
 assert_bytes!(KeyExpect, 12);
 assert_bytes!(KeyTypeAlias, 4);
 assert_words!(KeyExport, 3);
+assert_words!(KeyExportNameAssignTypeForm, 3);
 assert_words!(KeyClass, 1);
 assert_bytes!(KeyTParams, 4);
 assert_bytes!(KeyClassBaseType, 4);
@@ -144,6 +146,7 @@ pub enum AnyIdx {
     KeyVarianceCheck(Idx<KeyVarianceCheck>),
     KeyClassSynthesizedFields(Idx<KeyClassSynthesizedFields>),
     KeyExport(Idx<KeyExport>),
+    KeyExportNameAssignTypeForm(Idx<KeyExportNameAssignTypeForm>),
     KeyDecorator(Idx<KeyDecorator>),
     KeyDecoratedFunction(Idx<KeyDecoratedFunction>),
     KeyUndecoratedFunction(Idx<KeyUndecoratedFunction>),
@@ -204,6 +207,9 @@ macro_rules! dispatch_anyidx {
                 $self.$method::<$crate::binding::binding::KeyClassSynthesizedFields>(*idx)
             }
             AnyIdx::KeyExport(idx) => $self.$method::<$crate::binding::binding::KeyExport>(*idx),
+            AnyIdx::KeyExportNameAssignTypeForm(idx) => {
+                $self.$method::<$crate::binding::binding::KeyExportNameAssignTypeForm>(*idx)
+            }
             AnyIdx::KeyDecorator(idx) => {
                 $self.$method::<$crate::binding::binding::KeyDecorator>(*idx)
             }
@@ -277,6 +283,9 @@ macro_rules! dispatch_anyidx {
             AnyIdx::KeyExport(idx) => {
                 $self.$method::<$crate::binding::binding::KeyExport>(*idx, $($args),+)
             }
+            AnyIdx::KeyExportNameAssignTypeForm(idx) => {
+                $self.$method::<$crate::binding::binding::KeyExportNameAssignTypeForm>(*idx, $($args),+)
+            }
             AnyIdx::KeyDecorator(idx) => {
                 $self.$method::<$crate::binding::binding::KeyDecorator>(*idx, $($args),+)
             }
@@ -335,6 +344,7 @@ impl DisplayWith<Bindings> for AnyIdx {
             Self::KeyVarianceCheck(idx) => write!(f, "{}", ctx.display(*idx)),
             Self::KeyClassSynthesizedFields(idx) => write!(f, "{}", ctx.display(*idx)),
             Self::KeyExport(idx) => write!(f, "{}", ctx.display(*idx)),
+            Self::KeyExportNameAssignTypeForm(idx) => write!(f, "{}", ctx.display(*idx)),
             Self::KeyDecorator(idx) => write!(f, "{}", ctx.display(*idx)),
             Self::KeyDecoratedFunction(idx) => write!(f, "{}", ctx.display(*idx)),
             Self::KeyUndecoratedFunction(idx) => write!(f, "{}", ctx.display(*idx)),
@@ -361,6 +371,7 @@ pub enum AnyExportedKey {
     KeyClassSynthesizedFields(KeyClassSynthesizedFields),
     KeyVariance(KeyVariance),
     KeyExport(KeyExport),
+    KeyExportNameAssignTypeForm(KeyExportNameAssignTypeForm),
     KeyClassMetadata(KeyClassMetadata),
     KeyClassMro(KeyClassMro),
     KeyAbstractClassCheck(KeyAbstractClassCheck),
@@ -602,7 +613,7 @@ impl Keyed for KeyVarianceCheck {
 impl Keyed for KeyExport {
     const EXPORTED: bool = true;
     type Value = BindingExport;
-    type Answer = TypeInfo;
+    type Answer = Type;
     fn to_anyidx(idx: Idx<Self>) -> AnyIdx {
         AnyIdx::KeyExport(idx)
     }
@@ -619,6 +630,28 @@ impl Keyed for KeyExport {
 impl Exported for KeyExport {
     fn to_anykey(&self) -> AnyExportedKey {
         AnyExportedKey::KeyExport(self.clone())
+    }
+}
+impl Keyed for KeyExportNameAssignTypeForm {
+    const EXPORTED: bool = true;
+    type Value = BindingExport;
+    type Answer = NameAssignTypeFormInfo;
+    fn to_anyidx(idx: Idx<Self>) -> AnyIdx {
+        AnyIdx::KeyExportNameAssignTypeForm(idx)
+    }
+    fn range_with(idx: Idx<Self>, bindings: &Bindings) -> TextRange
+    where
+        BindingTable: TableKeyed<Self, Value = BindingEntry<Self>>,
+    {
+        bindings.idx_to_key(bindings.get(idx).key_idx()).range()
+    }
+    fn try_to_anykey(&self) -> Option<AnyExportedKey> {
+        Some(AnyExportedKey::KeyExportNameAssignTypeForm(self.clone()))
+    }
+}
+impl Exported for KeyExportNameAssignTypeForm {
+    fn to_anykey(&self) -> AnyExportedKey {
+        AnyExportedKey::KeyExportNameAssignTypeForm(self.clone())
     }
 }
 impl Keyed for KeyDecorator {
@@ -1381,6 +1414,15 @@ pub struct KeyExport(pub Name);
 impl DisplayWith<ModuleInfo> for KeyExport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, _: &ModuleInfo) -> fmt::Result {
         write!(f, "KeyExport({})", self.0)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct KeyExportNameAssignTypeForm(pub Name);
+
+impl DisplayWith<ModuleInfo> for KeyExportNameAssignTypeForm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, _: &ModuleInfo) -> fmt::Result {
+        write!(f, "KeyExportNameAssignTypeForm({})", self.0)
     }
 }
 

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -602,7 +602,7 @@ impl Keyed for KeyVarianceCheck {
 impl Keyed for KeyExport {
     const EXPORTED: bool = true;
     type Value = BindingExport;
-    type Answer = Type;
+    type Answer = TypeInfo;
     fn to_anyidx(idx: Idx<Self>) -> AnyIdx {
         AnyIdx::KeyExport(idx)
     }

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -692,9 +692,14 @@ impl Bindings {
             if exported.contains_key_hashed(name.as_ref()) {
                 let key = name.into_key().clone();
                 exported_names.insert(key.clone());
-                builder
-                    .table
-                    .insert(KeyExportNameAssignTypeForm(key.clone()), binding.clone());
+                if BindingsBuilder::export_may_have_implicit_alias_syntax_problem(
+                    &builder.table,
+                    binding.key_idx(),
+                ) {
+                    builder
+                        .table
+                        .insert(KeyExportNameAssignTypeForm(key.clone()), binding.clone());
+                }
                 builder.table.insert(KeyExport(key), binding);
             }
         }
@@ -706,10 +711,6 @@ impl Bindings {
                 exported_names.insert(name.clone());
                 builder.table.insert(
                     KeyExport(name.clone()),
-                    BindingExport::forward_maybe_promote(key, &name),
-                );
-                builder.table.insert(
-                    KeyExportNameAssignTypeForm(name.clone()),
                     BindingExport::forward_maybe_promote(key, &name),
                 );
             }
@@ -941,6 +942,57 @@ impl<'a> BindingsBuilder<'a> {
         BindingTable: TableKeyed<K, Value = BindingEntry<K>>,
     {
         self.table.get_mut::<K>().1.get_mut(idx)
+    }
+
+    fn export_may_have_implicit_alias_syntax_problem(
+        table: &BindingTable,
+        mut idx: Idx<Key>,
+    ) -> bool {
+        let mut visited = SmallSet::new();
+        loop {
+            if !visited.insert(idx) {
+                return false;
+            }
+            match table.get::<Key>().1.get(idx) {
+                Some(
+                    Binding::Forward(next)
+                    | Binding::PromoteForward(next)
+                    | Binding::ForwardToFirstUse(next)
+                    | Binding::Phi(JoinStyle::NarrowOf(next), _),
+                ) => idx = *next,
+                Some(Binding::NameAssign(name_assign)) => {
+                    return name_assign.annotation.is_none()
+                        && !name_assign.is_in_function_scope
+                        && Self::expr_may_have_implicit_alias_syntax_problem(&name_assign.expr);
+                }
+                _ => return false,
+            }
+        }
+    }
+
+    fn expr_may_have_implicit_alias_syntax_problem(expr: &Expr) -> bool {
+        match expr {
+            Expr::Name(..)
+            | Expr::Attribute(..)
+            | Expr::StringLiteral(..)
+            | Expr::BytesLiteral(..)
+            | Expr::NoneLiteral(..)
+            | Expr::EllipsisLiteral(..)
+            | Expr::Starred(..) => false,
+            Expr::Subscript(subscript) => !matches!(
+                subscript.value.as_ref(),
+                Expr::Name(..)
+                    | Expr::BinOp(ruff_python_ast::ExprBinOp {
+                        op: ruff_python_ast::Operator::BitOr,
+                        ..
+                    })
+                    | Expr::Named(..)
+                    | Expr::StringLiteral(..)
+                    | Expr::NoneLiteral(..)
+                    | Expr::Attribute(..)
+            ),
+            _ => true,
+        }
     }
 
     /// Declare a `Key` as a usage, which can be used for name lookups. Like `idx_for_promise`,

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -66,6 +66,7 @@ use crate::binding::binding::KeyClass;
 use crate::binding::binding::KeyDecoratedFunction;
 use crate::binding::binding::KeyExpect;
 use crate::binding::binding::KeyExport;
+use crate::binding::binding::KeyExportNameAssignTypeForm;
 use crate::binding::binding::KeyLegacyTypeParam;
 use crate::binding::binding::KeyTypeAlias;
 use crate::binding::binding::KeyUndecoratedFunction;
@@ -691,6 +692,9 @@ impl Bindings {
             if exported.contains_key_hashed(name.as_ref()) {
                 let key = name.into_key().clone();
                 exported_names.insert(key.clone());
+                builder
+                    .table
+                    .insert(KeyExportNameAssignTypeForm(key.clone()), binding.clone());
                 builder.table.insert(KeyExport(key), binding);
             }
         }
@@ -702,6 +706,10 @@ impl Bindings {
                 exported_names.insert(name.clone());
                 builder.table.insert(
                     KeyExport(name.clone()),
+                    BindingExport::forward_maybe_promote(key, &name),
+                );
+                builder.table.insert(
+                    KeyExportNameAssignTypeForm(name.clone()),
                     BindingExport::forward_maybe_promote(key, &name),
                 );
             }

--- a/pyrefly/lib/binding/table.rs
+++ b/pyrefly/lib/binding/table.rs
@@ -29,6 +29,7 @@ macro_rules! table {
             $($vis)* type_aliases: $t<$crate::binding::binding::KeyTypeAlias>,
             $($vis)* consistent_override_checks: $t<$crate::binding::binding::KeyConsistentOverrideCheck>,
             $($vis)* exports: $t<$crate::binding::binding::KeyExport>,
+            $($vis)* export_name_assign_type_forms: $t<$crate::binding::binding::KeyExportNameAssignTypeForm>,
             $($vis)* decorators: $t<$crate::binding::binding::KeyDecorator>,
             $($vis)* decorated_functions: $t<$crate::binding::binding::KeyDecoratedFunction>,
             $($vis)* undecorated_functions: $t<$crate::binding::binding::KeyUndecoratedFunction>,
@@ -78,6 +79,12 @@ macro_rules! table {
             type Value = $t<$crate::binding::binding::KeyExport>;
             fn get(&self) -> &Self::Value { &self.exports }
             fn get_mut(&mut self) -> &mut Self::Value { &mut self.exports }
+        }
+
+        impl $crate::binding::table::TableKeyed<$crate::binding::binding::KeyExportNameAssignTypeForm> for $name {
+            type Value = $t<$crate::binding::binding::KeyExportNameAssignTypeForm>;
+            fn get(&self) -> &Self::Value { &self.export_name_assign_type_forms }
+            fn get_mut(&mut self) -> &mut Self::Value { &mut self.export_name_assign_type_forms }
         }
 
         impl $crate::binding::table::TableKeyed<$crate::binding::binding::KeyDecorator> for $name {
@@ -222,6 +229,7 @@ macro_rules! table_for_each(
         $f(&($e).type_aliases);
         $f(&($e).consistent_override_checks);
         $f(&($e).exports);
+        $f(&($e).export_name_assign_type_forms);
         $f(&($e).decorators);
         $f(&($e).decorated_functions);
         $f(&($e).undecorated_functions);
@@ -252,6 +260,7 @@ macro_rules! table_mut_for_each(
         $f(&mut ($e).type_aliases);
         $f(&mut ($e).consistent_override_checks);
         $f(&mut ($e).exports);
+        $f(&mut ($e).export_name_assign_type_forms);
         $f(&mut ($e).decorators);
         $f(&mut ($e).decorated_functions);
         $f(&mut ($e).undecorated_functions);
@@ -282,6 +291,7 @@ macro_rules! table_try_for_each(
         $f(&($e).type_aliases)?;
         $f(&($e).consistent_override_checks)?;
         $f(&($e).exports)?;
+        $f(&($e).export_name_assign_type_forms)?;
         $f(&($e).decorators)?;
         $f(&($e).decorated_functions)?;
         $f(&($e).undecorated_functions)?;

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -92,6 +92,7 @@ use crate::binding::binding::KeyClassMro;
 use crate::binding::binding::KeyClassSubscriptSymmetry;
 use crate::binding::binding::KeyClassSynthesizedFields;
 use crate::binding::binding::KeyExport;
+use crate::binding::binding::KeyExportNameAssignTypeForm;
 use crate::binding::binding::KeyTParams;
 use crate::binding::binding::KeyVariance;
 use crate::binding::binding::Keyed;
@@ -140,6 +141,7 @@ use crate::types::class::Class;
 use crate::types::class::ClassDefIndex;
 use crate::types::class::ClassFields;
 use crate::types::stdlib::Stdlib;
+use crate::types::type_info::NameAssignTypeFormInfo;
 use crate::types::types::TParams;
 use crate::types::types::Type;
 
@@ -2937,6 +2939,38 @@ impl<'a> LookupAnswer for TransactionHandle<'a> {
             }
         }
         res
+    }
+
+    fn get_name_assign_type_form(
+        &self,
+        module: ModuleName,
+        path: Option<&ModulePath>,
+        k: &KeyExportNameAssignTypeForm,
+        thread_state: &ThreadState,
+    ) -> Option<Arc<NameAssignTypeFormInfo>> {
+        let path = match path {
+            Some(path) => path.dupe(),
+            None => self
+                .module_data
+                .imports
+                .read()
+                .get(&module)?
+                .clone()
+                .finding()?,
+        };
+        if matches!(path.details(), ModulePathDetails::BundledTypeshed(_)) {
+            return None;
+        }
+        let handle = Handle::new(module, path, self.module_data.handle.sys_info().dupe());
+        let module_data = self.transaction.get_module(&handle);
+        let answers_guard = module_data.state.load_answers();
+        let Some(answers) = answers_guard.as_ref() else {
+            let solutions = module_data.state.get_solutions()?;
+            solutions.get_hashed_opt(Hashed::new(k))?;
+            return self.get(module, Some(handle.path()), k, thread_state);
+        };
+        answers.0.key_to_idx_hashed_opt(Hashed::new(k))?;
+        self.get(module, Some(handle.path()), k, thread_state)
     }
 
     fn commit_to_module(

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -140,7 +140,6 @@ use crate::types::class::Class;
 use crate::types::class::ClassDefIndex;
 use crate::types::class::ClassFields;
 use crate::types::stdlib::Stdlib;
-use crate::types::type_info::TypeInfo;
 use crate::types::types::TParams;
 use crate::types::types::Type;
 
@@ -242,6 +241,9 @@ impl ModuleChanges {
             AnyExportedKey::KeyExport(k) => {
                 self.0.names.entry(k.0).or_default();
             }
+            AnyExportedKey::KeyExportNameAssignTypeForm(k) => {
+                self.0.names.entry(k.0).or_default();
+            }
             // Classes and type aliases don't distinguish between existence and change.
             _ => self.add_key(key),
         }
@@ -299,6 +301,9 @@ impl ModuleDeps {
     fn add_key(&mut self, key: AnyExportedKey) {
         match key {
             AnyExportedKey::KeyExport(k) => {
+                self.names.entry(k.0).or_default().type_ = true;
+            }
+            AnyExportedKey::KeyExportNameAssignTypeForm(k) => {
                 self.names.entry(k.0).or_default().type_ = true;
             }
             AnyExportedKey::KeyTypeAlias(k) => {
@@ -1673,7 +1678,7 @@ impl<'a> Transaction<'a> {
         }
 
         let t = self.lookup_answer(module_data, &KeyExport(name.clone()), thread_state);
-        let class = match t.as_deref().map(TypeInfo::ty) {
+        let class = match t.as_deref() {
             Some(Type::ClassDef(cls)) => Some(cls.dupe()),
             ty => {
                 self.add_error(

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -140,6 +140,7 @@ use crate::types::class::Class;
 use crate::types::class::ClassDefIndex;
 use crate::types::class::ClassFields;
 use crate::types::stdlib::Stdlib;
+use crate::types::type_info::TypeInfo;
 use crate::types::types::TParams;
 use crate::types::types::Type;
 
@@ -1672,7 +1673,7 @@ impl<'a> Transaction<'a> {
         }
 
         let t = self.lookup_answer(module_data, &KeyExport(name.clone()), thread_state);
-        let class = match t.as_deref() {
+        let class = match t.as_deref().map(TypeInfo::ty) {
             Some(Type::ClassDef(cls)) => Some(cls.dupe()),
             ty => {
                 self.add_error(

--- a/pyrefly/lib/test/generic_legacy.rs
+++ b/pyrefly/lib/test/generic_legacy.rs
@@ -706,12 +706,20 @@ class C4(Generic[int]):  # E: Expected a type variable, got `int`
 
 testcase!(
     test_typevar_not_treated_as_bad_implicit_alias,
+    TestEnv::one(
+        "_typings",
+        "from typing import ParamSpec, TypeVar, TypeVarTuple",
+    ),
     r#"
+import _typings as t
 from typing import Callable, ParamSpec, TypeVar, TypeVarTuple, assert_type
 
 T = TypeVar("T")
 P = ParamSpec("P")
 Ts = TypeVarTuple("Ts")
+U = t.TypeVar("U")
+P2 = t.ParamSpec("P2")
+Ts2 = t.TypeVarTuple("Ts2")
 
 def f(x: T) -> T:
     assert_type(x, T)
@@ -721,6 +729,16 @@ def g(cb: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
     return cb(*args, **kwargs)
 
 def h(x: tuple[*Ts]) -> tuple[*Ts]:
+    return x
+
+def indirect(x: U) -> U:
+    assert_type(x, U)
+    return x
+
+def indirect_cb(cb: Callable[P2, U], *args: P2.args, **kwargs: P2.kwargs) -> U:
+    return cb(*args, **kwargs)
+
+def indirect_tuple(x: tuple[*Ts2]) -> tuple[*Ts2]:
     return x
     "#,
 );

--- a/pyrefly/lib/test/generic_legacy.rs
+++ b/pyrefly/lib/test/generic_legacy.rs
@@ -708,7 +708,7 @@ testcase!(
     test_typevar_not_treated_as_bad_implicit_alias,
     TestEnv::one(
         "_typings",
-        "from typing import ParamSpec, TypeVar, TypeVarTuple",
+        "from typing import Callable, ParamSpec, TypeVar, TypeVarTuple",
     ),
     r#"
 import _typings as t

--- a/pyrefly/lib/test/type_alias.rs
+++ b/pyrefly/lib/test/type_alias.rs
@@ -1133,6 +1133,22 @@ class Foo(BadBase):
 );
 
 testcase!(
+    test_bad_implicit_type_alias_imported,
+    TestEnv::one(
+        "mod_a",
+        r#"
+BadAlias = (lambda: int)()
+"#,
+    ),
+    r#"
+from mod_a import BadAlias
+
+def f(x: BadAlias):  # E: `BadAlias` is not a valid type alias: Function call cannot be used in annotations
+    pass
+"#,
+);
+
+testcase!(
     test_type_alias_variance_conformance,
     r#"
 from typing import Generic, TypeVar, TypeAlias

--- a/pyrefly/lib/test/type_alias.rs
+++ b/pyrefly/lib/test/type_alias.rs
@@ -1161,6 +1161,15 @@ def f(x: DynClass) -> None:
 );
 
 testcase!(
+    test_implicit_alias_runtime_type_call_minimal,
+    r#"
+DynClass = type("DynClass", (), {})
+def f(x: DynClass) -> None:
+    pass
+"#,
+);
+
+testcase!(
     test_implicit_alias_functional_typed_dict_and_named_tuple,
     r#"
 from typing import NamedTuple

--- a/pyrefly/lib/test/type_alias.rs
+++ b/pyrefly/lib/test/type_alias.rs
@@ -1161,6 +1161,20 @@ def f(x: DynClass) -> None:
 );
 
 testcase!(
+    test_implicit_alias_functional_typed_dict_and_named_tuple,
+    r#"
+from typing import NamedTuple
+from typing_extensions import TypedDict
+
+Point = NamedTuple("Point", [("x", int), ("y", int)])
+Config = TypedDict("Config", {"x": int})
+
+def f(p: Point, c: Config) -> tuple[Point, Config]:
+    return p, c
+"#,
+);
+
+testcase!(
     test_type_alias_variance_conformance,
     r#"
 from typing import Generic, TypeVar, TypeAlias

--- a/pyrefly/lib/test/type_alias.rs
+++ b/pyrefly/lib/test/type_alias.rs
@@ -1149,6 +1149,18 @@ def f(x: BadAlias):  # E: `BadAlias` is not a valid type alias: Function call ca
 );
 
 testcase!(
+    test_implicit_alias_runtime_type_call,
+    r#"
+DynClass = type("DynClass", (), {})
+
+def f(x: DynClass) -> None:
+    y = DynClass()
+    _ = x
+    _ = y
+"#,
+);
+
+testcase!(
     test_type_alias_variance_conformance,
     r#"
 from typing import Generic, TypeVar, TypeAlias

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -762,7 +762,7 @@ pub fn mk_state(code: &str) -> (Handle, State) {
 pub fn get_class(name: &str, handle: &Handle, state: &State) -> Class {
     let solutions = state.transaction().get_solutions(handle).unwrap();
 
-    match solutions.get(&KeyExport(Name::new(name))).ty() {
+    match &**solutions.get(&KeyExport(Name::new(name))) {
         Type::ClassDef(cls) => cls.dupe(),
         _ => unreachable!(),
     }

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -762,7 +762,7 @@ pub fn mk_state(code: &str) -> (Handle, State) {
 pub fn get_class(name: &str, handle: &Handle, state: &State) -> Class {
     let solutions = state.transaction().get_solutions(handle).unwrap();
 
-    match &**solutions.get(&KeyExport(Name::new(name))) {
+    match solutions.get(&KeyExport(Name::new(name))).ty() {
         Type::ClassDef(cls) => cls.dupe(),
         _ => unreachable!(),
     }

--- a/pyrefly/test_laziness/test_attribute_inherited.md
+++ b/pyrefly/test_laziness/test_attribute_inherited.md
@@ -47,7 +47,7 @@ a: Solutions
 b: Answers
 c: Answers
 
-(170 builtin demands hidden)
+(172 builtin demands hidden)
 a -> b::Exports(is_special_export)
 a -> b::Load(module_exists)
 a -> b::Exports(export_exists)
@@ -71,4 +71,5 @@ a -> b::KeyClassMro(ClassDefIndex(0))
 a -> c::KeyClassSynthesizedFields(ClassDefIndex(0))
 a -> b::KeyClassMro(ClassDefIndex(0))
 a -> c::KeyClassField(ClassDefIndex(0), Name("base_attr"))
+a -> b::KeyAbstractClassCheck(ClassDefIndex(0))
 ```

--- a/pyrefly/test_laziness/test_attribute_on_class_itself.md
+++ b/pyrefly/test_laziness/test_attribute_on_class_itself.md
@@ -49,7 +49,7 @@ a: Solutions
 b: Answers
 c: Answers
 
-(181 builtin demands hidden)
+(183 builtin demands hidden)
 a -> b::Exports(is_special_export)
 a -> b::Load(module_exists)
 a -> b::Exports(export_exists)
@@ -73,4 +73,5 @@ a -> b::KeyClassMro(ClassDefIndex(0))
 a -> c::KeyClassSynthesizedFields(ClassDefIndex(0))
 a -> b::KeyClassMro(ClassDefIndex(0))
 a -> b::KeyClassField(ClassDefIndex(0), Name("child_attr"))
+a -> b::KeyAbstractClassCheck(ClassDefIndex(0))
 ```

--- a/pyrefly/test_laziness/test_import_class_instantiated.md
+++ b/pyrefly/test_laziness/test_import_class_instantiated.md
@@ -34,7 +34,7 @@ class Foo:
 a: Solutions
 b: Answers
 
-(159 builtin demands hidden)
+(161 builtin demands hidden)
 a -> b::Exports(is_special_export)
 a -> b::Load(module_exists)
 a -> b::Exports(export_exists)

--- a/pyrefly/test_laziness/test_transitive_import_annotated.md
+++ b/pyrefly/test_laziness/test_transitive_import_annotated.md
@@ -35,7 +35,7 @@ a: Solutions
 b: Answers
 c: Nothing
 
-(164 builtin demands hidden)
+(169 builtin demands hidden)
 a -> b::Load(module_exists)
 a -> b::Exports(export_exists)
 a -> b::Exports(get_deprecated)

--- a/pyrefly/test_laziness/test_transitive_import_unannotated.md
+++ b/pyrefly/test_laziness/test_transitive_import_unannotated.md
@@ -37,7 +37,7 @@ a: Solutions
 b: Answers
 c: Answers
 
-(168 builtin demands hidden)
+(173 builtin demands hidden)
 a -> b::Load(module_exists)
 a -> b::Exports(export_exists)
 a -> b::Exports(get_deprecated)


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2451

factored the syntax check into a reusable helper.

detect NameAssign bindings that were never real implicit aliases and surface the syntax error at the annotation use site.

preserves normal runtime-value typing while fixing the implicit-alias false negatives.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

update test