### PR TITLE
fix asyncio.to_thread always chooses the first overload. #3255

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1383,6 +1383,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     context,
                     hint,
                     ctor_targs,
+                    true,
                 )
                 .0
             }
@@ -1398,6 +1399,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     context,
                     hint,
                     ctor_targs,
+                    true,
                 )
                 .0
             }

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -36,6 +36,7 @@ use vec1::vec1;
 
 use crate::alt::answers::LookupAnswer;
 use crate::alt::answers_solver::AnswersSolver;
+use crate::alt::call::TargetWithTParams;
 use crate::alt::expr::TypeOrExpr;
 use crate::alt::solve::Iterable;
 use crate::alt::unwrap::HintRef;
@@ -55,6 +56,7 @@ use crate::types::callable::ParamList;
 use crate::types::callable::Params;
 use crate::types::callable::Required;
 use crate::types::quantified::Quantified;
+use crate::types::types::OverloadType;
 use crate::types::types::Type;
 use crate::types::types::Var;
 
@@ -391,6 +393,93 @@ impl CallArgPreEval<'_> {
         }
     }
 
+    /// For wrappers like `func: Callable[P, R], *args: P.args`, use the forwarded
+    /// arguments to pick an overload before checking `func` against `Callable[P, R]`.
+    fn post_check_overload_callable_paramspec<Ans: LookupAnswer>(
+        &mut self,
+        solver: &AnswersSolver<Ans>,
+        callable_name: Option<&FunctionKind>,
+        hint: &Type,
+        param_name: Option<&Name>,
+        paramspec: Option<Var>,
+        remaining_args: &[CallArg],
+        keywords: &[CallKeyword],
+        arguments_range: TextRange,
+        range: TextRange,
+        arg_errors: &ErrorCollector,
+        call_errors: &ErrorCollector,
+        context: Option<&dyn Fn() -> ErrorContext>,
+    ) -> Option<Type> {
+        let Type::Callable(box Callable {
+            params: Params::ParamSpec(prefix, Type::Var(want_paramspec)),
+            ..
+        }) = hint
+        else {
+            return None;
+        };
+        if !prefix.is_empty() || paramspec != Some(*want_paramspec) {
+            return None;
+        }
+
+        let got = match self {
+            Self::Type(ty, done) if matches!(ty, Type::Overload(_)) => {
+                *done = true;
+                (*ty).clone()
+            }
+            Self::Expr(expr @ (Expr::Name(_) | Expr::Attribute(_)), done) => {
+                let got = solver.expr_infer(expr, arg_errors);
+                if !matches!(got, Type::Overload(_)) {
+                    return None;
+                }
+                *done = true;
+                got
+            }
+            _ => return None,
+        };
+
+        let Type::Overload(overload) = &got else {
+            unreachable!("checked that the argument is an overload");
+        };
+        let overloads = overload
+            .signatures
+            .clone()
+            .mapped(|signature| match signature {
+                OverloadType::Function(function) => TargetWithTParams(None, function),
+                OverloadType::Forall(forall) => {
+                    TargetWithTParams(Some(forall.tparams), forall.body)
+                }
+            });
+        let silent_errors = solver.error_collector();
+        let (_, selected) = solver.call_overloads(
+            overloads,
+            &overload.metadata,
+            None,
+            remaining_args,
+            keywords,
+            arguments_range,
+            &silent_errors,
+            context,
+            None,
+            None,
+            false,
+        );
+        let tcc = &|| {
+            TypeCheckContext::of_kind(TypeCheckKind::CallArgument(
+                param_name.cloned(),
+                callable_name.cloned(),
+            ))
+            .with_context(context.map(|ctx| ctx()))
+        };
+        solver.check_type(
+            &solver.heap.mk_callable_from(selected),
+            hint,
+            range,
+            call_errors,
+            tcc,
+        );
+        Some(got)
+    }
+
     // Step the argument or mark it as done similar to `post_infer`, but without checking the type
     // Intended for arguments matched to unpack-annotated *args, which are typechecked separately later
     fn post_skip(&mut self) {
@@ -648,7 +737,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             };
             Ok(param_list_owner.push(ps).items().iter().rev().collect())
         };
-        for arg in self_arg.iter().chain(args.iter()) {
+        let positional_args = self_arg.iter().chain(args.iter()).collect::<Vec<_>>();
+        for (arg_idx, arg) in positional_args.iter().enumerate() {
             let mut arg_pre = arg.pre_eval(self, arg_errors);
             while arg_pre.step() {
                 let param = if let Some(p) = rparams.last() {
@@ -707,17 +797,39 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             seen_names.insert(name, ty);
                         }
                         expected_types.insert(arg.range(), ty.clone());
-                        let arg_ty = arg_pre.post_check(
-                            self,
-                            callable_name,
-                            ty,
-                            name,
-                            false,
-                            arg.range(),
-                            arg_errors,
-                            call_errors,
-                            context,
-                        );
+                        let remaining_args = if self_arg.is_some() {
+                            &args[arg_idx..]
+                        } else {
+                            &args[arg_idx + 1..]
+                        };
+                        let arg_ty = arg_pre
+                            .post_check_overload_callable_paramspec(
+                                self,
+                                callable_name,
+                                ty,
+                                name,
+                                paramspec,
+                                remaining_args,
+                                keywords,
+                                arguments_range,
+                                arg.range(),
+                                arg_errors,
+                                call_errors,
+                                context,
+                            )
+                            .or_else(|| {
+                                arg_pre.post_check(
+                                    self,
+                                    callable_name,
+                                    ty,
+                                    name,
+                                    false,
+                                    arg.range(),
+                                    arg_errors,
+                                    call_errors,
+                                    context,
+                                )
+                            });
                         if let Some(name) = name
                             && let Some(ty) = arg_ty
                         {

--- a/pyrefly/lib/alt/class/dataclass.rs
+++ b/pyrefly/lib/alt/class/dataclass.rs
@@ -651,6 +651,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 None,
                 None,
                 None,
+                true,
             )
             .1
         } else {

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -239,6 +239,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         hint: Option<HintRef>,
         // If we're constructing a class, its type arguments. A successful call will fill these in.
         ctor_targs: Option<&mut TArgs>,
+        record_trace: bool,
     ) -> (Type, Callable) {
         // There may be Expr values in args and keywords.
         // If we infer them for each overload, we may end up inferring them multiple times.
@@ -353,23 +354,25 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         {
             *targs = chosen_targs;
         }
-        // Record the closest overload to power IDE services.
-        let mut overload_trace = |target: &TargetWithTParams<Function>| {
-            let tparams = target
-                .0
-                .as_ref()
-                .filter(|tparams| !tparams.is_empty())
-                .cloned();
-            OverloadTrace::new(target.1.signature.clone(), tparams)
-        };
-        let all_overload_traces = overloads.iter().map(&mut overload_trace).collect();
-        let closest_overload_trace = overload_trace(closest_overload.func);
-        self.record_overload_trace(
-            arguments_range,
-            all_overload_traces,
-            closest_overload_trace,
-            matched,
-        );
+        if record_trace {
+            // Record the closest overload to power IDE services.
+            let mut overload_trace = |target: &TargetWithTParams<Function>| {
+                let tparams = target
+                    .0
+                    .as_ref()
+                    .filter(|tparams| !tparams.is_empty())
+                    .cloned();
+                OverloadTrace::new(target.1.signature.clone(), tparams)
+            };
+            let all_overload_traces = overloads.iter().map(&mut overload_trace).collect();
+            let closest_overload_trace = overload_trace(closest_overload.func);
+            self.record_overload_trace(
+                arguments_range,
+                all_overload_traces,
+                closest_overload_trace,
+                matched,
+            );
+        }
         if matched {
             // If the selected overload is deprecated, we log a deprecation error.
             if let Some(deprecation) = &closest_overload.func.1.metadata.flags.deprecation {

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -95,6 +95,24 @@ def test(o: P):
 );
 
 testcase!(
+    test_overload_through_paramspec_callable,
+    r#"
+import asyncio
+from typing import Any, Coroutine, assert_type, overload
+
+@overload
+def foo(x: int) -> int: ...
+@overload
+def foo(x: str) -> None: ...
+def foo(x: int | str) -> int | None:
+    return None
+
+assert_type(foo("str"), None)
+assert_type(asyncio.to_thread(foo, "str"), Coroutine[Any, Any, None])
+    "#,
+);
+
+testcase!(
     test_method,
     r#"
 from typing import assert_type, overload


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3255

 The change makes Callable[P, R] wrapper calls, like asyncio.to_thread(foo, "str"), select an overloaded foo using the forwarded P.args before pinning R.

I also added a no-trace mode for the synthetic overload selection so IDE overload traces are not polluted.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test