### PR TITLE
Add multi-connection protocol types (#3199)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
 name = "dupe"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1501,19 @@ name = "interpolator"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
+name = "interprocess"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+dependencies = [
+ "doctest-file",
+ "libc",
+ "recvmsg",
+ "widestring",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "is-macro"
@@ -2226,6 +2245,7 @@ dependencies = [
  "fuzzy-matcher",
  "fxhash",
  "indicatif",
+ "interprocess",
  "itertools 0.14.0",
  "lsp-server",
  "lsp-types",
@@ -2608,6 +2628,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -3921,6 +3947,12 @@ dependencies = [
  "once_cell",
  "rustix 0.38.44",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/crates/tsp_types/protocol_generator/tsp.json
+++ b/crates/tsp_types/protocol_generator/tsp.json
@@ -66,6 +66,20 @@
     ],
     "requests": [
         {
+            "method": "typeServer/connection",
+            "typeName": "ConnectionRequest",
+            "messageDirection": "clientToServer",
+            "documentation": "Main-connection-only request used to open or close an extra TSP transport. Extra transports must remain read-only and must not be used for LSP traffic.",
+            "params": {
+                "kind": "reference",
+                "name": "ConnectionRequestParams"
+            },
+            "result": {
+                "kind": "reference",
+                "name": "ConnectionRequestResult"
+            }
+        },
+        {
             "method": "typeServer/getComputedType",
             "typeName": "GetComputedTypeRequest",
             "messageDirection": "clientToServer",
@@ -301,13 +315,21 @@
                 "v0_1_0": "0.1.0",
                 "v0_2_0": "0.2.0",
                 "v0_3_0": "0.3.0",
-                "current": "0.4.0"
+                "v0_4_0": "0.4.0",
+                "current": "0.5.0"
             },
             "valueDocumentation": {
                 "v0_1_0": "Initial protocol version",
                 "v0_2_0": "Added new request types and fields",
                 "v0_3_0": "Switch to more complex types",
-                "current": "Switch to Type union and using stubs"
+                "v0_4_0": "Switch to Type union and using stubs",
+                "current": "Add multi-connection negotiation and control requests"
+            }
+        },
+        "ConnectionTransportKind": {
+            "kind": "stringEnum",
+            "values": {
+                "Ipc": "ipc"
             }
         },
         "Variance": {
@@ -344,6 +366,77 @@
                 }
             ],
             "documentation": "Represents a location in source code (a node in the AST). Used to point to specific declarations, expressions, or statements in Python source files. Used for: - Pointing to where a type is declared - Identifying the location of expressions for type inference - Error reporting and diagnostics - Linking types back to their source definitions Examples: - For `def foo():`, the node points to the function declaration - For a variable `x = 42`, the node points to the assignment - For default parameter values in functions"
+        },
+        "TypeServerMultiConnectionCapability": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "supportedTransports",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "reference",
+                            "name": "ConnectionTransportKind"
+                        }
+                    },
+                    "optional": false
+                }
+            ],
+            "documentation": "Capability shape exchanged via the LSP initialize request/response under `capabilities.experimental.typeServerMultiConnection`."
+        },
+        "ConnectionRequestParams": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "type",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": false
+                },
+                {
+                    "name": "kind",
+                    "type": {
+                        "kind": "reference",
+                        "name": "ConnectionTransportKind"
+                    },
+                    "optional": false
+                },
+                {
+                    "name": "args",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "base",
+                            "name": "string"
+                        }
+                    },
+                    "optional": true
+                }
+            ],
+            "documentation": "Main-connection-only control request used to open or close extra read-only TSP channels after LSP initialization has completed."
+        },
+        "ConnectionRequestResult": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "success",
+                    "type": {
+                        "kind": "base",
+                        "name": "boolean"
+                    },
+                    "optional": false
+                },
+                {
+                    "name": "message",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": true
+                }
+            ]
         },
         "ModuleName": {
             "kind": "interface",
@@ -501,8 +594,8 @@
                 {
                     "name": "returnType",
                     "type": {
-                                "kind": "reference",
-                                "name": "Type"
+                        "kind": "reference",
+                        "name": "Type"
                     },
                     "optional": true,
                     "documentation": "Specialized type of the declared return type. Undefined if there is no declared return type. Example: For `def foo[T](x: T) -> T` specialized to `T=int`, returnType=int."
@@ -589,7 +682,7 @@
                     "documentation": "Discriminator field that determines which declaration variant this is. Regular: Has source code and AST node Synthesized: Created by type checker, no source node"
                 }
             ],
-            "documentation": "Base interface for all declaration types. Provides the discriminator field for the Declaration union."
+            "documentation": "Base interface for all declaration types. Provides the discriminator field for the Declaration union. This is a generic interface that is extended by: - RegularDeclaration (kind = Regular) - SynthesizedDeclaration (kind = Synthesized) The type parameter T ensures that the kind field matches the implementing interface. Used for type-safe discrimination: ```typescript if (declaration.kind === DeclarationKind.Regular) { // TypeScript knows this is RegularDeclaration const node = declaration.node; } ```"
         },
         "RegularDeclaration": {
             "kind": "interface",
@@ -615,8 +708,8 @@
                 {
                     "name": "name",
                     "type": {
-                                "kind": "base",
-                                "name": "string"
+                        "kind": "base",
+                        "name": "string"
                     },
                     "optional": true,
                     "documentation": "Name of the declared symbol, or undefined for anonymous declarations. Example: \"foo\" for `def foo():`, undefined for lambda functions."

--- a/crates/tsp_types/src/protocol.rs
+++ b/crates/tsp_types/src/protocol.rs
@@ -110,6 +110,8 @@ pub enum LSPNull {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
 pub enum TSPRequestMethods {
+    #[serde(rename = "typeServer/connection")]
+    TypeServerConnection,
     #[serde(rename = "typeServer/getComputedType")]
     TypeServerGetComputedType,
     #[serde(rename = "typeServer/getDeclaredType")]
@@ -129,6 +131,11 @@ pub enum TSPRequestMethods {
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
 #[serde(tag = "method")]
 pub enum TSPRequests {
+    #[serde(rename = "typeServer/connection")]
+    ConnectionRequest {
+        id: serde_json::Value,
+        params: ConnectionRequestParams,
+    },
     #[serde(rename = "typeServer/getComputedType")]
     GetComputedTypeRequest {
         id: serde_json::Value,
@@ -347,7 +354,17 @@ pub enum TypeServerVersion {
 
     /// Switch to Type union and using stubs
     #[serde(rename = "0.4.0")]
+    V040,
+
+    /// Add multi-connection negotiation and control requests
+    #[serde(rename = "0.5.0")]
     Current,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+pub enum ConnectionTransportKind {
+    #[serde(rename = "ipc")]
+    Ipc,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
@@ -416,6 +433,33 @@ pub struct Node {
 
     /// URI of the source file containing this node.
     pub uri: String,
+}
+
+/// Capability shape exchanged via the LSP initialize request/response under `capabilities.experimental.typeServerMultiConnection`.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TypeServerMultiConnectionCapability {
+    pub supported_transports: Vec<ConnectionTransportKind>,
+}
+
+/// Main-connection-only control request used to open or close extra read-only TSP channels after LSP initialization has completed.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConnectionRequestParams {
+    pub args: Option<Vec<String>>,
+
+    pub kind: ConnectionTransportKind,
+
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConnectionRequestResult {
+    pub message: Option<String>,
+
+    pub success: bool,
 }
 
 /// Represents a Python module name, handling both absolute and relative imports. Used for: - Import statement resolution - Tracking module dependencies - Resolving relative imports (from . import, from .. import) Examples: - `import os.path`: leadingDots=0, nameParts=['os', 'path'] - `from . import utils`: leadingDots=1, nameParts=['utils'] - `from ...parent import module`: leadingDots=3, nameParts=['parent', 'module'] - `import mymodule`: leadingDots=0, nameParts=['mymodule']
@@ -510,7 +554,7 @@ pub struct SentinelLiteral {
     pub module_name: String,
 }
 
-/// Base interface for all declaration types. Provides the discriminator field for the Declaration union.
+/// Base interface for all declaration types. Provides the discriminator field for the Declaration union. This is a generic interface that is extended by: - RegularDeclaration (kind = Regular) - SynthesizedDeclaration (kind = Synthesized) The type parameter T ensures that the kind field matches the implementing interface. Used for type-safe discrimination: ```typescript if (declaration.kind === DeclarationKind.Regular) { // TypeScript knows this is RegularDeclaration const node = declaration.node; } ```
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DeclarationBase {
@@ -863,6 +907,25 @@ pub enum LSPIdOptional {
     String(String),
     None,
 }
+
+/// Main-connection-only request used to open or close an extra TSP transport. Extra transports must remain read-only and must not be used for LSP traffic.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConnectionRequest {
+    /// The version of the JSON RPC protocol.
+    pub jsonrpc: String,
+
+    /// The method to be invoked.
+    pub method: TSPRequestMethods,
+
+    /// The request id.
+    pub id: LSPId,
+
+    pub params: ConnectionRequestParams,
+}
+
+/// Response to the [ConnectionRequest].
+pub type ConnectionResponse = ConnectionRequestResult;
 
 /// Requests and notifications for the type server protocol. Request for the computed type of a declaration or node. Computed type is the type that is inferred based on the code flow. Example: def foo(a: int | str): if instanceof(a, int): b = a + 1  # Computed type of 'b' is 'int'
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]

--- a/crates/tsp_types/tests/protocol_types.rs
+++ b/crates/tsp_types/tests/protocol_types.rs
@@ -76,7 +76,7 @@ fn test_variance_round_trip() {
 fn test_type_server_version_round_trip() {
     let v = TypeServerVersion::Current;
     let json = serde_json::to_value(&v).unwrap();
-    assert_eq!(json, serde_json::json!("0.4.0"));
+    assert_eq!(json, serde_json::json!("0.5.0"));
     let back: TypeServerVersion = serde_json::from_value(json).unwrap();
     assert_eq!(back, v);
 }

--- a/pyrefly/Cargo.toml
+++ b/pyrefly/Cargo.toml
@@ -34,6 +34,7 @@ faster-hex = "0.6.1"
 fuzzy-matcher = "0.3.7"
 fxhash = "0.2.1"
 indicatif = { version = "0.18.4", features = ["futures", "improved_unicode", "rayon", "tokio"] }
+interprocess = "2.2.3"
 itertools = "0.14.0"
 lsp-server = "0.7.9"
 lsp-types = { git = "https://github.com/astral-sh/lsp-types", rev = "3512a9f33eadc5402cfab1b8f7340824c8ca1439" }

--- a/pyrefly/lib/commands/tsp.rs
+++ b/pyrefly/lib/commands/tsp.rs
@@ -38,6 +38,10 @@ pub struct TspArgs {
     /// Note that indexing files is a performance-intensive task.
     #[arg(long, default_value_t = if cfg!(fbcode_build) {0} else {2000})]
     pub(crate) workspace_indexing_limit: usize,
+    /// Selects the transport for the main JSON-RPC connection.
+    /// Use `stdio` (default) or `ipc://<name>` for a local socket / named pipe.
+    #[arg(long, default_value = "stdio")]
+    pub(crate) transport: String,
 }
 
 pub fn run_tsp(
@@ -107,9 +111,7 @@ impl TspArgs {
         // Note that we must have our logging only write out to stderr.
         eprintln!("starting TSP server");
 
-        // Create the transport. Includes the stdio (stdin and stdout) versions but this could
-        // also be implemented to use sockets or HTTP.
-        let (connection, reader, io_threads) = Connection::stdio();
+        let (connection, reader, io_threads) = Connection::from_transport(&self.transport)?;
 
         run_tsp(connection, reader, self, telemetry, wrapper, thread_count)?;
         io_threads.join()?;

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -31,6 +31,14 @@ use crossbeam_channel::Receiver;
 use crossbeam_channel::Sender;
 use dupe::Dupe;
 use dupe::OptionDupedExt;
+use interprocess::TryClone;
+#[cfg(unix)]
+use interprocess::local_socket::GenericFilePath;
+use interprocess::local_socket::ToFsName;
+use interprocess::local_socket::prelude::LocalSocketStream;
+use interprocess::local_socket::traits::Stream;
+#[cfg(windows)]
+use interprocess::os::windows::local_socket::NamedPipe;
 use itertools::Itertools;
 use lsp_server::ErrorCode;
 use lsp_server::RequestId;
@@ -393,7 +401,7 @@ impl TypeErrorDisplayStatus {
 }
 
 /// Interface exposed for TSP to interact with the LSP server
-pub trait TspInterface: Send + Sync {
+pub trait TspInterface: Send + Sync + 'static {
     /// Send a response back to the LSP client
     fn send_response(&self, response: Response);
 
@@ -494,6 +502,7 @@ pub struct Connection {
 pub enum MessageReader {
     Channel(Receiver<Message>),
     Stdio(BufReader<Stdin>),
+    Stream(BufReader<Box<dyn std::io::Read + Send>>),
 }
 
 impl MessageReader {
@@ -504,6 +513,7 @@ impl MessageReader {
         match self {
             MessageReader::Channel(r) => r.recv().ok(),
             MessageReader::Stdio(r) => read_lsp_message(r).ok().flatten(),
+            MessageReader::Stream(r) => read_lsp_message(r).ok().flatten(),
         }
     }
 }
@@ -542,6 +552,47 @@ impl Connection {
             MessageReader::Stdio(BufReader::new(std::io::stdin())),
             IoThread { writer },
         )
+    }
+
+    pub fn ipc(pipe_name: &str) -> std::io::Result<(Self, MessageReader, IoThread)> {
+        #[cfg(windows)]
+        let socket_name = pipe_name.to_fs_name::<NamedPipe>()?;
+        #[cfg(unix)]
+        let socket_name = pipe_name.to_fs_name::<GenericFilePath>()?;
+
+        let stream = LocalSocketStream::connect(socket_name)?;
+        let reader_stream = stream.try_clone()?;
+        let (writer_sender, writer_receiver) = crossbeam_channel::unbounded();
+        let writer = std::thread::spawn(move || {
+            let mut output = stream;
+            while let Ok(msg) = writer_receiver.recv() {
+                write_lsp_message(&mut output, msg)?;
+            }
+            Ok(())
+        });
+        Ok((
+            Self {
+                sender: writer_sender,
+                channel_receiver: None,
+            },
+            MessageReader::Stream(BufReader::new(Box::new(reader_stream))),
+            IoThread { writer },
+        ))
+    }
+
+    pub fn from_transport(transport: &str) -> std::io::Result<(Self, MessageReader, IoThread)> {
+        if transport == "stdio" {
+            return Ok(Self::stdio());
+        }
+
+        if let Some(pipe_name) = transport.strip_prefix("ipc://") {
+            return Self::ipc(pipe_name);
+        }
+
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Unsupported TSP transport: {transport}"),
+        ))
     }
 
     pub fn memory() -> ((Self, MessageReader), (Self, MessageReader)) {
@@ -1080,6 +1131,12 @@ pub struct ServerCapabilitiesWithTypeHierarchy {
     base: ServerCapabilities,
     #[serde(skip_serializing_if = "Option::is_none")]
     type_hierarchy_provider: Option<bool>,
+}
+
+impl ServerCapabilitiesWithTypeHierarchy {
+    pub fn set_experimental(&mut self, value: serde_json::Value) {
+        self.base.experimental = Some(value);
+    }
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
Summary:

Add the protocol-level types needed for TSP multi-connection support: ConnectionRequest, ConnectionRequestParams, ConnectionRequestResult, ConnectionTransportKind, and TypeServerMultiConnectionCapability. Bump TSP protocol version to 0.5.0.

Also add IPC transport plumbing: Connection::ipc(), Connection::from_transport(), MessageReader::Stream, and a --transport CLI arg for the TSP server. These are transport-layer changes independent of the server architecture.

Differential Revision: D102005012


