### PR TITLE
Add safe mode recovery for sandbox crashes

### DIFF
--- a/website/src/pages/sandbox.tsx
+++ b/website/src/pages/sandbox.tsx
@@ -12,6 +12,7 @@ import BrowserOnly from '@docusaurus/BrowserOnly';
 import Layout from '@theme/Layout';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import * as stylex from '@stylexjs/stylex';
+import { enableSandboxSafeMode } from '../sandbox/safeMode';
 
 const Sandbox = React.lazy(() => import('../sandbox/Sandbox'));
 
@@ -43,13 +44,79 @@ export default function SandboxPage(): JSX.Element {
                     <BrowserOnly>
                         {() => (
                             <React.Suspense fallback={<div>Loading...</div>}>
-                                <Sandbox sampleFilename={SANDBOX_FILE_NAME} />
+                                <SandboxErrorBoundary>
+                                    <Sandbox
+                                        sampleFilename={SANDBOX_FILE_NAME}
+                                    />
+                                </SandboxErrorBoundary>
                             </React.Suspense>
                         )}
                     </BrowserOnly>
                 )
             }
         </Layout>
+    );
+}
+
+class SandboxErrorBoundary extends React.Component<
+    { children: React.ReactNode },
+    { error: Error | null }
+> {
+    state: { error: Error | null } = { error: null };
+
+    componentDidCatch(error: Error): void {
+        this.setState({ error });
+    }
+
+    render(): React.ReactNode {
+        if (this.state.error) {
+            return (
+                <SandboxCrashFallback
+                    error={this.state.error}
+                    tryAgain={() => this.setState({ error: null })}
+                />
+            );
+        }
+        return this.props.children;
+    }
+}
+
+function SandboxCrashFallback({
+    error,
+    tryAgain,
+}: {
+    error: Error;
+    tryAgain: () => void;
+}): JSX.Element {
+    return (
+        <main {...stylex.props(styles.crashContainer)}>
+            <h1 {...stylex.props(styles.crashTitle)}>The sandbox crashed.</h1>
+            <p {...stylex.props(styles.crashText)}>
+                Try again keeps your files and reruns the sandbox. Safe mode
+                keeps your files but pauses Pyrefly type checking so you can
+                edit the code that triggered the crash.
+            </p>
+            <div {...stylex.props(styles.crashActions)}>
+                <button
+                    type="button"
+                    {...stylex.props(styles.primaryButton)}
+                    onClick={tryAgain}
+                >
+                    Try again
+                </button>
+                <button
+                    type="button"
+                    {...stylex.props(styles.secondaryButton)}
+                    onClick={() => {
+                        enableSandboxSafeMode();
+                        tryAgain();
+                    }}
+                >
+                    Open in safe mode
+                </button>
+            </div>
+            <pre {...stylex.props(styles.crashError)}>{String(error)}</pre>
+        </main>
     );
 }
 
@@ -62,5 +129,51 @@ const styles = stylex.create({
     hyperlink: {
         textDecoration: 'underline',
         color: '#337ab7',
+    },
+    crashContainer: {
+        margin: '48px auto',
+        maxWidth: '720px',
+        padding: '0 20px',
+    },
+    crashTitle: {
+        fontSize: '32px',
+        marginBottom: '12px',
+    },
+    crashText: {
+        fontSize: '16px',
+        lineHeight: 1.5,
+        marginBottom: '20px',
+    },
+    crashActions: {
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '12px',
+        marginBottom: '24px',
+    },
+    primaryButton: {
+        background: 'var(--ifm-color-primary)',
+        border: '1px solid var(--ifm-color-primary)',
+        borderRadius: '4px',
+        color: '#fff',
+        cursor: 'pointer',
+        fontWeight: 600,
+        padding: '10px 16px',
+    },
+    secondaryButton: {
+        background: 'var(--ifm-background-color)',
+        border: '1px solid var(--ifm-color-primary)',
+        borderRadius: '4px',
+        color: 'var(--ifm-color-primary)',
+        cursor: 'pointer',
+        fontWeight: 600,
+        padding: '10px 16px',
+    },
+    crashError: {
+        background: 'var(--ifm-code-background)',
+        borderRadius: '4px',
+        fontSize: '12px',
+        overflow: 'auto',
+        padding: '12px',
+        whiteSpace: 'pre-wrap',
     },
 });

--- a/website/src/sandbox/Sandbox.tsx
+++ b/website/src/sandbox/Sandbox.tsx
@@ -39,6 +39,7 @@ import { editor } from 'monaco-editor';
 import type { PyreflyErrorMessage } from './SandboxResults';
 import { DEFAULT_SANDBOX_PROGRAM } from './DefaultSandboxProgram';
 import { usePythonWorker } from './usePythonWorker';
+import { disableSandboxSafeMode, isSandboxSafeModeEnabled } from './safeMode';
 
 // Import type for Pyrefly State
 export interface PyreflyState {
@@ -119,6 +120,7 @@ export default function Sandbox({
     const [activeTab, setActiveTab] = useState<string>('errors');
     const [isHovered, setIsHovered] = useState(false);
     const [pythonVersion, setPythonVersion] = useState('3.12');
+    const [safeMode, setSafeMode] = useState(isSandboxSafeModeEnabled);
     // Absolute pixel height for the editor pane (null = not yet initialized)
     const [editorHeight, setEditorHeight] = useState<number | null>(null);
     const [isResizing, setIsResizing] = useState(false);
@@ -641,6 +643,14 @@ export default function Sandbox({
             return;
         }
 
+        if (safeMode) {
+            setLoading(false);
+            setPyreService(null);
+            setInternalError('');
+            setErrors([]);
+            return;
+        }
+
         setLoading(true);
         // Initialize the WebAssembly module only when the component is mounted
         if (!pyreflyWasmInitializedPromise) {
@@ -664,7 +674,7 @@ export default function Sandbox({
                 setLoading(false);
                 setInternalError(JSON.stringify(e));
             });
-    }, [isInViewport, pythonVersion]); // Re-run when isInViewport or pythonVersion changes
+    }, [isInViewport, pythonVersion, safeMode]); // Re-run when isInViewport, pythonVersion, or safeMode changes
 
     // Need to add createModel handler in case monaco model was not created at mount time
     monaco.editor.onDidCreateModel((_newModel) => {
@@ -719,6 +729,23 @@ export default function Sandbox({
     }, [models.size, pyreService, model, activeFileName]);
 
     function forceRecheck() {
+        if (safeMode) {
+            if (model !== null) {
+                setAutoCompleteFunction(model, () => []);
+                setGetDefFunction(model, () => null);
+                setHoverFunctionForMonaco(model, () => null);
+                setInlayHintFunctionForMonaco(model, () => []);
+                setSemanticTokensFunctionForMonaco(model, () => null);
+                setSemanticTokensLegendForMonaco(() => ({
+                    tokenTypes: [],
+                    tokenModifiers: [],
+                }));
+            }
+            setLoading(false);
+            setInternalError('');
+            setErrors([]);
+            return;
+        }
         if (model == null || pyreService == null) return;
 
         setAutoCompleteFunction(model, (l: number, c: number) =>
@@ -897,6 +924,12 @@ export default function Sandbox({
         setActiveFileName
     );
 
+    const resumeTypeChecking = () => {
+        disableSandboxSafeMode();
+        setSafeMode(false);
+        setLoading(true);
+    };
+
     // Calculate heights based on stored editor height (only used in sandbox mode)
     // Uses stored pixel value to avoid recalculation on every render
     const getSandboxEditorHeight = () => {
@@ -931,6 +964,21 @@ export default function Sandbox({
                 !isCodeSnippet && !isMobile() && styles.sandboxPadding
             )}
         >
+            {safeMode && !isCodeSnippet && (
+                <div {...stylex.props(styles.safeModeBanner)}>
+                    <span>
+                        Type checking is paused so you can edit the code that
+                        crashed the sandbox.
+                    </span>
+                    <button
+                        type="button"
+                        {...stylex.props(styles.safeModeButton)}
+                        onClick={resumeTypeChecking}
+                    >
+                        Resume type checking
+                    </button>
+                </div>
+            )}
             {!isCodeSnippet && <TabBar />}
             <div
                 ref={sandboxContainerRef}
@@ -997,6 +1045,7 @@ export default function Sandbox({
                             pyodideStatus={pyodideStatus}
                             activeTab={activeTab}
                             setActiveTab={setActiveTab}
+                            typeCheckingPaused={safeMode}
                             height={getResultsHeight()}
                         />
                     </>
@@ -1536,6 +1585,26 @@ const styles = stylex.create({
     },
     sandboxPadding: {
         paddingHorizontal: '10px',
+    },
+    safeModeBanner: {
+        alignItems: 'center',
+        background: 'var(--ifm-alert-background-color-highlight)',
+        border: '1px solid var(--ifm-color-warning-dark)',
+        color: 'var(--ifm-font-color-base)',
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '10px',
+        justifyContent: 'space-between',
+        padding: '10px 14px',
+    },
+    safeModeButton: {
+        background: 'var(--ifm-color-primary)',
+        border: '1px solid var(--ifm-color-primary)',
+        borderRadius: '4px',
+        color: '#fff',
+        cursor: 'pointer',
+        fontWeight: 600,
+        padding: '6px 10px',
     },
     codeEditorContainer: {
         position: 'relative',

--- a/website/src/sandbox/SandboxResults.tsx
+++ b/website/src/sandbox/SandboxResults.tsx
@@ -45,6 +45,7 @@ interface SandboxResultsProps {
     pyodideStatus: PyodideStatus;
     activeTab: string;
     setActiveTab: (tab: string) => void;
+    typeCheckingPaused?: boolean;
     height?: number; // Dynamic height in pixels (from resizable splitter)
 }
 
@@ -134,12 +135,22 @@ export default function SandboxResults({
     pyodideStatus,
     activeTab,
     setActiveTab = () => {},
+    typeCheckingPaused = false,
     height,
 }: SandboxResultsProps): React.ReactElement {
     const activeToolbarTab = activeTab;
 
     const hasTypecheckErrors =
         errors !== undefined && errors !== null && errors.length > 0;
+    const emptyErrorsMessage = typeCheckingPaused
+        ? 'Type checking is paused in safe mode.'
+        : internalError
+          ? `Pyrefly encountered an internal error: ${internalError}.`
+          : errors === undefined || errors === null
+            ? 'Pyrefly failed to fetch errors.'
+            : errors?.length === 0
+              ? 'No errors!'
+              : null;
 
     // Use dynamic height if provided, otherwise fall back to default CSS
     const containerStyle = height ? { height: `${height}px` } : undefined;
@@ -196,16 +207,7 @@ export default function SandboxResults({
                                         </li>
                                     ))
                             ) : (
-                                <li>
-                                    {internalError
-                                        ? `Pyrefly encountered an internal error: ${internalError}.`
-                                        : errors === undefined ||
-                                            errors === null
-                                          ? 'Pyrefly failed to fetch errors.'
-                                          : errors?.length === 0
-                                            ? 'No errors!'
-                                            : null}
-                                </li>
+                                <li>{emptyErrorsMessage}</li>
                             )}
                         </ul>
                     </pre>

--- a/website/src/sandbox/safeMode.ts
+++ b/website/src/sandbox/safeMode.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+export const SANDBOX_SAFE_MODE_SESSION_STORAGE_KEY =
+    'pyrefly-sandbox-safe-mode';
+
+export function isSandboxSafeModeEnabled(): boolean {
+    if (typeof window === 'undefined') {
+        return false;
+    }
+    return (
+        window.sessionStorage.getItem(SANDBOX_SAFE_MODE_SESSION_STORAGE_KEY) ===
+        '1'
+    );
+}
+
+export function enableSandboxSafeMode(): void {
+    window.sessionStorage.setItem(SANDBOX_SAFE_MODE_SESSION_STORAGE_KEY, '1');
+}
+
+export function disableSandboxSafeMode(): void {
+    window.sessionStorage.removeItem(SANDBOX_SAFE_MODE_SESSION_STORAGE_KEY);
+}


### PR DESCRIPTION
## Summary
Quick follow up from #3539 regarding sandbox crashes, vibed coded a crash helmet called "safe mode"
- add a sandbox-specific crash fallback with a safe-mode recovery button
- preserve the user's sandbox files while safe mode pauses wasm-backed type checking
- add a resume action and results-panel messaging for paused type checking

## Test Plan
- yarn test sandbox --runInBand
- python3 test.py --no-test --no-conformance --no-jsonschema
- built and served the production website locally with the generated wasm artifacts

https://github.com/user-attachments/assets/55f89b99-69c6-4562-949b-5d358f9fe4b0

