### PR TITLE
Fix @no_type_check panic

### DIFF
--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -33,6 +33,7 @@ use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use serde::Serialize;
+use starlark_map::Hashed;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 
@@ -1007,9 +1008,12 @@ impl ReportArgs {
                     } else if param.annotation.is_some() {
                         let annot_key =
                             KeyAnnotation::Annotation(ShortIdentifier::new(&param.name));
-                        let annot_idx = bindings.key_to_idx(&annot_key);
-                        answers
-                            .get_idx(annot_idx)
+                        // Use fallible lookup to handle @no_type_check functions gracefully.
+                        // The binding pass skips creating KeyAnnotation entries for parameters
+                        // of @no_type_check functions since their bodies are not analyzed.
+                        bindings
+                            .key_to_idx_hashed_opt(Hashed::new(&annot_key))
+                            .and_then(|annot_idx| answers.get_idx(annot_idx))
                             .and_then(|awt| awt.annotation.ty.as_ref().map(Self::is_type_known))
                             .unwrap_or(false)
                     } else {
@@ -2453,5 +2457,58 @@ mod tests {
     fn test_report_type_aliases() {
         let report = build_module_report_for_test("type_aliases.py");
         compare_snapshot("type_aliases.expected.json", &report);
+    }
+
+    /// Regression test for panic when running `report` on @no_type_check decorated functions.
+    ///
+    /// Previously, running `pyrefly report` on functions decorated with `@no_type_check`
+    /// would panic because the binding pass skips creating KeyAnnotation entries for
+    /// parameters of @no_type_check functions (since their bodies are not analyzed),
+    /// but `parse_functions` would try to look them up unconditionally.
+    ///
+    /// The fix uses fallible lookup (`key_to_idx_hashed_opt`) to gracefully handle
+    /// missing annotations, treating them as unknown types.
+    ///
+    /// Minimal repro:
+    /// ```python
+    /// from typing import no_type_check
+    /// @no_type_check
+    /// def f(x: int):
+    ///     pass
+    /// ```
+    #[test]
+    fn test_report_no_type_check_panic() {
+        let code = r#"
+from typing import no_type_check
+
+@no_type_check
+def f(x: int):
+    pass
+"#;
+        let (state, handle_fn) = TestEnv::one("test", code)
+            .with_default_require_level(Require::Everything)
+            .to_state();
+        let handle = handle_fn("test");
+        let transaction = state.transaction();
+
+        let module = transaction.get_module_info(&handle).unwrap();
+        let bindings = transaction.get_bindings(&handle).unwrap();
+        let answers = transaction.get_answers(&handle).unwrap();
+        let exports = transaction.get_exports(&handle);
+
+        let tco_classes = ReportArgs::collect_type_check_only_classes(&bindings);
+        // This should complete without panic
+        let functions =
+            ReportArgs::parse_functions(&module, &bindings, &answers, &exports, &tco_classes);
+
+        // The function should be reported with untyped parameter and Any return
+        assert_eq!(functions.len(), 1);
+        assert_eq!(functions[0].name, "test.f");
+        assert_eq!(functions[0].parameters.len(), 1);
+        assert_eq!(functions[0].parameters[0].name, "x");
+        assert!(!functions[0].parameters[0].is_type_known);
+        // @no_type_check functions return Any
+        assert_eq!(functions[0].slots.n_any, 1); // return type is Any
+        assert_eq!(functions[0].slots.n_untyped, 1); // parameter x is untyped
     }
 }


### PR DESCRIPTION
Summary:
Add a regression test that reproduces the panic when running `pyrefly report` on functions decorated with `no_type_check`. The test currently asserts the panic behavior using `#[should_panic]`.

When running `pyrefly report` on a function like:
```python
from typing import no_type_check
no_type_check
def f(x: int):
    pass
```

The report command panics at `pyrefly/lib/binding/bindings.rs:429` in `key_to_idx_hashed` with the error: "Internal error: key not found, module `<module>`, path `<path>`, key Annotation(ShortIdentifier(...))"

Root cause: The binding pass skips creating `KeyAnnotation` entries for parameters of `no_type_check` decorated functions (since their bodies are not analyzed), but `parse_functions` in `report.rs` unconditionally tries to look them up.

A follow-up diff will fix the panic and update this test to assert correct behavior instead of the panic.

Differential Revision: D102023871


