### PR TITLE
fix cached_property overriding unannotated class variable #3062

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -4537,9 +4537,49 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 got_is_classvar,
             }));
         }
+        let cached_property_value_type = |getter: &Type| {
+            let ty = getter
+                .callable_return_type(self.heap)
+                .expect("cached_property getter should have a callable return type");
+            if getter.visit_toplevel_func_metadata(&|meta| meta.flags.is_return_inferred) {
+                ty.promote_implicit_literals(self.stdlib)
+            } else {
+                ty
+            }
+        };
         match (got, want) {
             (_, ClassAttribute::NoAccess(_)) | (ClassAttribute::NoAccess(_), _) => {
                 unreachable!("handled above")
+            }
+            (ClassAttribute::Property(got_getter, None, _), ClassAttribute::ReadWrite(want))
+                if got_getter.is_cached_property() =>
+            {
+                let got = cached_property_value_type(got_getter);
+                let subset_error = is_subset(&got, want)
+                    .map_or_else(Some, |_| is_subset(want, &got).map_or_else(Some, |_| None));
+                if let Some(subset_error) = subset_error {
+                    Err(Box::new(AttrSubsetError::Invariant {
+                        got,
+                        want: want.clone(),
+                        subset_error,
+                    }))
+                } else {
+                    Ok(())
+                }
+            }
+            (ClassAttribute::Property(got_getter, None, _), ClassAttribute::ReadOnly(want, _))
+                if got_getter.is_cached_property() =>
+            {
+                let got = cached_property_value_type(got_getter);
+                is_subset(&got, want).map_err(|subset_error| {
+                    Box::new(AttrSubsetError::Covariant {
+                        got,
+                        want: want.clone(),
+                        got_is_property: true,
+                        want_is_property: false,
+                        subset_error,
+                    })
+                })
             }
             (
                 ClassAttribute::Property(_, _, _),

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -5574,6 +5574,19 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         };
         let got_is_classvar = is_classvar_compatible(got);
         let want_is_classvar = is_classvar_compatible(want);
+        let cached_property_value_type = |getter: &Type| {
+            let ty = getter
+                .callable_return_type(self.heap)
+                .expect("cached_property getter should have a callable return type");
+            if getter
+                .toplevel_func_metadata()
+                .is_some_and(|meta| meta.flags.is_return_inferred)
+            {
+                ty.promote_implicit_literals(self.stdlib)
+            } else {
+                ty
+            }
+        };
         match (got, want) {
             (_, ClassAttribute::NoAccess(_)) => Ok(()),
             (ClassAttribute::NoAccess(_), _) => Err(Box::new(AttrSubsetError::NoAccess)),
@@ -5625,6 +5638,40 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 is_subset(want, &setter_value_type).map_err(|subset_error| {
                     Box::new(AttrSubsetError::Contravariant {
                         got: got_setter.clone(),
+                        want: want.clone(),
+                        got_is_property: true,
+                        want_is_property: false,
+                        subset_error,
+                    })
+                })
+            }
+            (ClassAttribute::Property(got_getter, None, _), ClassAttribute::ReadWrite(want))
+                if got_getter
+                    .toplevel_func_metadata()
+                    .is_some_and(|meta| meta.flags.is_cached_property) =>
+            {
+                let got = cached_property_value_type(got_getter);
+                let subset_error = is_subset(&got, want)
+                    .map_or_else(Some, |_| is_subset(want, &got).map_or_else(Some, |_| None));
+                if let Some(subset_error) = subset_error {
+                    Err(Box::new(AttrSubsetError::Invariant {
+                        got,
+                        want: want.clone(),
+                        subset_error,
+                    }))
+                } else {
+                    Ok(())
+                }
+            }
+            (ClassAttribute::Property(got_getter, None, _), ClassAttribute::ReadOnly(want, _))
+                if got_getter
+                    .toplevel_func_metadata()
+                    .is_some_and(|meta| meta.flags.is_cached_property) =>
+            {
+                let got = cached_property_value_type(got_getter);
+                is_subset(&got, want).map_err(|subset_error| {
+                    Box::new(AttrSubsetError::Covariant {
+                        got,
                         want: want.clone(),
                         got_is_property: true,
                         want_is_property: false,

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -698,6 +698,30 @@ class B(A):
     "#,
 );
 
+// Regression test for https://github.com/facebook/pyrefly/issues/3062
+testcase!(
+    test_cached_property_overrides_unannotated_class_variable,
+    r#"
+from functools import cached_property
+
+class BaseDatabaseFeatures:
+    can_introspect_fk = True
+    update_can_self_select = True
+
+class MySQLFeatures(BaseDatabaseFeatures):
+    @cached_property
+    def can_introspect_fk(self):
+        return self._check()
+
+    @cached_property
+    def update_can_self_select(self):
+        return True
+
+    def _check(self) -> bool:
+        return False
+    "#,
+);
+
 testcase!(
     test_inherit_type_attribute,
     r#"

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -783,6 +783,30 @@ class B(A):
     "#,
 );
 
+// Regression test for https://github.com/facebook/pyrefly/issues/3062
+testcase!(
+    test_cached_property_overrides_unannotated_class_variable,
+    r#"
+from functools import cached_property
+
+class BaseDatabaseFeatures:
+    can_introspect_fk = True
+    update_can_self_select = True
+
+class MySQLFeatures(BaseDatabaseFeatures):
+    @cached_property
+    def can_introspect_fk(self):
+        return self._check()
+
+    @cached_property
+    def update_can_self_select(self):
+        return True
+
+    def _check(self) -> bool:
+        return False
+    "#,
+);
+
 testcase!(
     test_inherit_type_attribute,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3062

cached properties are now treated as writable for override consistency, using the getter return type and promoting inferred literal returns like return True to match class-variable inference.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test