### PR TITLE
remove extensionDependency on ms-python.python (#3326)

### DIFF
--- a/lsp/package-lock.json
+++ b/lsp/package-lock.json
@@ -7,7 +7,7 @@
         "": {
             "name": "pyrefly",
             "version": "0.0.1",
-            "license": "Apache2",
+            "license": "MIT",
             "dependencies": {
                 "@vscode/python-extension": "^1.0.5",
                 "serialize-javascript": "^7.0.5",

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -323,8 +323,5 @@
         "underscore": "^1.13.8",
         "vsce": "^2.15.0",
         "vscode-languageclient": "9.0.1"
-    },
-    "extensionDependencies": [
-        "ms-python.python"
-    ]
+    }
 }

--- a/lsp/src/codeLens.ts
+++ b/lsp/src/codeLens.ts
@@ -11,7 +11,7 @@ import {execFile} from 'child_process';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import {ExtensionContext} from 'vscode';
-import {PythonExtension} from '@vscode/python-extension';
+import {PythonEnvironment} from './python-environment';
 
 type CodeLensPosition = {
   line: number;
@@ -89,16 +89,6 @@ function parseUri(rawUri: string | undefined): vscode.Uri | undefined {
   } catch {
     return undefined;
   }
-}
-
-async function interpreterForUri(
-  uri: vscode.Uri,
-  pythonExtension: PythonExtension,
-): Promise<string | undefined> {
-  const envPath = await pythonExtension.environments.getActiveEnvironmentPath(
-    uri,
-  );
-  return envPath.path.length > 0 ? envPath.path : undefined;
 }
 
 function configurationTargetForUri(uri: vscode.Uri): vscode.ConfigurationTarget {
@@ -227,13 +217,13 @@ async function executeProcessTask(
 
 async function runMainFile(
   args: RunMainArgs,
-  pythonExtension: PythonExtension,
+  pythonEnv: PythonEnvironment,
 ): Promise<void> {
   const uri = parseUri(args.uri);
   if (!uri) {
     return;
   }
-  const interpreter = await interpreterForUri(uri, pythonExtension);
+  const interpreter = await pythonEnv.getInterpreterPath(uri);
   if (!interpreter) {
     void showRunnableCodeLensError(
       uri,
@@ -254,7 +244,7 @@ async function runMainFile(
 
 async function runTestAtLocation(
   args: RunTestArgs,
-  pythonExtension: PythonExtension,
+  pythonEnv: PythonEnvironment,
 ): Promise<void> {
   const uri = parseUri(args.uri);
   if (!uri) {
@@ -269,7 +259,7 @@ async function runTestAtLocation(
     return;
   }
 
-  const interpreter = await interpreterForUri(uri, pythonExtension);
+  const interpreter = await pythonEnv.getInterpreterPath(uri);
   if (!interpreter) {
     void showRunnableCodeLensError(
       uri,
@@ -331,7 +321,7 @@ async function runTestAtLocation(
 
 export function registerCodeLensCommands(
   context: ExtensionContext,
-  pythonExtension: PythonExtension,
+  pythonEnv: PythonEnvironment,
 ): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('pyrefly.runTest', async args => {
@@ -339,7 +329,7 @@ export function registerCodeLensCommands(
       if (!parsedArgs) {
         return;
       }
-      await runTestAtLocation(parsedArgs, pythonExtension);
+      await runTestAtLocation(parsedArgs, pythonEnv);
     }),
   );
 
@@ -349,7 +339,7 @@ export function registerCodeLensCommands(
       if (!parsedArgs) {
         return;
       }
-      await runMainFile(parsedArgs, pythonExtension);
+      await runMainFile(parsedArgs, pythonEnv);
     }),
   );
 }

--- a/lsp/src/extension-interop.ts
+++ b/lsp/src/extension-interop.ts
@@ -17,7 +17,10 @@ import * as vscode from 'vscode';
  *
  * We then change the setting back so we don't end up messing up the users settings.
  */
-export async function triggerMsPythonRefreshLanguageServers() {
+export async function triggerMsPythonRefreshLanguageServersIfInstalled() {
+  if (!vscode.extensions.getExtension('ms-python.python')) {
+    return;
+  }
   const config = vscode.workspace.getConfiguration('python');
   const setting = 'languageServer';
   let previousSetting = config.get(setting);

--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -30,7 +30,7 @@ import {runDocstringFoldingCommand} from './docstring';
 import {registerCodeLensCommands} from './codeLens';
 import {PythonEnvironment} from './python-environment';
 import {
-  triggerMsPythonRefreshLanguageServers,
+  triggerMsPythonRefreshLanguageServersIfInstalled,
   disableWindsurfPyrightIfInstalled,
   disableBasedPyrightIfInstalled,
   disableCursorPyrightIfInstalled,
@@ -112,7 +112,7 @@ export async function activate(context: ExtensionContext) {
     process.platform === 'win32' ? 'pyrefly.exe' : 'pyrefly',
   );
 
-  const pythonEnv = new PythonEnvironment();
+  const pythonEnv = new PythonEnvironment(context);
 
   // Otherwise to spawn the server
   let serverOptions: ServerOptions = {
@@ -258,12 +258,12 @@ export async function activate(context: ExtensionContext) {
 
   // When our extension is activated, make sure ms-python knows
   // TODO(kylei): remove this hack once ms-python has this behavior
-  await triggerMsPythonRefreshLanguageServers();
+  await triggerMsPythonRefreshLanguageServersIfInstalled();
 
   vscode.workspace.onDidChangeConfiguration(async e => {
     if (e.affectsConfiguration(`python.pyrefly.disableLanguageServices`)) {
       // TODO(kylei): remove this hack once ms-python has this behavior
-      await triggerMsPythonRefreshLanguageServers();
+      await triggerMsPythonRefreshLanguageServersIfInstalled();
     }
   });
 

--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -21,7 +21,6 @@ import {
   ResponseError,
   ServerOptions,
 } from 'vscode-languageclient/node';
-import {PythonExtension} from '@vscode/python-extension';
 import {
   TYPE_ERROR_DISPLAY_STATUS_VERSION,
   getStatusBarItem,
@@ -29,6 +28,7 @@ import {
 } from './status-bar';
 import {runDocstringFoldingCommand} from './docstring';
 import {registerCodeLensCommands} from './codeLens';
+import {PythonEnvironment} from './python-environment';
 import {
   triggerMsPythonRefreshLanguageServers,
   disableWindsurfPyrightIfInstalled,
@@ -60,37 +60,28 @@ function requireSetting<T>(path: string): T {
  * - VSCode returns a configuration of {setting: 'value'} from settings.json
  * - This function will add pythonPath: '/usr/bin/python3' from the Python extension to the configuration
  * - {setting: 'value', pythonPath: '/usr/bin/python3'} is returned
- *
- * @param pythonExtension the python extension API
- * @param configurationItems the sections within the workspace
- * @param configuration the configuration returned by vscode in response to a workspace/configuration request (usually what's in settings.json)
- * corresponding to the sections described in configurationItems
  */
 async function overridePythonPath(
-  pythonExtension: PythonExtension,
+  pythonEnv: PythonEnvironment,
   configurationItems: ConfigurationItem[],
   configuration: (object | null)[],
 ): Promise<(object | null)[]> {
-  const getPythonPathForConfigurationItem = async (index: number) => {
-    if (
-      configurationItems.length <= index ||
-      configurationItems[index].section !== 'python'
-    ) {
-      return undefined;
-    }
-    let scopeUri = configurationItems[index].scopeUri;
-    return await pythonExtension.environments.getActiveEnvironmentPath(
-      scopeUri === undefined ? undefined : vscode.Uri.parse(scopeUri),
-    ).path;
-  };
   const newResult = await Promise.all(
     configuration.map(async (item, index) => {
-      const pythonPath = await getPythonPathForConfigurationItem(index);
+      if (
+        configurationItems.length <= index ||
+        configurationItems[index].section !== 'python'
+      ) {
+        return item;
+      }
+      const scopeUri = configurationItems[index].scopeUri;
+      const pythonPath = await pythonEnv.getInterpreterPath(
+        scopeUri === undefined ? undefined : vscode.Uri.parse(scopeUri),
+      );
       if (pythonPath === undefined) {
         return item;
-      } else {
-        return {...item, pythonPath};
       }
+      return {...item, pythonPath};
     }),
   );
   return newResult;
@@ -121,7 +112,7 @@ export async function activate(context: ExtensionContext) {
     process.platform === 'win32' ? 'pyrefly.exe' : 'pyrefly',
   );
 
-  let pythonExtension = await PythonExtension.api();
+  const pythonEnv = new PythonEnvironment();
 
   // Otherwise to spawn the server
   let serverOptions: ServerOptions = {
@@ -189,12 +180,11 @@ export async function activate(context: ExtensionContext) {
           if (result instanceof ResponseError) {
             return result;
           }
-          const newResult = await overridePythonPath(
-            pythonExtension,
+          return await overridePythonPath(
+            pythonEnv,
             params.items,
             result as (object | null)[],
           );
-          return newResult;
         },
       },
     },
@@ -214,13 +204,17 @@ export async function activate(context: ExtensionContext) {
     }),
   );
 
-  context.subscriptions.push(
-    pythonExtension.environments.onDidChangeActiveEnvironmentPath(() => {
+  pythonEnv
+    .onDidChangeInterpreter(() => {
       client.sendNotification(DidChangeConfigurationNotification.type, {
         settings: {},
       });
-    }),
-  );
+    })
+    .then(disposable => {
+      if (disposable) {
+        context.subscriptions.push(disposable);
+      }
+    });
 
   context.subscriptions.push(
     workspace.onDidChangeConfiguration(async event => {
@@ -260,7 +254,7 @@ export async function activate(context: ExtensionContext) {
       await runDocstringFoldingCommand(client, outputChannel, 'editor.unfold');
     }),
   );
-  registerCodeLensCommands(context, pythonExtension);
+  registerCodeLensCommands(context, pythonEnv);
 
   // When our extension is activated, make sure ms-python knows
   // TODO(kylei): remove this hack once ms-python has this behavior

--- a/lsp/src/python-environment.ts
+++ b/lsp/src/python-environment.ts
@@ -10,16 +10,61 @@
 import * as vscode from 'vscode';
 import {PythonExtension} from '@vscode/python-extension';
 
+const DISMISSED_KEY = 'pyrefly.dismissedPythonExtensionWarning';
+
 export class PythonEnvironment {
   private api: Promise<PythonExtension | undefined>;
+  private pendingListeners: (() => void)[] = [];
+  private context: vscode.ExtensionContext;
 
-  constructor() {
-    this.api = PythonExtension.api().catch(() => undefined);
+  constructor(context: vscode.ExtensionContext) {
+    this.context = context;
+    this.api = PythonExtension.api().catch(() => {
+      if (!context.globalState.get(DISMISSED_KEY)) {
+        const install = 'Install';
+        const dismiss = "Don't Show Again";
+        vscode.window
+          .showInformationMessage(
+            'Install the Python extension (ms-python.python) for improved experience with Pyrefly, including automatic Python environment detection.',
+            install,
+            dismiss,
+          )
+          .then(selection => {
+            if (selection === install) {
+              vscode.commands.executeCommand(
+                'workbench.extensions.installExtension',
+                'ms-python.python',
+              );
+            } else if (selection === dismiss) {
+              context.globalState.update(DISMISSED_KEY, true);
+            }
+          });
+      }
+      this.retryPythonAPIOnExtensionInstall();
+      return undefined;
+    });
   }
 
-  async getInterpreterPath(
-    uri?: vscode.Uri,
-  ): Promise<string | undefined> {
+  /**
+   * Retry accessing python API on every extension install until successful. Once successful, we call all callbacks and no longer try.
+   */
+  private retryPythonAPIOnExtensionInstall() {
+    const disposable = vscode.extensions.onDidChange(() => {
+      PythonExtension.api()
+        .then(ext => {
+          this.api = Promise.resolve(ext);
+          disposable.dispose();
+          for (const listener of this.pendingListeners) {
+            listener();
+            ext.environments.onDidChangeActiveEnvironmentPath(listener);
+          }
+        })
+        .catch(() => {});
+    });
+    this.context.subscriptions.push(disposable);
+  }
+
+  async getInterpreterPath(uri?: vscode.Uri): Promise<string | undefined> {
     const ext = await this.api;
     if (!ext) {
       return undefined;
@@ -32,9 +77,10 @@ export class PythonEnvironment {
     callback: () => void,
   ): Promise<vscode.Disposable | undefined> {
     const ext = await this.api;
-    if (!ext) {
-      return undefined;
+    if (ext) {
+      return ext.environments.onDidChangeActiveEnvironmentPath(callback);
     }
-    return ext.environments.onDidChangeActiveEnvironmentPath(callback);
+    this.pendingListeners.push(callback);
+    return undefined;
   }
 }

--- a/lsp/src/python-environment.ts
+++ b/lsp/src/python-environment.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import * as vscode from 'vscode';
+import {PythonExtension} from '@vscode/python-extension';
+
+export class PythonEnvironment {
+  private api: Promise<PythonExtension | undefined>;
+
+  constructor() {
+    this.api = PythonExtension.api().catch(() => undefined);
+  }
+
+  async getInterpreterPath(
+    uri?: vscode.Uri,
+  ): Promise<string | undefined> {
+    const ext = await this.api;
+    if (!ext) {
+      return undefined;
+    }
+    const envPath = await ext.environments.getActiveEnvironmentPath(uri);
+    return envPath.path.length > 0 ? envPath.path : undefined;
+  }
+
+  async onDidChangeInterpreter(
+    callback: () => void,
+  ): Promise<vscode.Disposable | undefined> {
+    const ext = await this.api;
+    if (!ext) {
+      return undefined;
+    }
+    return ext.environments.onDidChangeActiveEnvironmentPath(callback);
+  }
+}


### PR DESCRIPTION
Summary:

# This stack
with the python-environments extension, there are now multiple places Pyrefly needs to look for interpreter info. This stack serves to support the new extension.

Steps:
- Abstract away API
- remove dependency on ms-python
- add support for python-environments

# This diff
removes the extension dependency on ms-python. in order to do that, we need to:
- make triggerMsPythonRefreshLanguageServers optional
- invalidate interpreter on extension install (otherwise it won't update automatically)
- add a warning when no interpreter selector is installed

Differential Revision: D104095645


