### PR TITLE
fix TypeIs overload not selected for filter constructor #3394

### DIFF
--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -2251,6 +2251,11 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                 // TypeGuard is covariant
                 self.is_subset_eq(l, u)
             }
+            (Type::TypeIs(l), Type::TypeIs(u)) => {
+                // TypeIs is invariant: the narrowed type is both a positive and negative refinement.
+                self.is_subset_eq(l, u)
+                    .and_then(|_| self.is_subset_eq(u, l))
+            }
             (Type::TypeGuard(_) | Type::TypeIs(_), _) => self.is_subset_eq(
                 &self
                     .solver

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -1575,6 +1575,23 @@ def g(x: str, y: int):
 );
 
 testcase!(
+    test_filter_selects_typeis_overload,
+    r#"
+import ast
+from typing import TypeIs, assert_type
+
+type IsDef = ast.FunctionDef | ast.ClassDef
+
+def is_def(n: object) -> TypeIs[IsDef]:
+    return isinstance(n, ast.FunctionDef | ast.ClassDef)
+
+def f(node: ast.ClassDef):
+    for child in filter(is_def, node.body):
+        assert_type(child, ast.ClassDef | ast.FunctionDef)
+    "#,
+);
+
+testcase!(
     test_tuple_any_with_tuple_ambigious_overload,
     r#"
 from typing import Any, Literal, Never, overload, assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3394

added invariant TypeIs[T] vs TypeIs[U] subtyping instead of falling through to runtime bool.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test