### PR TITLE
Support multi-target assign aliases in `pyrefly coverage report`

### DIFF
--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -799,6 +799,14 @@ impl ReportArgs {
         functions: &[Function],
         classes: &[ReportClass],
     ) -> Vec<Variable> {
+        fn untyped_if_call(expr: &Expr) -> SlotCounts {
+            if let Expr::Call(_) = expr {
+                SlotCounts::untyped()
+            } else {
+                SlotCounts::default()
+            }
+        }
+
         let module_prefix = if module.name() != ModuleName::unknown() {
             format!("{}.", module.name())
         } else {
@@ -888,8 +896,16 @@ impl ReportArgs {
                         // IMPLICIT: non-call assignments have 0 slots;
                         // call assignments are untyped (1 slot)
                         Binding::NameAssign(na) => {
-                            let slots = if matches!(na.expr.as_ref(), Expr::Call(_)) {
-                                SlotCounts::untyped()
+                            variables.push(Variable {
+                                name: qualified_name,
+                                annotation: None,
+                                slots: untyped_if_call(na.expr.as_ref()),
+                                location,
+                            });
+                        }
+                        Binding::MultiTargetAssign(_, rhs_idx, _) => {
+                            let slots = if let Binding::Expr(_, expr) = bindings.get(*rhs_idx) {
+                                untyped_if_call(expr.as_ref())
                             } else {
                                 SlotCounts::default()
                             };
@@ -2314,6 +2330,12 @@ mod tests {
     fn test_report_variables() {
         let report = build_module_report_for_test("variables.py");
         compare_snapshot("variables.expected.json", &report);
+    }
+
+    #[test]
+    fn test_report_multi_target_aliases() {
+        let report = build_module_report_for_test("multi_target_aliases.py");
+        compare_snapshot("multi_target_aliases.expected.json", &report);
     }
 
     #[test]

--- a/pyrefly/lib/test/report/test_files/multi_target_aliases.expected.json
+++ b/pyrefly/lib/test/report/test_files/multi_target_aliases.expected.json
@@ -1,0 +1,89 @@
+{
+  "name": "test",
+  "path": "test.py",
+  "names": [
+    "test.b",
+    "test.asbytes",
+    "test.x",
+    "test.y",
+    "test.cast_bytes"
+  ],
+  "line_count": 11,
+  "symbol_reports": [
+    {
+      "kind": "attr",
+      "name": "test.b",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 9,
+        "column": 1
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.asbytes",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 9,
+        "column": 5
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.x",
+      "n_typable": 1,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 1,
+      "location": {
+        "line": 10,
+        "column": 1
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.y",
+      "n_typable": 1,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 1,
+      "location": {
+        "line": 10,
+        "column": 5
+      }
+    },
+    {
+      "kind": "function",
+      "name": "test.cast_bytes",
+      "n_typable": 2,
+      "n_typed": 2,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 6,
+        "column": 1
+      }
+    }
+  ],
+  "type_ignores": [],
+  "n_typable": 4,
+  "n_typed": 2,
+  "n_any": 0,
+  "n_untyped": 2,
+  "coverage": 50.0,
+  "strict_coverage": 50.0,
+  "n_functions": 1,
+  "n_methods": 0,
+  "n_function_params": 1,
+  "n_method_params": 0,
+  "n_classes": 0,
+  "n_attrs": 4,
+  "n_properties": 0,
+  "n_type_ignores": 0
+}

--- a/pyrefly/lib/test/report/test_files/multi_target_aliases.py
+++ b/pyrefly/lib/test/report/test_files/multi_target_aliases.py
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+def cast_bytes(s: object) -> bytes:
+    return b""
+
+b = asbytes = cast_bytes
+x = y = cast_bytes(b"")


### PR DESCRIPTION
# Summary

Multi-target assignment aliases of functions (`a = b = func`) are now treated consistently with single-target assignments (`a = func; b = func`). 

Fixes #3506

# Test Plan

This includes unit- and integration tests.