### PR TITLE
Rename parameters across files in keyword arguments

### DIFF
--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3542,6 +3542,7 @@ impl<'a> Transaction<'a> {
     fn local_references_from_external_definition(
         &self,
         handle: &Handle,
+        definition_metadata: &DefinitionMetadata,
         definition_range: TextRange,
         module: &Module,
     ) -> Option<Vec<TextRange>> {
@@ -3581,6 +3582,20 @@ impl<'a> Transaction<'a> {
                     }
                 }
             }
+        }
+        if let DefinitionMetadata::Variable(Some(kind)) = definition_metadata
+            && (*kind == SymbolKind::Parameter || *kind == SymbolKind::Variable)
+        {
+            let expected_name = Name::new(module.code_at(definition_range));
+            references.extend(
+                self.local_keyword_argument_references_from_parameter_definition(
+                    handle,
+                    definition_range,
+                    module,
+                    &expected_name,
+                )
+                .unwrap_or_default(),
+            );
         }
         Some(references)
     }
@@ -3646,7 +3661,12 @@ impl<'a> Transaction<'a> {
         include_declaration: bool,
     ) -> Option<Vec<TextRange>> {
         let mut references = if handle.path() != module.path() {
-            self.local_references_from_external_definition(handle, definition_range, module)?
+            self.local_references_from_external_definition(
+                handle,
+                &definition_metadata,
+                definition_range,
+                module,
+            )?
         } else {
             let definition_name = Name::new(module.code_at(definition_range));
             self.local_references_from_local_definition(
@@ -3798,35 +3818,23 @@ impl<'a> Transaction<'a> {
         &self,
         handle: &Handle,
         definition_range: TextRange,
+        definition_module: &Module,
         expected_name: &Name,
     ) -> Option<Vec<TextRange>> {
-        let ast = self.get_ast(handle)?;
         let keyword_args = self.collect_local_keyword_arguments_by_name(handle, expected_name);
         let mut references = Vec::new();
 
-        let definition_module = self.get_module_info(handle)?;
-
         for (kw_identifier, callee_kind) in keyword_args {
-            let callee_locations =
-                self.get_callee_location(handle, &callee_kind, FindPreference::default());
-
-            for TextRangeWithModule {
-                module,
-                range: callee_def_range,
-            } in callee_locations
-            {
-                if module.path() == definition_module.path() {
-                    // Refine to get the actual parameter location
-                    if let Some(param_range) = self.refine_param_location_for_callee(
-                        ast.as_ref(),
-                        callee_def_range,
-                        &kw_identifier,
-                    ) {
-                        // If the parameter location matches our definition, this is a valid reference
-                        if param_range == definition_range {
-                            references.push(kw_identifier.range);
-                        }
-                    }
+            for definition in self.find_definition_for_keyword_argument(
+                handle,
+                &kw_identifier,
+                &callee_kind,
+                FindPreference::default(),
+            ) {
+                if definition.module.path() == definition_module.path()
+                    && definition.definition_range == definition_range
+                {
+                    references.push(kw_identifier.range);
                 }
             }
         }
@@ -3882,6 +3890,7 @@ impl<'a> Transaction<'a> {
                 .local_keyword_argument_references_from_parameter_definition(
                     handle,
                     definition_range,
+                    &self.get_module_info(handle)?,
                     expected_name,
                 );
 

--- a/pyrefly/lib/test/lsp/lsp_interaction/rename.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/rename.rs
@@ -187,6 +187,65 @@ fn test_rename_editable_package_symbols_is_allowed() {
 }
 
 #[test]
+fn test_rename_parameter_updates_keyword_arguments_across_files() {
+    let root = get_test_files_root();
+    let root_path = root.path().join("rename_parameter_keywords_across_files");
+    let scope_uri = Url::from_file_path(root_path.clone()).unwrap();
+
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root_path.clone());
+    interaction
+        .initialize(InitializeSettings {
+            workspace_folders: Some(vec![("test".to_owned(), scope_uri.clone())]),
+            configuration: Some(Some(json!([{ "indexing_mode": "lazy_blocking" }]))),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let file_a = root_path.join("fileA.py");
+    let file_b = root_path.join("fileB.py");
+
+    interaction.client.did_open("fileA.py");
+    interaction.client.did_open("fileB.py");
+
+    interaction
+        .client
+        .send_request::<Rename>(json!({
+            "textDocument": {
+                "uri": Url::from_file_path(&file_a).unwrap().to_string()
+            },
+            "position": {
+                "line": 0,
+                "character": 9
+            },
+            "newName": "new_name"
+        }))
+        .expect_response(json!({
+            "changes": {
+                Url::from_file_path(&file_a).unwrap().to_string(): [
+                    {
+                        "newText": "new_name",
+                        "range": {"start": {"line": 0, "character": 9}, "end": {"line": 0, "character": 14}}
+                    },
+                    {
+                        "newText": "new_name",
+                        "range": {"start": {"line": 1, "character": 11}, "end": {"line": 1, "character": 16}}
+                    },
+                ],
+                Url::from_file_path(&file_b).unwrap().to_string(): [
+                    {
+                        "newText": "new_name",
+                        "range": {"start": {"line": 5, "character": 14}, "end": {"line": 5, "character": 19}}
+                    },
+                ],
+            }
+        }))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
 fn test_rename() {
     let root = get_test_files_root();
     let root_path = root.path().join("tests_requiring_config");

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/rename_parameter_keywords_across_files/fileA.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/rename_parameter_keywords_across_files/fileA.py
@@ -1,0 +1,2 @@
+def test(param):
+    return param

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/rename_parameter_keywords_across_files/fileB.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/rename_parameter_keywords_across_files/fileB.py
@@ -1,0 +1,7 @@
+from fileA import test
+
+def unrelated(param):
+    return param
+
+result = test(param="hello")
+other = unrelated(param="skip")

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/rename_parameter_keywords_across_files/pyrefly.toml
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/rename_parameter_keywords_across_files/pyrefly.toml
@@ -1,0 +1,1 @@
+search_path = ["."]


### PR DESCRIPTION
# Summary

Part of #2207.

This PR fixes parameter rename across files when the external use is a keyword argument. For example, renaming `param` in:

```python
# fileA.py
def test(param):
    return param
```

now also updates the caller-side keyword in another file:

```python
# fileB.py
from fileA import test

result = test(param="hello")
```

The implementation adds keyword-argument references to the external reverse-dependency reference path. It does not rename keyword textually: each matching `param=` candidate resolves its callee, refines that callee back to the actual parameter definition, and only edits the keyword when the refined parameter range matches the parameter being renamed.

## Relationship to branch `1583`

Branch `1583` overlaps with this PR. It targets the same cross-file parameter-keyword rename behavior and adds a similar LSP regression fixture. It is broader than this PR because it also carries fallback logic around external-definition range/line matching.

This PR is the narrower version: it only wires parameter keyword-argument references into the existing external reverse-dependency lookup. If `1583` lands first, this branch should be rebased or dropped rather than landed independently with duplicate coverage.

# Test Plan

`cargo test rename::test_rename`

`python3 test.py --no-test --no-conformance --no-jsonschema`
