### PR TITLE
fix keep the 0o777 in hover #3230

### DIFF
--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -32,9 +32,7 @@ use pyrefly_util::owner::Owner;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::visit::Visit;
 use ruff_python_ast::Expr;
-use ruff_python_ast::ExprNumberLiteral;
 use ruff_python_ast::Identifier;
-use ruff_python_ast::Number;
 use ruff_python_ast::UnaryOp;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
@@ -90,23 +88,15 @@ use crate::types::types::Overload;
 use crate::types::types::OverloadType;
 use crate::types::types::Type;
 
-/// Extract a display string for default values whose types don't preserve the literal value.
-/// Float literals like `3.14` become `ClassType(float)` which loses the actual value.
-fn default_display_for_expr(expr: &Expr) -> Option<String> {
-    let (is_negative, inner_expr) = match expr {
-        Expr::UnaryOp(x) if x.op == UnaryOp::USub => (true, x.operand.as_ref()),
-        _ => (false, expr),
+/// Extract a display string for numeric default values whose types don't preserve
+/// the source spelling. This preserves both values that lose precision in the
+/// type, like floats, and integer literal spelling, like `0o777`.
+fn default_display_for_expr(expr: &Expr, source: &str) -> Option<String> {
+    let inner_expr = match expr {
+        Expr::UnaryOp(x) if x.op == UnaryOp::USub => x.operand.as_ref(),
+        _ => expr,
     };
-
-    if let Expr::NumberLiteral(ExprNumberLiteral {
-        value: Number::Float(f),
-        ..
-    }) = inner_expr
-    {
-        Some(format!("{}{f}", if is_negative { "-" } else { "" }))
-    } else {
-        None
-    }
+    matches!(inner_expr, Expr::NumberLiteral(_)).then(|| source.to_owned())
 }
 
 fn is_class_property_decorator_class_object(cls: &Class) -> bool {
@@ -903,7 +893,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 Required::Optional(None)
             }
             Some(default) => {
-                let display = default_display_for_expr(default);
+                let display =
+                    default_display_for_expr(default, self.module().code_at(default.range()));
                 let ty = self.expr(default, check, errors);
                 Required::Optional(Some(match display {
                     Some(d) => DefaultValue::with_display(ty, d),

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -1410,6 +1410,22 @@ f(y=1, x=1.0)
 }
 
 #[test]
+fn hover_preserves_int_default_literal_spelling() {
+    let code = r#"
+def f(mode: int = 0o777) -> None:
+    pass
+
+f(mode=0)
+#^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert!(
+        report.contains("mode: int = 0o777"),
+        "Expected hover to preserve octal default '0o777', got: {report}"
+    );
+}
+
+#[test]
 fn hover_shows_negative_float_default_value() {
     let code = r#"
 def f(x: float = -1.5) -> None:


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3230

now numeric parameter defaults preserve their source spelling in hover/signature display metadata.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test