### PR TITLE
Fix false positive unbound-name for walrus operator in while condition (#3278)

### DIFF
--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -2136,6 +2136,28 @@ impl Scopes {
     /// Also updates base entries that are uninitialized (e.g. `x: int` with no
     /// assignment) when the branch has an initialized binding, so that the
     /// merge does not falsely report "may be uninitialized".
+    /// Propagate names introduced by walrus operators in a `while` condition
+    /// into the loop's base flow. The condition always executes at least once,
+    /// so these names are guaranteed to be defined after the loop.
+    pub fn propagate_new_flow_entries_to_loop_base(&mut self) {
+        let scope = self.current_mut();
+        let loop_ = scope
+            .loops
+            .last_mut()
+            .expect("propagate_new_flow_entries_to_loop_base called outside of a loop");
+        for (name, info) in scope.flow.info.iter() {
+            if let Some(existing) = loop_.base.info.get(name) {
+                if matches!(existing.initialized(), InitializedInFlow::No)
+                    && !matches!(info.initialized(), InitializedInFlow::No)
+                {
+                    loop_.base.info.insert(name.clone(), info.clone());
+                }
+            } else {
+                loop_.base.info.insert(name.clone(), info.clone());
+            }
+        }
+    }
+
     pub fn propagate_new_flow_entries_to_fork_base(&mut self) {
         let scope = self.current_mut();
         let fork = scope

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -961,6 +961,9 @@ impl<'a> BindingsBuilder<'a> {
                 // made in the loop (e.g. if we reassign the test variable).
                 // Typecheck the test condition during solving.
                 self.ensure_expr(&mut x.test, &mut Usage::Narrowing(None));
+                // The while condition always runs at least once, so walrus-defined
+                // names are guaranteed to be initialized after the loop.
+                self.scopes.propagate_new_flow_entries_to_loop_base();
                 let is_while_true = self.sys_info.evaluate_bool(&x.test) == Some(true);
                 let narrow_ops = NarrowOps::from_expr(self, Some(&x.test));
                 self.bind_narrow_ops(

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -1168,7 +1168,6 @@ def f():
 );
 
 testcase!(
-    bug = "walrus in while condition should not be flagged as uninitialized after loop",
     test_walrus_in_while_condition,
     r#"
 from typing import Callable, Any
@@ -1180,7 +1179,7 @@ class Cat:
 def main(f: Callable[[], Cat]) -> None:
     while (a := f()).equals(1):
         break
-    print(a)  # E: `a` may be uninitialized
+    print(a)
 "#,
 );
 

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -1168,6 +1168,23 @@ def f():
 );
 
 testcase!(
+    bug = "walrus in while condition should not be flagged as uninitialized after loop",
+    test_walrus_in_while_condition,
+    r#"
+from typing import Callable, Any
+
+class Cat:
+    def equals(self, other: Any) -> bool:
+        return False
+
+def main(f: Callable[[], Cat]) -> None:
+    while (a := f()).equals(1):
+        break
+    print(a)  # E: `a` may be uninitialized
+"#,
+);
+
+testcase!(
     test_walrus_on_first_branch_of_if,
     r#"
 def condition() -> bool: ...


### PR DESCRIPTION
Summary:

When a walrus operator (:=) assigns a variable in a `while` condition, pyrefly incorrectly reports the variable as possibly uninitialized after the loop. The `while` condition always executes at least once, so the variable is guaranteed to be defined.

The root cause is that `setup_loop` saves the current flow as the loop's base *before* the test expression is evaluated. Walrus-defined names are introduced into the in-loop flow but not the base, so `teardown_loop` merges base (no variable) with loop flow (has variable) and concludes it's possibly uninitialized.

The fix adds `propagate_new_flow_entries_to_loop_base`, analogous to the existing `propagate_new_flow_entries_to_fork_base` used for elif walrus bindings. After evaluating the while test, any newly introduced names are copied into the loop's base flow so they are treated as unconditionally defined after the loop.

fixes https://github.com/facebook/pyrefly/issues/3272

Reviewed By: stroxler

Differential Revision: D103302224


