### PR TITLE
fix option to ban explicit Any #3442

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -153,6 +153,8 @@ pub enum ErrorKind {
     Deprecated,
     /// Division, floor division, or modulo by a literal zero value.
     DivisionByZero,
+    /// Explicit usage of `typing.Any` in an annotation.
+    ExplicitAny,
     /// Raised when a class implicitly becomes abstract by defining abstract members without
     /// inheriting from `abc.ABC` or using `abc.ABCMeta`.
     ImplicitAbstractClass,
@@ -418,6 +420,7 @@ impl ErrorKind {
         match self {
             ErrorKind::Deprecated => Severity::Warn,
             ErrorKind::DivisionByZero => Severity::Warn,
+            ErrorKind::ExplicitAny => Severity::Ignore,
             ErrorKind::ImplicitAbstractClass => Severity::Ignore,
             ErrorKind::ImplicitAny => Severity::Ignore,
             ErrorKind::ImplicitAnyAttribute => Severity::Ignore,

--- a/crates/pyrefly_config/src/migration/error_codes.rs
+++ b/crates/pyrefly_config/src/migration/error_codes.rs
@@ -356,6 +356,22 @@ mod tests {
     }
 
     #[test]
+    fn test_migrate_from_mypy_strict_does_not_enable_explicit_any() {
+        let mut mypy_cfg = Ini::new();
+        mypy_cfg.set("mypy", "strict", Some("True".to_owned()));
+
+        let mut pyrefly_cfg = ConfigFile::default();
+
+        let error_codes = ErrorCodes;
+        let _ = error_codes.migrate_from_mypy(&mypy_cfg, &mut pyrefly_cfg);
+
+        assert!(pyrefly_cfg.root.errors.is_some());
+        let errors = pyrefly_cfg.root.errors.as_ref().unwrap();
+        assert_eq!(errors.severity(ErrorKind::RedundantCast), Severity::Warn);
+        assert_eq!(errors.severity(ErrorKind::ExplicitAny), Severity::Ignore);
+    }
+
+    #[test]
     fn test_migrate_from_pyright_report_explicit_any() {
         let mut pyright_cfg = default_pyright_config();
         pyright_cfg.errors.report_explicit_any = Some(Severity::Warn);

--- a/crates/pyrefly_config/src/migration/error_codes.rs
+++ b/crates/pyrefly_config/src/migration/error_codes.rs
@@ -31,6 +31,8 @@ impl ConfigOptionMigrater for ErrorCodes {
             util::get_bool_or_default(mypy_cfg, "mypy", "disallow_incomplete_defs");
         let disallow_any_generics =
             util::get_bool_or_default(mypy_cfg, "mypy", "disallow_any_generics");
+        let disallow_any_explicit =
+            util::get_bool_or_default(mypy_cfg, "mypy", "disallow_any_explicit");
         let report_deprecated_as_note =
             util::get_bool_or_default(mypy_cfg, "mypy", "report_deprecated_as_note");
         let allow_redefinitions =
@@ -41,6 +43,7 @@ impl ConfigOptionMigrater for ErrorCodes {
             disallow_untyped_defs,
             disallow_incomplete_defs,
             disallow_any_generics,
+            disallow_any_explicit,
             report_deprecated_as_note,
             allow_redefinitions,
             strict,
@@ -333,5 +336,38 @@ mod tests {
             errors.severity(ErrorKind::ImplicitAnyTypeArgument),
             Severity::Error
         );
+    }
+
+    #[test]
+    fn test_migrate_from_mypy_disallow_any_explicit() {
+        let mut mypy_cfg = Ini::new();
+        mypy_cfg
+            .read("[mypy]\ndisallow_any_explicit = True".to_owned())
+            .unwrap();
+
+        let mut pyrefly_cfg = ConfigFile::default();
+
+        let error_codes = ErrorCodes;
+        let _ = error_codes.migrate_from_mypy(&mypy_cfg, &mut pyrefly_cfg);
+
+        assert!(pyrefly_cfg.root.errors.is_some());
+        let errors = pyrefly_cfg.root.errors.as_ref().unwrap();
+        assert_eq!(errors.severity(ErrorKind::ExplicitAny), Severity::Error);
+    }
+
+    #[test]
+    fn test_migrate_from_pyright_report_explicit_any() {
+        let mut pyright_cfg = default_pyright_config();
+        pyright_cfg.errors.report_explicit_any = Some(Severity::Warn);
+
+        let mut pyrefly_cfg = ConfigFile::default();
+
+        let error_codes = ErrorCodes;
+        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+
+        assert!(result.is_ok());
+        assert!(pyrefly_cfg.root.errors.is_some());
+        let errors = pyrefly_cfg.root.errors.as_ref().unwrap();
+        assert_eq!(errors.severity(ErrorKind::ExplicitAny), Severity::Warn);
     }
 }

--- a/crates/pyrefly_config/src/migration/mypy/pyproject.rs
+++ b/crates/pyrefly_config/src/migration/mypy/pyproject.rs
@@ -90,6 +90,8 @@ struct MypySection {
     #[serde(default)]
     disallow_any_generics: Option<bool>,
     #[serde(default)]
+    disallow_any_explicit: Option<bool>,
+    #[serde(default)]
     strict: Option<bool>,
     #[serde(default)]
     report_deprecated_as_note: Option<bool>,
@@ -199,6 +201,13 @@ fn pyproject_to_ini(raw_file: &str) -> anyhow::Result<Ini> {
             "mypy",
             "disallow_any_generics",
             Some(disallow_any_generics.to_string()),
+        );
+    }
+    if let Some(disallow_any_explicit) = mypy.disallow_any_explicit {
+        ini.set(
+            "mypy",
+            "disallow_any_explicit",
+            Some(disallow_any_explicit.to_string()),
         );
     }
     if let Some(strict) = mypy.strict {

--- a/crates/pyrefly_config/src/migration/mypy/util.rs
+++ b/crates/pyrefly_config/src/migration/mypy/util.rs
@@ -83,6 +83,7 @@ pub struct MypyErrorConfigFlags {
     pub disallow_untyped_defs: bool,
     pub disallow_incomplete_defs: bool,
     pub disallow_any_generics: bool,
+    pub disallow_any_explicit: bool,
     pub strict: bool,
     pub report_deprecated_as_note: bool,
     pub allow_redefinitions: bool,
@@ -107,6 +108,7 @@ pub fn make_error_config(
         disallow_untyped_defs,
         disallow_incomplete_defs,
         disallow_any_generics,
+        disallow_any_explicit,
         strict,
         report_deprecated_as_note,
         allow_redefinitions,
@@ -114,20 +116,35 @@ pub fn make_error_config(
     {
         // These severities take precedence over enable/disable
         if warn_redundant_casts || strict {
-            errors.insert(ErrorKind::RedundantCast.to_string(), Severity::Warn);
+            errors.insert(
+                ErrorKind::RedundantCast.to_name().to_owned(),
+                Severity::Warn,
+            );
         }
         if disallow_untyped_defs || disallow_incomplete_defs || strict {
-            errors.insert(ErrorKind::ImplicitAnyParameter.to_string(), Severity::Error);
-            errors.insert(ErrorKind::UnannotatedReturn.to_string(), Severity::Error);
+            errors.insert(
+                ErrorKind::ImplicitAnyParameter.to_name().to_owned(),
+                Severity::Error,
+            );
+            errors.insert(
+                ErrorKind::UnannotatedReturn.to_name().to_owned(),
+                Severity::Error,
+            );
         }
         if disallow_any_generics || strict {
-            errors.insert(ErrorKind::ImplicitAny.to_string(), Severity::Error);
+            errors.insert(ErrorKind::ImplicitAny.to_name().to_owned(), Severity::Error);
         }
-        if report_deprecated_as_note && errors.contains_key(&ErrorKind::Deprecated.to_string()) {
-            errors.insert(ErrorKind::Deprecated.to_string(), Severity::Info);
+        if disallow_any_explicit || strict {
+            errors.insert(ErrorKind::ExplicitAny.to_name().to_owned(), Severity::Error);
+        }
+        if report_deprecated_as_note && errors.contains_key(ErrorKind::Deprecated.to_name()) {
+            errors.insert(ErrorKind::Deprecated.to_name().to_owned(), Severity::Info);
         }
         if allow_redefinitions {
-            errors.insert(ErrorKind::Redefinition.to_string(), Severity::Ignore);
+            errors.insert(
+                ErrorKind::Redefinition.to_name().to_owned(),
+                Severity::Ignore,
+            );
         }
     }
     code_to_kind(errors)
@@ -156,6 +173,7 @@ fn code_to_kind(errors: HashMap<String, Severity>) -> Option<ErrorDisplayConfig>
                 add(severity, ErrorKind::UnsupportedOperation);
             }
             "dict-item" => add(severity, ErrorKind::BadTypedDict),
+            "explicit-any" => add(severity, ErrorKind::ExplicitAny),
             "operator" => add(severity, ErrorKind::UnsupportedOperation),
             "typeddict-unknown-key" => add(severity, ErrorKind::BadTypedDictKey),
             "typeddict-readonly-mutated" => add(severity, ErrorKind::ReadOnly),

--- a/crates/pyrefly_config/src/migration/mypy/util.rs
+++ b/crates/pyrefly_config/src/migration/mypy/util.rs
@@ -134,7 +134,7 @@ pub fn make_error_config(
         if disallow_any_generics || strict {
             errors.insert(ErrorKind::ImplicitAny.to_name().to_owned(), Severity::Error);
         }
-        if disallow_any_explicit || strict {
+        if disallow_any_explicit {
             errors.insert(ErrorKind::ExplicitAny.to_name().to_owned(), Severity::Error);
         }
         if report_deprecated_as_note && errors.contains_key(ErrorKind::Deprecated.to_name()) {

--- a/crates/pyrefly_config/src/migration/pyright.rs
+++ b/crates/pyrefly_config/src/migration/pyright.rs
@@ -187,6 +187,8 @@ pub struct RuleOverrides {
     // Type annotation rules
     #[serde_as(as = "Option<FromInto<DiagnosticLevelOrBool>>")]
     pub report_invalid_type_form: Option<Severity>,
+    #[serde_as(as = "Option<FromInto<DiagnosticLevelOrBool>>")]
+    pub report_explicit_any: Option<Severity>,
 
     // Abstract/instantiation rules
     #[serde_as(as = "Option<FromInto<DiagnosticLevelOrBool>>")]
@@ -322,6 +324,7 @@ impl RuleOverrides {
         add(self.report_missing_module_source, ErrorKind::MissingSource);
         add(self.report_missing_type_stubs, ErrorKind::UntypedImport);
         add(self.report_invalid_type_form, ErrorKind::InvalidAnnotation);
+        add(self.report_explicit_any, ErrorKind::ExplicitAny);
         add(self.report_abstract_usage, ErrorKind::BadInstantiation);
         add(self.report_argument_type, ErrorKind::BadArgumentType);
         add(self.report_assert_type_failure, ErrorKind::AssertType);

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -237,6 +237,18 @@ impl TypeFormContext {
             _ => false,
         }
     }
+
+    fn can_report_explicit_any(self) -> bool {
+        !matches!(
+            self,
+            TypeFormContext::GenericBase
+                | TypeFormContext::ParamSpecDefault
+                | TypeFormContext::TupleOrCallableParam
+                | TypeFormContext::TypeArgument
+                | TypeFormContext::TypeArgumentCallableReturn
+                | TypeFormContext::TypeArgumentForType
+        )
+    }
 }
 
 #[derive(Debug)]
@@ -1271,6 +1283,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let ty = if let Some(untyped) = untyped {
             let validated =
                 self.validate_type_form(untyped, range, TypeFormContext::TypeAlias, errors);
+            self.check_explicit_any(&validated, range, errors);
             if validated.is_error() {
                 return TypeAlias::error(name.clone(), style);
             }
@@ -5893,6 +5906,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         ty
     }
 
+    fn check_explicit_any(&self, ty: &Type, range: TextRange, errors: &ErrorCollector) {
+        if ty.any(|ty| matches!(ty, Type::Any(AnyStyle::Explicit))) {
+            errors
+                .error_builder(
+                    range,
+                    ErrorKind::ExplicitAny,
+                    "Explicit `Any` is not allowed".to_owned(),
+                )
+                .emit();
+        }
+    }
+
     /// Type check a delete expression, including ensuring that the target of the
     /// delete is legal.
     fn check_del_statement(&self, delete_target: &Expr, errors: &ErrorCollector) -> Type {
@@ -6047,6 +6072,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 self.untype(inferred_ty, x.range(), errors)
             }
         };
-        self.validate_type_form(result, x.range(), type_form_context, errors)
+        let result = self.validate_type_form(result, x.range(), type_form_context, errors);
+        if type_form_context.can_report_explicit_any() {
+            self.check_explicit_any(&result, x.range(), errors);
+        }
+        result
     }
 }

--- a/pyrefly/lib/test/inference.rs
+++ b/pyrefly/lib/test/inference.rs
@@ -172,6 +172,32 @@ x2 = {}
 );
 
 testcase!(
+    test_explicit_any_default_disabled,
+    r#"
+from typing import Any
+
+def fn(value: Any) -> Any:
+    print(value.asdfsdf)
+    return value
+"#,
+);
+
+testcase!(
+    test_explicit_any_error,
+    TestEnv::new().enable_explicit_any_error(),
+    r#"
+from typing import Any, TypeAlias
+
+def fn(value: Any) -> Any:  # E: Explicit `Any` is not allowed # E: Explicit `Any` is not allowed
+    print(value.asdfsdf)
+    return value
+
+xs: list[Any] = []  # E: Explicit `Any` is not allowed
+Alias: TypeAlias = dict[str, Any]  # E: Explicit `Any` is not allowed
+"#,
+);
+
+testcase!(
     test_warn_on_implicit_any_in_attribute,
     TestEnv::new().enable_implicit_any_attribute_error(),
     r#"

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -107,6 +107,7 @@ pub struct TestEnv {
     infer_with_first_use: bool,
     site_package_path: Vec<PathBuf>,
     implicitly_defined_attribute_error: bool,
+    explicit_any_error: bool,
     implicit_any_error: bool,
     unannotated_return_error: bool,
     implicit_any_parameter_error: bool,
@@ -137,6 +138,7 @@ impl TestEnv {
             infer_with_first_use: true,
             site_package_path: Vec::new(),
             implicitly_defined_attribute_error: false,
+            explicit_any_error: false,
             implicit_any_error: false,
             unannotated_return_error: false,
             implicit_any_parameter_error: false,
@@ -241,6 +243,11 @@ impl TestEnv {
 
     pub fn enable_implicitly_defined_attribute_error(mut self) -> Self {
         self.implicitly_defined_attribute_error = true;
+        self
+    }
+
+    pub fn enable_explicit_any_error(mut self) -> Self {
+        self.explicit_any_error = true;
         self
     }
 
@@ -391,6 +398,9 @@ impl TestEnv {
         let errors = config.root.errors.as_mut().unwrap();
         if self.implicitly_defined_attribute_error {
             errors.set_error_severity(ErrorKind::ImplicitlyDefinedAttribute, Severity::Error);
+        }
+        if self.explicit_any_error {
+            errors.set_error_severity(ErrorKind::ExplicitAny, Severity::Error);
         }
         if self.implicit_any_error {
             errors.set_error_severity(ErrorKind::ImplicitAny, Severity::Error);

--- a/scripts/pyrefly_primer_wrapper.sh
+++ b/scripts/pyrefly_primer_wrapper.sh
@@ -4,12 +4,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Wrapper script for mypy_primer that runs `pyrefly init --non-interactive`
-# before forwarding arguments to the real pyrefly binary.
+# Wrapper script for mypy_primer that generates a Pyrefly config for the real
+# pyrefly binary before forwarding arguments.
 #
 # mypy_primer calls: {pyrefly} check {paths} --summary=none --output-format min-text
-# This wrapper intercepts that call, runs init on the current directory first,
-# then forwards the original arguments to the real pyrefly binary.
+# This wrapper intercepts that call, generates a config for the current
+# directory, then forwards the original arguments to the real pyrefly binary.
 #
 # When PYREFLY_SCRIPTS_DIR is set, the wrapper also sets up project dependencies
 # via setup_primer_deps.py, giving pyrefly access to third-party type stubs
@@ -19,19 +19,21 @@
 REAL_PYREFLY="$(dirname "$0")/pyrefly-real"
 
 # mypy_primer runs old and new pyrefly concurrently (asyncio.gather) in the
-# same project directory.  Without serialization the two wrapper instances race
-# on pyrefly init (writes pyrefly.toml) and venv creation, producing false
-# primer deltas.  We use mkdir as a portable atomic lock to ensure only one
-# instance performs setup; the second waits, then reuses the results.
+# same project directory. Without serialization, the two wrapper instances race
+# on venv creation. We use mkdir as a portable atomic lock to ensure only one
+# instance performs shared dependency setup; the second waits, then reuses it.
+#
+# Config migration is intentionally not shared: a new pyrefly binary can emit
+# config error codes that the old binary cannot parse. Each real binary writes a
+# private generated config and checks with --config so primer compares checker
+# behavior rather than config-parser compatibility.
 
 
 # TODO/BE: cleaner solution is to run the setup/initialization steps once before running both old/new pyrefly binaries
 LOCKDIR=".pyrefly_primer.lock"
 
 if mkdir "$LOCKDIR" 2>/dev/null; then
-    # We won the lock — perform init + deps setup.
-    "$REAL_PYREFLY" init --non-interactive . >/dev/null 2>&1 || true
-
+    # We won the lock — perform shared dependency setup.
     if [ -n "$PYREFLY_SCRIPTS_DIR" ]; then
         PROJECT_NAME=$(basename "$(pwd)")
         if [ ! -d ".venv" ]; then
@@ -49,6 +51,17 @@ else
     done
 fi
 
+CONFIG_TAG=$(printf "%s" "$REAL_PYREFLY" | cksum | cut -d " " -f 1)
+CONFIG_PATH=".pyrefly_primer_${CONFIG_TAG}.toml"
+CONFIG_TMP="${CONFIG_PATH}.tmp"
+if [ ! -f "$CONFIG_PATH" ]; then
+    if "$REAL_PYREFLY" init --non-interactive --dry-run --print-config . >"$CONFIG_TMP" 2>/dev/null; then
+        mv "$CONFIG_TMP" "$CONFIG_PATH"
+    else
+        rm -f "$CONFIG_TMP"
+    fi
+fi
+
 # Extract site-package paths (read-only, safe to run after setup is complete).
 SITE_PATH_ARGS=()
 if [ -n "$PYREFLY_SCRIPTS_DIR" ] && [ -f ".venv/bin/python" ]; then
@@ -62,4 +75,7 @@ for p in site.getsitepackages():
 fi
 
 # Forward all original arguments to the real pyrefly binary
+if [ "$1" = "check" ] && [ -f "$CONFIG_PATH" ]; then
+    exec "$REAL_PYREFLY" "$@" "${SITE_PATH_ARGS[@]}" --config "$CONFIG_PATH"
+fi
 exec "$REAL_PYREFLY" "$@" "${SITE_PATH_ARGS[@]}"

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -484,6 +484,23 @@ y = 10 // 0  # error: division by zero
 z = 10 % 0   # error: division by zero
 ```
 
+## explicit-any
+
+`typing.Any` was written explicitly in an annotation. This diagnostic is useful for codebases that want to prevent `Any` from silently allowing arbitrary operations.
+
+The default severity of this diagnostic is `ignore`.
+
+```python
+from typing import Any
+
+def f(x: Any) -> Any:  # explicit-any on both annotations
+    return x
+
+# Fix:
+def f(x: object) -> object:
+    return x
+```
+
 ## implicit-abstract-class
 
 Pyrefly emits this error when a class that inherits from an abstract class but is not itself explicitly abstract (for example, it does not directly inherit from `abc.ABC` or use `abc.ABCMeta`) has unimplemented abstract members. Such classes cannot be instantiated at runtime. To resolve the issue, explicitly declare the class as abstract or provide concrete implementations.

--- a/website/docs/migrating-from-mypy.mdx
+++ b/website/docs/migrating-from-mypy.mdx
@@ -152,6 +152,7 @@ This table shows the mapping between mypy's [error codes](https://mypy.readthedo
 | call-overload | no-matching-overload |
 | deprecated | deprecated |
 | dict-item | bad-typed-dict |
+| explicit-any | explicit-any |
 | import | missing-import |
 | import-not-found | missing-import |
 | import-untyped | untyped-import |

--- a/website/docs/migrating-from-pyright.mdx
+++ b/website/docs/migrating-from-pyright.mdx
@@ -132,6 +132,7 @@ This means users migrating from pyright will see familiar diagnostics even befor
 | reportAssignmentType | bad-assignment |
 | reportAttributeAccessIssue | missing-attribute |
 | reportDeprecated | deprecated |
+| reportExplicitAny | explicit-any |
 | reportIncompatibleMethodOverride | bad-override |
 | reportIncompatibleVariableOverride | bad-override |
 | reportInconsistentOverload | inconsistent-overload |


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3442

Added ignored-by-default ErrorKind::ExplicitAny, Emitted it for explicit Any in annotations and type alias bodies when enabled.

Wired migration support for: mypy disallow_any_explicit, mypy explicit-any, pyright/basedpyright reportExplicitAny

Updated error-kind and migration docs.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added regression tests