### PR TITLE
Use per-binary config in primer wrapper to avoid cross-version config crashes

### DIFF
--- a/scripts/pyrefly_primer_wrapper.sh
+++ b/scripts/pyrefly_primer_wrapper.sh
@@ -4,12 +4,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Wrapper script for mypy_primer that runs `pyrefly init --non-interactive`
-# before forwarding arguments to the real pyrefly binary.
+# Wrapper script for mypy_primer that generates a Pyrefly config for the real
+# pyrefly binary before forwarding arguments.
 #
 # mypy_primer calls: {pyrefly} check {paths} --summary=none --output-format min-text
-# This wrapper intercepts that call, runs init on the current directory first,
-# then forwards the original arguments to the real pyrefly binary.
+# This wrapper intercepts that call, generates a config for the current
+# directory, then forwards the original arguments to the real pyrefly binary.
 #
 # When PYREFLY_SCRIPTS_DIR is set, the wrapper also sets up project dependencies
 # via setup_primer_deps.py, giving pyrefly access to third-party type stubs
@@ -19,19 +19,21 @@
 REAL_PYREFLY="$(dirname "$0")/pyrefly-real"
 
 # mypy_primer runs old and new pyrefly concurrently (asyncio.gather) in the
-# same project directory.  Without serialization the two wrapper instances race
-# on pyrefly init (writes pyrefly.toml) and venv creation, producing false
-# primer deltas.  We use mkdir as a portable atomic lock to ensure only one
-# instance performs setup; the second waits, then reuses the results.
+# same project directory. Without serialization, the two wrapper instances race
+# on venv creation. We use mkdir as a portable atomic lock to ensure only one
+# instance performs shared dependency setup; the second waits, then reuses it.
+#
+# Config migration is intentionally not shared: a new pyrefly binary can emit
+# config error codes that the old binary cannot parse. Each real binary writes a
+# private generated config and checks with --config so primer compares checker
+# behavior rather than config-parser compatibility.
 
 
 # TODO/BE: cleaner solution is to run the setup/initialization steps once before running both old/new pyrefly binaries
 LOCKDIR=".pyrefly_primer.lock"
 
 if mkdir "$LOCKDIR" 2>/dev/null; then
-    # We won the lock — perform init + deps setup.
-    "$REAL_PYREFLY" init --non-interactive . >/dev/null 2>&1 || true
-
+    # We won the lock — perform shared dependency setup.
     if [ -n "$PYREFLY_SCRIPTS_DIR" ]; then
         PROJECT_NAME=$(basename "$(pwd)")
         if [ ! -d ".venv" ]; then
@@ -49,6 +51,17 @@ else
     done
 fi
 
+CONFIG_TAG=$(printf "%s" "$REAL_PYREFLY" | cksum | cut -d " " -f 1)
+CONFIG_PATH=".pyrefly_primer_${CONFIG_TAG}.toml"
+CONFIG_TMP="${CONFIG_PATH}.tmp"
+if [ ! -f "$CONFIG_PATH" ]; then
+    if "$REAL_PYREFLY" init --non-interactive --dry-run --print-config . >"$CONFIG_TMP" 2>/dev/null; then
+        mv "$CONFIG_TMP" "$CONFIG_PATH"
+    else
+        rm -f "$CONFIG_TMP"
+    fi
+fi
+
 # Extract site-package paths (read-only, safe to run after setup is complete).
 SITE_PATH_ARGS=()
 if [ -n "$PYREFLY_SCRIPTS_DIR" ] && [ -f ".venv/bin/python" ]; then
@@ -61,5 +74,12 @@ for p in site.getsitepackages():
     )
 fi
 
-# Forward all original arguments to the real pyrefly binary
+# Forward all original arguments to the real pyrefly binary.
+# Normalize the per-binary config filename in output so that old and new
+# binaries produce identical warnings and primer doesn't report spurious diffs.
+if [ "$1" = "check" ] && [ -f "$CONFIG_PATH" ]; then
+    "$REAL_PYREFLY" "$@" "${SITE_PATH_ARGS[@]}" --config "$CONFIG_PATH" 2>&1 \
+        | sed "s|$CONFIG_PATH|pyrefly.toml|g"
+    exit "${PIPESTATUS[0]}"
+fi
 exec "$REAL_PYREFLY" "$@" "${SITE_PATH_ARGS[@]}"


### PR DESCRIPTION
Summary:
When a new pyrefly binary adds error codes (e.g. `explicit-any`) and `pyrefly init` writes them into a shared config, the old binary from the base revision crashes because it cannot parse the unknown error code. Since mypy_primer runs old and new binaries concurrently in the same directory, sharing a single generated config causes spurious primer failures whenever a new error code is introduced.

This change gives each binary its own generated config file (tagged by a checksum of the binary path) and passes it via `--config`. The shared `pyrefly init` call is removed from the lock-protected section since config generation is now per-binary.

Because the per-binary config filenames differ between old and new runs, warnings that reference the config path would show up as spurious diffs. The output is piped through `sed` to normalize the config filename to `pyrefly.toml` so primer compares actual checker behavior.

Differential Revision: D105679430

-------

Exporting to verify that the sed piping works, the original version of this logic incorrectly gave deltas due to the two different filenames


