### PR TITLE
Warn when class instance without __bool__ or __len__ is used as boolean condition

### DIFF
--- a/crates/pyrefly_python/src/dunder.rs
+++ b/crates/pyrefly_python/src/dunder.rs
@@ -159,6 +159,7 @@ pub const INIT_SUBCLASS: Name = Name::new_static("__init_subclass__");
 pub const INVERT: Name = Name::new_static("__invert__");
 pub const ITER: Name = Name::new_static("__iter__");
 pub const LE: Name = Name::new_static("__le__");
+pub const LEN: Name = Name::new_static("__len__");
 pub const LT: Name = Name::new_static("__lt__");
 pub const MATCH_ARGS: Name = Name::new_static("__match_args__");
 pub const NE: Name = Name::new_static("__ne__");

--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -1197,6 +1197,29 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         false
     }
 
+    /// Returns `true` if `cls` or any of its non-object ancestors defines `__bool__`, `__len__`,
+    /// or `__getattr__` (which can intercept `__bool__` dynamically).
+    /// Used to detect class instances that are always truthy.
+    pub fn class_has_bool_or_len(&self, cls: &Class) -> bool {
+        let has_relevant_dunder = |c: &Class| {
+            self.get_class_fields(c).is_some_and(|f| {
+                f.contains(&dunder::BOOL)
+                    || f.contains(&dunder::LEN)
+                    || f.contains(&dunder::GETATTR)
+            })
+        };
+        if has_relevant_dunder(cls) {
+            return true;
+        }
+        let mro = self.get_mro_for_class(cls);
+        for ancestor in mro.ancestors_no_object() {
+            if has_relevant_dunder(ancestor.class_object()) {
+                return true;
+            }
+        }
+        false
+    }
+
     fn has_custom_setattr(&self, cls: &Class) -> bool {
         if self
             .get_class_fields(cls)

--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -1197,8 +1197,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         false
     }
 
-    /// Returns `true` if `cls` or any of its non-object ancestors defines `__bool__`, `__len__`,
-    /// or `__getattr__` (which can intercept `__bool__` dynamically).
+    /// Returns `true` if `cls` or any of its non-object ancestors defines a dunder that
+    /// could affect truthiness or attribute resolution at runtime: `__bool__`, `__len__`,
+    /// `__getattr__`, `__getattribute__` (which can intercept `__bool__` dynamically), or
+    /// `__get__` (descriptor classes whose instances are typically used via the descriptor
+    /// protocol rather than as standalone values).
     /// Used to detect class instances that are always truthy.
     pub fn class_has_bool_or_len(&self, cls: &Class) -> bool {
         let has_relevant_dunder = |c: &Class| {
@@ -1206,6 +1209,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 f.contains(&dunder::BOOL)
                     || f.contains(&dunder::LEN)
                     || f.contains(&dunder::GETATTR)
+                    || f.contains(&dunder::GETATTRIBUTE)
+                    || f.contains(&dunder::GET)
             })
         };
         if has_relevant_dunder(cls) {

--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -1620,9 +1620,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 return true;
             }
             if let Some(metaclass) = base_metadata.custom_metaclass()
-                && metaclass
-                    .class_object()
-                    .has_toplevel_qname("abc", "ABCMeta")
+                && self.metaclass_extends_abcmeta(metaclass.class_object())
             {
                 return true;
             }
@@ -1631,11 +1629,29 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         }
         if let Some(metaclass) = metaclass
-            && metaclass
-                .class_object()
-                .has_toplevel_qname("abc", "ABCMeta")
+            && self.metaclass_extends_abcmeta(metaclass.class_object())
         {
             return true;
+        }
+        false
+    }
+
+    /// Check if `metaclass_cls` is `abc.ABCMeta` or has `abc.ABCMeta` anywhere in its
+    /// inheritance chain. HA-style frameworks define custom metaclasses that mix
+    /// `ABCMeta` with other behavior (e.g. `class ABCCachedProperties(CachedProperties,
+    /// ABCMeta)`), and a class using such a metaclass should be treated as abstract.
+    fn metaclass_extends_abcmeta(&self, metaclass_cls: &Class) -> bool {
+        if metaclass_cls.has_toplevel_qname("abc", "ABCMeta") {
+            return true;
+        }
+        let metadata = self.get_metadata_for_class(metaclass_cls);
+        for base in metadata.base_class_objects() {
+            if base.has_toplevel_qname("abc", "ABCMeta") {
+                return true;
+            }
+            if self.metaclass_extends_abcmeta(base) {
+                return true;
+            }
         }
         false
     }

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -2979,7 +2979,21 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 let metadata = self.get_metadata_for_class(cls);
                 let is_abstract =
                     cls.is_builtin("object") || metadata.is_protocol() || metadata.extends_abc();
-                if !is_abstract && !self.class_has_bool_or_len(cls) {
+                // Skip warning for classes coming from bundled stubs (typeshed stdlib,
+                // typeshed third-party, custom third-party). Stub-only classes often have
+                // dynamic runtime behavior (e.g. `datetime`, `asyncio.Future`, `Lock`,
+                // sqlalchemy `Session`) that the stubs don't model, and the idiomatic
+                // `if x:` None-guard pattern is widespread in real-world code.
+                let is_from_stub = cls.module_path().is_bundled();
+                // Skip warning for dataclasses. These are commonly used as plain data
+                // containers and `if obj:` is frequently a defensive pattern; the
+                // warning would create excessive noise for little benefit.
+                let is_dataclass = metadata.dataclass_metadata().is_some();
+                if !is_abstract
+                    && !is_from_stub
+                    && !is_dataclass
+                    && !self.class_has_bool_or_len(cls)
+                {
                     Some(ConditionRedundantReason::InstanceAlwaysTruthy(
                         cls.name().clone(),
                     ))

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -162,14 +162,16 @@ enum ConditionRedundantReason {
     EnumLiteral(Name, Name),
     Function(ModuleName, FunctionKind),
     Class(Name),
+    /// Instance of a class that defines neither `__bool__` nor `__len__`, so always truthy
+    InstanceAlwaysTruthy(Name),
 }
 
 impl ConditionRedundantReason {
     fn equivalent_boolean(&self) -> Option<bool> {
         match self {
-            ConditionRedundantReason::Function(..) | ConditionRedundantReason::Class(..) => {
-                Some(true)
-            }
+            ConditionRedundantReason::Function(..)
+            | ConditionRedundantReason::Class(..)
+            | ConditionRedundantReason::InstanceAlwaysTruthy(..) => Some(true),
             ConditionRedundantReason::IntLiteral(b)
             | ConditionRedundantReason::StrLiteral(b)
             | ConditionRedundantReason::BytesLiteral(b) => Some(*b),
@@ -199,6 +201,12 @@ impl ConditionRedundantReason {
             }
             ConditionRedundantReason::Class(name) => {
                 format!("Class name `{name}` used as condition")
+            }
+            ConditionRedundantReason::InstanceAlwaysTruthy(name) => {
+                format!(
+                    "Instance of `{name}` used as condition, but `{name}` defines neither \
+                     `__bool__` nor `__len__`, so instances are always truthy"
+                )
             }
         }
     }
@@ -2963,6 +2971,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 f.func.metadata().kind.clone(),
             )),
             Type::ClassDef(cls) => Some(ConditionRedundantReason::Class(cls.name().clone())),
+            Type::ClassType(ct) => {
+                if !self.class_has_bool_or_len(ct.class_object()) {
+                    Some(ConditionRedundantReason::InstanceAlwaysTruthy(
+                        ct.class_object().name().clone(),
+                    ))
+                } else {
+                    None
+                }
+            }
             _ => None,
         }
     }

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -2972,9 +2972,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             )),
             Type::ClassDef(cls) => Some(ConditionRedundantReason::Class(cls.name().clone())),
             Type::ClassType(ct) => {
-                if !self.class_has_bool_or_len(ct.class_object()) {
+                let cls = ct.class_object();
+                // Skip warning for `object` itself and for abstract/protocol types:
+                // a variable typed as `Hashable`, `Iterable`, etc. may hold a concrete
+                // instance that defines `__bool__` or `__len__` at runtime.
+                let metadata = self.get_metadata_for_class(cls);
+                let is_abstract = cls.is_builtin("object")
+                    || metadata.is_protocol()
+                    || metadata.extends_abc();
+                if !is_abstract && !self.class_has_bool_or_len(cls) {
                     Some(ConditionRedundantReason::InstanceAlwaysTruthy(
-                        ct.class_object().name().clone(),
+                        cls.name().clone(),
                     ))
                 } else {
                     None

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -2977,9 +2977,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // a variable typed as `Hashable`, `Iterable`, etc. may hold a concrete
                 // instance that defines `__bool__` or `__len__` at runtime.
                 let metadata = self.get_metadata_for_class(cls);
-                let is_abstract = cls.is_builtin("object")
-                    || metadata.is_protocol()
-                    || metadata.extends_abc();
+                let is_abstract =
+                    cls.is_builtin("object") || metadata.is_protocol() || metadata.extends_abc();
                 if !is_abstract && !self.class_has_bool_or_len(cls) {
                     Some(ConditionRedundantReason::InstanceAlwaysTruthy(
                         cls.name().clone(),

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -1119,6 +1119,59 @@ def test(
 );
 
 testcase!(
+    test_redundant_condition_no_false_positives_for_descriptors_and_special_classes,
+    r#"
+from dataclasses import dataclass
+from datetime import datetime
+import asyncio
+
+class Descriptor:
+    def __get__(self, obj, objtype=None) -> int: ...
+
+class HasGetattr:
+    def __getattr__(self, name: str) -> object: ...
+
+class HasGetattribute:
+    def __getattribute__(self, name: str) -> object: ...
+
+@dataclass
+class MyData:
+    x: int
+    y: str
+
+def test(
+    d: Descriptor,
+    g1: HasGetattr,
+    g2: HasGetattribute,
+    md: MyData,
+    dt: datetime,
+    fut: asyncio.Future[int],
+    lk: asyncio.Lock,
+) -> None:
+    # None of these should warn:
+    # - descriptor classes (with __get__) might intercept attribute access
+    # - classes with __getattr__/__getattribute__ have dynamic attribute behavior
+    # - dataclasses are commonly used with `if obj:` as a defensive guard
+    # - stdlib types come from bundled stubs and often have runtime behavior
+    #   not modeled in the stubs
+    if d:
+        ...
+    if g1:
+        ...
+    if g2:
+        ...
+    if md:
+        ...
+    if dt:
+        ...
+    if fut:
+        ...
+    if lk:
+        ...
+    "#,
+);
+
+testcase!(
     crash_no_try_type,
     r#"
 # Used to crash, https://github.com/facebook/pyrefly/issues/766

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -1096,12 +1096,26 @@ import abc
 class MyABC(abc.ABC):
     pass
 
+# Custom metaclass that mixes ABCMeta with other type-level behavior.
+# Real-world frameworks (e.g. Home Assistant's `ABCCachedProperties`) define
+# such metaclasses, and classes using them should be treated as abstract.
+class MyMixedMeta(abc.ABCMeta):
+    pass
+
+class WithMixedMeta(metaclass=MyMixedMeta):
+    pass
+
+class WithMixedMetaSub(WithMixedMeta):
+    pass
+
 def test(
     o: object,
     h: Hashable,
     it: Iterable[int],
     sz: Sized,
     ab: MyABC,
+    mm: WithMixedMeta,
+    mms: WithMixedMetaSub,
 ) -> None:
     # None of these should warn: static type is abstract/protocol/object,
     # so the concrete runtime instance may define __bool__ or __len__.
@@ -1114,6 +1128,10 @@ def test(
     if sz:
         ...
     if ab:
+        ...
+    if mm:
+        ...
+    if mms:
         ...
     "#,
 );

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -1052,6 +1052,41 @@ while E.B:  # E: Enum literal `E.B` used as condition
 );
 
 testcase!(
+    test_redundant_condition_instance_always_truthy,
+    r#"
+class NoBool:
+    pass
+
+class HasBool:
+    def __bool__(self) -> bool: ...
+
+class HasLen:
+    def __len__(self) -> int: ...
+
+class InheritsHasBool(HasBool):
+    pass
+
+class InheritsHasLen(HasLen):
+    pass
+
+def test(x: NoBool, y: HasBool, z: HasLen, a: InheritsHasBool, b: InheritsHasLen) -> None:
+    if x:  # E: Instance of `NoBool` used as condition
+        ...
+    while x:  # E: Instance of `NoBool` used as condition
+        ...
+    [i for i in range(10) if x]  # E: Instance of `NoBool` used as condition
+    if y:
+        ...
+    if z:
+        ...
+    if a:
+        ...
+    if b:
+        ...
+    "#,
+);
+
+testcase!(
     crash_no_try_type,
     r#"
 # Used to crash, https://github.com/facebook/pyrefly/issues/766

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -1087,6 +1087,38 @@ def test(x: NoBool, y: HasBool, z: HasLen, a: InheritsHasBool, b: InheritsHasLen
 );
 
 testcase!(
+    test_redundant_condition_no_false_positives_for_abstract_types,
+    r#"
+from typing import Hashable, Iterable
+from collections.abc import Sized
+import abc
+
+class MyABC(abc.ABC):
+    pass
+
+def test(
+    o: object,
+    h: Hashable,
+    it: Iterable[int],
+    sz: Sized,
+    ab: MyABC,
+) -> None:
+    # None of these should warn: static type is abstract/protocol/object,
+    # so the concrete runtime instance may define __bool__ or __len__.
+    if o:
+        ...
+    if h:
+        ...
+    if it:
+        ...
+    if sz:
+        ...
+    if ab:
+        ...
+    "#,
+);
+
+testcase!(
     crash_no_try_type,
     r#"
 # Used to crash, https://github.com/facebook/pyrefly/issues/766


### PR DESCRIPTION
# Summary

closes #3282 closes #868

adds `ConditionRedundantReason::InstanceAlwaysTruthy` - fires when a class instance is used in a boolean context but the class defines neither `__bool__` nor `__len__` (so instances are unconditionally truthy)

```python
class NoBool:
    pass

x = NoBool()
if x:   # warning: NoBool defines neither __bool__ nor __len__, instances are always truthy
    pass
```

## skipped to keep noise down

- `object` itself
- protocols and ABCs (`extends_abc`) - concrete subclasses can define the dunders at runtime
- custom metaclasses inheriting from `ABCMeta` via MRO (covers HA's `ABCCachedProperties(CachedProperties, ABCMeta)`)
- classes from bundled stubs (typeshed stdlib + third-party stubs) - many stub-only classes have dynamic runtime behavior not in stubs (`datetime`, `asyncio.Future`, `Lock`, sqlalchemy `Session`, etc)
- dataclasses
- classes with `__bool__` / `__len__` / `__getattr__` / `__getattribute__` / `__get__` anywhere in MRO (descriptors, dynamic attribute interception)

## remaining warnings on home-assistant primer

23 warnings, three patterns:

- **dead defensive checks (~16)**: `device = random.choice(...)` returns non-optional T then code does `if device:`. dead by types, lint working as intended
- **subclass narrowing (~2)**: base declares `attr: T | None`, subclass redeclares `attr: T`. after redeclaration `if obj.attr:` is dead by types
- **lying types via `# type: ignore[assignment]` (~5)**: `platform: EntityPlatform = None  # type: ignore[assignment]`. attr annotated T but assigned None with the assignment error suppressed. `if self.platform:` is meaningful at runtime but dead by declared types. proper fix is `T | None`. not suppressed because doing so needs initializer tracking on `ClassField` to hide what are arguably real type-annotation bugs

none look like the "incomplete stubs" failure mode the issue author flagged

# Test Plan

tests in `flow_branching.rs` cover plain classes, inheritance, descriptors, `__getattr*__`, dataclasses, stub-only classes, protocols, ABCs, custom-metaclass-via-MRO

`cargo test -p pyrefly` clean