### PR TITLE
fix: improve decorator error messages for injected parameter mismatches

### DIFF
--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -736,7 +736,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         .forall(tparams);
         ty = self.move_return_tparams_of_type(ty);
         for (x, range) in def.decorators.iter().rev() {
-            ty = self.apply_function_decorator(x.clone(), ty, &def.metadata, *range, errors);
+            ty = self.apply_function_decorator(
+                x.clone(),
+                ty,
+                &def.metadata,
+                &stmt.name,
+                *range,
+                errors,
+            );
         }
         Arc::new(ty)
     }
@@ -1596,11 +1603,53 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
+    fn decorator_missing_injected_parameter_message(
+        &self,
+        decorator: &Type,
+        decoratee_name: &Identifier,
+        decoratee: &Type,
+    ) -> Option<String> {
+        let decorator_name = decorator
+            .visit_toplevel_func_metadata(&|meta| Some(meta.kind.function_name().to_string()))?;
+        let expected_decoratee = decorator.callable_first_param(self.heap)?;
+        let expected_signature = expected_decoratee
+            .callable_signatures()
+            .into_iter()
+            .find(|signature| {
+                matches!(&signature.params, Params::ParamSpec(prefix, _) if !prefix.is_empty())
+            })?;
+
+        let actual_signature = match decoratee {
+            Type::Function(func) => &func.signature,
+            Type::Callable(callable) => callable.as_ref(),
+            _ => return None,
+        };
+
+        let Params::ParamSpec(prefix, _) = &expected_signature.params else {
+            return None;
+        };
+        let Params::List(actual_params) = &actual_signature.params else {
+            return None;
+        };
+        if actual_params.len() + 1 != prefix.len() {
+            return None;
+        }
+
+        let missing = prefix.get(actual_params.len())?;
+        Some(format!(
+            "Function `{}` is missing required parameter of type `{}` injected by decorator `{}`",
+            decoratee_name.as_str(),
+            self.for_display(missing.ty().clone()),
+            decorator_name,
+        ))
+    }
+
     fn apply_function_decorator(
         &self,
         decorator: Type,
         decoratee: Type,
         metadata: &FuncMetadata,
+        decoratee_name: &Identifier,
         range: TextRange,
         errors: &ErrorCollector,
     ) -> Type {
@@ -1610,6 +1659,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         {
             return decoratee;
         }
+        let decorator_for_message = decorator.clone();
         let application = self.prepare_decorator_application(decorator, decoratee, range, errors);
         // Run a decorator call, buffering errors so we can decide between the primary
         // and Self-rewritten fallback without double-reporting.
@@ -1638,6 +1688,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             && fallback_errors.is_empty()
         {
             fallback_return
+        } else if let Some(message) = self.decorator_missing_injected_parameter_message(
+            &decorator_for_message,
+            decoratee_name,
+            &application.decoratee_arg,
+        ) {
+            self.error(
+                errors,
+                decoratee_name.range(),
+                ErrorKind::InvalidDecorator,
+                message,
+            )
         } else {
             errors.extend(primary_errors);
             primary_return

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -1636,10 +1636,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
 
         let missing = prefix.get(actual_params.len())?;
+        let missing_ty = match missing {
+            PrefixParam::PosOnly(_, ty, Required::Required)
+            | PrefixParam::Pos(_, ty, Required::Required) => ty,
+            PrefixParam::PosOnly(_, _, Required::Optional(_))
+            | PrefixParam::Pos(_, _, Required::Optional(_)) => return None,
+        };
         Some(format!(
             "Function `{}` is missing required parameter of type `{}` injected by decorator `{}`",
             decoratee_name.as_str(),
-            self.for_display(missing.ty().clone()),
+            self.for_display(missing_ty.clone()),
             decorator_name,
         ))
     }

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -1643,7 +1643,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             | PrefixParam::Pos(_, _, Required::Optional(_)) => return None,
         };
         Some(format!(
-            "Function `{}` is missing required parameter of type `{}` injected by decorator `{}`",
+            "Function `{}` is missing parameter of type `{}` injected by decorator `{}`",
             decoratee_name.as_str(),
             self.for_display(missing_ty.clone()),
             decorator_name,

--- a/pyrefly/lib/test/decorators.rs
+++ b/pyrefly/lib/test/decorators.rs
@@ -420,6 +420,23 @@ g(f)
 );
 
 testcase!(
+    test_decorator_missing_injected_parameter,
+    r#"
+from typing import Callable, Concatenate
+
+def with_current_tenant_id[T, **P, R](
+    view: Callable[Concatenate[T, str, P], R],
+) -> Callable[Concatenate[T, P], R]:
+    ...
+
+class Foo:
+    @with_current_tenant_id
+    def get(self) -> int:  # E: Function `get` is missing required parameter of type `str` injected by decorator `with_current_tenant_id`
+        return 0
+    "#,
+);
+
+testcase!(
     bug = "This error message is confusing, I think we need to be clearer when we are printing the *type* of an argument",
     test_decorator_error_message,
     r#"

--- a/pyrefly/lib/test/decorators.rs
+++ b/pyrefly/lib/test/decorators.rs
@@ -431,7 +431,7 @@ def with_current_tenant_id[T, **P, R](
 
 class Foo:
     @with_current_tenant_id
-    def get(self) -> int:  # E: Function `get` is missing required parameter of type `str` injected by decorator `with_current_tenant_id`
+    def get(self) -> int:  # E: Function `get` is missing parameter of type `str` injected by decorator `with_current_tenant_id`
         return 0
     "#,
 );


### PR DESCRIPTION
This improves decorator-related diagnostics when a `Callable[Concatenate[..., ...]]` decorator injects a parameter into the wrapped function.

Before, the checker surfaced a low-level callable mismatch such as:

`Argument (self: Self@ExternalApiTemplateListApi) -> ... is not assignable to parameter view with type (@_, str, ParamSpec(@_)) -> @_ in function with_current_tenant_id`

After this change, the same case reports a function-level diagnostic that points to the wrapped function:

`Function \`get\` is missing required parameter of type \`str\` injected by decorator \`with_current_tenant_id\``

This keeps ParamSpec / Concatenate semantics unchanged and only improves the diagnostic layer for decorator application.

Fixes #3569