### PR TITLE
Fix notebook cell index mismatch

### DIFF
--- a/crates/pyrefly_util/src/lined_buffer.rs
+++ b/crates/pyrefly_util/src/lined_buffer.rs
@@ -707,4 +707,86 @@ mod tests {
         let offset = lined_buffer.from_lsp_position(position, None);
         assert_eq!(offset, TextSize::new(contents.len() as u32));
     }
+
+    /// Bug: `LspNotebook::get_cell_index` returns an index among ALL cells
+    /// (code + markdown), but `Notebook::cell_offsets()` is indexed by valid
+    /// CODE cells only. When a notebook has markdown cells interspersed with
+    /// code cells, the all-cells index doesn't match the code-cell index,
+    /// causing `from_lsp_position` to resolve to the wrong offset or panic.
+    ///
+    /// For a notebook [code_0, markdown, code_1]:
+    ///   - `get_cell_index` returns 2 for code_1 (its position among all cells)
+    ///   - `cell_offsets` has 3 entries: [0, end_of_code_0, total_len]
+    ///   - `cell_offsets[2]` is the trailing sentinel (source length), not the
+    ///     start of code_1 — giving the wrong concatenated line
+    #[test]
+    fn test_from_lsp_position_notebook_cell_index_mismatch() {
+        use ruff_notebook::Cell;
+        use ruff_notebook::CellMetadata;
+        use ruff_notebook::CodeCell;
+        use ruff_notebook::MarkdownCell;
+        use ruff_notebook::Notebook;
+        use ruff_notebook::RawNotebook;
+        use ruff_notebook::RawNotebookMetadata;
+        use ruff_notebook::SourceValue;
+
+        let raw = RawNotebook {
+            cells: vec![
+                Cell::Code(CodeCell {
+                    execution_count: None,
+                    id: None,
+                    metadata: CellMetadata::default(),
+                    outputs: vec![],
+                    source: SourceValue::String("x = 1".to_owned()),
+                }),
+                Cell::Markdown(MarkdownCell {
+                    attachments: None,
+                    id: None,
+                    metadata: CellMetadata::default(),
+                    source: SourceValue::String("# heading".to_owned()),
+                }),
+                Cell::Code(CodeCell {
+                    execution_count: None,
+                    id: None,
+                    metadata: CellMetadata::default(),
+                    outputs: vec![],
+                    source: SourceValue::String("y = 2".to_owned()),
+                }),
+            ],
+            metadata: RawNotebookMetadata::default(),
+            nbformat: 4,
+            nbformat_minor: 5,
+        };
+        let notebook = Notebook::from_raw_notebook(raw, false).unwrap();
+        // source_code() concatenates only code cells: "x = 1\ny = 2\n"
+        let source = notebook.source_code().to_owned();
+        assert_eq!(source, "x = 1\ny = 2\n");
+        let lined_buffer = LinedBuffer::new(Arc::new(source.clone()));
+
+        let position = lsp_types::Position {
+            line: 0,
+            character: 0,
+        };
+
+        // Correct: code_1 is at code-cell index 1, so cell_offsets[1] points
+        // to the start of "y = 2".
+        let correct_offset = lined_buffer.from_lsp_position(position, Some((&notebook, 1)));
+        assert_eq!(correct_offset, TextSize::new(6)); // offset of 'y'
+        assert_eq!(
+            &source[correct_offset.to_usize()..correct_offset.to_usize() + 5],
+            "y = 2"
+        );
+
+        // If the all-cells index (2) were used instead of the code-cell index
+        // (1), cell_offsets[2] would be the trailing sentinel (12 = source
+        // length) and from_lsp_position would resolve to EOF. This is
+        // prevented by LspNotebook::get_cell_index translating to the
+        // code-cell index.
+        let wrong_offset = lined_buffer.from_lsp_position(position, Some((&notebook, 2)));
+        assert_ne!(
+            correct_offset, wrong_offset,
+            "all-cells index 2 must differ from code-cell index 1 — \
+             callers must translate via get_cell_index"
+        );
+    }
 }

--- a/pyrefly/lib/state/notebook.rs
+++ b/pyrefly/lib/state/notebook.rs
@@ -43,8 +43,25 @@ impl LspNotebook {
         &self.notebook_document
     }
 
+    /// Returns the code-cell index for a cell URL, i.e. the index among only
+    /// code cells. This matches the indexing used by `Notebook::cell_offsets()`.
+    /// Returns `None` if the URL is not found or the cell is not a code cell.
+    ///
+    /// Note: this uses `Cell::is_code_cell()` rather than ruff's internal
+    /// `is_valid_python_code_cell()` (which also excludes cell-magic and
+    /// non-Python cells) because the latter is not public. In practice the
+    /// two filters agree for typical Python notebooks.
     pub fn get_cell_index(&self, cell_url: &Url) -> Option<usize> {
-        self.cell_url_to_index.get(cell_url).copied()
+        let all_cells_idx = *self.cell_url_to_index.get(cell_url)?;
+        let cells = self.ruff_notebook.cells();
+        if !cells.get(all_cells_idx)?.is_code_cell() {
+            return None;
+        }
+        let code_cell_index = cells[..all_cells_idx]
+            .iter()
+            .filter(|c| c.is_code_cell())
+            .count();
+        Some(code_cell_index)
     }
 
     pub fn get_cell_url(&self, cell_index: usize) -> Option<&Url> {
@@ -67,5 +84,69 @@ impl LspNotebook {
 
     pub fn ruff_notebook(&self) -> &Arc<Notebook> {
         &self.ruff_notebook
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use lsp_types::Url;
+
+    use super::*;
+    use crate::lsp::wasm::notebook::NotebookCell;
+    use crate::lsp::wasm::notebook::NotebookCellKind;
+    use crate::lsp::wasm::notebook::NotebookDocument;
+
+    #[test]
+    fn test_get_cell_index_returns_code_cell_index() {
+        let cell0_url = Url::parse("vscode-notebook-cell://notebook/cell0").unwrap();
+        let cell1_url = Url::parse("vscode-notebook-cell://notebook/cell1").unwrap();
+        let cell2_url = Url::parse("vscode-notebook-cell://notebook/cell2").unwrap();
+
+        let notebook_doc = NotebookDocument {
+            uri: Url::parse("file:///notebook.ipynb").unwrap(),
+            notebook_type: "jupyter-notebook".to_owned(),
+            version: 1,
+            metadata: None,
+            cells: vec![
+                NotebookCell {
+                    kind: NotebookCellKind::Code,
+                    document: cell0_url.clone(),
+                    metadata: None,
+                    execution_summary: None,
+                },
+                NotebookCell {
+                    kind: NotebookCellKind::Markup,
+                    document: cell1_url.clone(),
+                    metadata: None,
+                    execution_summary: None,
+                },
+                NotebookCell {
+                    kind: NotebookCellKind::Code,
+                    document: cell2_url.clone(),
+                    metadata: None,
+                    execution_summary: None,
+                },
+            ],
+        };
+
+        let mut cell_content = HashMap::new();
+        cell_content.insert(cell0_url.clone(), "x = 1".to_owned());
+        cell_content.insert(cell1_url.clone(), "# heading".to_owned());
+        cell_content.insert(cell2_url.clone(), "y = 2".to_owned());
+
+        let ruff_notebook = notebook_doc
+            .clone()
+            .to_ruff_notebook(&cell_content)
+            .unwrap();
+        let lsp_notebook = LspNotebook::new(ruff_notebook, notebook_doc);
+
+        // First code cell (all-cells index 0) → code-cell index 0
+        assert_eq!(lsp_notebook.get_cell_index(&cell0_url), Some(0));
+        // Markdown cell → None (not a code cell)
+        assert_eq!(lsp_notebook.get_cell_index(&cell1_url), None);
+        // Second code cell (all-cells index 2) → code-cell index 1
+        assert_eq!(lsp_notebook.get_cell_index(&cell2_url), Some(1));
     }
 }


### PR DESCRIPTION
Summary:
LspNotebook::get_cell_index returned the index among all cells (code + markdown), but callers pass it to Notebook::cell_offsets() which is indexed by valid code cells only. For notebooks with markdown cells, this mismatch caused from_lsp_position to resolve to the wrong byte offset — or panic — because the all-cells index would hit the wrong entry in cell_offsets (e.g., the trailing sentinel instead of the target cell's start offset).

Fix get_cell_index to translate the all-cells index to a code-cell index by counting preceding code cells. Returns None for non-code cells.

Differential Revision: D102678315


