### PR TITLE
Add IPC transport for TSP connections (#3217)

### DIFF
--- a/crates/tsp_types/protocol_generator/tsp.json
+++ b/crates/tsp_types/protocol_generator/tsp.json
@@ -66,6 +66,20 @@
     ],
     "requests": [
         {
+            "method": "typeServer/connection",
+            "typeName": "ConnectionRequest",
+            "messageDirection": "clientToServer",
+            "documentation": "Main-connection-only request used to open or close an extra TSP transport. Extra transports must remain read-only and must not be used for LSP traffic.",
+            "params": {
+                "kind": "reference",
+                "name": "ConnectionRequestParams"
+            },
+            "result": {
+                "kind": "reference",
+                "name": "ConnectionRequestResult"
+            }
+        },
+        {
             "method": "typeServer/getComputedType",
             "typeName": "GetComputedTypeRequest",
             "messageDirection": "clientToServer",
@@ -301,13 +315,21 @@
                 "v0_1_0": "0.1.0",
                 "v0_2_0": "0.2.0",
                 "v0_3_0": "0.3.0",
-                "current": "0.4.0"
+                "v0_4_0": "0.4.0",
+                "current": "0.5.0"
             },
             "valueDocumentation": {
                 "v0_1_0": "Initial protocol version",
                 "v0_2_0": "Added new request types and fields",
                 "v0_3_0": "Switch to more complex types",
-                "current": "Switch to Type union and using stubs"
+                "v0_4_0": "Switch to Type union and using stubs",
+                "current": "Add multi-connection negotiation and control requests"
+            }
+        },
+        "ConnectionTransportKind": {
+            "kind": "stringEnum",
+            "values": {
+                "Ipc": "ipc"
             }
         },
         "Variance": {
@@ -344,6 +366,77 @@
                 }
             ],
             "documentation": "Represents a location in source code (a node in the AST). Used to point to specific declarations, expressions, or statements in Python source files. Used for: - Pointing to where a type is declared - Identifying the location of expressions for type inference - Error reporting and diagnostics - Linking types back to their source definitions Examples: - For `def foo():`, the node points to the function declaration - For a variable `x = 42`, the node points to the assignment - For default parameter values in functions"
+        },
+        "TypeServerMultiConnectionCapability": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "supportedTransports",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "reference",
+                            "name": "ConnectionTransportKind"
+                        }
+                    },
+                    "optional": false
+                }
+            ],
+            "documentation": "Capability shape exchanged via the LSP initialize request/response under `capabilities.experimental.typeServerMultiConnection`."
+        },
+        "ConnectionRequestParams": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "type",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": false
+                },
+                {
+                    "name": "kind",
+                    "type": {
+                        "kind": "reference",
+                        "name": "ConnectionTransportKind"
+                    },
+                    "optional": false
+                },
+                {
+                    "name": "args",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "base",
+                            "name": "string"
+                        }
+                    },
+                    "optional": true
+                }
+            ],
+            "documentation": "Main-connection-only control request used to open or close extra read-only TSP channels after LSP initialization has completed."
+        },
+        "ConnectionRequestResult": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "success",
+                    "type": {
+                        "kind": "base",
+                        "name": "boolean"
+                    },
+                    "optional": false
+                },
+                {
+                    "name": "message",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": true
+                }
+            ]
         },
         "ModuleName": {
             "kind": "interface",
@@ -501,8 +594,8 @@
                 {
                     "name": "returnType",
                     "type": {
-                                "kind": "reference",
-                                "name": "Type"
+                        "kind": "reference",
+                        "name": "Type"
                     },
                     "optional": true,
                     "documentation": "Specialized type of the declared return type. Undefined if there is no declared return type. Example: For `def foo[T](x: T) -> T` specialized to `T=int`, returnType=int."
@@ -589,7 +682,7 @@
                     "documentation": "Discriminator field that determines which declaration variant this is. Regular: Has source code and AST node Synthesized: Created by type checker, no source node"
                 }
             ],
-            "documentation": "Base interface for all declaration types. Provides the discriminator field for the Declaration union."
+            "documentation": "Base interface for all declaration types. Provides the discriminator field for the Declaration union. This is a generic interface that is extended by: - RegularDeclaration (kind = Regular) - SynthesizedDeclaration (kind = Synthesized) The type parameter T ensures that the kind field matches the implementing interface. Used for type-safe discrimination: ```typescript if (declaration.kind === DeclarationKind.Regular) { // TypeScript knows this is RegularDeclaration const node = declaration.node; } ```"
         },
         "RegularDeclaration": {
             "kind": "interface",
@@ -615,8 +708,8 @@
                 {
                     "name": "name",
                     "type": {
-                                "kind": "base",
-                                "name": "string"
+                        "kind": "base",
+                        "name": "string"
                     },
                     "optional": true,
                     "documentation": "Name of the declared symbol, or undefined for anonymous declarations. Example: \"foo\" for `def foo():`, undefined for lambda functions."

--- a/crates/tsp_types/src/protocol.rs
+++ b/crates/tsp_types/src/protocol.rs
@@ -110,6 +110,8 @@ pub enum LSPNull {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
 pub enum TSPRequestMethods {
+    #[serde(rename = "typeServer/connection")]
+    TypeServerConnection,
     #[serde(rename = "typeServer/getComputedType")]
     TypeServerGetComputedType,
     #[serde(rename = "typeServer/getDeclaredType")]
@@ -129,6 +131,11 @@ pub enum TSPRequestMethods {
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
 #[serde(tag = "method")]
 pub enum TSPRequests {
+    #[serde(rename = "typeServer/connection")]
+    ConnectionRequest {
+        id: serde_json::Value,
+        params: ConnectionRequestParams,
+    },
     #[serde(rename = "typeServer/getComputedType")]
     GetComputedTypeRequest {
         id: serde_json::Value,
@@ -347,7 +354,17 @@ pub enum TypeServerVersion {
 
     /// Switch to Type union and using stubs
     #[serde(rename = "0.4.0")]
+    V040,
+
+    /// Add multi-connection negotiation and control requests
+    #[serde(rename = "0.5.0")]
     Current,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+pub enum ConnectionTransportKind {
+    #[serde(rename = "ipc")]
+    Ipc,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
@@ -416,6 +433,33 @@ pub struct Node {
 
     /// URI of the source file containing this node.
     pub uri: String,
+}
+
+/// Capability shape exchanged via the LSP initialize request/response under `capabilities.experimental.typeServerMultiConnection`.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TypeServerMultiConnectionCapability {
+    pub supported_transports: Vec<ConnectionTransportKind>,
+}
+
+/// Main-connection-only control request used to open or close extra read-only TSP channels after LSP initialization has completed.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConnectionRequestParams {
+    pub args: Option<Vec<String>>,
+
+    pub kind: ConnectionTransportKind,
+
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConnectionRequestResult {
+    pub message: Option<String>,
+
+    pub success: bool,
 }
 
 /// Represents a Python module name, handling both absolute and relative imports. Used for: - Import statement resolution - Tracking module dependencies - Resolving relative imports (from . import, from .. import) Examples: - `import os.path`: leadingDots=0, nameParts=['os', 'path'] - `from . import utils`: leadingDots=1, nameParts=['utils'] - `from ...parent import module`: leadingDots=3, nameParts=['parent', 'module'] - `import mymodule`: leadingDots=0, nameParts=['mymodule']
@@ -510,7 +554,7 @@ pub struct SentinelLiteral {
     pub module_name: String,
 }
 
-/// Base interface for all declaration types. Provides the discriminator field for the Declaration union.
+/// Base interface for all declaration types. Provides the discriminator field for the Declaration union. This is a generic interface that is extended by: - RegularDeclaration (kind = Regular) - SynthesizedDeclaration (kind = Synthesized) The type parameter T ensures that the kind field matches the implementing interface. Used for type-safe discrimination: ```typescript if (declaration.kind === DeclarationKind.Regular) { // TypeScript knows this is RegularDeclaration const node = declaration.node; } ```
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DeclarationBase {
@@ -863,6 +907,25 @@ pub enum LSPIdOptional {
     String(String),
     None,
 }
+
+/// Main-connection-only request used to open or close an extra TSP transport. Extra transports must remain read-only and must not be used for LSP traffic.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConnectionRequest {
+    /// The version of the JSON RPC protocol.
+    pub jsonrpc: String,
+
+    /// The method to be invoked.
+    pub method: TSPRequestMethods,
+
+    /// The request id.
+    pub id: LSPId,
+
+    pub params: ConnectionRequestParams,
+}
+
+/// Response to the [ConnectionRequest].
+pub type ConnectionResponse = ConnectionRequestResult;
 
 /// Requests and notifications for the type server protocol. Request for the computed type of a declaration or node. Computed type is the type that is inferred based on the code flow. Example: def foo(a: int | str): if instanceof(a, int): b = a + 1  # Computed type of 'b' is 'int'
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]

--- a/crates/tsp_types/tests/protocol_types.rs
+++ b/crates/tsp_types/tests/protocol_types.rs
@@ -76,7 +76,7 @@ fn test_variance_round_trip() {
 fn test_type_server_version_round_trip() {
     let v = TypeServerVersion::Current;
     let json = serde_json::to_value(&v).unwrap();
-    assert_eq!(json, serde_json::json!("0.4.0"));
+    assert_eq!(json, serde_json::json!("0.5.0"));
     let back: TypeServerVersion = serde_json::from_value(json).unwrap();
     assert_eq!(back, v);
 }

--- a/pyrefly/lib/commands/tsp.rs
+++ b/pyrefly/lib/commands/tsp.rs
@@ -38,6 +38,10 @@ pub struct TspArgs {
     /// Note that indexing files is a performance-intensive task.
     #[arg(long, default_value_t = if cfg!(fbcode_build) {0} else {2000})]
     pub(crate) workspace_indexing_limit: usize,
+    /// Selects the transport for the main JSON-RPC connection.
+    /// Use `stdio` (default) or `ipc://<name>` for a local socket / named pipe.
+    #[arg(long, default_value = "stdio")]
+    pub(crate) transport: String,
 }
 
 pub fn run_tsp(
@@ -107,9 +111,7 @@ impl TspArgs {
         // Note that we must have our logging only write out to stderr.
         eprintln!("starting TSP server");
 
-        // Create the transport. Includes the stdio (stdin and stdout) versions but this could
-        // also be implemented to use sockets or HTTP.
-        let (connection, reader, io_threads) = Connection::stdio();
+        let (connection, reader, io_threads) = Connection::from_transport(&self.transport)?;
 
         run_tsp(connection, reader, self, telemetry, wrapper, thread_count)?;
         io_threads.join()?;

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -16,6 +16,8 @@ use std::io::Stdin;
 use std::io::Write;
 use std::iter::once;
 use std::num::NonZeroUsize;
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -393,7 +395,7 @@ impl TypeErrorDisplayStatus {
 }
 
 /// Interface exposed for TSP to interact with the LSP server
-pub trait TspInterface: Send + Sync {
+pub trait TspInterface: Send + Sync + 'static {
     /// Send a response back to the LSP client
     fn send_response(&self, response: Response);
 
@@ -494,6 +496,9 @@ pub struct Connection {
 pub enum MessageReader {
     Channel(Receiver<Message>),
     Stdio(BufReader<Stdin>),
+    /// A generic byte stream, used for IPC transports (Unix domain sockets,
+    /// Windows named pipes).
+    Stream(BufReader<Box<dyn std::io::Read + Send>>),
 }
 
 impl MessageReader {
@@ -504,6 +509,7 @@ impl MessageReader {
         match self {
             MessageReader::Channel(r) => r.recv().ok(),
             MessageReader::Stdio(r) => read_lsp_message(r).ok().flatten(),
+            MessageReader::Stream(r) => read_lsp_message(r).ok().flatten(),
         }
     }
 }
@@ -542,6 +548,67 @@ impl Connection {
             MessageReader::Stdio(BufReader::new(std::io::stdin())),
             IoThread { writer },
         )
+    }
+
+    /// Create a connection over a local IPC mechanism (Unix domain socket on
+    /// Unix, named pipe on Windows). The `pipe_name` is a socket path on Unix
+    /// or a pipe name on Windows (automatically prefixed with `\\.\pipe\`).
+    pub fn ipc(pipe_name: &str) -> std::io::Result<(Self, MessageReader, IoThread)> {
+        let (writer_stream, reader_stream) = Self::connect_ipc(pipe_name)?;
+        let (writer_sender, writer_receiver) = crossbeam_channel::unbounded();
+        let writer = std::thread::spawn(move || {
+            let mut output = writer_stream;
+            while let Ok(msg) = writer_receiver.recv() {
+                write_lsp_message(&mut output, msg)?;
+            }
+            Ok(())
+        });
+        Ok((
+            Self {
+                sender: writer_sender,
+                channel_receiver: None,
+            },
+            MessageReader::Stream(BufReader::new(Box::new(reader_stream))),
+            IoThread { writer },
+        ))
+    }
+
+    #[cfg(unix)]
+    fn connect_ipc(
+        pipe_name: &str,
+    ) -> std::io::Result<(Box<dyn Write + Send>, Box<dyn std::io::Read + Send>)> {
+        let stream = UnixStream::connect(pipe_name)?;
+        let reader = stream.try_clone()?;
+        Ok((Box::new(stream), Box::new(reader)))
+    }
+
+    #[cfg(windows)]
+    fn connect_ipc(
+        pipe_name: &str,
+    ) -> std::io::Result<(Box<dyn Write + Send>, Box<dyn std::io::Read + Send>)> {
+        use std::fs::OpenOptions;
+        let path = format!(r"\\.\pipe\{}", pipe_name);
+        let stream = OpenOptions::new().read(true).write(true).open(&path)?;
+        let reader = stream.try_clone()?;
+        Ok((Box::new(stream), Box::new(reader)))
+    }
+
+    /// Create a connection from a transport specification string.
+    /// Supported values: `"stdio"` for stdin/stdout, or `"ipc://<name>"` for a
+    /// local socket / named pipe.
+    pub fn from_transport(transport: &str) -> std::io::Result<(Self, MessageReader, IoThread)> {
+        if transport == "stdio" {
+            return Ok(Self::stdio());
+        }
+
+        if let Some(pipe_name) = transport.strip_prefix("ipc://") {
+            return Self::ipc(pipe_name);
+        }
+
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Unsupported TSP transport: {transport}"),
+        ))
     }
 
     pub fn memory() -> ((Self, MessageReader), (Self, MessageReader)) {

--- a/pyrefly/lib/test/tsp/tsp_interaction/get_supported_protocol_version.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/get_supported_protocol_version.rs
@@ -39,7 +39,7 @@ print("Hello, World!")
     // Expect protocol version response
     tsp.client.expect_response(Response {
         id: RequestId::from(2),
-        result: Some(serde_json::json!("0.4.0")),
+        result: Some(serde_json::json!("0.5.0")),
         error: None,
     });
 
@@ -74,7 +74,7 @@ x = 42
     // Expect protocol version response
     tsp.client.expect_response(Response {
         id: RequestId::from(2),
-        result: Some(serde_json::json!("0.4.0")),
+        result: Some(serde_json::json!("0.5.0")),
         error: None,
     });
 

--- a/pyrefly/lib/test/tsp/tsp_interaction/object_model.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/object_model.rs
@@ -480,6 +480,7 @@ impl TspInteraction {
         let args = TspArgs {
             indexing_mode: IndexingMode::LazyBlocking,
             workspace_indexing_limit: 0,
+            transport: "stdio".to_owned(),
         };
 
         let args = args.clone();

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -194,6 +194,11 @@ impl<T: TspInterface> TspServer<T> {
                 });
                 Ok(true)
             }
+            TSPRequests::ConnectionRequest { .. } => {
+                // Multi-connection management is handled at the transport layer,
+                // not inside the TSP request loop.
+                unreachable!("ConnectionRequest should be handled before reaching the TSP server")
+            }
         }
     }
 


### PR DESCRIPTION
Summary:

Add IPC transport plumbing using platform-native mechanisms (Unix domain sockets on Unix, named pipes on Windows) with no external dependencies. Includes Connection::ipc(), Connection::from_transport(), MessageReader::Stream, and a --transport CLI arg for the TSP server.

IPC unfortunately requires separate implementations on windows vs unix, even with dependencies like interprocess. Since the implementation is fairly small, I implement it here instead of depending on interprocess. 

We use IPC rather than TCP (localhost) for several reasons:

- **Port forwarding interference:** VS Code Remote (dev containers, WSL, SSH tunneling) automatically forwards TCP ports opened on the remote host to the local client machine. VS Code cannot distinguish between ports meant for external access and ports meant only for local inter-process communication, so it forwards them by default. This would require explicitly configuring VS Code to not auto-forward the TSP port, adding unnecessary complexity.
- **Dynamic port allocation:** TCP requires finding an unused port at runtime, adding complexity and potential race conditions.
- **Simplicity:** IPC (Unix domain sockets / named pipes) avoids both problems entirely. This is also why the VS Code LSP library (vscode-languageserver-node) defaults to IPC for local language servers.

Reviewed By: jvansch1

Differential Revision: D102190031


