### PR TITLE
modify TSP connection (#3308)

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -400,7 +400,7 @@ pub trait TspInterface: Send + Sync + 'static {
     /// Send a response back to the LSP client
     fn send_response(&self, response: Response);
 
-    fn sender(&self) -> &Sender<Message>;
+    fn sender(&self) -> &MessageSender;
 
     fn lsp_queue(&self) -> &LspQueue;
 
@@ -502,11 +502,105 @@ pub trait TspInterface: Send + Sync + 'static {
 }
 
 pub struct Connection {
-    pub sender: Sender<Message>,
+    pub sender: MessageSender,
     /// Channel receiver, only present for test connections created via
     /// `Connection::memory()`. The test client reads from this to observe
     /// messages sent by the server.
     channel_receiver: Option<Receiver<Message>>,
+}
+
+/// Send side of a connection's message channel.
+///
+/// - **`Channel`** (`Connection::stdio`, `Connection::memory`): fire-and-forget
+///   passthrough to a `crossbeam_channel::Sender<Message>`.
+/// - **`BlockingWriter`** (`Connection::ipc`): sends the message on a work
+///   channel, then blocks on a persistent ack channel until the writer thread
+///   confirms the write succeeded. This provides back-pressure and synchronous
+///   write-error detection.
+#[derive(Clone)]
+pub enum MessageSender {
+    Channel(Sender<Message>),
+    /// (work_tx, ack_rx): send the message, then wait for the write result.
+    BlockingWriter(Sender<Message>, Receiver<std::io::Result<()>>),
+}
+
+/// Error returned by [`MessageSender::send`].
+#[derive(Debug)]
+pub struct SendError;
+
+impl std::fmt::Display for SendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("sending on a closed/failed channel")
+    }
+}
+
+/// Error returned by [`MessageSender::send_timeout`].
+#[derive(Debug)]
+pub enum SendTimeoutError {
+    Timeout,
+    Disconnected,
+}
+
+impl std::fmt::Display for SendTimeoutError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Timeout => f.write_str("timed out waiting for send"),
+            Self::Disconnected => f.write_str("sending on a closed/failed channel"),
+        }
+    }
+}
+
+impl MessageSender {
+    pub fn send(&self, message: Message) -> Result<(), SendError> {
+        match self {
+            Self::Channel(sender) => sender.send(message).map_err(|_| SendError),
+            Self::BlockingWriter(work_tx, ack_rx) => {
+                work_tx.send(message).map_err(|_| SendError)?;
+                match ack_rx.recv() {
+                    Ok(Ok(())) => Ok(()),
+                    _ => Err(SendError),
+                }
+            }
+        }
+    }
+
+    pub fn send_timeout(
+        &self,
+        message: Message,
+        timeout: Duration,
+    ) -> Result<(), SendTimeoutError> {
+        match self {
+            Self::Channel(sender) => sender.send_timeout(message, timeout).map_err(|e| match e {
+                crossbeam_channel::SendTimeoutError::Timeout(_) => SendTimeoutError::Timeout,
+                crossbeam_channel::SendTimeoutError::Disconnected(_) => {
+                    SendTimeoutError::Disconnected
+                }
+            }),
+            Self::BlockingWriter(work_tx, ack_rx) => {
+                let start = Instant::now();
+                work_tx
+                    .send_timeout(message, timeout)
+                    .map_err(|e| match e {
+                        crossbeam_channel::SendTimeoutError::Timeout(_) => {
+                            SendTimeoutError::Timeout
+                        }
+                        crossbeam_channel::SendTimeoutError::Disconnected(_) => {
+                            SendTimeoutError::Disconnected
+                        }
+                    })?;
+                let remaining = timeout.saturating_sub(start.elapsed());
+                match ack_rx.recv_timeout(remaining) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(_)) | Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
+                        Err(SendTimeoutError::Disconnected)
+                    }
+                    Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
+                        Err(SendTimeoutError::Timeout)
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Owns the message source for the LSP/TSP server. Either a crossbeam channel
@@ -565,7 +659,7 @@ impl Connection {
         });
         (
             Self {
-                sender: writer_sender,
+                sender: MessageSender::Channel(writer_sender),
                 channel_receiver: None,
             },
             MessageReader::Stdio(BufReader::new(std::io::stdin())),
@@ -578,17 +672,25 @@ impl Connection {
     /// or a pipe name on Windows (automatically prefixed with `\\.\pipe\`).
     pub fn ipc(pipe_name: &str) -> std::io::Result<(Self, MessageReader, IoThread)> {
         let (writer_stream, reader_stream) = Self::connect_ipc(pipe_name)?;
-        let (writer_sender, writer_receiver) = crossbeam_channel::unbounded();
+        let (work_tx, work_rx) = crossbeam_channel::unbounded::<Message>();
+        // Rendezvous channel: the sender blocks until the writer thread has
+        // consumed the ack, providing back-pressure and write-error feedback.
+        let (ack_tx, ack_rx) = crossbeam_channel::bounded(0);
         let writer = std::thread::spawn(move || {
             let mut output = writer_stream;
-            while let Ok(msg) = writer_receiver.recv() {
-                write_lsp_message(&mut output, msg)?;
+            while let Ok(msg) = work_rx.recv() {
+                let result = write_lsp_message(&mut output, msg);
+                let is_err = result.is_err();
+                // If the ack receiver is dropped, stop writing.
+                if ack_tx.send(result).is_err() || is_err {
+                    break;
+                }
             }
             Ok(())
         });
         Ok((
             Self {
-                sender: writer_sender,
+                sender: MessageSender::BlockingWriter(work_tx, ack_rx),
                 channel_receiver: None,
             },
             MessageReader::Stream(BufReader::new(Box::new(reader_stream))),
@@ -610,7 +712,7 @@ impl Connection {
         pipe_name: &str,
     ) -> std::io::Result<(Box<dyn Write + Send>, Box<dyn std::io::Read + Send>)> {
         use std::fs::OpenOptions;
-        let stream = OpenOptions::new().read(true).write(true).open(&pipe_name)?;
+        let stream = OpenOptions::new().read(true).write(true).open(pipe_name)?;
         let reader = stream.try_clone()?;
         Ok((Box::new(stream), Box::new(reader)))
     }
@@ -639,14 +741,14 @@ impl Connection {
         (
             (
                 Self {
-                    sender: s1,
+                    sender: MessageSender::Channel(s1),
                     channel_receiver: Some(r2.clone()),
                 },
                 MessageReader::Channel(r2),
             ),
             (
                 Self {
-                    sender: s2,
+                    sender: MessageSender::Channel(s2),
                     channel_receiver: Some(r1.clone()),
                 },
                 MessageReader::Channel(r1),
@@ -926,6 +1028,8 @@ fn format_diagnostic_message_for_markdown(message: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use lsp_types::CodeActionKind;
 
     use super::SOURCE_FIX_ALL_PYREFLY;
@@ -990,6 +1094,115 @@ mod tests {
         )));
         assert!(!matches_fix_all_kind(&CodeActionKind::QUICKFIX));
         assert!(!matches_fix_all_kind(&CodeActionKind::REFACTOR_EXTRACT));
+    }
+
+    #[test]
+    fn test_blocking_writer_waits_for_ack() {
+        use std::sync::atomic::AtomicU32;
+        use std::sync::atomic::Ordering;
+        use std::time::Duration;
+        use std::time::Instant;
+
+        use super::Message;
+        use super::MessageSender;
+        use super::Notification;
+
+        let write_delay = Duration::from_millis(50);
+
+        // Set up channels: unbounded work channel, rendezvous ack channel.
+        let (work_tx, work_rx) = crossbeam_channel::unbounded::<Message>();
+        let (ack_tx, ack_rx) = crossbeam_channel::bounded::<std::io::Result<()>>(0);
+
+        // Track how many writes have completed.
+        let writes_completed = Arc::new(AtomicU32::new(0));
+        let writes_completed_clone = writes_completed.clone();
+
+        // Simulate a slow writer thread.
+        std::thread::spawn(move || {
+            while let Ok(_msg) = work_rx.recv() {
+                std::thread::sleep(write_delay);
+                writes_completed_clone.fetch_add(1, Ordering::SeqCst);
+                if ack_tx.send(Ok(())).is_err() {
+                    break;
+                }
+            }
+        });
+
+        let sender = MessageSender::BlockingWriter(work_tx, ack_rx);
+
+        let make_msg = || {
+            Message::Notification(Notification {
+                method: "test".to_owned(),
+                params: serde_json::Value::Null,
+                activity_key: None,
+            })
+        };
+
+        // Send 3 messages. Each should block until the writer acks.
+        let start = Instant::now();
+        for _ in 0..3 {
+            sender.send(make_msg()).unwrap();
+        }
+        let elapsed = start.elapsed();
+
+        // With the ack channel, total time should be >= 3 * write_delay because
+        // each send blocks until the writer finishes. With fire-and-forget, all
+        // three sends would return nearly instantly.
+        assert!(
+            elapsed >= write_delay * 3,
+            "expected >= {write_delay:?} * 3, got {elapsed:?}; sends did not block for acks"
+        );
+
+        // All 3 writes must have completed by the time the last send() returns.
+        assert_eq!(
+            writes_completed.load(Ordering::SeqCst),
+            3,
+            "not all writes completed before send() returned"
+        );
+    }
+
+    #[test]
+    fn test_blocking_writer_propagates_write_error() {
+        use super::Message;
+        use super::MessageSender;
+        use super::Notification;
+
+        // Set up channels.
+        let (work_tx, work_rx) = crossbeam_channel::unbounded::<Message>();
+        let (ack_tx, ack_rx) = crossbeam_channel::bounded::<std::io::Result<()>>(0);
+
+        // Writer thread that fails on the second message.
+        std::thread::spawn(move || {
+            let mut count = 0u32;
+            while let Ok(_msg) = work_rx.recv() {
+                count += 1;
+                if count == 2 {
+                    let _ = ack_tx.send(Err(std::io::Error::new(
+                        std::io::ErrorKind::BrokenPipe,
+                        "simulated write failure",
+                    )));
+                    break;
+                }
+                if ack_tx.send(Ok(())).is_err() {
+                    break;
+                }
+            }
+        });
+
+        let sender = MessageSender::BlockingWriter(work_tx, ack_rx);
+
+        let make_msg = || {
+            Message::Notification(Notification {
+                method: "test".to_owned(),
+                params: serde_json::Value::Null,
+                activity_key: None,
+            })
+        };
+
+        // First send succeeds.
+        assert!(sender.send(make_msg()).is_ok());
+        // Second send gets the write error.
+        assert!(sender.send(make_msg()).is_err());
     }
 }
 
@@ -1092,7 +1305,7 @@ pub struct Server {
     server_start_time: Instant,
 }
 
-pub fn shutdown_finish(sender: &Sender<Message>, reader: &mut MessageReader, id: RequestId) {
+pub fn shutdown_finish(sender: &MessageSender, reader: &mut MessageReader, id: RequestId) {
     let response = Response::new_ok(id, ());
     if sender.send(response.into()).is_err() {
         return;
@@ -1129,7 +1342,7 @@ pub fn shutdown_finish(sender: &Sender<Message>, reader: &mut MessageReader, id:
 // If the connection is closed, or we receive an exit notification, returns None.
 // If we receive an unexpected shutdown notification, respond and wait for exit.
 pub fn initialize_start(
-    sender: &Sender<Message>,
+    sender: &MessageSender,
     reader: &mut MessageReader,
 ) -> anyhow::Result<Option<(RequestId, InitializeInfo)>> {
     while let Some(msg) = reader.recv() {
@@ -1205,7 +1418,7 @@ struct InitializeResult<C> {
 }
 
 pub fn initialize_finish<C: Serialize>(
-    sender: &Sender<Message>,
+    sender: &MessageSender,
     reader: &mut MessageReader,
     id: RequestId,
     capabilities: C,
@@ -6291,7 +6504,7 @@ impl TspInterface for Server {
         self.send_response(response)
     }
 
-    fn sender(&self) -> &Sender<Message> {
+    fn sender(&self) -> &MessageSender {
         &self.connection.0.sender
     }
 

--- a/pyrefly/lib/test/lsp/lsp_interaction/object_model.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/object_model.rs
@@ -290,11 +290,10 @@ impl TestClient {
         }
     }
 
-    #[allow(clippy::result_large_err)]
     fn send_timeout(
         &self,
         message: Message,
-    ) -> Result<(), crossbeam_channel::SendTimeoutError<Message>> {
+    ) -> Result<(), pyrefly::lsp::non_wasm::server::SendTimeoutError> {
         self.conn
             .as_ref()
             .unwrap()

--- a/pyrefly/lib/test/tsp/tsp_interaction/object_model.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/object_model.rs
@@ -35,6 +35,7 @@ use crate::lsp::non_wasm::protocol::Notification;
 use crate::lsp::non_wasm::protocol::Request;
 use crate::lsp::non_wasm::protocol::Response;
 use crate::lsp::non_wasm::server::Connection;
+use crate::lsp::non_wasm::server::MessageSender;
 use crate::test::util::TEST_THREAD_COUNT;
 use crate::test::util::init_test;
 
@@ -50,7 +51,7 @@ pub struct InitializeSettings {
 }
 
 pub struct TestTspServer {
-    sender: crossbeam_channel::Sender<Message>,
+    sender: MessageSender,
     timeout: Duration,
     /// Handle to the spawned server thread
     server_thread: Option<JoinHandle<Result<(), io::Error>>>,
@@ -60,7 +61,7 @@ pub struct TestTspServer {
 }
 
 impl TestTspServer {
-    pub fn new(sender: crossbeam_channel::Sender<Message>, request_idx: Arc<Mutex<i32>>) -> Self {
+    pub fn new(sender: MessageSender, request_idx: Arc<Mutex<i32>>) -> Self {
         Self {
             sender,
             timeout: Duration::from_secs(25),

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -39,6 +39,7 @@ use crate::lsp::non_wasm::queue::LspEvent;
 use crate::lsp::non_wasm::server::Connection;
 use crate::lsp::non_wasm::server::InitializeInfo;
 use crate::lsp::non_wasm::server::MessageReader;
+use crate::lsp::non_wasm::server::MessageSender;
 use crate::lsp::non_wasm::server::ProcessEvent;
 use crate::lsp::non_wasm::server::ServerCapabilitiesWithTypeHierarchy;
 use crate::lsp::non_wasm::server::TspInterface;
@@ -51,7 +52,6 @@ use crate::tsp::validation::snapshot_outdated_error;
 
 struct ExtraConnectionHandle {
     close_tx: crossbeam_channel::Sender<()>,
-    response_sender: crossbeam_channel::Sender<Message>,
 }
 
 pub struct TspServer<T: TspInterface> {
@@ -71,28 +71,16 @@ impl<T: TspInterface> TspServer<T> {
         })
     }
 
-    /// Send a `snapshotChanged` notification to the main connection and every extra connection.
+    /// Send a `snapshotChanged` notification to the main connection.
     fn broadcast_snapshot_changed(
         &self,
-        main_sender: &crossbeam_channel::Sender<Message>,
+        main_sender: &MessageSender,
         old_snapshot: i32,
         new_snapshot: i32,
     ) {
         let notification = snapshot_changed_notification(old_snapshot, new_snapshot);
         if let Err(e) = main_sender.send(Message::Notification(notification.clone())) {
             warn!("Failed to send snapshotChanged notification: {e}");
-        }
-        let handles = self
-            .extra_connections
-            .lock()
-            .expect("extra_connections mutex poisoned");
-        for (name, handle) in handles.iter() {
-            if let Err(e) = handle
-                .response_sender
-                .send(Message::Notification(notification.clone()))
-            {
-                warn!("Failed to send snapshotChanged to extra connection {name}: {e}");
-            }
         }
     }
 }
@@ -103,11 +91,11 @@ impl<T: TspInterface> TspServer<T> {
 /// `TspServer` core with all other connections.
 pub struct TspConnection<T: TspInterface> {
     pub(crate) server: Arc<TspServer<T>>,
-    response_sender: crossbeam_channel::Sender<Message>,
+    response_sender: MessageSender,
 }
 
 impl<T: TspInterface> TspConnection<T> {
-    fn new(server: Arc<TspServer<T>>, response_sender: crossbeam_channel::Sender<Message>) -> Self {
+    fn new(server: Arc<TspServer<T>>, response_sender: MessageSender) -> Self {
         Self {
             server,
             response_sender,
@@ -251,7 +239,7 @@ impl<T: TspInterface> TspConnection<T> {
 pub struct TspMainConnection<T: TspInterface>(TspConnection<T>);
 
 impl<T: TspInterface> TspMainConnection<T> {
-    fn new(server: Arc<TspServer<T>>, response_sender: crossbeam_channel::Sender<Message>) -> Self {
+    fn new(server: Arc<TspServer<T>>, response_sender: MessageSender) -> Self {
         Self(TspConnection::new(server, response_sender))
     }
 }
@@ -383,13 +371,7 @@ impl<T: TspInterface> TspMainConnection<T> {
         let (close_tx, close_rx) = crossbeam_channel::bounded::<()>(1);
         let name_owned = name.to_owned();
 
-        extra_connections.insert(
-            name_owned.clone(),
-            ExtraConnectionHandle {
-                close_tx,
-                response_sender: extra_sender,
-            },
-        );
+        extra_connections.insert(name_owned.clone(), ExtraConnectionHandle { close_tx });
         drop(extra_connections);
 
         extra_conn.run(reader, close_rx, name_owned);
@@ -436,7 +418,7 @@ impl<T: TspInterface> TspMainConnection<T> {
 struct TspExtraConnection<T: TspInterface>(TspConnection<T>);
 
 impl<T: TspInterface> TspExtraConnection<T> {
-    fn new(server: Arc<TspServer<T>>, response_sender: crossbeam_channel::Sender<Message>) -> Self {
+    fn new(server: Arc<TspServer<T>>, response_sender: MessageSender) -> Self {
         Self(TspConnection::new(server, response_sender))
     }
 }
@@ -456,7 +438,11 @@ impl<T: TspInterface> TspExtraConnection<T> {
         std::thread::spawn(move || {
             std::thread::spawn(move || {
                 while let Some(message) = reader.recv() {
-                    if message_tx.send(message).is_err() {
+                    let (processed_tx, processed_rx) = crossbeam_channel::bounded(1);
+                    if message_tx.send((message, processed_tx)).is_err() {
+                        break;
+                    }
+                    if processed_rx.recv().is_err() {
                         break;
                     }
                 }
@@ -468,9 +454,12 @@ impl<T: TspInterface> TspExtraConnection<T> {
             loop {
                 let selected = selector.select();
                 match selected.index() {
-                    i if i == close_index => break,
+                    i if i == close_index => {
+                        let _ = selected.recv(&close_rx);
+                        break;
+                    }
                     i if i == message_index => {
-                        let Ok(message) = selected.recv(&message_rx) else {
+                        let Ok((message, processed_tx)) = selected.recv(&message_rx) else {
                             break;
                         };
 
@@ -513,6 +502,8 @@ impl<T: TspInterface> TspExtraConnection<T> {
                             }
                             Message::Notification(_) | Message::Response(_) => {}
                         }
+
+                        let _ = processed_tx.send(());
                     }
                     _ => unreachable!(),
                 }


### PR DESCRIPTION
Summary:

- last diff introduced an unused clone on every `Message` - large messages can take a long time to clone
- timeout wasn't entirely accurate
- can we achieve the same thing without MessageReader?

Differential Revision: D103757383
