### PR TITLE
Fix TypeVar resolution through arbatrary multi-level module attribute access (e.g. `Foo.Bar.ImportedT`). Closes #3431

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -45,7 +45,6 @@ use starlark_map::small_map::Entry;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 use vec1::Vec1;
-use vec1::vec1;
 
 use crate::alt::answers::LookupAnswer;
 use crate::alt::answers_solver::AnswersSolver;
@@ -262,18 +261,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Arc<LegacyTypeParameterLookup> {
         let maybe_parameter = match binding {
             BindingLegacyTypeParam::ParamKeyed(k) => self.get_idx(*k),
-            BindingLegacyTypeParam::ModuleKeyed(k, attr) => {
-                let module = self.get_idx(*k);
-                // Errors in attribute lookup are reported elsewhere, so we provide dummy values
-                // for arguments related to error reporting.
-                self.attr_infer(
-                    &module,
-                    attr,
-                    TextRange::default(),
-                    &self.error_swallower(),
-                    None,
-                )
-                .into()
+            BindingLegacyTypeParam::ModuleKeyed(k, attrs) => {
+                // Errors in attribute lookup are reported elsewhere.
+                attrs.iter().fold(self.get_idx(*k), |acc, attr| {
+                    self.attr_infer(
+                        &acc,
+                        attr,
+                        TextRange::default(),
+                        &self.error_swallower(),
+                        None,
+                    )
+                    .into()
+                })
             }
         };
         // Use the scope_anchor (the KeyLegacyTypeParam's own range, i.e. the first occurrence
@@ -4539,15 +4538,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             LegacyTypeParameterLookup::NotParameter(ty) => ty.clone(),
         };
         match self.bindings().get(key) {
-            BindingLegacyTypeParam::ModuleKeyed(idx, attr) => {
-                // `idx` points to a module whose `attr` attribute may be a legacy type
+            BindingLegacyTypeParam::ModuleKeyed(idx, attrs) => {
+                // `idx` points to a module whose attr chain may end in a legacy type
                 // variable that needs to be replaced with a QuantifiedValue. Since the
-                // ModuleKeyed binding is for the module itself, we use the mechanism for
-                // attribute ("facet") type narrowing to change the type that will be
-                // produced when `attr` is accessed.
+                // binding is for the module itself, we use the mechanism for attribute
+                // ("facet") type narrowing to change the type produced when the final
+                // attr is accessed.
                 let module = (*self.get_idx(*idx)).clone();
                 if matches!(ty, Type::QuantifiedValue(_)) {
-                    module.with_narrow(&vec1![FacetKind::Attribute((**attr).clone())], ty)
+                    let facets = attrs.mapped_ref(|a| FacetKind::Attribute(a.clone()));
+                    module.with_narrow(&facets, ty)
                 } else {
                     module
                 }

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -47,6 +47,7 @@ use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use starlark_map::small_set::SmallSet;
+use vec1::Vec1;
 
 use crate::alt::class::class_field::ClassField;
 use crate::alt::class::variance_inference::VarianceMap;
@@ -123,7 +124,7 @@ assert_bytes!(BindingAbstractClassCheck, 4);
 assert_bytes!(BindingClassSubscriptSymmetry, 4);
 assert_words!(BindingClassField, 11);
 assert_bytes!(BindingClassSynthesizedFields, 4);
-assert_bytes!(BindingLegacyTypeParam, 16);
+assert_bytes!(BindingLegacyTypeParam, 32);
 assert_words!(BindingYield, 4);
 assert_words!(BindingYieldFrom, 4);
 assert_words!(BindingDecorator, 10);
@@ -3181,20 +3182,25 @@ impl DisplayWith<Bindings> for BindingClassSubscriptSymmetry {
 pub enum BindingLegacyTypeParam {
     /// The key points directly to an expression that may be a legacy type parameter.
     ParamKeyed(Idx<Key>),
-    /// The key points to a module with an attribute that may be a legacy type parameter.
-    ModuleKeyed(Idx<Key>, Box<Name>),
+    /// The key points to a module with attribute(s) that may be a legacy type parameter.
+    /// Supports multi-level dotted access (e.g. `mod.T` or `pkg.mod.T`).
+    ModuleKeyed(Idx<Key>, Vec1<Name>),
 }
 
 impl DisplayWith<Bindings> for BindingLegacyTypeParam {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, ctx: &Bindings) -> fmt::Result {
-        write!(
-            f,
-            "BindingLegacyTypeParam({})",
-            match self {
-                Self::ParamKeyed(k) => format!("{}", ctx.display(*k)),
-                Self::ModuleKeyed(k, attr) => format!("{}.{attr}", ctx.display(*k)),
+        write!(f, "BindingLegacyTypeParam(")?;
+        match self {
+            Self::ParamKeyed(k) => write!(f, "{}", ctx.display(*k)),
+            Self::ModuleKeyed(k, attrs) => {
+                write!(f, "{}", ctx.display(*k))?;
+                for attr in attrs.iter() {
+                    write!(f, ".{}", attr)?;
+                }
+                Ok(())
             }
-        )
+        }?;
+        write!(f, ")")
     }
 }
 

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -48,6 +48,7 @@ use ruff_text_size::TextSize;
 use starlark_map::Hashed;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
+use vec1::Vec1;
 
 use crate::binding::binding::AnnotationTarget;
 use crate::binding::binding::Binding;
@@ -1934,13 +1935,15 @@ impl<'a> BindingsBuilder<'a> {
 pub enum LegacyTParamId {
     /// A simple name referring to a legacy type parameter.
     Name(Identifier),
-    /// A <name>.<name> reference to a legacy type parameter.
-    Attr(Identifier, Identifier),
+    /// A dotted reference to a legacy type parameter (e.g. `mod.T` or `pkg.mod.T`).
+    /// The first Identifier is the base name looked up in scope (mod or pkg), the
+    /// vector contains the attribute chain, i.e T or mod.T
+    Attr(Identifier, Vec1<Identifier>),
 }
 
 impl LegacyTParamId {
     /// Get the identifier of the name that will actually be bound (for a normal name, this is
-    /// just itself; for a `<base>.<attr>` attribute it is the base portion, which gets narrowed).
+    /// just itself; for a `<base>.<attr>*` attribute it is the base portion, which gets narrowed).
     fn as_identifier(&self) -> &Identifier {
         match self {
             Self::Name(name) => name,
@@ -1963,7 +1966,14 @@ impl LegacyTParamId {
     fn tvar_name(&self) -> String {
         match self {
             Self::Name(name) => name.id.as_str().to_owned(),
-            Self::Attr(base, attr) => format!("{base}.{attr}"),
+            Self::Attr(base, attrs) => {
+                let mut result = format!("{base}");
+                for attr in attrs {
+                    result.push('.');
+                    result.push_str(attr.as_str());
+                }
+                result
+            }
         }
     }
 }
@@ -1972,7 +1982,7 @@ impl Ranged for LegacyTParamId {
     fn range(&self) -> TextRange {
         match self {
             Self::Name(name) => name.range,
-            Self::Attr(_, attr) => attr.range,
+            Self::Attr(_, attrs) => attrs.last().range,
         }
     }
 }
@@ -2213,10 +2223,13 @@ impl<'a> BindingsBuilder<'a> {
                 )),
                 Some(_) => None,
             },
-            LegacyTParamId::Attr(_, attr) => match binding {
+            LegacyTParamId::Attr(_, attrs) => match binding {
                 Some(Binding::Module(..) | Binding::Import(..)) | None => Some((
-                    KeyLegacyTypeParam(ShortIdentifier::new(attr)),
-                    BindingLegacyTypeParam::ModuleKeyed(original_idx, Box::new(attr.id.clone())),
+                    KeyLegacyTypeParam(ShortIdentifier::new(attrs.last())),
+                    BindingLegacyTypeParam::ModuleKeyed(
+                        original_idx,
+                        attrs.mapped_ref(|a| a.id.clone()),
+                    ),
                 )),
                 Some(_) => None,
             },

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -93,11 +93,9 @@ fn chase_static_attr_chain_impl(
     }
 
     match expr {
-        Expr::Attribute(ExprAttribute {
-            value: box Expr::Name(name),
-            attr,
-            ..
-        }) => Some((name.clone(), vec1![attr.clone()])),
+        Expr::Attribute(ExprAttribute { value, attr, .. }) if let Expr::Name(name) = &**value => {
+            Some((name.clone(), vec1![attr.clone()]))
+        }
         Expr::Attribute(ExprAttribute { value, attr, .. }) => {
             chase_static_attr_chain_impl(value, gas).map(|(name, mut attrs)| {
                 attrs.push(attr.clone());

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -9,6 +9,7 @@ use pyrefly_graph::index::Idx;
 use pyrefly_python::ast::Ast;
 use pyrefly_python::module_path::ModuleStyle;
 use pyrefly_python::short_identifier::ShortIdentifier;
+use pyrefly_util::gas::Gas;
 use pyrefly_util::visit::VisitMut;
 use ruff_python_ast::AtomicNodeIndex;
 use ruff_python_ast::BoolOp;
@@ -33,6 +34,8 @@ use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use starlark_map::Hashed;
+use vec1::Vec1;
+use vec1::vec1;
 
 use crate::binding::binding::Binding;
 use crate::binding::binding::BindingDecorator;
@@ -69,6 +72,40 @@ use crate::types::types::AnyStyle;
 /// like reveal_type.
 fn is_special_name(name: &str) -> bool {
     matches!(name, "reveal_type" | "assert_type")
+}
+
+/// Walk a chain of `Expr::Attribute` nodes (e.g. `a.b.c`) and collect the
+/// base `ExprName` and attribute identifiers in order. Returns `None` if the
+/// chain doesn't end in a Name
+fn chase_static_attr_chain(expr: &Expr) -> Option<(ExprName, Vec1<Identifier>)> {
+    // For now arbitrarily cap attribute unwinding at length 10 which should be ok
+    // for any reasonably formed code
+    let mut gas = Gas::new(10);
+    chase_static_attr_chain_impl(expr, &mut gas)
+}
+
+fn chase_static_attr_chain_impl(
+    expr: &Expr,
+    gas: &mut Gas,
+) -> Option<(ExprName, Vec1<Identifier>)> {
+    if gas.stop() {
+        return None;
+    }
+
+    match expr {
+        Expr::Attribute(ExprAttribute {
+            value: box Expr::Name(name),
+            attr,
+            ..
+        }) => Some((name.clone(), vec1![attr.clone()])),
+        Expr::Attribute(ExprAttribute { value, attr, .. }) => {
+            chase_static_attr_chain_impl(value, gas).map(|(name, mut attrs)| {
+                attrs.push(attr.clone());
+                (name, attrs)
+            })
+        }
+        _ => None,
+    }
 }
 
 /// Looking up names in an expression requires knowing the identity of the binding
@@ -276,7 +313,7 @@ impl<'a> BindingsBuilder<'a> {
     fn ensure_simple_attr(
         &mut self,
         value: &Identifier,
-        attr: &Identifier,
+        attrs: Vec1<Identifier>,
         usage: &mut Usage,
         tparams_builder: &mut Option<LegacyTParamCollector>,
     ) -> Idx<Key> {
@@ -284,10 +321,7 @@ impl<'a> BindingsBuilder<'a> {
             value,
             usage,
             tparams_builder.as_mut().map(|tparams_builder| {
-                (
-                    tparams_builder,
-                    LegacyTParamId::Attr(value.clone(), attr.clone()),
-                )
+                (tparams_builder, LegacyTParamId::Attr(value.clone(), attrs))
             }),
         )
     }
@@ -1189,12 +1223,14 @@ impl<'a> BindingsBuilder<'a> {
                     },
                 );
             }
-            Expr::Attribute(ExprAttribute { value, attr, .. })
-                if let Expr::Name(value) = &**value
+            Expr::Attribute(..)
+                if let Some((base, attrs)) = chase_static_attr_chain(x)
                 // We assume "args" and "kwargs" are ParamSpec attributes rather than imported TypeVars.
-                    && attr.id != "args" && attr.id != "kwargs" =>
+                    && attrs.last().id != "args" 
+                    && attrs.last().id != "kwargs" =>
             {
-                // We intercept <name>.<name> to check if this is an imported legacy type parameter.
+                // We intercept dotted names (e.g. `mod.T` or `pkg.mod.T`) to check if the
+                // final attribute is an imported legacy type parameter.
                 //
                 // The value part of an attribute access is a module/object reference,
                 // not a type annotation. For example, in `x: pd.DataFrame`, `pd` is a
@@ -1208,8 +1244,8 @@ impl<'a> BindingsBuilder<'a> {
                     ref u => u.clone(),
                 };
                 self.ensure_simple_attr(
-                    &Ast::expr_name_identifier(value.clone()),
-                    attr,
+                    &Ast::expr_name_identifier(base),
+                    attrs,
                     &mut attr_value_usage,
                     tparams_builder,
                 );

--- a/pyrefly/lib/test/generic_legacy.rs
+++ b/pyrefly/lib/test/generic_legacy.rs
@@ -796,6 +796,46 @@ assert_type(A[int]().x, int)
     "#,
 );
 
+fn env_pkg_exported_type_var() -> TestEnv {
+    let mut t = TestEnv::new();
+    t.add_with_path("Foo", "Foo/__init__.py", "");
+    t.add_with_path(
+        "Foo.Bar",
+        "Foo/Bar.py",
+        r#"
+from typing import TypeVar
+ImportedT = TypeVar("ImportedT")
+"#,
+    );
+    t
+}
+
+testcase!(
+    test_function_legacy_typevar_nested_dotted_name,
+    env_pkg_exported_type_var(),
+    r#"
+import Foo.Bar
+from typing import assert_type
+
+def myFunc(t: Foo.Bar.ImportedT) -> Foo.Bar.ImportedT:
+    return t
+assert_type(myFunc(0), int)
+    "#,
+);
+
+testcase!(
+    test_class_legacy_typevar_nested_dotted_name,
+    env_pkg_exported_type_var(),
+    r#"
+import Foo.Bar
+from typing import assert_type, Generic
+
+class A(Generic[Foo.Bar.ImportedT]):
+    x: Foo.Bar.ImportedT
+assert_type(A[int]().x, int)
+    "#,
+);
+
 testcase!(
     test_legacy_typevar_defined_after_use,
     r#"


### PR DESCRIPTION
Previously, legacy TypeVar interception only handled single-level dotted access like `mod.T`. When a TypeVar was accessed through deeper module chains (e.g. `Foo.Bar.ImportedT`), pyrefly reported "Type variable is not in scope" because the binding phase only matched `Expr::Attribute` where the value was directly an `Expr::Name`.

**Notable Changes**

**`binding/expr.rs`** — Added `chase_static_attr_chain`, a recursive helper that walks nested `Expr::Attribute` nodes to collect the full dotted chain (base name + attributes).

**`binding/bindings.rs`** — `LegacyTParamId::Attr` changed from `(Identifier, Identifier)` to `(Identifier, Vec1<Identifier>)` to support arbitrary-depth attribute chains.

**`binding/binding.rs`** — `BindingLegacyTypeParam::ModuleKeyed` changed from `(Idx<Key>, Box<Name>)` to `(Idx<Key>, Vec1<Name>)` to store the full attribute chain.

## Testing
Added two tests, one for classes and another for functions.

## Tradeoffs
The current implementation uses `Vec1<T>` for readability and to enforce the non-empty invariant at the type level. As such, this change increases the memory size of bound legacy type vars from 16 bytes to 32. An alternative would be to pack everything into a single `Box<[T]>` (16 bytes), with the first element as the base and the rest as attributes, saving 16 bytes per instance. I opted for clarity over compactness here, but let me know if you would like the more performant option.