### PR TITLE
Fix unbound-name false positive for walrus in comprehension

### DIFF
--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -924,23 +924,37 @@ impl<'a> BindingsBuilder<'a> {
                 x.recurse_mut(&mut |x| self.ensure_expr(x, usage));
             }
             Expr::Named(x) => {
-                // For scopes defined in terms of Definitions, we should normally already have the name in Static, but
-                // we still need this for comprehensions, whose scope is defined on-the-fly.
-                self.scopes.add_lvalue_to_current_static(&x.target);
-                self.bind_target_with_expr(&mut x.target, &mut x.value, &|expr, ann| {
-                    Binding::Expr(ann, Box::new(expr.clone()))
-                });
-                // PEP 572: walrus operators inside comprehensions bind to
-                // the enclosing (non-comprehension) scope.
+                // PEP 572: walrus operators inside comprehensions bind to the
+                // enclosing (non-comprehension) scope. Evaluate the RHS before
+                // adding the target to the comprehension's static scope, so
+                // any reference to the target's name inside the RHS resolves
+                // against the enclosing scope rather than the (still
+                // uninitialized) comprehension binding we're about to create.
+                // See https://github.com/facebook/pyrefly/issues/3398.
                 if self.scopes.in_comprehension()
                     && let Expr::Name(name) = &*x.target
-                    && let Some(idx) = self.scopes.get_current_flow_idx(&name.id)
                 {
-                    self.scopes.define_in_enclosing_non_comprehension_scope(
-                        Hashed::new(&name.id),
-                        idx,
-                        FlowStyle::Other,
-                    );
+                    let identifier = ShortIdentifier::expr_name(name);
+                    let mut user = self.declare_current_idx(Key::Definition(identifier));
+                    self.ensure_expr(&mut x.value, user.usage());
+                    self.scopes.add_lvalue_to_current_static(&x.target);
+                    let ann = self.bind_current(&name.id, &user, FlowStyle::Other);
+                    let binding = Binding::Expr(ann, Box::new((*x.value).clone()));
+                    self.insert_binding_current(user, binding);
+                    if let Some(idx) = self.scopes.get_current_flow_idx(&name.id) {
+                        self.scopes.define_in_enclosing_non_comprehension_scope(
+                            Hashed::new(&name.id),
+                            idx,
+                            FlowStyle::Other,
+                        );
+                    }
+                } else {
+                    // For scopes defined in terms of Definitions, we should normally already have the name in Static, but
+                    // we still need this for comprehensions, whose scope is defined on-the-fly.
+                    self.scopes.add_lvalue_to_current_static(&x.target);
+                    self.bind_target_with_expr(&mut x.target, &mut x.value, &|expr, ann| {
+                        Binding::Expr(ann, Box::new(expr.clone()))
+                    });
                 }
             }
             Expr::Lambda(x) => {

--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -675,6 +675,21 @@ def h(matrix: list[list[int]]) -> None:
 "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/3398
+// The RHS of a walrus inside a comprehension must resolve names against the
+// enclosing scope, not the (yet uninitialized) comprehension binding the
+// walrus is about to create.
+testcase!(
+    test_walrus_in_comprehension_reads_outer_name,
+    r#"
+def demo(text: str) -> None:
+    [text := text.replace(s, f"\\{s}") for s in "&#" if s in text]
+
+def with_int(n: int) -> None:
+    [n := n + 1 for _ in range(3)]
+"#,
+);
+
 testcase!(
     test_forward_reference_ok,
     r#"


### PR DESCRIPTION
## Summary

- The `Expr::Named` handler added the walrus target to the comprehension's static scope **before** evaluating the RHS, so a same-named read in the RHS resolved to the (still uninitialized) comprehension entry instead of walking up to the enclosing scope.
- Per PEP 572, walrus targets inside a comprehension bind to the enclosing non-comprehension scope. For walrus inside a comprehension, evaluate the RHS first, then add the lvalue and write the flow, before lifting the binding to the enclosing scope.

Closes #3398.

Repro that previously errored, now clean:

```python
def demo(text: str) -> None:
    [text := text.replace(s, f"\\{s}") for s in "&#" if s in text]
```

## Test plan

- [x] New regression test `test_walrus_in_comprehension_reads_outer_name` in `pyrefly/lib/test/scope.rs` (covers the exact issue snippet plus an `int` variant).
- [x] All existing walrus tests pass (53 total, including `test_walrus_behaviors`, `test_walrus_in_comprehension_outer_scope`, `test_walrus_inside_comprehension_if`).
- [x] Full `cargo test --lib -p pyrefly` green (5156 tests).
- [x] `python3 test.py --no-test --no-conformance --no-jsonschema` (rustfmt + clippy) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)