### PR TITLE
fix(suppress): handle removal of unused ignores

### DIFF
--- a/pyrefly/lib/commands/suppress.rs
+++ b/pyrefly/lib/commands/suppress.rs
@@ -62,26 +62,26 @@ impl SuppressArgs {
                     .filter(|e| e.is_unused_ignore())
                     .collect()
             } else {
-                // Run type checking to collect unused ignore errors
+                // Delegate to `check --remove-unused-ignores`, which calls
+                // collect_unused_ignore_errors directly (bypassing severity
+                // filtering) and handles removal in one step.
                 self.config_override.validate()?;
                 let (files_to_check, config_finder) = self
                     .files
                     .clone()
                     .resolve(self.config_override.clone(), wrapper.clone())?;
 
-                let check_args = CheckArgs::parse_from(["check", "--output-format", "omit-errors"]);
-                let (_, errors, _check_result) =
-                    check_args.run_once(files_to_check, config_finder, thread_count)?;
-
-                // Convert to SerializedErrors, filtering for UnusedIgnore only
-                errors
-                    .into_iter()
-                    .filter_map(|e| SerializedError::from_error(&e))
-                    .filter(|e| e.is_unused_ignore())
-                    .collect()
+                let check_args = CheckArgs::parse_from([
+                    "check",
+                    "--output-format",
+                    "omit-errors",
+                    "--remove-unused-ignores",
+                ]);
+                check_args.run_once(files_to_check, config_finder, thread_count)?;
+                return Ok(CommandExitStatus::Success);
             };
 
-            // Remove unused ignores
+            // Remove unused ignores (JSON path only)
             suppress::remove_unused_ignores_from_serialized(unused_errors);
         } else {
             // Add suppressions mode (existing behavior)

--- a/pyrefly/lib/error/suppress.rs
+++ b/pyrefly/lib/error/suppress.rs
@@ -675,6 +675,23 @@ mod tests {
         assert_eq!(removals, expected_removals);
     }
 
+    /// Mimics the `suppress --remove-unused` code path, which delegates to
+    /// `check --remove-unused-ignores` internally. This collects unused ignore
+    /// errors without severity filtering and removes them.
+    fn assert_remove_ignores_via_suppress_command(
+        before: &str,
+        after: &str,
+        expected_removals: usize,
+    ) {
+        let (errors, tdir) = get_errors(before);
+        let collected = errors.collect_errors();
+        let unused_errors = errors.collect_unused_ignore_errors(&collected);
+        let removals = suppress::remove_unused_ignores(unused_errors);
+        let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
+        assert_eq!(after, got_file);
+        assert_eq!(removals, expected_removals);
+    }
+
     fn get_errors(contents: &str) -> (Errors, TempDir) {
         let tdir = tempfile::tempdir().unwrap();
 
@@ -1971,5 +1988,21 @@ x: int = \
     2
 "#,
         );
+    }
+
+    #[test]
+    fn test_suppress_remove_unused_without_config() {
+        // `suppress --remove-unused` should remove unused ignore comments even
+        // without explicit config, matching `check --remove-unused-ignores`.
+        let input = r#"
+def f() -> int:
+    # pyrefly: ignore [bad-return]
+    return 1
+"#;
+        let want = r#"
+def f() -> int:
+    return 1
+"#;
+        assert_remove_ignores_via_suppress_command(input, want, 1);
     }
 }


### PR DESCRIPTION
# Summary

Ensure that `pyrefly suppress --remove-unused` actually works.

Fixes https://github.com/facebook/pyrefly/issues/3198.

# Test Plan

`cargo test`
<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
