### PR TITLE
Fix dataclass field collection to only include class body fields

### DIFF
--- a/pyrefly/lib/alt/class/dataclass.rs
+++ b/pyrefly/lib/alt/class/dataclass.rs
@@ -72,7 +72,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         }
         if let Some(class_fields) = self.get_class_fields(cls) {
-            for name in class_fields.names() {
+            for name in class_fields.class_body_fields() {
                 if class_fields.is_field_annotated(name) {
                     all_fields.insert(name.clone());
                 }

--- a/pyrefly/lib/test/dataclass_transform.rs
+++ b/pyrefly/lib/test/dataclass_transform.rs
@@ -573,11 +573,10 @@ SmallModule(x=1)
 testcase!(
     test_class_method_field_ignored_by_dataclass_repro,
     r#"
-from typing import Any, dataclass_transform, reveal_type, TYPE_CHECKING
+from typing import Any, dataclass_transform, reveal_type
 
 @dataclass_transform()
 class ModuleBase:
-  if TYPE_CHECKING:
     field: Any | None
 
 class Module(ModuleBase):
@@ -586,17 +585,17 @@ class Module(ModuleBase):
     cls.field: Any = None
 
 reveal_type(Module.__init__)  # E: revealed type: (self: Module) -> None
+Module()
     "#,
 );
 
 testcase!(
     test_instance_method_field_ignored_by_dataclass_repro,
     r#"
-from typing import Any, dataclass_transform, reveal_type, TYPE_CHECKING
+from typing import Any, dataclass_transform, reveal_type
 
 @dataclass_transform()
 class ModuleBase:
-  if TYPE_CHECKING:
     field: Any | None
 
 class Module(ModuleBase):
@@ -604,5 +603,6 @@ class Module(ModuleBase):
     self.field: Any = None
 
 reveal_type(Module.__init__)  # E: revealed type: (self: Module) -> None
+Module()
     "#,
 );

--- a/pyrefly/lib/test/dataclass_transform.rs
+++ b/pyrefly/lib/test/dataclass_transform.rs
@@ -571,57 +571,38 @@ SmallModule(x=1)
 );
 
 testcase!(
-    test_init_subclass_scope_issue,
+    test_class_method_field_ignored_by_dataclass_repro,
     r#"
-from typing import Any, reveal_type
-import typing
-import typing as tpe
+from typing import Any, dataclass_transform, reveal_type, TYPE_CHECKING
 
-def module_field(*, kw_only: bool = False, default: Any | None = ...) -> Any:
-  ...
-
-@tpe.dataclass_transform(field_specifiers=(module_field,))
+@dataclass_transform()
 class ModuleBase:
-  if typing.TYPE_CHECKING:
-    scope: Any | None
-
-class Module(ModuleBase):
-  @classmethod
-  def __init_subclass__(cls, kw_only: bool = False, **kwargs: Any) -> None:
-    cls.scope: Any = None
-
-class MyModel(Module):
-    features: int
-
-reveal_type(MyModel.__init__)  # E: revealed type: (self: MyModel, features: int) -> None
-MyModel(features=5)
-    "#,
-);
-
-testcase!(
-    test_class_method_foo_scope_issue,
-    r#"
-from typing import Any, reveal_type
-import typing
-import typing as tpe
-
-def module_field(*, kw_only: bool = False, default: Any | None = ...) -> Any:
-  ...
-
-@tpe.dataclass_transform(field_specifiers=(module_field,))
-class ModuleBase:
-  if typing.TYPE_CHECKING:
-    scope: Any | None
+  if TYPE_CHECKING:
+    field: Any | None
 
 class Module(ModuleBase):
   @classmethod
   def foo(cls) -> None:
-    cls.scope: Any = None
+    cls.field: Any = None
 
-class MyModel(Module):
-    features: int
+reveal_type(Module.__init__)  # E: revealed type: (self: Module) -> None
+    "#,
+);
 
-reveal_type(MyModel.__init__)  # E: revealed type: (self: MyModel, features: int) -> None
-MyModel(features=5)
+testcase!(
+    test_instance_method_field_ignored_by_dataclass_repro,
+    r#"
+from typing import Any, dataclass_transform, reveal_type, TYPE_CHECKING
+
+@dataclass_transform()
+class ModuleBase:
+  if TYPE_CHECKING:
+    field: Any | None
+
+class Module(ModuleBase):
+  def foo(self) -> None:
+    self.field: Any = None
+
+reveal_type(Module.__init__)  # E: revealed type: (self: Module) -> None
     "#,
 );

--- a/pyrefly/lib/test/dataclass_transform.rs
+++ b/pyrefly/lib/test/dataclass_transform.rs
@@ -571,7 +571,7 @@ SmallModule(x=1)
 );
 
 testcase!(
-    test_class_method_field_ignored_by_dataclass_repro,
+    test_classmethod_shadowing_base_annotation_ignored,
     r#"
 from typing import Any, dataclass_transform, reveal_type
 
@@ -590,7 +590,7 @@ Module()
 );
 
 testcase!(
-    test_instance_method_field_ignored_by_dataclass_repro,
+    test_method_shadowing_base_annotation_ignored,
     r#"
 from typing import Any, dataclass_transform, reveal_type
 

--- a/pyrefly/lib/test/dataclass_transform.rs
+++ b/pyrefly/lib/test/dataclass_transform.rs
@@ -569,3 +569,59 @@ class SmallModule(Module):
 SmallModule(x=1)
     "#,
 );
+
+testcase!(
+    test_init_subclass_scope_issue,
+    r#"
+from typing import Any, reveal_type
+import typing
+import typing as tpe
+
+def module_field(*, kw_only: bool = False, default: Any | None = ...) -> Any:
+  ...
+
+@tpe.dataclass_transform(field_specifiers=(module_field,))
+class ModuleBase:
+  if typing.TYPE_CHECKING:
+    scope: Any | None
+
+class Module(ModuleBase):
+  @classmethod
+  def __init_subclass__(cls, kw_only: bool = False, **kwargs: Any) -> None:
+    cls.scope: Any = None
+
+class MyModel(Module):
+    features: int
+
+reveal_type(MyModel.__init__)  # E: revealed type: (self: MyModel, features: int) -> None
+MyModel(features=5)
+    "#,
+);
+
+testcase!(
+    test_class_method_foo_scope_issue,
+    r#"
+from typing import Any, reveal_type
+import typing
+import typing as tpe
+
+def module_field(*, kw_only: bool = False, default: Any | None = ...) -> Any:
+  ...
+
+@tpe.dataclass_transform(field_specifiers=(module_field,))
+class ModuleBase:
+  if typing.TYPE_CHECKING:
+    scope: Any | None
+
+class Module(ModuleBase):
+  @classmethod
+  def foo(cls) -> None:
+    cls.scope: Any = None
+
+class MyModel(Module):
+    features: int
+
+reveal_type(MyModel.__init__)  # E: revealed type: (self: MyModel, features: int) -> None
+MyModel(features=5)
+    "#,
+);


### PR DESCRIPTION
# Summary

Restricts dataclass field collection in `get_dataclass_fields` to use `class_body_fields()` instead of `names()`.

Previously, `pyrefly` collected all annotated fields for dataclasses, including those defined via assignments in methods (e.g., `cls.field: Any = None` in a class method). This caused issues when such an assignment shadowed a declaration in a base class decorated with `@dataclass_transform`, leading to false positive `missing-argument` errors at call sites.

By restricting collection to class body fields, we ensure that only fields declared in the class body are considered candidates for dataclass fields, aligning with standard dataclass semantics.

Fixes #3346

# Test Plan

Added two new unit tests in `dataclass_transform.rs` to verify that fields shadowed by method assignments (both class methods and instance methods) are correctly ignored:
*   `test_classmethod_shadowing_base_annotation_ignored`
*   `test_method_shadowing_base_annotation_ignored`
