### PR TITLE
fix False positive [not-iterable] for dict literal with heterogeneous values built in a loop #2798

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1007,6 +1007,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         errors: &ErrorCollector,
     ) -> Type {
         let flattened_items = Ast::flatten_dict_items(items);
+        let hint =
+            hint.filter(|hint| !matches!(hint.types(), [ty] if self.solver().is_partial(ty)));
         if let Some(hint) = hint {
             for hint_ty in hint.types() {
                 let (typed_dict, is_update) = match hint_ty {

--- a/pyrefly/lib/test/dict.rs
+++ b/pyrefly/lib/test/dict.rs
@@ -106,6 +106,22 @@ for topic, token in items:
 );
 
 testcase!(
+    test_loop_assigned_heterogeneous_inner_dict,
+    r#"
+import datetime
+
+def bin_tasks(dates: list[datetime.date]) -> None:
+    bins = {}
+    for d in dates:
+        bins[d] = {"start": d, "tasks": []}
+
+    for val in bins.values():
+        for task in val["tasks"]:
+            print(task)
+"#,
+);
+
+testcase!(
     test_large_dict_literal_mixed_none,
     r#"
 # Regression test: dict literals with many entries of mixed str | None values


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2798

dict literals ignore a bare unconstrained partial hint.

That lets the inner heterogeneous literal form an anonymous TypedDict first, then the surrounding assignment pins the partial container type to that precise result instead of collapsing it

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test