### PR TITLE
fix Missing Cargo.lock checksum for rustversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2866,6 +2866,7 @@ dependencies = [
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"


### PR DESCRIPTION
# Summary

With an incomplete Cargo.lock, the project fails to build or be vendored with `--locked`.

Fixes #3383 

# Test Plan

Running `cargo check` or most other Cargo commands fixes the Cargo.lock.

<!-- Run test.py and commit any changes to generated files -->
