### PR TITLE
stubgen: emit reduced field metadata in dataclass / Pydantic stubs

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1110,7 +1110,7 @@ impl ClassField {
         }
     }
 
-    fn dataclass_flags_of(&self, heap: &TypeHeap) -> DataclassFieldKeywords {
+    pub(crate) fn dataclass_flags_of(&self, heap: &TypeHeap) -> DataclassFieldKeywords {
         match &self.0 {
             ClassFieldInner::Property { .. } => DataclassFieldKeywords::new(),
             // Descriptors are always initialized in the class body (otherwise they wouldn't

--- a/pyrefly/lib/stubgen/extract.rs
+++ b/pyrefly/lib/stubgen/extract.rs
@@ -18,8 +18,11 @@ use pyrefly_build::handle::Handle;
 use pyrefly_python::module::Module;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_python::sys_info::SysInfo;
+use pyrefly_graph::index::Idx;
 use pyrefly_types::callable::Param;
+use pyrefly_types::class::ClassDefIndex;
 use pyrefly_types::display::TypeDisplayContext;
+use pyrefly_types::keywords::DataclassFieldKeywords;
 use pyrefly_types::types::Type;
 use ruff_python_ast::Expr;
 use ruff_python_ast::Operator;
@@ -33,7 +36,9 @@ use starlark_map::Hashed;
 
 use crate::alt::answers::Answers;
 use crate::alt::types::decorated_function::DecoratedFunction;
+use crate::binding::binding::BindingClass;
 use crate::binding::binding::Key;
+use crate::binding::binding::KeyClass;
 use crate::binding::binding::KeyClassField;
 use crate::binding::binding::KeyDecoratedFunction;
 use crate::binding::bindings::Bindings;
@@ -127,6 +132,15 @@ pub fn extract_module_stub(
 
     let dunder_all = resolve_dunder_all(&ast.body, &module_info);
 
+    let class_field_by_def_and_name: HashMap<(ClassDefIndex, Name), Idx<KeyClassField>> =
+        bindings
+            .keys::<KeyClassField>()
+            .map(|idx| {
+                let k = bindings.idx_to_key(idx);
+                ((k.0, k.1.clone()), idx)
+            })
+            .collect();
+
     let mut ctx = ExtractionContext {
         bindings: &bindings,
         answers: &answers,
@@ -136,6 +150,8 @@ pub fn extract_module_stub(
         uses_self: false,
         function_map: &function_map,
         dunder_all: &dunder_all,
+        class_field_by_def_and_name,
+        class_def_index_stack: Vec::new(),
     };
 
     let items = extract_stmts(&ast.body, &mut ctx, false);
@@ -158,6 +174,9 @@ struct ExtractionContext<'a> {
     /// When `__all__` is explicitly defined, only these names are exported
     /// at module level. `None` means no explicit `__all__` — use convention.
     dunder_all: &'a Option<HashSet<Name>>,
+    class_field_by_def_and_name: HashMap<(ClassDefIndex, Name), Idx<KeyClassField>>,
+    /// Innermost class is at the end (nested `class` bodies).
+    class_def_index_stack: Vec<ClassDefIndex>,
 }
 
 fn extract_stmts(stmts: &[Stmt], ctx: &mut ExtractionContext, in_class: bool) -> Vec<StubItem> {
@@ -619,9 +638,16 @@ fn extract_class(class_def: &StmtClassDef, ctx: &mut ExtractionContext) -> Optio
         .as_ref()
         .map(|tp| source_text(ctx.module_info, tp.range()).to_owned());
 
+    let def_index = class_def_index_for_class_def(ctx, class_def);
+    if let Some(d) = def_index {
+        ctx.class_def_index_stack.push(d);
+    }
     let body = extract_stmts(&class_def.body, ctx, true);
     let extra = extract_instance_attr_stubs_from_class_fields(class_def, &body, ctx);
     let body = merge_instance_field_stubs(extra, body);
+    if def_index.is_some() {
+        ctx.class_def_index_stack.pop();
+    }
 
     Some(StubClass {
         name: name.to_owned(),
@@ -648,10 +674,27 @@ fn extract_ann_assign(
 
     let annotation = source_text(ctx.module_info, ann_assign.annotation.range()).to_owned();
 
-    let value = ann_assign
-        .value
-        .as_deref()
-        .and_then(|v| simple_value_text(v, ctx.module_info));
+    let value = ann_assign.value.as_deref().and_then(|v| {
+        simple_value_text(v, ctx.module_info)
+            .or_else(|| {
+                if in_class {
+                    type_stub_stripped_field_specifier_call(
+                        v,
+                        ctx.module_info,
+                        ctx.config.include_docstrings,
+                    )
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
+                if in_class {
+                    class_body_default_ellipsis_from_solved_class_field(ctx, ann_assign)
+                } else {
+                    None
+                }
+            })
+    });
 
     Some(StubVariable {
         name: name.to_owned(),
@@ -715,6 +758,162 @@ fn simple_value_text(expr: &Expr, module_info: &Module) -> Option<String> {
         }
         Expr::EllipsisLiteral(_) => Some("...".to_owned()),
         _ => None,
+    }
+}
+
+/// dataclass `field` / Pydantic `Field` calls are re-emitted in stubs with a reduced keyword
+/// set so `kw_only`, `init`, and defaults are preserved for type checkers, while
+/// `metadata` / (when docstrings are off) `description` and other runtime-only options are
+/// dropped. For `default_factory=`, only simple callable references (names and `a.b` chains) are
+/// kept; `lambda` bodies, calls, and other complex expressions are replaced with `lambda: ...`.
+/// When [ExtractConfig::include_docstrings] is set, Pydantic `Field` keeps `description` and
+/// `title` in the reduced call (schema doc strings).
+fn type_stub_stripped_field_specifier_call(
+    expr: &Expr,
+    module: &Module,
+    include_docstrings: bool,
+) -> Option<String> {
+    let Expr::Call(call) = expr else {
+        return None;
+    };
+    if call.arguments.args.iter().any(|a| a.is_starred_expr())
+        || call
+            .arguments
+            .keywords
+            .iter()
+            .any(|kw| kw.arg.is_none())
+    {
+        return None;
+    }
+    let kind = field_specifier_kind(&call.func)?;
+    let mut parts: Vec<String> = Vec::new();
+    for arg in &call.arguments.args {
+        parts.push(source_text(module, arg.range()).to_owned());
+    }
+    for kw in &call.arguments.keywords {
+        let name = kw.arg.as_ref()?.as_str();
+        if field_specifier_keyword_retained(
+            kind,
+            name,
+            include_docstrings,
+        ) {
+            let value_str = if name == "default_factory" {
+                default_factory_stub_value(&kw.value, module)
+            } else {
+                source_text(module, kw.value.range()).to_owned()
+            };
+            parts.push(format!("{}={}", name, value_str));
+        }
+    }
+    Some(format!(
+        "{}({})",
+        source_text(module, call.func.as_ref().range()),
+        parts.join(", ")
+    ))
+}
+
+fn field_specifier_keyword_retained(
+    kind: FieldSpecifierKind,
+    name: &str,
+    include_docstrings: bool,
+) -> bool {
+    match kind {
+        FieldSpecifierKind::Dataclass => {
+            matches!(name, "default" | "default_factory" | "init" | "kw_only")
+        }
+        FieldSpecifierKind::Pydantic => {
+            matches!(name, "default" | "default_factory" | "alias" | "validation_alias" | "init")
+                || (include_docstrings && matches!(name, "description" | "title"))
+        }
+    }
+}
+
+/// A simple reference to a callable (`list`, `dict`, `m.nested.fn`) is kept in the stub; a
+/// `lambda` body, a call, or any other non-trivial expression is replaced with `lambda: ...` so
+/// the stub does not echo large or nested runtime logic.
+fn default_factory_stub_value(expr: &Expr, module: &Module) -> String {
+    if is_simple_callable_ref(expr) {
+        return source_text(module, expr.range()).to_owned();
+    }
+    "lambda: ...".to_owned()
+}
+
+/// Unqualified name or a chain of attributes (`collections.deque`) with no calls or literals.
+fn is_simple_callable_ref(expr: &Expr) -> bool {
+    match expr {
+        Expr::Name(_) => true,
+        Expr::Attribute(a) => is_simple_callable_ref(&a.value),
+        _ => false,
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FieldSpecifierKind {
+    /// `field` (typically `from dataclasses import field` or `dataclasses.field`).
+    Dataclass,
+    /// `Field` (Pydantic or similar); distinguish by callee name `Field` vs `field`.
+    Pydantic,
+}
+
+fn field_specifier_kind(func: &Expr) -> Option<FieldSpecifierKind> {
+    match func {
+        Expr::Name(n) if n.id.as_str() == "field" => Some(FieldSpecifierKind::Dataclass),
+        Expr::Name(n) if n.id.as_str() == "Field" => Some(FieldSpecifierKind::Pydantic),
+        Expr::Attribute(a) if a.attr.as_str() == "field" => Some(FieldSpecifierKind::Dataclass),
+        Expr::Attribute(a) if a.attr.as_str() == "Field" => Some(FieldSpecifierKind::Pydantic),
+        _ => None,
+    }
+}
+
+/// When the RHS is not a simple literal and not a stripped `field`/`Field` call, still emit `= ...`
+/// if the solved class field’s `__init__` has a default (e.g. custom descriptors, or `*`-spread
+/// field calls we could not reprint).
+fn class_body_default_ellipsis_from_solved_class_field(
+    ctx: &ExtractionContext,
+    ann_assign: &ruff_python_ast::StmtAnnAssign,
+) -> Option<String> {
+    let def_index = ctx.class_def_index_stack.last().copied()?;
+    let name = match ann_assign.target.as_ref() {
+        Expr::Name(n) => n.id.clone(),
+        _ => return None,
+    };
+    let idx = ctx.class_field_by_def_and_name.get(&(def_index, name))?;
+    let class_field = ctx.answers.get_idx(*idx)?;
+    let kws = class_field.as_ref().dataclass_flags_of(ctx.answers.heap());
+    if !dataclass_init_param_has_default_for_stub(&kws) {
+        return None;
+    }
+    Some("...".to_owned())
+}
+
+fn class_def_index_for_class_def(
+    ctx: &ExtractionContext,
+    class_def: &StmtClassDef,
+) -> Option<ClassDefIndex> {
+    let key = KeyClass(ShortIdentifier::new(&class_def.name));
+    let class_idx = ctx
+        .bindings
+        .key_to_idx_hashed_opt(Hashed::new(&key))?;
+    match ctx.bindings.get(class_idx) {
+        BindingClass::ClassDef(cb) => Some(cb.def_index),
+        BindingClass::FunctionalClassDef(def_index, ..) => Some(*def_index),
+    }
+}
+
+/// Aligned with `get_dataclass_init`’s `default.is_some()` part of `has_default` (see
+/// `dataclass.rs`), not the full `has_default` expression: we do **not** include
+/// `init_by_name && init_by_alias` because that disjunct is a Pydantic-ism for emitting two
+/// `__init__` parameters (name and alias) and is not a reliable signal that a **single** field
+/// line in a stub should carry `= ...`.
+fn dataclass_init_param_has_default_for_stub(kws: &DataclassFieldKeywords) -> bool {
+    if !kws.init {
+        return false;
+    }
+    match &kws.default {
+        None => false,
+        // `ty` is `&Type` when matching on `&Option<Type>`.
+        Some(ty) if *ty == Type::Ellipsis => false,
+        Some(_) => true,
     }
 }
 

--- a/pyrefly/lib/stubgen/mod.rs
+++ b/pyrefly/lib/stubgen/mod.rs
@@ -304,4 +304,265 @@ class A:
             actual.trim(),
         );
     }
+
+    #[test]
+    fn test_stubgen_dataclass_field_strips_metadata() {
+        let input = r#"from dataclasses import dataclass, field
+
+@dataclass
+class A:
+    n: int = field(default=1, metadata={"a": 1}, repr=True)
+"#;
+        let actual = run_stubgen(input);
+        let expected = r#"from dataclasses import dataclass, field
+
+
+@dataclass
+class A:
+    n: int = field(default=1)
+"#;
+        pretty_assertions::assert_str_eq!(expected, &actual);
+    }
+
+    /// Non-literal `field(...)` RHS is re-emitted in the stub with typing-relevant kwargs only
+    /// (dropping e.g. `metadata`).
+    #[test]
+    fn test_stubgen_dataclass_field_strips_field_call() {
+        let input = r#"from dataclasses import dataclass, field
+
+@dataclass
+class A:
+    name: str | None = field(default=None)
+"#;
+        let actual = run_stubgen(input);
+        let expected = r#"from dataclasses import dataclass, field
+
+
+@dataclass
+class A:
+    name: str | None = field(default=None)
+"#;
+        pretty_assertions::assert_str_eq!(expected, &actual);
+    }
+
+    /// `default_factory` and other whitelisted dataclass `field` kwargs are kept; `metadata` is
+    /// dropped.
+    #[test]
+    fn test_stubgen_dataclass_field_retains_default_factory() {
+        let input = r#"from dataclasses import dataclass, field
+
+@dataclass
+class A:
+    items: list[str] = field(default_factory=list, metadata={"k": 1})
+"#;
+        let actual = run_stubgen(input);
+        let expected = r#"from dataclasses import dataclass, field
+
+
+@dataclass
+class A:
+    items: list[str] = field(default_factory=list)
+"#;
+        pretty_assertions::assert_str_eq!(expected, &actual);
+    }
+
+    /// Same for Pydantic: `default_factory` is kept; validation kwargs such as `min_length` are
+    /// not typing-relevant for the stub and are dropped.
+    #[test]
+    fn test_stubgen_pydantic_field_retains_default_factory() {
+        let input = r#"from pydantic import BaseModel, Field
+
+class A(BaseModel):
+    items: list[str] = Field(default_factory=list, min_length=0)
+"#;
+        let actual = run_stubgen(input);
+        let expected = r#"from pydantic import BaseModel, Field
+
+
+class A(BaseModel):
+    items: list[str] = Field(default_factory=list)
+"#;
+        pretty_assertions::assert_str_eq!(expected, &actual);
+    }
+
+    /// `default_factory` that is not a simple name/attribute (e.g. a `lambda` or a call) is
+    /// replaced with `lambda: ...` in the stub.
+    #[test]
+    fn test_stubgen_dataclass_field_default_factory_complex_uses_placeholder() {
+        let input = r#"from dataclasses import dataclass, field
+
+@dataclass
+class A:
+    x: list[int] = field(default_factory=lambda: [1, 2, 3])
+"#;
+        let actual = run_stubgen(input);
+        let expected = r#"from dataclasses import dataclass, field
+
+
+@dataclass
+class A:
+    x: list[int] = field(default_factory=lambda: ...)
+"#;
+        pretty_assertions::assert_str_eq!(expected, &actual);
+    }
+
+    #[test]
+    fn test_stubgen_pydantic_field_default_factory_complex_uses_placeholder() {
+        let input = r#"import functools
+from pydantic import BaseModel, Field
+
+class A(BaseModel):
+    x: list[int] = Field(default_factory=functools.partial(list, [0]))
+"#;
+        let actual = run_stubgen(input);
+        let expected = r#"import functools
+from pydantic import BaseModel, Field
+
+
+class A(BaseModel):
+    x: list[int] = Field(default_factory=lambda: ...)
+"#;
+        pretty_assertions::assert_str_eq!(expected, &actual);
+    }
+
+    /// Same for Pydantic `Field(...)`: keep a reduced call for type checking.
+    #[test]
+    fn test_stubgen_pydantic_field_strips_field_call() {
+        let input = r#"from pydantic import BaseModel, Field
+
+class A(BaseModel):
+    x: int = Field(default=0)
+"#;
+        let actual = run_stubgen(input);
+        let expected = r#"from pydantic import BaseModel, Field
+
+
+class A(BaseModel):
+    x: int = Field(default=0)
+"#;
+        pretty_assertions::assert_str_eq!(expected, &actual);
+    }
+
+    /// Required: first positional is `...`. With default stub config, `description=` is dropped.
+    #[test]
+    fn test_stubgen_pydantic_field_required_strips_description() {
+        let input = r#"from pydantic import BaseModel, Field
+
+class A(BaseModel):
+    u: int = Field(..., description="required")
+"#;
+        let actual = run_stubgen(input);
+        let expected = r#"from pydantic import BaseModel, Field
+
+
+class A(BaseModel):
+    u: int = Field(...)
+"#;
+        pretty_assertions::assert_str_eq!(expected, &actual);
+    }
+
+    /// When `ExtractConfig::include_docstrings` is true, Pydantic `Field` keeps `description` and
+    /// `title` (same flag as class/function docstrings).
+    #[test]
+    fn test_stubgen_pydantic_field_retains_description_with_include_docstrings() {
+        let input = r#"from pydantic import BaseModel, Field
+
+class A(BaseModel):
+    u: int = Field(..., description="required", title="T")
+"#;
+        let config = ExtractConfig {
+            include_private: false,
+            include_docstrings: true,
+        };
+        let actual = run_stubgen_with_config(input, &config);
+        let expected = r#"from pydantic import BaseModel, Field
+
+
+class A(BaseModel):
+    u: int = Field(..., description="required", title="T")
+"#;
+        pretty_assertions::assert_str_eq!(expected, &actual);
+    }
+
+    /// A bare `field()` call (no `default=`) is preserved; there is no literal to simplify to.
+    #[test]
+    fn test_stubgen_dataclass_field_bare_preserved() {
+        let input = r#"from dataclasses import dataclass, field
+
+@dataclass
+class A:
+    name: str = field()
+"#;
+        let actual = run_stubgen(input);
+        let expected = r#"from dataclasses import dataclass, field
+
+
+@dataclass
+class A:
+    name: str = field()
+"#;
+        pretty_assertions::assert_str_eq!(expected, &actual);
+    }
+
+    /// Mix of required fields, `field()` with no default, `field(..., kw_only=True)`, and literals.
+    /// Non-typing `field` kwargs (e.g. `metadata=`) are dropped from the printed stub.
+    #[test]
+    fn test_stubgen_dataclass_mixed_field_defaults() {
+        let input = r#"from dataclasses import dataclass, field
+
+@dataclass
+class Mixed:
+    required: int
+    literal_default: str = "x"
+    field_with_default: int = field(default=0)
+    field_with_none: str | None = field(default=None)
+    field_no_default: int = field()
+    field_ellipsis: int = field(..., kw_only=True)
+"#;
+        let actual = run_stubgen(input);
+        let expected = r#"from dataclasses import dataclass, field
+
+
+@dataclass
+class Mixed:
+    required: int
+    literal_default: str = "x"
+    field_with_default: int = field(default=0)
+    field_with_none: str | None = field(default=None)
+    field_no_default: int = field()
+    field_ellipsis: int = field(..., kw_only=True)
+"#;
+        pretty_assertions::assert_str_eq!(expected, &actual);
+    }
+
+    /// Same as `test_stubgen_dataclass_mixed_field_defaults` for Pydantic `Field` (strip
+    /// `description`, etc., keep `default=`, `...` positionals, and a bare `Field()`).
+    #[test]
+    fn test_stubgen_pydantic_mixed_field_defaults() {
+        let input = r#"from pydantic import BaseModel, Field
+
+class Mixed(BaseModel):
+    required: int
+    literal_default: int = 7
+    field_with_default: int = Field(default=0)
+    field_with_none: str | None = Field(default=None)
+    field_bare: int = Field()
+    field_ellipsis: int = Field(..., description="req")
+    field_ellipsis_only: int = Field(...)
+"#;
+        let actual = run_stubgen(input);
+        let expected = r#"from pydantic import BaseModel, Field
+
+
+class Mixed(BaseModel):
+    required: int
+    literal_default: int = 7
+    field_with_default: int = Field(default=0)
+    field_with_none: str | None = Field(default=None)
+    field_bare: int = Field()
+    field_ellipsis: int = Field(...)
+    field_ellipsis_only: int = Field(...)
+"#;
+        pretty_assertions::assert_str_eq!(expected, &actual);
+    }
 }


### PR DESCRIPTION
## Context

As identified in #3221, stub generation for class body annotated assignments only handled **simple** RHS values (e.g. literals, `...`). `dataclasses.field` / Pydantic `Field` calls are not "simple" text, so stubs either dropped the real `__init__` / field behavior or were forced into lossy workarounds. Callers that care about **`kw_only`**, **defaults**, and **field metadata** need something closer to the real declaration without copying the whole module.

## Intent

Make `.pyi` output for `field(...)` and `Field(...)` **type-checking oriented**: keep a **reduced** call that still reflects init-altering options, strip runtime-only or validation noise, and avoid echoing **heavy** `default_factory` bodies. **Optional** Pydantic schema doc strings on `Field` should follow the same `include_docstrings` switch as other stub doc content.

## Changes

- **Stub extract (`extract.rs`)**  
  - For class `AnnAssign` RHS, after simple literals, try a **structured strip** of `field` / `Field` (by callee name, including `dataclasses.field` / `pydantic.Field`-style attributes).  
  - **Whitelist** kwargs per "kind" (dataclass vs Pydantic `Field`): defaults, `default_factory`, `init`, `kw_only` (dataclass), aliasing-related kwargs (Pydantic), etc.; drop the rest (e.g. `metadata`, `min_length`, …).  
  - **`default_factory`:** keep only **simple callable refs** (bare name or `a.b` chains); otherwise emit **`default_factory=lambda: ...`**.  
  - With **`include_docstrings`**, Pydantic `Field` also keeps **`description`** and **`title`**.  
  - **Fallback:** if the RHS is not a re-printable `field`/`Field` (e.g. `*args`), use the solver plus **`ClassField::dataclass_flags_of`** to emit **`= ...`** when the solved field’s init parameter has a default, matching the existing init-default notion (with the documented Pydantic caveat for dual name/alias params).  
- **`ClassField`:** `dataclass_flags_of` is **`pub(crate)`** for stubgen.  
- **Tests (`stubgen/mod.rs`):** dataclass + Pydantic coverage for stripping, `default_factory`, complex factory placeholder, mixed fields, and docstring retention under config.

## Testing

- `cargo test -p pyrefly stubgen::tests::`

---

Fixes #3221.