### PR TITLE
fix pydantic - Strict types are not treated as strict mode #3543

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1573,6 +1573,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 ..
             } => {
                 let mut direct_annotation = annot.map(|a| self.get_idx(a).annotation.clone());
+                let mut annotation_flags = annot.and_then(|annot| {
+                    self.extract_pydantic_field_from_annotation(annot, name, &metadata)
+                });
                 if metadata.is_protocol()
                     && direct_annotation.is_none()
                     && !is_dunder(name.as_str())
@@ -1627,6 +1630,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         direct_annotation.as_ref().and_then(|a| a.ty.as_ref()),
                         dm,
                     );
+                    if let Some(f) = &mut flags
+                        && let Some(annotation_flags) = annotation_flags.as_ref()
+                        && f.strict.is_none()
+                    {
+                        f.strict = annotation_flags.strict;
+                    }
                     if flags.is_some() {
                         // A field specifier with no type annotation is a definition-time error,
                         // except under classic attrs (`auto_attribs=False`), where an unannotated
@@ -1720,7 +1729,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         f.converter_param =
                             Some(self.attrs_converter_decorator_param(method_range));
                     }
-                    ClassFieldInitialization::ClassBody(flags.map(Box::new))
+                    if let Some(flags) = flags {
+                        ClassFieldInitialization::ClassBody(Some(Box::new(flags)))
+                    } else if let Some(mut flags) = annotation_flags.take() {
+                        flags.default = Some(self.heap.mk_any_implicit());
+                        ClassFieldInitialization::ClassBody(Some(Box::new(flags)))
+                    } else {
+                        ClassFieldInitialization::ClassBody(None)
+                    }
+                } else if let Some(mut flags) = annotation_flags.take() {
+                    flags.default = Some(self.heap.mk_any_implicit());
+                    ClassFieldInitialization::ClassBody(Some(Box::new(flags)))
                 } else {
                     ClassFieldInitialization::ClassBody(None)
                 };

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1640,6 +1640,9 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 ..
             } => {
                 let mut direct_annotation = annot.map(|a| self.get_idx(a).annotation.clone());
+                let mut annotation_flags = annot.and_then(|annot| {
+                    self.extract_pydantic_field_from_annotation(annot, name, &metadata)
+                });
                 if metadata.is_protocol()
                     && direct_annotation.is_none()
                     && !is_dunder(name.as_str())
@@ -1694,6 +1697,12 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                         direct_annotation.as_ref().and_then(|a| a.ty.as_ref()),
                         dm,
                     );
+                    if let Some(f) = &mut flags
+                        && let Some(annotation_flags) = annotation_flags.as_ref()
+                        && f.strict.is_none()
+                    {
+                        f.strict = annotation_flags.strict;
+                    }
                     if flags.is_some() {
                         // A field specifier with no type annotation is a definition-time error,
                         // except under classic attrs (`auto_attribs=False`), where an unannotated
@@ -1774,7 +1783,17 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                         f.converter_param =
                             Some(self.attrs_converter_decorator_param(method_range));
                     }
-                    ClassFieldInitialization::ClassBody(flags.map(Box::new))
+                    if let Some(flags) = flags {
+                        ClassFieldInitialization::ClassBody(Some(Box::new(flags)))
+                    } else if let Some(mut flags) = annotation_flags.take() {
+                        flags.default = Some(self.heap.mk_any_implicit());
+                        ClassFieldInitialization::ClassBody(Some(Box::new(flags)))
+                    } else {
+                        ClassFieldInitialization::ClassBody(None)
+                    }
+                } else if let Some(mut flags) = annotation_flags.take() {
+                    flags.default = Some(self.heap.mk_any_implicit());
+                    ClassFieldInitialization::ClassBody(Some(Box::new(flags)))
                 } else {
                     ClassFieldInitialization::ClassBody(None)
                 };

--- a/pyrefly/lib/alt/class/pydantic.rs
+++ b/pyrefly/lib/alt/class/pydantic.rs
@@ -175,6 +175,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
+    pub fn is_pydantic_strict_type_alias(&self, ty: &Type) -> bool {
+        if let Type::TypeAlias(ta) = ty {
+            let alias = self.get_type_alias(ta);
+            if let Type::Annotated(_, metadata) = alias.as_type() {
+                return metadata
+                    .iter()
+                    .any(|metadata| self.is_pydantic_strict_metadata(metadata));
+            }
+        }
+        false
+    }
+
     /// Helper function to find inherited keyword values from parent pydantic model metadata.
     /// Only inherits from parents that are themselves pydantic models, not from arbitrary
     /// dataclass parents whose config values (e.g. strict) may have different defaults.
@@ -567,6 +579,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             return None;
         }
         if let BindingAnnotation::AnnotateExpr(_, annotation_expr, _) = self.bindings().get(annot) {
+            let mut keywords = None;
             let metadata_items = self.get_annotated_metadata(
                 annotation_expr,
                 TypeFormContext::ClassVarAnnotation,
@@ -575,12 +588,28 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             // Look through metadata items and find a Field(...) call, then extract its keywords
             for metadata_item in &metadata_items {
                 if let Expr::Call(call) = metadata_item
-                    && let Some(keywords) =
+                    && let Some(field_keywords) =
                         self.compute_dataclass_field_initialization(call, field_name, None, dm)
                 {
-                    return Some(keywords);
+                    keywords = Some(field_keywords);
+                    break;
                 }
             }
+            let errors = self.error_swallower();
+            let has_strict_metadata = metadata_items.iter().any(|metadata| {
+                self.is_pydantic_strict_metadata(&self.expr_infer(metadata, &errors))
+            }) || self
+                .is_pydantic_strict_type_alias(&self.expr_infer(annotation_expr, &errors));
+            if has_strict_metadata
+                && keywords
+                    .as_ref()
+                    .is_none_or(|keywords| keywords.strict.is_none())
+            {
+                keywords
+                    .get_or_insert_with(DataclassFieldKeywords::new)
+                    .strict = Some(true);
+            }
+            return keywords;
         }
         None
     }

--- a/pyrefly/lib/alt/class/pydantic.rs
+++ b/pyrefly/lib/alt/class/pydantic.rs
@@ -183,6 +183,18 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         }
     }
 
+    pub fn is_pydantic_strict_type_alias(&self, ty: &Type) -> bool {
+        if let Type::TypeAlias(ta) = ty {
+            let alias = self.get_type_alias(ta);
+            if let Type::Annotated(_, metadata) = alias.as_type() {
+                return metadata
+                    .iter()
+                    .any(|metadata| self.is_pydantic_strict_metadata(metadata));
+            }
+        }
+        false
+    }
+
     /// Helper function to find inherited keyword values from parent pydantic model metadata.
     /// Only inherits from parents that are themselves pydantic models, not from arbitrary
     /// dataclass parents whose config values (e.g. strict) may have different defaults.
@@ -636,6 +648,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             return None;
         }
         if let BindingAnnotation::AnnotateExpr(_, annotation_expr, _) = self.bindings().get(annot) {
+            let mut keywords = None;
             let metadata_items = self.get_annotated_metadata(
                 annotation_expr,
                 TypeFormContext::ClassVarAnnotation,
@@ -644,12 +657,28 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             // Look through metadata items and find a Field(...) call, then extract its keywords
             for metadata_item in &metadata_items {
                 if let Expr::Call(call) = metadata_item
-                    && let Some(keywords) =
+                    && let Some(field_keywords) =
                         self.compute_dataclass_field_initialization(call, field_name, None, dm)
                 {
-                    return Some(keywords);
+                    keywords = Some(field_keywords);
+                    break;
                 }
             }
+            let errors = self.error_swallower();
+            let has_strict_metadata = metadata_items.iter().any(|metadata| {
+                self.is_pydantic_strict_metadata(&self.expr_infer(metadata, &errors))
+            }) || self
+                .is_pydantic_strict_type_alias(&self.expr_infer(annotation_expr, &errors));
+            if has_strict_metadata
+                && keywords
+                    .as_ref()
+                    .is_none_or(|keywords| keywords.strict.is_none())
+            {
+                keywords
+                    .get_or_insert_with(DataclassFieldKeywords::new)
+                    .strict = Some(true);
+            }
+            return keywords;
         }
         None
     }

--- a/pyrefly/lib/alt/types/class_bases.rs
+++ b/pyrefly/lib/alt/types/class_bases.rs
@@ -203,18 +203,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
-    fn is_type_alias_with_pydantic_strict_metadata(&self, ty: &Type) -> bool {
-        if let Type::TypeAlias(ta) = ty {
-            let alias = self.get_type_alias(ta);
-            if let Type::Annotated(_, metadata) = alias.as_type() {
-                return metadata
-                    .iter()
-                    .any(|metadata| self.is_pydantic_strict_metadata(metadata));
-            }
-        }
-        false
-    }
-
     /// Get the untyped form (in other words, the instance type, after applying
     /// any type arguments) for a base class.
     ///
@@ -229,7 +217,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let range = base_expr.range();
         let (inferred_ty, has_strict_from_infer) = self.base_class_expr_infer(base_expr, errors);
         let has_pydantic_strict_metadata =
-            self.is_type_alias_with_pydantic_strict_metadata(&inferred_ty) || has_strict_from_infer;
+            self.is_pydantic_strict_type_alias(&inferred_ty) || has_strict_from_infer;
         let ty = self.untype(inferred_ty, range, errors);
         (
             self.validate_type_form(ty, range, type_form_context, errors),

--- a/pyrefly/lib/alt/types/class_bases.rs
+++ b/pyrefly/lib/alt/types/class_bases.rs
@@ -221,18 +221,6 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         }
     }
 
-    fn is_type_alias_with_pydantic_strict_metadata(&self, ty: &Type) -> bool {
-        if let Type::TypeAlias(ta) = ty {
-            let alias = self.get_type_alias(ta);
-            if let Type::Annotated(_, metadata) = alias.as_type() {
-                return metadata
-                    .iter()
-                    .any(|metadata| self.is_pydantic_strict_metadata(metadata));
-            }
-        }
-        false
-    }
-
     /// Get the untyped form (in other words, the instance type, after applying
     /// any type arguments) for a base class.
     ///
@@ -246,9 +234,8 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     ) -> (Type, bool) {
         let range = base_expr.range();
         let (inferred_ty, has_strict_from_infer) = self.base_class_expr_infer(base_expr, errors);
-        let has_pydantic_strict_metadata = self
-            .is_type_alias_with_pydantic_strict_metadata(inferred_ty.ty())
-            || has_strict_from_infer;
+        let has_pydantic_strict_metadata =
+            self.is_pydantic_strict_type_alias(inferred_ty.ty()) || has_strict_from_infer;
         let ty = self.untype(inferred_ty.into_ty(), range, errors);
         (
             self.validate_type_form(ty, range, type_form_context, errors),

--- a/pyrefly/lib/test/pydantic/strictness.rs
+++ b/pyrefly/lib/test/pydantic/strictness.rs
@@ -33,6 +33,22 @@ Model(x='0', y='1') # E: Argument `Literal['1']` is not assignable to parameter 
 );
 
 pydantic_testcase!(
+    test_strict_annotated_types,
+    r#"
+from typing import Annotated
+from pydantic import BaseModel, Strict, StrictInt
+
+class Model(BaseModel):
+    x: StrictInt = 1
+    y: Annotated[int, Strict()]
+
+Model(x=1, y=1)
+Model(x='1', y=1)  # E: Argument `Literal['1']` is not assignable to parameter `x`
+Model(x=1, y='1')  # E: Argument `Literal['1']` is not assignable to parameter `y`
+    "#,
+);
+
+pydantic_testcase!(
     test_class_keyword,
     r#"
 from pydantic import BaseModel, Field


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3543

detects Pydantic Strict metadata on Annotated aliases like StrictInt, then carries that metadata into per-field strict flags, including assigned defaults.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test