### PR TITLE
Fix stub function counts of reexports in `pyrefly coverage report`

### DIFF
--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -1701,26 +1701,27 @@ impl ReportArgs {
         py_variables: Vec<Variable>,
         py_classes: Vec<ReportClass>,
     ) {
-        let stub_func_names: SmallSet<String> =
-            stub_functions.iter().map(|f| f.name.clone()).collect();
+        // Dedupe py-side symbols against all stub-side names regardless of kind, so a name defined
+        // as a function or class in the stub isn't re-added as an untyped attr by a .py re-export.
+        let stub_names: SmallSet<String> = stub_functions
+            .iter()
+            .map(|f| &f.name)
+            .chain(stub_variables.iter().map(|v| &v.name))
+            .chain(stub_classes.iter().map(|c| &c.name))
+            .cloned()
+            .collect();
         for py_func in py_functions {
-            if !stub_func_names.contains(&py_func.name) {
+            if !stub_names.contains(&py_func.name) {
                 stub_functions.push(py_func);
             }
         }
-
-        let stub_var_names: SmallSet<String> =
-            stub_variables.iter().map(|v| v.name.clone()).collect();
         for py_var in py_variables {
-            if !stub_var_names.contains(&py_var.name) {
+            if !stub_names.contains(&py_var.name) {
                 stub_variables.push(py_var);
             }
         }
-
-        let stub_class_names: SmallSet<String> =
-            stub_classes.iter().map(|c| c.name.clone()).collect();
         for py_class in py_classes {
-            if !stub_class_names.contains(&py_class.name) {
+            if !stub_names.contains(&py_class.name) {
                 stub_classes.push(py_class);
             }
         }
@@ -2352,6 +2353,13 @@ mod tests {
     fn test_report_partial_stub() {
         let report = build_stub_module_report("partial_stub.pyi", "partial_stub.py");
         compare_snapshot("partial_stub.expected.json", &report);
+    }
+
+    /// gh-3524: stub functions/classes must not be re-added as untyped attrs by .py re-exports.
+    #[test]
+    fn test_report_stub_reexport() {
+        let report = build_stub_module_report("stub_reexport.pyi", "stub_reexport.py");
+        compare_snapshot("stub_reexport.expected.json", &report);
     }
 
     /// Stubs-only packages: .py discovered via site-package-path, merged like co-located stubs.

--- a/pyrefly/lib/test/report/test_files/stub_reexport.expected.json
+++ b/pyrefly/lib/test/report/test_files/stub_reexport.expected.json
@@ -1,0 +1,50 @@
+{
+  "name": "test",
+  "path": "test.pyi",
+  "names": [
+    "test.reexported_func",
+    "test.ReexportedClass"
+  ],
+  "line_count": 9,
+  "symbol_reports": [
+    {
+      "kind": "function",
+      "name": "test.reexported_func",
+      "n_typable": 2,
+      "n_typed": 2,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 6,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.ReexportedClass",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 8,
+        "column": 1
+      }
+    }
+  ],
+  "type_ignores": [],
+  "n_typable": 2,
+  "n_typed": 2,
+  "n_any": 0,
+  "n_untyped": 0,
+  "coverage": 100.0,
+  "strict_coverage": 100.0,
+  "n_functions": 1,
+  "n_methods": 0,
+  "n_function_params": 1,
+  "n_method_params": 0,
+  "n_classes": 1,
+  "n_attrs": 0,
+  "n_properties": 0,
+  "n_type_ignores": 0
+}

--- a/pyrefly/lib/test/report/test_files/stub_reexport.py
+++ b/pyrefly/lib/test/report/test_files/stub_reexport.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from os import getcwd as reexported_func
+from os import PathLike as ReexportedClass

--- a/pyrefly/lib/test/report/test_files/stub_reexport.pyi
+++ b/pyrefly/lib/test/report/test_files/stub_reexport.pyi
@@ -1,0 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+def reexported_func(x: int) -> int: ...
+
+class ReexportedClass: ...


### PR DESCRIPTION
# Summary

I confirmed that this fixes the issue in NumPy in all 21 cases, increasing strict coverage from 87.0% -> 94.3%.

Fixes #3524

# Test Plan

This includes unit- and integration tests.