### PR TITLE
fix support show init for MagicMock #2855

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -54,6 +54,7 @@ use crate::types::callable::Callable;
 use crate::types::callable::FuncMetadata;
 use crate::types::callable::Function;
 use crate::types::callable::FunctionKind;
+use crate::types::callable::Param;
 use crate::types::callable::ParamList;
 use crate::types::callable::Params;
 use crate::types::class::ClassType;
@@ -785,24 +786,21 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         };
         let hint = None; // discard hint
         let class_metadata = self.get_metadata_for_class(cls.class_object());
-        // Tracks whether we've already recorded a trace for IDE features.
-        // Priority: metaclass __call__ > overridden __new__ > __init__.
-        let mut recorded_trace = false;
+        // IDE features want a single constructor signature, even when runtime dispatch
+        // splits construction across `__new__` and inherited `__init__` methods.
+        self.record_resolved_trace(arguments_range, self.constructor_to_display_callable(&cls));
         if let Some(ret) =
             self.call_metaclass(&cls, arguments_range, args, keywords, errors, context, hint)
         {
-            if let Some(metaclass_dunder_call) = self.get_metaclass_dunder_call(&cls) {
-                if let Some(callee_range) = callee_range
-                    && let Some(metaclass) = class_metadata.custom_metaclass()
-                {
-                    self.record_external_attribute_definition_index(
-                        &self.heap.mk_class_type(metaclass.clone()),
-                        &dunder::CALL,
-                        callee_range,
-                    );
-                }
-                self.record_resolved_trace(arguments_range, metaclass_dunder_call);
-                recorded_trace = true;
+            if self.get_metaclass_dunder_call(&cls).is_some()
+                && let Some(callee_range) = callee_range
+                && let Some(metaclass) = class_metadata.custom_metaclass()
+            {
+                self.record_external_attribute_definition_index(
+                    &self.heap.mk_class_type(metaclass.clone()),
+                    &dunder::CALL,
+                    callee_range,
+                );
             }
             // Enum construction is routed through EnumMeta.__call__, which performs
             // member lookup by value. A custom enum __new__ is used for member creation
@@ -865,10 +863,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         callee_range,
                     );
                 }
-                if !recorded_trace {
-                    self.record_resolved_trace(arguments_range, new_method);
-                    recorded_trace = true;
-                }
                 if self.is_compatible_constructor_return(&ret, cls.class_object()) {
                     dunder_new_ret = Some(ret);
                 } else if !matches!(ret, Type::Any(AnyStyle::Error | AnyStyle::Implicit)) {
@@ -922,9 +916,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     &dunder::INIT,
                     callee_range,
                 );
-            }
-            if !recorded_trace {
-                self.record_resolved_trace(arguments_range, init_method);
             }
         }
         if class_metadata.is_pydantic_model()
@@ -1693,6 +1684,184 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             // If both are overridden, take the union
             // Only if neither are overridden, use the `__new__` and `__init__` from object
             self.unions(vec![new_attr_ty, init_attr_ty])
+        }
+    }
+
+    fn bind_dunder_init_for_display(
+        &self,
+        init_method: Type,
+        class_type: &Type,
+    ) -> Option<Callable> {
+        let mut callable = init_method.to_callable()?;
+        callable.ret = callable
+            .get_first_param()
+            .unwrap_or_else(|| class_type.clone());
+        Some(callable)
+    }
+
+    fn constructor_param_count(params: &[Param]) -> usize {
+        let params = match params.first() {
+            Some(first)
+                if first
+                    .name()
+                    .is_some_and(|name| matches!(name.as_str(), "self" | "cls" | "_cls")) =>
+            {
+                &params[1..]
+            }
+            _ => params,
+        };
+        params
+            .iter()
+            .filter(|param| !matches!(param, Param::Varargs(..) | Param::Kwargs(..)))
+            .count()
+    }
+
+    fn constructor_param_insert_index(params: &[Param]) -> usize {
+        params
+            .iter()
+            .position(|param| matches!(param, Param::Varargs(..) | Param::Kwargs(..)))
+            .unwrap_or(params.len())
+    }
+
+    fn constructor_param_is_more_precise(&self, candidate: &Param, current: &Param) -> bool {
+        if current.as_type().any(|ty| ty.is_any()) && !candidate.as_type().any(|ty| ty.is_any()) {
+            return true;
+        }
+        self.is_subset_eq(candidate.as_type(), current.as_type())
+            && !self.is_subset_eq(current.as_type(), candidate.as_type())
+    }
+
+    fn merge_constructor_params(&self, merged: &mut Vec<Param>, other: Vec<Param>) {
+        for param in other {
+            match &param {
+                Param::Varargs(..) => {
+                    if !merged
+                        .iter()
+                        .any(|existing| matches!(existing, Param::Varargs(..)))
+                    {
+                        let idx = Self::constructor_param_insert_index(merged);
+                        merged.insert(idx, param);
+                    }
+                }
+                Param::Kwargs(..) => {
+                    if !merged
+                        .iter()
+                        .any(|existing| matches!(existing, Param::Kwargs(..)))
+                    {
+                        merged.push(param);
+                    }
+                }
+                _ => {
+                    let Some(name) = param.name() else {
+                        let idx = Self::constructor_param_insert_index(merged);
+                        merged.insert(idx, param);
+                        continue;
+                    };
+                    if let Some(existing) = merged.iter_mut().find(|existing| {
+                        existing
+                            .name()
+                            .is_some_and(|existing_name| existing_name == name)
+                    }) {
+                        if self.constructor_param_is_more_precise(&param, existing) {
+                            *existing = param;
+                        }
+                    } else {
+                        let idx = Self::constructor_param_insert_index(merged);
+                        merged.insert(idx, param);
+                    }
+                }
+            }
+        }
+    }
+
+    fn merged_dunder_init_for_display(&self, cls: &ClassType, class_type: &Type) -> Option<Type> {
+        let mut merged_params = None;
+        for init_method in self.get_dunder_init_candidates(cls) {
+            let Some(callable) = self.bind_dunder_init_for_display(init_method, class_type) else {
+                continue;
+            };
+            let Params::List(params) = callable.params else {
+                continue;
+            };
+            let params = params.into_items();
+            if Self::constructor_param_count(&params) == 0 {
+                continue;
+            }
+            if let Some(merged) = &mut merged_params {
+                self.merge_constructor_params(merged, params);
+            } else {
+                merged_params = Some(params);
+            }
+        }
+        merged_params.map(|params| {
+            self.heap
+                .mk_callable_from(Callable::list(ParamList::new(params), class_type.clone()))
+        })
+    }
+
+    pub fn constructor_to_display_callable(&self, cls: &ClassType) -> Type {
+        let class_type = self.heap.mk_class_type(cls.clone());
+        if let Some(metaclass_call_attr_ty) = self.get_metaclass_dunder_call(cls) {
+            if metaclass_call_attr_ty
+                .callable_return_type(self.heap)
+                .is_some_and(|ret| !self.is_compatible_constructor_return(&ret, cls.class_object()))
+            {
+                return metaclass_call_attr_ty;
+            }
+            if self.get_metadata_for_class(cls.class_object()).is_enum() {
+                return metaclass_call_attr_ty;
+            }
+        }
+
+        let default_constructor = self.heap.mk_callable_from(Callable::list(
+            ParamList::new(Vec::new()),
+            class_type.clone(),
+        ));
+
+        let new_callable = if let Some(t) = self.get_dunder_new(cls, false) {
+            if t.callable_return_type(self.heap)
+                .is_some_and(|ret| !self.is_compatible_constructor_return(&ret, cls.class_object()))
+            {
+                return t;
+            }
+            t
+        } else {
+            default_constructor.clone()
+        };
+
+        let init_callable = self
+            .merged_dunder_init_for_display(cls, &class_type)
+            .or_else(|| {
+                self.get_dunder_init(cls, false).and_then(|init_method| {
+                    self.bind_dunder_init_for_display(init_method, &class_type)
+                        .map(|callable| self.heap.mk_callable_from(callable))
+                })
+            })
+            .unwrap_or_else(|| default_constructor.clone());
+
+        let init_param_count = init_callable
+            .clone()
+            .to_callable()
+            .map(|callable| match callable.params {
+                Params::List(params) => Self::constructor_param_count(params.items()),
+                _ => 0,
+            })
+            .unwrap_or(0);
+        let new_param_count = new_callable
+            .clone()
+            .to_callable()
+            .map(|callable| match callable.params {
+                Params::List(params) => Self::constructor_param_count(params.items()),
+                _ => 0,
+            })
+            .unwrap_or(0);
+
+        if init_param_count > new_param_count {
+            init_callable
+        } else if new_param_count > 0 {
+            new_callable
+        } else {
+            init_callable
         }
     }
 

--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1700,7 +1700,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     }
 
     fn constructor_param_count(params: &[Param]) -> usize {
-        let params = match params.first() {
+        let params = Self::constructor_params_without_receiver(params);
+        params
+            .iter()
+            .filter(|param| !matches!(param, Param::Varargs(..) | Param::Kwargs(..)))
+            .count()
+    }
+
+    fn constructor_params_without_receiver(params: &[Param]) -> &[Param] {
+        match params.first() {
             Some(first)
                 if first
                     .name()
@@ -1709,11 +1717,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 &params[1..]
             }
             _ => params,
-        };
-        params
+        }
+    }
+
+    fn constructor_has_variadic_params(params: &[Param]) -> bool {
+        Self::constructor_params_without_receiver(params)
             .iter()
-            .filter(|param| !matches!(param, Param::Varargs(..) | Param::Kwargs(..)))
-            .count()
+            .any(|param| matches!(param, Param::Varargs(..) | Param::Kwargs(..)))
+    }
+
+    fn constructor_should_merge_inherited_init(callable: &Callable) -> bool {
+        match &callable.params {
+            Params::List(params) => {
+                let params = params.items();
+                Self::constructor_param_count(params) == 0
+                    && Self::constructor_has_variadic_params(params)
+            }
+            _ => false,
+        }
     }
 
     fn constructor_param_insert_index(params: &[Param]) -> usize {
@@ -1857,14 +1878,20 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             default_constructor.clone()
         };
 
-        let init_callable = self
-            .merged_dunder_init_for_display(cls, &class_type)
-            .or_else(|| {
-                self.get_dunder_init(cls, false).and_then(|init_method| {
-                    self.bind_dunder_init_for_display(init_method, &class_type)
-                        .map(|callable| self.heap.mk_callable_from(callable))
-                })
+        let resolved_init_callable = self.get_dunder_init(cls, false).and_then(|init_method| {
+            self.bind_dunder_init_for_display(init_method, &class_type)
+                .map(|callable| self.heap.mk_callable_from(callable))
+        });
+
+        let init_callable = resolved_init_callable
+            .clone()
+            .and_then(|init_callable| {
+                init_callable
+                    .to_callable()
+                    .filter(Self::constructor_should_merge_inherited_init)
+                    .and_then(|_| self.merged_dunder_init_for_display(cls, &class_type))
             })
+            .or(resolved_init_callable)
             .unwrap_or_else(|| default_constructor.clone());
 
         let init_param_count = init_callable

--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1799,6 +1799,34 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         })
     }
 
+    pub fn constructor_to_provide_type_callable(&self, cls: &ClassType) -> Type {
+        if let Some(metaclass_call_attr_ty) = self.get_metaclass_dunder_call(cls) {
+            return metaclass_call_attr_ty
+                .clone()
+                .to_callable()
+                .map(|callable| self.heap.mk_callable_from(callable))
+                .unwrap_or(metaclass_call_attr_ty);
+        }
+        if let Some(new_method) = self.get_dunder_new(cls, false) {
+            return new_method
+                .clone()
+                .to_callable()
+                .map(|callable| self.heap.mk_callable_from(callable))
+                .unwrap_or(new_method);
+        }
+        if let Some(init_method) = self.get_dunder_init(cls, false) {
+            return init_method
+                .clone()
+                .to_callable()
+                .map(|callable| self.heap.mk_callable_from(callable))
+                .unwrap_or(init_method);
+        }
+        self.heap.mk_callable_from(Callable::list(
+            ParamList::new(Vec::new()),
+            self.heap.mk_none(),
+        ))
+    }
+
     pub fn constructor_to_display_callable(&self, cls: &ClassType) -> Type {
         let class_type = self.heap.mk_class_type(cls.clone());
         if let Some(metaclass_call_attr_ty) = self.get_metaclass_dunder_call(cls) {

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -4125,7 +4125,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         self.get_dunder_init_helper(&Instance::of_class(cls), get_object_init)
     }
 
-    /// Get every concrete `__init__` definition visible through the MRO, excluding
+    /// Get all concrete `__init__` definitions declared along the MRO, excluding
     /// `object.__init__`, bound to `cls`.
     pub fn get_dunder_init_candidates(&self, cls: &ClassType) -> Vec<Type> {
         let instance = Instance::of_class(cls);

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -4125,6 +4125,36 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         self.get_dunder_init_helper(&Instance::of_class(cls), get_object_init)
     }
 
+    /// Get every concrete `__init__` definition visible through the MRO, excluding
+    /// `object.__init__`, bound to `cls`.
+    pub fn get_dunder_init_candidates(&self, cls: &ClassType) -> Vec<Type> {
+        let instance = Instance::of_class(cls);
+        let mut init_candidates = Vec::new();
+        for ancestor in iter::once(cls).chain(
+            self.get_mro_for_class(cls.class_object())
+                .ancestors(self.stdlib),
+        ) {
+            if ancestor.is_builtin("object") {
+                continue;
+            }
+            let Some(field) = self.get_non_synthesized_field_from_current_class_only(
+                ancestor.class_object(),
+                &dunder::INIT,
+            ) else {
+                continue;
+            };
+            let field =
+                field.instantiate_helper(&mut |ty| ancestor.targs().substitute_into_mut(ty));
+            let Some(init_method) = field.as_special_method_type(self.heap, &instance) else {
+                continue;
+            };
+            if !init_candidates.contains(&init_method) {
+                init_candidates.push(init_method);
+            }
+        }
+        init_candidates
+    }
+
     pub fn get_typed_dict_dunder_init(&self, td: &TypedDictInner) -> Type {
         // We synthesize `__init__`, so the lookup will never entirely fail.
         //

--- a/pyrefly/lib/lsp/wasm/provide_type.rs
+++ b/pyrefly/lib/lsp/wasm/provide_type.rs
@@ -60,7 +60,7 @@ pub fn provide_type(
 
     for position in positions {
         let text_size = info.from_lsp_position(position, None);
-        if let Some(ty) = transaction.get_result_type_at(handle, text_size) {
+        if let Some(ty) = transaction.get_provide_type_at(handle, text_size) {
             let mut c = TypeDisplayContext::new(&[&ty]);
             c.set_lsp_display_mode(LspDisplayMode::ProvideType);
             contents.push(MarkupContent {

--- a/pyrefly/lib/lsp/wasm/signature_help.rs
+++ b/pyrefly/lib/lsp/wasm/signature_help.rs
@@ -248,7 +248,27 @@ impl Transaction<'_> {
             })
         } else {
             answers.get_type_trace(callee_range).map(|t| {
-                let coerced = self.coerce_type_to_callable(handle, t);
+                let coerced = if is_constructor_call(t.clone()) {
+                    self.ad_hoc_solve(handle, "coerce_constructor_display_callable", |solver| {
+                        match t.clone() {
+                            Type::ClassDef(cls)
+                                if !solver.get_metadata_for_class(&cls).is_typed_dict() =>
+                            {
+                                Some(solver.constructor_to_display_callable(
+                                    &solver.promote_nontypeddict_silently_to_classtype(&cls),
+                                ))
+                            }
+                            Type::Type(box Type::ClassType(cls)) => {
+                                Some(solver.constructor_to_display_callable(&cls))
+                            }
+                            _ => None,
+                        }
+                    })
+                    .flatten()
+                    .unwrap_or_else(|| self.coerce_type_to_callable(handle, t))
+                } else {
+                    self.coerce_type_to_callable(handle, t)
+                };
                 // If the coerced type is an Overload, expand it into multiple signatures
                 // so signature help displays each overload separately.
                 if let Type::Overload(overload) = coerced {

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -1069,6 +1069,91 @@ impl<'a> Transaction<'a> {
         }
     }
 
+    /// Like `get_result_type_at`, but when the cursor is on the callee of a call
+    /// expression it preserves the underlying callable shape instead of the
+    /// call-site-resolved trace recorded for hover/signature help.
+    pub fn get_provide_type_at(&self, handle: &Handle, position: TextSize) -> Option<Type> {
+        let coerce_callee_for_provide_type = |transaction: &Self, ty: Type| {
+            transaction
+                .ad_hoc_solve(handle, "coerce_provide_type_callee", |solver| {
+                    match ty.clone() {
+                        Type::ClassDef(cls)
+                            if !solver.get_metadata_for_class(&cls).is_typed_dict() =>
+                        {
+                            Some(solver.constructor_to_provide_type_callable(
+                                &solver.promote_nontypeddict_silently_to_classtype(&cls),
+                            ))
+                        }
+                        Type::Type(box Type::ClassType(cls)) => {
+                            Some(solver.constructor_to_provide_type_callable(&cls))
+                        }
+                        _ => None,
+                    }
+                })
+                .flatten()
+                .unwrap_or_else(|| transaction.coerce_type_to_callable(handle, ty))
+        };
+        match self.identifier_at(handle, position) {
+            Some(IdentifierWithContext {
+                identifier: id,
+                context: IdentifierContext::Expr(expr_context),
+            }) => {
+                let key = match expr_context {
+                    ExprContext::Store => Key::Definition(ShortIdentifier::new(&id)),
+                    ExprContext::Load | ExprContext::Del | ExprContext::Invalid => {
+                        Key::BoundName(ShortIdentifier::new(&id))
+                    }
+                };
+
+                let bindings = self.get_bindings(handle)?;
+                if !bindings.is_valid_key(&key) {
+                    return None;
+                }
+                let mut ty = self.get_type(handle, &key)?;
+                let call_args_range = self.callee_at(handle, position).and_then(
+                    |ExprCall {
+                         func, arguments, ..
+                     }| (func.range() == id.range).then_some(arguments.range),
+                );
+                if call_args_range.is_some() {
+                    ty = coerce_callee_for_provide_type(self, ty);
+                }
+                Some(ty)
+            }
+            Some(IdentifierWithContext {
+                identifier: _,
+                context:
+                    IdentifierContext::ImportedName {
+                        name_after_import, ..
+                    },
+            }) => {
+                let key = Key::Definition(ShortIdentifier::new(&name_after_import));
+                let bindings = self.get_bindings(handle)?;
+                if !bindings.is_valid_key(&key) {
+                    return None;
+                }
+                let mut ty = self.get_type(handle, &key)?;
+                let call_args_range = self.callee_at(handle, position).and_then(
+                    |ExprCall {
+                         func, arguments, ..
+                     }| {
+                        (func.range() == name_after_import.range).then_some(arguments.range)
+                    },
+                );
+                if call_args_range.is_some() {
+                    ty = coerce_callee_for_provide_type(self, ty);
+                }
+                Some(ty)
+            }
+            Some(IdentifierWithContext {
+                identifier: _,
+                context: IdentifierContext::Attribute { range, .. },
+            }) => self.get_type_trace(handle, range),
+            Some(_) => self.get_type_at(handle, position),
+            None => self.result_type_from_expression_at(handle, position),
+        }
+    }
+
     /// If `ty` represents a callable instance (e.g., a class with `__call__`), return the
     /// bound `__call__` signature. Otherwise, return the type unchanged.
     ///

--- a/pyrefly/lib/test/lsp/signature_help.rs
+++ b/pyrefly/lib/test/lsp/signature_help.rs
@@ -1026,6 +1026,28 @@ Signature Help Result: active=0
 }
 
 #[test]
+fn magicmock_constructor_signature_merges_inherited_init_params() {
+    let code = r#"
+from unittest.mock import MagicMock
+
+MagicMock(
+#        ^
+"#;
+    let report = get_batched_lsp_operations_report_allow_error(&[("main", code)], get_test_report);
+    assert_eq!(
+        r#"
+# main.py
+4 | MagicMock(
+             ^
+Signature Help Result: active=0
+- (self: MagicMock, spec: list[str] | object | type[object] | None = None, side_effect: Any | None = None, return_value: Any = ..., wraps: Any | None = None, name: str | None = None, spec_set: list[str] | object | type[object] | None = None, parent: NonCallableMock | None = None, _spec_state: Any | None = None, _new_name: str = '', _new_parent: NonCallableMock | None = None, _spec_as_instance: bool = False, _eat_self: bool | None = None, unsafe: bool = False, **kwargs: Any) -> MagicMock, parameters=[spec: list[str] | object | type[object] | None = None, side_effect: Any | None = None, return_value: Any = ..., wraps: Any | None = None, name: str | None = None, spec_set: list[str] | object | type[object] | None = None, parent: NonCallableMock | None = None, _spec_state: Any | None = None, _new_name: str = '', _new_parent: NonCallableMock | None = None, _spec_as_instance: bool = False, _eat_self: bool | None = None, unsafe: bool = False, **kwargs: Any], active parameter = 0
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn method_call_signature_unchanged() {
     let code = r#"
 class Foo:

--- a/pyrefly/lib/test/lsp/signature_help.rs
+++ b/pyrefly/lib/test/lsp/signature_help.rs
@@ -1048,6 +1048,58 @@ Signature Help Result: active=0
 }
 
 #[test]
+fn overriding_constructor_signature_does_not_merge_base_params() {
+    let code = r#"
+class Base:
+    def __init__(self, base: str) -> None: ...
+
+class Child(Base):
+    def __init__(self, child: int) -> None: ...
+
+Child(
+#    ^
+"#;
+    let report = get_batched_lsp_operations_report_allow_error(&[("main", code)], get_test_report);
+    assert_eq!(
+        r#"
+# main.py
+8 | Child(
+         ^
+Signature Help Result: active=0
+- (self: Child, child: int) -> Child, parameters=[child: int], active parameter = 0
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
+fn forwarding_constructor_signature_merges_inherited_base_params() {
+    let code = r#"
+class Base:
+    def __init__(self, base: str, flag: bool) -> None: ...
+
+class Child(Base):
+    def __init__(self, *args: object, **kwargs: object) -> None: ...
+
+Child(
+#    ^
+"#;
+    let report = get_batched_lsp_operations_report_allow_error(&[("main", code)], get_test_report);
+    assert_eq!(
+        r#"
+# main.py
+8 | Child(
+         ^
+Signature Help Result: active=0
+- (self: Child, base: str, flag: bool) -> Child, parameters=[base: str, flag: bool], active parameter = 0
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn method_call_signature_unchanged() {
     let code = r#"
 class Foo:


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2855

For IDE display only, Pyrefly now walks inherited `__init__` definitions, merges their named parameters, and prefers that merged constructor signature when it is more informative than `__new__`.

That gives MagicMock a signature with side_effect, return_value, _spec_as_instance, unsafe, and the more precise types from NonCallableMock.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test