### PR TITLE
docs: add dict-to-model refactor docs (fixes #2040)

### DIFF
--- a/website/docs/IDE-features.mdx
+++ b/website/docs/IDE-features.mdx
@@ -422,6 +422,12 @@ Flips the value of a boolean and updates all usages to work with new value.
   preload="metadata"
 />
 
+**Convert dict to model**
+
+Creates a `TypedDict`, `dataclass`, or Pydantic model from a selected dict literal.
+Pyrefly inserts the required imports and generates a matching class skeleton from
+the selected fields.
+
 ---
 
 ### [Diagnostics](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics)


### PR DESCRIPTION
# Summary


## Fixes #2040

Added documentation for "Convert dict to model" code action in website/docs/IDE-features.mdx. The code action creates a TypedDict, dataclass, or Pydantic model from a selected dict literal, inserting required imports and generating a matching class skeleton from the selected fields.

## Test Plan

Verified the documentation change renders correctly
Ran python3 test.py --no-test --no-conformance --no-jsonschema — formatting and linting passed
