### PR TITLE
Fix if-branch pruning for Final bool constants

### DIFF
--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -69,6 +69,7 @@ use crate::binding::expr::Usage;
 use crate::binding::scope::FlowStyle;
 use crate::binding::scope::InstanceAttribute;
 use crate::binding::scope::Scope;
+use crate::binding::scope::Scopes;
 use crate::binding::scope::UnusedParameter;
 use crate::binding::scope::UnusedVariable;
 use crate::binding::scope::YieldsAndReturns;
@@ -399,7 +400,7 @@ impl<'a> BindingsBuilder<'a> {
     /// it relies on that binding to ensure we don't have a dangling `Idx<Key>` (which could lead
     /// to a panic).
     fn implicit_return(&mut self, body: &[Stmt], func_name: &Identifier) -> Idx<Key> {
-        let last_exprs = function_last_expressions(body, self.sys_info).map(|x| {
+        let last_exprs = function_last_expressions(body, self.sys_info, &self.scopes).map(|x| {
             x.into_map(|(last, x)| {
                 (
                     last.clone(),
@@ -965,8 +966,14 @@ impl<'a> BindingsBuilder<'a> {
 fn function_last_expressions<'a>(
     x: &'a [Stmt],
     sys_info: SysInfo,
+    scopes: &Scopes,
 ) -> Option<Vec<(LastStmt, &'a Expr)>> {
-    fn f<'a>(sys_info: SysInfo, x: &'a [Stmt], res: &mut Vec<(LastStmt, &'a Expr)>) -> Option<()> {
+    fn f<'a>(
+        sys_info: SysInfo,
+        scopes: &Scopes,
+        x: &'a [Stmt],
+        res: &mut Vec<(LastStmt, &'a Expr)>,
+    ) -> Option<()> {
         fn loop_body_has_break_statement(statement: &Stmt, has_break: &mut bool) {
             match statement {
                 Stmt::Break(_) => {
@@ -987,7 +994,7 @@ fn function_last_expressions<'a>(
                 for y in &x.items {
                     res.push((LastStmt::With(kind), &y.context_expr));
                 }
-                f(sys_info, &x.body, res)?;
+                f(sys_info, scopes, &x.body, res)?;
             }
             Stmt::While(x) => {
                 let test_value = sys_info.evaluate_bool(&x.test);
@@ -1002,7 +1009,7 @@ fn function_last_expressions<'a>(
                 } else if has_break || x.orelse.is_empty() {
                     return None;
                 } else {
-                    f(sys_info, &x.orelse, res)?;
+                    f(sys_info, scopes, &x.orelse, res)?;
                 }
             }
             Stmt::For(x) => {
@@ -1012,15 +1019,33 @@ fn function_last_expressions<'a>(
                 if has_break || x.orelse.is_empty() {
                     return None;
                 }
-                f(sys_info, &x.orelse, res)?;
+                f(sys_info, scopes, &x.orelse, res)?;
             }
             Stmt::If(x) => {
                 let mut last_test = None;
                 let mut any_branch_processed = false;
-                for (test, body) in sys_info.pruned_if_branches(x) {
+                // Prune branches consistently with how the binding traversal prunes
+                // them (see `BindingsBuilder::stmts` handling of `Stmt::If`), i.e. taking
+                // `Final` bool constants into account and not just `sys_info` tests.
+                // If this scan disagreed with the traversal and kept a branch the
+                // traversal drops, we would record a `LastStmt` pointing at a statement
+                // that never gets a binding, and panic at solve time with a dangling key.
+                for (test, body) in Ast::if_branches(x) {
+                    let chosen = match test {
+                        None => Some(true),
+                        Some(test) => scopes.evaluate_bool_for_control_flow(sys_info, test),
+                    };
+                    if chosen == Some(false) {
+                        // Statically-false branch: never executed, so skip it.
+                        continue;
+                    }
                     any_branch_processed = true;
-                    last_test = test;
-                    f(sys_info, body, res)?;
+                    last_test = if chosen == Some(true) { None } else { test };
+                    f(sys_info, scopes, body, res)?;
+                    if chosen == Some(true) {
+                        // Statically-true branch: later branches are unreachable.
+                        break;
+                    }
                 }
                 if !any_branch_processed {
                     // All branches were pruned, so the code falls through
@@ -1045,16 +1070,16 @@ fn function_last_expressions<'a>(
                         .iter()
                         .any(|stmt| matches!(stmt, Stmt::Return(_)))
                 {
-                    f(sys_info, &x.finalbody, res)?;
+                    f(sys_info, scopes, &x.finalbody, res)?;
                 } else {
                     if x.orelse.is_empty() {
-                        f(sys_info, &x.body, res)?;
+                        f(sys_info, scopes, &x.body, res)?;
                     } else {
-                        f(sys_info, &x.orelse, res)?;
+                        f(sys_info, scopes, &x.orelse, res)?;
                     }
                     for handler in &x.handlers {
                         match handler {
-                            ExceptHandler::ExceptHandler(x) => f(sys_info, &x.body, res)?,
+                            ExceptHandler::ExceptHandler(x) => f(sys_info, scopes, &x.body, res)?,
                         }
                     }
                     // If we don't have a matching handler, we raise an exception, which is fine.
@@ -1063,7 +1088,7 @@ fn function_last_expressions<'a>(
             Stmt::Match(x) => {
                 let mut syntactically_exhaustive = false;
                 for case in x.cases.iter() {
-                    f(sys_info, &case.body, res)?;
+                    f(sys_info, scopes, &case.body, res)?;
                     if case.pattern.is_wildcard() || case.pattern.is_irrefutable() {
                         syntactically_exhaustive = true;
                         break;
@@ -1086,7 +1111,7 @@ fn function_last_expressions<'a>(
     }
 
     let mut res = Vec::new();
-    f(sys_info, x, &mut res)?;
+    f(sys_info, scopes, x, &mut res)?;
     Some(res)
 }
 

--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -321,6 +321,7 @@ impl<'a> BindingsBuilder<'a> {
         Option<SelfAssignments>,
         Vec<UnusedParameter>,
         Vec<UnusedVariable>,
+        Idx<Key>,
     ) {
         self.scopes
             .push_function_scope(range, func_name, class_key.is_some(), is_async);
@@ -345,6 +346,7 @@ impl<'a> BindingsBuilder<'a> {
             );
             self.bind_name(&dunder_class_identifier.id, idx, FlowStyle::Other);
         }
+        let implicit_return = self.implicit_return(&body, func_name);
         self.stmts(
             body,
             &NestingContext::function(ShortIdentifier::new(func_name), parent.dupe()),
@@ -356,6 +358,7 @@ impl<'a> BindingsBuilder<'a> {
             self_assignments,
             unused_parameters,
             unused_variables,
+            implicit_return,
         )
     }
 
@@ -398,7 +401,8 @@ impl<'a> BindingsBuilder<'a> {
     ///
     /// This function must not be called unless the function body statements will be bound;
     /// it relies on that binding to ensure we don't have a dangling `Idx<Key>` (which could lead
-    /// to a panic).
+    /// to a panic). For the same reason it must be called from inside the function's own scope,
+    /// after `init_static_scope`, so that it prunes on the same `Final` bool values as `stmts`.
     fn implicit_return(&mut self, body: &[Stmt], func_name: &Identifier) -> Idx<Key> {
         let last_exprs = function_last_expressions(body, self.sys_info, &self.scopes).map(|x| {
             x.into_map(|(last, x)| {
@@ -709,18 +713,19 @@ impl<'a> BindingsBuilder<'a> {
             );
             (false, self_assignments)
         } else if is_unannotated {
-            let implicit_return = Some(self.implicit_return(&body, func_name));
-            let (yields_and_returns, self_assignments, _, _) = self.function_body_scope(
-                parameters,
-                body,
-                range,
-                func_name,
-                parent,
-                undecorated_idx,
-                class_key,
-                is_async,
-                method_self_kind,
-            );
+            let (yields_and_returns, self_assignments, _, _, implicit_return) = self
+                .function_body_scope(
+                    parameters,
+                    body,
+                    range,
+                    func_name,
+                    parent,
+                    undecorated_idx,
+                    class_key,
+                    is_async,
+                    method_self_kind,
+                );
+            let implicit_return = Some(implicit_return);
             self.analyze_return_type(
                 func_name,
                 class_key,
@@ -733,21 +738,26 @@ impl<'a> BindingsBuilder<'a> {
             );
             (false, self_assignments)
         } else {
-            // Compute implicit_return: in this branch the body is always fully analyzed,
-            // so we can always determine whether there's an implicit return.
-            let implicit_return = Some(self.implicit_return(&body, func_name));
-            let (yields_and_returns, self_assignments, unused_parameters, unused_variables) = self
-                .function_body_scope(
-                    parameters,
-                    body,
-                    range,
-                    func_name,
-                    parent,
-                    undecorated_idx,
-                    class_key,
-                    is_async,
-                    method_self_kind,
-                );
+            // In this branch the body is always fully analyzed, so we can always
+            // determine whether there's an implicit return.
+            let (
+                yields_and_returns,
+                self_assignments,
+                unused_parameters,
+                unused_variables,
+                implicit_return,
+            ) = self.function_body_scope(
+                parameters,
+                body,
+                range,
+                func_name,
+                parent,
+                undecorated_idx,
+                class_key,
+                is_async,
+                method_self_kind,
+            );
+            let implicit_return = Some(implicit_return);
             if should_report_unused_parameters {
                 self.record_unused_parameters(unused_parameters);
                 self.record_unused_variables(unused_variables);

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -465,7 +465,8 @@ impl Static {
     /// Populate static definitions from a list of statements.
     /// Returns the set of implicit captures (names read but not locally defined),
     /// the fallback builtins shadowed by module definitions, the set of all Final
-    /// names, and a map of Final variable string values.
+    /// names, a map of Final variable string values, and a map of Final variable
+    /// bool values.
     fn stmts(
         &mut self,
         x: &[Stmt],
@@ -480,6 +481,7 @@ impl Static {
         SmallMap<Name, ModuleName>,
         SmallSet<Name>,
         SmallMap<Name, String>,
+        SmallMap<Name, bool>,
     ) {
         let mut d = Definitions::new(
             x,
@@ -545,11 +547,13 @@ impl Static {
             .into_iter()
             .filter_map(|(name, value)| value.map(|v| (name, v)))
             .collect();
+        let final_bool_values = d.final_bool_values;
         (
             implicit_captures,
             shadowed_implicit_builtins,
             final_names,
             final_string_values,
+            final_bool_values,
         )
     }
 
@@ -1298,6 +1302,9 @@ pub struct Scope {
     final_string_values: SmallMap<Name, String>,
     /// Names removed by a `del NAME` statement in this scope.
     deleted_names: SmallSet<Name>,
+    /// Names marked `Final` with bool literal values, e.g. `FLAG: Final = False`.
+    /// Used to statically evaluate control-flow tests like `if FLAG:`.
+    final_bool_values: SmallMap<Name, bool>,
 }
 
 impl Scope {
@@ -1320,6 +1327,7 @@ impl Scope {
             final_names: SmallSet::new(),
             final_string_values: SmallMap::new(),
             deleted_names: SmallSet::new(),
+            final_bool_values: SmallMap::new(),
         }
     }
 
@@ -1788,20 +1796,26 @@ impl Scopes {
         get_annotation_idx: &mut impl FnMut(ShortIdentifier) -> Idx<KeyAnnotation>,
     ) {
         let mut initialize = |scope: &mut Scope, myself: Option<&Self>| {
-            let (implicit_captures, shadowed_implicit_builtins, final_names, final_string_values) =
-                scope.stat.stmts(
-                    x,
-                    module_info,
-                    top_level,
-                    lookup,
-                    sys_info,
-                    get_annotation_idx,
-                    myself,
-                );
+            let (
+                implicit_captures,
+                shadowed_implicit_builtins,
+                final_names,
+                final_string_values,
+                final_bool_values,
+            ) = scope.stat.stmts(
+                x,
+                module_info,
+                top_level,
+                lookup,
+                sys_info,
+                get_annotation_idx,
+                myself,
+            );
             scope.implicit_captures = implicit_captures;
             scope.shadowed_implicit_builtins = shadowed_implicit_builtins;
             scope.final_names = final_names;
             scope.final_string_values = final_string_values;
+            scope.final_bool_values = final_bool_values;
             // Presize the flow, as its likely to need as much space as static.
             scope.flow.info.reserve(scope.stat.0.len());
         };
@@ -1835,6 +1849,30 @@ impl Scopes {
             if node.scope.stat.0.contains_key(name) {
                 return None;
             }
+        }
+        None
+    }
+
+    /// Look up a Final variable's bool literal value in the current scope stack.
+    pub fn lookup_final_bool_value(&self, name: &Name) -> Option<bool> {
+        for node in self.scopes.iter().rev() {
+            if let Some(value) = node.scope.final_bool_values.get(name) {
+                return Some(*value);
+            }
+            if node.scope.stat.0.contains_key(name) {
+                return None;
+            }
+        }
+        None
+    }
+
+    /// Return true/false if a control-flow test can be statically evaluated.
+    pub fn evaluate_bool_for_control_flow(&self, sys_info: SysInfo, x: &Expr) -> Option<bool> {
+        if let Some(value) = sys_info.evaluate_bool(x) {
+            return Some(value);
+        }
+        if let Expr::Name(name) = x {
+            return self.lookup_final_bool_value(&name.id);
         }
         None
     }

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -24,11 +24,13 @@ use ruff_python_ast::AtomicNodeIndex;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprName;
+use ruff_python_ast::ExprUnaryOp;
 use ruff_python_ast::ExprYield;
 use ruff_python_ast::ExprYieldFrom;
 use ruff_python_ast::Identifier;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtReturn;
+use ruff_python_ast::UnaryOp;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
@@ -1871,10 +1873,17 @@ impl Scopes {
         if let Some(value) = sys_info.evaluate_bool(x) {
             return Some(value);
         }
-        if let Expr::Name(name) = x {
-            return self.lookup_final_bool_value(&name.id);
+        match x {
+            Expr::Name(name) => self.lookup_final_bool_value(&name.id),
+            // `SysInfo::evaluate_bool` only negates tests it can evaluate itself,
+            // so `not FLAG` must be negated here to stay in step with `FLAG`.
+            Expr::UnaryOp(ExprUnaryOp {
+                op: UnaryOp::Not,
+                operand,
+                ..
+            }) => Some(!self.evaluate_bool_for_control_flow(sys_info, operand)?),
+            _ => None,
         }
-        None
     }
 
     pub fn push(&mut self, scope: Scope) {

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -1261,7 +1261,8 @@ impl<'a> BindingsBuilder<'a> {
                             Some(true)
                         }
                         Some(x) => {
-                            let result = self.sys_info.evaluate_bool(x);
+                            let result =
+                                self.scopes.evaluate_bool_for_control_flow(self.sys_info, x);
                             if result.is_some() {
                                 contains_static_test_with_no_else = true;
                             }

--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -172,6 +172,9 @@ pub struct Definitions {
     /// The `Option<String>` is `Some` when the RHS is a string literal (e.g. `X: Final = "x"`),
     /// used to resolve Final variable references in synthesized class field names.
     pub final_names: SmallMap<Name, Option<String>>,
+    /// Names marked `Final` with bool literal values, e.g. `FLAG: Final = False`.
+    /// Used to statically evaluate `if FLAG:` / `if not FLAG:` control flow.
+    pub final_bool_values: SmallMap<Name, bool>,
     /// Special exports defined in this module
     pub special_exports: SmallMap<Name, SpecialExport>,
     /// Names that are read (not just defined) in this scope.
@@ -699,6 +702,14 @@ impl DefinitionsBuilder {
                 } else {
                     None
                 };
+                let final_bool_value = if has_final_annotation {
+                    match x.value.as_deref() {
+                        Some(Expr::BooleanLiteral(b)) => Some(b.value),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
                 match &*x.target {
                     Expr::Name(x) => {
                         self.add_name(
@@ -713,6 +724,9 @@ impl DefinitionsBuilder {
                             self.inner
                                 .final_names
                                 .insert(x.id.clone(), final_string_value);
+                            if let Some(value) = final_bool_value {
+                                self.inner.final_bool_values.insert(x.id.clone(), value);
+                            }
                         }
                     }
                     _ => self.expr_lvalue(&x.target),

--- a/pyrefly/lib/export/exports.rs
+++ b/pyrefly/lib/export/exports.rs
@@ -234,6 +234,8 @@ impl Exports {
                         // for import variants — others carry positional data
                         || (self_def.style.is_import() && self_def.style != other_def.style)
                         || self_defs.final_names.get(name) != other_defs.final_names.get(name)
+                        || self_defs.final_bool_values.get(name)
+                            != other_defs.final_bool_values.get(name)
                         || self_defs.implicitly_imported_submodules.contains(name)
                             != other_defs.implicitly_imported_submodules.contains(name)
                         || self_defs.deprecated.get(name) != other_defs.deprecated.get(name)

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -108,6 +108,59 @@ def f(x: str | None):
 );
 
 testcase!(
+    test_final_bool_unreachable_if_branch,
+    r#"
+from typing import Final, Literal, reveal_type
+asdf: Final = False
+if asdf:
+    foo = 1
+else:
+    foo = 2
+reveal_type(foo)  # E: revealed type: Literal[2]
+"#,
+);
+
+testcase!(
+    test_final_bool_unreachable_else_branch,
+    r#"
+from typing import Final, Literal, reveal_type
+flag: Final = True
+if flag:
+    bar = 1
+else:
+    bar = 2
+reveal_type(bar)  # E: revealed type: Literal[1]
+"#,
+);
+
+// Regression test: when a function's trailing statement is an `if` gated by a
+// `Final` bool constant, the implicit-return scan (`function_last_expressions`)
+// must prune the same branch the binding traversal prunes. Otherwise it records
+// a `LastStmt` inside the pruned branch whose binding is never created, and we
+// panic at solve time with "key lacking binding".
+testcase!(
+    test_final_bool_if_branch_implicit_return_no_panic,
+    r#"
+from typing import Final
+FLAG_FALSE: Final = False
+FLAG_TRUE: Final = True
+def prune_if() -> None:
+    if FLAG_FALSE:
+        print("pruned")
+    else:
+        print("kept")
+def prune_else() -> None:
+    if FLAG_TRUE:
+        print("kept")
+    else:
+        print("pruned")
+def prune_if_no_else() -> None:
+    if FLAG_FALSE:
+        print("pruned and last")
+"#,
+);
+
+testcase!(
     test_is_subtype,
     r#"
 from typing import assert_type

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -160,6 +160,63 @@ def prune_if_no_else() -> None:
 "#,
 );
 
+// Same regression, but for `Final` bools declared inside the function. These are
+// only visible once `init_static_scope` has populated the function scope, so the
+// implicit-return scan has to run inside that scope to prune what the traversal
+// prunes.
+testcase!(
+    test_final_bool_function_scoped_implicit_return_no_panic,
+    r#"
+from typing import Final, Literal, reveal_type
+def prune_if_no_else_local() -> None:
+    FLAG_FALSE: Final = False
+    if FLAG_FALSE:
+        print("pruned and last")
+def prune_else_local() -> None:
+    FLAG_FALSE: Final = False
+    if FLAG_FALSE:
+        print("pruned")
+    else:
+        print("kept")
+def prune_if_local() -> None:
+    FLAG_TRUE: Final = True
+    if FLAG_TRUE:
+        foo = 1
+    else:
+        foo = 2
+    reveal_type(foo)  # E: revealed type: Literal[1]
+"#,
+);
+
+testcase!(
+    test_final_bool_not_operator,
+    r#"
+from typing import Final, Literal, reveal_type
+FLAG: Final = False
+if not FLAG:
+    foo = 1
+else:
+    foo = 2
+reveal_type(foo)  # E: revealed type: Literal[1]
+"#,
+);
+
+// A binding closer than the `Final` must win, so neither branch may be pruned
+// even though the outer name is statically known.
+testcase!(
+    test_final_bool_shadowed_by_closer_binding,
+    r#"
+from typing import Final, Literal, reveal_type
+flag: Final = True
+def foo(flag: bool):
+    if flag:
+        bar = 1
+    else:
+        bar = 2
+    reveal_type(bar)  # E: revealed type: Literal[1, 2]
+"#,
+);
+
 testcase!(
     test_is_subtype,
     r#"


### PR DESCRIPTION
## Summary

Fixes #3537.

When a variable is declared `Final` and assigned a bool literal (`False` or `True`), control-flow tests like `if flag:` now prune unreachable branches the same way as literal `if False:` / `if True:`.

Before this change, both arms of an `if/else` could contribute to merged types even when the condition was statically known to be always false via `Final = False`.

## Test plan

- [x] Added `test_final_bool_unreachable_if_branch` — `Final = False` → else-only assignment type
- [x] Added `test_final_bool_unreachable_else_branch` — `Final = True` → if-only assignment type
- [x] `cargo test test_final_bool_unreachable`