### PR TITLE
Fix document symbol search for editors without hierarchical support

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/document_symbols.rs
+++ b/pyrefly/lib/lsp/non_wasm/document_symbols.rs
@@ -287,3 +287,42 @@ fn recurse_stmt_adding_symbols<'a>(
     };
     symbols.append(&mut recursed_symbols);
 }
+
+pub fn flatten_to_symbol_information(
+    symbols: Vec<DocumentSymbol>,
+    uri: &lsp_types::Url,
+) -> Vec<lsp_types::SymbolInformation> {
+    let mut results = Vec::new();
+    flatten_recursive(symbols, uri, None, &mut results);
+    results
+}
+
+fn flatten_recursive(
+    symbols: Vec<DocumentSymbol>,
+    uri: &lsp_types::Url,
+    container_name: Option<String>,
+    result: &mut Vec<lsp_types::SymbolInformation>,
+) {
+    for sym in symbols {
+        let children = sym.children.unwrap_or_default();
+        let qualified_name = match &container_name {
+            Some(parent) => format!("{}.{}", parent, sym.name),
+            None => sym.name.clone(),
+        };
+
+        #[allow(deprecated)]
+        result.push(lsp_types::SymbolInformation {
+            name: sym.name,
+            kind: sym.kind,
+            tags: sym.tags,
+            deprecated: sym.deprecated,
+            location: lsp_types::Location {
+                uri: uri.clone(),
+                range: sym.range,
+            },
+            container_name: container_name.clone(),
+        });
+
+        flatten_recursive(children, uri, Some(qualified_name), result);
+    }
+}

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -5115,16 +5115,24 @@ impl Server {
         }) {
             return Err(EmptyResponseReason::LanguageServicesDisabled);
         }
-        let handle = self.make_handle_if_enabled(uri, Some(DocumentSymbolRequest::METHOD))?;
-        let symbols = transaction.symbols(&handle, maybe_cell_idx);
-        let supports_hierarchical = self
+
+        // Avoid creating a handle when the client doesn't support document symbols
+        let document_symbols_caps = self
             .initialize_params
             .capabilities
             .text_document
             .as_ref()
-            .and_then(|t| t.document_symbol.as_ref())
+            .and_then(|t| t.document_symbol.as_ref());
+        if document_symbols_caps.is_none() {
+            return Ok(None);
+        }
+
+        let supports_hierarchical = document_symbols_caps
             .and_then(|d| d.hierarchical_document_symbol_support)
             == Some(true);
+
+        let handle = self.make_handle_if_enabled(uri, Some(DocumentSymbolRequest::METHOD))?;
+        let symbols = transaction.symbols(&handle, maybe_cell_idx);
         Ok(symbols.map(|syms| {
             if supports_hierarchical {
                 DocumentSymbolResponse::Nested(syms)

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -65,7 +65,6 @@ use lsp_types::DocumentDiagnosticReport;
 use lsp_types::DocumentHighlight;
 use lsp_types::DocumentHighlightKind;
 use lsp_types::DocumentHighlightParams;
-use lsp_types::DocumentSymbol;
 use lsp_types::DocumentSymbolParams;
 use lsp_types::DocumentSymbolResponse;
 use lsp_types::FileEvent;
@@ -270,6 +269,7 @@ use crate::lsp::non_wasm::call_hierarchy::transform_incoming_calls;
 use crate::lsp::non_wasm::call_hierarchy::transform_outgoing_calls;
 use crate::lsp::non_wasm::code_lens::runnable_lsp_code_lens;
 use crate::lsp::non_wasm::convert_module_package::convert_module_package_code_actions;
+use crate::lsp::non_wasm::document_symbols::flatten_to_symbol_information;
 use crate::lsp::non_wasm::external_provider::ExternalProvider;
 use crate::lsp::non_wasm::external_provider::compute_qualified_name;
 use crate::lsp::non_wasm::lsp::apply_change_events;
@@ -2229,14 +2229,13 @@ impl Server {
                             params, &x.id,
                         )
                     {
-                        let response =
-                            match self.hierarchical_document_symbols(&transaction, params) {
-                                Ok(response) => response.map(DocumentSymbolResponse::Nested),
-                                Err(reason) => {
-                                    telemetry_event.set_empty_response_reason(reason);
-                                    None
-                                }
-                            };
+                        let response = match self.document_symbol(&transaction, params) {
+                            Ok(response) => response,
+                            Err(reason) => {
+                                telemetry_event.set_empty_response_reason(reason);
+                                None
+                            }
+                        };
                         self.send_response(new_response(x.id, Ok(response)));
                     }
                 } else if let Some(params) = as_request::<WorkspaceSymbolRequest>(&x) {
@@ -5101,34 +5100,38 @@ impl Server {
         })))
     }
 
-    fn hierarchical_document_symbols(
+    fn document_symbol(
         &self,
         transaction: &Transaction<'_>,
         params: DocumentSymbolParams,
-    ) -> Result<Option<Vec<DocumentSymbol>>, EmptyResponseReason> {
+    ) -> Result<Option<DocumentSymbolResponse>, EmptyResponseReason> {
         let uri = &params.text_document.uri;
         let maybe_cell_idx = self.maybe_get_code_cell_index(uri);
         let path = self
             .path_for_uri_or_notebook_cell(uri)
             .ok_or(EmptyResponseReason::NoFilePath)?;
-        if self
-            .workspaces
-            .get_with(path, |(_, workspace)| workspace.disable_language_services)
-        {
+        if self.workspaces.get_with(path, |(_, workspace)| {
+            workspace.disabled_language_services.is_some()
+        }) {
             return Err(EmptyResponseReason::LanguageServicesDisabled);
         }
-        let Some(true) = self
+        let handle = self.make_handle_if_enabled(uri, Some(DocumentSymbolRequest::METHOD))?;
+        let symbols = transaction.symbols(&handle, maybe_cell_idx);
+        let supports_hierarchical = self
             .initialize_params
             .capabilities
             .text_document
             .as_ref()
             .and_then(|t| t.document_symbol.as_ref())
             .and_then(|d| d.hierarchical_document_symbol_support)
-        else {
-            return Ok(None);
-        };
-        let handle = self.make_handle_if_enabled(uri, Some(DocumentSymbolRequest::METHOD))?;
-        Ok(transaction.symbols(&handle, maybe_cell_idx))
+            == Some(true);
+        Ok(symbols.map(|syms| {
+            if supports_hierarchical {
+                DocumentSymbolResponse::Nested(syms)
+            } else {
+                DocumentSymbolResponse::Flat(flatten_to_symbol_information(syms, uri))
+            }
+        }))
     }
 
     /// Run local and external workspace symbol queries in parallel, merging

--- a/pyrefly/lib/test/lsp/document_symbols.rs
+++ b/pyrefly/lib/test/lsp/document_symbols.rs
@@ -8,6 +8,7 @@
 use pretty_assertions::assert_eq;
 use pyrefly_build::handle::Handle;
 
+use crate::lsp::non_wasm::document_symbols::flatten_to_symbol_information;
 use crate::state::state::State;
 use crate::test::util::get_batched_lsp_operations_report_no_cursor;
 use crate::test::util::get_batched_lsp_operations_report_no_cursor_allow_error;
@@ -16,6 +17,17 @@ fn get_test_report(state: &State, handle: &Handle) -> String {
     let transaction = state.transaction();
     if let Some(symbols) = transaction.symbols(handle, None) {
         serde_json::to_string_pretty(&symbols).unwrap()
+    } else {
+        "No document symbols found".to_owned()
+    }
+}
+
+fn get_flat_symbol_report(state: &State, handle: &Handle) -> String {
+    let transactions = state.transaction();
+    let uri = lsp_types::Url::parse("file:///main.py").unwrap();
+    if let Some(symbols) = transactions.symbols(handle, None) {
+        let flat = flatten_to_symbol_information(symbols, &uri);
+        serde_json::to_string_pretty(&flat).unwrap()
     } else {
         "No document symbols found".to_owned()
     }
@@ -1168,4 +1180,90 @@ b = 2
     assert_eq!(config_children.len(), 2);
     assert_eq!(config_children[0].name, "DEBUG");
     assert_eq!(config_children[1].name, "b");
+}
+
+#[test]
+fn test_flatten_basic_class() {
+    let code = r#"
+class MyClass:
+  def __init__(self):
+    self.x = 1
+
+  def method1(self):
+    return self.x
+
+  def method2(self, y):
+    return self.x + y
+"#;
+
+    let report =
+        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_flat_symbol_report);
+    let uri = lsp_types::Url::parse("file:///main.py").unwrap();
+
+    #[allow(deprecated)]
+    let flat: Vec<lsp_types::SymbolInformation> =
+        serde_json::from_str(&report.split("\n").skip(2).collect::<Vec<_>>().join("\n")).unwrap();
+
+    assert_eq!(flat.len(), 4);
+
+    assert_eq!(flat[0].name, "MyClass");
+    assert_eq!(flat[0].container_name, None);
+    assert_eq!(flat[0].location.uri, uri);
+
+    assert_eq!(flat[1].name, "__init__");
+    assert_eq!(flat[1].container_name, Some("MyClass".to_owned()));
+
+    assert_eq!(flat[2].name, "method1");
+    assert_eq!(flat[2].container_name, Some("MyClass".to_owned()));
+
+    assert_eq!(flat[3].name, "method2");
+    assert_eq!(flat[3].container_name, Some("MyClass".to_owned()));
+}
+
+#[test]
+fn test_flatten_deep_nesting() {
+    let code = r#"
+class Outer:
+  class Inner:
+    def foo(self):
+      pass
+"#;
+
+    let report =
+        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_flat_symbol_report);
+    let uri = lsp_types::Url::parse("file:///main.py").unwrap();
+
+    #[allow(deprecated)]
+    let flat: Vec<lsp_types::SymbolInformation> =
+        serde_json::from_str(&report.split("\n").skip(2).collect::<Vec<_>>().join("\n")).unwrap();
+
+    assert_eq!(flat.len(), 3);
+
+    assert_eq!(flat[0].name, "Outer");
+    assert_eq!(flat[0].container_name, None);
+    assert_eq!(flat[0].location.uri, uri);
+
+    assert_eq!(flat[1].name, "Inner");
+    assert_eq!(flat[1].container_name, Some("Outer".to_owned()));
+
+    assert_eq!(flat[2].name, "foo");
+    assert_eq!(flat[2].container_name, Some("Outer.Inner".to_owned()));
+}
+
+#[test]
+fn test_flatten_empty_file() {
+    let code = r#"
+# just a comment, no symbols
+"#;
+
+    let report =
+        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_flat_symbol_report);
+
+    // The report is either "No document symbols found" or an empty JSON array
+    let body = report.split("\n").skip(2).collect::<Vec<_>>().join("\n");
+    if body.trim() != "No document symbols found" {
+        #[allow(deprecated)]
+        let flat: Vec<lsp_types::SymbolInformation> = serde_json::from_str(body.trim()).unwrap();
+        assert!(flat.is_empty());
+    }
 }

--- a/pyrefly/lib/test/lsp/document_symbols.rs
+++ b/pyrefly/lib/test/lsp/document_symbols.rs
@@ -13,7 +13,13 @@ use crate::state::state::State;
 use crate::test::util::get_batched_lsp_operations_report_no_cursor;
 use crate::test::util::get_batched_lsp_operations_report_no_cursor_allow_error;
 
-fn get_test_report(state: &State, handle: &Handle) -> String {
+fn get_combined_report(state: &State, handle: &Handle) -> String {
+    let hierarchical = get_hierarchical_symbol_report(state, handle);
+    let flat = get_flat_symbol_report(state, handle);
+    format!("## Hierarchical\n{hierarchical}\n## Flat\n{flat}")
+}
+
+fn get_hierarchical_symbol_report(state: &State, handle: &Handle) -> String {
     let transaction = state.transaction();
     if let Some(symbols) = transaction.symbols(handle, None) {
         serde_json::to_string_pretty(&symbols).unwrap()
@@ -33,6 +39,17 @@ fn get_flat_symbol_report(state: &State, handle: &Handle) -> String {
     }
 }
 
+fn extract_section<'a>(report: &'a str, section: &str) -> &'a str {
+    let marker = format!("## {section}");
+    let start = report
+        .find(&marker)
+        .expect("missing section marker in combined symbol report")
+        + marker.len();
+    let rest = &report[start..];
+    let end = rest.find("\n## ").map(|i| i + 1).unwrap_or(rest.len());
+    rest[..end].trim()
+}
+
 #[test]
 fn function_test() {
     let code = r#"
@@ -45,10 +62,12 @@ def function2(param1, param2):
     y = param1 + param2
     return y
 "#;
-    let report = get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_test_report);
+    let report =
+        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_combined_report);
     assert_eq!(
         r#"# main.py
 
+## Hierarchical
 [
   {
     "name": "function1",
@@ -150,6 +169,79 @@ def function2(param1, param2):
       }
     ]
   }
+]
+## Flat
+[
+  {
+    "name": "function1",
+    "kind": 12,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 0
+        },
+        "end": {
+          "line": 4,
+          "character": 12
+        }
+      }
+    }
+  },
+  {
+    "name": "x",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 4
+        },
+        "end": {
+          "line": 3,
+          "character": 9
+        }
+      }
+    },
+    "containerName": "function1"
+  },
+  {
+    "name": "function2",
+    "kind": 12,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 0
+        },
+        "end": {
+          "line": 8,
+          "character": 12
+        }
+      }
+    }
+  },
+  {
+    "name": "y",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 4
+        },
+        "end": {
+          "line": 7,
+          "character": 23
+        }
+      }
+    },
+    "containerName": "function2"
+  }
 ]"#
         .trim(),
         report.trim(),
@@ -171,10 +263,12 @@ class MyClass:
     def method2(self, y):
         return self.x + y
 "#;
-    let report = get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_test_report);
+    let report =
+        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_combined_report);
     assert_eq!(
         r#"# main.py
 
+## Hierarchical
 [
   {
     "name": "MyClass",
@@ -277,6 +371,80 @@ class MyClass:
       }
     ]
   }
+]
+## Flat
+[
+  {
+    "name": "MyClass",
+    "kind": 5,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 0
+        },
+        "end": {
+          "line": 11,
+          "character": 25
+        }
+      }
+    }
+  },
+  {
+    "name": "__init__",
+    "kind": 6,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 4
+        },
+        "end": {
+          "line": 5,
+          "character": 18
+        }
+      }
+    },
+    "containerName": "MyClass"
+  },
+  {
+    "name": "method1",
+    "kind": 6,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 4
+        },
+        "end": {
+          "line": 8,
+          "character": 21
+        }
+      }
+    },
+    "containerName": "MyClass"
+  },
+  {
+    "name": "method2",
+    "kind": 6,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 4
+        },
+        "end": {
+          "line": 11,
+          "character": 25
+        }
+      }
+    },
+    "containerName": "MyClass"
+  }
 ]"#
         .trim(),
         report.trim(),
@@ -290,11 +458,13 @@ while True:
     class Foo: pass
     print(str(Foo))
 "#;
-    let report = get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_test_report);
+    let report =
+        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_combined_report);
     assert_eq!(
         r#"
 # main.py
 
+## Hierarchical
 [
   {
     "name": "Foo",
@@ -321,6 +491,26 @@ while True:
     },
     "children": []
   }
+]
+## Flat
+[
+  {
+    "name": "Foo",
+    "kind": 5,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 4
+        },
+        "end": {
+          "line": 2,
+          "character": 19
+        }
+      }
+    }
+  }
 ]"#
         .trim(),
         report.trim(),
@@ -337,10 +527,14 @@ fn test_syntax_error_empty_name_assign() {
 def foo():
     x = = None
 "#;
-    let report =
-        get_batched_lsp_operations_report_no_cursor_allow_error(&[("main", code)], get_test_report);
-    let symbols: Vec<lsp_types::DocumentSymbol> =
-        serde_json::from_str(&report.split('\n').skip(2).collect::<Vec<_>>().join("\n")).unwrap();
+    let report = get_batched_lsp_operations_report_no_cursor_allow_error(
+        &[("main", code)],
+        get_combined_report,
+    );
+
+    // --- Hierarchical ---
+    let hierarchical_json = extract_section(&report, "Hierarchical");
+    let symbols: Vec<lsp_types::DocumentSymbol> = serde_json::from_str(hierarchical_json).unwrap();
 
     assert_eq!(symbols.len(), 1);
     assert_eq!(symbols[0].name, "foo");
@@ -350,6 +544,16 @@ def foo():
     // from the parser's error recovery must be filtered out.
     assert_eq!(children.len(), 1);
     assert_eq!(children[0].name, "x");
+
+    // ---- Flat ----
+    let flat_json = extract_section(&report, "Flat");
+    let flat_symbols: Vec<lsp_types::SymbolInformation> = serde_json::from_str(flat_json).unwrap();
+
+    assert_eq!(flat_symbols.len(), 2);
+    assert_eq!(flat_symbols[0].name, "foo");
+    assert_eq!(flat_symbols[0].container_name, None);
+    assert_eq!(flat_symbols[1].name, "x");
+    assert_eq!(flat_symbols[1].container_name, Some("foo".to_owned()));
 }
 
 // TODO(kylei): list comprehension document symbol
@@ -358,11 +562,15 @@ fn list_comprehension_test() {
     let code = r#"
 [x for x in list()]
 "#;
-    let report = get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_test_report);
+    let report =
+        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_combined_report);
     assert_eq!(
         r#"
 # main.py
 
+## Hierarchical
+[]
+## Flat
 []
 "#
         .trim(),
@@ -391,11 +599,13 @@ class MyClass:
 y = MyClass()
 result = y.method()
  "#;
-    let report = get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_test_report);
+    let report =
+        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_combined_report);
     assert_eq!(
         r#"
 # main.py
 
+## Hierarchical
 [
   {
     "name": "x",
@@ -595,7 +805,148 @@ result = y.method()
     }
   }
 ]
-"#
+## Flat
+[
+  {
+    "name": "x",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 0
+        },
+        "end": {
+          "line": 4,
+          "character": 5
+        }
+      }
+    }
+  },
+  {
+    "name": "helper_function",
+    "kind": 12,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 0
+        },
+        "end": {
+          "line": 7,
+          "character": 13
+        }
+      }
+    }
+  },
+  {
+    "name": "MyClass",
+    "kind": 5,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 0
+        },
+        "end": {
+          "line": 14,
+          "character": 24
+        }
+      }
+    }
+  },
+  {
+    "name": "class_var",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 4
+        },
+        "end": {
+          "line": 10,
+          "character": 23
+        }
+      }
+    },
+    "containerName": "MyClass"
+  },
+  {
+    "name": "method",
+    "kind": 6,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 4
+        },
+        "end": {
+          "line": 14,
+          "character": 24
+        }
+      }
+    },
+    "containerName": "MyClass"
+  },
+  {
+    "name": "local_var",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 8
+        },
+        "end": {
+          "line": 13,
+          "character": 37
+        }
+      }
+    },
+    "containerName": "MyClass.method"
+  },
+  {
+    "name": "y",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 16,
+          "character": 0
+        },
+        "end": {
+          "line": 16,
+          "character": 13
+        }
+      }
+    }
+  },
+  {
+    "name": "result",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 0
+        },
+        "end": {
+          "line": 17,
+          "character": 19
+        }
+      }
+    }
+  }
+]"#
         .trim(),
         report.trim(),
     );
@@ -626,11 +977,13 @@ y: MyClass = MyClass()
 result: int = y.method()
 items: List[str] = ["a", "b", "c"]
  "#;
-    let report = get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_test_report);
+    let report =
+        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_combined_report);
     assert_eq!(
         r#"
 # main.py
 
+## Hierarchical
 [
   {
     "name": "x",
@@ -935,7 +1288,218 @@ items: List[str] = ["a", "b", "c"]
     }
   }
 ]
-"#
+## Flat
+[
+  {
+    "name": "x",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 0
+        },
+        "end": {
+          "line": 4,
+          "character": 10
+        }
+      }
+    }
+  },
+  {
+    "name": "name",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 0
+        },
+        "end": {
+          "line": 5,
+          "character": 18
+        }
+      }
+    }
+  },
+  {
+    "name": "helper_function",
+    "kind": 12,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 0
+        },
+        "end": {
+          "line": 8,
+          "character": 13
+        }
+      }
+    }
+  },
+  {
+    "name": "MyClass",
+    "kind": 5,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 0
+        },
+        "end": {
+          "line": 17,
+          "character": 24
+        }
+      }
+    }
+  },
+  {
+    "name": "class_var",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 11,
+          "character": 4
+        },
+        "end": {
+          "line": 11,
+          "character": 28
+        }
+      }
+    },
+    "containerName": "MyClass"
+  },
+  {
+    "name": "counter",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 4
+        },
+        "end": {
+          "line": 12,
+          "character": 20
+        }
+      }
+    },
+    "containerName": "MyClass"
+  },
+  {
+    "name": "method",
+    "kind": 6,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 14,
+          "character": 4
+        },
+        "end": {
+          "line": 17,
+          "character": 24
+        }
+      }
+    },
+    "containerName": "MyClass"
+  },
+  {
+    "name": "local_var",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 8
+        },
+        "end": {
+          "line": 15,
+          "character": 42
+        }
+      }
+    },
+    "containerName": "MyClass.method"
+  },
+  {
+    "name": "message",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 16,
+          "character": 8
+        },
+        "end": {
+          "line": 16,
+          "character": 29
+        }
+      }
+    },
+    "containerName": "MyClass.method"
+  },
+  {
+    "name": "y",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 19,
+          "character": 0
+        },
+        "end": {
+          "line": 19,
+          "character": 22
+        }
+      }
+    }
+  },
+  {
+    "name": "result",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 20,
+          "character": 0
+        },
+        "end": {
+          "line": 20,
+          "character": 24
+        }
+      }
+    }
+  },
+  {
+    "name": "items",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 21,
+          "character": 0
+        },
+        "end": {
+          "line": 21,
+          "character": 34
+        }
+      }
+    }
+  }
+]"#
         .trim(),
         report.trim(),
     );
@@ -958,11 +1522,13 @@ def foo():
 class MyClass:
     pass
 "#;
-    let report = get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_test_report);
+    let report =
+        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_combined_report);
     assert_eq!(
         r#"
 # main.py
 
+## Hierarchical
 [
   {
     "name": "Section 1",
@@ -1117,7 +1683,115 @@ class MyClass:
     ]
   }
 ]
-"#
+## Flat
+[
+  {
+    "name": "Section 1",
+    "kind": 15,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 0
+        },
+        "end": {
+          "line": 1,
+          "character": 16
+        }
+      }
+    }
+  },
+  {
+    "name": "x",
+    "kind": 13,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 0
+        },
+        "end": {
+          "line": 3,
+          "character": 5
+        }
+      }
+    },
+    "containerName": "Section 1"
+  },
+  {
+    "name": "Section 1.1",
+    "kind": 15,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 0
+        },
+        "end": {
+          "line": 5,
+          "character": 19
+        }
+      }
+    },
+    "containerName": "Section 1"
+  },
+  {
+    "name": "foo",
+    "kind": 12,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 0
+        },
+        "end": {
+          "line": 8,
+          "character": 8
+        }
+      }
+    },
+    "containerName": "Section 1.Section 1.1"
+  },
+  {
+    "name": "Section 2",
+    "kind": 15,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 0
+        },
+        "end": {
+          "line": 10,
+          "character": 16
+        }
+      }
+    }
+  },
+  {
+    "name": "MyClass",
+    "kind": 5,
+    "location": {
+      "uri": "file:///main.py",
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 0
+        },
+        "end": {
+          "line": 13,
+          "character": 8
+        }
+      }
+    },
+    "containerName": "Section 2"
+  }
+]"#
         .trim(),
         report.trim(),
     );
@@ -1143,7 +1817,8 @@ DEBUG = True
 
 b = 2
 "#;
-    let report = get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_test_report);
+    let report =
+        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_combined_report);
 
     // Verify the structure:
     // - "Imports" should contain:
@@ -1155,8 +1830,9 @@ b = 2
     //   - DEBUG (variable)
     //   - b (variable)
 
-    let symbols: Vec<lsp_types::DocumentSymbol> =
-        serde_json::from_str(&report.split('\n').skip(2).collect::<Vec<_>>().join("\n")).unwrap();
+    // --- Hierarchical ---
+    let hierarchical_json = extract_section(&report, "Hierarchical");
+    let symbols: Vec<lsp_types::DocumentSymbol> = serde_json::from_str(hierarchical_json).unwrap();
 
     // Check top-level sections
     assert_eq!(symbols.len(), 2);
@@ -1180,90 +1856,45 @@ b = 2
     assert_eq!(config_children.len(), 2);
     assert_eq!(config_children[0].name, "DEBUG");
     assert_eq!(config_children[1].name, "b");
-}
 
-#[test]
-fn test_flatten_basic_class() {
-    let code = r#"
-class MyClass:
-  def __init__(self):
-    self.x = 1
+    // --- Flat ---
+    let flat_json = extract_section(&report, "Flat");
+    let flat_symbols: Vec<lsp_types::SymbolInformation> = serde_json::from_str(flat_json).unwrap();
 
-  def method1(self):
-    return self.x
+    assert_eq!(flat_symbols.len(), 8);
+    assert_eq!(flat_symbols[0].name, "Imports");
+    assert_eq!(flat_symbols[0].container_name, None);
 
-  def method2(self, y):
-    return self.x + y
-"#;
+    assert_eq!(flat_symbols[1].name, "Standard Library");
+    assert_eq!(flat_symbols[1].container_name, Some("Imports".to_owned()));
 
-    let report =
-        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_flat_symbol_report);
-    let uri = lsp_types::Url::parse("file:///main.py").unwrap();
+    assert_eq!(flat_symbols[2].name, "a");
+    assert_eq!(
+        flat_symbols[2].container_name,
+        Some("Imports.Standard Library".to_owned())
+    );
 
-    #[allow(deprecated)]
-    let flat: Vec<lsp_types::SymbolInformation> =
-        serde_json::from_str(&report.split("\n").skip(2).collect::<Vec<_>>().join("\n")).unwrap();
+    assert_eq!(flat_symbols[3].name, "greeting");
+    assert_eq!(
+        flat_symbols[3].container_name,
+        Some("Imports.Standard Library".to_owned())
+    );
 
-    assert_eq!(flat.len(), 4);
+    assert_eq!(flat_symbols[4].name, "Another second level");
+    assert_eq!(flat_symbols[4].container_name, Some("Imports".to_owned()));
 
-    assert_eq!(flat[0].name, "MyClass");
-    assert_eq!(flat[0].container_name, None);
-    assert_eq!(flat[0].location.uri, uri);
+    assert_eq!(flat_symbols[5].name, "Configuration");
+    assert_eq!(flat_symbols[5].container_name, None);
 
-    assert_eq!(flat[1].name, "__init__");
-    assert_eq!(flat[1].container_name, Some("MyClass".to_owned()));
+    assert_eq!(flat_symbols[6].name, "DEBUG");
+    assert_eq!(
+        flat_symbols[6].container_name,
+        Some("Configuration".to_owned())
+    );
 
-    assert_eq!(flat[2].name, "method1");
-    assert_eq!(flat[2].container_name, Some("MyClass".to_owned()));
-
-    assert_eq!(flat[3].name, "method2");
-    assert_eq!(flat[3].container_name, Some("MyClass".to_owned()));
-}
-
-#[test]
-fn test_flatten_deep_nesting() {
-    let code = r#"
-class Outer:
-  class Inner:
-    def foo(self):
-      pass
-"#;
-
-    let report =
-        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_flat_symbol_report);
-    let uri = lsp_types::Url::parse("file:///main.py").unwrap();
-
-    #[allow(deprecated)]
-    let flat: Vec<lsp_types::SymbolInformation> =
-        serde_json::from_str(&report.split("\n").skip(2).collect::<Vec<_>>().join("\n")).unwrap();
-
-    assert_eq!(flat.len(), 3);
-
-    assert_eq!(flat[0].name, "Outer");
-    assert_eq!(flat[0].container_name, None);
-    assert_eq!(flat[0].location.uri, uri);
-
-    assert_eq!(flat[1].name, "Inner");
-    assert_eq!(flat[1].container_name, Some("Outer".to_owned()));
-
-    assert_eq!(flat[2].name, "foo");
-    assert_eq!(flat[2].container_name, Some("Outer.Inner".to_owned()));
-}
-
-#[test]
-fn test_flatten_empty_file() {
-    let code = r#"
-# just a comment, no symbols
-"#;
-
-    let report =
-        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_flat_symbol_report);
-
-    // The report is either "No document symbols found" or an empty JSON array
-    let body = report.split("\n").skip(2).collect::<Vec<_>>().join("\n");
-    if body.trim() != "No document symbols found" {
-        #[allow(deprecated)]
-        let flat: Vec<lsp_types::SymbolInformation> = serde_json::from_str(body.trim()).unwrap();
-        assert!(flat.is_empty());
-    }
+    assert_eq!(flat_symbols[7].name, "b");
+    assert_eq!(
+        flat_symbols[7].container_name,
+        Some("Configuration".to_owned())
+    );
 }


### PR DESCRIPTION
# Summary

Editors like Helix do not declare `hierarchicalDocumentSymbolSupport`
in their client capabilities. Previously pyrefly treated this as a
signal to return nothing, so document symbol search was completely
broken in Helix.

Check the client capability at request time and return a flat
`SymbolInformation` list when hierarchical support is absent, falling
back to the existing nested `DocumentSymbol` response for clients like
VS Code that support it. The flat list is produced by recursively
unwrapping the symbol tree, preserving dotted container names
(e.g. `Outer.Inner`) so clients can still display symbol hierarchy
contextually.

Fixes #2945 

# Test Plan

Added unit tests for `flatten_to_symbol_information` covering:
- Basic class with methods flattened correctly with container_name
- Deep nesting with dotted container names (e.g. Outer.Inner)
- Empty file returns empty list

Run with: cargo test test_flatten
