### PR TITLE
[website] Center error line in sandbox when scrolling from results panel

### DIFF
--- a/website/src/sandbox/Sandbox.tsx
+++ b/website/src/sandbox/Sandbox.tsx
@@ -878,7 +878,7 @@ export default function Sandbox({
             endColumn,
         };
 
-        editor.revealRange(range);
+        editor.revealRangeInCenterIfOutsideViewport(range);
         editor.setSelection(range);
     };
 


### PR DESCRIPTION
## Summary

Switches the SandboxResults error-click handler from `editor.revealRange(range)` to `editor.revealRangeInCenterIfOutsideViewport(range)` so the target line lands with surrounding context instead of flush against the viewport edge.

## Why this API, not `revealRangeInCenter`?

The issue title says "in the middle of the screen", but the body clarifies the actual complaint is the offscreen case — when the line being scrolled to ends up at the very top or bottom with no context around it. `revealRangeInCenter` would forcibly recenter on every click, including when the line is already comfortably visible, which is jarring and unexpected for a "go-to-error" action. `revealRangeInCenterIfOutsideViewport` only recenters when the line is offscreen and leaves it alone otherwise — matching standard editor "jump-to" behavior (VS Code, IntelliJ, etc.).

## Test plan

- [x] `tsc --noEmit` passes
- [x] Existing test suite passes
- [ ] Manual smoke test in the sandbox recommended for visual UX confirmation: trigger an error far offscreen (line should center), then trigger one already visible (no scroll should occur)

Closes #338