### PR TITLE
Fix cross-file references lost when CRLF/LF line endings differ #3237 (#3359)

### DIFF
--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3172,6 +3172,9 @@ impl<'a> Transaction<'a> {
         .concat()
     }
 
+    /// Find references to an external definition within the given handle's module.
+    /// When the exact byte-range comparison fails (e.g. CRLF/LF differences),
+    /// falls back to comparing line numbers, which are encoding-invariant.
     fn local_references_from_external_definition(
         &self,
         handle: &Handle,
@@ -3181,6 +3184,10 @@ impl<'a> Transaction<'a> {
         let index = self.get_solutions(handle)?.get_index()?;
         let index = index.lock();
         let mut references = Vec::new();
+
+        // Lazily computed line number for fallback comparison.
+        let definition_line = || module.to_lsp_position(definition_range.start()).line;
+
         for ((imported_module_name, imported_name), ranges) in index
             .externally_defined_variable_references
             .iter()
@@ -3192,7 +3199,8 @@ impl<'a> Transaction<'a> {
                 imported_name.clone(),
                 FindPreference::default(),
             ) && imported_handle.path().as_path() == module.path().as_path()
-                && export.location == definition_range
+                && (export.location == definition_range
+                    || module.to_lsp_position(export.location.start()).line == definition_line())
             {
                 references.extend(ranges.iter().copied());
             }
@@ -3202,7 +3210,9 @@ impl<'a> Transaction<'a> {
         {
             if attribute_module_path == module.path() {
                 for (def_range, ref_range) in def_and_ref_ranges {
-                    if def_range == &definition_range {
+                    if *def_range == definition_range
+                        || module.to_lsp_position(def_range.start()).line == definition_line()
+                    {
                         references.push(*ref_range);
                     }
                 }
@@ -3947,18 +3957,25 @@ fn patch_definition_for_handle_impl<T: RdepTransaction>(
     match definition.module.path().details() {
         ModulePathDetails::Memory(path_buf) if handle.path() != definition.module.path() => {
             let TextRangeWithModule { module, range } = definition;
-            let module = if let Some(info) = transaction.module_info(&Handle::new(
+            let new_module = if let Some(info) = transaction.module_info(&Handle::new(
                 module.name(),
                 ModulePath::filesystem((**path_buf).clone()),
                 handle.sys_info().dupe(),
             )) {
                 info
             } else {
-                module.dupe()
+                return TextRangeWithModule {
+                    module: module.dupe(),
+                    range: *range,
+                };
             };
+            // Remap range from in-memory to on-disk byte offsets so that
+            // module and range stay consistent (e.g. when CRLF/LF differ).
+            let lsp_range = module.to_lsp_range(*range);
+            let range = new_module.from_lsp_range(lsp_range, None);
             TextRangeWithModule {
-                module,
-                range: *range,
+                module: new_module,
+                range,
             }
         }
         _ => definition.clone(),

--- a/pyrefly/lib/test/lsp/lsp_interaction/references.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/references.rs
@@ -916,3 +916,78 @@ fn test_references_for_metaclass_call_priority() {
 
     interaction.shutdown().unwrap();
 }
+
+/// Regression test for https://github.com/facebook/pyrefly/issues/3237:
+/// `textDocument/references` should find cross-file references even when the
+/// target module starts with a docstring and the on-disk files use CRLF line
+/// endings while the editor sends LF-normalized content via `did_open`.
+#[test]
+fn test_references_cross_file_with_module_docstring() {
+    let root = get_test_files_root();
+    let root_path = root.path().join("references_docstring");
+    let scope_uri = Url::from_file_path(&root_path).unwrap();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root_path.clone());
+    interaction
+        .initialize(InitializeSettings {
+            workspace_folders: Some(vec![("test".to_owned(), scope_uri)]),
+            configuration: Some(None),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let a = root_path.join("a.py");
+    let b = root_path.join("b.py");
+    let services = root_path.join("services.py");
+
+    // The source fixtures use LF (to satisfy linters). Convert them to CRLF
+    // on disk in the temp directory so we can simulate an editor that
+    // normalizes CRLF→LF when opening files via `did_open`.
+    for path in [&a, &b, &services] {
+        let raw = std::fs::read_to_string(path).unwrap();
+        let lf_content = raw.replace("\r\n", "\n");
+        let crlf_content = lf_content.replace('\n', "\r\n");
+        std::fs::write(path, &crlf_content).unwrap();
+    }
+
+    for (name, path) in [("a.py", &a), ("b.py", &b), ("services.py", &services)] {
+        let on_disk = std::fs::read_to_string(path).unwrap();
+        let normalized = on_disk.replace("\r\n", "\n");
+        let uri = Url::from_file_path(path).unwrap();
+        interaction.client.did_open_uri(&uri, "python", normalized);
+        assert!(
+            on_disk.contains("\r\n"),
+            "{name} should have CRLF line endings on disk"
+        );
+    }
+
+    // BUG: Class A (preceded by a docstring) loses cross-file references because
+    // the CRLF->LF byte offset drift causes the definition range comparison to
+    // fail. Only the declaration is returned.
+    interaction
+        .client
+        .references("a.py", 8, 6, true)
+        .expect_response(json!([
+            {
+                "range": {"start":{"line":8,"character":6},"end":{"line":8,"character":7}},
+                "uri": Url::from_file_path(a.clone()).unwrap().to_string()
+            },
+        ]))
+        .unwrap();
+
+    // BUG: Class B also loses cross-file references because the license header
+    // introduces line breaks before the class definition, causing the same
+    // CRLF->LF byte offset drift. Only the declaration is returned.
+    interaction
+        .client
+        .references("b.py", 6, 6, true)
+        .expect_response(json!([
+            {
+                "range": {"start":{"line":6,"character":6},"end":{"line":6,"character":7}},
+                "uri": Url::from_file_path(b.clone()).unwrap().to_string()
+            },
+        ]))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}

--- a/pyrefly/lib/test/lsp/lsp_interaction/references.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/references.rs
@@ -961,9 +961,8 @@ fn test_references_cross_file_with_module_docstring() {
         );
     }
 
-    // BUG: Class A (preceded by a docstring) loses cross-file references because
-    // the CRLF->LF byte offset drift causes the definition range comparison to
-    // fail. Only the declaration is returned.
+    // Class A defined in a.py (which starts with a docstring) should find
+    // cross-file references from services.py just like B.
     interaction
         .client
         .references("a.py", 8, 6, true)
@@ -972,12 +971,22 @@ fn test_references_cross_file_with_module_docstring() {
                 "range": {"start":{"line":8,"character":6},"end":{"line":8,"character":7}},
                 "uri": Url::from_file_path(a.clone()).unwrap().to_string()
             },
+            {
+                "range": {"start":{"line":5,"character":14},"end":{"line":5,"character":15}},
+                "uri": Url::from_file_path(services.clone()).unwrap().to_string()
+            },
+            {
+                "range": {"start":{"line":9,"character":13},"end":{"line":9,"character":14}},
+                "uri": Url::from_file_path(services.clone()).unwrap().to_string()
+            },
+            {
+                "range": {"start":{"line":9,"character":19},"end":{"line":9,"character":20}},
+                "uri": Url::from_file_path(services.clone()).unwrap().to_string()
+            },
         ]))
         .unwrap();
 
-    // BUG: Class B also loses cross-file references because the license header
-    // introduces line breaks before the class definition, causing the same
-    // CRLF->LF byte offset drift. Only the declaration is returned.
+    // Class B should also find cross-file refs.
     interaction
         .client
         .references("b.py", 6, 6, true)
@@ -985,6 +994,18 @@ fn test_references_cross_file_with_module_docstring() {
             {
                 "range": {"start":{"line":6,"character":6},"end":{"line":6,"character":7}},
                 "uri": Url::from_file_path(b.clone()).unwrap().to_string()
+            },
+            {
+                "range": {"start":{"line":6,"character":14},"end":{"line":6,"character":15}},
+                "uri": Url::from_file_path(services.clone()).unwrap().to_string()
+            },
+            {
+                "range": {"start":{"line":13,"character":13},"end":{"line":13,"character":14}},
+                "uri": Url::from_file_path(services.clone()).unwrap().to_string()
+            },
+            {
+                "range": {"start":{"line":13,"character":19},"end":{"line":13,"character":20}},
+                "uri": Url::from_file_path(services.clone()).unwrap().to_string()
             },
         ]))
         .unwrap();

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/references_docstring/a.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/references_docstring/a.py
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Module docstring."""
+
+
+class A:
+    pass

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/references_docstring/b.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/references_docstring/b.py
@@ -1,0 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+class B:
+    pass

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/references_docstring/services.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/references_docstring/services.py
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from a import A
+from b import B
+
+
+def use_a(x: A) -> A:
+    return x
+
+
+def use_b(x: B) -> B:
+    return x


### PR DESCRIPTION
Summary:

When files on disk use CRLF but the editor sends LF-normalized content via did_open, byte offsets diverge between the on-disk exports and the in-memory definition. The exact byte-range comparison in local_references_from_external_definition fails for any definition after a line break, dropping cross-file references.

The fix adds a line-number fallback to the comparison. When the exact byte range doesn't match, it compares the line number of the export location against the definition's line number. Line numbers are invariant across CRLF/LF differences, so this correctly matches definitions even when byte offsets differ. The fallback preserves the exact-range fast path for the common case and only activates when content encoding differs.

fixes #3237

Reviewed By: yangdanny97, jvansch1

Differential Revision: D104303086


