### PR TITLE
Fix Windows CI on main: normalize `.mdx` EOL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mdx text eol=lf


### PR DESCRIPTION
# Summary

This addresses an issue was introduced in https://github.com/facebook/pyrefly/commit/25ac9f6e185782d6c722c7ead9e19b8bb8e1fcab causing the Windows CI job to fail on main. 

See for example https://github.com/facebook/pyrefly/actions/runs/26207799459/job/77111366325

It might be interesting to use this `.gitattributes` for other things as well, such as marking of certain files as generated to clean up github diffs.

# Test Plan

I guess that'll be waiting to see if the Windows CI job no longer fails now ;)