### PR TITLE
ci: declare contents:read on Test Pyrefly Action workflow

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -17,6 +17,9 @@ on:
       - ".github/workflows/test_action.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-action:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `test_action` workflow only checks out the repo, writes a single test file, runs the local pyrefly action, and asserts the expected failure path. No comment on PRs, no upload to releases, no GitHub API beyond `actions/checkout`. So `contents: read` is enough.

This brings the workflow in line with `mypy_primer.yml`, `auto_assign.yml`, `label_new_issues.yml`, and the other workflows here that already carry workflow-level `permissions:` blocks. With it set:

- the workflow token can't be widened by a future change to the repo's default token grant
- the SLSA / Scorecard `Token-Permissions` check passes for this file
- a hypothetical compromise of `actions/checkout` (cf. tj-actions/changed-files CVE-2025-30066) can't escalate beyond reading the working tree

`deploy_extension.yml` and `rollback_website.yml` deliberately left untouched: both invoke reusable workflows (`./.github/workflows/check_publish.yml`, `./.github/workflows/build_extension.yml`, `./.github/workflows/deploy_website.yml`), so any caller-level `permissions:` block intersects with the callees' scopes (notably the publish jobs). That deserves a more careful look than a single-line drop-in.