### PR TITLE
fix Pyrefly doesn't reveal type as Never in unreachable code #3202

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -4424,12 +4424,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         &self,
         binding: &Binding,
         expr: &Expr,
+        flow_narrow_exhaustive: Option<Idx<Key>>,
         errors: &ErrorCollector,
     ) -> TypeInfo {
-        let ty = self.binding_to_type(binding, errors);
+        let ty = if let Some(key) = flow_narrow_exhaustive
+            && self.get_idx(key).ty().is_never()
+        {
+            // Keep checking the RHS so unreachable branches still report real errors,
+            // but the assigned name itself should collapse to Never.
+            let _ = self.binding_to_type(binding, errors);
+            self.heap.mk_never()
+        } else {
+            self.binding_to_type(binding, errors)
+        };
         let mut type_info = TypeInfo::of_ty(ty);
-        let mut prefix = Vec::new();
-        self.populate_dict_literal_facets(&mut type_info, &mut prefix, expr);
+        if !type_info.ty().is_never() {
+            let mut prefix = Vec::new();
+            self.populate_dict_literal_facets(&mut type_info, &mut prefix, expr);
+        }
         type_info
     }
 
@@ -4468,7 +4480,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if x.receiver_idx.is_some() {
                     TypeInfo::of_ty(self.binding_to_type(binding, errors))
                 } else {
-                    self.binding_to_type_info_name_assign(binding, x.expr.as_ref(), errors)
+                    self.binding_to_type_info_name_assign(
+                        binding,
+                        x.expr.as_ref(),
+                        x.flow_narrow_exhaustive,
+                        errors,
+                    )
                 }
             }
             Binding::AssignToAttribute(x) => self.binding_to_type_info_assign_to_attribute(

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -1978,6 +1978,9 @@ pub struct NameAssign {
     pub expr: Box<Expr>,
     pub legacy_tparams: Option<Box<[Idx<KeyLegacyTypeParam>]>>,
     pub is_in_function_scope: bool,
+    /// If the current flow has active narrows, this key resolves to `Never`
+    /// whenever those narrows make the branch impossible.
+    pub flow_narrow_exhaustive: Option<Idx<Key>>,
     pub first_use: FirstUse,
     /// The Definition idx for this NameAssign, if infer_with_first_use is enabled.
     /// Used at solve time for inline first-use pinning and partial answer storage.

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -56,6 +56,8 @@ use crate::binding::binding::BindingAnnotation;
 use crate::binding::binding::BindingExport;
 use crate::binding::binding::BindingLegacyTypeParam;
 use crate::binding::binding::BranchInfo;
+use crate::binding::binding::ExhaustiveBinding;
+use crate::binding::binding::ExhaustivenessKind;
 use crate::binding::binding::FirstUse;
 use crate::binding::binding::FunctionParameter;
 use crate::binding::binding::Key;
@@ -1364,6 +1366,34 @@ impl<'a> BindingsBuilder<'a> {
             narrow_entries.push((idx, Box::new(op.clone()), *range));
         }
         narrow_entries
+    }
+
+    pub fn current_flow_narrow_exhaustive_key(&mut self, range: TextRange) -> Option<Idx<Key>> {
+        let narrow_entries: Vec<(Idx<Key>, Box<NarrowOp>, TextRange)> = self
+            .scopes
+            .current_flow_narrow_idxs()
+            .into_iter()
+            .filter_map(|idx| {
+                let Some(Binding::Narrow(initial_idx, op, _)) = self.idx_to_binding(idx) else {
+                    return None;
+                };
+                let Key::Narrow(key) = self.idx_to_key(idx) else {
+                    return None;
+                };
+                Some((*initial_idx, op.clone(), key.1))
+            })
+            .collect();
+        if narrow_entries.is_empty() {
+            None
+        } else {
+            Some(self.insert_binding(
+                Key::Exhaustive(ExhaustivenessKind::IfElif, range),
+                Binding::Exhaustive(Box::new(ExhaustiveBinding {
+                    kind: ExhaustivenessKind::IfElif,
+                    narrow_entries,
+                })),
+            ))
+        }
     }
 
     /// Defer creation of a BoundName binding until after AST traversal.

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -2136,6 +2136,15 @@ impl Scopes {
         Some(self.current().flow.get_info(name)?.value()?.idx)
     }
 
+    pub fn current_flow_narrow_idxs(&self) -> Vec<Idx<Key>> {
+        self.current()
+            .flow
+            .info
+            .iter()
+            .filter_map(|(_, info)| info.narrow.as_ref().map(|narrow| narrow.idx))
+            .collect()
+    }
+
     /// Get the flow idx for `name` in the current fork's **base** flow (the flow captured
     /// at `start_fork` time, before any branches were started).
     ///

--- a/pyrefly/lib/binding/target.rs
+++ b/pyrefly/lib/binding/target.rs
@@ -548,6 +548,7 @@ impl<'a> BindingsBuilder<'a> {
             self.scopes.flow_style_for_name(&name.id),
             Some(FlowStyle::Uninitialized)
         );
+        let is_new_binding_in_flow = self.scopes.current_flow_idx(&name.id).is_none();
         let canonical_ann = self.bind_name(&name.id, scope_idx, style);
         let ann = match direct_ann {
             Some((_, idx)) => Some((AnnotationStyle::Direct, idx)),
@@ -587,7 +588,11 @@ impl<'a> BindingsBuilder<'a> {
                 expr: value,
                 legacy_tparams: tparams,
                 is_in_function_scope: self.scopes.in_function_scope(),
-                flow_narrow_exhaustive: self.current_flow_narrow_exhaustive_key(name.range),
+                flow_narrow_exhaustive: if is_new_binding_in_flow {
+                    self.current_flow_narrow_exhaustive_key(name.range)
+                } else {
+                    None
+                },
                 first_use: FirstUse::Undetermined,
                 def_idx: if uses_first_use { Some(def_idx) } else { None },
                 receiver_idx,

--- a/pyrefly/lib/binding/target.rs
+++ b/pyrefly/lib/binding/target.rs
@@ -587,6 +587,7 @@ impl<'a> BindingsBuilder<'a> {
                 expr: value,
                 legacy_tparams: tparams,
                 is_in_function_scope: self.scopes.in_function_scope(),
+                flow_narrow_exhaustive: self.current_flow_narrow_exhaustive_key(name.range),
                 first_use: FirstUse::Undetermined,
                 def_idx: if uses_first_use { Some(def_idx) } else { None },
                 receiver_idx,

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -130,6 +130,18 @@ def f(x: str):
 );
 
 testcase!(
+    test_assigned_name_in_never_branch,
+    r#"
+from typing import Literal, assert_never, reveal_type
+def main(some: Literal['a']) -> None:
+    if some != 'a':
+        assigned = 'b'
+        reveal_type(assigned)  # E: revealed type: Never
+        assert_never(assigned)
+    "#,
+);
+
+testcase!(
     test_is_not_bool_literal,
     r#"
 from typing import assert_type, Literal, Never


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3202

makes local name assignments inside a type-impossible branch resolve to Never instead of preserving the RHS literal type.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test
