### PR TITLE
Fix negative narrowing for isinstance tuple targets

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -432,39 +432,44 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         errors: &ErrorCollector,
     ) -> Type {
         let force_allow_negative = matches!(source, NarrowSource::Pattern);
-        let mut res = Vec::new();
-        for (right, allows_negative_narrow) in self.expr_as_class_info(right_expr, errors) {
-            res.push(self.distribute_over_union(left, |l| {
-                let allows_negative_narrow = allows_negative_narrow || force_allow_negative;
+        let class_infos = self.expr_as_class_info(right_expr, errors);
+        // Subtract each class info from each union member of `left` in turn,
+        // rather than computing per-target results and intersecting them.
+        // Intersecting `subtract(L, A)` with `subtract(L, B)` reintroduces
+        // any union member that overlaps with both A and B (e.g. `Iterable[Any]`
+        // overlaps with both `str` and `bytes`), so `isinstance(x, (str, bytes))`
+        // would leave the negative branch unchanged. Sequential per-element
+        // subtraction avoids that.
+        self.distribute_over_union(left, |l| {
+            let mut result = l.clone();
+            for (right, allows_negative_narrow) in &class_infos {
+                let allows_negative_narrow = *allows_negative_narrow || force_allow_negative;
                 if !allows_negative_narrow {
-                    return l.clone();
+                    continue;
                 }
-                if let Some((tparams, right)) = self.unwrap_isinstance_target(l, &right) {
+                if let Some((tparams, right)) = self.unwrap_isinstance_target(&result, right) {
                     let (vs, right) = self
                         .solver()
                         .fresh_quantified(&tparams, right, self.uniques);
                     // For constrained TypeVars, subtract from the concrete constraints
                     // so that e.g. isinstance(x, (int, float)) with T(int, str, float)
                     // narrows the else branch to str instead of leaving it as T.
-                    let result = if let Type::Quantified(q) = l
+                    result = if let Type::Quantified(q) = &result
                         && let Restriction::Constraints(_) = q.restriction()
                     {
                         let concrete = q.bound_type(self.stdlib, self.heap);
                         self.subtract(&concrete, &right)
                     } else {
-                        self.subtract(l, &right)
+                        self.subtract(&result, &right)
                     };
                     // These are safe to ignore, as the only possible specialization errors are handled elsewhere:
                     // * If `left` is an invalid specialization, the error has already been reported at its definition site.
                     // * Unsafe runtime protocol overlaps are separately checked for in special_calls.rs.
                     let _specialization_errors = self.solver().finish_quantified(vs, false);
-                    result
-                } else {
-                    l.clone()
                 }
-            }));
-        }
-        self.intersects(&res)
+            }
+            result
+        })
     }
 
     /// Narrow `type(X) != Y`. We can only do negative narrowing if Y is final,

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -966,6 +966,23 @@ def f(x: str | int | None):
 );
 
 testcase!(
+    test_isinstance_tuple_negative_with_overlap,
+    r#"
+from typing import Any, Iterable, assert_type
+
+# `Iterable[Any]` overlaps with both `str` and `bytes` (both are iterable).
+# In the negative branch of `isinstance(a, (str, bytes))` we should still
+# remove the `str` and `bytes` alternatives from the remaining union.
+# Regression test for facebook/pyrefly#3412.
+def f(a: float | str | bytes | Iterable[Any]) -> None:
+    if isinstance(a, (str, bytes)):
+        pass
+    else:
+        assert_type(a, float | Iterable[Any])
+    "#,
+);
+
+testcase!(
     test_isinstance_unbounded_tuple,
     r#"
 from typing import assert_type


### PR DESCRIPTION
Fixes #3412.

This fixes negative narrowing for `isinstance` checks where the target is a tuple of runtime classes, such as `isinstance(x, (str, bytes))`.

## Summary

- For `isinstance(x, (A, B))`, `narrow_is_not_instance` previously subtracted each tuple element from the full input type independently and then intersected the per-element results.
- When the input contained a member that overlapped with multiple tuple elements (e.g. `Iterable[Any]` is a supertype of both `str` and `bytes`), the intersection step would reintroduce the subtracted alternatives through subset-based intersection. Concretely, `intersect_impl(Iterable[Any], str)` returns `str` because `str <: Iterable[Any]`.
- The fix walks the input union once and subtracts every tuple element from each union member sequentially, so the per-element scope doesn't reintroduce the overlap. Targets that don't allow negative narrowing (e.g. a non-final `type[C]` variable) are skipped, preserving existing conservative behavior.

## Repro

```py
from typing import reveal_type, Any, Iterable

def arrlen(obj: Any) -> int | None: ...

def main(a: float | str | bytes | Iterable[Any]) -> None:
    if isinstance(a, (str, bytes)):
        pass
    elif arrlen(a) is not None:
        reveal_type(a)
```

Before: `Iterable[Any] | bytes | float | str`
After:  `Iterable[Any] | float`

## Test plan

- [x] Added `test_isinstance_tuple_negative_with_overlap` in `pyrefly/lib/test/narrow.rs`.
- [x] `cargo test -p pyrefly --lib` — 5152 passed, 0 failed.
- [x] All 40 `test_isinstance_*` tests continue to pass, including the existing `test_isinstance_type_negative_partial_narrow` which exercises the not-final `type[C]` skip path.
- [x] Verified the repro file against the locally built `target/debug/pyrefly`.