### PR TITLE
fix Pydantic Field(ge/gt/le/lt=N) with int literal flagged as bad-argument-type on Decimal fields #3403

### DIFF
--- a/pyrefly/lib/alt/class/pydantic.rs
+++ b/pyrefly/lib/alt/class/pydantic.rs
@@ -469,9 +469,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         range: TextRange,
         errors: &ErrorCollector,
     ) {
-        // Note: the subset check here is too conservative when it comes to modeling runtime behavior
-        // we want to check if the bound_val is coercible to the annotation type at runtime.
-        // statically, this could be a challenge, which is why we go with this more conservative approach for now.
+        let field_ty = Self::pydantic_range_field_type(field_ty);
         for (bound_val, label) in [
             (&keywords.gt, "gt"),
             (&keywords.lt, "lt"),
@@ -479,7 +477,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             (&keywords.le, "le"),
         ] {
             let Some(val) = bound_val else { continue };
-            if !self.is_subset_eq(val, field_ty) {
+            if !self.is_pydantic_range_constraint_type_compatible(val, field_ty) {
                 self.error(
                     errors,
                     range,
@@ -493,6 +491,39 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         }
         self.check_pydantic_range_default(field_name, keywords, range, errors);
+    }
+
+    fn pydantic_range_field_type(field_ty: &Type) -> &Type {
+        match field_ty {
+            Type::Annotated(inner, _) => Self::pydantic_range_field_type(inner),
+            _ => field_ty,
+        }
+    }
+
+    fn is_pydantic_range_constraint_type_compatible(&self, val: &Type, field_ty: &Type) -> bool {
+        let field_ty = Self::pydantic_range_field_type(field_ty);
+        if self.is_subset_eq(val, field_ty) {
+            return true;
+        }
+        match field_ty {
+            Type::Union(union) => union.members.iter().any(|member| {
+                !member.is_none() && self.is_pydantic_range_constraint_type_compatible(val, member)
+            }),
+            Type::ClassType(cls) if cls.has_qname("decimal", "Decimal") => {
+                self.is_pydantic_decimal_constraint_value(val)
+            }
+            _ => false,
+        }
+    }
+
+    fn is_pydantic_decimal_constraint_value(&self, val: &Type) -> bool {
+        matches!(
+            val.clone().promote_implicit_literals(self.stdlib),
+            Type::ClassType(cls)
+                if cls.is_builtin("int")
+                    || cls.is_builtin("float")
+                    || cls.has_qname("decimal", "Decimal")
+        )
     }
 
     fn check_pydantic_range_default(

--- a/pyrefly/lib/alt/class/pydantic.rs
+++ b/pyrefly/lib/alt/class/pydantic.rs
@@ -542,9 +542,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         range: TextRange,
         errors: &ErrorCollector,
     ) {
-        // Note: the subset check here is too conservative when it comes to modeling runtime behavior
-        // we want to check if the bound_val is coercible to the annotation type at runtime.
-        // statically, this could be a challenge, which is why we go with this more conservative approach for now.
+        let field_ty = Self::pydantic_range_field_type(field_ty);
         for (bound_val, label) in [
             (&keywords.gt, "gt"),
             (&keywords.lt, "lt"),
@@ -552,7 +550,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             (&keywords.le, "le"),
         ] {
             let Some(val) = bound_val else { continue };
-            if !self.is_subset_eq(val, field_ty) {
+            if !self.is_pydantic_range_constraint_type_compatible(val, field_ty) {
                 self.error(
                     errors,
                     range,
@@ -566,6 +564,39 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         }
         self.check_pydantic_range_default(field_name, keywords, range, errors);
+    }
+
+    fn pydantic_range_field_type(field_ty: &Type) -> &Type {
+        match field_ty {
+            Type::Annotated(inner, _) => Self::pydantic_range_field_type(inner),
+            _ => field_ty,
+        }
+    }
+
+    fn is_pydantic_range_constraint_type_compatible(&self, val: &Type, field_ty: &Type) -> bool {
+        let field_ty = Self::pydantic_range_field_type(field_ty);
+        if self.is_subset_eq(val, field_ty) {
+            return true;
+        }
+        match field_ty {
+            Type::Union(union) => union.members.iter().any(|member| {
+                !member.is_none() && self.is_pydantic_range_constraint_type_compatible(val, member)
+            }),
+            Type::ClassType(cls) if cls.has_qname("decimal", "Decimal") => {
+                self.is_pydantic_decimal_constraint_value(val)
+            }
+            _ => false,
+        }
+    }
+
+    fn is_pydantic_decimal_constraint_value(&self, val: &Type) -> bool {
+        matches!(
+            val.clone().promote_implicit_literals(self.stdlib),
+            Type::ClassType(cls)
+                if cls.is_builtin("int")
+                    || cls.is_builtin("float")
+                    || cls.has_qname("decimal", "Decimal")
+        )
     }
 
     fn check_pydantic_range_default(

--- a/pyrefly/lib/test/pydantic/field.rs
+++ b/pyrefly/lib/test/pydantic/field.rs
@@ -136,6 +136,25 @@ Model(x=5)
 );
 
 pydantic_testcase!(
+    test_field_range_decimal,
+    r#"
+from decimal import Decimal
+from typing import Annotated
+from pydantic import BaseModel, Field
+
+class DecimalField(BaseModel):
+    a: Decimal = Field(ge=0)
+    b: Decimal = Field(gt=0)
+    c: Decimal = Field(le=100)
+    d: Decimal = Field(lt=100)
+    e: Decimal | None = Field(default=None, ge=0)
+    f: Decimal = Field(ge="0")  # E: Pydantic `ge` value has type `Literal['0']`, which is not assignable to field type `Decimal`
+    g: Annotated[Decimal, Field(ge=0)]
+    h: Annotated[Decimal, Field(ge="0")]  # E: Pydantic `ge` value has type `Literal['0']`, which is not assignable to field type `Decimal`
+"#,
+);
+
+pydantic_testcase!(
     test_field_optional,
     r#"
 from pydantic import BaseModel, Field

--- a/pyrefly/lib/test/pydantic/field.rs
+++ b/pyrefly/lib/test/pydantic/field.rs
@@ -169,6 +169,25 @@ Model(x=5)
 );
 
 pydantic_testcase!(
+    test_field_range_decimal,
+    r#"
+from decimal import Decimal
+from typing import Annotated
+from pydantic import BaseModel, Field
+
+class DecimalField(BaseModel):
+    a: Decimal = Field(ge=0)
+    b: Decimal = Field(gt=0)
+    c: Decimal = Field(le=100)
+    d: Decimal = Field(lt=100)
+    e: Decimal | None = Field(default=None, ge=0)
+    f: Decimal = Field(ge="0")  # E: Pydantic `ge` value has type `Literal['0']`, which is not assignable to field type `Decimal`
+    g: Annotated[Decimal, Field(ge=0)]
+    h: Annotated[Decimal, Field(ge="0")]  # E: Pydantic `ge` value has type `Literal['0']`, which is not assignable to field type `Decimal`
+"#,
+);
+
+pydantic_testcase!(
     test_field_optional,
     r#"
 from pydantic import BaseModel, Field


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3403

Pydantic range constraint metadata unwraps `Annotated[...]`, handles `Decimal | None`, and accepts int/float-compatible constraint values for Decimal instead of relying only on strict subtype checks.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test