### PR TITLE
Preserve tuple match narrows across subsequent cases

### DIFF
--- a/pyrefly/lib/binding/pattern.rs
+++ b/pyrefly/lib/binding/pattern.rs
@@ -213,11 +213,17 @@ impl<'a> BindingsBuilder<'a> {
                                             Some(idx) => idx,
                                             Option::None => {
                                                 // More patterns than tuple elements, skip narrowing
-                                                narrow_ops.and_all(self.bind_pattern(
-                                                    MatchSubject::None,
-                                                    x,
-                                                    key_for_subpattern,
-                                                ));
+                                                for (name, (op, range)) in self
+                                                    .bind_pattern(
+                                                        MatchSubject::None,
+                                                        x,
+                                                        key_for_subpattern,
+                                                    )
+                                                    .0
+                                                {
+                                                    let subject = NarrowingSubject::Name(name);
+                                                    narrow_ops.and_for_subject(&subject, op, range);
+                                                }
                                                 continue;
                                             }
                                         }
@@ -238,11 +244,13 @@ impl<'a> BindingsBuilder<'a> {
                                 }
                                 _ => MatchSubject::None,
                             };
-                            narrow_ops.and_all(self.bind_pattern(
-                                subject_for_subpattern,
-                                x,
-                                key_for_subpattern,
-                            ));
+                            for (name, (op, range)) in self
+                                .bind_pattern(subject_for_subpattern, x, key_for_subpattern)
+                                .0
+                            {
+                                let subject = NarrowingSubject::Name(name);
+                                narrow_ops.and_for_subject(&subject, op, range);
+                            }
                         }
                     }
                 }
@@ -599,11 +607,13 @@ impl<'a> BindingsBuilder<'a> {
             // shadow outer variables. When there is no narrowing subject
             // (e.g. `match make_color():`), drop all narrows so that alias
             // names don't resolve against unrelated outer variables.
-            new_narrow_ops.0.retain(|name, _| {
-                match_subject
-                    .as_single()
-                    .as_ref()
-                    .is_some_and(|s| name == s.name())
+            new_narrow_ops.0.retain(|name, _| match &match_subject {
+                MatchSubject::Single(subject) => name == subject.name(),
+                MatchSubject::Tuple(subjects) => subjects
+                    .iter()
+                    .flatten()
+                    .any(|subject| name == subject.name()),
+                MatchSubject::None => false,
             });
             negated_prev_ops.and_all(new_narrow_ops.negate());
             self.stmts(body, parent);

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -4174,9 +4174,7 @@ impl Server {
         let allow_fix_all = only_kinds.is_none_or(|kinds| {
             kinds.iter().any(|kind| {
                 kind == &CodeActionKind::SOURCE_FIX_ALL
-                    || kind
-                        .as_str()
-                        .starts_with(CodeActionKind::SOURCE_FIX_ALL.as_str())
+                    || kind.as_str().starts_with(SOURCE_FIX_ALL_PYREFLY)
             })
         });
         let allow_refactor = only_kinds.is_none_or(|kinds| {

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -1279,7 +1279,11 @@ const PYTHON_SECTION: &str = "python";
 const SOURCE_FIX_ALL_PYREFLY: &str = "source.fixAll.pyrefly";
 
 fn is_fix_all_code_action_kind_requested(kind: &CodeActionKind) -> bool {
-    kind == &CodeActionKind::SOURCE_FIX_ALL || kind.as_str() == SOURCE_FIX_ALL_PYREFLY
+    let requested = kind.as_str();
+    requested == SOURCE_FIX_ALL_PYREFLY
+        || SOURCE_FIX_ALL_PYREFLY
+            .strip_prefix(requested)
+            .is_some_and(|suffix| suffix.starts_with('.'))
 }
 
 struct TypeHierarchyTarget {

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -681,7 +681,11 @@ fn format_diagnostic_message_for_markdown(message: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use lsp_types::CodeActionKind;
+
+    use super::SOURCE_FIX_ALL_PYREFLY;
     use super::format_diagnostic_message_for_markdown;
+    use super::is_fix_all_code_action_kind_requested;
 
     #[test]
     fn test_format_diagnostic_message_for_markdown() {
@@ -721,6 +725,26 @@ mod tests {
     #[test]
     fn test_format_only_special_characters() {
         assert_eq!(format_diagnostic_message_for_markdown("***"), "\\*\\*\\*");
+    }
+
+    #[test]
+    fn test_fix_all_kind_filter_matches_supported_kinds() {
+        assert!(is_fix_all_code_action_kind_requested(
+            &CodeActionKind::SOURCE_FIX_ALL
+        ));
+        assert!(is_fix_all_code_action_kind_requested(&CodeActionKind::new(
+            SOURCE_FIX_ALL_PYREFLY,
+        )));
+    }
+
+    #[test]
+    fn test_fix_all_kind_filter_rejects_pyrefly_suffix_kinds() {
+        assert!(!is_fix_all_code_action_kind_requested(
+            &CodeActionKind::new("source.fixAll.pyrefly.foo",)
+        ));
+        assert!(!is_fix_all_code_action_kind_requested(
+            &CodeActionKind::new("source.fixAll.pyreflyyyyyy",)
+        ));
     }
 }
 
@@ -1253,6 +1277,10 @@ pub enum ProcessEvent {
 
 const PYTHON_SECTION: &str = "python";
 const SOURCE_FIX_ALL_PYREFLY: &str = "source.fixAll.pyrefly";
+
+fn is_fix_all_code_action_kind_requested(kind: &CodeActionKind) -> bool {
+    kind == &CodeActionKind::SOURCE_FIX_ALL || kind.as_str() == SOURCE_FIX_ALL_PYREFLY
+}
 
 struct TypeHierarchyTarget {
     def_index: ClassDefIndex,
@@ -4171,12 +4199,8 @@ impl Server {
         let only_kinds = params.context.only.as_ref();
         let allow_quickfix = only_kinds
             .is_none_or(|kinds| kinds.iter().any(|kind| kind == &CodeActionKind::QUICKFIX));
-        let allow_fix_all = only_kinds.is_none_or(|kinds| {
-            kinds.iter().any(|kind| {
-                kind == &CodeActionKind::SOURCE_FIX_ALL
-                    || kind.as_str().starts_with(SOURCE_FIX_ALL_PYREFLY)
-            })
-        });
+        let allow_fix_all =
+            only_kinds.is_none_or(|kinds| kinds.iter().any(is_fix_all_code_action_kind_requested));
         let allow_refactor = only_kinds.is_none_or(|kinds| {
             kinds
                 .iter()

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -1142,7 +1142,7 @@ pub fn capabilities(
                 CodeActionKind::new("refactor.delete"),
                 CodeActionKind::new("refactor.move"),
                 CodeActionKind::REFACTOR_INLINE,
-                CodeActionKind::SOURCE_FIX_ALL,
+                CodeActionKind::new(SOURCE_FIX_ALL_PYREFLY),
             ]),
             ..Default::default()
         })),
@@ -1252,6 +1252,7 @@ pub enum ProcessEvent {
 }
 
 const PYTHON_SECTION: &str = "python";
+const SOURCE_FIX_ALL_PYREFLY: &str = "source.fixAll.pyrefly";
 
 struct TypeHierarchyTarget {
     def_index: ClassDefIndex,
@@ -4171,9 +4172,12 @@ impl Server {
         let allow_quickfix = only_kinds
             .is_none_or(|kinds| kinds.iter().any(|kind| kind == &CodeActionKind::QUICKFIX));
         let allow_fix_all = only_kinds.is_none_or(|kinds| {
-            kinds
-                .iter()
-                .any(|kind| kind == &CodeActionKind::SOURCE_FIX_ALL)
+            kinds.iter().any(|kind| {
+                kind == &CodeActionKind::SOURCE_FIX_ALL
+                    || kind
+                        .as_str()
+                        .starts_with(CodeActionKind::SOURCE_FIX_ALL.as_str())
+            })
         });
         let allow_refactor = only_kinds.is_none_or(|kinds| {
             kinds
@@ -4276,7 +4280,7 @@ impl Server {
                 if !changes.is_empty() {
                     actions.push(CodeActionOrCommand::CodeAction(CodeAction {
                         title: "Remove all redundant casts".to_owned(),
-                        kind: Some(CodeActionKind::SOURCE_FIX_ALL),
+                        kind: Some(CodeActionKind::new(SOURCE_FIX_ALL_PYREFLY)),
                         edit: Some(WorkspaceEdit {
                             changes: Some(changes),
                             ..Default::default()

--- a/pyrefly/lib/test/lsp/lsp_interaction/basic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/basic.rs
@@ -36,7 +36,7 @@ fn test_initialize_basic() {
             "definitionProvider": true,
             "typeDefinitionProvider": true,
             "codeActionProvider": {
-                "codeActionKinds": ["quickfix", "refactor.extract", "refactor.rewrite", "refactor.delete", "refactor.move", "refactor.inline", "source.fixAll"]
+                "codeActionKinds": ["quickfix", "refactor.extract", "refactor.rewrite", "refactor.delete", "refactor.move", "refactor.inline", "source.fixAll.pyrefly"]
             },
             "codeLensProvider": {
                 "resolveProvider": false,

--- a/pyrefly/lib/test/pattern_match.rs
+++ b/pyrefly/lib/test/pattern_match.rs
@@ -737,7 +737,9 @@ def test(a: list[int] | None, b: list[int] | None) -> None:
             pass
         case _, None:
             assert_type(a, list[int])
+            assert_type(b, None)
         case None, _:
+            assert_type(a, None)
             assert_type(b, list[int])
         case _:
             assert_type(a, list[int])

--- a/pyrefly/lib/test/pattern_match.rs
+++ b/pyrefly/lib/test/pattern_match.rs
@@ -727,6 +727,25 @@ def test_sequence_after_none(seq_or_none: list[int] | None):
 );
 
 testcase!(
+    test_match_tuple_subject_narrowing_after_none,
+    r#"
+from typing import assert_type
+
+def test(a: list[int] | None, b: list[int] | None) -> None:
+    match a, b:
+        case None, None:
+            pass
+        case _, None:
+            assert_type(a, list[int])
+        case None, _:
+            assert_type(b, list[int])
+        case _:
+            assert_type(a, list[int])
+            assert_type(b, list[int])
+"#,
+);
+
+testcase!(
     test_match_mapping_before_none,
     r#"
 from typing import Any, assert_type


### PR DESCRIPTION
This keeps per-element narrows from tuple match cases alive when control falls through to later cases, so a `case None, None` no longer drops the surviving type information for the remaining branches.

Fixes #3213.