### PR TITLE
Document warn default severity for invalid-decorator

### DIFF
--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -747,6 +747,8 @@ if isinstance(1, UserId):
 
 This error indicates that a decorator was used incorrectly. For example, using `@typing.final` on a non-method function.
 
+The default severity of this diagnostic is `warn`.
+
 ```python
 from typing import final
 @final


### PR DESCRIPTION
## Summary

The [error-kinds documentation](https://pyrefly.org/en/docs/error-kinds/) states:

> The default severity for diagnostics is `error` unless otherwise noted.

However, the [`invalid-decorator`](https://pyrefly.org/en/docs/error-kinds/#invalid-decorator) section did not note that its default severity is `warn`.

As confirmed by a maintainer in the issue, `warn` is the intended severity (lowered in #2610) and the docs were simply out of date. This PR adds the standard severity note already used by other warn-level diagnostics (e.g. `deprecated`, `redundant-cast`).

## Test plan

Documentation-only change to `website/docs/error-kinds.mdx`. The added line is identical in format to existing severity notes throughout the same file, so no behavior or tests are affected.

Fixes #3448

---

*Disclosure: this PR was prepared with the assistance of an AI agent. The change has been reviewed for correctness.*