### PR TITLE
Reject concrete-class returns for `Self` unless the class is `@final`

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -6351,6 +6351,28 @@
   "generics_self_basic.py": [
     {
       "code": -2,
+      "column": 16,
+      "concise_description": "Returned type `Shape` is not assignable to declared return type `Self@Shape`",
+      "description": "Returned type `Shape` is not assignable to declared return type `Self@Shape`",
+      "line": 20,
+      "name": "bad-return",
+      "severity": "error",
+      "stop_column": 23,
+      "stop_line": 20
+    },
+    {
+      "code": -2,
+      "column": 16,
+      "concise_description": "Returned type `Shape` is not assignable to declared return type `Self@Shape`",
+      "description": "Returned type `Shape` is not assignable to declared return type `Self@Shape`",
+      "line": 33,
+      "name": "bad-return",
+      "severity": "error",
+      "stop_column": 23,
+      "stop_line": 33
+    },
+    {
+      "code": -2,
       "column": 26,
       "concise_description": "`Self` may not be subscripted",
       "description": "`Self` may not be subscripted",
@@ -6429,6 +6451,17 @@
       "severity": "error",
       "stop_column": 37,
       "stop_line": 82
+    },
+    {
+      "code": -2,
+      "column": 16,
+      "concise_description": "Returned type `Foo3` is not assignable to declared return type `Self@Foo3`",
+      "description": "Returned type `Foo3` is not assignable to declared return type `Self@Foo3`",
+      "line": 87,
+      "name": "bad-return",
+      "severity": "error",
+      "stop_column": 22,
+      "stop_line": 87
     },
     {
       "code": -2,

--- a/conformance/third_party/conformance.result
+++ b/conformance/third_party/conformance.result
@@ -106,14 +106,9 @@
   ],
   "generics_self_advanced.py": [],
   "generics_self_attributes.py": [],
-  "generics_self_basic.py": [
-    "Line 20: Expected 1 errors",
-    "Line 33: Expected 1 errors"
-  ],
+  "generics_self_basic.py": [],
   "generics_self_protocols.py": [],
-  "generics_self_usage.py": [
-    "Line 87: Expected 1 errors"
-  ],
+  "generics_self_usage.py": [],
   "generics_syntax_compatibility.py": [],
   "generics_syntax_declarations.py": [],
   "generics_syntax_infer_variance.py": [],

--- a/conformance/third_party/results.json
+++ b/conformance/third_party/results.json
@@ -1,9 +1,9 @@
 {
   "total": 140,
-  "pass": 129,
-  "fail": 11,
-  "pass_rate": 0.92,
-  "differences": 33,
+  "pass": 131,
+  "fail": 9,
+  "pass_rate": 0.94,
+  "differences": 30,
   "passing": [
     "aliases_explicit.py",
     "aliases_newtype.py",
@@ -67,7 +67,9 @@
     "generics_paramspec_specialization.py",
     "generics_self_advanced.py",
     "generics_self_attributes.py",
+    "generics_self_basic.py",
     "generics_self_protocols.py",
+    "generics_self_usage.py",
     "generics_syntax_compatibility.py",
     "generics_syntax_declarations.py",
     "generics_syntax_infer_variance.py",
@@ -144,8 +146,6 @@
     "directives_disjoint_base.py": 6,
     "exceptions_context_managers.py": 2,
     "generics_scoping.py": 4,
-    "generics_self_basic.py": 2,
-    "generics_self_usage.py": 1,
     "typeforms_typeform.py": 2
   },
   "comment": "@generated"

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -2026,11 +2026,18 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
             {
                 self.is_subset_eq(&got, want)
             }
-            (Type::ClassType(got), Type::SelfType(want)) => ok_or(
-                self.type_order
-                    .has_superclass(got.class_object(), want.class_object()),
-                SubsetError::Other,
-            ),
+            (Type::ClassType(got), Type::SelfType(want)) => {
+                // `Self` is bound to the (unknown) runtime class of the receiver, which
+                // may be a subclass of `want`. A concrete instance of `want` is therefore
+                // only assignable to `Self` if no subclass can ever rebind `Self` — i.e.
+                // when `want` is `@final`. Strict subclasses remain assignable as usual
+                // because `Self` covers the whole subtree below `want`.
+                let got_cls = got.class_object();
+                let want_cls = want.class_object();
+                let ok = self.type_order.has_superclass(got_cls, want_cls)
+                    && (got_cls != want_cls || self.type_order.is_final(want_cls));
+                ok_or(ok, SubsetError::Other)
+            }
             (Type::Type(box Type::ClassType(got)), Type::SelfType(want)) => ok_or(
                 self.type_order.has_metaclass(got.class_object(), want),
                 SubsetError::Other,

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -2038,10 +2038,16 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                     && (got_cls != want_cls || self.type_order.is_final(want_cls));
                 ok_or(ok, SubsetError::Other)
             }
-            (Type::Type(box Type::ClassType(got)), Type::SelfType(want)) => ok_or(
-                self.type_order.has_metaclass(got.class_object(), want),
-                SubsetError::Other,
-            ),
+            (Type::Type(box Type::ClassType(got)), Type::SelfType(want)) => {
+                // Parallel to the `ClassType <: SelfType` arm above: `Self` ranges over
+                // every subclass, so a concrete metaclass relationship is only safe when
+                // `want` cannot be further subclassed.
+                let got_cls = got.class_object();
+                let want_cls = want.class_object();
+                let ok = self.type_order.has_metaclass(got_cls, want)
+                    && (got_cls != want_cls || self.type_order.is_final(want_cls));
+                ok_or(ok, SubsetError::Other)
+            }
             (Type::SelfType(_), Type::SelfType(_)) => Ok(()),
             (Type::SelfType(got), _) => self.is_subset_eq(&Type::ClassType(got.clone()), want),
             (Type::Tuple(l), Type::Tuple(u)) => self.is_subset_tuple(l, u),

--- a/pyrefly/lib/solver/type_order.rs
+++ b/pyrefly/lib/solver/type_order.rs
@@ -85,6 +85,10 @@ impl<'a, Ans: LookupAnswer> TypeOrder<'a, Ans> {
         self.0.get_metadata_for_class(cls).is_protocol()
     }
 
+    pub fn is_final(self, cls: &Class) -> bool {
+        self.0.get_metadata_for_class(cls).is_final()
+    }
+
     pub fn is_new_type(self, cls: &Class) -> bool {
         self.0.get_metadata_for_class(cls).is_new_type()
     }

--- a/pyrefly/lib/test/constructors.rs
+++ b/pyrefly/lib/test/constructors.rs
@@ -1086,7 +1086,7 @@ from typing import assert_type, overload
 
 class C:
     @overload
-    def __new__(cls, x: int) -> "C": ...
+    def __new__(cls, x: int) -> "C": ...  # E: Overload return type `C` is not assignable to implementation return type `Self@C`
     @overload
     def __new__(cls, x: str): ...
     def __new__(cls, x: int | str):

--- a/pyrefly/lib/test/descriptors.rs
+++ b/pyrefly/lib/test/descriptors.rs
@@ -397,7 +397,7 @@ def cache_on_self(fn: Callable[[Constraint], int]) -> CachedMethod:
     return CachedMethod(fn)
 
 class Constraint:
-    @cache_on_self
+    @cache_on_self  # E: Argument `(self: Self@Constraint) -> int` is not assignable to parameter `fn` with type `(Constraint) -> int`
     def pointwise_read_writes(self) -> int:
         return 0
 

--- a/pyrefly/lib/test/enums.rs
+++ b/pyrefly/lib/test/enums.rs
@@ -876,6 +876,7 @@ constructor: Callable[[str], SeFileType] = SeFileType
 );
 
 testcase!(
+    bug = "cls(code) is inferred as the concrete `__new__` return type instead of Self@cls",
     test_enum_call_with_self_type,
     r#"
 from enum import Enum
@@ -893,8 +894,8 @@ class SeFileType(Enum):
     @classmethod
     def from_code(cls, code: str) -> Self:
         assert_type(cls, type[Self])
-        assert_type(cls(code), Self)
-        return cls(code)
+        assert_type(cls(code), Self)  # E: assert_type(SeFileType, Self@SeFileType) failed
+        return cls(code)  # E: Returned type `SeFileType` is not assignable to declared return type `Self@SeFileType`
     "#,
 );
 

--- a/pyrefly/lib/test/generic_basic.rs
+++ b/pyrefly/lib/test/generic_basic.rs
@@ -274,11 +274,11 @@ _Ts = TypeVarTuple("_Ts")
 
 class partial(Generic[_P1, _P2, _T, _R_co, *_Ts]):
     @overload
-    def __new__(cls, __func: Callable[_P1, _R_co]) -> partial[_P1, _P1, Any, _R_co]: ...
+    def __new__(cls, __func: Callable[_P1, _R_co]) -> partial[_P1, _P1, Any, _R_co]: ...  # E: Overload return type
     @overload
-    def __new__(cls, __func: Callable[Concatenate[*_Ts, _P2], _R_co], *args: *_Ts) -> partial[Concatenate[*_Ts, _P2], _P2, Any, _R_co, *_Ts]: ...
+    def __new__(cls, __func: Callable[Concatenate[*_Ts, _P2], _R_co], *args: *_Ts) -> partial[Concatenate[*_Ts, _P2], _P2, Any, _R_co, *_Ts]: ...  # E: Overload return type
     @overload
-    def __new__(cls, __func: Callable[_P1, _R_co], *args: *_Ts, **kwargs: _T) -> partial[_P1, ..., _T, _R_co, *_Ts]: ...
+    def __new__(cls, __func: Callable[_P1, _R_co], *args: *_Ts, **kwargs: _T) -> partial[_P1, ..., _T, _R_co, *_Ts]: ...  # E: Overload return type
     def __new__(cls, __func, *args, **kwargs):
         return super().__new__(cls)
     def __call__(self, *args: _P2.args, **kwargs: _P2.kwargs) -> _R_co: ...

--- a/pyrefly/lib/test/typing_self.rs
+++ b/pyrefly/lib/test/typing_self.rs
@@ -237,6 +237,33 @@ class Container[T]:
 );
 
 testcase!(
+    test_self_return_concrete_class_object,
+    r#"
+from typing import Self
+
+class C:
+    @classmethod
+    def make(cls) -> type[Self]:
+        x: type[C] = C
+        return x  # E: Returned type `type[C]` is not assignable to declared return type `type[Self@C]`
+"#,
+);
+
+testcase!(
+    test_self_return_concrete_class_object_final_ok,
+    r#"
+from typing import Self, final
+
+@final
+class C:
+    @classmethod
+    def make(cls) -> type[Self]:
+        x: type[C] = C
+        return x
+"#,
+);
+
+testcase!(
     test_self_in_class_body_expression,
     r#"
 from typing import Self, assert_type

--- a/pyrefly/lib/test/typing_self.rs
+++ b/pyrefly/lib/test/typing_self.rs
@@ -201,11 +201,11 @@ from typing import Self
 
 class Shape:
     def method(self) -> Self:
-        return Shape()  # E: Returned type `Shape` is not assignable to declared return type `Self`
+        return Shape()  # E: Returned type `Shape` is not assignable to declared return type `Self@Shape`
 
     @classmethod
     def cls_method(cls) -> Self:
-        return Shape()  # E: Returned type `Shape` is not assignable to declared return type `Self`
+        return Shape()  # E: Returned type `Shape` is not assignable to declared return type `Self@Shape`
 "#,
 );
 
@@ -232,7 +232,7 @@ from typing import Self
 
 class Container[T]:
     def m(self) -> Self:
-        return Container()  # E: Returned type `Container[Unknown]` is not assignable to declared return type `Self`
+        return Container()  # E: is not assignable to declared return type `Self@Container`
 "#,
 );
 
@@ -438,25 +438,23 @@ class E(Enum):
 
 // Passing a concrete class to `cls.__new__` is incorrect when `cls` could be a subclass.
 testcase!(
-    bug = "Should error: concrete type[C] is not assignable to type[Self@C]",
     test_cls_new_with_concrete_class,
     r#"
 class C:
     @classmethod
     def create(cls) -> C:
-        return cls.__new__(C)
+        return cls.__new__(C)  # E: Argument `type[C]` is not assignable to parameter `cls` with type `type[Self@C]`
 "#,
 );
 
 // Self is pinned when `[self]` is inferred, so `append(other: C)` fails against `Self@C`.
 testcase!(
-    bug = "Should error: C is not assignable to Self@C in list.append",
     test_self_in_container_pinning,
     r#"
 class C:
     def foo(self, other: C) -> list:
         xs = [self]
-        xs.append(other)
+        xs.append(other)  # E: Argument `C` is not assignable to parameter `object` with type `Self@C`
         return xs
 "#,
 );
@@ -646,16 +644,15 @@ class Base:
 );
 
 testcase!(
-    bug = "Should raise error in the overloads when returning concrete class instead of Self",
     test_overload_returning_self,
     r#"
 from typing import Self, overload
 
 class C:
     @overload
-    def clone(self, x: int) -> C: ...
+    def clone(self, x: int) -> C: ...  # E: Overload return type `C` is not assignable to implementation return type `Self@C`
     @overload
-    def clone(self, x: str) -> C: ...
+    def clone(self, x: str) -> C: ...  # E: Overload return type `C` is not assignable to implementation return type `Self@C`
     def clone(self, x) -> Self: ...
     "#,
 );

--- a/pyrefly/lib/test/typing_self.rs
+++ b/pyrefly/lib/test/typing_self.rs
@@ -195,18 +195,44 @@ class C:
 );
 
 testcase!(
-    bug = "conformance: Should error when returning concrete class instead of Self",
     test_self_return_concrete_class,
     r#"
 from typing import Self
 
 class Shape:
     def method(self) -> Self:
-        return Shape()  # should error: returns Shape, not Self
+        return Shape()  # E: Returned type `Shape` is not assignable to declared return type `Self`
 
     @classmethod
     def cls_method(cls) -> Self:
-        return Shape()  # should error: returns Shape, not Self
+        return Shape()  # E: Returned type `Shape` is not assignable to declared return type `Self`
+"#,
+);
+
+testcase!(
+    test_self_return_concrete_class_final_ok,
+    r#"
+from typing import Self, final
+
+@final
+class Shape:
+    def method(self) -> Self:
+        return Shape()
+
+    @classmethod
+    def cls_method(cls) -> Self:
+        return Shape()
+"#,
+);
+
+testcase!(
+    test_self_return_concrete_class_generic,
+    r#"
+from typing import Self
+
+class Container[T]:
+    def m(self) -> Self:
+        return Container()  # E: Returned type `Container[Unknown]` is not assignable to declared return type `Self`
 "#,
 );
 


### PR DESCRIPTION
## Summary

The `ClassType <: SelfType` (and parallel `type[ClassType] <: type[SelfType]`) checks were too permissive — they accepted `return Shape()` (or `return Shape`) when the declared return type was `Self`, even though a subclass `Circle(Shape)` inheriting the method would have `Self = Circle` and the contract would break.

This PR tightens both arms to require a strict subclass UNLESS the class is `@final`.

Fixes #2304.

## The fix

Two arms in `pyrefly/lib/solver/subset.rs` now consult a small `is_final` pass-through added to `TypeOrder`:

- `ClassType <: SelfType` (line ~2029): `has_superclass(got, want) && (got != want || is_final(want))`. This is the primary fix — it catches `return Shape()` from `def m(self) -> Self`.
- `type[ClassType] <: SelfType` (line ~2041): mirrors the structure but keeps the existing `has_metaclass` check, with the same final-or-strict-subclass guard. This locks the rule in for the metaclass-relationship path so the two arms cannot drift again.

The `type[Self]` return case (e.g. `def make(cls) -> type[Self]: return C`) is also rejected — it falls through the `Type::Type(l), Type::Type(u)` recursion arm into the patched `ClassType <: SelfType` arm, so both arms collaborate to keep the rule consistent.

## Test cases

New `typing_self.rs` tests covering the fix:

- `test_self_return_concrete_class_final_ok` — @yangdanny97's `@final` example from the issue
- `test_self_return_concrete_class_generic` — generic-class case
- `test_self_return_concrete_class_object` and `test_self_return_concrete_class_object_final_ok` — `type[Self]` return-type case (non-final and `@final`)

Updated existing tests (dropped `bug = "..."` markers, added `# E:` markers per @migeed-z's review on #2405):

- `test_self_return_concrete_class` — the original repro
- `test_cls_new_with_concrete_class`
- `test_self_in_container_pinning`
- `test_overload_returning_self`

## Notable test fallout

The stricter check exposed adjacent patterns in four tests outside `typing_self.rs`. **Please weigh in on whether the rule should narrow for any of these — happy to follow up either way:**

1. **`test_bound_method_preserves_function_attributes_from_descriptor` (descriptors.rs)** — a `cache_on_self`-style decorator's `Callable[[Constraint], int]` parameter receives a method whose `self` is `Self@Constraint`. Function parameter positions are contravariant, so satisfying the assignment requires `Constraint <: Self@Constraint`, which now fails for non-final classes. Strictly correct under PEP 484 contravariance, but ergonomically painful for the `cache_on_self` decorator pattern. Marked with `# E:` to lock in current behavior; happy to narrow the rule (e.g. relax for parameters of decorator callables) if preferred.

2. **`test_functools_partial_pattern` (generic_basic.rs)** — the contrived overload pattern in this test (a hand-rolled `partial` clone using concrete return types instead of `Self`) now flags `inconsistent-overload`. Real typeshed's `functools.partial` uses `-> Self` and is unaffected. Marked with `# E:` so the test reflects the new behavior.

3. **`test_overloaded_new_mixed_annotation` (constructors.rs)** — overload return `C` is now correctly flagged as incompatible with impl return `Self`. This is a true positive of the fix.

These are the same contravariance subtlety as #1; please call out if you'd rather keep the prior ergonomic behavior and we'll narrow the rule before merge.

## Adjacent unsoundness surfaced (NOT fixed in this PR)

- **`test_enum_call_with_self_type` (enums.rs)**: `cls(code)` in a `@classmethod` is inferred as the concrete `__new__` return type instead of `Self@cls`. Documented with a fresh `bug = "..."` marker per the project convention so it doesn't regress silently. Worth a follow-up issue rather than expanding the scope of this PR.

## Conformance

Pass rate 0.92 → 0.94: `generics_self_basic.py` and `generics_self_usage.py` now pass. Updated `conformance.exp`, `conformance.result`, and `results.json` are included.