### PR TITLE
Symlink pyrefly/README.md to pyrefly/pyrefly/README.md

### DIFF
--- a/pyrefly/README.md
+++ b/pyrefly/README.md
@@ -1,14 +1,1 @@
-# Pyrefly
-
-Pyrefly is a type checker and language server for Python, which provides
-lightning-fast type checking along with IDE features such as code navigation,
-semantic highlighting, and code completion. It is available as a
-[command-line tool](https://pyrefly.org/en/docs/installation/) and a
-[VSCode extension](https://marketplace.visualstudio.com/items?itemName=meta.pyrefly).
-
-See the [Pyrefly website](https://pyrefly.org) for full documentation and how to
-add Pyrefly to your editor of choice.
-
-Currently under active development with known issues. Please
-[open an issue](https://github.com/facebook/pyrefly/issues/new/choose) if you
-find bugs.
+../README.md


### PR DESCRIPTION
Summary: We had a stub README.md in the inner pyrefly directory for pyproject.toml to pick up. Symlinking the LICENSE file (D98305784) seems to have worked, so let's try symlinking the real README.md as well.

Differential Revision: D103236976


