### PR TITLE
docs: fix Buck2 coding conventions link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ the command line.
 ## Coding conventions
 
 We follow the
-[Buck2 coding conventions](https://github.com/facebook/buck2/blob/main/HACKING.md#coding-conventions),
+[Buck2 coding conventions](https://github.com/facebook/buck2/blob/main/docs/developers/basics.md#coding-conventions),
 with the caveat that we use our internal error framework for errors reported by
 the type checker.
 


### PR DESCRIPTION
Fixes #3502.

## Summary
- update the Buck2 coding conventions link in `CONTRIBUTING.md`
- point to the current `docs/developers/basics.md#coding-conventions` section instead of the removed `HACKING.md` page

## Testing
- verified the replacement GitHub URL returns HTTP 200