### PR TITLE
Fix `DeprecationWarning` from `jsonschema` in `test.py`

### DIFF
--- a/schemas/validate_schemas.py
+++ b/schemas/validate_schemas.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 try:
     import jsonschema
+    import referencing
     import toml
 except ImportError:
     print("Error: Required packages not installed.")
@@ -37,7 +38,7 @@ SCHEMAS_DIR = Path(__file__).parent
 def _make_validator(schema_file: Path):
     """Create a JSON schema validator with $ref support.
 
-    Uses RefResolver with a store mapping to handle cross-file $ref resolution.
+    Uses a referencing Registry with a store mapping to handle cross-file $ref resolution.
     """
     with open(schema_file, "r") as f:
         schema = json.load(f)
@@ -55,9 +56,11 @@ def _make_validator(schema_file: Path):
         # Also register by relative name so "$ref": "pyrefly.json" resolves.
         store["pyrefly.json"] = main_schema
 
-    resolver = jsonschema.RefResolver.from_schema(schema, store=store)
+    registry = referencing.Registry().with_resources(
+        (uri, referencing.Resource.from_contents(s)) for uri, s in store.items()
+    )
     validator_cls = jsonschema.validators.validator_for(schema)
-    return validator_cls(schema, resolver=resolver)
+    return validator_cls(schema, registry=registry)
 
 
 class TestPositiveValidation(unittest.TestCase):


### PR DESCRIPTION
# Summary

This addreses the following deprecation warning while running `test.py`:

```
/home/joren/Workspace/pyrefly/schemas/validate_schemas.py:58: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
  resolver = jsonschema.RefResolver.from_schema(schema, store=store)
```

The `referencing` library is already a required dependency of `jsonschema` (https://github.com/python-jsonschema/jsonschema/blob/c6dc09209c0224af200f0663c52cecaea063de36/pyproject.toml#L43), so there's no need to include it in the `pip install` error message.

# Test Plan

N/A