### PR TITLE
Narrow tuple out of union for irrefutable sequence patterns

### DIFF
--- a/pyrefly/lib/binding/pattern.rs
+++ b/pyrefly/lib/binding/pattern.rs
@@ -135,6 +135,15 @@ impl<'a> BindingsBuilder<'a> {
                     .iter()
                     .filter(|x| !matches!(x, Pattern::MatchStar(_)))
                     .count();
+                // If every sub-pattern is irrefutable (wildcards like `_`, bare names,
+                // or `*rest`), the structural `IsSequence + LenEq/LenGte` narrow on the
+                // subject fully captures what the pattern proves. Spurious Placeholders
+                // added by `and_all` for empty sub-pattern narrow ops would otherwise
+                // block negative narrowing (see equivalent fix in MatchClass below).
+                let all_subpatterns_irrefutable = x
+                    .patterns
+                    .iter()
+                    .all(|p| p.is_irrefutable() || p.is_wildcard());
                 let mut subject_idx = subject_idx;
                 let synthesized_len = Expr::NumberLiteral(ExprNumberLiteral {
                     node_index: AtomicNodeIndex::default(),
@@ -254,6 +263,12 @@ impl<'a> BindingsBuilder<'a> {
                     KeyExpect::UnpackedLength(x.range),
                     BindingExpect::UnpackedLength(subject_idx, x.range, expect),
                 );
+                if all_subpatterns_irrefutable
+                    && let Some(subject) = match_subject.as_single()
+                    && let Some((op, _)) = narrow_ops.0.get_mut(subject.name())
+                {
+                    op.strip_placeholders();
+                }
                 narrow_ops
             }
             Pattern::MatchMapping(x) => {

--- a/pyrefly/lib/test/pattern_match.rs
+++ b/pyrefly/lib/test/pattern_match.rs
@@ -259,6 +259,54 @@ def f0(x: A | B):
 );
 
 testcase!(
+    test_match_sequence_pattern_narrows_tuple_out_of_union,
+    r#"
+from typing import assert_never
+
+def f(value: float | tuple[float, float]) -> None:
+    match value:
+        case (_, _):
+            pass
+        case float():
+            pass
+        case _ as unreachable:
+            assert_never(unreachable)
+"#,
+);
+
+testcase!(
+    test_match_sequence_star_pattern_narrows,
+    r#"
+from typing import assert_never
+
+def f(value: int | list[int]) -> None:
+    match value:
+        case [*_]:
+            pass
+        case int():
+            pass
+        case _ as unreachable:
+            assert_never(unreachable)
+"#,
+);
+
+testcase!(
+    test_match_sequence_refutable_subpattern_no_strip,
+    r#"
+from typing import assert_type
+
+def f(value: float | tuple[float, float]) -> float | tuple[float, float]:
+    match value:
+        case (1.0, 2.0):
+            return value
+        case _:
+            # The (1.0, 2.0) case is refutable, so tuple[float, float] must still be possible here.
+            assert_type(value, float | tuple[float, float])
+            return value
+"#,
+);
+
+testcase!(
     test_match_exhaustive_enum_assign,
     r#"
 from enum import IntEnum


### PR DESCRIPTION
## Summary

- Fixes #3147 — sequence patterns like `case (_, _):` failed to narrow the matched tuple type out of a union in later cases, causing spurious `bad-argument-type` errors on `assert_never` exhaustiveness checks.
- Mirrors the existing `MatchClass` fix: when every sub-pattern is irrefutable (wildcards, bare names, `*rest`), strip the spurious `Placeholder` narrow ops that `and_all` appends, so negation of the scope-level `And(IsSequence, LenEq/LenGte)` narrow actually eliminates the matched sequence type from subsequent cases. Refutable sub-patterns (e.g. `case (1.0, 2.0)`) are left alone — the case can still fail when the structural narrow holds.

The commit message has the full root-cause analysis.

## Test plan

- [x] New test `test_match_sequence_pattern_narrows_tuple_out_of_union` — verbatim issue repro, asserts zero errors.
- [x] New test `test_match_sequence_star_pattern_narrows` — confirms `[*_]` narrows correctly.
- [x] New test `test_match_sequence_refutable_subpattern_no_strip` — guards against over-stripping: `case (1.0, 2.0)` followed by `_` must leave `float | tuple[float, float]` in the fall-through.
- [x] `cargo test --package pyrefly --lib pattern_match` — 64 passed.
- [x] `cargo test --package pyrefly --lib test::narrow` — 192 passed.
- [x] `cargo test --package pyrefly --lib flow_branching` — 151 passed.
- [x] `python3 test.py --no-test --no-conformance --no-jsonschema` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)