### PR TITLE
fix: resolve walrus operator name lookup in comprehension filter (fix…

### DIFF
--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -2925,6 +2925,23 @@ impl Scopes {
             // compiler has identified as local shadows enclosing scopes, so we should prefer
             // inner static lookups to outer flow lookups.
             if !is_class && let Some(static_info) = scope.stat.0.get_hashed(name) {
+                // For comprehension scopes, check if the name exists in an enclosing scope first.
+                // This handles the case where a walrus operator's target was added to the
+                // comprehension's static scope (via `add_lvalue_to_current_static`) but should
+                // still resolve to the enclosing scope's binding.
+                if matches!(scope.kind, ScopeKind::Comprehension { .. }) {
+                    for enclosing_scope in self.scopes.iter().rev().skip(1) {
+                        if let Some(enclosing_flow_info) =
+                            enclosing_scope.scope.flow.get_info_hashed(name)
+                        {
+                            return Some(NameReadInfo::Flow {
+                                idx: enclosing_flow_info.idx(),
+                                initialized: enclosing_flow_info.initialized(),
+                            });
+                        }
+                    }
+                }
+
                 let forward_ref_key = static_info.as_key(name.into_key());
                 return Some(NameReadInfo::Anywhere {
                     key: forward_ref_key,

--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -1370,3 +1370,12 @@ class Config:
         debug = True
 "#,
 );
+
+// https://github.com/facebook/pyrefly/issues/3398
+testcase!(
+    test_walrus_in_comprehension_reads_enclosing_scope_param,
+    r#"
+def demo(text: str) -> None:
+    [text := text.replace(s, f"\\{s}") for s in "&#" if s in text]
+"#,
+);


### PR DESCRIPTION
# Summary

Fixed false positive "X is uninitialized" errors when walrus operator (:=) in comprehension filter reads a variable from the enclosing function scope.

Root cause: In look_up_name_for_read, when a name was found via static lookup in the comprehension scope (added via add_lvalue_to_current_static), the function returned InitializedInFlow::No without checking enclosing scopes. This caused false positive errors for parameters or local variables from enclosing scopes.

Fix: For comprehension scopes, check enclosing scopes via flow lookup before returning static lookup result. If the name exists in an enclosing scope's flow, use that instead of the comprehension scope's static info.

### Fixes #3398

## Test Plan

Added test test_walrus_in_comprehension_reads_enclosing_scope_param in pyrefly/lib/test/scope.rs reproducing the bug
All existing scope and comprehension tests pass
Ran python3 test.py --no-test --no-conformance --no-jsonschema — formatting and linting passed successfully
