### PR TITLE
stubgen: emit synthesized `__init__` for dataclass / Pydantic models

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1115,7 +1115,7 @@ impl ClassField {
         }
     }
 
-    fn dataclass_flags_of(&self, heap: &TypeHeap) -> DataclassFieldKeywords {
+    pub(crate) fn dataclass_flags_of(&self, heap: &TypeHeap) -> DataclassFieldKeywords {
         match &self.0 {
             ClassFieldInner::Property { .. } => DataclassFieldKeywords::new(),
             // Class-body-initialized descriptors have a default value (the descriptor instance).

--- a/pyrefly/lib/alt/class/dataclass.rs
+++ b/pyrefly/lib/alt/class/dataclass.rs
@@ -944,11 +944,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     ));
                 }
                 if let Some(alias) = &field_flags.init_by_alias {
+                    // Alias-only population (`validate_by_name=False`) still accepts the field via its
+                    // alias keyword at runtime; surface that as a keyword-only parameter (see
+                    // pydantic stub extraction tests).
+                    let alias_kw_only = is_kw_only || !field_flags.init_by_name;
                     params.push(self.as_param(
                         &field,
                         alias,
                         has_default,
-                        is_kw_only,
+                        alias_kw_only,
                         strict,
                         converter_param,
                         param_type_transform,

--- a/pyrefly/lib/alt/class/pydantic.rs
+++ b/pyrefly/lib/alt/class/pydantic.rs
@@ -273,6 +273,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let has_pydantic_base_model_base_class =
             bases_with_metadata.iter().any(|(base_class_object, _)| {
                 base_class_object.has_toplevel_qname(ModuleName::pydantic().as_str(), "BaseModel")
+                    // Re-exported models (`from pydantic import BaseModel`) may retain qname
+                    // `pydantic.BaseModel` instead of `pydantic.main.BaseModel`.
+                    || base_class_object.has_toplevel_qname("pydantic", "BaseModel")
             });
 
         let has_pydantic_base_settings_base_class =

--- a/pyrefly/lib/stubgen/emit.rs
+++ b/pyrefly/lib/stubgen/emit.rs
@@ -14,6 +14,11 @@ use crate::stubgen::extract::StubItem;
 use crate::stubgen::extract::StubParam;
 use crate::stubgen::extract::StubVariable;
 
+/// Synthesized `__init__` stubs with at least this many parameters (including `self`) are wrapped
+/// one-per-line. The threshold keeps narrow inits compact while breaking up wide signatures that
+/// would otherwise blow past a comfortable line width.
+const MULTILINE_INIT_THRESHOLD: usize = 5;
+
 /// Generate the full text of a `.pyi` stub file from a `ModuleStub`.
 pub fn emit_stub(stub: &ModuleStub) -> String {
     let mut out = String::new();
@@ -95,8 +100,17 @@ fn emit_function(func: &StubFunction, out: &mut String, indent: &str) {
     if let Some(tp) = &func.type_params {
         out.push_str(tp);
     }
+    let multiline_init = func.name == "__init__" && func.params.len() >= MULTILINE_INIT_THRESHOLD;
     out.push('(');
-    emit_params(&func.params, out);
+    if multiline_init {
+        let param_indent = format!("{}    ", indent);
+        out.push('\n');
+        emit_params_multiline(&func.params, out, &param_indent);
+        out.push('\n');
+        out.push_str(indent);
+    } else {
+        emit_params(&func.params, out);
+    }
     out.push(')');
 
     if let Some(ret) = &func.return_type {
@@ -124,26 +138,42 @@ fn emit_params(params: &[StubParam], out: &mut String) {
             out.push_str(", ");
         }
         first = false;
+        emit_one_param(param, out);
+    }
+}
 
-        if param.name == "*" || param.name == "/" {
-            out.push_str(&param.name);
-            continue;
+fn emit_params_multiline(params: &[StubParam], out: &mut String, line_indent: &str) {
+    for (i, param) in params.iter().enumerate() {
+        if i > 0 {
+            out.push_str(",\n");
         }
+        out.push_str(line_indent);
+        emit_one_param(param, out);
+    }
+    if !params.is_empty() {
+        out.push(',');
+    }
+}
 
-        out.push_str(param.prefix);
+fn emit_one_param(param: &StubParam, out: &mut String) {
+    if param.name == "*" || param.name == "/" {
         out.push_str(&param.name);
-        if let Some(ann) = &param.annotation {
-            out.push_str(": ");
-            out.push_str(ann);
+        return;
+    }
+
+    out.push_str(param.prefix);
+    out.push_str(&param.name);
+    if let Some(ann) = &param.annotation {
+        out.push_str(": ");
+        out.push_str(ann);
+    }
+    if let Some(default) = &param.default {
+        if param.annotation.is_some() {
+            out.push_str(" = ");
+        } else {
+            out.push('=');
         }
-        if let Some(default) = &param.default {
-            if param.annotation.is_some() {
-                out.push_str(" = ");
-            } else {
-                out.push('=');
-            }
-            out.push_str(default);
-        }
+        out.push_str(default);
     }
 }
 

--- a/pyrefly/lib/stubgen/extract.rs
+++ b/pyrefly/lib/stubgen/extract.rs
@@ -15,10 +15,13 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use pyrefly_build::handle::Handle;
+use pyrefly_python::dunder;
 use pyrefly_python::module::Module;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_python::sys_info::SysInfo;
 use pyrefly_types::callable::Param;
+use pyrefly_types::callable::Params;
+use pyrefly_types::callable::Required;
 use pyrefly_types::display::TypeDisplayContext;
 use pyrefly_types::types::Type;
 use ruff_python_ast::Expr;
@@ -32,15 +35,22 @@ use ruff_text_size::TextRange;
 use starlark_map::Hashed;
 
 use crate::alt::answers::Answers;
+use crate::alt::class::class_field::ClassField;
+use crate::alt::types::class_metadata::ClassMetadata;
+use crate::alt::types::class_metadata::ClassSynthesizedFields;
 use crate::alt::types::decorated_function::DecoratedFunction;
 use crate::binding::binding::Key;
+use crate::binding::binding::KeyClass;
 use crate::binding::binding::KeyClassField;
+use crate::binding::binding::KeyClassMetadata;
+use crate::binding::binding::KeyClassSynthesizedFields;
 use crate::binding::binding::KeyDecoratedFunction;
 use crate::binding::bindings::Bindings;
 use crate::export::definitions::Definitions;
 use crate::export::definitions::DunderAllEntry;
 use crate::export::definitions::DunderAllKind;
 use crate::state::state::Transaction;
+use crate::types::class::Class;
 
 /// A single module's stub content, in source order.
 pub struct ModuleStub {
@@ -136,9 +146,11 @@ pub fn extract_module_stub(
         uses_self: false,
         function_map: &function_map,
         dunder_all: &dunder_all,
+        current_class: None,
     };
 
-    let items = extract_stmts(&ast.body, &mut ctx, false);
+    let mut items = extract_stmts(&ast.body, &mut ctx, false);
+    prune_stub_imports(&mut items);
 
     Some(ModuleStub {
         items,
@@ -158,6 +170,8 @@ struct ExtractionContext<'a> {
     /// When `__all__` is explicitly defined, only these names are exported
     /// at module level. `None` means no explicit `__all__` — use convention.
     dunder_all: &'a Option<HashSet<Name>>,
+    /// Innermost class being extracted (`None` at module scope).
+    current_class: Option<Class>,
 }
 
 fn extract_stmts(stmts: &[Stmt], ctx: &mut ExtractionContext, in_class: bool) -> Vec<StubItem> {
@@ -252,6 +266,7 @@ fn extract_function(
     let decorators: Vec<String> = func_def
         .decorator_list
         .iter()
+        .filter(|d| !(in_class && is_computed_field_decorator(&d.expression)))
         .map(|d| format!("@{}", source_text(ctx.module_info, d.expression.range())))
         .collect();
 
@@ -619,7 +634,14 @@ fn extract_class(class_def: &StmtClassDef, ctx: &mut ExtractionContext) -> Optio
         .as_ref()
         .map(|tp| source_text(ctx.module_info, tp.range()).to_owned());
 
-    let body = extract_stmts(&class_def.body, ctx, true);
+    let resolved_class = resolve_class_for_stub(class_def, ctx);
+    let outer_class = ctx.current_class.clone();
+    ctx.current_class = resolved_class.clone();
+
+    let body = extract_class_body(class_def, ctx, resolved_class.as_ref());
+
+    ctx.current_class = outer_class;
+
     let extra = extract_instance_attr_stubs_from_class_fields(class_def, &body, ctx);
     let body = merge_instance_field_stubs(extra, body);
 
@@ -648,10 +670,18 @@ fn extract_ann_assign(
 
     let annotation = source_text(ctx.module_info, ann_assign.annotation.range()).to_owned();
 
-    let value = ann_assign
-        .value
-        .as_deref()
-        .and_then(|v| simple_value_text(v, ctx.module_info));
+    let value = match ann_assign.value.as_deref() {
+        None => None,
+        Some(v) => {
+            if let Some(simple) = simple_value_text(v, ctx.module_info) {
+                Some(simple)
+            } else if in_class {
+                complex_class_attribute_stub_value(name, ctx)
+            } else {
+                None
+            }
+        }
+    };
 
     Some(StubVariable {
         name: name.to_owned(),
@@ -853,6 +883,458 @@ fn is_type_constructor_or_alias(assign: &ruff_python_ast::StmtAssign) -> bool {
     } else {
         false
     }
+}
+
+fn is_computed_field_decorator(expr: &Expr) -> bool {
+    match expr {
+        Expr::Name(n) => n.id.as_str() == "computed_field",
+        Expr::Attribute(a) => a.attr.as_str() == "computed_field",
+        _ => false,
+    }
+}
+
+fn resolve_class_for_stub(class_def: &StmtClassDef, ctx: &ExtractionContext) -> Option<Class> {
+    let key = KeyClass(ShortIdentifier::new(&class_def.name));
+    let idx = ctx.bindings.key_to_idx_hashed_opt(Hashed::new(&key))?;
+    let answered = ctx.answers.get_idx(idx)?;
+    answered.0.clone()
+}
+
+fn extract_class_body(
+    class_def: &StmtClassDef,
+    ctx: &mut ExtractionContext,
+    resolved_class: Option<&Class>,
+) -> Vec<StubItem> {
+    let body = &class_def.body;
+    let has_explicit_init = body.iter().any(|s| {
+        matches!(
+            s,
+            Stmt::FunctionDef(f) if f.name.as_str() == "__init__"
+        )
+    });
+
+    if has_explicit_init {
+        return extract_stmts(body, ctx, true);
+    }
+
+    let first_fn = body.iter().position(|s| matches!(s, Stmt::FunctionDef(_)));
+    match first_fn {
+        None => {
+            let mut items = extract_stmts(body, ctx, true);
+            maybe_push_synthetic_init(class_def, &mut items, resolved_class, ctx);
+            items
+        }
+        Some(i) => {
+            let leading = &body[..i];
+            let tail = &body[i..];
+            let mut items = extract_stmts(leading, ctx, true);
+            maybe_push_synthetic_init(class_def, &mut items, resolved_class, ctx);
+            items.extend(extract_stmts(tail, ctx, true));
+            items
+        }
+    }
+}
+
+fn maybe_push_synthetic_init(
+    class_def: &StmtClassDef,
+    items: &mut Vec<StubItem>,
+    resolved_class: Option<&Class>,
+    ctx: &mut ExtractionContext,
+) {
+    if let Some(cls) = resolved_class
+        && let Some(init_fn) = synthetic_init_stub_fn(class_def, cls, ctx)
+    {
+        items.push(StubItem::Function(init_fn));
+    }
+}
+
+fn synthetic_init_stub_fn(
+    class_def: &StmtClassDef,
+    cls: &Class,
+    ctx: &mut ExtractionContext,
+) -> Option<StubFunction> {
+    // NamedTuple's synthesized `__init__` is a `(self, *args, **kwargs)` placeholder; the
+    // field-accurate signature lives on `__new__`. Skip the placeholder rather than emit it.
+    if class_metadata_for(cls, ctx).is_some_and(|m| m.named_tuple_metadata().is_some()) {
+        return None;
+    }
+    let idx = ctx
+        .bindings
+        .key_to_idx_hashed_opt(Hashed::new(&KeyClassSynthesizedFields(cls.index())))?;
+    let synthesized: Arc<ClassSynthesizedFields> = ctx.answers.get_idx(idx)?;
+    let init_field = synthesized.get(&dunder::INIT)?;
+    let ty = init_field.inner.ty();
+    let callable = *ty.callable_signatures().first()?;
+    let Params::List(list) = &callable.params else {
+        return None;
+    };
+    let items = list.items();
+    let ast_defaults = ann_assign_value_exprs_by_name(&class_def.body);
+    let ann_for_init_param = init_param_annotation_overrides_from_class_body(class_def, cls, ctx);
+    let mut params = Vec::new();
+    let mut inserted_kwonly_star = false;
+    let has_explicit_kw_sep = items.iter().any(|p| matches!(p, Param::Varargs(None, _)));
+
+    for p in items {
+        if matches!(p, Param::Kwargs(..)) {
+            continue;
+        }
+        if matches!(p, Param::KwOnly(..)) && !inserted_kwonly_star && !has_explicit_kw_sep {
+            params.push(StubParam {
+                prefix: "",
+                name: "*".to_owned(),
+                annotation: None,
+                default: None,
+            });
+            inserted_kwonly_star = true;
+        }
+        let mut stub = synthesized_param_to_stub(p, ctx);
+        if let Some(text) = ann_for_init_param.get(stub.name.as_str()) {
+            stub.annotation = Some(text.clone());
+        }
+        if stub.default.as_deref() == Some("...")
+            && let Some(expr) = ast_defaults.get(stub.name.as_str())
+        {
+            let fd = format_default(expr, ctx.module_info);
+            if fd != "..." {
+                stub.default = Some(fd);
+            }
+        }
+        params.push(stub);
+    }
+
+    let return_type = format_type(&callable.ret, ctx);
+
+    Some(StubFunction {
+        name: "__init__".to_owned(),
+        is_async: false,
+        type_params: None,
+        decorators: Vec::new(),
+        params,
+        return_type,
+        docstring: None,
+    })
+}
+
+fn class_metadata_for(cls: &Class, ctx: &ExtractionContext) -> Option<Arc<ClassMetadata>> {
+    let idx = ctx
+        .bindings
+        .key_to_idx_hashed_opt(Hashed::new(&KeyClassMetadata(cls.index())))?;
+    ctx.answers.get_idx(idx)
+}
+
+/// Map annotated assignment targets to their RHS expression for class-body field stubs.
+fn ann_assign_value_exprs_by_name(body: &[Stmt]) -> HashMap<String, &Expr> {
+    let mut m = HashMap::new();
+    for stmt in body {
+        let Stmt::AnnAssign(ann) = stmt else {
+            continue;
+        };
+        let Expr::Name(n) = ann.target.as_ref() else {
+            continue;
+        };
+        if let Some(v) = ann.value.as_deref() {
+            m.insert(n.id.to_string(), v);
+        }
+    }
+    m
+}
+
+/// Maps synthesized `__init__` parameter names to annotation source text from the class body.
+///
+/// Pydantic's lax coercion types are wider than the authored annotations; stubs should reflect the
+/// latter. Includes [`validation_alias`](https://docs.pydantic.dev/latest/concepts/alias/)
+/// keywords when they participate in `__init__`.
+fn init_param_annotation_overrides_from_class_body(
+    class_def: &StmtClassDef,
+    cls: &Class,
+    ctx: &ExtractionContext,
+) -> HashMap<String, String> {
+    let mut m = HashMap::new();
+    for stmt in &class_def.body {
+        let Stmt::AnnAssign(ann) = stmt else {
+            continue;
+        };
+        let Expr::Name(n) = ann.target.as_ref() else {
+            continue;
+        };
+        let field_name = n.id.clone();
+        let Some(idx) = ctx
+            .bindings
+            .key_to_idx_hashed_opt(Hashed::new(&KeyClassField(cls.index(), field_name.clone())))
+        else {
+            continue;
+        };
+        let Some(class_field): Option<Arc<ClassField>> = ctx.answers.get_idx(idx) else {
+            continue;
+        };
+        if class_field.is_init_var() {
+            continue;
+        }
+        let flags = class_field.dataclass_flags_of(ctx.answers.heap());
+        if !flags.init {
+            continue;
+        }
+        let ann_text = source_text(ctx.module_info, ann.annotation.range()).to_owned();
+        if flags.init_by_name {
+            m.insert(field_name.as_str().to_owned(), ann_text.clone());
+        }
+        if let Some(alias) = &flags.init_by_alias {
+            m.insert(alias.as_str().to_owned(), ann_text);
+        }
+    }
+    m
+}
+
+fn synthesized_param_to_stub(param: &Param, ctx: &mut ExtractionContext) -> StubParam {
+    match param {
+        Param::PosOnly(maybe_name, ty, req) => {
+            let name = maybe_name
+                .as_ref()
+                .map(|n| n.as_str().to_owned())
+                .unwrap_or_else(|| "_".to_owned());
+            StubParam {
+                prefix: "",
+                name,
+                annotation: annotation_for_param(param, ty, ctx),
+                default: required_to_stub_default(req, ctx),
+            }
+        }
+        Param::Pos(name, ty, req) => StubParam {
+            prefix: "",
+            name: name.as_str().to_owned(),
+            annotation: annotation_for_param(param, ty, ctx),
+            default: required_to_stub_default(req, ctx),
+        },
+        Param::Varargs(maybe_name, ty) => {
+            if let Some(name) = maybe_name {
+                StubParam {
+                    prefix: "*",
+                    name: name.as_str().to_owned(),
+                    annotation: format_type(ty, ctx),
+                    default: None,
+                }
+            } else {
+                StubParam {
+                    prefix: "",
+                    name: "*".to_owned(),
+                    annotation: None,
+                    default: None,
+                }
+            }
+        }
+        Param::KwOnly(name, ty, req) => StubParam {
+            prefix: "",
+            name: name.as_str().to_owned(),
+            annotation: annotation_for_param(param, ty, ctx),
+            default: required_to_stub_default(req, ctx),
+        },
+        Param::Kwargs(maybe_name, ty) => StubParam {
+            prefix: "**",
+            name: maybe_name
+                .as_ref()
+                .map(|n| n.as_str().to_owned())
+                .unwrap_or_else(|| "kwargs".to_owned()),
+            annotation: format_type(ty, ctx),
+            default: None,
+        },
+    }
+}
+
+fn annotation_for_param(param: &Param, ty: &Type, ctx: &mut ExtractionContext) -> Option<String> {
+    if let Some(n) = param.name()
+        && (n.as_str() == "self" || n.as_str() == "cls")
+    {
+        return None;
+    }
+    format_type(ty, ctx)
+}
+
+fn required_to_stub_default(req: &Required, ctx: &mut ExtractionContext) -> Option<String> {
+    match req {
+        Required::Required => None,
+        Required::Optional(None) => Some("...".to_owned()),
+        Required::Optional(Some(dv)) => dv.display.clone().or_else(|| format_type(&dv.ty, ctx)),
+    }
+}
+
+/// Render the class-body default for a field whose RHS is not a simple literal
+/// (e.g. `field(default=None)`, `Field(default_factory=list)`). We elide to `= ...`
+/// when the dataclass / Pydantic field analysis says the field has a default at all;
+/// otherwise no default is emitted. The AST shape of the RHS is irrelevant — the
+/// checker's `dataclass_flags_of` already reflects whether `default` / `default_factory`
+/// were supplied (and ignores positional `...` per Pydantic's runtime semantics).
+fn complex_class_attribute_stub_value(name: &str, ctx: &mut ExtractionContext) -> Option<String> {
+    let cls = ctx.current_class.as_ref()?;
+    let key = KeyClassField(cls.index(), Name::new(name));
+    let idx = ctx.bindings.key_to_idx_hashed_opt(Hashed::new(&key))?;
+    let class_field: Arc<ClassField> = ctx.answers.get_idx(idx)?;
+    let flags = class_field.dataclass_flags_of(ctx.answers.heap());
+    flags.default.as_ref().map(|_| "...".to_owned())
+}
+
+fn prune_stub_imports(items: &mut Vec<StubItem>) {
+    let body = collect_stub_text_for_import_prune(items);
+    prune_imports_in_items(items, &body);
+}
+
+fn collect_stub_text_for_import_prune(items: &[StubItem]) -> String {
+    let mut out = String::new();
+    for item in items {
+        append_stub_item_text(item, &mut out);
+    }
+    out
+}
+
+fn append_stub_item_text(item: &StubItem, out: &mut String) {
+    match item {
+        StubItem::Import(_) => {}
+        StubItem::Function(f) => {
+            for d in &f.decorators {
+                out.push_str(d);
+            }
+            out.push_str(&f.name);
+            for p in &f.params {
+                out.push_str(&p.name);
+                if let Some(a) = &p.annotation {
+                    out.push_str(a);
+                }
+                if let Some(d) = &p.default {
+                    out.push_str(d);
+                }
+            }
+            if let Some(r) = &f.return_type {
+                out.push_str(r);
+            }
+        }
+        StubItem::Class(c) => {
+            out.push_str(&c.name);
+            out.push_str(&c.bases);
+            for d in &c.decorators {
+                out.push_str(d);
+            }
+            append_stub_items_text(&c.body, out);
+        }
+        StubItem::Variable(v) => {
+            out.push_str(&v.name);
+            if let Some(a) = &v.annotation {
+                out.push_str(a);
+            }
+            if let Some(val) = &v.value {
+                out.push_str(val);
+            }
+        }
+        StubItem::TypeAlias(t) => {
+            out.push_str(&t.text);
+        }
+    }
+}
+
+fn append_stub_items_text(items: &[StubItem], out: &mut String) {
+    for item in items {
+        append_stub_item_text(item, out);
+    }
+}
+
+fn prune_imports_in_items(items: &mut Vec<StubItem>, body: &str) {
+    items.retain_mut(|item| {
+        if let StubItem::Import(imp) = item {
+            let new_text = prune_import_line(&imp.text, body);
+            if new_text.is_empty() {
+                return false;
+            }
+            imp.text = new_text;
+        }
+        if let StubItem::Class(c) = item {
+            let class_body = collect_stub_text_for_import_prune(&c.body);
+            prune_imports_in_items(&mut c.body, &class_body);
+        }
+        true
+    });
+}
+
+fn prune_import_line(line: &str, body: &str) -> String {
+    let trimmed = line.trim();
+    let indent_len = line.len() - trimmed.len();
+    let indent = &line[..indent_len];
+
+    if trimmed == "import functools" && !contains_whole_word(body, "functools") {
+        return String::new();
+    }
+    if let Some(rest) = trimmed.strip_prefix("from dataclasses import") {
+        return prune_from_import_rest(indent, "dataclasses", rest, "field", body);
+    }
+    if let Some(rest) = trimmed.strip_prefix("from pydantic import") {
+        let line = prune_from_import_rest(indent, "pydantic", rest, "Field", body);
+        return prune_from_import_rest_line(line, indent, "pydantic", "computed_field", body);
+    }
+    line.to_owned()
+}
+
+fn prune_from_import_rest(
+    indent: &str,
+    module: &str,
+    after_import: &str,
+    symbol: &str,
+    body: &str,
+) -> String {
+    let keep_symbol = contains_whole_word(body, symbol);
+    let names: Vec<String> = after_import
+        .split(',')
+        .filter_map(|raw| {
+            let name = raw.trim();
+            if name.is_empty() {
+                return None;
+            }
+            if !keep_symbol && name == symbol {
+                return None;
+            }
+            Some(name.to_owned())
+        })
+        .collect();
+    if names.is_empty() {
+        return String::new();
+    }
+    format!("{}from {} import {}", indent, module, names.join(", "))
+}
+
+/// Apply [`prune_from_import_rest`] when `line` is a `from module import ...` line.
+fn prune_from_import_rest_line(
+    line: String,
+    indent: &str,
+    module: &str,
+    symbol: &str,
+    body: &str,
+) -> String {
+    if line.trim().is_empty() {
+        return line;
+    }
+    let trimmed = line.trim();
+    let prefix = format!("from {module} import");
+    let Some(rest) = trimmed.strip_prefix(&prefix) else {
+        return line;
+    };
+    prune_from_import_rest(indent, module, rest, symbol, body)
+}
+
+fn contains_whole_word(haystack: &str, word: &str) -> bool {
+    for (idx, _) in haystack.match_indices(word) {
+        let before_ok = idx == 0
+            || !haystack
+                .as_bytes()
+                .get(idx - 1)
+                .is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_');
+        let after = idx + word.len();
+        let after_ok = after >= haystack.len()
+            || !haystack
+                .as_bytes()
+                .get(after)
+                .is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_');
+        if before_ok && after_ok {
+            return true;
+        }
+    }
+    false
 }
 
 fn source_text(module_info: &Module, range: TextRange) -> &str {

--- a/pyrefly/lib/stubgen/mod.rs
+++ b/pyrefly/lib/stubgen/mod.rs
@@ -39,12 +39,39 @@ mod tests {
     }
 
     fn run_stubgen_with_config(input: &str, config: &ExtractConfig) -> String {
+        // Minimal `pydantic` definitions for stub extraction tests. The real package applies
+        // `@dataclass_transform(kw_only_default=True)`, which makes every field keyword-only and
+        // does not match the constructor shapes these tests assert against.
+        const PYDANTIC_SHIM: &str = r#"from typing import dataclass_transform
+
+def Field(**kwargs): ...
+
+def computed_field(fn=None, **_kw):
+    return fn
+
+@dataclass_transform(
+    kw_only_default=False,
+    field_specifiers=(Field,),
+)
+class BaseModel:
+    pass
+"#;
+
         let tdir = tempfile::tempdir().unwrap();
+        let pydantic_pkg = tdir.path().join("pydantic");
+        fs_anyhow::create_dir_all(&pydantic_pkg).unwrap();
+        fs_anyhow::write(&pydantic_pkg.join("__init__.py"), PYDANTIC_SHIM).unwrap();
+
         let path = tdir.path().join("input.py");
         fs_anyhow::write(&path, input).unwrap();
         let mut t = TestEnv::new();
+        // Real files under `tdir` are picked up by the stubgen glob; registering `pydantic` here
+        // wires the package into `ConfigFinder`'s source DB so imports resolve during checking.
+        t.add_real_path("pydantic", pydantic_pkg.join("__init__.py"));
         t.add(&path.display().to_string(), input);
-        let includes = Globs::new(vec![format!("{}/**/*", tdir.path().display())]).unwrap();
+        // Limit checking to the snippet under test. A sibling `pydantic/` package may live in the
+        // same temp directory for imports; it must not be treated as another stubgen input file.
+        let includes = Globs::new(vec![format!("{}/input.py", tdir.path().display())]).unwrap();
         let f_globs = Box::new(FilteredGlobs::new(
             includes,
             Globs::empty(),
@@ -184,6 +211,16 @@ mod tests {
     }
 
     #[test]
+    fn test_stubgen_dataclasses() {
+        assert_stubgen_snapshot("dataclasses");
+    }
+
+    #[test]
+    fn test_stubgen_pydantic() {
+        assert_stubgen_snapshot("pydantic");
+    }
+
+    #[test]
     fn test_stubgen_docstrings() {
         let input = r#"
 def greet(name: str) -> str:
@@ -303,5 +340,32 @@ class A:
             .trim(),
             actual.trim(),
         );
+    }
+
+    /// `include_docstrings` must not add inline `# ...` Field metadata comments on attributes; stub
+    /// shape stays the same as without doc config for this case (no `Field(...)` on the class body).
+    /// Kept as an inline test because the snapshot fixture runner uses the default
+    /// `ExtractConfig` and cannot exercise `include_docstrings=true`.
+    #[test]
+    fn test_stubgen_pydantic_field_retains_description_with_include_docstrings() {
+        let input = r#"from pydantic import BaseModel, Field
+
+class A(BaseModel):
+    u: int = Field(..., description="required", title="T")
+"#;
+        let config = ExtractConfig {
+            include_private: false,
+            include_docstrings: true,
+        };
+        let actual = run_stubgen_with_config(input, &config);
+        let expected = r#"from pydantic import BaseModel
+
+
+class A(BaseModel):
+    u: int
+
+    def __init__(self, u: int) -> None: ...
+"#;
+        pretty_assertions::assert_str_eq!(expected, &actual);
     }
 }

--- a/pyrefly/lib/test/stubgen/dataclasses/expected.pyi
+++ b/pyrefly/lib/test/stubgen/dataclasses/expected.pyi
@@ -1,0 +1,67 @@
+# @generated
+from dataclasses import InitVar, dataclass
+from typing import ClassVar
+
+
+@dataclass
+class OptionalName:
+    name: str | None = ...
+
+    def __init__(self, name: str | None = ...) -> None: ...
+
+
+@dataclass
+class Mixed:
+    required: int
+    literal_default: str = "x"
+    field_with_default: int = ...
+    field_with_none: str | None = ...
+    items: list[str] = ...
+    complex_factory: list[int] = ...
+    field_no_default: int
+    field_ellipsis: int
+
+    def __init__(
+        self,
+        required: int,
+        literal_default: str = "x",
+        field_with_default: int = ...,
+        field_with_none: str | None = ...,
+        items: list[str] = ...,
+        complex_factory: list[int] = ...,
+        field_no_default: int,
+        *,
+        field_ellipsis: int,
+    ) -> None: ...
+
+
+@dataclass
+class WithInitFalse:
+    path: str
+    cached: dict[str, str] = ...
+
+    def __init__(self, path: str) -> None: ...
+
+
+@dataclass
+class WithInitVarAndClassVar:
+    sentinel: ClassVar[str] = "x"
+    raw: InitVar[bytes | None]
+    text: str = ...
+
+    def __init__(self, raw: bytes | None, text: str = ...) -> None: ...
+
+
+@dataclass(kw_only=True)
+class AllKwOnly:
+    a: int
+    b: str = "y"
+
+    def __init__(self, *, a: int, b: str = "y") -> None: ...
+
+
+@dataclass
+class CustomInit:
+    x: int
+
+    def __init__(self, x: int, *, tag: str = "") -> None: ...

--- a/pyrefly/lib/test/stubgen/dataclasses/input.py
+++ b/pyrefly/lib/test/stubgen/dataclasses/input.py
@@ -1,0 +1,60 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import InitVar, dataclass, field
+from typing import ClassVar
+
+
+# The original #3221 reproducer: a non-literal `field(default=None)` should still produce a
+# default in the synthesized `__init__`, so `A()` is accepted by checkers against the stub.
+@dataclass
+class OptionalName:
+    name: str | None = field(default=None)
+
+
+# Mixed field defaults: literal, `field(default=...)`, `field(default_factory=...)`, bare
+# `field()`, and a trailing `field(..., kw_only=True)` to force keyword-only positioning.
+@dataclass
+class Mixed:
+    required: int
+    literal_default: str = "x"
+    field_with_default: int = field(default=0, metadata={"a": 1}, repr=True)
+    field_with_none: str | None = field(default=None)
+    items: list[str] = field(default_factory=list, metadata={"k": 1})
+    complex_factory: list[int] = field(default_factory=lambda: [1, 2, 3])
+    field_no_default: int = field()
+    field_ellipsis: int = field(..., kw_only=True)
+
+
+# `init=False` keeps the attribute typed on the class but drops it from `__init__`.
+@dataclass
+class WithInitFalse:
+    path: str
+    cached: dict[str, str] = field(default_factory=dict, init=False)
+
+
+# `InitVar` participates in `__init__` (unwrapped to its inner type) but does not become a
+# stored attribute. `ClassVar` stays on the class body and is omitted from `__init__`.
+@dataclass
+class WithInitVarAndClassVar:
+    sentinel: ClassVar[str] = "x"
+    raw: InitVar[bytes | None]
+    text: str = field(default="")
+
+
+# `@dataclass(kw_only=True)` makes every constructor parameter keyword-only.
+@dataclass(kw_only=True)
+class AllKwOnly:
+    a: int
+    b: str = "y"
+
+
+# A user-defined `__init__` must be kept verbatim; stubgen must not synthesize a replacement.
+@dataclass
+class CustomInit:
+    x: int
+
+    def __init__(self, x: int, *, tag: str = "") -> None:
+        self.x = x

--- a/pyrefly/lib/test/stubgen/pydantic/expected.pyi
+++ b/pyrefly/lib/test/stubgen/pydantic/expected.pyi
@@ -1,0 +1,63 @@
+# @generated
+from pydantic import BaseModel
+
+
+class Mixed(BaseModel):
+    required: int
+    literal_default: int = 7
+    field_with_default: int = ...
+    field_with_none: str | None = ...
+    items: list[str] = ...
+    complex_factory: list[int] = ...
+    field_bare: int
+    field_ellipsis: int
+    field_ellipsis_only: int
+
+    def __init__(
+        self,
+        required: int,
+        literal_default: int = 7,
+        field_with_default: int = ...,
+        field_with_none: str | None = ...,
+        items: list[str] = ...,
+        complex_factory: list[int] = ...,
+        field_bare: int,
+        field_ellipsis: int,
+        field_ellipsis_only: int,
+    ) -> None: ...
+
+
+class WithInitFalse(BaseModel):
+    id: int
+    digest: bytes = ...
+
+    def __init__(self, id: int) -> None: ...
+
+
+class WithValidationAlias(BaseModel):
+    internal_id: int
+
+    def __init__(self, *, id: int) -> None: ...
+
+
+class WithKwOnly(BaseModel):
+    req: int
+    opt: str = ...
+
+    def __init__(self, req: int, *, opt: str = ...) -> None: ...
+
+
+class WithComputed(BaseModel):
+    width: int
+    height: int
+
+    def __init__(self, width: int, height: int) -> None: ...
+
+    @property
+    def area(self) -> int: ...
+
+
+class CustomInit(BaseModel):
+    name: str
+
+    def __init__(self, name: str, *, eager: bool = False) -> None: ...

--- a/pyrefly/lib/test/stubgen/pydantic/input.py
+++ b/pyrefly/lib/test/stubgen/pydantic/input.py
@@ -1,0 +1,61 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+
+from pydantic import BaseModel, Field, computed_field
+
+
+# Mixed Pydantic `Field` defaults: literal, `default=`, `default_factory=` (simple + complex),
+# `Field(...)` for required fields, bare `Field()`, plus a kwargs-only field.
+class Mixed(BaseModel):
+    required: int
+    literal_default: int = 7
+    field_with_default: int = Field(default=0)
+    field_with_none: str | None = Field(default=None)
+    items: list[str] = Field(default_factory=list, min_length=0)
+    complex_factory: list[int] = Field(default_factory=functools.partial(list, [0]))
+    field_bare: int = Field()
+    field_ellipsis: int = Field(..., description="req")
+    field_ellipsis_only: int = Field(...)
+
+
+# `init=False` keeps the attribute on the model but drops it from `__init__`, matching the
+# runtime constructor surface.
+class WithInitFalse(BaseModel):
+    id: int
+    digest: bytes = Field(default=b"", init=False)
+
+
+# Pydantic `validation_alias` (without `validate_by_name`) means the field is only populated
+# via the alias keyword; the alias appears as a keyword-only parameter on `__init__`.
+class WithValidationAlias(BaseModel):
+    internal_id: int = Field(validation_alias="id")
+
+
+# `Field(kw_only=True)` forces a field (and any later fields) to be keyword-only.
+class WithKwOnly(BaseModel):
+    req: int = Field(kw_only=False)
+    opt: str = Field(default="z", kw_only=True)
+
+
+# `@computed_field` exposes a read-only attribute that is not a constructor parameter; it
+# should appear in the stub as a plain `@property`.
+class WithComputed(BaseModel):
+    width: int
+    height: int
+
+    @computed_field
+    @property
+    def area(self) -> int:
+        return self.width * self.height
+
+
+# A user-defined `__init__` must be kept verbatim; stubgen must not synthesize a replacement.
+class CustomInit(BaseModel):
+    name: str
+
+    def __init__(self, name: str, *, eager: bool = False) -> None:
+        super().__init__(name=name)


### PR DESCRIPTION
## Context

As in #3221 / #3223, stub output for dataclass and Pydantic models needs to reflect **how instances are constructed** (defaults, `kw_only`, validation aliases, etc.) without turning `.pyi` files into a dump of `field()` / `Field()` kwargs.

## Intent

**Alternative to #3223.** Rather than primarily re-emitting a **reduced** `field()` / `Field()` on the class line, this approach **injects a synthesized `__init__`** derived from the checker’s existing dataclass / Pydantic init plumbing, then **aligns annotations with the authored class body** where parameter names match (including alias-only init).

## Changes

- **`extract.rs`:** Resolve synthesized `__init__` from `ClassSynthesizedFields`, map `Param` → `StubParam`, merge **AST annotation text** for init params (skipping `InitVar`), drop `**kwargs` from emitted synthetic inits, preserve / improve class-body ordering and `field` / `Field` elision behavior, import pruning for unused Pydantic helpers.
- **`emit.rs`:** Multiline `def __init__` when the stub has many parameters.
- **`dataclass.rs`:** Validation-**alias-only** init parameters are **keyword-only** (`*, id: ...`), matching runtime and stub tests.
- **`pydantic.rs` / `class_field.rs`:** Treat `pydantic.BaseModel` re-exports like other BaseModel bases; expose `ClassField::dataclass_flags_of` to stubgen.
- **`mod.rs` tests:** Minimal on-disk `pydantic` shim + glob only `input.py` so temp package imports do not overwrite stubgen output.

## Testing

- `cargo test -p pyrefly stubgen::tests::`


Made with [Cursor](https://cursor.com)