### PR TITLE
Fix TSP server crash on Jupyter notebook cell URIs (#3234)

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -474,6 +474,17 @@ pub trait TspInterface: Send + Sync {
         &self,
         func_id: &pyrefly_types::callable::FuncId,
     ) -> Option<TextRange>;
+
+    /// Resolve a URI to a filesystem path.
+    ///
+    /// Handles both `file://` URIs (via [`Url::to_file_path`]) and notebook
+    /// cell URIs (via the `open_notebook_cells` map). Returns `None` when
+    /// the URI cannot be mapped to a path.
+    fn resolve_uri_to_path(&self, uri: &Url) -> Option<PathBuf>;
+
+    /// Return the cell index if `uri` is an open notebook cell, or `None`
+    /// for regular file URIs.
+    fn maybe_get_cell_index(&self, uri: &Url) -> Option<usize>;
 }
 
 pub struct Connection {
@@ -6277,15 +6288,14 @@ impl TspInterface for Server {
         let url = Url::parse(uri)
             .ok()
             .or_else(|| Url::from_file_path(uri).ok())?;
-        let path = url.to_file_path().ok()?;
+        let path = self.path_for_uri_or_notebook_cell(&url)?;
+        let notebook_cell = self.maybe_get_cell_index(&url);
 
         let handle = make_open_handle(&self.state, &path);
         let transaction = self.state.transaction();
         let module_info = transaction.get_module_info(&handle)?;
-        let position = module_info.from_lsp_position(
-            lsp_types::Position { line, character },
-            /* notebook_cell */ None,
-        );
+        let position =
+            module_info.from_lsp_position(lsp_types::Position { line, character }, notebook_cell);
         transaction.get_type_at(&handle, position)
     }
 
@@ -6300,5 +6310,13 @@ impl TspInterface for Server {
         let key = KeyUndecoratedFunctionRange(def_index);
         let idx = bindings.key_to_idx_hashed_opt(Hashed::new(&key))?;
         Some(bindings.get(idx).0.range())
+    }
+
+    fn resolve_uri_to_path(&self, uri: &Url) -> Option<PathBuf> {
+        self.path_for_uri_or_notebook_cell(uri)
+    }
+
+    fn maybe_get_cell_index(&self, uri: &Url) -> Option<usize> {
+        Self::maybe_get_cell_index(self, uri)
     }
 }

--- a/pyrefly/lib/tsp/requests/get_computed_type.rs
+++ b/pyrefly/lib/tsp/requests/get_computed_type.rs
@@ -13,6 +13,7 @@ use tsp_types::Type;
 
 use crate::lsp::non_wasm::server::TspInterface;
 use crate::tsp::server::TspServer;
+use crate::tsp::validation::parse_uri;
 
 impl<T: TspInterface> TspServer<T> {
     /// Return the computed (inferred) type at the given position.
@@ -25,6 +26,10 @@ impl<T: TspInterface> TspServer<T> {
         params: GetTypeParams,
     ) -> Result<Option<Type>, ResponseError> {
         self.validate_snapshot(params.snapshot)?;
+        // Validate the URI is parseable (rejects malformed strings).
+        // Any valid scheme is accepted — notebook cell URIs are resolved
+        // to notebook paths inside get_type_at_position.
+        parse_uri(params.uri())?;
         let position = params.position();
         let ty = self
             .inner

--- a/pyrefly/lib/tsp/requests/get_declared_type.rs
+++ b/pyrefly/lib/tsp/requests/get_declared_type.rs
@@ -13,6 +13,7 @@ use tsp_types::Type;
 
 use crate::lsp::non_wasm::server::TspInterface;
 use crate::tsp::server::TspServer;
+use crate::tsp::validation::parse_uri;
 
 impl<T: TspInterface> TspServer<T> {
     /// Return the declared type at the given position.
@@ -29,6 +30,10 @@ impl<T: TspInterface> TspServer<T> {
         params: GetTypeParams,
     ) -> Result<Option<Type>, ResponseError> {
         self.validate_snapshot(params.snapshot)?;
+        // Validate the URI is parseable (rejects malformed strings).
+        // Any valid scheme is accepted — notebook cell URIs are resolved
+        // to notebook paths inside get_type_at_position.
+        parse_uri(params.uri())?;
         let position = params.position();
         let ty = self
             .inner

--- a/pyrefly/lib/tsp/requests/get_expected_type.rs
+++ b/pyrefly/lib/tsp/requests/get_expected_type.rs
@@ -13,6 +13,7 @@ use tsp_types::Type;
 
 use crate::lsp::non_wasm::server::TspInterface;
 use crate::tsp::server::TspServer;
+use crate::tsp::validation::parse_uri;
 
 impl<T: TspInterface> TspServer<T> {
     /// Return the expected type at the given position.
@@ -29,6 +30,10 @@ impl<T: TspInterface> TspServer<T> {
         params: GetTypeParams,
     ) -> Result<Option<Type>, ResponseError> {
         self.validate_snapshot(params.snapshot)?;
+        // Validate the URI is parseable (rejects malformed strings).
+        // Any valid scheme is accepted — notebook cell URIs are resolved
+        // to notebook paths inside get_type_at_position.
+        parse_uri(params.uri())?;
         let position = params.position();
         let ty = self
             .inner

--- a/pyrefly/lib/tsp/requests/get_python_search_paths.rs
+++ b/pyrefly/lib/tsp/requests/get_python_search_paths.rs
@@ -12,12 +12,13 @@
 //! search paths, inferred import roots, and site-packages directories.
 
 use lsp_server::RequestId;
+use lsp_types::Url;
 use tsp_types::protocol::GetPythonSearchPathsParams;
 
 use crate::lsp::non_wasm::server::TspInterface;
 use crate::tsp::server::TspServer;
 use crate::tsp::validation::internal_error;
-use crate::tsp::validation::parse_file_uri;
+use crate::tsp::validation::parse_uri;
 
 impl<T: TspInterface> TspServer<T> {
     /// Handle a `typeServer/getPythonSearchPaths` request.
@@ -25,6 +26,9 @@ impl<T: TspInterface> TspServer<T> {
     /// Validates the snapshot, parses the `from_uri`, and delegates to
     /// [`TspInterface::get_python_search_paths`] to collect the ordered
     /// list of directories used for import resolution.
+    ///
+    /// For notebook cell URIs, resolves to the parent notebook's filesystem
+    /// path so that search paths reflect the notebook's project context.
     pub fn handle_get_python_search_paths(
         &self,
         id: RequestId,
@@ -36,42 +40,61 @@ impl<T: TspInterface> TspServer<T> {
             return;
         }
 
-        // --- 2. Parse from_uri and delegate ---
-        match parse_file_uri(&params.from_uri) {
-            Ok(url) => match self.inner.get_python_search_paths(&url) {
-                Ok(paths) => self.send_ok(id, paths),
-                Err(detail) => self.send_err(id, internal_error(&detail)),
-            },
+        // --- 2. Parse and resolve from_uri ---
+        let url = match parse_uri(&params.from_uri) {
+            Ok(url) => url,
             Err(err) => {
                 self.send_err(id, err);
+                return;
             }
+        };
+
+        // For non-file URIs (e.g. notebook cells), resolve to the parent
+        // notebook's filesystem path so we return the right search paths.
+        let resolved_url = if url.scheme() != "file" {
+            match self
+                .inner
+                .resolve_uri_to_path(&url)
+                .and_then(|p| Url::from_file_path(p).ok())
+            {
+                Some(file_url) => file_url,
+                None => {
+                    // Cannot resolve to a filesystem path — return empty list.
+                    self.send_ok::<Vec<String>>(id, vec![]);
+                    return;
+                }
+            }
+        } else {
+            url
+        };
+
+        match self.inner.get_python_search_paths(&resolved_url) {
+            Ok(paths) => self.send_ok(id, paths),
+            Err(detail) => self.send_err(id, internal_error(&detail)),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::tsp::validation::parse_file_uri;
-
-    // --- parse_file_uri unit tests (exercised via this module) ---
+    use crate::tsp::validation::parse_uri;
 
     #[test]
     fn test_valid_file_uri() {
-        let url = parse_file_uri("file:///home/user/project/main.py").unwrap();
+        let url = parse_uri("file:///home/user/project/main.py").unwrap();
         assert_eq!(url.scheme(), "file");
     }
 
     #[test]
     fn test_valid_file_uri_windows_style() {
-        let url = parse_file_uri("file:///C:/Users/test/project/main.py").unwrap();
+        let url = parse_uri("file:///C:/Users/test/project/main.py").unwrap();
         assert_eq!(url.scheme(), "file");
-        // Should be convertible to a file path
         assert!(url.to_file_path().is_ok());
     }
 
     #[test]
     fn test_empty_uri_is_error() {
-        let result = parse_file_uri("");
+        let result = parse_uri("");
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.message.contains("not valid"));
@@ -79,38 +102,20 @@ mod tests {
 
     #[test]
     fn test_relative_path_is_error() {
-        // A bare path without a scheme is not a valid URI
-        let result = parse_file_uri("some/path/main.py");
-        assert!(result.is_err());
+        assert!(parse_uri("some/path/main.py").is_err());
     }
 
     #[test]
-    fn test_http_scheme_is_error() {
-        let result = parse_file_uri("http://example.com/main.py");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.message.contains("file://"));
-    }
-
-    #[test]
-    fn test_https_scheme_is_error() {
-        let result = parse_file_uri("https://example.com/main.py");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.message.contains("file://"));
-    }
-
-    #[test]
-    fn test_untitled_scheme_is_error() {
-        let result = parse_file_uri("untitled:Untitled-1");
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.message.contains("file://"));
+    fn test_notebook_cell_uri_is_valid() {
+        let url =
+            parse_uri("vscode-notebook-cell:/Users/kylei/projects/test/test.ipynb#W0sZmlsZQ%3D%3D")
+                .unwrap();
+        assert_eq!(url.scheme(), "vscode-notebook-cell");
     }
 
     #[test]
     fn test_uri_with_spaces_encoded() {
-        let url = parse_file_uri("file:///home/user/my%20project/main.py").unwrap();
+        let url = parse_uri("file:///home/user/my%20project/main.py").unwrap();
         assert_eq!(url.scheme(), "file");
     }
 }

--- a/pyrefly/lib/tsp/requests/resolve_import.rs
+++ b/pyrefly/lib/tsp/requests/resolve_import.rs
@@ -25,7 +25,7 @@ use crate::lsp::non_wasm::server::TspInterface;
 use crate::lsp::non_wasm::transaction_manager::TransactionManager;
 use crate::tsp::server::TspServer;
 use crate::tsp::validation::invalid_params_error;
-use crate::tsp::validation::parse_file_uri;
+use crate::tsp::validation::parse_uri;
 
 impl<T: TspInterface> TspServer<T> {
     /// Handle a `typeServer/resolveImport` request.
@@ -46,18 +46,19 @@ impl<T: TspInterface> TspServer<T> {
             return;
         }
 
-        // --- 2. Parse source URI ---
-        let source_url = match parse_file_uri(&params.source_uri) {
+        // --- 2. Parse and resolve source URI ---
+        let source_url = match parse_uri(&params.source_uri) {
             Ok(url) => url,
             Err(err) => {
                 self.send_err(id, err);
                 return;
             }
         };
-        let source_path = match source_url.to_file_path() {
-            Ok(p) => p,
-            Err(_) => {
-                self.send_err(id, invalid_params_error("sourceUri is not a file:// URI"));
+        let source_path = match self.inner.resolve_uri_to_path(&source_url) {
+            Some(p) => p,
+            None => {
+                // URI cannot be resolved to a filesystem path — return null.
+                self.send_ok::<Option<String>>(id, None);
                 return;
             }
         };

--- a/pyrefly/lib/tsp/validation.rs
+++ b/pyrefly/lib/tsp/validation.rs
@@ -66,20 +66,13 @@ pub fn internal_error(detail: &str) -> ResponseError {
 // URI parsing
 // ---------------------------------------------------------------------------
 
-/// Parse and validate a `file://` URI string.
+/// Parse a URI string, rejecting only malformed/unparseable input.
 ///
-/// Accepts a URI string and returns a validated [`Url`] that must have a
-/// `file` scheme.  Returns an `InvalidParams` error if the URI is malformed
-/// or uses a non-file scheme.
-///
-/// This is the canonical validation entrypoint for any TSP parameter that
-/// accepts a file URI (e.g. `sourceUri`, `fromUri`).
-pub fn parse_file_uri(uri: &str) -> Result<Url, ResponseError> {
-    let url = Url::parse(uri).map_err(|_| invalid_params_error("URI is not valid"))?;
-    if url.scheme() != "file" {
-        return Err(invalid_params_error("URI must use the file:// scheme"));
-    }
-    Ok(url)
+/// Returns the parsed [`Url`] for any valid URI regardless of scheme.
+/// Use this when the handler can resolve non-file URIs (e.g. notebook
+/// cell URIs) via [`TspInterface::resolve_uri_to_path`].
+pub fn parse_uri(uri: &str) -> Result<Url, ResponseError> {
+    Url::parse(uri).map_err(|_| invalid_params_error("URI is not valid"))
 }
 
 // ---------------------------------------------------------------------------
@@ -175,27 +168,41 @@ mod tests {
         assert_ne!(params, internal);
     }
 
-    // --- parse_file_uri unit tests ---
+    // --- parse_uri unit tests ---
 
     #[test]
-    fn test_parse_file_uri_valid() {
-        let url = parse_file_uri("file:///home/user/project/main.py").unwrap();
+    fn test_parse_uri_file() {
+        let url = parse_uri("file:///home/user/project/main.py").unwrap();
         assert_eq!(url.scheme(), "file");
     }
 
     #[test]
-    fn test_parse_file_uri_empty_is_error() {
-        assert!(parse_file_uri("").is_err());
+    fn test_parse_uri_notebook_cell() {
+        let url =
+            parse_uri("vscode-notebook-cell:/Users/kylei/projects/test/test.ipynb#W0sZmlsZQ%3D%3D")
+                .unwrap();
+        assert_eq!(url.scheme(), "vscode-notebook-cell");
     }
 
     #[test]
-    fn test_parse_file_uri_http_is_error() {
-        let err = parse_file_uri("http://example.com").unwrap_err();
-        assert!(err.message.contains("file://"));
+    fn test_parse_uri_empty_is_error() {
+        assert!(parse_uri("").is_err());
     }
 
     #[test]
-    fn test_parse_file_uri_relative_path_is_error() {
-        assert!(parse_file_uri("some/path").is_err());
+    fn test_parse_uri_relative_path_is_error() {
+        assert!(parse_uri("some/path").is_err());
+    }
+
+    #[test]
+    fn test_parse_uri_http() {
+        let url = parse_uri("http://example.com").unwrap();
+        assert_eq!(url.scheme(), "http");
+    }
+
+    #[test]
+    fn test_parse_uri_untitled() {
+        let url = parse_uri("untitled:Untitled-1").unwrap();
+        assert_eq!(url.scheme(), "untitled");
     }
 }


### PR DESCRIPTION
Summary:

Pyrefly's TSP server crashed when Pylance sent `vscode-notebook-cell:` URIs for Jupyter notebook cells, failing with "Invalid params: URI must use the file:// scheme".

The root cause was that `parse_file_uri` rejected any non-`file://` scheme as an error, and `get_type_at_position` called `url.to_file_path()` which fails for non-file schemes. Additionally, `get_type_at_position` hardcoded `notebook_cell: None`, so even if the URI were resolved, position offsets would be wrong for multi-cell notebooks.

This diff:
- Adds `parse_uri` which accepts any valid URI scheme (replacing `parse_file_uri` in all handlers)
- Adds `resolve_uri_to_path` and `maybe_get_cell_index` to `TspInterface`, leveraging the existing LSP notebook infrastructure (`open_notebook_cells`, `path_for_uri_or_notebook_cell`) that is already live inside the shared `Server` instance
- Updates all 5 TSP handlers (`resolveImport`, `getDeclaredType`, `getComputedType`, `getExpectedType`, `getPythonSearchPaths`) to resolve notebook cell URIs
- Fixes `get_type_at_position` to properly look up cell indices for position offsetting in multi-cell notebooks

Reviewed By: rchen152

Differential Revision: D102376882


