### PR TITLE
fix Support single-file scripts with PEP 723 metadata #3176

### DIFF
--- a/crates/pyrefly_config/src/environment/conda.rs
+++ b/crates/pyrefly_config/src/environment/conda.rs
@@ -44,7 +44,7 @@ pub fn get_env_path(env_name: &str) -> anyhow::Result<PathBuf> {
 
     if !output.status.success() {
         let stderr = String::from_utf8(output.stderr)
-            .unwrap_or("<Failed to parse STDOUT from UTF-8 string>".to_owned());
+            .unwrap_or("<Failed to parse STDERR from UTF-8 string>".to_owned());
         return Err(anyhow::anyhow!(
             "Unable to conda for interpreter:\nSTDOUT: {}\nSTDERR: {}",
             stdout,

--- a/crates/pyrefly_config/src/environment/environment.rs
+++ b/crates/pyrefly_config/src/environment/environment.rs
@@ -129,7 +129,10 @@ impl PythonEnvironment {
         command.arg("-c");
         command.arg(Self::query_script());
 
-        Self::get_env_from_command(command, interpreter.display().to_string())
+        Self::get_env_from_command(
+            command,
+            format!("Python interpreter (`{}`)", interpreter.display()),
+        )
     }
 
     /// Query the environment that `uv` would create for a PEP 723 script.

--- a/crates/pyrefly_config/src/environment/environment.rs
+++ b/crates/pyrefly_config/src/environment/environment.rs
@@ -125,7 +125,39 @@ impl PythonEnvironment {
             );
         }
 
-        let script = "\
+        let mut command = Command::new(interpreter);
+        command.arg("-c");
+        command.arg(Self::query_script());
+
+        Self::get_env_from_command(command, interpreter.display().to_string())
+    }
+
+    /// Query the environment that `uv` would create for a PEP 723 script.
+    pub fn get_env_from_uv_script(script: &Path) -> anyhow::Result<PythonEnvironment> {
+        let Some(script_dir) = script.parent() else {
+            return Err(anyhow!(
+                "Unable to query PEP 723 environment for `{}` because it has no parent directory",
+                script.display()
+            ));
+        };
+
+        let mut command = Command::new("uv");
+        command.arg("run");
+        command.arg("--directory");
+        command.arg(script_dir);
+        command.arg("--no-project");
+        command.arg("--isolated");
+        command.arg("--with-requirements");
+        command.arg(script);
+        command.arg("python");
+        command.arg("-c");
+        command.arg(Self::query_script());
+
+        Self::get_env_from_command(command, format!("uv PEP 723 script {}", script.display()))
+    }
+
+    fn query_script() -> &'static str {
+        "\
 import json, sys, sysconfig
 platform = sys.platform
 v = sys.version_info
@@ -133,26 +165,24 @@ version = '{}.{}.{}'.format(v.major, v.minor, v.micro)
 stdlib_paths = [p for p in [sysconfig.get_path('stdlib')] if p is not None]
 site_package_path = [p for p in sys.path if p != '' and '.zip' not in p and not p.endswith('/lib-dynload') and p not in stdlib_paths]
 print(json.dumps({'python_platform': platform, 'python_version': version, 'site_package_path': site_package_path, 'stdlib_paths': stdlib_paths}))
-";
+"
+    }
 
-        let mut command = Command::new(interpreter);
-        command.arg("-c");
-        command.arg(script);
-
+    fn get_env_from_command(
+        mut command: Command,
+        command_description: String,
+    ) -> anyhow::Result<PythonEnvironment> {
         let python_info = command.output()?;
 
         let stdout = String::from_utf8(python_info.stdout).with_context(|| {
-            format!(
-                "while parsing Python interpreter (`{}`) stdout for environment configuration",
-                interpreter.display()
-            )
+            format!("while parsing `{command_description}` stdout for environment configuration")
         })?;
         if !python_info.status.success() {
             let stderr = String::from_utf8(python_info.stderr)
                 .unwrap_or("<Failed to parse STDOUT from UTF-8 string>".to_owned());
             return Err(anyhow::anyhow!(
-                "Unable to query interpreter {} for environment info:\nSTDOUT: {}\nSTDERR: {}",
-                interpreter.display(),
+                "Unable to query {} for environment info:\nSTDOUT: {}\nSTDERR: {}",
+                command_description,
                 stdout,
                 stderr
             ));

--- a/crates/pyrefly_config/src/environment/environment.rs
+++ b/crates/pyrefly_config/src/environment/environment.rs
@@ -182,7 +182,7 @@ print(json.dumps({'python_platform': platform, 'python_version': version, 'site_
         })?;
         if !python_info.status.success() {
             let stderr = String::from_utf8(python_info.stderr)
-                .unwrap_or("<Failed to parse STDOUT from UTF-8 string>".to_owned());
+                .unwrap_or("<Failed to parse STDERR from UTF-8 string>".to_owned());
             return Err(anyhow::anyhow!(
                 "Unable to query {} for environment info:\nSTDOUT: {}\nSTDERR: {}",
                 command_description,

--- a/crates/pyrefly_config/src/environment/interpreters.rs
+++ b/crates/pyrefly_config/src/environment/interpreters.rs
@@ -98,6 +98,14 @@ impl Interpreters {
         self.python_interpreter_path = Some(ConfigOrigin::lsp(interpreter));
     }
 
+    /// Freeze interpreter discovery and clear any previously selected interpreter source.
+    pub fn disable_query(&mut self) {
+        self.skip_interpreter_query = true;
+        self.python_interpreter_path = None;
+        self.fallback_python_interpreter_name = None;
+        self.conda_environment = None;
+    }
+
     /// Finds interpreters by searching in prioritized locations for the given project
     /// and interpreter settings.
     ///

--- a/crates/pyrefly_config/src/environment/interpreters.rs
+++ b/crates/pyrefly_config/src/environment/interpreters.rs
@@ -156,6 +156,14 @@ impl Interpreters {
         self.python_interpreter_path = Some(ConfigOrigin::lsp(interpreter));
     }
 
+    /// Freeze interpreter discovery and clear any previously selected interpreter source.
+    pub fn disable_query(&mut self) {
+        self.skip_interpreter_query = true;
+        self.python_interpreter_path = None;
+        self.fallback_python_interpreter_name = None;
+        self.conda_environment = None;
+    }
+
     /// Finds interpreters by searching in prioritized locations for the given project
     /// and interpreter settings.
     ///

--- a/crates/pyrefly_config/src/finder.rs
+++ b/crates/pyrefly_config/src/finder.rs
@@ -103,6 +103,13 @@ type LoadCallback = Box<dyn Fn(&Path) -> (ArcId<ConfigFile>, Vec<ConfigError>) +
 type FallbackCallback =
     Box<dyn Fn(ModuleNameWithKind, &ModulePath) -> ArcId<ConfigFile> + Send + Sync>;
 
+/// Function to augment a config for a specific Python file after it has been selected.
+type AfterCallback = Box<
+    dyn Fn(ModuleNameWithKind, &ModulePath, ArcId<ConfigFile>) -> anyhow::Result<ArcId<ConfigFile>>
+        + Send
+        + Sync,
+>;
+
 /// A way to find a config file given a directory or Python file.
 /// Uses a lot of caching.
 pub struct ConfigFinder {
@@ -113,6 +120,8 @@ pub struct ConfigFinder {
     /// If this returns a value, it is _not_ cached.
     /// If this returns anything other than `Ok`, the rest of the functions are used.
     before: BeforeCallback,
+    /// If this returns `Err`, the original config is returned and the error is recorded.
+    after: AfterCallback,
     /// If there is no config file, or loading it fails, use this fallback.
     fallback: FallbackCallback,
     clear_extra_caches: Box<dyn Fn() + Send + Sync>,
@@ -128,6 +137,7 @@ impl ConfigFinder {
         Self::new_custom(
             Box::new(|_, _| Ok(None)),
             load,
+            Box::new(|_, _, config| Ok(config)),
             fallback,
             clear_extra_caches,
         )
@@ -142,6 +152,7 @@ impl ConfigFinder {
         Self::new_custom(
             Box::new(move |_, _| Ok(Some(c1.dupe()))),
             Box::new(move |_| (c2.dupe(), Vec::new())),
+            Box::new(move |_, _, config| Ok(config)),
             Box::new(move |_, _| c3.dupe()),
             Box::new(|| {}),
         )
@@ -153,6 +164,7 @@ impl ConfigFinder {
     pub fn new_custom(
         before: BeforeCallback,
         load: LoadCallback,
+        after: AfterCallback,
         fallback: FallbackCallback,
         clear_extra_caches: Box<dyn Fn() + Send + Sync>,
     ) -> Self {
@@ -208,6 +220,7 @@ impl ConfigFinder {
             ),
             errors,
             before,
+            after,
             fallback,
             clear_extra_caches,
         }
@@ -271,7 +284,7 @@ impl ConfigFinder {
             None => (self.fallback)(name, path),
         };
 
-        match path.details() {
+        let config = match path.details() {
             ModulePathDetails::FileSystem(x) | ModulePathDetails::Memory(x) => {
                 let absolute = x.absolutize();
                 f(absolute.parent())
@@ -280,6 +293,14 @@ impl ConfigFinder {
             ModulePathDetails::BundledTypeshed(_) => f(None),
             ModulePathDetails::BundledTypeshedThirdParty(_) => f(None),
             ModulePathDetails::BundledThirdParty(_) => f(None),
+        };
+
+        match (self.after)(name, path, config.dupe()) {
+            Ok(config) => config,
+            Err(e) => {
+                self.errors.lock().push(ConfigError::warn(e));
+                config
+            }
         }
     }
 

--- a/pyrefly/lib/commands/config_finder.rs
+++ b/pyrefly/lib/commands/config_finder.rs
@@ -16,8 +16,10 @@ use pyrefly_config::config::ConfigSource;
 use pyrefly_config::config::DirectoryRelativeFallbackSearchPathCache;
 use pyrefly_config::config::FallbackSearchPath;
 use pyrefly_config::config::GENERATED_FILE_CONFIG_OVERRIDE;
+use pyrefly_config::environment::environment::PythonEnvironment;
 use pyrefly_config::resolve_unconfigured::UnconfiguredOverride;
 use pyrefly_config::resolve_unconfigured::resolve_unconfigured_config;
+use pyrefly_python::module_path::ModulePath;
 use pyrefly_python::module_path::ModulePathDetails;
 use pyrefly_util::arc_id::ArcId;
 use pyrefly_util::lock::Mutex;
@@ -186,6 +188,90 @@ pub fn default_config_finder_with_overrides(
     )
 }
 
+struct Pep723ScriptOverrides {
+    cache: Arc<Mutex<SmallMap<(PathBuf, String), ArcId<ConfigFile>>>>,
+    query_environment: Arc<dyn Fn(&Path) -> anyhow::Result<PythonEnvironment> + Send + Sync>,
+}
+
+impl Pep723ScriptOverrides {
+    fn new(
+        query_environment: Arc<dyn Fn(&Path) -> anyhow::Result<PythonEnvironment> + Send + Sync>,
+    ) -> Self {
+        Self {
+            cache: Arc::new(Mutex::new(SmallMap::new())),
+            query_environment,
+        }
+    }
+
+    fn override_config(
+        &self,
+        path: &ModulePath,
+        config: ArcId<ConfigFile>,
+    ) -> anyhow::Result<ArcId<ConfigFile>> {
+        let Some(script_path) = Self::script_path(path) else {
+            return Ok(config);
+        };
+        let Some(metadata) = Self::read_pep723_metadata(script_path)? else {
+            return Ok(config);
+        };
+
+        let cache_key = (script_path.to_path_buf(), metadata);
+        if let Some(config) = self.cache.lock().get(&cache_key) {
+            return Ok(config.dupe());
+        }
+
+        let mut script_environment = (self.query_environment)(script_path)?;
+        // Preserve explicit user-specified site-package paths such as `typings/`,
+        // while replacing interpreter-derived environment data with the script's.
+        script_environment.site_package_path = config.python_environment.site_package_path.clone();
+
+        let mut config = config.as_ref().clone();
+        config.interpreters.disable_query();
+        config.python_environment = script_environment;
+
+        let config = ArcId::new(config);
+        self.cache.lock().insert(cache_key, config.dupe());
+        Ok(config)
+    }
+
+    fn script_path(path: &ModulePath) -> Option<&Path> {
+        match path.details() {
+            ModulePathDetails::FileSystem(path) | ModulePathDetails::Memory(path) => Some(path),
+            ModulePathDetails::Namespace(_)
+            | ModulePathDetails::BundledTypeshed(_)
+            | ModulePathDetails::BundledTypeshedThirdParty(_)
+            | ModulePathDetails::BundledThirdParty(_) => None,
+        }
+    }
+
+    fn read_pep723_metadata(path: &Path) -> anyhow::Result<Option<String>> {
+        let contents = std::fs::read_to_string(path)?;
+        Ok(Self::extract_pep723_metadata(&contents))
+    }
+
+    fn extract_pep723_metadata(contents: &str) -> Option<String> {
+        let mut metadata = Vec::new();
+        let mut in_script_block = false;
+
+        for line in contents.lines() {
+            match line.trim_start() {
+                "# /// script" if !in_script_block => {
+                    in_script_block = true;
+                    metadata.push(line);
+                }
+                "# ///" if in_script_block => {
+                    metadata.push(line);
+                    return Some(metadata.join("\n"));
+                }
+                _ if in_script_block => metadata.push(line),
+                _ => {}
+            }
+        }
+
+        None
+    }
+}
+
 /// Create a standard `ConfigFinder`, using the provided [`ConfigConfigurer`] to finalize
 /// the config before caching/returning it.
 ///
@@ -201,6 +287,8 @@ pub fn standard_config_finder(
     };
     let configure2 = configure.dupe();
     let configure3 = configure.dupe();
+    let pep723_script_overrides =
+        Pep723ScriptOverrides::new(Arc::new(PythonEnvironment::get_env_from_uv_script));
 
     // A cache where path `p` maps to config file with `search_path = [p]`. If we can find the root.
     let cache_one: Arc<Mutex<SmallMap<PathBuf, ArcId<ConfigFile>>>> =
@@ -228,11 +316,13 @@ pub fn standard_config_finder(
         let cache_parents = cache_parents.dupe();
         let cache_ancestors = cache_ancestors.dupe();
         let cache_empty = cache_empty.dupe();
+        let pep723_script_overrides = pep723_script_overrides.cache.dupe();
         Box::new(move || {
             cache_one.lock().clear();
             cache_parents.lock().clear();
             cache_ancestors.clear();
             *cache_empty.lock() = None;
+            pep723_script_overrides.lock().clear();
             GENERATED_FILE_CONFIG_OVERRIDE.write().clear();
         })
     };
@@ -261,6 +351,16 @@ pub fn standard_config_finder(
             let (config, validation_errors) =
                 configure.configure(file.parent(), file_config, parse_errors);
             (config, validation_errors)
+        }),
+        Box::new(move |_, path, config| {
+            pep723_script_overrides
+                .override_config(path, config)
+                .map_err(|err| {
+                    err.context(format!(
+                        "While resolving PEP 723 metadata for `{}`",
+                        path.as_path().display()
+                    ))
+                })
         }),
         // Fall back to using a default config, but let's see if we can make the `search_path` somewhat useful
         // based on a few heuristics.
@@ -340,12 +440,16 @@ pub fn standard_config_finder(
 mod tests {
 
     use std::ops::Deref as _;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
 
     use pretty_assertions::assert_eq;
     use pyrefly_config::args::ConfigOverrideArgs;
     use pyrefly_python::module_name::ModuleName;
     use pyrefly_python::module_name::ModuleNameWithKind;
     use pyrefly_python::module_path::ModulePath;
+    use pyrefly_python::sys_info::PythonPlatform;
+    use pyrefly_python::sys_info::PythonVersion;
     use pyrefly_util::test_path::TestPath;
 
     use super::*;
@@ -389,6 +493,106 @@ mod tests {
         ) -> (ArcId<ConfigFile>, Vec<ConfigError>) {
             (self.0)(root, config, errors)
         }
+    }
+
+    #[test]
+    fn test_extract_pep723_metadata() {
+        let contents = "\
+# /// script
+# requires-python = \">=3.12\"
+# dependencies = [\"click\"]
+# ///
+print('hello')
+";
+
+        assert_eq!(
+            Pep723ScriptOverrides::extract_pep723_metadata(contents),
+            Some(
+                [
+                    "# /// script",
+                    "# requires-python = \">=3.12\"",
+                    "# dependencies = [\"click\"]",
+                    "# ///",
+                ]
+                .join("\n")
+            )
+        );
+        assert_eq!(
+            Pep723ScriptOverrides::extract_pep723_metadata("print('hello')"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_pep723_override_preserves_explicit_site_packages_and_caches() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        let script_path = root.join("script.py");
+        TestPath::setup_test_directory(
+            root,
+            vec![TestPath::file_with_contents(
+                "script.py",
+                "\
+# /// script
+# requires-python = \">=3.12\"
+# dependencies = [\"click\"]
+# ///
+import click
+",
+            )],
+        );
+
+        let query_count = Arc::new(AtomicUsize::new(0));
+        let query_count_for_closure = Arc::clone(&query_count);
+        let overrides = Pep723ScriptOverrides::new(Arc::new(move |_| {
+            query_count_for_closure.fetch_add(1, Ordering::Relaxed);
+            Ok(PythonEnvironment {
+                python_platform: Some(PythonPlatform::windows()),
+                python_version: Some(PythonVersion::new(3, 12, 5)),
+                site_package_path: Some(vec![]),
+                interpreter_site_package_path: vec![PathBuf::from("/tmp/site-packages")],
+                interpreter_stdlib_path: vec![PathBuf::from("/tmp/stdlib")],
+            })
+        }));
+
+        let mut config = ConfigFile::default();
+        config.search_path_from_file = vec![root.to_path_buf()];
+        config.python_environment.site_package_path = Some(vec![PathBuf::from("/tmp/typings")]);
+        let config = ArcId::new(config);
+        let module_path = ModulePath::filesystem(script_path.clone());
+
+        let overridden = overrides
+            .override_config(&module_path, config.dupe())
+            .unwrap();
+        let cached = overrides.override_config(&module_path, config).unwrap();
+
+        assert_eq!(query_count.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            overridden.search_path().cloned().collect::<Vec<_>>(),
+            vec![root.to_path_buf()]
+        );
+        assert_eq!(
+            overridden.python_environment.site_package_path,
+            Some(vec![PathBuf::from("/tmp/typings")])
+        );
+        assert_eq!(
+            overridden.python_environment.interpreter_site_package_path,
+            vec![PathBuf::from("/tmp/site-packages")]
+        );
+        assert_eq!(
+            overridden.python_environment.interpreter_stdlib_path,
+            vec![PathBuf::from("/tmp/stdlib")]
+        );
+        assert_eq!(
+            overridden.python_environment.python_version,
+            Some(PythonVersion::new(3, 12, 5))
+        );
+        assert_eq!(
+            overridden.python_environment.python_platform,
+            Some(PythonPlatform::windows())
+        );
+        assert!(overridden.interpreters.skip_interpreter_query);
+        assert_eq!(overridden, cached);
     }
 
     #[test]

--- a/pyrefly/lib/commands/config_finder.rs
+++ b/pyrefly/lib/commands/config_finder.rs
@@ -6,9 +6,13 @@
  */
 
 use std::fs;
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use dupe::Dupe;
 use pyrefly_config::args::ConfigOverrideArgs;
@@ -189,7 +193,20 @@ pub fn default_config_finder_with_overrides(
     )
 }
 
-type CachedPep723Override = (String, Result<ArcId<ConfigFile>, Arc<str>>);
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct Pep723FileVersion {
+    modified: SystemTime,
+    len: u64,
+}
+
+#[derive(Clone)]
+struct CachedPep723Override {
+    file_version: Option<Pep723FileVersion>,
+    metadata: Option<String>,
+    result: Pep723OverrideResult,
+}
+
+type Pep723OverrideResult = Result<Option<ArcId<ConfigFile>>, Arc<str>>;
 
 struct Pep723ScriptOverrides {
     cache: Arc<Mutex<SmallMap<PathBuf, CachedPep723Override>>>,
@@ -214,41 +231,58 @@ impl Pep723ScriptOverrides {
         let Some(script_path) = Self::script_path(path) else {
             return Ok(config);
         };
-        let Some(metadata) = Self::read_pep723_metadata(script_path)? else {
-            return Ok(config);
-        };
-
-        let cached = self
-            .cache
-            .lock()
-            .get(script_path)
-            .filter(|(cached_metadata, _)| cached_metadata == &metadata)
-            .map(|(_, result)| result.clone());
-        if let Some(result) = cached {
-            return result.map_err(|error| anyhow::anyhow!(error.to_string()));
+        let file_version = Self::file_version(script_path)?;
+        let cached = self.cache.lock().get(script_path).cloned();
+        if let Some(cached) = cached.as_ref()
+            && file_version.is_some()
+            && cached.file_version == file_version
+        {
+            return Self::apply_result(cached.result.clone(), config);
         }
 
-        // This cannot live solely in `ConfigFile::get_sys_info`: PEP 723 affects dependency
-        // search paths as well as the Python version and platform, so the full environment
-        // must be replaced for this script.
-        let result = (|| {
-            let mut script_environment = (self.query_environment)(script_path)?;
-            // Preserve explicit user-specified site-package paths such as `typings/`,
-            // while replacing interpreter-derived environment data with the script's.
-            script_environment.site_package_path =
-                config.python_environment.site_package_path.clone();
+        let metadata = Self::read_pep723_metadata(script_path)?;
+        let result = match cached.filter(|cached| cached.metadata == metadata) {
+            Some(cached) => cached.result,
+            None if metadata.is_none() => Ok(None),
+            None => {
+                // This cannot live solely in `ConfigFile::get_sys_info`: PEP 723 affects dependency
+                // search paths as well as the Python version and platform, so the full environment
+                // must be replaced for this script.
+                (self.query_environment)(script_path)
+                    .map(|mut script_environment| {
+                        // Preserve explicit user-specified site-package paths such as `typings/`,
+                        // while replacing interpreter-derived environment data with the script's.
+                        script_environment.site_package_path =
+                            config.python_environment.site_package_path.clone();
 
-            let mut config = config.as_ref().clone();
-            config.interpreters.disable_query();
-            config.python_environment = script_environment;
-            Ok(ArcId::new(config))
-        })()
-        .map_err(|error: anyhow::Error| Arc::<str>::from(format!("{error:#}")));
+                        let mut config = config.as_ref().clone();
+                        config.interpreters.disable_query();
+                        config.python_environment = script_environment;
+                        Some(ArcId::new(config))
+                    })
+                    .map_err(|error| Arc::<str>::from(format!("{error:#}")))
+            }
+        };
+        self.cache.lock().insert(
+            script_path.to_path_buf(),
+            CachedPep723Override {
+                file_version,
+                metadata,
+                result: result.clone(),
+            },
+        );
+        Self::apply_result(result, config)
+    }
 
-        self.cache
-            .lock()
-            .insert(script_path.to_path_buf(), (metadata, result.clone()));
-        result.map_err(|error| anyhow::anyhow!(error.to_string()))
+    fn apply_result(
+        result: Pep723OverrideResult,
+        config: ArcId<ConfigFile>,
+    ) -> anyhow::Result<ArcId<ConfigFile>> {
+        match result {
+            Ok(Some(config)) => Ok(config),
+            Ok(None) => Ok(config),
+            Err(error) => Err(anyhow::anyhow!(error.to_string())),
+        }
     }
 
     fn script_path(path: &ModulePath) -> Option<&Path> {
@@ -262,16 +296,31 @@ impl Pep723ScriptOverrides {
         }
     }
 
-    fn read_pep723_metadata(path: &Path) -> anyhow::Result<Option<String>> {
-        let contents = fs::read_to_string(path)?;
-        Ok(Self::extract_pep723_metadata(&contents))
+    fn file_version(path: &Path) -> anyhow::Result<Option<Pep723FileVersion>> {
+        let metadata = fs::metadata(path)?;
+        // Filesystems without modification times cannot safely use the pre-read cache check.
+        Ok(metadata.modified().ok().map(|modified| Pep723FileVersion {
+            modified,
+            len: metadata.len(),
+        }))
     }
 
-    fn extract_pep723_metadata(contents: &str) -> Option<String> {
+    fn read_pep723_metadata(path: &Path) -> anyhow::Result<Option<String>> {
+        Self::extract_pep723_metadata(
+            BufReader::new(File::open(path)?)
+                .lines()
+                .map(|line| line.map_err(anyhow::Error::from)),
+        )
+    }
+
+    fn extract_pep723_metadata(
+        lines: impl Iterator<Item = anyhow::Result<String>>,
+    ) -> anyhow::Result<Option<String>> {
         let mut metadata = Vec::new();
         let mut in_script_block = false;
 
-        for line in contents.lines() {
+        for line in lines {
+            let line = line?;
             let trimmed = line.trim_start();
             match trimmed {
                 "# /// script" if !in_script_block => {
@@ -280,15 +329,15 @@ impl Pep723ScriptOverrides {
                 }
                 "# ///" if in_script_block => {
                     metadata.push(line);
-                    return Some(metadata.join("\n"));
+                    return Ok(Some(metadata.join("\n")));
                 }
-                _ if in_script_block && !trimmed.starts_with('#') => return None,
+                _ if in_script_block && !trimmed.starts_with('#') => return Ok(None),
                 _ if in_script_block => metadata.push(line),
                 _ => {}
             }
         }
 
-        None
+        Ok(None)
     }
 }
 
@@ -472,7 +521,6 @@ mod tests {
     use pyrefly_python::module_name::ModuleNameWithKind;
     use pyrefly_python::module_path::ModulePath;
     use pyrefly_python::module_path::ModulePathDetails;
-    use pyrefly_util::includes::Includes;
     use pyrefly_python::sys_info::PythonPlatform;
     use pyrefly_python::sys_info::PythonVersion;
     use pyrefly_util::includes::Includes;
@@ -525,6 +573,12 @@ mod tests {
 
     #[test]
     fn test_extract_pep723_metadata() {
+        let extract = |contents: &str| {
+            Pep723ScriptOverrides::extract_pep723_metadata(
+                contents.lines().map(|line| Ok(line.to_owned())),
+            )
+            .unwrap()
+        };
         let contents = "\
 # /// script
 # requires-python = \">=3.12\"
@@ -534,7 +588,7 @@ print('hello')
 ";
 
         assert_eq!(
-            Pep723ScriptOverrides::extract_pep723_metadata(contents),
+            extract(contents),
             Some(
                 [
                     "# /// script",
@@ -545,15 +599,22 @@ print('hello')
                 .join("\n")
             )
         );
+        assert_eq!(extract("print('hello')"), None);
         assert_eq!(
-            Pep723ScriptOverrides::extract_pep723_metadata("print('hello')"),
+            extract("# /// script\n# dependencies = [\"click\"]\nprint('invalid')\n# ///"),
             None
         );
         assert_eq!(
             Pep723ScriptOverrides::extract_pep723_metadata(
-                "# /// script\n# dependencies = [\"click\"]\nprint('invalid')\n# ///"
-            ),
-            None
+                vec![
+                    Ok("# /// script".to_owned()),
+                    Ok("# ///".to_owned()),
+                    Err(anyhow::anyhow!("should not read past the end marker")),
+                ]
+                .into_iter()
+            )
+            .unwrap(),
+            Some(["# /// script", "# ///"].join("\n"))
         );
     }
 
@@ -595,12 +656,30 @@ import click
         let config = ArcId::new(config);
         let module_path = ModulePath::filesystem(script_path.clone());
         let memory_path = ModulePath::memory(script_path);
+        let plain_path = root.join("plain.py");
+        fs::write(&plain_path, "print('hello')\n").unwrap();
+        let plain_path = ModulePath::filesystem(plain_path);
 
         let unchanged = overrides
             .override_config(&memory_path, config.dupe())
             .unwrap();
         assert_eq!(query_count.load(Ordering::Relaxed), 0);
         assert_eq!(unchanged, config);
+
+        assert_eq!(
+            overrides
+                .override_config(&plain_path, config.dupe())
+                .unwrap(),
+            config
+        );
+        assert_eq!(
+            overrides
+                .override_config(&plain_path, config.dupe())
+                .unwrap(),
+            config
+        );
+        assert_eq!(query_count.load(Ordering::Relaxed), 0);
+        assert_eq!(overrides.cache.lock().len(), 1);
 
         let overridden = overrides
             .override_config(&module_path, config.dupe())
@@ -669,7 +748,19 @@ import click
 
         fs::write(
             &script_path,
-            "# /// script\n# dependencies = [\"rich\"]\n# ///\nimport rich\n",
+            "# /// script\n# dependencies = [\"click\"]\n# ///\nimport click\nprint(click)\n",
+        )
+        .unwrap();
+        assert!(
+            overrides
+                .override_config(&module_path, config.dupe())
+                .is_err()
+        );
+        assert_eq!(query_count.load(Ordering::Relaxed), 1);
+
+        fs::write(
+            &script_path,
+            "# /// script\n# dependencies = [\"rich-click\"]\n# ///\nimport rich\n",
         )
         .unwrap();
         assert!(overrides.override_config(&module_path, config).is_err());

--- a/pyrefly/lib/commands/config_finder.rs
+++ b/pyrefly/lib/commands/config_finder.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -188,8 +189,10 @@ pub fn default_config_finder_with_overrides(
     )
 }
 
+type CachedPep723Override = (String, Result<ArcId<ConfigFile>, Arc<str>>);
+
 struct Pep723ScriptOverrides {
-    cache: Arc<Mutex<SmallMap<(PathBuf, String), ArcId<ConfigFile>>>>,
+    cache: Arc<Mutex<SmallMap<PathBuf, CachedPep723Override>>>,
     query_environment: Arc<dyn Fn(&Path) -> anyhow::Result<PythonEnvironment> + Send + Sync>,
 }
 
@@ -215,29 +218,44 @@ impl Pep723ScriptOverrides {
             return Ok(config);
         };
 
-        let cache_key = (script_path.to_path_buf(), metadata);
-        if let Some(config) = self.cache.lock().get(&cache_key) {
-            return Ok(config.dupe());
+        let cached = self
+            .cache
+            .lock()
+            .get(script_path)
+            .filter(|(cached_metadata, _)| cached_metadata == &metadata)
+            .map(|(_, result)| result.clone());
+        if let Some(result) = cached {
+            return result.map_err(|error| anyhow::anyhow!(error.to_string()));
         }
 
-        let mut script_environment = (self.query_environment)(script_path)?;
-        // Preserve explicit user-specified site-package paths such as `typings/`,
-        // while replacing interpreter-derived environment data with the script's.
-        script_environment.site_package_path = config.python_environment.site_package_path.clone();
+        // This cannot live solely in `ConfigFile::get_sys_info`: PEP 723 affects dependency
+        // search paths as well as the Python version and platform, so the full environment
+        // must be replaced for this script.
+        let result = (|| {
+            let mut script_environment = (self.query_environment)(script_path)?;
+            // Preserve explicit user-specified site-package paths such as `typings/`,
+            // while replacing interpreter-derived environment data with the script's.
+            script_environment.site_package_path =
+                config.python_environment.site_package_path.clone();
 
-        let mut config = config.as_ref().clone();
-        config.interpreters.disable_query();
-        config.python_environment = script_environment;
+            let mut config = config.as_ref().clone();
+            config.interpreters.disable_query();
+            config.python_environment = script_environment;
+            Ok(ArcId::new(config))
+        })()
+        .map_err(|error: anyhow::Error| Arc::<str>::from(format!("{error:#}")));
 
-        let config = ArcId::new(config);
-        self.cache.lock().insert(cache_key, config.dupe());
-        Ok(config)
+        self.cache
+            .lock()
+            .insert(script_path.to_path_buf(), (metadata, result.clone()));
+        result.map_err(|error| anyhow::anyhow!(error.to_string()))
     }
 
     fn script_path(path: &ModulePath) -> Option<&Path> {
         match path.details() {
-            ModulePathDetails::FileSystem(path) | ModulePathDetails::Memory(path) => Some(path),
-            ModulePathDetails::Namespace(_)
+            ModulePathDetails::FileSystem(path) => Some(path),
+            ModulePathDetails::Memory(_)
+            | ModulePathDetails::Namespace(_)
             | ModulePathDetails::BundledTypeshed(_)
             | ModulePathDetails::BundledTypeshedThirdParty(_)
             | ModulePathDetails::BundledThirdParty(_) => None,
@@ -245,7 +263,7 @@ impl Pep723ScriptOverrides {
     }
 
     fn read_pep723_metadata(path: &Path) -> anyhow::Result<Option<String>> {
-        let contents = std::fs::read_to_string(path)?;
+        let contents = fs::read_to_string(path)?;
         Ok(Self::extract_pep723_metadata(&contents))
     }
 
@@ -254,7 +272,8 @@ impl Pep723ScriptOverrides {
         let mut in_script_block = false;
 
         for line in contents.lines() {
-            match line.trim_start() {
+            let trimmed = line.trim_start();
+            match trimmed {
                 "# /// script" if !in_script_block => {
                     in_script_block = true;
                     metadata.push(line);
@@ -263,6 +282,7 @@ impl Pep723ScriptOverrides {
                     metadata.push(line);
                     return Some(metadata.join("\n"));
                 }
+                _ if in_script_block && !trimmed.starts_with('#') => return None,
                 _ if in_script_block => metadata.push(line),
                 _ => {}
             }
@@ -455,6 +475,7 @@ mod tests {
     use pyrefly_util::includes::Includes;
     use pyrefly_python::sys_info::PythonPlatform;
     use pyrefly_python::sys_info::PythonVersion;
+    use pyrefly_util::includes::Includes;
     use pyrefly_util::test_path::TestPath;
 
     use super::*;
@@ -528,6 +549,12 @@ print('hello')
             Pep723ScriptOverrides::extract_pep723_metadata("print('hello')"),
             None
         );
+        assert_eq!(
+            Pep723ScriptOverrides::extract_pep723_metadata(
+                "# /// script\n# dependencies = [\"click\"]\nprint('invalid')\n# ///"
+            ),
+            None
+        );
     }
 
     #[test]
@@ -567,6 +594,13 @@ import click
         config.python_environment.site_package_path = Some(vec![PathBuf::from("/tmp/typings")]);
         let config = ArcId::new(config);
         let module_path = ModulePath::filesystem(script_path.clone());
+        let memory_path = ModulePath::memory(script_path);
+
+        let unchanged = overrides
+            .override_config(&memory_path, config.dupe())
+            .unwrap();
+        assert_eq!(query_count.load(Ordering::Relaxed), 0);
+        assert_eq!(unchanged, config);
 
         let overridden = overrides
             .override_config(&module_path, config.dupe())
@@ -600,6 +634,47 @@ import click
         );
         assert!(overridden.interpreters.skip_interpreter_query);
         assert_eq!(overridden, cached);
+    }
+
+    #[test]
+    fn test_pep723_override_caches_failures_and_replaces_changed_metadata() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let script_path = tempdir.path().join("script.py");
+        fs::write(
+            &script_path,
+            "# /// script\n# dependencies = [\"click\"]\n# ///\nimport click\n",
+        )
+        .unwrap();
+
+        let query_count = Arc::new(AtomicUsize::new(0));
+        let query_count_for_closure = Arc::clone(&query_count);
+        let overrides = Pep723ScriptOverrides::new(Arc::new(move |_| {
+            query_count_for_closure.fetch_add(1, Ordering::Relaxed);
+            Err(anyhow::anyhow!("uv failed"))
+        }));
+        let module_path = ModulePath::filesystem(script_path.clone());
+        let config = ArcId::new(ConfigFile::default());
+
+        assert!(
+            overrides
+                .override_config(&module_path, config.dupe())
+                .is_err()
+        );
+        assert!(
+            overrides
+                .override_config(&module_path, config.dupe())
+                .is_err()
+        );
+        assert_eq!(query_count.load(Ordering::Relaxed), 1);
+
+        fs::write(
+            &script_path,
+            "# /// script\n# dependencies = [\"rich\"]\n# ///\nimport rich\n",
+        )
+        .unwrap();
+        assert!(overrides.override_config(&module_path, config).is_err());
+        assert_eq!(query_count.load(Ordering::Relaxed), 2);
+        assert_eq!(overrides.cache.lock().len(), 1);
     }
 
     #[test]

--- a/pyrefly/lib/commands/config_finder.rs
+++ b/pyrefly/lib/commands/config_finder.rs
@@ -16,8 +16,10 @@ use pyrefly_config::config::ConfigSource;
 use pyrefly_config::config::DirectoryRelativeFallbackSearchPathCache;
 use pyrefly_config::config::FallbackSearchPath;
 use pyrefly_config::config::GENERATED_FILE_CONFIG_OVERRIDE;
+use pyrefly_config::environment::environment::PythonEnvironment;
 use pyrefly_config::resolve_unconfigured::UnconfiguredOverride;
 use pyrefly_config::resolve_unconfigured::resolve_unconfigured_config;
+use pyrefly_python::module_path::ModulePath;
 use pyrefly_python::module_path::ModulePathDetails;
 use pyrefly_util::arc_id::ArcId;
 use pyrefly_util::lock::Mutex;
@@ -186,6 +188,90 @@ pub fn default_config_finder_with_overrides(
     )
 }
 
+struct Pep723ScriptOverrides {
+    cache: Arc<Mutex<SmallMap<(PathBuf, String), ArcId<ConfigFile>>>>,
+    query_environment: Arc<dyn Fn(&Path) -> anyhow::Result<PythonEnvironment> + Send + Sync>,
+}
+
+impl Pep723ScriptOverrides {
+    fn new(
+        query_environment: Arc<dyn Fn(&Path) -> anyhow::Result<PythonEnvironment> + Send + Sync>,
+    ) -> Self {
+        Self {
+            cache: Arc::new(Mutex::new(SmallMap::new())),
+            query_environment,
+        }
+    }
+
+    fn override_config(
+        &self,
+        path: &ModulePath,
+        config: ArcId<ConfigFile>,
+    ) -> anyhow::Result<ArcId<ConfigFile>> {
+        let Some(script_path) = Self::script_path(path) else {
+            return Ok(config);
+        };
+        let Some(metadata) = Self::read_pep723_metadata(script_path)? else {
+            return Ok(config);
+        };
+
+        let cache_key = (script_path.to_path_buf(), metadata);
+        if let Some(config) = self.cache.lock().get(&cache_key) {
+            return Ok(config.dupe());
+        }
+
+        let mut script_environment = (self.query_environment)(script_path)?;
+        // Preserve explicit user-specified site-package paths such as `typings/`,
+        // while replacing interpreter-derived environment data with the script's.
+        script_environment.site_package_path = config.python_environment.site_package_path.clone();
+
+        let mut config = config.as_ref().clone();
+        config.interpreters.disable_query();
+        config.python_environment = script_environment;
+
+        let config = ArcId::new(config);
+        self.cache.lock().insert(cache_key, config.dupe());
+        Ok(config)
+    }
+
+    fn script_path(path: &ModulePath) -> Option<&Path> {
+        match path.details() {
+            ModulePathDetails::FileSystem(path) | ModulePathDetails::Memory(path) => Some(path),
+            ModulePathDetails::Namespace(_)
+            | ModulePathDetails::BundledTypeshed(_)
+            | ModulePathDetails::BundledTypeshedThirdParty(_)
+            | ModulePathDetails::BundledThirdParty(_) => None,
+        }
+    }
+
+    fn read_pep723_metadata(path: &Path) -> anyhow::Result<Option<String>> {
+        let contents = std::fs::read_to_string(path)?;
+        Ok(Self::extract_pep723_metadata(&contents))
+    }
+
+    fn extract_pep723_metadata(contents: &str) -> Option<String> {
+        let mut metadata = Vec::new();
+        let mut in_script_block = false;
+
+        for line in contents.lines() {
+            match line.trim_start() {
+                "# /// script" if !in_script_block => {
+                    in_script_block = true;
+                    metadata.push(line);
+                }
+                "# ///" if in_script_block => {
+                    metadata.push(line);
+                    return Some(metadata.join("\n"));
+                }
+                _ if in_script_block => metadata.push(line),
+                _ => {}
+            }
+        }
+
+        None
+    }
+}
+
 /// Create a standard `ConfigFinder`, using the provided [`ConfigConfigurer`] to finalize
 /// the config before caching/returning it.
 ///
@@ -201,6 +287,8 @@ pub fn standard_config_finder(
     };
     let configure2 = configure.dupe();
     let configure3 = configure.dupe();
+    let pep723_script_overrides =
+        Pep723ScriptOverrides::new(Arc::new(PythonEnvironment::get_env_from_uv_script));
 
     // A cache where path `p` maps to config file with `search_path = [p]`. If we can find the root.
     let cache_one: Arc<Mutex<SmallMap<PathBuf, ArcId<ConfigFile>>>> =
@@ -228,11 +316,13 @@ pub fn standard_config_finder(
         let cache_parents = cache_parents.dupe();
         let cache_ancestors = cache_ancestors.dupe();
         let cache_empty = cache_empty.dupe();
+        let pep723_script_overrides = pep723_script_overrides.cache.dupe();
         Box::new(move || {
             cache_one.lock().clear();
             cache_parents.lock().clear();
             cache_ancestors.clear();
             *cache_empty.lock() = None;
+            pep723_script_overrides.lock().clear();
             GENERATED_FILE_CONFIG_OVERRIDE.write().clear();
         })
     };
@@ -261,6 +351,16 @@ pub fn standard_config_finder(
             let (config, validation_errors) =
                 configure.configure(file.parent(), file_config, parse_errors);
             (config, validation_errors)
+        }),
+        Box::new(move |_, path, config| {
+            pep723_script_overrides
+                .override_config(path, config)
+                .map_err(|err| {
+                    err.context(format!(
+                        "While resolving PEP 723 metadata for `{}`",
+                        path.as_path().display()
+                    ))
+                })
         }),
         // Fall back to using a default config, but let's see if we can make the `search_path` somewhat useful
         // based on a few heuristics.
@@ -342,6 +442,8 @@ mod tests {
 
     use std::fs;
     use std::ops::Deref as _;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
 
     use pretty_assertions::assert_eq;
     use pyrefly_config::args::ConfigOverrideArgs;
@@ -351,6 +453,8 @@ mod tests {
     use pyrefly_python::module_path::ModulePath;
     use pyrefly_python::module_path::ModulePathDetails;
     use pyrefly_util::includes::Includes;
+    use pyrefly_python::sys_info::PythonPlatform;
+    use pyrefly_python::sys_info::PythonVersion;
     use pyrefly_util::test_path::TestPath;
 
     use super::*;
@@ -396,6 +500,106 @@ mod tests {
         ) -> (ArcId<ConfigFile>, Vec<ConfigError>) {
             (self.0)(root, config, errors)
         }
+    }
+
+    #[test]
+    fn test_extract_pep723_metadata() {
+        let contents = "\
+# /// script
+# requires-python = \">=3.12\"
+# dependencies = [\"click\"]
+# ///
+print('hello')
+";
+
+        assert_eq!(
+            Pep723ScriptOverrides::extract_pep723_metadata(contents),
+            Some(
+                [
+                    "# /// script",
+                    "# requires-python = \">=3.12\"",
+                    "# dependencies = [\"click\"]",
+                    "# ///",
+                ]
+                .join("\n")
+            )
+        );
+        assert_eq!(
+            Pep723ScriptOverrides::extract_pep723_metadata("print('hello')"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_pep723_override_preserves_explicit_site_packages_and_caches() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        let script_path = root.join("script.py");
+        TestPath::setup_test_directory(
+            root,
+            vec![TestPath::file_with_contents(
+                "script.py",
+                "\
+# /// script
+# requires-python = \">=3.12\"
+# dependencies = [\"click\"]
+# ///
+import click
+",
+            )],
+        );
+
+        let query_count = Arc::new(AtomicUsize::new(0));
+        let query_count_for_closure = Arc::clone(&query_count);
+        let overrides = Pep723ScriptOverrides::new(Arc::new(move |_| {
+            query_count_for_closure.fetch_add(1, Ordering::Relaxed);
+            Ok(PythonEnvironment {
+                python_platform: Some(PythonPlatform::windows()),
+                python_version: Some(PythonVersion::new(3, 12, 5)),
+                site_package_path: Some(vec![]),
+                interpreter_site_package_path: vec![PathBuf::from("/tmp/site-packages")],
+                interpreter_stdlib_path: vec![PathBuf::from("/tmp/stdlib")],
+            })
+        }));
+
+        let mut config = ConfigFile::default();
+        config.search_path_from_file = vec![root.to_path_buf()];
+        config.python_environment.site_package_path = Some(vec![PathBuf::from("/tmp/typings")]);
+        let config = ArcId::new(config);
+        let module_path = ModulePath::filesystem(script_path.clone());
+
+        let overridden = overrides
+            .override_config(&module_path, config.dupe())
+            .unwrap();
+        let cached = overrides.override_config(&module_path, config).unwrap();
+
+        assert_eq!(query_count.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            overridden.search_path().cloned().collect::<Vec<_>>(),
+            vec![root.to_path_buf()]
+        );
+        assert_eq!(
+            overridden.python_environment.site_package_path,
+            Some(vec![PathBuf::from("/tmp/typings")])
+        );
+        assert_eq!(
+            overridden.python_environment.interpreter_site_package_path,
+            vec![PathBuf::from("/tmp/site-packages")]
+        );
+        assert_eq!(
+            overridden.python_environment.interpreter_stdlib_path,
+            vec![PathBuf::from("/tmp/stdlib")]
+        );
+        assert_eq!(
+            overridden.python_environment.python_version,
+            Some(PythonVersion::new(3, 12, 5))
+        );
+        assert_eq!(
+            overridden.python_environment.python_platform,
+            Some(PythonPlatform::windows())
+        );
+        assert!(overridden.interpreters.skip_interpreter_query);
+        assert_eq!(overridden, cached);
     }
 
     #[test]

--- a/pyrefly/lib/commands/config_finder.rs
+++ b/pyrefly/lib/commands/config_finder.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -188,8 +189,10 @@ pub fn default_config_finder_with_overrides(
     )
 }
 
+type CachedPep723Override = (String, Result<ArcId<ConfigFile>, Arc<str>>);
+
 struct Pep723ScriptOverrides {
-    cache: Arc<Mutex<SmallMap<(PathBuf, String), ArcId<ConfigFile>>>>,
+    cache: Arc<Mutex<SmallMap<PathBuf, CachedPep723Override>>>,
     query_environment: Arc<dyn Fn(&Path) -> anyhow::Result<PythonEnvironment> + Send + Sync>,
 }
 
@@ -215,29 +218,44 @@ impl Pep723ScriptOverrides {
             return Ok(config);
         };
 
-        let cache_key = (script_path.to_path_buf(), metadata);
-        if let Some(config) = self.cache.lock().get(&cache_key) {
-            return Ok(config.dupe());
+        let cached = self
+            .cache
+            .lock()
+            .get(script_path)
+            .filter(|(cached_metadata, _)| cached_metadata == &metadata)
+            .map(|(_, result)| result.clone());
+        if let Some(result) = cached {
+            return result.map_err(|error| anyhow::anyhow!(error.to_string()));
         }
 
-        let mut script_environment = (self.query_environment)(script_path)?;
-        // Preserve explicit user-specified site-package paths such as `typings/`,
-        // while replacing interpreter-derived environment data with the script's.
-        script_environment.site_package_path = config.python_environment.site_package_path.clone();
+        // This cannot live solely in `ConfigFile::get_sys_info`: PEP 723 affects dependency
+        // search paths as well as the Python version and platform, so the full environment
+        // must be replaced for this script.
+        let result = (|| {
+            let mut script_environment = (self.query_environment)(script_path)?;
+            // Preserve explicit user-specified site-package paths such as `typings/`,
+            // while replacing interpreter-derived environment data with the script's.
+            script_environment.site_package_path =
+                config.python_environment.site_package_path.clone();
 
-        let mut config = config.as_ref().clone();
-        config.interpreters.disable_query();
-        config.python_environment = script_environment;
+            let mut config = config.as_ref().clone();
+            config.interpreters.disable_query();
+            config.python_environment = script_environment;
+            Ok(ArcId::new(config))
+        })()
+        .map_err(|error: anyhow::Error| Arc::<str>::from(format!("{error:#}")));
 
-        let config = ArcId::new(config);
-        self.cache.lock().insert(cache_key, config.dupe());
-        Ok(config)
+        self.cache
+            .lock()
+            .insert(script_path.to_path_buf(), (metadata, result.clone()));
+        result.map_err(|error| anyhow::anyhow!(error.to_string()))
     }
 
     fn script_path(path: &ModulePath) -> Option<&Path> {
         match path.details() {
-            ModulePathDetails::FileSystem(path) | ModulePathDetails::Memory(path) => Some(path),
-            ModulePathDetails::Namespace(_)
+            ModulePathDetails::FileSystem(path) => Some(path),
+            ModulePathDetails::Memory(_)
+            | ModulePathDetails::Namespace(_)
             | ModulePathDetails::BundledTypeshed(_)
             | ModulePathDetails::BundledTypeshedThirdParty(_)
             | ModulePathDetails::BundledThirdParty(_) => None,
@@ -245,7 +263,7 @@ impl Pep723ScriptOverrides {
     }
 
     fn read_pep723_metadata(path: &Path) -> anyhow::Result<Option<String>> {
-        let contents = std::fs::read_to_string(path)?;
+        let contents = fs::read_to_string(path)?;
         Ok(Self::extract_pep723_metadata(&contents))
     }
 
@@ -254,7 +272,8 @@ impl Pep723ScriptOverrides {
         let mut in_script_block = false;
 
         for line in contents.lines() {
-            match line.trim_start() {
+            let trimmed = line.trim_start();
+            match trimmed {
                 "# /// script" if !in_script_block => {
                     in_script_block = true;
                     metadata.push(line);
@@ -263,6 +282,7 @@ impl Pep723ScriptOverrides {
                     metadata.push(line);
                     return Some(metadata.join("\n"));
                 }
+                _ if in_script_block && !trimmed.starts_with('#') => return None,
                 _ if in_script_block => metadata.push(line),
                 _ => {}
             }
@@ -521,6 +541,12 @@ print('hello')
             Pep723ScriptOverrides::extract_pep723_metadata("print('hello')"),
             None
         );
+        assert_eq!(
+            Pep723ScriptOverrides::extract_pep723_metadata(
+                "# /// script\n# dependencies = [\"click\"]\nprint('invalid')\n# ///"
+            ),
+            None
+        );
     }
 
     #[test]
@@ -560,6 +586,13 @@ import click
         config.python_environment.site_package_path = Some(vec![PathBuf::from("/tmp/typings")]);
         let config = ArcId::new(config);
         let module_path = ModulePath::filesystem(script_path.clone());
+        let memory_path = ModulePath::memory(script_path);
+
+        let unchanged = overrides
+            .override_config(&memory_path, config.dupe())
+            .unwrap();
+        assert_eq!(query_count.load(Ordering::Relaxed), 0);
+        assert_eq!(unchanged, config);
 
         let overridden = overrides
             .override_config(&module_path, config.dupe())
@@ -593,6 +626,47 @@ import click
         );
         assert!(overridden.interpreters.skip_interpreter_query);
         assert_eq!(overridden, cached);
+    }
+
+    #[test]
+    fn test_pep723_override_caches_failures_and_replaces_changed_metadata() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let script_path = tempdir.path().join("script.py");
+        fs::write(
+            &script_path,
+            "# /// script\n# dependencies = [\"click\"]\n# ///\nimport click\n",
+        )
+        .unwrap();
+
+        let query_count = Arc::new(AtomicUsize::new(0));
+        let query_count_for_closure = Arc::clone(&query_count);
+        let overrides = Pep723ScriptOverrides::new(Arc::new(move |_| {
+            query_count_for_closure.fetch_add(1, Ordering::Relaxed);
+            Err(anyhow::anyhow!("uv failed"))
+        }));
+        let module_path = ModulePath::filesystem(script_path.clone());
+        let config = ArcId::new(ConfigFile::default());
+
+        assert!(
+            overrides
+                .override_config(&module_path, config.dupe())
+                .is_err()
+        );
+        assert!(
+            overrides
+                .override_config(&module_path, config.dupe())
+                .is_err()
+        );
+        assert_eq!(query_count.load(Ordering::Relaxed), 1);
+
+        fs::write(
+            &script_path,
+            "# /// script\n# dependencies = [\"rich\"]\n# ///\nimport rich\n",
+        )
+        .unwrap();
+        assert!(overrides.override_config(&module_path, config).is_err());
+        assert_eq!(query_count.load(Ordering::Relaxed), 2);
+        assert_eq!(overrides.cache.lock().len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3176

teaching config resolution to apply a per-file post-processing override for PEP 723 scripts instead of forcing a separate project config.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add tests