### PR TITLE
upgrading tokio to 1.52.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,12 +3127,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3429,9 +3429,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3446,9 +3446,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/pyrefly/Cargo.toml
+++ b/pyrefly/Cargo.toml
@@ -63,7 +63,7 @@ serde_repr = "0.1.14"
 starlark_map = "0.13.0"
 static_assertions = "1.1.0"
 tempfile = "3.27.0"
-tokio = { version = "1.50.0", features = ["macros", "rt"] }
+tokio = { version = "1.52.1", features = ["macros", "rt"] }
 toml = { version = "0.9.12", features = ["preserve_order"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tsp_types = { path = "../crates/tsp_types" }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/unigraph/pull/11

X-link: https://github.com/facebookexperimental/reverie/pull/36

X-link: https://github.com/facebookincubator/reindeer/pull/103

X-link: https://github.com/facebookincubator/below/pull/8278

X-link: https://github.com/facebookexperimental/dapper/pull/1

X-link: https://github.com/meta-pytorch/monarch/pull/3495

Upgrading `tokio` from `1.50.0` to `1.52.1`.
- All downstream consumers checked with arc rust-check — 0 errors.

Reviewed By: dtolnay

Differential Revision: D101580193
