### PR TITLE
fix Goto definition goes to stub files instead of actual definitions with functools @cache decorator #3356

### DIFF
--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -1724,6 +1724,9 @@ impl<'a> Transaction<'a> {
                 );
                 defs
             }
+            Type::ClassType(class) if class.has_qname("functools", "_lru_cache_wrapper") => {
+                vec![]
+            }
             Type::ClassType(_) => self
                 .find_attribute_definition_for_base_type(handle, preference, ty, &dunder::CALL)
                 .map(Vec1::into_vec)

--- a/pyrefly/lib/test/lsp/definition.rs
+++ b/pyrefly/lib/test/lsp/definition.rs
@@ -2781,24 +2781,61 @@ Definition Result:
 #[test]
 fn goto_def_cached_function_call_goes_to_function() {
     let code = r#"
-from functools import cache
+from functools import cache, lru_cache
+import functools
 
 @cache
-def add(a: int, b: int) -> int:
+def cached_add(a: int, b: int) -> int:
     return a + b
 
-add(1, 2)
+@lru_cache
+def bare_lru_add(a: int, b: int) -> int:
+    return a + b
+
+@lru_cache(maxsize=None)
+def called_lru_add(a: int, b: int) -> int:
+    return a + b
+
+@functools.lru_cache(maxsize=128)
+def qualified_lru_add(a: int, b: int) -> int:
+    return a + b
+
+cached_add(1, 2)
+# ^
+bare_lru_add(1, 2)
+# ^
+called_lru_add(1, 2)
+# ^
+qualified_lru_add(1, 2)
 # ^
 "#;
     let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
     assert_eq!(
         r#"
 # main.py
-8 | add(1, 2)
-      ^
+21 | cached_add(1, 2)
+       ^
 Definition Result:
-5 | def add(a: int, b: int) -> int:
-        ^^^
+6 | def cached_add(a: int, b: int) -> int:
+        ^^^^^^^^^^
+
+23 | bare_lru_add(1, 2)
+       ^
+Definition Result:
+10 | def bare_lru_add(a: int, b: int) -> int:
+         ^^^^^^^^^^^^
+
+25 | called_lru_add(1, 2)
+       ^
+Definition Result:
+14 | def called_lru_add(a: int, b: int) -> int:
+         ^^^^^^^^^^^^^^
+
+27 | qualified_lru_add(1, 2)
+       ^
+Definition Result:
+18 | def qualified_lru_add(a: int, b: int) -> int:
+         ^^^^^^^^^^^^^^^^^
 "#
         .trim(),
         report.trim(),

--- a/pyrefly/lib/test/lsp/definition.rs
+++ b/pyrefly/lib/test/lsp/definition.rs
@@ -2779,6 +2779,33 @@ Definition Result:
 }
 
 #[test]
+fn goto_def_cached_function_call_goes_to_function() {
+    let code = r#"
+from functools import cache
+
+@cache
+def add(a: int, b: int) -> int:
+    return a + b
+
+add(1, 2)
+# ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert_eq!(
+        r#"
+# main.py
+8 | add(1, 2)
+      ^
+Definition Result:
+5 | def add(a: int, b: int) -> int:
+        ^^^
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn goto_def_class_name_without_call_goes_to_class() {
     let code = r#"
 class Baz:


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3356

now `functools._lru_cache_wrapper` does not hijack call-site go-to-definition to `__call__`

it now falls back to the normal symbol definition path.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test