### PR TITLE
Fix typo in "Adding Pyrefly Type Checking to Your Agentic Loop" blog

### DIFF
--- a/website/blog/2026-04-13-pyrefly-agentic-loop.md
+++ b/website/blog/2026-04-13-pyrefly-agentic-loop.md
@@ -15,7 +15,7 @@ Type checking sits right in the sweet spot for agents. It's fast enough for iter
 
 **TL;DR**: We recommend:
 
-- Adding a skill file for your agent with an `agent.md` directive to ensure the project checks clean before finishing a feature.
+- Adding a skill file for your agent with an `AGENTS.md` directive to ensure the project checks clean before finishing a feature.
 - If your model doesn't trigger this reliably, set up a hook on the Stop event.
 
 <!-- truncate -->


### PR DESCRIPTION
I think this should be agents.md not agent.md

