### PR TITLE
fix False positive: incompatible default value error on TypeVar-typed parameter when default satisfies Literal bound #3418

### DIFF
--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -947,10 +947,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         )
                     )
                 );
+                let quantified_bound = match &param_ty {
+                    Type::Quantified(q) if q.is_type_var() => {
+                        Some(q.bound_type(self.stdlib, self.heap))
+                    }
+                    _ => None,
+                };
+                let check_ty = quantified_bound.as_ref().unwrap_or(&param_ty);
                 let check: Option<(&Type, &dyn Fn() -> TypeCheckContext)> = if skip_check {
                     None
                 } else {
-                    Some((&param_ty, &make_context))
+                    Some((check_ty, &make_context))
                 };
                 let required = self.get_requiredness(default, check, stub_or_impl, errors);
                 (param_ty, required, false)

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -2000,6 +2000,21 @@ def f(x: int = "test"): # E: Default `Literal['test']` is not assignable to para
 );
 
 testcase!(
+    test_parameter_default_typevar_bound,
+    r#"
+from typing import Literal, TypeVar
+
+T = TypeVar("T", bound=Literal["foo"])
+
+def ok(t: T = "foo") -> None:
+    pass
+
+def bad(t: T = "bar") -> None:  # E: Default `Literal['bar']` is not assignable to parameter `t` with type `Literal['foo']`
+    pass
+"#,
+);
+
+testcase!(
     test_parameter_default_infer,
     r#"
 from typing import reveal_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3418

a bare TypeVar parameter default is checked against the TypeVar’s bound instead of against the unresolved quantified type itself.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test