### PR TITLE
Fix false positives when assigning super().method to self.attribute (#3414)

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -2429,7 +2429,20 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     Some(inherited_ty) if inferred_from_method => {
                         // Inherit the previous type of the attribute if the only declaration-like
                         // thing the current class does is assign to the attribute in a method.
-                        inherited_ty
+                        //
+                        // Exception: if the assigned value is a `BoundMethod` (e.g.
+                        // `self.meth = super().meth`), the bound form is callable *without*
+                        // `self`. Using the inherited unbound function type here would make
+                        // the field appear to require `self` at call sites, and would also
+                        // make the assignment itself look type-incompatible (bound vs
+                        // unbound). Preserve the bound-method type instead.
+                        let swallowed = self.error_swallower();
+                        let inferred = self.attribute_expr_infer(e, None, name, &swallowed);
+                        if matches!(&inferred, Type::BoundMethod(_)) {
+                            inferred
+                        } else {
+                            inherited_ty
+                        }
                     }
                     Some(inherited_ty)
                         if inherited_annotation.is_none() && direct_annotation.is_none() =>

--- a/pyrefly/lib/test/class_super.rs
+++ b/pyrefly/lib/test/class_super.rs
@@ -144,6 +144,21 @@ class Triangle(Shape):
 );
 
 testcase!(
+    test_super_method_assigned_to_self_attribute,
+    r#"
+class Parent:
+    def meth(self) -> None: ...
+
+class Child(Parent):
+    def __init__(self) -> None:
+        self.meth = super().meth
+
+Parent().meth()
+Child().meth()
+"#,
+);
+
+testcase!(
     test_illegal_location,
     r#"
 class A:


### PR DESCRIPTION
## Summary

Fixes https://github.com/facebook/pyrefly/issues/3414.

`self.attr = X` inside a method, when a parent class already has `attr`, was unconditionally substituting the inherited unbound type for the RHS's inferred type. For `self.meth = super().meth` this discarded the `BoundMethod` wrapper, leaving the field stored as a raw `Function(self) -> None` and producing three false positives:

- `bad-override` on the assignment target
- `bad-assignment` on the RHS
- `missing-argument self` at the call site

In `analyze_class_field_value`, the `inferred_from_method` branch now infers the RHS first and keeps it whenever it produced a `BoundMethod`, falling back to the inherited type otherwise. The existing stability behavior for plain attribute assignments (e.g. `self.x = 5` against an inherited `x: int`) is unchanged because those RHS types are not `BoundMethod`s.

This works because a `BoundMethod` already encodes the receiver, so its call signature is the parent method minus `self` — exactly what the runtime sees, and what makes the assignment, override, and call all type-check.

## Test plan

- [x] New regression test `test_super_method_assigned_to_self_attribute` in `pyrefly/lib/test/class_super.rs`
- [x] Original repro now reports 0 errors
- [x] `cargo test --lib -p pyrefly class_super class_overrides class_subtyping attributes` all pass
- [x] `python3 test.py --no-test --no-conformance --no-jsonschema` passes
- [x] Full lib suite: the 9 unrelated `config_finder` / `tsp_interaction` failures reproduce on baseline `main` and are not caused by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)