### PR TITLE
Ignore attribute types of schema classes in `pyrefly report`

### DIFF
--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -745,8 +745,8 @@ impl ReportArgs {
     }
 
     /// Returns the ClassBinding if the class owning this field is a schema class (dataclass, enum,
-    /// TypedDict, or NamedTuple). Fields of schema classes are IMPLICIT — they have
-    /// 0 typable slots because the class definition itself governs their types.
+    /// TypedDict, NamedTuple, pydantic model, or attrs class). Fields of schema classes are
+    /// IMPLICIT — they have 0 typable slots because the class definition itself governs their types.
     fn get_cls_binding_if_schema_class_field<'a>(
         bindings: &'a Bindings,
         answers: &Answers,
@@ -762,6 +762,8 @@ impl ReportArgs {
             || metadata.is_enum()
             || metadata.is_typed_dict()
             || metadata.named_tuple_metadata().is_some()
+            || metadata.is_pydantic_model()
+            || metadata.is_attrs_class()
         {
             Some(cls_binding)
         } else {
@@ -953,14 +955,13 @@ impl ReportArgs {
                     annotation,
                     initialized_in_recognized_method,
                 } => {
-                    if !initialized_in_recognized_method {
-                        // Check if this is a schema class body field
-                        if let Some(cls_binding) =
-                            Self::get_cls_binding_if_schema_class_field(bindings, answers, field)
-                        {
-                            if Self::has_function_ancestor(&cls_binding.parent) {
-                                continue;
-                            }
+                    // Schema class fields are always IMPLICIT regardless of whether they're
+                    // also initialized in a recognized method — the class definition governs
+                    // their types.
+                    if let Some(cls_binding) =
+                        Self::get_cls_binding_if_schema_class_field(bindings, answers, field)
+                    {
+                        if !Self::has_function_ancestor(&cls_binding.parent) {
                             let class_name = Self::class_qualified_name(
                                 module,
                                 &cls_binding.parent,
@@ -976,6 +977,10 @@ impl ReportArgs {
                                 location,
                             });
                         }
+                        continue;
+                    }
+                    // Non-schema fields only count when initialized in a recognized method.
+                    if !initialized_in_recognized_method {
                         continue;
                     }
                     Some(*annotation)
@@ -2053,11 +2058,12 @@ mod tests {
         );
     }
 
-    /// Build a `ModuleReport` from a checked-in Python test file,
+    /// Build a `ModuleReport` from a checked-in Python test file using a custom `TestEnv`,
     /// mirroring the production pipeline in `run_inner`.
-    fn build_module_report_for_test(py_file: &str) -> ModuleReport {
+    fn build_module_report_for_test_with_env(py_file: &str, mut env: TestEnv) -> ModuleReport {
         let code = load_test_file(py_file);
-        let (state, handle_fn) = TestEnv::one("test", &code)
+        env.add("test", &code);
+        let (state, handle_fn) = env
             .with_default_require_level(Require::Everything)
             .to_state();
         let handle = handle_fn("test");
@@ -2101,6 +2107,12 @@ mod tests {
             &classes,
             suppressions,
         )
+    }
+
+    /// Build a `ModuleReport` from a checked-in Python test file,
+    /// mirroring the production pipeline in `run_inner`.
+    fn build_module_report_for_test(py_file: &str) -> ModuleReport {
+        build_module_report_for_test_with_env(py_file, TestEnv::new())
     }
 
     /// Build a `ModuleReport` with a module name override, mirroring
@@ -2903,5 +2915,45 @@ def g(x: int) -> int:
         assert!(fqns.contains("pkg._internal.bar"));
         assert!(!fqns.contains("pkg._internal.foo"));
         assert!(!fqns.contains("pkg.baz"));
+    }
+
+    /// Dataclass and NamedTuple fields are IMPLICIT; methods on those classes count normally.
+    #[test]
+    fn test_report_schema_classes_methods() {
+        let report = build_module_report_for_test("schema_classes_methods.py");
+        compare_snapshot("schema_classes_methods.expected.json", &report);
+    }
+
+    /// IntEnum, StrEnum, Flag, IntFlag members are IMPLICIT (0 typable).
+    #[test]
+    fn test_report_schema_classes_enums() {
+        let report = build_module_report_for_test("schema_classes_enums.py");
+        compare_snapshot("schema_classes_enums.expected.json", &report);
+    }
+
+    /// TypedDict and dataclass subclasses: fields of all classes are IMPLICIT.
+    /// Inherited fields appear only under the defining class.
+    #[test]
+    fn test_report_schema_classes_inherited() {
+        let report = build_module_report_for_test("schema_classes_inherited.py");
+        compare_snapshot("schema_classes_inherited.expected.json", &report);
+    }
+
+    /// Pydantic BaseModel fields are IMPLICIT (0 typable).
+    #[test]
+    fn test_report_schema_classes_pydantic() {
+        let path = std::env::var("PYDANTIC_TEST_PATH").expect("PYDANTIC_TEST_PATH must be set");
+        let env = TestEnv::new_with_site_package_paths(&[&path]);
+        let report = build_module_report_for_test_with_env("schema_classes_pydantic.py", env);
+        compare_snapshot("schema_classes_pydantic.expected.json", &report);
+    }
+
+    /// attrs @define and @attr.s(auto_attribs=True) fields are IMPLICIT (0 typable).
+    #[test]
+    fn test_report_schema_classes_attrs() {
+        let path = std::env::var("ATTRS_TEST_PATH").expect("ATTRS_TEST_PATH must be set");
+        let env = TestEnv::new_with_site_package_paths(&[&path]);
+        let report = build_module_report_for_test_with_env("schema_classes_attrs.py", env);
+        compare_snapshot("schema_classes_attrs.expected.json", &report);
     }
 }

--- a/pyrefly/lib/test/report/test_files/schema_classes_attrs.expected.json
+++ b/pyrefly/lib/test/report/test_files/schema_classes_attrs.expected.json
@@ -1,0 +1,114 @@
+{
+  "name": "test",
+  "names": [
+    "test.Point.x",
+    "test.Point.y",
+    "test.Color.r",
+    "test.Color.g",
+    "test.Color.b",
+    "test.Color",
+    "test.Point"
+  ],
+  "line_count": 24,
+  "symbol_reports": [
+    {
+      "kind": "attr",
+      "name": "test.Point.x",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 15,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Point.y",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 16,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Color.r",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 21,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Color.g",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 22,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Color.b",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 23,
+        "column": 5
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.Color",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 19,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.Point",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 13,
+        "column": 1
+      }
+    }
+  ],
+  "type_ignores": [],
+  "n_typable": 0,
+  "n_typed": 0,
+  "n_any": 0,
+  "n_untyped": 0,
+  "coverage": 100.0,
+  "strict_coverage": 100.0,
+  "n_functions": 0,
+  "n_methods": 0,
+  "n_function_params": 0,
+  "n_method_params": 0,
+  "n_classes": 2,
+  "n_attrs": 5,
+  "n_properties": 0,
+  "n_type_ignores": 0
+}

--- a/pyrefly/lib/test/report/test_files/schema_classes_attrs.py
+++ b/pyrefly/lib/test/report/test_files/schema_classes_attrs.py
@@ -1,0 +1,23 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# attrs @define and @attr.s(auto_attribs=True) class fields are IMPLICIT (0 typable),
+# matching typestats behavior.
+
+import attr
+from attrs import define
+
+
+@define
+class Point:
+    x: float
+    y: float
+
+
+@attr.s(auto_attribs=True)
+class Color:
+    r: int
+    g: int
+    b: int

--- a/pyrefly/lib/test/report/test_files/schema_classes_enums.expected.json
+++ b/pyrefly/lib/test/report/test_files/schema_classes_enums.expected.json
@@ -1,0 +1,179 @@
+{
+  "name": "test",
+  "names": [
+    "test.Direction.NORTH",
+    "test.Direction.SOUTH",
+    "test.Color.RED",
+    "test.Color.GREEN",
+    "test.Permission.READ",
+    "test.Permission.WRITE",
+    "test.Priority.LOW",
+    "test.Priority.HIGH",
+    "test.Color",
+    "test.Direction",
+    "test.Permission",
+    "test.Priority"
+  ],
+  "line_count": 29,
+  "symbol_reports": [
+    {
+      "kind": "attr",
+      "name": "test.Direction.NORTH",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 12,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Direction.SOUTH",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 13,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Color.RED",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 17,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Color.GREEN",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 18,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Permission.READ",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 22,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Permission.WRITE",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 23,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Priority.LOW",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 27,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Priority.HIGH",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 28,
+        "column": 5
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.Color",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 16,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.Direction",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 11,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.Permission",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 21,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.Priority",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 26,
+        "column": 1
+      }
+    }
+  ],
+  "type_ignores": [],
+  "n_typable": 0,
+  "n_typed": 0,
+  "n_any": 0,
+  "n_untyped": 0,
+  "coverage": 100.0,
+  "strict_coverage": 100.0,
+  "n_functions": 0,
+  "n_methods": 0,
+  "n_function_params": 0,
+  "n_method_params": 0,
+  "n_classes": 4,
+  "n_attrs": 8,
+  "n_properties": 0,
+  "n_type_ignores": 0
+}

--- a/pyrefly/lib/test/report/test_files/schema_classes_enums.py
+++ b/pyrefly/lib/test/report/test_files/schema_classes_enums.py
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Enum subclasses (IntEnum, StrEnum, Flag, IntFlag) members are IMPLICIT (0 typable).
+
+from enum import Flag, IntEnum, IntFlag, StrEnum, auto
+
+
+class Direction(IntEnum):
+    NORTH = 1
+    SOUTH = 2
+
+
+class Color(StrEnum):
+    RED = auto()
+    GREEN = auto()
+
+
+class Permission(Flag):
+    READ = auto()
+    WRITE = auto()
+
+
+class Priority(IntFlag):
+    LOW = 1
+    HIGH = 4

--- a/pyrefly/lib/test/report/test_files/schema_classes_inherited.expected.json
+++ b/pyrefly/lib/test/report/test_files/schema_classes_inherited.expected.json
@@ -1,0 +1,127 @@
+{
+  "name": "test",
+  "names": [
+    "test.BaseConfig.name",
+    "test.ExtendedConfig.value",
+    "test.Base.x",
+    "test.Derived.y",
+    "test.Base",
+    "test.BaseConfig",
+    "test.Derived",
+    "test.ExtendedConfig"
+  ],
+  "line_count": 29,
+  "symbol_reports": [
+    {
+      "kind": "attr",
+      "name": "test.BaseConfig.name",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 14,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.ExtendedConfig.value",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 18,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Base.x",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 23,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Derived.y",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 28,
+        "column": 5
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.Base",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 21,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.BaseConfig",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 13,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.Derived",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 26,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.ExtendedConfig",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 17,
+        "column": 1
+      }
+    }
+  ],
+  "type_ignores": [],
+  "n_typable": 0,
+  "n_typed": 0,
+  "n_any": 0,
+  "n_untyped": 0,
+  "coverage": 100.0,
+  "strict_coverage": 100.0,
+  "n_functions": 0,
+  "n_methods": 0,
+  "n_function_params": 0,
+  "n_method_params": 0,
+  "n_classes": 4,
+  "n_attrs": 4,
+  "n_properties": 0,
+  "n_type_ignores": 0
+}

--- a/pyrefly/lib/test/report/test_files/schema_classes_inherited.py
+++ b/pyrefly/lib/test/report/test_files/schema_classes_inherited.py
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# TypedDict and dataclass subclasses: all schema class fields are IMPLICIT.
+# Inherited fields appear only under the defining class.
+
+from dataclasses import dataclass
+from typing import TypedDict
+
+
+class BaseConfig(TypedDict):
+    name: str
+
+
+class ExtendedConfig(BaseConfig):
+    value: int
+
+
+@dataclass
+class Base:
+    x: int
+
+
+@dataclass
+class Derived(Base):
+    y: float

--- a/pyrefly/lib/test/report/test_files/schema_classes_methods.expected.json
+++ b/pyrefly/lib/test/report/test_files/schema_classes_methods.expected.json
@@ -1,0 +1,127 @@
+{
+  "name": "test",
+  "names": [
+    "test.Point.x",
+    "test.Point.y",
+    "test.Vector.x",
+    "test.Vector.y",
+    "test.Point.distance",
+    "test.Vector.magnitude",
+    "test.Point",
+    "test.Vector"
+  ],
+  "line_count": 28,
+  "symbol_reports": [
+    {
+      "kind": "attr",
+      "name": "test.Point.x",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 15,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Point.y",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 16,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Vector.x",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 23,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Vector.y",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 24,
+        "column": 5
+      }
+    },
+    {
+      "kind": "function",
+      "name": "test.Point.distance",
+      "n_typable": 1,
+      "n_typed": 1,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 18,
+        "column": 5
+      }
+    },
+    {
+      "kind": "function",
+      "name": "test.Vector.magnitude",
+      "n_typable": 1,
+      "n_typed": 1,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 26,
+        "column": 5
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.Point",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 13,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.Vector",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 22,
+        "column": 1
+      }
+    }
+  ],
+  "type_ignores": [],
+  "n_typable": 2,
+  "n_typed": 2,
+  "n_any": 0,
+  "n_untyped": 0,
+  "coverage": 100.0,
+  "strict_coverage": 100.0,
+  "n_functions": 0,
+  "n_methods": 2,
+  "n_function_params": 0,
+  "n_method_params": 0,
+  "n_classes": 2,
+  "n_attrs": 4,
+  "n_properties": 0,
+  "n_type_ignores": 0
+}

--- a/pyrefly/lib/test/report/test_files/schema_classes_methods.py
+++ b/pyrefly/lib/test/report/test_files/schema_classes_methods.py
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Schema class fields (dataclass, NamedTuple) are IMPLICIT (0 typable),
+# but methods defined on those classes still count toward coverage.
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+
+@dataclass
+class Point:
+    x: float
+    y: float
+
+    def distance(self) -> float:
+        return (self.x**2 + self.y**2) ** 0.5
+
+
+class Vector(NamedTuple):
+    x: float
+    y: float
+
+    def magnitude(self) -> float:
+        return (self.x**2 + self.y**2) ** 0.5

--- a/pyrefly/lib/test/report/test_files/schema_classes_pydantic.expected.json
+++ b/pyrefly/lib/test/report/test_files/schema_classes_pydantic.expected.json
@@ -1,0 +1,88 @@
+{
+  "name": "test",
+  "names": [
+    "test.User.name",
+    "test.User.age",
+    "test.AdminUser.role",
+    "test.AdminUser",
+    "test.User"
+  ],
+  "line_count": 18,
+  "symbol_reports": [
+    {
+      "kind": "attr",
+      "name": "test.User.name",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 12,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.User.age",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 13,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.AdminUser.role",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 17,
+        "column": 5
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.AdminUser",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 16,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.User",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 11,
+        "column": 1
+      }
+    }
+  ],
+  "type_ignores": [],
+  "n_typable": 0,
+  "n_typed": 0,
+  "n_any": 0,
+  "n_untyped": 0,
+  "coverage": 100.0,
+  "strict_coverage": 100.0,
+  "n_functions": 0,
+  "n_methods": 0,
+  "n_function_params": 0,
+  "n_method_params": 0,
+  "n_classes": 2,
+  "n_attrs": 3,
+  "n_properties": 0,
+  "n_type_ignores": 0
+}

--- a/pyrefly/lib/test/report/test_files/schema_classes_pydantic.py
+++ b/pyrefly/lib/test/report/test_files/schema_classes_pydantic.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Pydantic BaseModel fields are IMPLICIT (0 typable), matching typestats behavior.
+
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+class AdminUser(User):
+    role: str


### PR DESCRIPTION
# Summary

This ports the typestats behavior where it ignores attributes of schema types like `TypedDict` and `NamedTuple`, which are always annotated, so that they no longer inflate the type coverage%.

Fixes #3301

# Test Plan

Tests added