### PR TITLE
Ignore CPython generated module dunders in `pyrefly coverage report`

### DIFF
--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -625,8 +625,26 @@ impl ReportArgs {
     }
 
     /// Module-level dunders that typestats always excludes from the report.
-    const EXCLUDED_MODULE_DUNDERS: &'static [&'static str] =
-        &["__all__", "__dir__", "__doc__", "__getattr__"];
+    const EXCLUDED_MODULE_DUNDERS: &'static [&'static str] = &[
+        // User-level module hooks.
+        "__all__",
+        "__dir__",
+        "__doc__",
+        "__getattr__",
+        // CPython-injected globals.
+        // Keep in sync with `IMPLICIT_GLOBALS` in `crates/pyrefly_types/src/globals.rs`.
+        "__annotations__",
+        "__builtins__",
+        "__cached__",
+        "__debug__",
+        "__dict__",
+        "__file__",
+        "__loader__",
+        "__name__",
+        "__package__",
+        "__path__",
+        "__spec__",
+    ];
 
     /// Walk re-exports to the defining module's FQN, `None` on cycle/miss.
     fn trace_export_origin(
@@ -2724,6 +2742,14 @@ mod tests {
     fn test_report_private_filtering() {
         let report = build_module_report_for_test("private_filtering.py");
         compare_snapshot("private_filtering.expected.json", &report);
+    }
+
+    /// CPython-injected module globals are excluded even when control flow
+    /// wraps them in Phi bindings (issue #3505).
+    #[test]
+    fn test_report_implicit_module_globals() {
+        let report = build_module_report_for_test("implicit_module_globals.py");
+        compare_snapshot("implicit_module_globals.expected.json", &report);
     }
 
     /// --module name override: entity counts (n_functions vs n_methods) must

--- a/pyrefly/lib/test/report/test_files/implicit_module_globals.expected.json
+++ b/pyrefly/lib/test/report/test_files/implicit_module_globals.expected.json
@@ -1,0 +1,22 @@
+{
+  "name": "test",
+  "path": "test.py",
+  "names": [],
+  "line_count": 17,
+  "symbol_reports": [],
+  "type_ignores": [],
+  "n_typable": 0,
+  "n_typed": 0,
+  "n_any": 0,
+  "n_untyped": 0,
+  "coverage": 100.0,
+  "strict_coverage": 100.0,
+  "n_functions": 0,
+  "n_methods": 0,
+  "n_function_params": 0,
+  "n_method_params": 0,
+  "n_classes": 0,
+  "n_attrs": 0,
+  "n_properties": 0,
+  "n_type_ignores": 0
+}

--- a/pyrefly/lib/test/report/test_files/implicit_module_globals.py
+++ b/pyrefly/lib/test/report/test_files/implicit_module_globals.py
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Regression test for gh-3505: end-of-loop Phi joins wrap CPython-injected module
+# globals (__file__, __name__, etc.), so the report filter must skip them by name
+# rather than by binding shape.
+
+"""Test module."""
+
+while True:
+    try:
+        pass
+    except KeyboardInterrupt:
+        break


### PR DESCRIPTION
# Summary

This excludes several CPython-injected dunder module attributes from the `pyrefly coverage report`, matching those from `crates/pyrefly_types/src/globals.rs`:

- `__annotations__`
- `__builtins__`
- `__cached__`
- `__debug__`
- `__dict__`
- `__file__`
- `__loader__`
- `__name__`
- `__package__`
- `__path__`

Fixes #3505

# Test Plan

This includes unit- and integration tests.