### PR TITLE
Add GitLab Code Quality output format

### DIFF
--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -134,6 +134,9 @@ pub enum OutputFormat {
     Json,
     /// Emit GitHub Actions workflow commands
     Github,
+    /// Emit a GitLab Code Quality JSON report
+    /// (https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format)
+    Gitlab,
     /// Only show error count, omitting individual errors
     OmitErrors,
 }

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -1255,6 +1255,7 @@ impl CheckArgs {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
     use std::path::PathBuf;
     use std::sync::Arc;
 
@@ -1335,6 +1336,93 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
         assert!(output.contains("::error file=/repo/foo.py"));
         assert!(output.ends_with("::bad\n"));
+    }
+
+    #[test]
+    fn gitlab_output_format_writes_valid_json() {
+        let errors = vec![sample_error(vec1!["bad".into()])];
+        let mut buf = Vec::new();
+        write_error_gitlab(&mut buf, Path::new("/repo"), &errors).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+        let arr = value.as_array().expect("top-level array");
+        assert_eq!(arr.len(), 1);
+        let entry = &arr[0];
+        for key in [
+            "description",
+            "check_name",
+            "fingerprint",
+            "severity",
+            "location",
+        ] {
+            assert!(entry.get(key).is_some(), "missing key {key} in {entry}");
+        }
+        assert_eq!(entry["check_name"], "bad-assignment");
+        assert_eq!(entry["location"]["path"], "foo.py");
+        assert_eq!(entry["location"]["lines"]["begin"], 1);
+    }
+
+    #[test]
+    fn gitlab_output_format_severity_mapping() {
+        let info = sample_error(vec1!["m".into()]).with_severity(Severity::Info);
+        let warn = sample_error(vec1!["m".into()]).with_severity(Severity::Warn);
+        let error = sample_error(vec1!["m".into()]).with_severity(Severity::Error);
+        let ignore = sample_error(vec1!["m".into()]).with_severity(Severity::Ignore);
+        let errors = vec![info, warn, error, ignore];
+        let mut buf = Vec::new();
+        write_error_gitlab(&mut buf, Path::new("/repo"), &errors).unwrap();
+        let value: serde_json::Value =
+            serde_json::from_str(&String::from_utf8(buf).unwrap()).expect("valid JSON");
+        let arr = value.as_array().unwrap();
+        // Ignore should be filtered out, leaving 3 entries.
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0]["severity"], "info");
+        assert_eq!(arr[1]["severity"], "minor");
+        assert_eq!(arr[2]["severity"], "major");
+    }
+
+    #[test]
+    fn gitlab_output_format_fingerprint_stability() {
+        let errors_a = vec![sample_error(vec1!["bad".into()])];
+        let errors_b = vec![sample_error(vec1!["different message".into()])];
+        let mut buf_a = Vec::new();
+        let mut buf_b = Vec::new();
+        write_error_gitlab(&mut buf_a, Path::new("/repo"), &errors_a).unwrap();
+        write_error_gitlab(&mut buf_b, Path::new("/repo"), &errors_b).unwrap();
+        let value_a: serde_json::Value =
+            serde_json::from_str(&String::from_utf8(buf_a).unwrap()).unwrap();
+        let value_b: serde_json::Value =
+            serde_json::from_str(&String::from_utf8(buf_b).unwrap()).unwrap();
+        // Fingerprint depends on (kind, path) only, so same kind+path => same fingerprint
+        // even when the message text differs.
+        assert_eq!(value_a[0]["fingerprint"], value_b[0]["fingerprint"]);
+    }
+
+    #[test]
+    fn gitlab_output_format_fingerprint_collision_resolution() {
+        // Two errors with the same (kind, path) would collide; the renderer must salt-rehash
+        // so each entry gets a unique fingerprint.
+        let errors = vec![
+            sample_error(vec1!["one".into()]),
+            sample_error(vec1!["two".into()]),
+        ];
+        let mut buf = Vec::new();
+        write_error_gitlab(&mut buf, Path::new("/repo"), &errors).unwrap();
+        let value: serde_json::Value =
+            serde_json::from_str(&String::from_utf8(buf).unwrap()).unwrap();
+        let arr = value.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_ne!(arr[0]["fingerprint"], arr[1]["fingerprint"]);
+    }
+
+    #[test]
+    fn gitlab_output_format_description_includes_check_name() {
+        let errors = vec![sample_error(vec1!["bad".into()])];
+        let mut buf = Vec::new();
+        write_error_gitlab(&mut buf, Path::new("/repo"), &errors).unwrap();
+        let value: serde_json::Value =
+            serde_json::from_str(&String::from_utf8(buf).unwrap()).unwrap();
+        assert_eq!(value[0]["description"], "bad-assignment: bad");
     }
 
     #[test]

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -9,6 +9,9 @@ use std::collections::HashSet;
 use std::fmt;
 use std::fmt::Display;
 use std::fs::File;
+use std::hash::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::io::BufWriter;
 use std::io::Write;
 use std::path::Path;
@@ -51,6 +54,7 @@ use pyrefly_util::memory::MemoryUsageTrace;
 use pyrefly_util::thread_pool::ThreadCount;
 use pyrefly_util::watcher::Watcher;
 use ruff_text_size::Ranged;
+use serde::Serialize;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 use tracing::debug;
@@ -424,6 +428,7 @@ fn write_errors_to_file(
         OutputFormat::FullText => write_error_text_to_file(path, relative_to, errors, true),
         OutputFormat::Json => write_error_json_to_file(path, relative_to, errors),
         OutputFormat::Github => write_error_github_to_file(path, errors),
+        OutputFormat::Gitlab => write_error_gitlab_to_file(path, relative_to, errors),
         OutputFormat::OmitErrors => Ok(()),
     }
 }
@@ -438,6 +443,7 @@ fn write_errors_to_console(
         OutputFormat::FullText => write_error_text_to_console(relative_to, errors, true),
         OutputFormat::Json => write_error_json_to_console(relative_to, errors),
         OutputFormat::Github => write_error_github_to_console(errors),
+        OutputFormat::Gitlab => write_error_gitlab_to_console(relative_to, errors),
         OutputFormat::OmitErrors => Ok(()),
     }
 }
@@ -575,6 +581,112 @@ fn escape_workflow_data(value: &str) -> String {
 
 fn escape_workflow_property(value: &str) -> String {
     utf8_percent_encode(value, WORKFLOW_PROPERTY_ENCODE_SET).to_string()
+}
+
+/// One entry in a GitLab Code Quality JSON report. The schema is the CodeClimate report
+/// format subset documented at
+/// https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format.
+#[derive(Serialize)]
+struct GitlabReportEntry<'a> {
+    description: String,
+    check_name: &'a str,
+    fingerprint: String,
+    severity: &'static str,
+    location: GitlabLocation,
+}
+
+#[derive(Serialize)]
+struct GitlabLocation {
+    path: String,
+    lines: GitlabLines,
+}
+
+#[derive(Serialize)]
+struct GitlabLines {
+    begin: u32,
+}
+
+/// Map a Pyrefly severity onto a GitLab Code Quality severity, returning `None` for
+/// `Ignore` so suppressed errors are dropped from the report.
+fn severity_to_gitlab(severity: Severity) -> Option<&'static str> {
+    match severity {
+        Severity::Ignore => None,
+        Severity::Info => Some("info"),
+        Severity::Warn => Some("minor"),
+        Severity::Error => Some("major"),
+    }
+}
+
+/// Stable per-issue identifier. Hashes the error kind name and (project-relative) path,
+/// salted with `salt`. The caller salt-rehashes on collision so multiple issues of the
+/// same kind in the same file still produce distinct fingerprints.
+fn gitlab_fingerprint(check_name: &str, path: &str, salt: u64) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    salt.hash(&mut hasher);
+    check_name.hash(&mut hasher);
+    path.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn write_error_gitlab(
+    writer: &mut impl Write,
+    relative_to: &Path,
+    errors: &[Error],
+) -> anyhow::Result<()> {
+    let mut fingerprints: HashSet<u64> = HashSet::new();
+    let mut entries: Vec<GitlabReportEntry> = Vec::new();
+    for error in errors {
+        let Some(severity) = severity_to_gitlab(error.severity()) else {
+            continue;
+        };
+        let check_name = error.error_kind().to_name();
+        let abs_path = error.path().as_path();
+        let path = abs_path
+            .strip_prefix(relative_to)
+            .unwrap_or(abs_path)
+            .to_string_lossy()
+            .into_owned();
+
+        let mut fp = gitlab_fingerprint(check_name, &path, 0);
+        while !fingerprints.insert(fp) {
+            fp = gitlab_fingerprint(check_name, &path, fp);
+        }
+
+        entries.push(GitlabReportEntry {
+            description: format!("{check_name}: {}", error.msg()),
+            check_name,
+            fingerprint: format!("{fp:x}"),
+            severity,
+            location: GitlabLocation {
+                path,
+                lines: GitlabLines {
+                    begin: error.display_range().start.line_within_file().get(),
+                },
+            },
+        });
+    }
+    serde_json::to_writer_pretty(writer.by_ref(), &entries)?;
+    writeln!(writer)?;
+    Ok(())
+}
+
+fn write_error_gitlab_to_file(
+    path: &Path,
+    relative_to: &Path,
+    errors: &[Error],
+) -> anyhow::Result<()> {
+    let mut file = BufWriter::new(File::create(path)?);
+    write_error_gitlab(&mut file, relative_to, errors)
+        .with_context(|| format!("while writing GitLab errors to `{}`", path.display()))?;
+    file.flush()?;
+    Ok(())
+}
+
+fn write_error_gitlab_to_console(relative_to: &Path, errors: &[Error]) -> anyhow::Result<()> {
+    let mut writer = BufWriter::new(stdout());
+    write_error_gitlab(&mut writer, relative_to, errors)?;
+    writer.flush()?;
+    Ok(())
 }
 
 /// A data structure to facilitate the creation of handles for all the files we want to check.

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -641,11 +641,17 @@ fn write_error_gitlab(
         };
         let check_name = error.error_kind().to_name();
         let abs_path = error.path().as_path();
-        let path = abs_path
+        let mut path = abs_path
             .strip_prefix(relative_to)
             .unwrap_or(abs_path)
             .to_string_lossy()
             .into_owned();
+        // GitLab CI runners are Linux containers and match report paths against
+        // repo files using forward-slash separators, so normalize any native
+        // separator (e.g. `\` on Windows hosts) to `/`.
+        if std::path::MAIN_SEPARATOR != '/' {
+            path = path.replace(std::path::MAIN_SEPARATOR, "/");
+        }
 
         let mut fp = gitlab_fingerprint(check_name, &path, 0);
         while !fingerprints.insert(fp) {
@@ -1382,9 +1388,13 @@ mod tests {
     use super::*;
 
     fn sample_error(msg: Vec1<String>) -> Error {
+        sample_error_at(msg, "/repo/foo.py")
+    }
+
+    fn sample_error_at(msg: Vec1<String>, path: &str) -> Error {
         let module = Module::new(
             ModuleName::from_str("sample"),
-            ModulePath::filesystem(PathBuf::from("/repo/foo.py")),
+            ModulePath::filesystem(PathBuf::from(path)),
             Arc::new("x = 1\n".to_owned()),
         );
         Error::new(
@@ -1535,6 +1545,31 @@ mod tests {
         let value: serde_json::Value =
             serde_json::from_str(&String::from_utf8(buf).unwrap()).unwrap();
         assert_eq!(value[0]["description"], "bad-assignment: bad");
+    }
+
+    #[test]
+    fn gitlab_output_format_empty_error_list() {
+        // An empty input must produce a valid empty JSON array, not `null` or
+        // an empty string — GitLab CI rejects anything that isn't a JSON array.
+        let mut buf = Vec::new();
+        write_error_gitlab(&mut buf, Path::new("/repo"), &[]).unwrap();
+        assert_eq!(String::from_utf8(buf).unwrap(), "[]\n");
+    }
+
+    #[test]
+    fn gitlab_output_format_path_outside_relative_to() {
+        // When an error's path can't be made relative to `relative_to`, the
+        // writer falls back to the absolute path rather than dropping the
+        // entry. Locks in the `unwrap_or(abs_path)` branch.
+        let errors = vec![sample_error_at(
+            vec1!["bad".into()],
+            "/different/root/foo.py",
+        )];
+        let mut buf = Vec::new();
+        write_error_gitlab(&mut buf, Path::new("/repo"), &errors).unwrap();
+        let value: serde_json::Value =
+            serde_json::from_str(&String::from_utf8(buf).unwrap()).unwrap();
+        assert_eq!(value[0]["location"]["path"], "/different/root/foo.py");
     }
 
     #[test]

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -484,7 +484,7 @@ min-severity = "warn"
 Default format for `pyrefly check` error output when `--output-format` is not
 set on the CLI.
 
-- Type: `"min-text" | "full-text" | "json" | "github" | "omit-errors"`
+- Type: `"min-text" | "full-text" | "json" | "github" | "gitlab" | "omit-errors"`
 - Default: `full-text`
 - Flag equivalent: `--output-format`
 - Notes:


### PR DESCRIPTION
## Summary

Adds `--output-format gitlab`, emitting a CodeClimate-style JSON report that GitLab CI can ingest directly via `artifacts:reports:codequality`. Today users have to pipe pyrefly through a third-party converter (mypy-gitlab-code-quality, pyright-to-gitlab-ci) to surface findings inline on merge requests; this gives them first-class support to match what `ty --output-format gitlab` already does for that ecosystem.

## Output format

Each emitted entry follows the GitLab Code Quality spec subset:

```json
{
  "description": "bad-assignment: Cannot assign str to int",
  "check_name": "bad-assignment",
  "fingerprint": "9f3c1a2b4d5e6f70",
  "severity": "major",
  "location": {
    "path": "src/foo.py",
    "lines": { "begin": 12 }
  }
}
```

## Design notes

- **Fingerprint**: hashed from `(error_kind, project-relative path)` only. Excluding line and message keeps fingerprints stable across runs when surrounding code shifts; collisions within a single run are resolved by salt-rehashing so multiple issues of the same kind in one file still get distinct IDs.
- **Severity mapping**: `Info` → `info`, `Warn` → `minor`, `Error` → `major`. `Ignore` is filtered out, mirroring the GitHub writer's treatment of suppressed errors.
- **Path normalization**: paths are emitted with forward slashes regardless of host OS. GitLab CI runners are Linux containers, so a Windows `src\foo.py` would silently fail to match repo files.

## Tests

- `gitlab_output_format_writes_valid_json` — entry shape and required keys
- `gitlab_output_format_severity_mapping` — Info/Warn/Error mapping; Ignore filtered
- `gitlab_output_format_fingerprint_stability` — same (kind, path) → same fingerprint across messages
- `gitlab_output_format_fingerprint_collision_resolution` — salt-rehash gives distinct IDs in-run
- `gitlab_output_format_description_includes_check_name` — `<kind>: <msg>` format
- `gitlab_output_format_empty_error_list` — empty input emits `[]\n`, not null
- `gitlab_output_format_path_outside_relative_to` — falls back to absolute path

## Why this format

The [GitLab Code Quality spec](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format) is the standard ingestion shape for `artifacts:reports:codequality`. Astral's `ty` ships this natively as `--output-format gitlab`, and ruff users adopt the same pattern via converters — picking up the same shape keeps pyrefly drop-in compatible with existing GitLab pipelines.

Fixes #3049