### PR TITLE
fix false positive in forward type reference #3387

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -1144,6 +1144,18 @@ impl<'a> BindingsBuilder<'a> {
         self.as_special_export_inner(e, &mut visited_names, &mut visited_keys)
     }
 
+    pub fn class_object_is_generic(&self, idx: Idx<Key>) -> bool {
+        let Some(Binding::ClassDef(class_idx, _)) = self.idx_to_binding(idx) else {
+            return false;
+        };
+        match self.idx_to_binding(*class_idx) {
+            Some(BindingClass::ClassDef(class)) => {
+                class.def.type_params.is_some() || class.tparams_require_binding
+            }
+            Some(BindingClass::FunctionalClassDef(..)) | None => false,
+        }
+    }
+
     fn as_special_export_inner(
         &self,
         e: &Expr,

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -695,9 +695,14 @@ impl<'a> BindingsBuilder<'a> {
                     }
                 } else if self.scopes.has_future_annotations()
                     && let Expr::Name(name) = &**value
-                    && matches!(
-                        self.scopes.flow_style_for_name(&name.id),
-                        Some(FlowStyle::ClassDef { .. })
+                    && let Some((class_object_idx, FlowStyle::ClassDef { .. })) =
+                        self.scopes.binding_idx_for_name(&name.id)
+                    && self.class_object_is_generic(class_object_idx)
+                    && !matches!(
+                        &**slice,
+                        // String-keyed class subscripts, such as Enum member lookup, are runtime
+                        // expressions even when future annotations are active.
+                        Expr::StringLiteral(_)
                     )
                 {
                     self.ensure_expr(&mut *value, usage);

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -693,6 +693,22 @@ impl<'a> BindingsBuilder<'a> {
                     } else {
                         self.ensure_type_impl(&mut *slice, &mut None, false, &mut type_usage);
                     }
+                } else if self.scopes.has_future_annotations()
+                    && let Expr::Name(name) = &**value
+                    && matches!(
+                        self.scopes.flow_style_for_name(&name.id),
+                        Some(FlowStyle::ClassDef { .. })
+                    )
+                {
+                    self.ensure_expr(&mut *value, usage);
+                    self.ensure_type_impl(
+                        &mut *slice,
+                        &mut None,
+                        false,
+                        &mut Usage::StaticTypeInformation {
+                            is_annotation: false,
+                        },
+                    );
                 } else {
                     self.ensure_expr(&mut *value, usage);
                     self.ensure_expr(&mut *slice, usage);

--- a/pyrefly/lib/test/enums.rs
+++ b/pyrefly/lib/test/enums.rs
@@ -69,6 +69,22 @@ def foo(member: MyEnum) -> None:
 );
 
 testcase!(
+    test_enum_string_getitem_with_future_annotations,
+    r#"
+from __future__ import annotations
+from enum import Enum
+from typing import Literal, assert_type
+
+class DEFAULT_TYPES(Enum):
+    EXE = "EXE"
+    LIB = "LIB"
+
+assert_type(DEFAULT_TYPES["EXE"], Literal[DEFAULT_TYPES.EXE])
+assert_type(DEFAULT_TYPES["LIB"], Literal[DEFAULT_TYPES.LIB])
+"#,
+);
+
+testcase!(
     test_enum_class_value,
     r#"
 from enum import Enum

--- a/pyrefly/lib/test/generic_basic.rs
+++ b/pyrefly/lib/test/generic_basic.rs
@@ -758,6 +758,19 @@ assert_type(b, A[int])
 "#,
 );
 
+// Regression test for https://github.com/facebook/pyrefly/issues/3387
+testcase!(
+    test_future_annotations_forward_ref_in_generic_constructor,
+    r#"
+from __future__ import annotations
+
+class Foo[T]: ...
+
+class Bar:
+    foo = Foo[Bar]()
+"#,
+);
+
 testcase!(
     test_typevar_type,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3387

`Foo[Bar]` under `from __future__ import annotations` binds Bar as static type information when Foo is a known class, avoiding the false Bar is uninitialized diagnostic.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test