### PR TITLE
Fix class attribute counts for stubs in `pyrefly coverage report`

### DIFF
--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -999,8 +999,9 @@ impl ReportArgs {
                         }
                         continue;
                     }
-                    // Non-schema fields only count when initialized in a recognized method.
-                    if !initialized_in_recognized_method {
+                    // Non-schema fields only count when initialized in a recognized method,
+                    // or declared in a stub.
+                    if !initialized_in_recognized_method && !module.path().is_interface() {
                         continue;
                     }
                     Some(*annotation)
@@ -2118,9 +2119,14 @@ mod tests {
 
     /// Build a `ModuleReport` from a checked-in Python test file using a custom `TestEnv`,
     /// mirroring the production pipeline in `run_inner`.
-    fn build_module_report_for_test_with_env(py_file: &str, mut env: TestEnv) -> ModuleReport {
-        let code = load_test_file(py_file);
-        env.add("test", &code);
+    fn build_module_report_for_test_with_env(file: &str, mut env: TestEnv) -> ModuleReport {
+        let code = load_test_file(file);
+        let module_path = format!(
+            "test.{}",
+            file.rsplit_once('.').map_or("py", |(_, ext)| ext)
+        );
+        env.add_with_path("test", &module_path, &code);
+
         let (state, handle_fn) = env
             .with_default_require_level(Require::Everything)
             .to_state();
@@ -2158,7 +2164,7 @@ mod tests {
 
         ReportArgs::build_module_report(
             "test".to_owned(),
-            "test.py".to_owned(),
+            module_path,
             "test",
             line_count,
             &functions,
@@ -2352,6 +2358,12 @@ mod tests {
     fn test_report_partial_stub() {
         let report = build_stub_module_report("partial_stub.pyi", "partial_stub.py");
         compare_snapshot("partial_stub.expected.json", &report);
+    }
+
+    #[test]
+    fn test_report_stub_class_attrs() {
+        let report = build_module_report_for_test("stub_class_attrs.pyi");
+        compare_snapshot("stub_class_attrs.expected.json", &report);
     }
 
     /// Stubs-only packages: .py discovered via site-package-path, merged like co-located stubs.

--- a/pyrefly/lib/test/report/test_files/stub_class_attrs.expected.json
+++ b/pyrefly/lib/test/report/test_files/stub_class_attrs.expected.json
@@ -1,0 +1,63 @@
+{
+  "name": "test",
+  "path": "test.pyi",
+  "names": [
+    "test.C.x",
+    "test.C.y",
+    "test.C"
+  ],
+  "line_count": 9,
+  "symbol_reports": [
+    {
+      "kind": "attr",
+      "name": "test.C.x",
+      "n_typable": 1,
+      "n_typed": 1,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 7,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.C.y",
+      "n_typable": 1,
+      "n_typed": 1,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 8,
+        "column": 5
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.C",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 6,
+        "column": 1
+      }
+    }
+  ],
+  "type_ignores": [],
+  "n_typable": 2,
+  "n_typed": 2,
+  "n_any": 0,
+  "n_untyped": 0,
+  "coverage": 100.0,
+  "strict_coverage": 100.0,
+  "n_functions": 0,
+  "n_methods": 0,
+  "n_function_params": 0,
+  "n_method_params": 0,
+  "n_classes": 1,
+  "n_attrs": 2,
+  "n_properties": 0,
+  "n_type_ignores": 0
+}

--- a/pyrefly/lib/test/report/test_files/stub_class_attrs.pyi
+++ b/pyrefly/lib/test/report/test_files/stub_class_attrs.pyi
@@ -1,0 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+class C:
+    x: int
+    y: str | None


### PR DESCRIPTION
# Summary

Non schema fields weren't counted if the init method had no implementation, not taking stubs into account.

Fixes #3400

# Test Plan

This includes unit- and integration tests.