### PR TITLE
[codex] Preserve specialized TypeVar bounds

### DIFF
--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -179,10 +179,9 @@ impl TParams {
     /// through the chain: TParams → Restriction → ClassType → TArgs → TParams → ...
     ///
     /// This method enforces a structural invariant: within a Quantified's restriction,
-    /// any ClassType whose TArgs embed TParams with their own non-trivial restrictions
-    /// (Bound or Constraints) has its TArgs stripped to empty. This prevents recursive
-    /// nesting while preserving TArgs for simple cases like `T: List[int]` where the
-    /// inner TParams have only unrestricted type variables.
+    /// any ClassType whose TArgs embed TParams that can reach the same class through
+    /// their own restrictions has its TArgs stripped to empty. This prevents recursive
+    /// nesting while preserving TArgs for non-recursive bounds like `T: P[Any]`.
     pub fn truncate_recursive_targs(self) -> Self {
         let quantifieds = self
             .0
@@ -206,22 +205,79 @@ impl TParams {
     }
 
     /// Walk a type tree and strip TArgs from any ClassType whose TArgs' TParams
-    /// have non-trivial restrictions (Bound or Constraints). Such TParams can
-    /// participate in recursive nesting across fixpoint iterations.
+    /// can recursively reach the same class.
     fn strip_recursive_class_targs(ty: Type) -> Type {
         ty.transform(&mut |t| {
             if let Type::ClassType(ct) = t
                 && !ct.targs().is_empty()
-                && Self::tparams_have_restrictions(ct.targs().tparams())
+                && Self::tparams_can_reach_class(ct.targs().tparams(), ct.class_object())
             {
                 *t = Type::ClassType(ClassType::new(ct.class_object().dupe(), TArgs::default()));
             }
         })
     }
 
-    /// Check if any Quantified in the TParams has a non-trivial restriction.
-    fn tparams_have_restrictions(tparams: &TParams) -> bool {
-        tparams.iter().any(|q| q.restriction().is_restricted())
+    fn tparams_can_reach_class(tparams: &TParams, class: &Class) -> bool {
+        Self::tparams_can_reach_class_with_seen(tparams, class, &mut Vec::new())
+    }
+
+    fn tparams_can_reach_class_with_seen(
+        tparams: &TParams,
+        class: &Class,
+        seen_classes: &mut Vec<Class>,
+    ) -> bool {
+        tparams
+            .iter()
+            .any(|q| Self::restriction_can_reach_class(q.restriction(), class, seen_classes))
+    }
+
+    fn restriction_can_reach_class(
+        restriction: &Restriction,
+        class: &Class,
+        seen_classes: &mut Vec<Class>,
+    ) -> bool {
+        match restriction {
+            Restriction::Bound(ty) => Self::type_can_reach_class(ty, class, seen_classes),
+            Restriction::Constraints(tys) => tys
+                .iter()
+                .any(|ty| Self::type_can_reach_class(ty, class, seen_classes)),
+            Restriction::Unrestricted => false,
+        }
+    }
+
+    fn type_can_reach_class(ty: &Type, class: &Class, seen_classes: &mut Vec<Class>) -> bool {
+        match ty {
+            Type::ClassType(cls) => {
+                if cls.class_object() == class {
+                    return true;
+                }
+                if seen_classes.iter().any(|seen| seen == cls.class_object()) {
+                    return false;
+                }
+                seen_classes.push(cls.class_object().dupe());
+                let found = cls
+                    .targs()
+                    .as_slice()
+                    .iter()
+                    .any(|ty| Self::type_can_reach_class(ty, class, seen_classes))
+                    || Self::tparams_can_reach_class_with_seen(
+                        cls.targs().tparams(),
+                        class,
+                        seen_classes,
+                    );
+                seen_classes.pop();
+                found
+            }
+            _ => {
+                let mut found = false;
+                ty.recurse(&mut |ty| {
+                    if !found && Self::type_can_reach_class(ty, class, seen_classes) {
+                        found = true;
+                    }
+                });
+                found
+            }
+        }
     }
 }
 

--- a/pyrefly/lib/test/protocol.rs
+++ b/pyrefly/lib/test/protocol.rs
@@ -180,6 +180,35 @@ def g(c1: C1, c2: C2) -> None:
 );
 
 testcase!(
+    test_protocol_typevar_bound_preserves_specialized_targs,
+    r#"
+from typing import Any, Callable, Protocol, Sequence, TypeVar
+
+class Base: ...
+
+T = TypeVar("T", bound=Base)
+T_co = TypeVar("T_co", bound=Base, covariant=True)
+P_co = TypeVar("P_co", bound="P[Any]", covariant=True)
+
+class P0(Protocol[T_co]): ...
+
+class P(P0[T], Protocol[T]):
+    @classmethod
+    def make(cls, f: Callable[[Sequence[T]], T]) -> None: ...
+
+class Namespace(Protocol[P_co, T_co]):
+    @property
+    def item(self) -> type[P_co]: ...
+
+    def test(self) -> None:
+        def f(x: Sequence[T_co]) -> T_co:
+            return x[0]
+
+        self.item.make(f)
+"#,
+);
+
+testcase!(
     test_protocol_property,
     r#"
 from typing import Protocol


### PR DESCRIPTION
Fixes facebook/pyrefly#3285.

## Summary

This fixes a false-positive `bad-argument-type` error when looking up a classmethod through a `type[T]` where `T` is a protocol-bounded TypeVar whose bound is itself specialized, for example `T: SQLExpr[Any]`.

The PR changes recursive type-argument truncation so it only erases generic arguments when there is an actual recursive path back to the same class. Non-recursive specialized bounds such as `P[Any]` are now preserved.

## Root Cause

`TParams::truncate_recursive_targs` was intentionally preventing fixpoint growth for recursive TypeVar bounds. The old predicate was too broad: it stripped type arguments from any `ClassType` whose formal type parameters had non-trivial restrictions.

That meant a bound like:

```py
P_co = TypeVar("P_co", bound="P[Any]", covariant=True)
```

could be truncated from `P[Any]` to bare `P` because `P`'s own type parameter had a bound. Later, attribute lookup on `type[P_co]` instantiated classmethod parameters from bare `P`, so the method leaked `P`'s class TypeVar instead of using the specialized `Any` from the bound.

In the original issue this made:

```text
self._expr.from_elementwise
```

look like:

```text
(cls: type[SQLExprT], func: (Sequence[NativeExprT]) -> NativeExprT) -> None
```

instead of the expected:

```text
(cls: type[SQLExprT], func: (Sequence[Any]) -> Any) -> None
```

## Fix

The truncation logic now walks the restriction graph and only strips `ClassType` arguments when the class's embedded type parameters can reach back to the same class through their own bounds or constraints.

That keeps the recursion guard for shapes like `Bar[Any]` where `Bar` participates in its own bound cycle, while preserving ordinary specialized bounds used for protocol classmethod lookup.

## Tests

Added a regression test covering a reduced protocol form of the issue:

```py
class Namespace(Protocol[P_co, T_co]):
    @property
    def item(self) -> type[P_co]: ...

    def test(self) -> None:
        def f(x: Sequence[T_co]) -> T_co:
            return x[0]

        self.item.make(f)
```

Validation run locally:

```text
cargo test test_protocol_typevar_bound_preserves_specialized_targs
cargo run -q -p pyrefly --bin pyrefly -- check /tmp/pyrefly_issue_3285.py
cargo test test_recursively_constrained_typevar
python3 test.py --no-test --no-conformance --no-jsonschema
git diff --check
```

I also reran a `reveal_type` probe for the original reproducer and confirmed the classmethod parameter is now specialized as `(Sequence[Any]) -> Any`.

## AI Disclosure

This PR was prepared with help from Codex.
