### PR TITLE
Implement multi-connection architecture

### DIFF
--- a/crates/tsp_types/protocol_generator/tsp.json
+++ b/crates/tsp_types/protocol_generator/tsp.json
@@ -66,6 +66,20 @@
     ],
     "requests": [
         {
+            "method": "typeServer/connection",
+            "typeName": "ConnectionRequest",
+            "messageDirection": "clientToServer",
+            "documentation": "Main-connection-only request used to open or close an extra TSP transport. Extra transports must remain read-only and must not be used for LSP traffic.",
+            "params": {
+                "kind": "reference",
+                "name": "ConnectionRequestParams"
+            },
+            "result": {
+                "kind": "reference",
+                "name": "ConnectionRequestResult"
+            }
+        },
+        {
             "method": "typeServer/getComputedType",
             "typeName": "GetComputedTypeRequest",
             "messageDirection": "clientToServer",
@@ -301,13 +315,21 @@
                 "v0_1_0": "0.1.0",
                 "v0_2_0": "0.2.0",
                 "v0_3_0": "0.3.0",
-                "current": "0.4.0"
+                "v0_4_0": "0.4.0",
+                "current": "0.5.0"
             },
             "valueDocumentation": {
                 "v0_1_0": "Initial protocol version",
                 "v0_2_0": "Added new request types and fields",
                 "v0_3_0": "Switch to more complex types",
-                "current": "Switch to Type union and using stubs"
+                "v0_4_0": "Switch to Type union and using stubs",
+                "current": "Add multi-connection negotiation and control requests"
+            }
+        },
+        "ConnectionTransportKind": {
+            "kind": "stringEnum",
+            "values": {
+                "Ipc": "ipc"
             }
         },
         "Variance": {
@@ -344,6 +366,77 @@
                 }
             ],
             "documentation": "Represents a location in source code (a node in the AST). Used to point to specific declarations, expressions, or statements in Python source files. Used for: - Pointing to where a type is declared - Identifying the location of expressions for type inference - Error reporting and diagnostics - Linking types back to their source definitions Examples: - For `def foo():`, the node points to the function declaration - For a variable `x = 42`, the node points to the assignment - For default parameter values in functions"
+        },
+        "TypeServerMultiConnectionCapability": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "supportedTransports",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "reference",
+                            "name": "ConnectionTransportKind"
+                        }
+                    },
+                    "optional": false
+                }
+            ],
+            "documentation": "Capability shape exchanged via the LSP initialize request/response under `capabilities.experimental.typeServerMultiConnection`."
+        },
+        "ConnectionRequestParams": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "type",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": false
+                },
+                {
+                    "name": "kind",
+                    "type": {
+                        "kind": "reference",
+                        "name": "ConnectionTransportKind"
+                    },
+                    "optional": false
+                },
+                {
+                    "name": "args",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "base",
+                            "name": "string"
+                        }
+                    },
+                    "optional": true
+                }
+            ],
+            "documentation": "Main-connection-only control request used to open or close extra read-only TSP channels after LSP initialization has completed."
+        },
+        "ConnectionRequestResult": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "success",
+                    "type": {
+                        "kind": "base",
+                        "name": "boolean"
+                    },
+                    "optional": false
+                },
+                {
+                    "name": "message",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": true
+                }
+            ]
         },
         "ModuleName": {
             "kind": "interface",
@@ -501,8 +594,8 @@
                 {
                     "name": "returnType",
                     "type": {
-                                "kind": "reference",
-                                "name": "Type"
+                        "kind": "reference",
+                        "name": "Type"
                     },
                     "optional": true,
                     "documentation": "Specialized type of the declared return type. Undefined if there is no declared return type. Example: For `def foo[T](x: T) -> T` specialized to `T=int`, returnType=int."
@@ -589,7 +682,7 @@
                     "documentation": "Discriminator field that determines which declaration variant this is. Regular: Has source code and AST node Synthesized: Created by type checker, no source node"
                 }
             ],
-            "documentation": "Base interface for all declaration types. Provides the discriminator field for the Declaration union."
+            "documentation": "Base interface for all declaration types. Provides the discriminator field for the Declaration union. This is a generic interface that is extended by: - RegularDeclaration (kind = Regular) - SynthesizedDeclaration (kind = Synthesized) The type parameter T ensures that the kind field matches the implementing interface. Used for type-safe discrimination: ```typescript if (declaration.kind === DeclarationKind.Regular) { // TypeScript knows this is RegularDeclaration const node = declaration.node; } ```"
         },
         "RegularDeclaration": {
             "kind": "interface",
@@ -615,8 +708,8 @@
                 {
                     "name": "name",
                     "type": {
-                                "kind": "base",
-                                "name": "string"
+                        "kind": "base",
+                        "name": "string"
                     },
                     "optional": true,
                     "documentation": "Name of the declared symbol, or undefined for anonymous declarations. Example: \"foo\" for `def foo():`, undefined for lambda functions."

--- a/crates/tsp_types/src/protocol.rs
+++ b/crates/tsp_types/src/protocol.rs
@@ -110,6 +110,8 @@ pub enum LSPNull {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
 pub enum TSPRequestMethods {
+    #[serde(rename = "typeServer/connection")]
+    TypeServerConnection,
     #[serde(rename = "typeServer/getComputedType")]
     TypeServerGetComputedType,
     #[serde(rename = "typeServer/getDeclaredType")]
@@ -129,6 +131,11 @@ pub enum TSPRequestMethods {
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
 #[serde(tag = "method")]
 pub enum TSPRequests {
+    #[serde(rename = "typeServer/connection")]
+    ConnectionRequest {
+        id: serde_json::Value,
+        params: ConnectionRequestParams,
+    },
     #[serde(rename = "typeServer/getComputedType")]
     GetComputedTypeRequest {
         id: serde_json::Value,
@@ -347,7 +354,17 @@ pub enum TypeServerVersion {
 
     /// Switch to Type union and using stubs
     #[serde(rename = "0.4.0")]
+    V040,
+
+    /// Add multi-connection negotiation and control requests
+    #[serde(rename = "0.5.0")]
     Current,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+pub enum ConnectionTransportKind {
+    #[serde(rename = "ipc")]
+    Ipc,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
@@ -416,6 +433,33 @@ pub struct Node {
 
     /// URI of the source file containing this node.
     pub uri: String,
+}
+
+/// Capability shape exchanged via the LSP initialize request/response under `capabilities.experimental.typeServerMultiConnection`.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TypeServerMultiConnectionCapability {
+    pub supported_transports: Vec<ConnectionTransportKind>,
+}
+
+/// Main-connection-only control request used to open or close extra read-only TSP channels after LSP initialization has completed.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConnectionRequestParams {
+    pub args: Option<Vec<String>>,
+
+    pub kind: ConnectionTransportKind,
+
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConnectionRequestResult {
+    pub message: Option<String>,
+
+    pub success: bool,
 }
 
 /// Represents a Python module name, handling both absolute and relative imports. Used for: - Import statement resolution - Tracking module dependencies - Resolving relative imports (from . import, from .. import) Examples: - `import os.path`: leadingDots=0, nameParts=['os', 'path'] - `from . import utils`: leadingDots=1, nameParts=['utils'] - `from ...parent import module`: leadingDots=3, nameParts=['parent', 'module'] - `import mymodule`: leadingDots=0, nameParts=['mymodule']
@@ -510,7 +554,7 @@ pub struct SentinelLiteral {
     pub module_name: String,
 }
 
-/// Base interface for all declaration types. Provides the discriminator field for the Declaration union.
+/// Base interface for all declaration types. Provides the discriminator field for the Declaration union. This is a generic interface that is extended by: - RegularDeclaration (kind = Regular) - SynthesizedDeclaration (kind = Synthesized) The type parameter T ensures that the kind field matches the implementing interface. Used for type-safe discrimination: ```typescript if (declaration.kind === DeclarationKind.Regular) { // TypeScript knows this is RegularDeclaration const node = declaration.node; } ```
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DeclarationBase {
@@ -863,6 +907,25 @@ pub enum LSPIdOptional {
     String(String),
     None,
 }
+
+/// Main-connection-only request used to open or close an extra TSP transport. Extra transports must remain read-only and must not be used for LSP traffic.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConnectionRequest {
+    /// The version of the JSON RPC protocol.
+    pub jsonrpc: String,
+
+    /// The method to be invoked.
+    pub method: TSPRequestMethods,
+
+    /// The request id.
+    pub id: LSPId,
+
+    pub params: ConnectionRequestParams,
+}
+
+/// Response to the [ConnectionRequest].
+pub type ConnectionResponse = ConnectionRequestResult;
 
 /// Requests and notifications for the type server protocol. Request for the computed type of a declaration or node. Computed type is the type that is inferred based on the code flow. Example: def foo(a: int | str): if instanceof(a, int): b = a + 1  # Computed type of 'b' is 'int'
 #[derive(Serialize, Deserialize, PartialEq, Debug, Eq, Clone)]

--- a/crates/tsp_types/tests/protocol_types.rs
+++ b/crates/tsp_types/tests/protocol_types.rs
@@ -76,7 +76,7 @@ fn test_variance_round_trip() {
 fn test_type_server_version_round_trip() {
     let v = TypeServerVersion::Current;
     let json = serde_json::to_value(&v).unwrap();
-    assert_eq!(json, serde_json::json!("0.4.0"));
+    assert_eq!(json, serde_json::json!("0.5.0"));
     let back: TypeServerVersion = serde_json::from_value(json).unwrap();
     assert_eq!(back, v);
 }

--- a/pyrefly/lib/commands/tsp.rs
+++ b/pyrefly/lib/commands/tsp.rs
@@ -38,6 +38,10 @@ pub struct TspArgs {
     /// Note that indexing files is a performance-intensive task.
     #[arg(long, default_value_t = if cfg!(fbcode_build) {0} else {2000})]
     pub(crate) workspace_indexing_limit: usize,
+    /// Selects the transport for the main JSON-RPC connection.
+    /// Use `stdio` (default) or `ipc://<name>` for a local socket / named pipe.
+    #[arg(long, default_value = "stdio")]
+    pub(crate) transport: String,
 }
 
 pub fn run_tsp(
@@ -107,9 +111,7 @@ impl TspArgs {
         // Note that we must have our logging only write out to stderr.
         eprintln!("starting TSP server");
 
-        // Create the transport. Includes the stdio (stdin and stdout) versions but this could
-        // also be implemented to use sockets or HTTP.
-        let (connection, reader, io_threads) = Connection::stdio();
+        let (connection, reader, io_threads) = Connection::from_transport(&self.transport)?;
 
         run_tsp(connection, reader, self, telemetry, wrapper, thread_count)?;
         io_threads.join()?;

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -16,6 +16,8 @@ use std::io::Stdin;
 use std::io::Write;
 use std::iter::once;
 use std::num::NonZeroUsize;
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -393,7 +395,7 @@ impl TypeErrorDisplayStatus {
 }
 
 /// Interface exposed for TSP to interact with the LSP server
-pub trait TspInterface: Send + Sync {
+pub trait TspInterface: Send + Sync + 'static {
     /// Send a response back to the LSP client
     fn send_response(&self, response: Response);
 
@@ -494,6 +496,9 @@ pub struct Connection {
 pub enum MessageReader {
     Channel(Receiver<Message>),
     Stdio(BufReader<Stdin>),
+    /// A generic byte stream, used for IPC transports (Unix domain sockets,
+    /// Windows named pipes).
+    Stream(BufReader<Box<dyn std::io::Read + Send>>),
 }
 
 impl MessageReader {
@@ -504,6 +509,7 @@ impl MessageReader {
         match self {
             MessageReader::Channel(r) => r.recv().ok(),
             MessageReader::Stdio(r) => read_lsp_message(r).ok().flatten(),
+            MessageReader::Stream(r) => read_lsp_message(r).ok().flatten(),
         }
     }
 }
@@ -542,6 +548,67 @@ impl Connection {
             MessageReader::Stdio(BufReader::new(std::io::stdin())),
             IoThread { writer },
         )
+    }
+
+    /// Create a connection over a local IPC mechanism (Unix domain socket on
+    /// Unix, named pipe on Windows). The `pipe_name` is a socket path on Unix
+    /// or a pipe name on Windows (automatically prefixed with `\\.\pipe\`).
+    pub fn ipc(pipe_name: &str) -> std::io::Result<(Self, MessageReader, IoThread)> {
+        let (writer_stream, reader_stream) = Self::connect_ipc(pipe_name)?;
+        let (writer_sender, writer_receiver) = crossbeam_channel::unbounded();
+        let writer = std::thread::spawn(move || {
+            let mut output = writer_stream;
+            while let Ok(msg) = writer_receiver.recv() {
+                write_lsp_message(&mut output, msg)?;
+            }
+            Ok(())
+        });
+        Ok((
+            Self {
+                sender: writer_sender,
+                channel_receiver: None,
+            },
+            MessageReader::Stream(BufReader::new(Box::new(reader_stream))),
+            IoThread { writer },
+        ))
+    }
+
+    #[cfg(unix)]
+    fn connect_ipc(
+        pipe_name: &str,
+    ) -> std::io::Result<(Box<dyn Write + Send>, Box<dyn std::io::Read + Send>)> {
+        let stream = UnixStream::connect(pipe_name)?;
+        let reader = stream.try_clone()?;
+        Ok((Box::new(stream), Box::new(reader)))
+    }
+
+    #[cfg(windows)]
+    fn connect_ipc(
+        pipe_name: &str,
+    ) -> std::io::Result<(Box<dyn Write + Send>, Box<dyn std::io::Read + Send>)> {
+        use std::fs::OpenOptions;
+        let path = format!(r"\\.\pipe\{}", pipe_name);
+        let stream = OpenOptions::new().read(true).write(true).open(&path)?;
+        let reader = stream.try_clone()?;
+        Ok((Box::new(stream), Box::new(reader)))
+    }
+
+    /// Create a connection from a transport specification string.
+    /// Supported values: `"stdio"` for stdin/stdout, or `"ipc://<name>"` for a
+    /// local socket / named pipe.
+    pub fn from_transport(transport: &str) -> std::io::Result<(Self, MessageReader, IoThread)> {
+        if transport == "stdio" {
+            return Ok(Self::stdio());
+        }
+
+        if let Some(pipe_name) = transport.strip_prefix("ipc://") {
+            return Self::ipc(pipe_name);
+        }
+
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Unsupported TSP transport: {transport}"),
+        ))
     }
 
     pub fn memory() -> ((Self, MessageReader), (Self, MessageReader)) {

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -1149,6 +1149,12 @@ pub struct ServerCapabilitiesWithTypeHierarchy {
     type_hierarchy_provider: Option<bool>,
 }
 
+impl ServerCapabilitiesWithTypeHierarchy {
+    pub fn set_experimental(&mut self, value: serde_json::Value) {
+        self.base.experimental = Some(value);
+    }
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct InitializeResult<C> {

--- a/pyrefly/lib/test/tsp/tsp_interaction/get_supported_protocol_version.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/get_supported_protocol_version.rs
@@ -39,7 +39,7 @@ print("Hello, World!")
     // Expect protocol version response
     tsp.client.expect_response(Response {
         id: RequestId::from(2),
-        result: Some(serde_json::json!("0.4.0")),
+        result: Some(serde_json::json!("0.5.0")),
         error: None,
     });
 
@@ -74,7 +74,7 @@ x = 42
     // Expect protocol version response
     tsp.client.expect_response(Response {
         id: RequestId::from(2),
-        result: Some(serde_json::json!("0.4.0")),
+        result: Some(serde_json::json!("0.5.0")),
         error: None,
     });
 

--- a/pyrefly/lib/test/tsp/tsp_interaction/object_model.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/object_model.rs
@@ -480,6 +480,7 @@ impl TspInteraction {
         let args = TspArgs {
             indexing_mode: IndexingMode::LazyBlocking,
             workspace_indexing_limit: 0,
+            transport: "stdio".to_owned(),
         };
 
         let args = args.clone();

--- a/pyrefly/lib/tsp/requests/get_computed_type.rs
+++ b/pyrefly/lib/tsp/requests/get_computed_type.rs
@@ -12,9 +12,9 @@ use tsp_types::GetTypeParams;
 use tsp_types::Type;
 
 use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     /// Return the computed (inferred) type at the given position.
     ///
     /// The computed type reflects the type checker's analysis of the code

--- a/pyrefly/lib/tsp/requests/get_computed_type.rs
+++ b/pyrefly/lib/tsp/requests/get_computed_type.rs
@@ -27,7 +27,7 @@ impl<T: TspInterface> TspConnection<T> {
         self.validate_snapshot(params.snapshot)?;
         let position = params.position();
         let ty = self
-            .inner
+            .inner()
             .get_type_at_position(params.uri(), position.line, position.character);
         Ok(ty.map(|t| self.convert_type(&t)))
     }

--- a/pyrefly/lib/tsp/requests/get_declared_type.rs
+++ b/pyrefly/lib/tsp/requests/get_declared_type.rs
@@ -12,9 +12,9 @@ use tsp_types::GetTypeParams;
 use tsp_types::Type;
 
 use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     /// Return the declared type at the given position.
     ///
     /// The declared type is the annotation explicitly written by the user.

--- a/pyrefly/lib/tsp/requests/get_declared_type.rs
+++ b/pyrefly/lib/tsp/requests/get_declared_type.rs
@@ -31,7 +31,7 @@ impl<T: TspInterface> TspConnection<T> {
         self.validate_snapshot(params.snapshot)?;
         let position = params.position();
         let ty = self
-            .inner
+            .inner()
             .get_type_at_position(params.uri(), position.line, position.character);
         Ok(ty.map(|t| self.convert_type(&t)))
     }

--- a/pyrefly/lib/tsp/requests/get_expected_type.rs
+++ b/pyrefly/lib/tsp/requests/get_expected_type.rs
@@ -31,7 +31,7 @@ impl<T: TspInterface> TspConnection<T> {
         self.validate_snapshot(params.snapshot)?;
         let position = params.position();
         let ty = self
-            .inner
+            .inner()
             .get_type_at_position(params.uri(), position.line, position.character);
         Ok(ty.map(|t| self.convert_type(&t)))
     }

--- a/pyrefly/lib/tsp/requests/get_expected_type.rs
+++ b/pyrefly/lib/tsp/requests/get_expected_type.rs
@@ -12,9 +12,9 @@ use tsp_types::GetTypeParams;
 use tsp_types::Type;
 
 use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     /// Return the expected type at the given position.
     ///
     /// The expected type is the type that a surrounding context demands.

--- a/pyrefly/lib/tsp/requests/get_python_search_paths.rs
+++ b/pyrefly/lib/tsp/requests/get_python_search_paths.rs
@@ -15,11 +15,11 @@ use lsp_server::RequestId;
 use tsp_types::protocol::GetPythonSearchPathsParams;
 
 use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 use crate::tsp::validation::internal_error;
 use crate::tsp::validation::parse_file_uri;
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     /// Handle a `typeServer/getPythonSearchPaths` request.
     ///
     /// Validates the snapshot, parses the `from_uri`, and delegates to

--- a/pyrefly/lib/tsp/requests/get_python_search_paths.rs
+++ b/pyrefly/lib/tsp/requests/get_python_search_paths.rs
@@ -38,7 +38,7 @@ impl<T: TspInterface> TspConnection<T> {
 
         // --- 2. Parse from_uri and delegate ---
         match parse_file_uri(&params.from_uri) {
-            Ok(url) => match self.inner.get_python_search_paths(&url) {
+            Ok(url) => match self.inner().get_python_search_paths(&url) {
                 Ok(paths) => self.send_ok(id, paths),
                 Err(detail) => self.send_err(id, internal_error(&detail)),
             },

--- a/pyrefly/lib/tsp/requests/get_snapshot.rs
+++ b/pyrefly/lib/tsp/requests/get_snapshot.rs
@@ -17,10 +17,13 @@ impl<T: TspInterface> TspConnection<T> {
     /// It changes whenever files are modified, configuration changes,
     /// or any other event that would trigger a recomputation.
     pub fn get_snapshot(&self) -> i32 {
-        *self.current_snapshot.lock().unwrap_or_else(|poisoned| {
-            // In case of poisoned mutex, recover and return the value
-            eprintln!("TSP: Warning - snapshot mutex was poisoned, recovering");
-            poisoned.into_inner()
-        })
+        *self
+            .server
+            .current_snapshot
+            .lock()
+            .unwrap_or_else(|poisoned| {
+                eprintln!("TSP: Warning - snapshot mutex was poisoned, recovering");
+                poisoned.into_inner()
+            })
     }
 }

--- a/pyrefly/lib/tsp/requests/get_snapshot.rs
+++ b/pyrefly/lib/tsp/requests/get_snapshot.rs
@@ -8,9 +8,9 @@
 //! Implementation of the getSnapshot TSP request
 
 use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     /// Get the current snapshot version
     ///
     /// The snapshot represents the current epoch of the global state.

--- a/pyrefly/lib/tsp/requests/get_supported_protocol_version.rs
+++ b/pyrefly/lib/tsp/requests/get_supported_protocol_version.rs
@@ -11,9 +11,9 @@ use tsp_types::TSP_PROTOCOL_VERSION;
 use tsp_types::protocol::TypeServerVersion;
 
 use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     pub fn get_supported_protocol_version(&self) -> TypeServerVersion {
         // Return the current protocol version from the generated enum
         TSP_PROTOCOL_VERSION

--- a/pyrefly/lib/tsp/requests/resolve_import.rs
+++ b/pyrefly/lib/tsp/requests/resolve_import.rs
@@ -23,11 +23,11 @@ use tsp_types::protocol::ResolveImportParams;
 use crate::lsp::module_helpers::to_real_path;
 use crate::lsp::non_wasm::server::TspInterface;
 use crate::lsp::non_wasm::transaction_manager::TransactionManager;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 use crate::tsp::validation::invalid_params_error;
 use crate::tsp::validation::parse_file_uri;
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     /// Handle a `typeServer/resolveImport` request.
     ///
     /// Converts the TSP [`ResolveImportParams`] into pyrefly's internal

--- a/pyrefly/lib/tsp/requests/resolve_import.rs
+++ b/pyrefly/lib/tsp/requests/resolve_import.rs
@@ -64,7 +64,7 @@ impl<T: TspInterface> TspConnection<T> {
 
         // --- 3. Build source handle and resolve the module name ---
         let source_module_path = ModulePath::filesystem(source_path.clone());
-        let source_handle = self.inner.handle_from_module_path(source_module_path);
+        let source_handle = self.inner().handle_from_module_path(source_module_path);
 
         let module_name = match resolve_module_name(
             &params.module_descriptor.name_parts,
@@ -84,7 +84,7 @@ impl<T: TspInterface> TspConnection<T> {
 
         // --- 4. Resolve the import via existing infrastructure ---
         let transaction = self
-            .inner
+            .inner()
             .non_committable_transaction(ide_transaction_manager);
         let result = transaction.import_handle(&source_handle, module_name, None);
 

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -10,11 +10,13 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use lsp_server::RequestId;
+use lsp_server::ResponseError;
 use lsp_types::InitializeParams;
 use pyrefly_util::telemetry::QueueName;
 use pyrefly_util::telemetry::Telemetry;
 use pyrefly_util::telemetry::TelemetryEvent;
 use pyrefly_util::telemetry::TelemetryEventKind;
+use serde::Serialize;
 use tracing::info;
 use tracing::warn;
 use tsp_types::GetTypeParams;
@@ -22,6 +24,7 @@ use tsp_types::TSPNotificationMethods;
 use tsp_types::TSPRequests;
 
 use crate::commands::lsp::IndexingMode;
+use crate::lsp::non_wasm::lsp::new_response;
 use crate::lsp::non_wasm::protocol::Message;
 use crate::lsp::non_wasm::protocol::Notification;
 use crate::lsp::non_wasm::protocol::Request;
@@ -35,6 +38,8 @@ use crate::lsp::non_wasm::server::TspInterface;
 use crate::lsp::non_wasm::server::capabilities;
 use crate::lsp::non_wasm::transaction_manager::TransactionManager;
 use crate::tsp::type_conversion::convert_type_with_resolver;
+use crate::tsp::validation::invalid_params_error;
+use crate::tsp::validation::snapshot_outdated_error;
 
 /// TSP server that delegates to LSP server infrastructure while handling only TSP requests
 pub struct TspConnection<T: TspInterface> {
@@ -57,6 +62,31 @@ impl<T: TspInterface> TspConnection<T> {
         let resolver =
             |func_id: &pyrefly_types::callable::FuncId| self.inner.resolve_func_def_range(func_id);
         convert_type_with_resolver(ty, &resolver)
+    }
+
+    /// Send a successful JSON-RPC response for `id` with `result`.
+    pub(crate) fn send_ok<R: Serialize>(&self, id: RequestId, result: R) {
+        self.inner.send_response(new_response(id, Ok(result)));
+    }
+
+    /// Send a JSON-RPC error response for `id`.
+    pub(crate) fn send_err(&self, id: RequestId, error: ResponseError) {
+        self.inner.send_response(Response {
+            id,
+            result: None,
+            error: Some(error),
+        });
+    }
+
+    /// Validate that the client-supplied snapshot matches the server's current
+    /// snapshot. Returns `Ok(())` on match or `Err(ResponseError)` on mismatch.
+    pub(crate) fn validate_snapshot(&self, client_snapshot: i32) -> Result<(), ResponseError> {
+        let current = self.get_snapshot();
+        if client_snapshot != current {
+            Err(snapshot_outdated_error(client_snapshot, current))
+        } else {
+            Ok(())
+        }
     }
 
     pub fn process_event<'a>(
@@ -146,15 +176,7 @@ impl<T: TspInterface> TspConnection<T> {
         ide_transaction_manager: &mut TransactionManager<'a>,
         request: &Request,
     ) -> anyhow::Result<bool> {
-        // Convert the request into a TSPRequests enum
-        let wrapper = serde_json::json!({
-            "method": request.method,
-            "id": request.id,
-            "params": request.params
-        });
-
-        let Ok(msg) = serde_json::from_value::<TSPRequests>(wrapper) else {
-            // Not a TSP request
+        let Some(msg) = parse_tsp_request(request) else {
             return Ok(false);
         };
 
@@ -217,10 +239,7 @@ impl<T: TspInterface> TspConnection<T> {
         let params: GetTypeParams = match serde_json::from_value::<GetTypeParams>(raw_params) {
             Ok(p) => p,
             Err(e) => {
-                self.send_err(
-                    id,
-                    crate::tsp::validation::invalid_params_error(&e.to_string()),
-                );
+                self.send_err(id, invalid_params_error(&e.to_string()));
                 return;
             }
         };
@@ -233,6 +252,16 @@ impl<T: TspInterface> TspConnection<T> {
             }
         }
     }
+}
+
+/// Try to parse a request as a `TSPRequests` enum variant.
+fn parse_tsp_request(request: &Request) -> Option<TSPRequests> {
+    let wrapper = serde_json::json!({
+        "method": request.method,
+        "id": request.id,
+        "params": request.params
+    });
+    serde_json::from_value::<TSPRequests>(wrapper).ok()
 }
 
 pub fn tsp_loop(

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -151,21 +151,13 @@ impl<T: TspInterface> TspConnection<T> {
     /// Called whenever the snapshot counter increments, so the client knows
     /// any previously-returned types are stale.
     fn send_snapshot_changed_notification(&self, old_snapshot: i32, new_snapshot: i32) {
-        let method = serde_json::to_value(TSPNotificationMethods::TypeServerSnapshotChanged)
-            .expect("TSPNotificationMethods serialization is infallible");
-        let method_str = method
-            .as_str()
-            .expect("TSPNotificationMethods serializes to a string")
-            .to_owned();
-
-        if let Err(e) = self
-            .inner
-            .sender()
-            .send(Message::Notification(Notification {
-                method: method_str,
-                params: serde_json::json!({ "old": old_snapshot, "new": new_snapshot }),
-                activity_key: None,
-            }))
+        if let Err(e) =
+            self.inner
+                .sender()
+                .send(Message::Notification(snapshot_changed_notification(
+                    old_snapshot,
+                    new_snapshot,
+                )))
         {
             warn!("Failed to send snapshotChanged notification: {e}");
         }
@@ -251,6 +243,21 @@ impl<T: TspInterface> TspConnection<T> {
                 self.send_err(id, err);
             }
         }
+    }
+}
+
+/// Build a `typeServer/snapshotChanged` notification.
+fn snapshot_changed_notification(old_snapshot: i32, new_snapshot: i32) -> Notification {
+    let method = serde_json::to_value(TSPNotificationMethods::TypeServerSnapshotChanged)
+        .expect("TSPNotificationMethods serialization is infallible");
+    let method_str = method
+        .as_str()
+        .expect("TSPNotificationMethods serializes to a string")
+        .to_owned();
+    Notification {
+        method: method_str,
+        params: serde_json::json!({ "old": old_snapshot, "new": new_snapshot }),
+        activity_key: None,
     }
 }
 

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -37,13 +37,13 @@ use crate::lsp::non_wasm::transaction_manager::TransactionManager;
 use crate::tsp::type_conversion::convert_type_with_resolver;
 
 /// TSP server that delegates to LSP server infrastructure while handling only TSP requests
-pub struct TspServer<T: TspInterface> {
+pub struct TspConnection<T: TspInterface> {
     pub inner: T,
     /// Current snapshot version, updated on RecheckFinished events
     pub(crate) current_snapshot: Arc<Mutex<i32>>,
 }
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     pub fn new(lsp_server: T) -> Self {
         Self {
             inner: lsp_server,
@@ -241,7 +241,7 @@ pub fn tsp_loop(
     _initialization: InitializeInfo,
     telemetry: &impl Telemetry,
 ) -> anyhow::Result<()> {
-    let server = TspServer::new(lsp_server);
+    let server = TspConnection::new(lsp_server);
 
     std::thread::scope(|scope| {
         // Start the recheck queue thread to process async tasks

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -5,10 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::collections::HashMap;
 use std::collections::HashSet;
+use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use lsp_server::ErrorCode;
 use lsp_server::RequestId;
 use lsp_server::ResponseError;
 use lsp_types::InitializeParams;
@@ -19,6 +22,9 @@ use pyrefly_util::telemetry::TelemetryEventKind;
 use serde::Serialize;
 use tracing::info;
 use tracing::warn;
+use tsp_types::ConnectionRequestParams;
+use tsp_types::ConnectionRequestResult;
+use tsp_types::ConnectionTransportKind;
 use tsp_types::GetTypeParams;
 use tsp_types::TSPNotificationMethods;
 use tsp_types::TSPRequests;
@@ -30,6 +36,7 @@ use crate::lsp::non_wasm::protocol::Notification;
 use crate::lsp::non_wasm::protocol::Request;
 use crate::lsp::non_wasm::protocol::Response;
 use crate::lsp::non_wasm::queue::LspEvent;
+use crate::lsp::non_wasm::server::Connection;
 use crate::lsp::non_wasm::server::InitializeInfo;
 use crate::lsp::non_wasm::server::MessageReader;
 use crate::lsp::non_wasm::server::ProcessEvent;
@@ -38,40 +45,103 @@ use crate::lsp::non_wasm::server::TspInterface;
 use crate::lsp::non_wasm::server::capabilities;
 use crate::lsp::non_wasm::transaction_manager::TransactionManager;
 use crate::tsp::type_conversion::convert_type_with_resolver;
+use crate::tsp::validation::internal_error;
 use crate::tsp::validation::invalid_params_error;
 use crate::tsp::validation::snapshot_outdated_error;
 
-/// TSP server that delegates to LSP server infrastructure while handling only TSP requests
-pub struct TspConnection<T: TspInterface> {
-    pub inner: T,
-    /// Current snapshot version, updated on RecheckFinished events
+struct ExtraConnectionHandle {
+    close_tx: crossbeam_channel::Sender<()>,
+    response_sender: crossbeam_channel::Sender<Message>,
+}
+
+pub struct TspServer<T: TspInterface> {
+    pub(crate) inner: Arc<T>,
+    /// Current snapshot version, updated on RecheckFinished events.
     pub(crate) current_snapshot: Arc<Mutex<i32>>,
+    extra_connections: Mutex<HashMap<String, ExtraConnectionHandle>>,
+}
+
+// Runs the TSP server.
+impl<T: TspInterface> TspServer<T> {
+    fn new(lsp_server: T) -> Arc<Self> {
+        Arc::new(Self {
+            inner: Arc::new(lsp_server),
+            current_snapshot: Arc::new(Mutex::new(0)),
+            extra_connections: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Send a `snapshotChanged` notification to the main connection and every extra connection.
+    fn broadcast_snapshot_changed(
+        &self,
+        main_sender: &crossbeam_channel::Sender<Message>,
+        old_snapshot: i32,
+        new_snapshot: i32,
+    ) {
+        let notification = snapshot_changed_notification(old_snapshot, new_snapshot);
+        if let Err(e) = main_sender.send(Message::Notification(notification.clone())) {
+            warn!("Failed to send snapshotChanged notification: {e}");
+        }
+        let handles = self
+            .extra_connections
+            .lock()
+            .expect("extra_connections mutex poisoned");
+        for (name, handle) in handles.iter() {
+            if let Err(e) = handle
+                .response_sender
+                .send(Message::Notification(notification.clone()))
+            {
+                warn!("Failed to send snapshotChanged to extra connection {name}: {e}");
+            }
+        }
+    }
+}
+
+/// A single JSON-RPC connection to the TSP server.
+///
+/// Each connection has its own response channel but shares the underlying
+/// `TspServer` core with all other connections.
+pub struct TspConnection<T: TspInterface> {
+    pub(crate) server: Arc<TspServer<T>>,
+    response_sender: crossbeam_channel::Sender<Message>,
 }
 
 impl<T: TspInterface> TspConnection<T> {
-    pub fn new(lsp_server: T) -> Self {
+    fn new(server: Arc<TspServer<T>>, response_sender: crossbeam_channel::Sender<Message>) -> Self {
         Self {
-            inner: lsp_server,
-            current_snapshot: Arc::new(Mutex::new(0)), // Start at 0, increments on RecheckFinished
+            server,
+            response_sender,
         }
+    }
+
+    /// Convenience accessor for the inner LSP server.
+    pub(crate) fn inner(&self) -> &T {
+        &self.server.inner
     }
 
     /// Convert a pyrefly `Type` to a TSP protocol `Type`, resolving function
     /// declaration ranges via the binding table.
     pub(crate) fn convert_type(&self, ty: &pyrefly_types::types::Type) -> tsp_types::Type {
-        let resolver =
-            |func_id: &pyrefly_types::callable::FuncId| self.inner.resolve_func_def_range(func_id);
+        let resolver = |func_id: &pyrefly_types::callable::FuncId| {
+            self.inner().resolve_func_def_range(func_id)
+        };
         convert_type_with_resolver(ty, &resolver)
+    }
+
+    pub(crate) fn send_response(&self, response: Response) {
+        if let Err(error) = self.response_sender.send(Message::Response(response)) {
+            warn!("Failed to send TSP response: {error}");
+        }
     }
 
     /// Send a successful JSON-RPC response for `id` with `result`.
     pub(crate) fn send_ok<R: Serialize>(&self, id: RequestId, result: R) {
-        self.inner.send_response(new_response(id, Ok(result)));
+        self.send_response(new_response(id, Ok(result)));
     }
 
     /// Send a JSON-RPC error response for `id`.
     pub(crate) fn send_err(&self, id: RequestId, error: ResponseError) {
-        self.inner.send_response(Response {
+        self.send_response(Response {
             id,
             result: None,
             error: Some(error),
@@ -89,32 +159,12 @@ impl<T: TspInterface> TspConnection<T> {
         }
     }
 
-    /// Send a `typeServer/snapshotChanged` notification to the client.
-    ///
-    /// Called whenever the snapshot counter increments, so the client knows
-    /// any previously-returned types are stale.
-    fn send_snapshot_changed_notification(&self, old_snapshot: i32, new_snapshot: i32) {
-        if let Err(e) =
-            self.inner
-                .sender()
-                .send(Message::Notification(snapshot_changed_notification(
-                    old_snapshot,
-                    new_snapshot,
-                )))
-        {
-            warn!("Failed to send snapshotChanged notification: {e}");
-        }
-    }
-
-    fn handle_tsp_request<'a>(
+    fn dispatch_tsp_request<'a>(
         &'a self,
         ide_transaction_manager: &mut TransactionManager<'a>,
         request: &Request,
+        msg: TSPRequests,
     ) -> anyhow::Result<bool> {
-        let Some(msg) = parse_tsp_request(request) else {
-            return Ok(false);
-        };
-
         match msg {
             TSPRequests::GetSupportedProtocolVersionRequest { .. } => {
                 self.send_ok(request.id.clone(), self.get_supported_protocol_version());
@@ -189,8 +239,25 @@ impl<T: TspInterface> TspConnection<T> {
     }
 }
 
-impl<T: TspInterface> TspConnection<T> {
-    pub fn process_event<'a>(
+/// The main (stdio) connection. Only this type can manage extra connections
+/// and trigger `snapshotChanged` notifications.
+pub struct TspMainConnection<T: TspInterface>(TspConnection<T>);
+
+impl<T: TspInterface> TspMainConnection<T> {
+    fn new(server: Arc<TspServer<T>>, response_sender: crossbeam_channel::Sender<Message>) -> Self {
+        Self(TspConnection::new(server, response_sender))
+    }
+}
+
+impl<T: TspInterface> Deref for TspMainConnection<T> {
+    type Target = TspConnection<T>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl<T: TspInterface> TspMainConnection<T> {
+    /// Process a single event on the main connection.
+    fn process_event<'a>(
         &'a self,
         ide_transaction_manager: &mut TransactionManager<'a>,
         canceled_requests: &mut HashSet<RequestId>,
@@ -213,20 +280,25 @@ impl<T: TspInterface> TspConnection<T> {
 
         // For TSP requests, handle them specially
         if let LspEvent::LspRequest(ref request) = event {
-            if self.handle_tsp_request(ide_transaction_manager, request)? {
-                return Ok(ProcessEvent::Continue);
+            match parse_tsp_request(request) {
+                Some(TSPRequests::ConnectionRequest { params, .. }) => {
+                    self.handle_connection_request(request.id.clone(), params);
+                }
+                Some(msg) => {
+                    self.dispatch_tsp_request(ide_transaction_manager, request, msg)?;
+                }
+                None => {
+                    self.send_response(Response::new_err(
+                        request.id.clone(),
+                        ErrorCode::MethodNotFound as i32,
+                        format!("TSP server does not support LSP method: {}", request.method),
+                    ));
+                }
             }
-            // If it's not a TSP request, let the LSP server reject it since TSP server shouldn't handle LSP requests
-            self.inner.send_response(Response::new_err(
-                request.id.clone(),
-                lsp_server::ErrorCode::MethodNotFound as i32,
-                format!("TSP server does not support LSP method: {}", request.method),
-            ));
             return Ok(ProcessEvent::Continue);
         }
 
-        // For all other events (notifications, responses, etc.), delegate to inner server
-        let result = self.inner.process_event(
+        let result = self.inner().process_event(
             ide_transaction_manager,
             canceled_requests,
             telemetry,
@@ -236,15 +308,222 @@ impl<T: TspInterface> TspConnection<T> {
         )?;
 
         // Increment snapshot after the inner server has processed the event
-        if should_increment_snapshot && let Ok(mut current) = self.current_snapshot.lock() {
+        if should_increment_snapshot {
+            let mut current = self
+                .server
+                .current_snapshot
+                .lock()
+                .expect("current_snapshot mutex poisoned");
             let old_snapshot = *current;
             *current += 1;
             let new_snapshot = *current;
-            drop(current); // Release the lock before sending the notification
-            self.send_snapshot_changed_notification(old_snapshot, new_snapshot);
+            drop(current);
+            self.server.broadcast_snapshot_changed(
+                &self.0.response_sender,
+                old_snapshot,
+                new_snapshot,
+            );
         }
 
         Ok(result)
+    }
+
+    fn handle_connection_request(&self, id: RequestId, params: ConnectionRequestParams) {
+        let result = match params.type_.as_str() {
+            "open" => self.open_extra_connection(params),
+            "close" => Ok(self.close_extra_connection(params)),
+            other => Err(invalid_params_error(&format!(
+                "Unsupported connection request type: {other}"
+            ))),
+        };
+
+        match result {
+            Ok(connection_result) => self.send_ok(id, connection_result),
+            Err(error) => self.send_err(id, error),
+        }
+    }
+
+    fn open_extra_connection(
+        &self,
+        params: ConnectionRequestParams,
+    ) -> Result<ConnectionRequestResult, ResponseError> {
+        let name = pipe_name(&params)?;
+
+        let mut extra_connections = self
+            .server
+            .extra_connections
+            .lock()
+            .map_err(|_| internal_error("extra connection state was poisoned"))?;
+
+        if extra_connections.contains_key(name) {
+            return Ok(ConnectionRequestResult {
+                success: true,
+                message: Some(format!("Extra connection already open: {name}")),
+            });
+        }
+
+        // IoThread owns the writer JoinHandle. Dropping it detaches the thread
+        // (no Drop impl), but the writer stays alive as long as the channel
+        // sender (`extra_sender`) is alive — stored in ExtraConnectionHandle.
+        let (ipc_connection, reader, _io_thread) = Connection::ipc(name).map_err(|error| {
+            internal_error(&format!(
+                "Failed to connect to IPC endpoint {name}: {error}"
+            ))
+        })?;
+
+        let extra_sender = ipc_connection.sender.clone();
+        let extra_conn = TspExtraConnection::new(self.server.clone(), extra_sender.clone());
+        let (close_tx, close_rx) = crossbeam_channel::bounded::<()>(1);
+        let name_owned = name.to_owned();
+
+        extra_connections.insert(
+            name_owned.clone(),
+            ExtraConnectionHandle {
+                close_tx,
+                response_sender: extra_sender,
+            },
+        );
+        drop(extra_connections);
+
+        extra_conn.run(reader, close_rx, name_owned);
+
+        Ok(ConnectionRequestResult {
+            success: true,
+            message: Some(format!("Opened extra IPC connection: {name}")),
+        })
+    }
+
+    /// Close is idempotent: closing an already-closed connection succeeds.
+    fn close_extra_connection(&self, params: ConnectionRequestParams) -> ConnectionRequestResult {
+        let Ok(name) = pipe_name(&params) else {
+            return ConnectionRequestResult {
+                success: false,
+                message: Some("Missing IPC pipe name in connection args".to_owned()),
+            };
+        };
+
+        let handle = self
+            .server
+            .extra_connections
+            .lock()
+            .expect("extra_connections mutex poisoned")
+            .remove(name);
+
+        if let Some(handle) = handle {
+            let _ = handle.close_tx.send(());
+            ConnectionRequestResult {
+                success: true,
+                message: Some(format!("Closing extra IPC connection: {name}")),
+            }
+        } else {
+            ConnectionRequestResult {
+                success: true,
+                message: Some(format!("Extra IPC connection already closed: {name}")),
+            }
+        }
+    }
+}
+
+/// An extra (IPC) connection. Can handle TSP query requests but cannot
+/// manage connections or process LSP lifecycle events.
+struct TspExtraConnection<T: TspInterface>(TspConnection<T>);
+
+impl<T: TspInterface> TspExtraConnection<T> {
+    fn new(server: Arc<TspServer<T>>, response_sender: crossbeam_channel::Sender<Message>) -> Self {
+        Self(TspConnection::new(server, response_sender))
+    }
+}
+
+impl<T: TspInterface> TspExtraConnection<T> {
+    /// Run the request loop for this extra connection until closed or
+    /// the IPC pipe disconnects. Consumes `self` because the connection
+    /// is moved into the spawned thread.
+    fn run(
+        self,
+        mut reader: MessageReader,
+        close_rx: crossbeam_channel::Receiver<()>,
+        pipe_name: String,
+    ) {
+        let (message_tx, message_rx) = crossbeam_channel::unbounded();
+
+        std::thread::spawn(move || {
+            std::thread::spawn(move || {
+                while let Some(message) = reader.recv() {
+                    if message_tx.send(message).is_err() {
+                        break;
+                    }
+                }
+            });
+
+            let mut selector = crossbeam_channel::Select::new();
+            let close_index = selector.recv(&close_rx);
+            let message_index = selector.recv(&message_rx);
+            loop {
+                let selected = selector.select();
+                match selected.index() {
+                    i if i == close_index => break,
+                    i if i == message_index => {
+                        let Ok(message) = selected.recv(&message_rx) else {
+                            break;
+                        };
+
+                        match message {
+                            Message::Request(request) => {
+                                let mut tm = TransactionManager::default();
+                                match parse_tsp_request(&request) {
+                                    Some(TSPRequests::ConnectionRequest { .. }) => {
+                                        self.send_err(
+                                            request.id,
+                                            ResponseError {
+                                                code: ErrorCode::InvalidRequest as i32,
+                                                message: format!(
+                                                    "TSP method {} is only allowed on the main connection",
+                                                    request.method
+                                                ),
+                                                data: None,
+                                            },
+                                        );
+                                    }
+                                    Some(msg) => {
+                                        if let Err(error) =
+                                            self.dispatch_tsp_request(&mut tm, &request, msg)
+                                        {
+                                            warn!("Extra TSP connection error: {error}");
+                                            break;
+                                        }
+                                    }
+                                    None => {
+                                        self.send_response(Response::new_err(
+                                            request.id,
+                                            ErrorCode::MethodNotFound as i32,
+                                            format!(
+                                                "Extra TSP connection does not support method: {}",
+                                                request.method
+                                            ),
+                                        ));
+                                    }
+                                }
+                            }
+                            Message::Notification(_) | Message::Response(_) => {}
+                        }
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            self.server
+                .extra_connections
+                .lock()
+                .expect("extra_connections mutex poisoned")
+                .remove(&pipe_name);
+        });
+    }
+}
+
+impl<T: TspInterface> Deref for TspExtraConnection<T> {
+    type Target = TspConnection<T>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -273,16 +552,35 @@ fn parse_tsp_request(request: &Request) -> Option<TSPRequests> {
     serde_json::from_value::<TSPRequests>(wrapper).ok()
 }
 
+/// Extract the IPC pipe name from connection request `args`, or return an error.
+fn pipe_name(params: &ConnectionRequestParams) -> Result<&str, ResponseError> {
+    if params.kind != ConnectionTransportKind::Ipc {
+        return Err(invalid_params_error(
+            "Only IPC extra connections are supported",
+        ));
+    }
+
+    params
+        .args
+        .as_ref()
+        .and_then(|args| args.first())
+        .map(|s| s.as_str())
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            invalid_params_error("Connection request args must include the IPC pipe name")
+        })
+}
+
 pub fn tsp_loop(
     lsp_server: impl TspInterface,
     mut reader: MessageReader,
     _initialization: InitializeInfo,
     telemetry: &impl Telemetry,
 ) -> anyhow::Result<()> {
-    let server = TspConnection::new(lsp_server);
+    let server = TspServer::new(lsp_server);
+    let main_conn = TspMainConnection::new(server.clone(), server.inner.sender().clone());
 
     std::thread::scope(|scope| {
-        // Start the recheck queue thread to process async tasks
         scope.spawn(|| server.inner.run_recheck_queue(telemetry));
 
         scope.spawn(|| {
@@ -305,7 +603,7 @@ pub fn tsp_loop(
             );
             let event_description = event.describe();
 
-            let result = server.process_event(
+            let result = main_conn.process_event(
                 &mut ide_transaction_manager,
                 &mut canceled_requests,
                 telemetry,
@@ -333,12 +631,16 @@ pub fn tsp_loop(
     })
 }
 
-/// Generate TSP-specific server capabilities using the same capabilities as LSP
+/// Generate TSP-specific server capabilities.
 pub fn tsp_capabilities(
     indexing_mode: IndexingMode,
     initialization_params: &InitializeParams,
 ) -> ServerCapabilitiesWithTypeHierarchy {
-    // Use the same capabilities as LSP - TSP server supports the same features
-    // but will only respond to TSP protocol requests
-    capabilities(indexing_mode, initialization_params)
+    let mut result = capabilities(indexing_mode, initialization_params);
+    result.set_experimental(serde_json::json!({
+        "typeServerMultiConnection": {
+            "supportedTransports": ["ipc"]
+        }
+    }));
+    result
 }

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -89,63 +89,6 @@ impl<T: TspInterface> TspConnection<T> {
         }
     }
 
-    pub fn process_event<'a>(
-        &'a self,
-        ide_transaction_manager: &mut TransactionManager<'a>,
-        canceled_requests: &mut HashSet<RequestId>,
-        telemetry: &'a impl Telemetry,
-        telemetry_event: &mut TelemetryEvent,
-        subsequent_mutation: bool,
-        event: LspEvent,
-    ) -> anyhow::Result<ProcessEvent> {
-        // Remember if this event should increment the snapshot after processing
-        let should_increment_snapshot = match &event {
-            LspEvent::RecheckFinished => true,
-            // Increment on DidChange since it affects type checker state via synchronous validation
-            LspEvent::DidChangeTextDocument(_) => true,
-            // Don't increment on DidChangeWatchedFiles directly since it triggers RecheckFinished
-            // LspEvent::DidChangeWatchedFiles => true,
-            // Don't increment on DidOpen since it triggers RecheckFinished events that will increment
-            // LspEvent::DidOpenTextDocument(_) => true,
-            _ => false,
-        };
-
-        // For TSP requests, handle them specially
-        if let LspEvent::LspRequest(ref request) = event {
-            if self.handle_tsp_request(ide_transaction_manager, request)? {
-                return Ok(ProcessEvent::Continue);
-            }
-            // If it's not a TSP request, let the LSP server reject it since TSP server shouldn't handle LSP requests
-            self.inner.send_response(Response::new_err(
-                request.id.clone(),
-                lsp_server::ErrorCode::MethodNotFound as i32,
-                format!("TSP server does not support LSP method: {}", request.method),
-            ));
-            return Ok(ProcessEvent::Continue);
-        }
-
-        // For all other events (notifications, responses, etc.), delegate to inner server
-        let result = self.inner.process_event(
-            ide_transaction_manager,
-            canceled_requests,
-            telemetry,
-            telemetry_event,
-            subsequent_mutation,
-            event,
-        )?;
-
-        // Increment snapshot after the inner server has processed the event
-        if should_increment_snapshot && let Ok(mut current) = self.current_snapshot.lock() {
-            let old_snapshot = *current;
-            *current += 1;
-            let new_snapshot = *current;
-            drop(current); // Release the lock before sending the notification
-            self.send_snapshot_changed_notification(old_snapshot, new_snapshot);
-        }
-
-        Ok(result)
-    }
-
     /// Send a `typeServer/snapshotChanged` notification to the client.
     ///
     /// Called whenever the snapshot counter increments, so the client knows
@@ -243,6 +186,65 @@ impl<T: TspInterface> TspConnection<T> {
                 self.send_err(id, err);
             }
         }
+    }
+}
+
+impl<T: TspInterface> TspConnection<T> {
+    pub fn process_event<'a>(
+        &'a self,
+        ide_transaction_manager: &mut TransactionManager<'a>,
+        canceled_requests: &mut HashSet<RequestId>,
+        telemetry: &'a impl Telemetry,
+        telemetry_event: &mut TelemetryEvent,
+        subsequent_mutation: bool,
+        event: LspEvent,
+    ) -> anyhow::Result<ProcessEvent> {
+        // Remember if this event should increment the snapshot after processing
+        let should_increment_snapshot = match &event {
+            LspEvent::RecheckFinished => true,
+            // Increment on DidChange since it affects type checker state via synchronous validation
+            LspEvent::DidChangeTextDocument(_) => true,
+            // Don't increment on DidChangeWatchedFiles directly since it triggers RecheckFinished
+            // LspEvent::DidChangeWatchedFiles => true,
+            // Don't increment on DidOpen since it triggers RecheckFinished events that will increment
+            // LspEvent::DidOpenTextDocument(_) => true,
+            _ => false,
+        };
+
+        // For TSP requests, handle them specially
+        if let LspEvent::LspRequest(ref request) = event {
+            if self.handle_tsp_request(ide_transaction_manager, request)? {
+                return Ok(ProcessEvent::Continue);
+            }
+            // If it's not a TSP request, let the LSP server reject it since TSP server shouldn't handle LSP requests
+            self.inner.send_response(Response::new_err(
+                request.id.clone(),
+                lsp_server::ErrorCode::MethodNotFound as i32,
+                format!("TSP server does not support LSP method: {}", request.method),
+            ));
+            return Ok(ProcessEvent::Continue);
+        }
+
+        // For all other events (notifications, responses, etc.), delegate to inner server
+        let result = self.inner.process_event(
+            ide_transaction_manager,
+            canceled_requests,
+            telemetry,
+            telemetry_event,
+            subsequent_mutation,
+            event,
+        )?;
+
+        // Increment snapshot after the inner server has processed the event
+        if should_increment_snapshot && let Ok(mut current) = self.current_snapshot.lock() {
+            let old_snapshot = *current;
+            *current += 1;
+            let new_snapshot = *current;
+            drop(current); // Release the lock before sending the notification
+            self.send_snapshot_changed_notification(old_snapshot, new_snapshot);
+        }
+
+        Ok(result)
     }
 }
 

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -194,6 +194,11 @@ impl<T: TspInterface> TspServer<T> {
                 });
                 Ok(true)
             }
+            TSPRequests::ConnectionRequest { .. } => {
+                // Multi-connection management is handled at the transport layer,
+                // not inside the TSP request loop.
+                unreachable!("ConnectionRequest should be handled before reaching the TSP server")
+            }
         }
     }
 

--- a/pyrefly/lib/tsp/validation.rs
+++ b/pyrefly/lib/tsp/validation.rs
@@ -23,7 +23,7 @@ use serde::Serialize;
 use crate::lsp::non_wasm::lsp::new_response;
 use crate::lsp::non_wasm::protocol::Response;
 use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspServer;
+use crate::tsp::server::TspConnection;
 
 // ---------------------------------------------------------------------------
 // Canonical TSP error constructors
@@ -86,7 +86,7 @@ pub fn parse_file_uri(uri: &str) -> Result<Url, ResponseError> {
 // Snapshot validation
 // ---------------------------------------------------------------------------
 
-impl<T: TspInterface> TspServer<T> {
+impl<T: TspInterface> TspConnection<T> {
     /// Validate that the client-supplied snapshot matches the server's current
     /// snapshot. Returns `Ok(())` on match or `Err(ResponseError)` on mismatch.
     pub fn validate_snapshot(&self, client_snapshot: i32) -> Result<(), ResponseError> {

--- a/pyrefly/lib/tsp/validation.rs
+++ b/pyrefly/lib/tsp/validation.rs
@@ -10,20 +10,11 @@
 //! Every TSP request handler should use these helpers to ensure consistent
 //! error behavior across the protocol surface. The helpers cover:
 //!
-//! - Snapshot freshness checks (stale-snapshot rejection)
 //! - Canonical TSP error construction (invalid params, internal, etc.)
-//! - Response dispatch (success or error, routed through `TspInterface`)
 
 use lsp_server::ErrorCode;
-use lsp_server::RequestId;
 use lsp_server::ResponseError;
 use lsp_types::Url;
-use serde::Serialize;
-
-use crate::lsp::non_wasm::lsp::new_response;
-use crate::lsp::non_wasm::protocol::Response;
-use crate::lsp::non_wasm::server::TspInterface;
-use crate::tsp::server::TspConnection;
 
 // ---------------------------------------------------------------------------
 // Canonical TSP error constructors
@@ -80,37 +71,6 @@ pub fn parse_file_uri(uri: &str) -> Result<Url, ResponseError> {
         return Err(invalid_params_error("URI must use the file:// scheme"));
     }
     Ok(url)
-}
-
-// ---------------------------------------------------------------------------
-// Snapshot validation
-// ---------------------------------------------------------------------------
-
-impl<T: TspInterface> TspConnection<T> {
-    /// Validate that the client-supplied snapshot matches the server's current
-    /// snapshot. Returns `Ok(())` on match or `Err(ResponseError)` on mismatch.
-    pub fn validate_snapshot(&self, client_snapshot: i32) -> Result<(), ResponseError> {
-        let current = self.get_snapshot();
-        if client_snapshot != current {
-            Err(snapshot_outdated_error(client_snapshot, current))
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Send a successful JSON-RPC response for `id` with `result`.
-    pub fn send_ok<R: Serialize>(&self, id: RequestId, result: R) {
-        self.inner.send_response(new_response(id, Ok(result)));
-    }
-
-    /// Send a JSON-RPC error response for `id`.
-    pub fn send_err(&self, id: RequestId, error: ResponseError) {
-        self.inner.send_response(Response {
-            id,
-            result: None,
-            error: Some(error),
-        });
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Summary:
Multi-connection architecture for the TSP (Type Server Protocol)

The commit splits the single monolithic TspConnection into a three-tier structure:
1. TspServer<T> — shared core holding the Arc<T> LSP server, the snapshot counter, and a registry of extra connections. All connections share this via Arc.
  2. TspMainConnection<T> — wraps a TspConnection (via Deref) and owns the main stdio event loop. Only this type can:
    - Process LSP lifecycle events (delegating to the inner server)
    - Handle typeServer/connection requests (open/close extra connections)
    - Broadcast snapshotChanged notifications to all connections
  3. TspExtraConnection<T> — also wraps TspConnection (via Deref). Spawned on demand over IPC named pipes. Can handle TSP query requests (getComputedType, resolveImport, etc.) but explicitly rejects connection management and LSP methods.

Key mechanics:
  - Extra connections are opened via a new ConnectionRequest with type: "open" and an IPC pipe name. Each gets its own reader thread + select loop, terminating on a close signal or pipe disconnect.
  - snapshotChanged notifications are broadcast from the main connection to all extra connections, so every client stays in sync.
  - The server advertises typeServerMultiConnection in its experimental capabilities.
  - All TSP request handlers now call self.inner() (method) instead of self.inner (field), since the inner server is accessed through the shared TspServer.

The result: multiple IDE clients can query the same pyrefly process concurrently over IPC without spawning separate server instances.

Differential Revision: D102228875
