### PR TITLE
Fix Pyrefly regression with imported TypeVars via attribute access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,6 +2867,7 @@ dependencies = [
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -2150,7 +2150,7 @@ impl<'a> BindingsBuilder<'a> {
                 Some(_) => None,
             },
             LegacyTParamId::Attr(_, attr) => match binding {
-                Some(Binding::Module(..)) | None => Some((
+                Some(Binding::Module(..) | Binding::Import(..)) | None => Some((
                     KeyLegacyTypeParam(ShortIdentifier::new(attr)),
                     BindingLegacyTypeParam::ModuleKeyed(original_idx, Box::new(attr.id.clone())),
                 )),

--- a/pyrefly/lib/test/generic_legacy.rs
+++ b/pyrefly/lib/test/generic_legacy.rs
@@ -890,3 +890,26 @@ my_list: MyList[int] = MyList()
 my_list.my_append(foo.C(), 5)  # E: Argument `Literal[5]` is not assignable to parameter `t` with type `TypeVar[T]` in function `MyList.my_append`
     "#,
 );
+
+fn env_with_package() -> TestEnv {
+    let mut env = TestEnv::new();
+    env.add_with_path("pkg", "pkg/__init__.py", "");
+    env.add_with_path(
+        "pkg.lib",
+        "pkg/lib.py",
+        "from typing import TypeVar\nT = TypeVar('T')",
+    );
+    env
+}
+
+testcase!(
+    test_class_generic_typevar_from_imported_module,
+    env_with_package(),
+    r#"
+from pkg import lib
+from typing import Generic
+
+class MyGeneric(Generic[lib.T]):
+  pass
+"#,
+);


### PR DESCRIPTION
# Summary

This PR fixes a regression introduced in v0.64 where Pyrefly reports `invalid-type-var` errors when a `TypeVar` is imported from another module using the `from pkg import lib` syntax and then accessed as an attribute (e.g., `lib.MyTypeT`).

The root cause was that `make_legacy_tparam` in `bindings.rs` was too strict for `LegacyTParamId::Attr` (handling dotted names like `lib.T`). It only allowed the base name to be bound to `Binding::Module`. However, when a module is imported via `from pkg import lib`, it results in `Binding::Import` rather than `Binding::Module`. This caused Pyrefly to fail to recognize the imported symbol as a potential legacy type variable holder.

This PR updates `make_legacy_tparam` to also allow `Binding::Import` for `LegacyTParamId::Attr`, allowing the solver to correctly resolve the type variable.

Fixes #3332

# Test Plan

Added a new unit test `test_class_generic_typevar_from_imported_module` to `pyrefly/lib/test/generic_legacy.rs` that sets up a package structure and verifies that `lib.T` is correctly recognized as a type variable. The test passes with this fix.
