### PR TITLE
gate fbcode jemalloc stats on non-Windows targets

### DIFF
--- a/crates/pyrefly_util/src/memory.rs
+++ b/crates/pyrefly_util/src/memory.rs
@@ -82,7 +82,7 @@ pub struct JemallocStats {
     pub allocated: Option<Bytes>,
 }
 
-#[cfg(not(fbcode_build))]
+#[cfg(not(all(fbcode_build, not(target_os = "windows"))))]
 fn get_jemalloc_stats() -> JemallocStats {
     JemallocStats {
         active: None,
@@ -90,7 +90,7 @@ fn get_jemalloc_stats() -> JemallocStats {
     }
 }
 
-#[cfg(fbcode_build)]
+#[cfg(all(fbcode_build, not(target_os = "windows")))]
 fn get_jemalloc_stats() -> JemallocStats {
     fn get_all() -> Option<serde_json::Value> {
         // This options configuration flag string is passed to `malloc_stats_print()`.


### PR DESCRIPTION
Summary:
pyrefly_util's `get_jemalloc_stats` references `allocator_stats::malloc_stats`, an fbcode-only crate that does not build on Windows (it uses weak symbols for `je_malloc_stats_print`). Today the function is gated on `cfg(fbcode_build)`, which is true for any fbcode Buck build including Windows ones, forcing downstream consumers that target Windows to overlay this file.

Lifeguard consumes pyrefly_util as a `git` Cargo dependency and ships Windows binaries. To avoid building `allocator-stats` on Windows it carries an overlay in `third-party/rust/fixups/pyrefly_util/overlay/` whose only difference from upstream is adding `not(target_os = "windows")` to the cfg attributes. Upstreaming the gate lets that overlay be deleted.

Differential Revision: D104015927


