### PR TITLE
fix(suppression): handle ignores on multi-line implicit concatenations

### DIFF
--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -33,6 +33,7 @@ use enum_iterator::Sequence;
 use fxhash::FxHashMap;
 use itertools::Itertools;
 use pyrefly_build::handle::Handle;
+use pyrefly_python::ast::Ast;
 use pyrefly_python::ignore::parse_ignore_all;
 use pyrefly_python::module::Module;
 use pyrefly_python::module_name::ModuleName;
@@ -745,10 +746,17 @@ impl<'a> Transaction<'a> {
                 .filter_map(|handle| {
                     self.with_module_config_inner(handle, |config, x| {
                         let load = x.get_load()?;
-                        let mut multi_line = x
-                            .get_ast()
-                            .map(|ast| sorted_multi_line_string_ranges(&ast, &load.module_info))
-                            .unwrap_or_default();
+                        let ast = x.get_ast().unwrap_or_else(|| {
+                            // AST may have been evicted after the Answers step.
+                            // Re-parse to compute multi-line string ranges.
+                            let (ast, _, _) = Ast::parse(
+                                load.module_info.contents(),
+                                load.module_info.source_type(),
+                            );
+                            Arc::new(ast)
+                        });
+                        let mut multi_line =
+                            sorted_multi_line_string_ranges(&ast, &load.module_info);
                         let lines: Vec<&str> = load.module_info.contents().lines().collect();
                         multi_line
                             .extend(sorted_backslash_continuation_ranges(&lines, &multi_line));
@@ -772,10 +780,14 @@ impl<'a> Transaction<'a> {
         /// Extract multi-line ranges and ignore-all directives from the AST
         /// and source text.
         fn module_ranges_from(state: &dyn ModuleStateReader, load: &Load) -> ModuleRanges {
-            let mut multi_line = state
-                .get_ast()
-                .map(|ast| sorted_multi_line_string_ranges(&ast, &load.module_info))
-                .unwrap_or_default();
+            let ast = state.get_ast().unwrap_or_else(|| {
+                // AST may have been evicted after the Answers step.
+                // Re-parse to compute multi-line string ranges.
+                let (ast, _, _) =
+                    Ast::parse(load.module_info.contents(), load.module_info.source_type());
+                Arc::new(ast)
+            });
+            let mut multi_line = sorted_multi_line_string_ranges(&ast, &load.module_info);
             let lines: Vec<&str> = load.module_info.contents().lines().collect();
             multi_line.extend(sorted_backslash_continuation_ranges(&lines, &multi_line));
             multi_line.sort();

--- a/pyrefly/lib/test/suppression.rs
+++ b/pyrefly/lib/test/suppression.rs
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use crate::state::require::Require;
+use crate::test::util::TestEnv;
 use crate::testcase;
 
 testcase!(
@@ -290,6 +292,21 @@ testcase!(
 x: int = \
     "a" + \
     2
+"#,
+);
+
+testcase!(
+    test_pyrefly_suppression_implicit_string_concat,
+    TestEnv::new().with_run_require(Require::Errors),
+    r#"
+from typing import Any
+
+def test(d: dict[str, Any] | str) -> None:
+    x = (
+        # pyrefly: ignore [bad-index]
+        f"{d['foo']}\n"
+        f"{d['bar']}"
+    )
 "#,
 );
 


### PR DESCRIPTION
# Summary
We did not respect ignore comments for the entirety of a multi-line implicit concatenation. This only happened in `pyrefly check`.

This occurred because we had thrown away the AST by the time we collect and check for errors. Instead, just reparse it.

Fixes https://github.com/facebook/pyrefly/issues/3188.

# Test Plan

- `cargo test`
- Manually (e.g. `cargo run --check`), with the following file:

```python
# lol.py
d = "lol"

x = (
    # pyrefly: ignore [bad-index]                                                                                 
    f"{d['foo']}\n" 
    f"{d['bar']}"
)
```

