### PR TITLE
[TSP] Add module uri to module tsp types

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -475,7 +475,7 @@ pub trait TspInterface: Send + Sync {
         func_id: &pyrefly_types::callable::FuncId,
     ) -> Option<TextRange>;
 
-    /// Resolve an importable module to its backing file URI using the
+    /// Resolve an importable module to its backing filesystem path using the
     /// import-resolution context of `source_uri`.
     ///
     /// Returns `None` when the source URI is invalid, cannot be mapped to a
@@ -484,7 +484,7 @@ pub trait TspInterface: Send + Sync {
         &self,
         source_uri: &str,
         module: &pyrefly_types::module::ModuleType,
-    ) -> Option<String>;
+    ) -> Option<PathBuf>;
 
     /// Resolve a URI to a filesystem path.
     ///
@@ -6327,7 +6327,7 @@ impl TspInterface for Server {
         &self,
         source_uri: &str,
         module: &pyrefly_types::module::ModuleType,
-    ) -> Option<String> {
+    ) -> Option<PathBuf> {
         let url = Url::parse(source_uri)
             .ok()
             .or_else(|| Url::from_file_path(source_uri).ok())?;
@@ -6341,9 +6341,7 @@ impl TspInterface for Server {
             .finding()?;
 
         let path = to_real_path(finding.path())?;
-        Url::from_file_path(path.canonicalize().unwrap_or(path))
-            .ok()
-            .map(|u| u.to_string())
+        Some(path.canonicalize().unwrap_or(path))
     }
 
     fn resolve_uri_to_path(&self, uri: &Url) -> Option<PathBuf> {

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -475,12 +475,16 @@ pub trait TspInterface: Send + Sync {
         func_id: &pyrefly_types::callable::FuncId,
     ) -> Option<TextRange>;
 
-    /// Resolve an importable module name to its backing file URI using the
+    /// Resolve an importable module to its backing file URI using the
     /// import-resolution context of `source_uri`.
     ///
     /// Returns `None` when the source URI is invalid, cannot be mapped to a
     /// path, or the target module cannot be resolved.
-    fn resolve_module_uri(&self, source_uri: &str, module_name: &str) -> Option<String>;
+    fn resolve_module_uri(
+        &self,
+        source_uri: &str,
+        module: &pyrefly_types::module::ModuleType,
+    ) -> Option<String>;
 
     /// Resolve a URI to a filesystem path.
     ///
@@ -6319,7 +6323,11 @@ impl TspInterface for Server {
         Some(bindings.get(idx).0.range())
     }
 
-    fn resolve_module_uri(&self, source_uri: &str, module_name: &str) -> Option<String> {
+    fn resolve_module_uri(
+        &self,
+        source_uri: &str,
+        module: &pyrefly_types::module::ModuleType,
+    ) -> Option<String> {
         let url = Url::parse(source_uri)
             .ok()
             .or_else(|| Url::from_file_path(source_uri).ok())?;
@@ -6327,7 +6335,7 @@ impl TspInterface for Server {
 
         let source_handle = make_open_handle(&self.state, &source_path);
         let transaction = self.state.transaction();
-        let module_name = ModuleName::from_str(module_name);
+        let module_name = ModuleName::from_str(&module.to_string());
         let finding = transaction
             .import_handle(&source_handle, module_name, None)
             .finding()?;

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -475,6 +475,13 @@ pub trait TspInterface: Send + Sync {
         func_id: &pyrefly_types::callable::FuncId,
     ) -> Option<TextRange>;
 
+    /// Resolve an importable module name to its backing file URI using the
+    /// import-resolution context of `source_uri`.
+    ///
+    /// Returns `None` when the source URI is invalid, cannot be mapped to a
+    /// path, or the target module cannot be resolved.
+    fn resolve_module_uri(&self, source_uri: &str, module_name: &str) -> Option<String>;
+
     /// Resolve a URI to a filesystem path.
     ///
     /// Handles both `file://` URIs (via [`Url::to_file_path`]) and notebook
@@ -6310,6 +6317,25 @@ impl TspInterface for Server {
         let key = KeyUndecoratedFunctionRange(def_index);
         let idx = bindings.key_to_idx_hashed_opt(Hashed::new(&key))?;
         Some(bindings.get(idx).0.range())
+    }
+
+    fn resolve_module_uri(&self, source_uri: &str, module_name: &str) -> Option<String> {
+        let url = Url::parse(source_uri)
+            .ok()
+            .or_else(|| Url::from_file_path(source_uri).ok())?;
+        let source_path = self.path_for_uri_or_notebook_cell(&url)?;
+
+        let source_handle = make_open_handle(&self.state, &source_path);
+        let transaction = self.state.transaction();
+        let module_name = ModuleName::from_str(module_name);
+        let finding = transaction
+            .import_handle(&source_handle, module_name, None)
+            .finding()?;
+
+        let path = to_real_path(finding.path())?;
+        Url::from_file_path(path.canonicalize().unwrap_or(path))
+            .ok()
+            .map(|u| u.to_string())
     }
 
     fn resolve_uri_to_path(&self, uri: &Url) -> Option<PathBuf> {

--- a/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
@@ -444,6 +444,40 @@ fn test_get_computed_type_module_import() {
 }
 
 #[test]
+fn test_get_computed_type_module_import_includes_package_init_uri() {
+    let temp_dir = TempDir::new().unwrap();
+    write_pyproject(temp_dir.path());
+
+    let package_dir = temp_dir.path().join("pkg");
+    std::fs::create_dir_all(&package_dir).unwrap();
+    std::fs::write(package_dir.join("__init__.pyi"), "value: int\n").unwrap();
+
+    let test_file = temp_dir.path().join("main.py");
+    std::fs::write(&test_file, "import pkg\npkg\n").unwrap();
+
+    let mut tsp = TspInteraction::new();
+    tsp.set_root(temp_dir.path().to_path_buf());
+    tsp.initialize(Default::default());
+
+    tsp.server.did_open("main.py");
+    tsp.client.expect_any_message();
+
+    let snapshot = get_current_snapshot(&mut tsp, 2);
+    let file_uri = Url::from_file_path(&test_file).unwrap().to_string();
+
+    let result = get_computed_type_ok(&mut tsp, &file_uri, 1, 0, snapshot);
+    assert_kind(&result, TypeKind::Module);
+
+    let uri = result.get("uri").and_then(|v| v.as_str());
+    assert!(
+        uri.is_some_and(|u| u.contains("pkg/__init__.pyi") || u.contains("pkg\\__init__.pyi")),
+        "Expected package module URI to point at __init__.pyi, got: {uri:?}"
+    );
+
+    tsp.shutdown();
+}
+
+#[test]
 fn test_get_computed_type_bound_method_is_function() {
     // `m = x.append` — querying `m` (position 0 on line 1) gives bound method type
     let (mut tsp, file_uri, snapshot) = setup_project("x = [1, 2]\nm = x.append\n");

--- a/pyrefly/lib/tsp/requests/get_computed_type.rs
+++ b/pyrefly/lib/tsp/requests/get_computed_type.rs
@@ -34,6 +34,6 @@ impl<T: TspInterface> TspServer<T> {
         let ty = self
             .inner
             .get_type_at_position(params.uri(), position.line, position.character);
-        Ok(ty.map(|t| self.convert_type(&t)))
+        Ok(ty.map(|t| self.convert_type(&t, Some(params.uri()))))
     }
 }

--- a/pyrefly/lib/tsp/requests/get_declared_type.rs
+++ b/pyrefly/lib/tsp/requests/get_declared_type.rs
@@ -38,6 +38,6 @@ impl<T: TspInterface> TspServer<T> {
         let ty = self
             .inner
             .get_type_at_position(params.uri(), position.line, position.character);
-        Ok(ty.map(|t| self.convert_type(&t)))
+        Ok(ty.map(|t| self.convert_type(&t, Some(params.uri()))))
     }
 }

--- a/pyrefly/lib/tsp/requests/get_expected_type.rs
+++ b/pyrefly/lib/tsp/requests/get_expected_type.rs
@@ -38,6 +38,6 @@ impl<T: TspInterface> TspServer<T> {
         let ty = self
             .inner
             .get_type_at_position(params.uri(), position.line, position.character);
-        Ok(ty.map(|t| self.convert_type(&t)))
+        Ok(ty.map(|t| self.convert_type(&t, Some(params.uri()))))
     }
 }

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -60,10 +60,10 @@ impl<T: TspInterface> TspServer<T> {
     ) -> tsp_types::Type {
         let resolver =
             |func_id: &pyrefly_types::callable::FuncId| self.inner.resolve_func_def_range(func_id);
-        let module_uri_resolver = |module: &pyrefly_types::module::ModuleType| {
+        let module_path_resolver = |module: &pyrefly_types::module::ModuleType| {
             source_uri.and_then(|uri| self.inner.resolve_module_uri(uri, module))
         };
-        convert_type_with_resolvers(ty, Some(&resolver), Some(&module_uri_resolver))
+        convert_type_with_resolvers(ty, Some(&resolver), Some(&module_path_resolver))
     }
 
     pub fn process_event<'a>(

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -34,7 +34,7 @@ use crate::lsp::non_wasm::server::ServerCapabilitiesWithTypeHierarchy;
 use crate::lsp::non_wasm::server::TspInterface;
 use crate::lsp::non_wasm::server::capabilities;
 use crate::lsp::non_wasm::transaction_manager::TransactionManager;
-use crate::tsp::type_conversion::convert_type_with_resolver;
+use crate::tsp::type_conversion::convert_type_with_resolvers;
 
 /// TSP server that delegates to LSP server infrastructure while handling only TSP requests
 pub struct TspServer<T: TspInterface> {
@@ -53,10 +53,17 @@ impl<T: TspInterface> TspServer<T> {
 
     /// Convert a pyrefly `Type` to a TSP protocol `Type`, resolving function
     /// declaration ranges via the binding table.
-    pub(crate) fn convert_type(&self, ty: &pyrefly_types::types::Type) -> tsp_types::Type {
+    pub(crate) fn convert_type(
+        &self,
+        ty: &pyrefly_types::types::Type,
+        source_uri: Option<&str>,
+    ) -> tsp_types::Type {
         let resolver =
             |func_id: &pyrefly_types::callable::FuncId| self.inner.resolve_func_def_range(func_id);
-        convert_type_with_resolver(ty, &resolver)
+        let module_uri_resolver = |module_name: &str| {
+            source_uri.and_then(|uri| self.inner.resolve_module_uri(uri, module_name))
+        };
+        convert_type_with_resolvers(ty, Some(&resolver), Some(&module_uri_resolver))
     }
 
     pub fn process_event<'a>(

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -60,8 +60,8 @@ impl<T: TspInterface> TspServer<T> {
     ) -> tsp_types::Type {
         let resolver =
             |func_id: &pyrefly_types::callable::FuncId| self.inner.resolve_func_def_range(func_id);
-        let module_uri_resolver = |module_name: &str| {
-            source_uri.and_then(|uri| self.inner.resolve_module_uri(uri, module_name))
+        let module_uri_resolver = |module: &pyrefly_types::module::ModuleType| {
+            source_uri.and_then(|uri| self.inner.resolve_module_uri(uri, module))
         };
         convert_type_with_resolvers(ty, Some(&resolver), Some(&module_uri_resolver))
     }

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -83,7 +83,7 @@ pub type FuncRangeResolver<'a> = dyn Fn(&FuncId) -> Option<TextRange> + 'a;
 
 /// Callback that resolves a module name (e.g. `pkg.subpkg`) to a canonical
 /// file URI for that module (preferably package `__init__.py[i]` for packages).
-pub type ModuleUriResolver<'a> = dyn Fn(&str) -> Option<String> + 'a;
+pub type ModuleUriResolver<'a> = dyn Fn(&pyrefly_types::module::ModuleType) -> Option<String> + 'a;
 
 /// Convert a pyrefly `Type` to a TSP protocol `Type` using optional
 /// source-range and module-URI resolvers.
@@ -175,7 +175,7 @@ impl TypeConverter<'_> {
                 let module_name = m.to_string();
                 let uri = self
                     .resolve_module_uri
-                    .and_then(|resolve| resolve(module_name.as_str()))
+                    .and_then(|resolve| resolve(m))
                     .unwrap_or_default();
                 TspType::Module(TspModuleType {
                     flags: TypeFlags::NONE,
@@ -996,8 +996,8 @@ mod tests {
     #[test]
     fn test_convert_module_with_resolver_sets_uri() {
         let ty = PyreflyType::Module(ModuleType::new_as(ModuleName::from_str("pkg")));
-        let module_uri_resolver = |module_name: &str| {
-            if module_name == "pkg" {
+        let module_uri_resolver = |module: &ModuleType| {
+            if module.to_string() == "pkg" {
                 Some("file:///repo/pkg/__init__.pyi".to_owned())
             } else {
                 None

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -665,6 +665,8 @@ fn builtin(name: &str) -> TspType {
 
 #[cfg(test)]
 mod tests {
+    use pyrefly_types::lit_int::LitInt;
+    use pyrefly_types::literal::Lit;
     use pyrefly_python::module_name::ModuleName;
     use pyrefly_types::module::ModuleType;
     use pyrefly_types::types::AnyStyle;
@@ -1013,7 +1015,7 @@ mod tests {
 
     #[test]
     fn test_convert_literal_int_uses_builtins_uri() {
-        let ty = PyreflyType::Literal(pyrefly_types::literal::Literal::int(7));
+        let ty = Lit::Int(LitInt::new(7)).to_implicit_type();
         let tsp = convert_type(&ty);
         match tsp {
             TspType::Class(c) => {

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -32,6 +32,7 @@
 use std::sync::Arc;
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::Ordering;
+use std::path::PathBuf;
 
 use lsp_types::Url;
 use pyrefly_types::callable::Callable;
@@ -80,34 +81,38 @@ fn next_id() -> i32 {
 /// `FuncDefIndex`, avoiding the need to store ranges on every `FuncId`.
 pub type FuncRangeResolver<'a> = dyn Fn(&FuncId) -> Option<TextRange> + 'a;
 
-/// Convert a pyrefly `Type` to a TSP protocol `Type`.
-///
-/// Function declarations will have zero-range nodes since no binding
-/// resolver is available. Use [`convert_type_with_resolver`] when source
-/// locations are needed.
-#[cfg(test)]
-pub fn convert_type(ty: &PyreflyType) -> TspType {
+/// Callback that resolves a module name (e.g. `pkg.subpkg`) to a canonical
+/// file URI for that module (preferably package `__init__.py[i]` for packages).
+pub type ModuleUriResolver<'a> = dyn Fn(&str) -> Option<String> + 'a;
+
+/// Convert a pyrefly `Type` to a TSP protocol `Type` using optional
+/// source-range and module-URI resolvers.
+pub fn convert_type_with_resolvers<'a>(
+    ty: &PyreflyType,
+    func_range_resolver: Option<&'a FuncRangeResolver<'a>>,
+    module_uri_resolver: Option<&'a ModuleUriResolver<'a>>,
+) -> TspType {
     TypeConverter {
-        resolve_func_range: None,
+        resolve_func_range: func_range_resolver,
+        resolve_module_uri: module_uri_resolver,
     }
     .convert(ty)
 }
 
-/// Convert a pyrefly `Type` to a TSP protocol `Type`, using `resolver` to
-/// look up function declaration source ranges from `FuncDefIndex`.
-pub fn convert_type_with_resolver<'a>(
-    ty: &PyreflyType,
-    resolver: &'a FuncRangeResolver<'a>,
-) -> TspType {
-    TypeConverter {
-        resolve_func_range: Some(resolver),
-    }
-    .convert(ty)
+/// Convert a pyrefly `Type` to a TSP protocol `Type`.
+///
+/// Function declarations will have zero-range nodes since no binding
+/// resolver is available. Use [`convert_type_with_resolvers`] when source
+/// locations are needed.
+#[cfg(test)]
+pub fn convert_type(ty: &PyreflyType) -> TspType {
+    convert_type_with_resolvers(ty, None, None)
 }
 
 /// Holds an optional range resolver and drives recursive type conversion.
 struct TypeConverter<'a> {
     resolve_func_range: Option<&'a FuncRangeResolver<'a>>,
+    resolve_module_uri: Option<&'a ModuleUriResolver<'a>>,
 }
 
 impl TypeConverter<'_> {
@@ -166,14 +171,21 @@ impl TypeConverter<'_> {
             }
 
             // --- Modules ---
-            PyreflyType::Module(m) => TspType::Module(TspModuleType {
-                flags: TypeFlags::NONE,
-                id: next_id(),
-                kind: TypeKind::Module,
-                module_name: m.to_string(),
-                type_alias_info: None,
-                uri: String::new(),
-            }),
+            PyreflyType::Module(m) => {
+                let module_name = m.to_string();
+                let uri = self
+                    .resolve_module_uri
+                    .and_then(|resolve| resolve(module_name.as_str()))
+                    .unwrap_or_default();
+                TspType::Module(TspModuleType {
+                    flags: TypeFlags::NONE,
+                    id: next_id(),
+                    kind: TypeKind::Module,
+                    module_name,
+                    type_alias_info: None,
+                    uri,
+                })
+            }
 
             // --- TypedDicts are instances of their class ---
             PyreflyType::TypedDict(td) | PyreflyType::PartialTypedDict(td) => {
@@ -510,15 +522,7 @@ fn convert_literal(lit: &pyrefly_types::literal::Literal) -> TspType {
             };
             if let Some(lv) = literal_value {
                 TspType::Class(TspClassType {
-                    declaration: Declaration::Regular(RegularDeclaration {
-                        kind: DeclarationKind::Regular,
-                        category: DeclarationCategory::Class,
-                        name: Some(class_name.to_owned()),
-                        node: Node {
-                            range: zero_range(),
-                            uri: String::new(),
-                        },
-                    }),
+                    declaration: Declaration::Regular(make_builtin_class_declaration(class_name)),
                     flags: TypeFlags::INSTANCE.with_literal(),
                     id: next_id(),
                     kind: TypeKind::Class,
@@ -542,6 +546,22 @@ fn convert_literal(lit: &pyrefly_types::literal::Literal) -> TspType {
                 })
             }
         }
+    }
+}
+
+/// Build a declaration for a class in `builtins.pyi`.
+fn make_builtin_class_declaration(name: &str) -> RegularDeclaration {
+    let module_path = pyrefly_python::module_path::ModulePath::bundled_typeshed(PathBuf::from(
+        "builtins.pyi",
+    ));
+    RegularDeclaration {
+        kind: DeclarationKind::Regular,
+        category: DeclarationCategory::Class,
+        name: Some(name.to_owned()),
+        node: Node {
+            range: zero_range(),
+            uri: path_to_uri(&module_path),
+        },
     }
 }
 
@@ -646,6 +666,8 @@ fn builtin(name: &str) -> TspType {
 
 #[cfg(test)]
 mod tests {
+    use pyrefly_python::module_name::ModuleName;
+    use pyrefly_types::module::ModuleType;
     use pyrefly_types::types::AnyStyle;
     use pyrefly_types::types::NeverStyle;
     use pyrefly_types::types::Type as PyreflyType;
@@ -954,6 +976,59 @@ mod tests {
         match tsp {
             TspType::BuiltInType(b) => assert_eq!(b.name, "any"),
             other => panic!("expected BuiltInType pass-through, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_convert_module_without_resolver_has_empty_uri() {
+        let ty = PyreflyType::Module(ModuleType::new_as(ModuleName::from_str("pkg")));
+        let tsp = convert_type(&ty);
+        match tsp {
+            TspType::Module(m) => {
+                assert_eq!(m.module_name, "pkg");
+                assert_eq!(m.uri, "");
+            }
+            other => panic!("expected ModuleType, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_convert_module_with_resolver_sets_uri() {
+        let ty = PyreflyType::Module(ModuleType::new_as(ModuleName::from_str("pkg")));
+        let module_uri_resolver = |module_name: &str| {
+            if module_name == "pkg" {
+                Some("file:///repo/pkg/__init__.pyi".to_owned())
+            } else {
+                None
+            }
+        };
+        let tsp = convert_type_with_resolvers(&ty, None, Some(&module_uri_resolver));
+        match tsp {
+            TspType::Module(m) => {
+                assert_eq!(m.module_name, "pkg");
+                assert_eq!(m.uri, "file:///repo/pkg/__init__.pyi");
+            }
+            other => panic!("expected ModuleType, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_convert_literal_int_uses_builtins_uri() {
+        let ty = PyreflyType::Literal(pyrefly_types::literal::Literal::int(7));
+        let tsp = convert_type(&ty);
+        match tsp {
+            TspType::Class(c) => {
+                let Declaration::Regular(decl) = c.declaration else {
+                    panic!("expected RegularDeclaration");
+                };
+                assert_eq!(decl.name.as_deref(), Some("int"));
+                assert!(
+                    decl.node.uri.contains("builtins.pyi"),
+                    "expected builtins URI, got {}",
+                    decl.node.uri
+                );
+            }
+            other => panic!("expected Class type, got {other:?}"),
         }
     }
 }

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -29,10 +29,10 @@
 //! All `Type` variants are explicitly handled; no types fall through to a
 //! generic `SynthesizedType` stub.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::Ordering;
-use std::path::PathBuf;
 
 use lsp_types::Url;
 use pyrefly_types::callable::Callable;
@@ -551,9 +551,8 @@ fn convert_literal(lit: &pyrefly_types::literal::Literal) -> TspType {
 
 /// Build a declaration for a class in `builtins.pyi`.
 fn make_builtin_class_declaration(name: &str) -> RegularDeclaration {
-    let module_path = pyrefly_python::module_path::ModulePath::bundled_typeshed(PathBuf::from(
-        "builtins.pyi",
-    ));
+    let module_path =
+        pyrefly_python::module_path::ModulePath::bundled_typeshed(PathBuf::from("builtins.pyi"));
     RegularDeclaration {
         kind: DeclarationKind::Regular,
         category: DeclarationCategory::Class,

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -82,19 +82,21 @@ fn next_id() -> i32 {
 pub type FuncRangeResolver<'a> = dyn Fn(&FuncId) -> Option<TextRange> + 'a;
 
 /// Callback that resolves a module name (e.g. `pkg.subpkg`) to a canonical
-/// file URI for that module (preferably package `__init__.py[i]` for packages).
-pub type ModuleUriResolver<'a> = dyn Fn(&pyrefly_types::module::ModuleType) -> Option<String> + 'a;
+/// filesystem path for that module (preferably package `__init__.py[i]` for
+/// packages).
+pub type ModulePathResolver<'a> =
+    dyn Fn(&pyrefly_types::module::ModuleType) -> Option<PathBuf> + 'a;
 
 /// Convert a pyrefly `Type` to a TSP protocol `Type` using optional
 /// source-range and module-URI resolvers.
 pub fn convert_type_with_resolvers<'a>(
     ty: &PyreflyType,
     func_range_resolver: Option<&'a FuncRangeResolver<'a>>,
-    module_uri_resolver: Option<&'a ModuleUriResolver<'a>>,
+    module_path_resolver: Option<&'a ModulePathResolver<'a>>,
 ) -> TspType {
     TypeConverter {
         resolve_func_range: func_range_resolver,
-        resolve_module_uri: module_uri_resolver,
+        resolve_module_path: module_path_resolver,
     }
     .convert(ty)
 }
@@ -112,7 +114,7 @@ pub fn convert_type(ty: &PyreflyType) -> TspType {
 /// Holds an optional range resolver and drives recursive type conversion.
 struct TypeConverter<'a> {
     resolve_func_range: Option<&'a FuncRangeResolver<'a>>,
-    resolve_module_uri: Option<&'a ModuleUriResolver<'a>>,
+    resolve_module_path: Option<&'a ModulePathResolver<'a>>,
 }
 
 impl TypeConverter<'_> {
@@ -174,8 +176,9 @@ impl TypeConverter<'_> {
             PyreflyType::Module(m) => {
                 let module_name = m.to_string();
                 let uri = self
-                    .resolve_module_uri
+                    .resolve_module_path
                     .and_then(|resolve| resolve(m))
+                    .map(|path| path_buf_to_uri(&path))
                     .unwrap_or_default();
                 TspType::Module(TspModuleType {
                     flags: TypeFlags::NONE,
@@ -622,6 +625,12 @@ fn path_to_uri(module_path: &pyrefly_python::module_path::ModulePath) -> String 
     }
 }
 
+/// Convert a local filesystem path to a URI string.
+fn path_buf_to_uri(path: &std::path::Path) -> String {
+    Url::from_file_path(path)
+        .map_or_else(|()| path.to_string_lossy().to_string(), |u| u.to_string())
+}
+
 /// Convert an `lsp_types::Range` to a TSP `Range`.
 fn lsp_range_to_tsp(r: lsp_types::Range) -> TspRange {
     TspRange {
@@ -996,18 +1005,18 @@ mod tests {
     #[test]
     fn test_convert_module_with_resolver_sets_uri() {
         let ty = PyreflyType::Module(ModuleType::new_as(ModuleName::from_str("pkg")));
-        let module_uri_resolver = |module: &ModuleType| {
+        let module_path_resolver = |module: &ModuleType| {
             if module.to_string() == "pkg" {
-                Some("file:///repo/pkg/__init__.pyi".to_owned())
+                Some(PathBuf::from("/repo/pkg/__init__.pyi"))
             } else {
                 None
             }
         };
-        let tsp = convert_type_with_resolvers(&ty, None, Some(&module_uri_resolver));
+        let tsp = convert_type_with_resolvers(&ty, None, Some(&module_path_resolver));
         match tsp {
             TspType::Module(m) => {
                 assert_eq!(m.module_name, "pkg");
-                assert_eq!(m.uri, "file:///repo/pkg/__init__.pyi");
+                assert!(m.uri.contains("/repo/pkg/__init__.pyi"));
             }
             other => panic!("expected ModuleType, got {other:?}"),
         }

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -665,9 +665,9 @@ fn builtin(name: &str) -> TspType {
 
 #[cfg(test)]
 mod tests {
+    use pyrefly_python::module_name::ModuleName;
     use pyrefly_types::lit_int::LitInt;
     use pyrefly_types::literal::Lit;
-    use pyrefly_python::module_name::ModuleName;
     use pyrefly_types::module::ModuleType;
     use pyrefly_types::types::AnyStyle;
     use pyrefly_types::types::NeverStyle;


### PR DESCRIPTION
# Summary

As found in these two issues:
https://github.com/microsoft/pylance-release/issues/8013
https://github.com/microsoft/pylance-release/issues/7999

Pyrefly wasn't returning a URI for module types. This prevents Pylance from finding the actual module and prevents completions and other things from working.

Here's a picture of Pylance now showing completions for sys:

<img width="923" height="401" alt="image" src="https://github.com/user-attachments/assets/2737c948-6fae-41fa-86ea-1ea07d59d491" />

I also updated the 'literal' types to use the real builtins.

# Test Plan

Unit tests and manual test with Pylance.

/cc @kinto0 