### PR TITLE
fix assert_type with metaclasses #3228

### DIFF
--- a/pyrefly/lib/alt/special_calls.rs
+++ b/pyrefly/lib/alt/special_calls.rs
@@ -57,7 +57,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 TypeFormContext::FunctionArgument,
                 errors,
             ));
-            if !self.is_equivalent(&a, &b) {
+            let matches_metaclass_instance = match (&a, &b) {
+                (Type::ClassDef(got), Type::ClassType(want)) => {
+                    !want.is_builtin("type") && self.type_order().has_metaclass(got, want)
+                }
+                (Type::Type(box Type::ClassType(got)), Type::ClassType(want)) => {
+                    !want.is_builtin("type")
+                        && self.type_order().has_metaclass(got.class_object(), want)
+                }
+                _ => false,
+            };
+            if matches_metaclass_instance || !self.is_equivalent(&a, &b) {
                 self.error(
                     errors,
                     range,

--- a/pyrefly/lib/alt/special_calls.rs
+++ b/pyrefly/lib/alt/special_calls.rs
@@ -57,17 +57,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 TypeFormContext::FunctionArgument,
                 errors,
             ));
-            let matches_metaclass_instance = match (&a, &b) {
-                (Type::ClassDef(got), Type::ClassType(want)) => {
-                    !want.is_builtin("type") && self.type_order().has_metaclass(got, want)
-                }
-                (Type::Type(box Type::ClassType(got)), Type::ClassType(want)) => {
-                    !want.is_builtin("type")
-                        && self.type_order().has_metaclass(got.class_object(), want)
-                }
-                _ => false,
-            };
-            if matches_metaclass_instance || !self.is_equivalent(&a, &b) {
+            if !self.is_equivalent(&a, &b) {
                 self.error(
                     errors,
                     range,

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -2224,6 +2224,28 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                     .mk_class_type(self.type_order.stdlib().builtins_type().clone()),
                 want,
             ),
+            (Type::ClassType(class), Type::Type(want))
+                if class != self.type_order.stdlib().builtins_type()
+                    && let Some(got_as_type) = self.type_order.as_superclass(
+                        class,
+                        self.type_order.stdlib().builtins_type().class_object(),
+                    )
+                    && got_as_type.targs().is_empty()
+                    && !(want.is_any()
+                        || matches!(want.as_ref(), Type::ClassType(cls) if cls.is_builtin("object"))) =>
+            {
+                Err(SubsetError::Other)
+            }
+            (Type::ClassType(class), Type::ClassDef(_))
+                if class != self.type_order.stdlib().builtins_type()
+                    && let Some(got_as_type) = self.type_order.as_superclass(
+                        class,
+                        self.type_order.stdlib().builtins_type().class_object(),
+                    )
+                    && got_as_type.targs().is_empty() =>
+            {
+                Err(SubsetError::Other)
+            }
             (
                 Type::ClassType(class),
                 Type::Type(_)

--- a/pyrefly/lib/test/class_subtyping.rs
+++ b/pyrefly/lib/test/class_subtyping.rs
@@ -60,6 +60,18 @@ b: type[B] = A  # E: `type[A]` is not assignable to `type[B]`
 );
 
 testcase!(
+    test_metaclass_instance_not_subtype_of_specific_type,
+    r#"
+class Meta(type): pass
+class A(metaclass=Meta): pass
+
+def f(x: Meta):
+    a: type[A] = x  # E: `Meta` is not assignable to `type[A]`
+    o: type[object] = x
+"#,
+);
+
+testcase!(
     test_generic_class_object_subtyping,
     r#"
 class A[T]: pass
@@ -172,7 +184,8 @@ testcase!(
     r#"
 class A(type): pass
 def test(a: A):
-    x: type[int] = a
+    x: type[int] = a  # E: `A` is not assignable to `type[int]`
+    y: type[object] = a
 "#,
 );
 

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -1186,6 +1186,16 @@ assert_type(A, type[A])
 );
 
 testcase!(
+    test_assert_type_metaclass,
+    r#"
+from typing import assert_type
+class Meta(type): pass
+class A(metaclass=Meta): pass
+assert_type(A, Meta)  # E: assert_type(type[A], Meta) failed
+    "#,
+);
+
+testcase!(
     test_compare_int_str_error,
     r#"
 0 < "oops"  # E: Argument `Literal['oops']` is not assignable to parameter `value` with type `int`


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3228

assert_type no longer accepts a class object as exactly equal to its non-type metaclass.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test