### PR TITLE
fix match case with type check #3295

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -1932,6 +1932,71 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         );
     }
 
+    pub fn check_match_case_reachability(
+        &self,
+        subject_idx: &Idx<Key>,
+        narrowing_subject: &NarrowingSubject,
+        narrow_ops_for_case: &(Box<NarrowOp>, TextRange),
+        case_range: &TextRange,
+        errors: &ErrorCollector,
+    ) {
+        let (op, narrow_range) = narrow_ops_for_case;
+        if !Self::is_value_match_case_op(op) {
+            return;
+        }
+        let subject_info = self.with_type_for_exhaustiveness_check(self.get_idx(*subject_idx));
+        let subject_ty = subject_info.ty().clone();
+        if subject_ty.is_any()
+            || subject_ty.is_never()
+            || matches!(&subject_ty, Type::ClassType(cls) if cls.is_builtin("object"))
+        {
+            return;
+        }
+        let ignore_errors = self.error_swallower();
+        let mut narrowed_ty = match narrowing_subject {
+            NarrowingSubject::Name(_) => self
+                .narrow(&subject_info, op.as_ref(), *narrow_range, &ignore_errors)
+                .ty()
+                .clone(),
+            NarrowingSubject::Facets(_, facets) => {
+                let Some(resolved_chain) = self.resolve_facet_chain(facets.chain.clone()) else {
+                    return;
+                };
+                let type_info = TypeInfo::of_ty(self.heap.mk_any_implicit());
+                let narrowing_subject_info =
+                    type_info.with_narrow(resolved_chain.facets(), subject_ty.clone());
+                let narrowed = self.narrow(
+                    &narrowing_subject_info,
+                    op.as_ref(),
+                    *narrow_range,
+                    &ignore_errors,
+                );
+                self.get_facet_chain_type(&narrowed, &resolved_chain, *case_range)
+            }
+        };
+        self.expand_vars_mut(&mut narrowed_ty);
+        if !narrowed_ty.is_never() {
+            return;
+        }
+        let subject_display = self.for_display(subject_ty);
+        self.error(
+            errors,
+            *case_range,
+            ErrorInfo::Kind(ErrorKind::Unreachable),
+            format!("Case pattern can never match subject of type `{subject_display}`"),
+        );
+    }
+
+    fn is_value_match_case_op(op: &NarrowOp) -> bool {
+        match op {
+            NarrowOp::Atomic(_, AtomicNarrowOp::Eq(_) | AtomicNarrowOp::Is(_)) => true,
+            NarrowOp::And(ops) | NarrowOp::Or(ops) => {
+                !ops.is_empty() && ops.iter().all(Self::is_value_match_case_op)
+            }
+            _ => false,
+        }
+    }
+
     pub fn resolve_facet_chain(&self, unresolved: UnresolvedFacetChain) -> Option<FacetChain> {
         let resolved: Option<Vec<FacetKind>> = unresolved
             .facets()

--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -1941,7 +1941,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         errors: &ErrorCollector,
     ) {
         let (op, narrow_range) = narrow_ops_for_case;
-        if !Self::is_value_match_case_op(op) {
+        if !Self::is_match_case_reachability_op(op) {
             return;
         }
         let subject_info = self.with_type_for_exhaustiveness_check(self.get_idx(*subject_idx));
@@ -1953,11 +1953,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             return;
         }
         let ignore_errors = self.error_swallower();
-        let mut narrowed_ty = match narrowing_subject {
-            NarrowingSubject::Name(_) => self
-                .narrow(&subject_info, op.as_ref(), *narrow_range, &ignore_errors)
-                .ty()
-                .clone(),
+        let (mut narrowed_ty, has_never_trigger_facet) = match narrowing_subject {
+            NarrowingSubject::Name(_) => {
+                let narrowed =
+                    self.narrow(&subject_info, op.as_ref(), *narrow_range, &ignore_errors);
+                let has_never_trigger_facet =
+                    self.has_never_match_trigger_facet(&narrowed, op, *case_range);
+                (narrowed.ty().clone(), has_never_trigger_facet)
+            }
             NarrowingSubject::Facets(_, facets) => {
                 let Some(resolved_chain) = self.resolve_facet_chain(facets.chain.clone()) else {
                     return;
@@ -1971,11 +1974,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     *narrow_range,
                     &ignore_errors,
                 );
-                self.get_facet_chain_type(&narrowed, &resolved_chain, *case_range)
+                (
+                    self.get_facet_chain_type(&narrowed, &resolved_chain, *case_range),
+                    false,
+                )
             }
         };
         self.expand_vars_mut(&mut narrowed_ty);
-        if !narrowed_ty.is_never() {
+        if !narrowed_ty.is_never() && !has_never_trigger_facet {
             return;
         }
         let subject_display = self.for_display(subject_ty);
@@ -1987,11 +1993,67 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         );
     }
 
-    fn is_value_match_case_op(op: &NarrowOp) -> bool {
+    fn is_match_case_reachability_op(op: &NarrowOp) -> bool {
+        let (can_check, has_trigger) = Self::classify_match_case_reachability_op(op);
+        can_check && has_trigger
+    }
+
+    fn classify_match_case_reachability_op(op: &NarrowOp) -> (bool, bool) {
         match op {
-            NarrowOp::Atomic(_, AtomicNarrowOp::Eq(_) | AtomicNarrowOp::Is(_)) => true,
+            NarrowOp::Atomic(_, AtomicNarrowOp::Eq(_) | AtomicNarrowOp::Is(_)) => (true, true),
+            NarrowOp::Atomic(Some(_), AtomicNarrowOp::IsInstance(_, NarrowSource::Pattern)) => {
+                (true, true)
+            }
+            NarrowOp::Atomic(
+                _,
+                AtomicNarrowOp::IsSequence
+                | AtomicNarrowOp::IsMapping
+                | AtomicNarrowOp::LenEq(_)
+                | AtomicNarrowOp::LenGte(_),
+            ) => (true, false),
             NarrowOp::And(ops) | NarrowOp::Or(ops) => {
-                !ops.is_empty() && ops.iter().all(Self::is_value_match_case_op)
+                let mut has_trigger = false;
+                for op in ops {
+                    let (can_check, op_has_trigger) = Self::classify_match_case_reachability_op(op);
+                    if !can_check {
+                        return (false, false);
+                    }
+                    has_trigger |= op_has_trigger;
+                }
+                (true, has_trigger)
+            }
+            _ => (false, false),
+        }
+    }
+
+    fn has_never_match_trigger_facet(
+        &self,
+        type_info: &TypeInfo,
+        op: &NarrowOp,
+        range: TextRange,
+    ) -> bool {
+        match op {
+            NarrowOp::Atomic(
+                Some(facet),
+                AtomicNarrowOp::Eq(_)
+                | AtomicNarrowOp::Is(_)
+                | AtomicNarrowOp::IsInstance(_, NarrowSource::Pattern),
+            ) => {
+                let Some(resolved_chain) = self.resolve_facet_chain(facet.chain.clone()) else {
+                    return false;
+                };
+                let mut facet_ty = self.get_facet_chain_type(type_info, &resolved_chain, range);
+                self.expand_vars_mut(&mut facet_ty);
+                facet_ty.is_never()
+            }
+            NarrowOp::And(ops) => ops
+                .iter()
+                .any(|op| self.has_never_match_trigger_facet(type_info, op, range)),
+            NarrowOp::Or(ops) => {
+                !ops.is_empty()
+                    && ops
+                        .iter()
+                        .all(|op| self.has_never_match_trigger_facet(type_info, op, range))
             }
             _ => false,
         }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -2338,6 +2338,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 range,
                 errors,
             ),
+            BindingExpect::MatchCaseReachability {
+                subject_idx,
+                narrowing_subject,
+                narrow_ops_for_case,
+                case_range,
+            } => self.check_match_case_reachability(
+                subject_idx,
+                narrowing_subject,
+                narrow_ops_for_case,
+                case_range,
+                errors,
+            ),
             BindingExpect::PrivateAttributeAccess(expectation) => {
                 self.check_private_attribute_access(expectation, errors);
             }

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -994,6 +994,8 @@ pub enum KeyExpect {
     Bool(TextRange),
     /// Match statement exhaustiveness check.
     MatchExhaustiveness(TextRange),
+    /// Match case reachability check.
+    MatchCaseReachability(TextRange),
     /// Private attribute access validation.
     PrivateAttributeAccess(TextRange),
     /// Deferred uninitialized variable check.
@@ -1012,6 +1014,7 @@ impl Ranged for KeyExpect {
             | KeyExpect::Redefinition(range)
             | KeyExpect::Bool(range)
             | KeyExpect::MatchExhaustiveness(range)
+            | KeyExpect::MatchCaseReachability(range)
             | KeyExpect::PrivateAttributeAccess(range)
             | KeyExpect::UninitializedCheck(range)
             | KeyExpect::ForwardRefUnion(range) => *range,
@@ -1029,6 +1032,7 @@ impl DisplayWith<ModuleInfo> for KeyExpect {
             KeyExpect::Redefinition(r) => ("Redefinition", r),
             KeyExpect::Bool(r) => ("Bool", r),
             KeyExpect::MatchExhaustiveness(r) => ("MatchExhaustiveness", r),
+            KeyExpect::MatchCaseReachability(r) => ("MatchCaseReachability", r),
             KeyExpect::PrivateAttributeAccess(r) => ("PrivateAttributeAccess", r),
             KeyExpect::UninitializedCheck(r) => ("UninitializedCheck", r),
             KeyExpect::ForwardRefUnion(r) => ("ForwardRefUnion", r),
@@ -1097,6 +1101,13 @@ pub enum BindingExpect {
         narrowing_subject: NarrowingSubject,
         narrow_ops_for_fall_through: (Box<NarrowOp>, TextRange),
         subject_range: TextRange,
+    },
+    /// A match case whose pattern may not overlap with the current subject type.
+    MatchCaseReachability {
+        subject_idx: Idx<Key>,
+        narrowing_subject: NarrowingSubject,
+        narrow_ops_for_case: (Box<NarrowOp>, TextRange),
+        case_range: TextRange,
     },
     /// Track private attribute accesses that need semantic validation.
     PrivateAttributeAccess(PrivateAttributeAccessCheck),
@@ -1199,6 +1210,18 @@ impl DisplayWith<Bindings> for BindingExpect {
                     "MatchExhaustiveness({}, {})",
                     ctx.display(*subject_idx),
                     ctx.module().display(range)
+                )
+            }
+            Self::MatchCaseReachability {
+                subject_idx,
+                case_range,
+                ..
+            } => {
+                write!(
+                    f,
+                    "MatchCaseReachability({}, {})",
+                    ctx.display(*subject_idx),
+                    ctx.module().display(case_range)
                 )
             }
             Self::UninitializedCheck {

--- a/pyrefly/lib/binding/pattern.rs
+++ b/pyrefly/lib/binding/pattern.rs
@@ -579,6 +579,19 @@ impl<'a> BindingsBuilder<'a> {
                 NarrowUseLocation::Span(case_range),
                 &Usage::Narrowing(None),
             );
+            if let Some(narrowing_subject) = match_subject.as_single()
+                && let Some((op, range)) = new_narrow_ops.0.get(narrowing_subject.name())
+            {
+                self.insert_binding(
+                    KeyExpect::MatchCaseReachability(case_range),
+                    BindingExpect::MatchCaseReachability {
+                        subject_idx: case_subject_idx,
+                        narrowing_subject: narrowing_subject.clone(),
+                        narrow_ops_for_case: (Box::new(op.clone()), *range),
+                        case_range,
+                    },
+                );
+            }
             if let Some(mut guard) = guard {
                 self.ensure_expr(&mut guard, &mut Usage::Narrowing(None));
                 let guard_narrow_ops = NarrowOps::from_expr(self, Some(guard.as_ref()));

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -464,7 +464,6 @@ match y:
 );
 
 testcase!(
-    bug = "does not detect unreachable branches based on nested patterns",
     test_match_narrow_len,
     r#"
 from typing import assert_type, Never
@@ -481,9 +480,9 @@ def foo(x: tuple[int, int] | tuple[str]):
             assert_type(x1, int)
     match x:
         # these two cases should be impossible to match
-        case [str(), str()]:
+        case [str(), str()]:  # E: Case pattern can never match subject of type `tuple[int, int] | tuple[str]`
             assert_type(x, tuple[int, int])
-        case [int()]:
+        case [int()]:  # E: Case pattern can never match subject of type `tuple[int, int] | tuple[str]`
             assert_type(x, tuple[str])
 "#,
 );

--- a/pyrefly/lib/test/pattern_match.rs
+++ b/pyrefly/lib/test/pattern_match.rs
@@ -43,6 +43,23 @@ match None:
 );
 
 testcase!(
+    test_match_case_unreachable_for_disjoint_subject_type,
+    r#"
+def bad(x: list[int]) -> None:
+    match x:
+        case 1:  # E: Case pattern can never match subject of type `list[int]`
+            pass
+        case 2:  # E: Case pattern can never match subject of type `list[int]`
+            pass
+
+def ok(x: int) -> None:
+    match x:
+        case 1:
+            pass
+"#,
+);
+
+testcase!(
     test_pattern_dict_key_enum,
     r#"
 from enum import StrEnum

--- a/pyrefly/lib/test/pattern_match.rs
+++ b/pyrefly/lib/test/pattern_match.rs
@@ -45,6 +45,8 @@ match None:
 testcase!(
     test_match_case_unreachable_for_disjoint_subject_type,
     r#"
+from typing import Any
+
 def bad(x: list[int]) -> None:
     match x:
         case 1:  # E: Case pattern can never match subject of type `list[int]`
@@ -52,9 +54,44 @@ def bad(x: list[int]) -> None:
         case 2:  # E: Case pattern can never match subject of type `list[int]`
             pass
 
+def bad_or(x: list[int]) -> None:
+    match x:
+        case 1 | 2:  # E: Case pattern can never match subject of type `list[int]`
+            pass
+
+class Obj:
+    field: list[int]
+
+def bad_facet(obj: Obj) -> None:
+    match obj.field:
+        case 1:  # E: Case pattern can never match subject of type `list[int]`
+            pass
+
+def bad_none(x: int) -> None:
+    match x:
+        case None:  # E: Case pattern can never match subject of type `int`
+            pass
+
 def ok(x: int) -> None:
     match x:
         case 1:
+            pass
+
+def ok_union(x: int | list[int]) -> None:
+    match x:
+        case 1:
+            pass
+
+def ok_any(x: Any) -> None:
+    match x:
+        case 1:
+            pass
+
+class SomeClass: ...
+
+def ok_class_pattern(x: int) -> None:
+    match x:
+        case SomeClass():
             pass
 "#,
 );


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

The match-case binder now records a deferred reachability check for each typed case pattern, and the solver warns when applying that case’s narrowing makes the current subject type Never.

The warning uses the existing unreachable kind, e.g. Case pattern can never match subject of type `list[int]`.

also skipped top-like object subjects to avoid false positives for runtime-matchable values.

Fixes #3295

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test