### PR TITLE
`pyrefly report` -> `pyrefly coverage report`

### DIFF
--- a/pyrefly/lib/commands/all.rs
+++ b/pyrefly/lib/commands/all.rs
@@ -27,6 +27,14 @@ use crate::commands::tsp::TspArgs;
 use crate::commands::util::CommandExitStatus;
 use crate::lsp::non_wasm::external_provider::NoExternalProvider;
 
+/// Subcommands of `pyrefly coverage`.
+#[deny(clippy::missing_docs_in_private_items)]
+#[derive(Debug, Clone, Subcommand)]
+pub enum CoverageCommand {
+    /// Generate a machine-readable type-coverage report from pyrefly type checking results.
+    Report(ReportArgs),
+}
+
 /// Subcommands to run Pyrefly with.
 #[deny(clippy::missing_docs_in_private_items)]
 #[derive(Debug, Clone, Subcommand)]
@@ -54,7 +62,14 @@ pub enum Command {
     Tsp(TspArgs),
     /// Automatically add type annotations to a file or directory.
     Infer(InferArgs),
-    /// Generate reports from pyrefly type checking results.
+    /// Type coverage commands.
+    Coverage {
+        /// Coverage subcommand to run.
+        #[command(subcommand)]
+        command: CoverageCommand,
+    },
+    /// Deprecated alias for `pyrefly coverage report`. Use `pyrefly coverage report` instead.
+    #[command(hide = true)]
     Report(ReportArgs),
     /// Suppress type errors by adding ignore comments, or remove unused ignores.
     Suppress(SuppressArgs),
@@ -96,7 +111,15 @@ impl Command {
             )),
             Command::Infer(args) => Ok((args.run(config_configurer_wrapper, thread_count)?, None)),
             Command::DumpConfig(args) => Ok((args.run(config_configurer_wrapper)?, None)),
-            Command::Report(args) => Ok((args.run(config_configurer_wrapper, thread_count)?, None)),
+            Command::Coverage {
+                command: CoverageCommand::Report(args),
+            } => Ok((args.run(config_configurer_wrapper, thread_count)?, None)),
+            Command::Report(args) => {
+                eprintln!(
+                    "warning: `pyrefly report` is deprecated; use `pyrefly coverage report` instead"
+                );
+                Ok((args.run(config_configurer_wrapper, thread_count)?, None))
+            }
             Command::Suppress(args) => {
                 Ok((args.run(config_configurer_wrapper, thread_count)?, None))
             }

--- a/test/basic.md
+++ b/test/basic.md
@@ -256,3 +256,29 @@ $ echo "x: str = 0" > $TMPDIR/test.py && \
  INFO 0 errors (1 warning not shown)* (glob)
 [0]
 ```
+
+## Main help shows `coverage` subcommand and not the hidden `report` alias
+
+```scrut
+$ $PYREFLY --help | grep -E "^ +(coverage|  report)"
+  coverage     Type coverage commands
+[0]
+```
+
+## `pyrefly coverage report --help` shows correct usage
+
+```scrut
+$ $PYREFLY coverage report --help | grep "^Usage:"
+Usage: pyrefly coverage report [OPTIONS] [FILES]...
+[0]
+```
+
+## Deprecated `pyrefly report` alias emits a warning on stderr
+
+```scrut
+$ touch $TMPDIR/pyrefly.toml && \
+> echo "def f(x: int) -> int: return x" > $TMPDIR/test.py && \
+> $PYREFLY report $TMPDIR/test.py 2>&1 | grep "warning:"
+warning: `pyrefly report` is deprecated; use `pyrefly coverage report` instead
+[0]
+```

--- a/website/docs/pyrefly-faq.mdx
+++ b/website/docs/pyrefly-faq.mdx
@@ -28,7 +28,7 @@ Here are the main reasons to consider Pyrefly:
 * **Battle-tested at scale.** Pyrefly runs in CI for Instagram and PyTorch, so it's proven on large, real-world codebases. It's also the default Python language server for the Antigravity and Positron editors.
 * **Built-in Pydantic and Django support.** Pyrefly has native support for [Pydantic](./pydantic.mdx) and [Django](./django.mdx), handling special type-checking behavior that can't be expressed in the current type system. Mypy is the only other type checker that supports these packages, via third-party plugins.
 * **Useful peripheral tools:** Pyrefly comes with a suite of useful tools to help you get the most out of your type annotations:
-    * [`pyrefly report`](./report.mdx) to measure type coverage across your codebase.
+    * [`pyrefly coverage report`](./report.mdx) to measure type coverage across your codebase.
     * [Error baselines](./error-suppressions.mdx#baseline-files-experimental) to track and suppress pre-existing errors without modifying source code.
     * [`pyrefly infer`](./autotype.mdx) to automatically add inferred type annotations to your code.
     * [`pyrefly init`](./migrating-to-pyrefly.mdx) for automatic config migration from mypy or pyright.

--- a/website/docs/report.mdx
+++ b/website/docs/report.mdx
@@ -1,7 +1,7 @@
 ---
 title: Report
 
-description: Measure type coverage in your Python codebase with the Pyrefly report command.
+description: Measure type coverage in your Python codebase with the Pyrefly coverage report command.
 ---
 
 {/*
@@ -13,7 +13,7 @@ description: Measure type coverage in your Python codebase with the Pyrefly repo
 
 # Pyrefly Report
 
-Understanding how much of your codebase is annotated with types can help you track progress toward full type coverage. The `pyrefly report` command produces a machine-readable JSON report with information about functions, classes, and error suppressions in your code.
+Understanding how much of your codebase is annotated with types can help you track progress toward full type coverage. The `pyrefly coverage report` command produces a machine-readable JSON report with information about functions, classes, and error suppressions in your code.
 
 :::warning Experimental
 This feature is experimental. The output format and behavior may change in future releases without notice.
@@ -21,11 +21,11 @@ This feature is experimental. The output format and behavior may change in futur
 
 ## Usage
 
-Run `pyrefly report` on a file or directory:
+Run `pyrefly coverage report` on a file or directory:
 
 ```
-pyrefly report path/to/file.py
-pyrefly report path/to/directory/
+pyrefly coverage report path/to/file.py
+pyrefly coverage report path/to/directory/
 ```
 
 The command outputs a JSON object with two top-level keys: `files` (per-file reports) and `summary` (aggregate statistics). For each file, the report includes:


### PR DESCRIPTION
# Summary

This renames the `pyrefly report` command to `pyrefly coverage report`. It's more specific this way, and makes is possible to add other commands related to type-coverage in the future (for example `pyrefly coverage check` to check that the coverage is above a given %).

The `pyrefly report` command still exists as a deprecated alias to `pyrefly coverage report` for the sake of backwards compatibility.

# Test Plan

Added scrut CLI tests.