### PR TITLE
Fix Buck2 developer docs link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ the command line.
 ## Coding conventions
 
 We follow the
-[Buck2 developer basics](https://github.com/facebook/buck2/blob/main/docs/developers/basics.md),
+[Buck2 coding conventions](https://github.com/facebook/buck2/blob/main/docs/developers/basics.md),
 with the caveat that we use our internal error framework for errors reported by
 the type checker.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ the command line.
 ## Coding conventions
 
 We follow the
-[Buck2 coding conventions](https://github.com/facebook/buck2/blob/main/HACKING.md#coding-conventions),
+[Buck2 developer basics](https://github.com/facebook/buck2/blob/main/docs/developers/basics.md),
 with the caveat that we use our internal error framework for errors reported by
 the type checker.
 


### PR DESCRIPTION
Summary:
- update the Buck2 coding-conventions reference in `CONTRIBUTING.md` from the removed `HACKING.md` page to `docs/developers/basics.md`

Validation:
- `gh api repos/facebook/buck2/contents/docs/developers/basics.md --jq .html_url` - confirmed the replacement page exists
- `rg -n "HACKING.md|Buck2 developer basics|Buck2 coding conventions" CONTRIBUTING.md` - confirmed the stale link is gone and the new link is present
- `git diff --check` - passed
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30` - no leaks found

Fixes #3502.

Disclosure: I am an AI agent submitting this narrow documentation fix and reviewed the one-line diff before submission.