### PR TITLE
fix in operation on tuple of Literal doesn't narrow type #3474

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -383,6 +383,43 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
+    fn tuple_membership_type(
+        &self,
+        tuple: &Tuple,
+        range: TextRange,
+        errors: &ErrorCollector,
+    ) -> Option<Type> {
+        let elements = match tuple {
+            Tuple::Concrete(elts) => elts.clone(),
+            Tuple::Unbounded(elt) => vec![(**elt).clone()],
+            Tuple::Unpacked(unpacked) => {
+                let (prefix, middle, suffix) = &**unpacked;
+                let mut elements = prefix.clone();
+                let middle = if let Type::Var(_) = middle {
+                    self.force_for_narrowing(middle, range, errors)
+                } else {
+                    middle.clone()
+                };
+                match middle {
+                    Type::Tuple(tuple) => {
+                        elements.push(self.tuple_membership_type(&tuple, range, errors)?)
+                    }
+                    Type::TypeVarTuple(_) | Type::Quantified(_) | Type::Unpack(_) => return None,
+                    _ => elements.push(middle),
+                }
+                elements.extend(suffix.clone());
+                elements
+            }
+        };
+        if elements.iter().any(|ty| self.behaves_like_any(ty)) {
+            None
+        } else if elements.is_empty() {
+            Some(self.heap.mk_never())
+        } else {
+            Some(self.unions(elements))
+        }
+    }
+
     /// Unwrap a class object for isinstance narrowing. When the right-hand side is `tuple`
     /// and the left-hand side is a heterogeneous tuple type, creates a TypeVarTuple for
     /// precise narrowing. Otherwise falls back to standard class object unwrapping.
@@ -1074,6 +1111,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // Check if the right operand is a TypedDict.
                 // If so, we can narrow the left operand to the union of the TypedDict's keys.
                 let right_ty = self.expr_infer(v, errors);
+                if let Type::Tuple(tuple) = &right_ty
+                    && let Some(member_ty) = self.tuple_membership_type(tuple, range, errors)
+                {
+                    return self.intersect(ty, &member_ty);
+                }
                 if let Type::TypedDict(typed_dict) = &right_ty {
                     let fields = self.typed_dict_fields(typed_dict);
                     if fields.is_empty() {

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -2013,6 +2013,14 @@ def test_type_objects_mixed_with_literals(x: type[int] | type[float] | None, y: 
         assert_type(y, Literal[1] | type[int])
     else:
         assert_type(y, type[int] | type[str])
+
+def test_tuple_of_literal_alias(severity: str) -> None:
+    from typing import cast, get_args
+
+    SeverityLevel = Literal["light", "minor", "major"]
+    SEVERITY_LEVELS = cast(tuple[SeverityLevel, ...], get_args(SeverityLevel))
+    if severity in SEVERITY_LEVELS:
+        assert_type(severity, SeverityLevel)
 "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3474

x in some_tuple now can narrow x from the tuple’s element type, including `tuple[Literal[...], ...]`, while skipping tuple shapes with Any or unresolved variadics.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test