### PR TITLE
Fix crashes / internal errors induced by parser error recovery

### DIFF
--- a/pyrefly/lib/binding/pattern.rs
+++ b/pyrefly/lib/binding/pattern.rs
@@ -103,9 +103,15 @@ impl<'a> BindingsBuilder<'a> {
                 // If there's no name for this pattern, refine the variable being matched
                 // If there is a new name, refine that instead
                 let original_subject = match_subject.clone();
-                let alias_name = p.name.as_ref().map(|name| name.id.clone());
+                let alias_name = p
+                    .name
+                    .as_ref()
+                    .filter(|name| !Ast::is_synthesized_empty_identifier(name))
+                    .map(|name| name.id.clone());
                 let mut subject = match_subject;
-                if let Some(name) = &p.name {
+                if let Some(name) = &p.name
+                    && !Ast::is_synthesized_empty_identifier(name)
+                {
                     self.bind_definition(name, Binding::Forward(subject_idx), FlowStyle::Other);
                     subject = MatchSubject::Single(NarrowingSubject::Name(name.id.clone()));
                 };
@@ -182,7 +188,9 @@ impl<'a> BindingsBuilder<'a> {
                     // Process each sub-pattern in the sequence pattern
                     match x {
                         Pattern::MatchStar(p) => {
-                            if let Some(name) = &p.name {
+                            if let Some(name) = &p.name
+                                && !Ast::is_synthesized_empty_identifier(name)
+                            {
                                 let position = UnpackedPosition::Slice(i, num_patterns - i - 1);
                                 self.bind_definition(
                                     name,
@@ -321,7 +329,9 @@ impl<'a> BindingsBuilder<'a> {
                             match_key_idx,
                         ))
                     });
-                if let Some(rest) = x.rest {
+                if let Some(rest) = x.rest
+                    && !Ast::is_synthesized_empty_identifier(&rest)
+                {
                     self.bind_definition(&rest, Binding::Forward(subject_idx), FlowStyle::Other);
                 }
                 narrow_ops
@@ -499,7 +509,9 @@ impl<'a> BindingsBuilder<'a> {
                 narrow_ops.unwrap_or_default()
             }
             Pattern::MatchStar(p) => {
-                if let Some(name) = &p.name {
+                if let Some(name) = &p.name
+                    && !Ast::is_synthesized_empty_identifier(name)
+                {
                     self.bind_definition(name, Binding::Forward(subject_idx), FlowStyle::Other);
                 }
                 NarrowOps::new()

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -708,6 +708,17 @@ impl<'a> BindingsBuilder<'a> {
             }
             Stmt::AnnAssign(mut x) => match *x.target {
                 Expr::Name(name) => {
+                    if Ast::is_synthesized_empty_name(&name) {
+                        self.ensure_type(&mut x.annotation, &mut None);
+                        if let Some(value) = x.value {
+                            self.bind_single_name_assign(
+                                &Ast::expr_name_identifier(name),
+                                value,
+                                None,
+                            );
+                        }
+                        return;
+                    }
                     // Handle annotated legacy TypeVar creation T: TypeVar = TypeVar("T")
                     if let Some(ref mut value) = x.value
                         && let Expr::Call(call) = value.as_mut()

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -1230,6 +1230,13 @@ testcase!(
 );
 
 testcase!(
+    test_syntax_error_empty_decorator_slice,
+    r#"
+@:[ # E: Parse # E: Parse
+    "#,
+);
+
+testcase!(
     test_mangled_for,
     r#"
 # This has identical Identifiers in the AST, which seems like the right AST.

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -1237,6 +1237,29 @@ testcase!(
 );
 
 testcase!(
+    test_syntax_error_empty_match_star,
+    r#"
+x = object()
+match x:
+    case [*]: # E: Parse
+        pass
+    "#,
+);
+
+testcase!(
+    test_syntax_error_empty_match_bindings,
+    r#"
+x = object()
+match x:
+    case as: # E: Parse
+        pass
+match x:
+    case {**}: # E: Parse
+        pass
+    "#,
+);
+
+testcase!(
     test_mangled_for,
     r#"
 # This has identical Identifiers in the AST, which seems like the right AST.


### PR DESCRIPTION
# Summary

Fixes #3343 

The fix is similar to 4980ddf9d3f46f99b6e581279a57b289bd453a63 / D104345441, just need to apply it to a few more places.

Asked GPT 5.5 to find a few other places where issues may occur and fix them as well, hopefully we're good.

P.S. I was testing the pre-patch behaviour using the web sandbox. It turns out that if the sandbox crashes, the text input is cached in local storage and makes the web sandbox unuseable without clearing local storage!

# Test Plan

New regression tests added