### PR TITLE
Add original reference to tensor shapes

### DIFF
--- a/website/docs/tensor-shapes.mdx
+++ b/website/docs/tensor-shapes.mdx
@@ -140,7 +140,7 @@ space, each with different trade-offs. Here's how Pyrefly's approach compares.
 ### Pyre and Pyright (static type checking)
 
 An early attempt at tensor shapes in Pyre, the precursor of Pyrefly, is
-described in [this PyCon 2023 talk](https://www.youtube.com/watch?v=iPVgG-W7ET8).
+described in [this PyCon 2021 talk](https://www.youtube.com/watch?v=ld9rwCvGdhc&t=11470s).
 That system used `Literal` to wrap concrete sizes and explicit type constructors
 like `IntDiv` for arithmetic — avoiding the need to support integers as type
 arguments or arithmetic on type variables, but at the cost of verbose syntax


### PR DESCRIPTION
The current documentation, when describing the early attempt to tensor shapes, refers to a presentation that predates the 2020 original proposal by nearly three years (see [Tensor Typing Open Design Meetings](https://docs.google.com/document/d/1oaG0V2ZE5BRDjd9N-Tr1N0IKGwZQcraIlZ0N8ayqVg8/edit?tab=t.0#heading=h.o4j2274jpgp8)) which was presented in PyCon 2021 (https://www.youtube.com/watch?v=ld9rwCvGdhc&t=11470s), and also PyCon 2022 (although the video quality is not great).

Updating this link to the actual debut at PyCon 2021 better reflects the deep history behind this work.