### PR TITLE
Fix pydantic private attribute handling in field inference

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -2436,6 +2436,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let Some(member) = self.get_non_synthesized_dataclass_member_impl(cls, name) else {
             return DataclassMember::NotAField;
         };
+        let metadata = self.get_metadata_for_class(cls);
+        if metadata.is_pydantic_model() && name.as_str().starts_with('_') {
+            return DataclassMember::NotAField;
+        }
         let field = &*member.value;
         // A field with type KW_ONLY is a sentinel value that indicates that the remaining
         // fields should be keyword-only params in the generated `__init__`.

--- a/pyrefly/lib/test/pydantic/field.rs
+++ b/pyrefly/lib/test/pydantic/field.rs
@@ -224,6 +224,23 @@ A()  # E: Missing argument `x`
 );
 
 pydantic_testcase!(
+    test_private_attributes_not_init_fields,
+    r#"
+from pydantic import BaseModel
+
+class Foo(BaseModel):
+    a: int
+    _a: int
+
+    def initialize(self):
+        self._a = 1
+
+Foo(a=1)
+Foo()  # E: Missing argument `a`
+    "#,
+);
+
+pydantic_testcase!(
     test_field_default_gt_violation,
     r#"
 from pydantic import BaseModel, Field


### PR DESCRIPTION
Problem: _ attributes incorrectly treated as fields
Root cause: field extraction logic does not exclude private attributes
Fix: add rule to exclude attributes starting with _
Testing: cargo test + reproduction verified fixed

Closes #3544