### PR TITLE
Add `path` field to `ModuleReport` in `pyrefly report`

### DIFF
--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -69,7 +69,7 @@ use crate::state::state::State;
 use crate::state::state::Transaction;
 
 /// `(major, minor)` version for the report JSON schema.
-const REPORT_SCHEMA_VERSION: (u32, u32) = (0, 1);
+const REPORT_SCHEMA_VERSION: (u32, u32) = (0, 2);
 
 /// Slot-level annotation counts for a symbol.
 ///
@@ -328,6 +328,8 @@ impl SymbolReport {
 struct ModuleReport {
     /// Fully-qualified module name (e.g. "mypackage.submodule").
     name: String,
+    /// Filesystem path to the module source file.
+    path: String,
     /// Names of symbols defined in this module.
     names: Vec<String>,
     line_count: usize,
@@ -1699,6 +1701,7 @@ impl ReportArgs {
 
     fn build_module_report(
         name: String,
+        path: String,
         derived_name: &str,
         line_count: usize,
         functions: &[Function],
@@ -1797,6 +1800,7 @@ impl ReportArgs {
 
         ModuleReport {
             name,
+            path,
             names,
             line_count,
             symbol_reports,
@@ -1956,8 +1960,10 @@ impl ReportArgs {
 
                 let derived_name = handle.module().to_string();
                 let name = module_name_override.clone().unwrap_or(derived_name.clone());
+                let path = handle.path().as_path().display().to_string();
                 let mut module_report = Self::build_module_report(
                     name.clone(),
+                    path,
                     &derived_name,
                     line_count,
                     &functions,
@@ -2094,6 +2100,7 @@ mod tests {
 
         ReportArgs::build_module_report(
             "test".to_owned(),
+            "test.py".to_owned(),
             "test",
             line_count,
             &functions,
@@ -2223,6 +2230,7 @@ mod tests {
 
         ReportArgs::build_module_report(
             "test".to_owned(),
+            "test.pyi".to_owned(),
             "test",
             line_count,
             &functions,
@@ -2740,6 +2748,7 @@ def g(x: int) -> int:
         let loc = |line| Location { line, column: 1 };
         let mut report = ModuleReport {
             name: "pkg".to_owned(),
+            path: "pkg/__init__.py".to_owned(),
             names: vec!["pkg.Foo".into(), "pkg.bar".into(), "pkg._private".into()],
             line_count: 10,
             symbol_reports: vec![

--- a/pyrefly/lib/test/report/test_files/any_annotations.expected.json
+++ b/pyrefly/lib/test/report/test_files/any_annotations.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.x",
     "test.y",

--- a/pyrefly/lib/test/report/test_files/any_detection.expected.json
+++ b/pyrefly/lib/test/report/test_files/any_detection.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.any_var",
     "test.typed_var",

--- a/pyrefly/lib/test/report/test_files/decorators.expected.json
+++ b/pyrefly/lib/test/report/test_files/decorators.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.WithDecorators.static_method",
     "test.WithDecorators.class_method",

--- a/pyrefly/lib/test/report/test_files/dunder_attrs.expected.json
+++ b/pyrefly/lib/test/report/test_files/dunder_attrs.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.WithDunderAttrs.x",
     "test.WithAnnotatedDunder.regular_attr",

--- a/pyrefly/lib/test/report/test_files/dunder_implicit.expected.json
+++ b/pyrefly/lib/test/report/test_files/dunder_implicit.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.MyClass.__init__",
     "test.MyClass.__bool__",

--- a/pyrefly/lib/test/report/test_files/dunder_params.expected.json
+++ b/pyrefly/lib/test/report/test_files/dunder_params.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.WithExit.__exit__",
     "test.WithGetattr.__getattr__",

--- a/pyrefly/lib/test/report/test_files/functions.expected.json
+++ b/pyrefly/lib/test/report/test_files/functions.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.foo",
     "test.foo_unannotated",

--- a/pyrefly/lib/test/report/test_files/incomplete_methods.expected.json
+++ b/pyrefly/lib/test/report/test_files/incomplete_methods.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.Complete.method",
     "test.Incomplete.method_unannotated",

--- a/pyrefly/lib/test/report/test_files/inheritance.expected.json
+++ b/pyrefly/lib/test/report/test_files/inheritance.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.Base.base_method",
     "test.Child.child_method",

--- a/pyrefly/lib/test/report/test_files/inherited_attrs.expected.json
+++ b/pyrefly/lib/test/report/test_files/inherited_attrs.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.Base.x",
     "test.Base.y",

--- a/pyrefly/lib/test/report/test_files/instance_attrs.expected.json
+++ b/pyrefly/lib/test/report/test_files/instance_attrs.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.Untyped.x",
     "test.Typed.x",

--- a/pyrefly/lib/test/report/test_files/method_aliases.expected.json
+++ b/pyrefly/lib/test/report/test_files/method_aliases.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.Simple.__and__",
     "test.Simple.__rand__",

--- a/pyrefly/lib/test/report/test_files/module_name_override.expected.json
+++ b/pyrefly/lib/test/report/test_files/module_name_override.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "my.package.module",
+  "path": "test.py",
   "names": [
     "my.package.module.foo",
     "my.package.module.foo_unannotated",

--- a/pyrefly/lib/test/report/test_files/multi_tool_suppressions.expected.json
+++ b/pyrefly/lib/test/report/test_files/multi_tool_suppressions.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.x",
     "test.y",

--- a/pyrefly/lib/test/report/test_files/nested_classes.expected.json
+++ b/pyrefly/lib/test/report/test_files/nested_classes.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.Outer.method",
     "test.Outer.Inner.inner_method",

--- a/pyrefly/lib/test/report/test_files/nested_exclusions.expected.json
+++ b/pyrefly/lib/test/report/test_files/nested_exclusions.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.outer",
     "test.top_level",

--- a/pyrefly/lib/test/report/test_files/overloads.expected.json
+++ b/pyrefly/lib/test/report/test_files/overloads.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.f",
     "test.WithOverloads.method",

--- a/pyrefly/lib/test/report/test_files/overloads_any_fallback.expected.json
+++ b/pyrefly/lib/test/report/test_files/overloads_any_fallback.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.f"
   ],

--- a/pyrefly/lib/test/report/test_files/overloads_partial.expected.json
+++ b/pyrefly/lib/test/report/test_files/overloads_partial.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.partial",
     "test.different_params",

--- a/pyrefly/lib/test/report/test_files/partial_any.expected.json
+++ b/pyrefly/lib/test/report/test_files/partial_any.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.x",
     "test.y",

--- a/pyrefly/lib/test/report/test_files/partial_stub.expected.json
+++ b/pyrefly/lib/test/report/test_files/partial_stub.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.pyi",
   "names": [
     "test.x",
     "test.y",

--- a/pyrefly/lib/test/report/test_files/private_filtering.expected.json
+++ b/pyrefly/lib/test/report/test_files/private_filtering.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.public_var",
     "test.__version__",

--- a/pyrefly/lib/test/report/test_files/property_basic.expected.json
+++ b/pyrefly/lib/test/report/test_files/property_basic.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.Getter.x",
     "test.GetterUntyped.x",

--- a/pyrefly/lib/test/report/test_files/protocol.expected.json
+++ b/pyrefly/lib/test/report/test_files/protocol.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.Drawable.draw",
     "test.Drawable.resize",

--- a/pyrefly/lib/test/report/test_files/schema_classes.expected.json
+++ b/pyrefly/lib/test/report/test_files/schema_classes.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.Point.x",
     "test.Point.y",

--- a/pyrefly/lib/test/report/test_files/string_annotations.expected.json
+++ b/pyrefly/lib/test/report/test_files/string_annotations.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.x",
     "test.y",

--- a/pyrefly/lib/test/report/test_files/suppressions.expected.json
+++ b/pyrefly/lib/test/report/test_files/suppressions.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.x",
     "test.y",

--- a/pyrefly/lib/test/report/test_files/type_aliases.expected.json
+++ b/pyrefly/lib/test/report/test_files/type_aliases.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.T",
     "test.Alias1",

--- a/pyrefly/lib/test/report/test_files/type_check_only.expected.json
+++ b/pyrefly/lib/test/report/test_files/type_check_only.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.RegularClass.name",
     "test.regular_function",

--- a/pyrefly/lib/test/report/test_files/variables.expected.json
+++ b/pyrefly/lib/test/report/test_files/variables.expected.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
+  "path": "test.py",
   "names": [
     "test.T",
     "test.x",


### PR DESCRIPTION
# Summary

This adds a `path` field to the module json report from `pyrefly report`, for compatibility with typestats.

Fixes #3302

# Test Plan

Tests added/updated.