### PR TITLE
Fix clippy warnings in {T,L}SP tests

### DIFF
--- a/crates/tsp_types/tests/protocol_types.rs
+++ b/crates/tsp_types/tests/protocol_types.rs
@@ -17,11 +17,11 @@ use tsp_types::*;
 #[test]
 fn test_type_kind_serialization() {
     let kind = TypeKind::Builtin;
-    let json = serde_json::to_value(&kind).unwrap();
+    let json = serde_json::to_value(kind).unwrap();
     assert_eq!(json, serde_json::json!(0));
 
     let kind = TypeKind::Function;
-    let json = serde_json::to_value(&kind).unwrap();
+    let json = serde_json::to_value(kind).unwrap();
     assert_eq!(json, serde_json::json!(2));
 }
 
@@ -46,14 +46,14 @@ fn test_declaration_kind_round_trip() {
 #[test]
 fn test_declaration_category_serialization() {
     let cat = DeclarationCategory::Function;
-    let json = serde_json::to_value(&cat).unwrap();
+    let json = serde_json::to_value(cat).unwrap();
     assert_eq!(json, serde_json::json!(5));
 }
 
 #[test]
 fn test_type_flags_serialization() {
     let flag = TypeFlags::CALLABLE;
-    let json = serde_json::to_value(&flag).unwrap();
+    let json = serde_json::to_value(flag).unwrap();
     assert_eq!(json, serde_json::json!(4));
 }
 

--- a/pyrefly/lib/test/lsp/lsp_interaction/empty_response_reason.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/empty_response_reason.rs
@@ -36,10 +36,10 @@ fn wait_for_lsp_event(
         let event = rx.recv_timeout(RECV_TIMEOUT).unwrap_or_else(|_| {
             panic!("timed out waiting for LspEvent containing '{method_substr}'")
         });
-        if let TelemetryEventKind::LspEvent(ref name) = event.event.kind {
-            if name.contains(method_substr) {
-                return event;
-            }
+        if let TelemetryEventKind::LspEvent(ref name) = event.event.kind
+            && name.contains(method_substr)
+        {
+            return event;
         }
     }
 }


### PR DESCRIPTION
# Summary

In the VSCode problems tab I was seeing the following clippy warnings:

<img width="2211" height="158" alt="Screenshot_2026-05-21_11-15-07" src="https://github.com/user-attachments/assets/45fc85a8-2e5c-45a9-a4da-546f4bb1896f" />

So, well, this fixes them.

# Test Plan

Tests still pass, and clippy no longer complains.
