### PR TITLE
Add Sentinel support (PEP-661)

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -225,6 +225,8 @@ pub enum ErrorKind {
     /// A use of `typing.Self` in a context where Pyrefly does not recognize it as
     /// mapping to a valid class type.
     InvalidSelfType,
+    /// An error caused by incorrect usage or definition of a Sentinel.
+    InvalidSentinel,
     /// Attempting to call `super()` in a way that is not allowed.
     /// e.g. calling `super(Y, x)` on an object `x` that does not match the class `Y`.
     InvalidSuperCall,

--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -585,6 +585,7 @@ impl<'a> TypeDisplayContext<'a> {
                 output.write_qname(t.qname())?;
                 output.write_str("]")
             }
+            Type::Sentinel(t) => output.write_qname(t.qname()),
             Type::TypeVarTuple(t) => {
                 let type_var_tuple_qname = self.stdlib.map(|s| s.type_var_tuple().qname());
                 output.write_builtin("TypeVarTuple", type_var_tuple_qname)?;

--- a/crates/pyrefly_types/src/equality.rs
+++ b/crates/pyrefly_types/src/equality.rs
@@ -28,6 +28,7 @@ use vec1::Vec1;
 
 use crate::param_spec::ParamSpec;
 use crate::quantified::QuantifiedIdentity;
+use crate::sentinel::Sentinel;
 use crate::type_var::TypeVar;
 use crate::type_var_tuple::TypeVarTuple;
 
@@ -47,6 +48,7 @@ pub struct TypeEqCtx {
     param_spec: SmallMap<ParamSpec, ParamSpec>,
     type_var: SmallMap<TypeVar, TypeVar>,
     type_var_tuple: SmallMap<TypeVarTuple, TypeVarTuple>,
+    sentinel: SmallMap<Sentinel, Sentinel>,
     /// Alpha-equivalence mapping for Quantified binders: LHS identity → RHS identity.
     /// First pairing wins; subsequent occurrences must match.
     quantified_identity: SmallMap<QuantifiedIdentity, QuantifiedIdentity>,
@@ -139,6 +141,18 @@ impl TypeEq for TypeVarTuple {
             other,
             ctx,
             |ctx| &mut ctx.type_var_tuple,
+            |ctx| self.type_eq_inner(other, ctx),
+        )
+    }
+}
+
+impl TypeEq for Sentinel {
+    fn type_eq(&self, other: &Self, ctx: &mut TypeEqCtx) -> bool {
+        type_eq_identity(
+            self,
+            other,
+            ctx,
+            |ctx| &mut ctx.sentinel,
             |ctx| self.type_eq_inner(other, ctx),
         )
     }

--- a/crates/pyrefly_types/src/heap.rs
+++ b/crates/pyrefly_types/src/heap.rs
@@ -37,6 +37,7 @@ use crate::literal::Literal;
 use crate::module::ModuleType;
 use crate::param_spec::ParamSpec;
 use crate::quantified::Quantified;
+use crate::sentinel::Sentinel;
 use crate::shaped_array::ShapedArrayType;
 use crate::special_form::SpecialForm;
 use crate::tuple::Tuple;
@@ -135,6 +136,11 @@ impl TypeHeap {
     /// Create a `Type::None`.
     pub fn mk_none(&self) -> Type {
         Type::None
+    }
+
+    /// Create a `Type::Sentinel`.
+    pub fn mk_sentinel(&self, sentinel: Sentinel) -> Type {
+        Type::Sentinel(sentinel)
     }
 
     /// Create a `Type::Union` from members.

--- a/crates/pyrefly_types/src/lib.rs
+++ b/crates/pyrefly_types/src/lib.rs
@@ -38,6 +38,7 @@ pub mod module;
 pub mod param_spec;
 pub mod quantified;
 pub mod read_only;
+pub mod sentinel;
 pub mod shaped_array;
 pub mod simplify;
 pub mod special_form;

--- a/crates/pyrefly_types/src/sentinel.rs
+++ b/crates/pyrefly_types/src/sentinel.rs
@@ -24,6 +24,21 @@ use crate::equality::TypeEqCtx;
 use crate::heap::TypeHeap;
 use crate::types::Type;
 
+#[derive(Clone, Copy, Dupe, Debug, PartialEq, Eq, Hash, Ord, PartialOrd, TypeEq)]
+pub enum SentinelKind {
+    Builtins,
+    TypingExtensions,
+}
+
+impl SentinelKind {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Builtins => "sentinel",
+            Self::TypingExtensions => "Sentinel",
+        }
+    }
+}
+
 /// Used to represent Sentinel calls. Each Sentinel is unique, so use the ArcId to separate them.
 #[derive(Clone, Dupe, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Sentinel(ArcId<SentinelInner>);
@@ -48,14 +63,20 @@ impl Display for Sentinel {
 #[derive(Debug, PartialEq, TypeEq, Eq, Ord, PartialOrd)]
 struct SentinelInner {
     qname: QName,
+    kind: SentinelKind,
 }
 
 impl Sentinel {
-    pub fn new(name: Identifier, module: Module) -> Self {
+    pub fn new(name: Identifier, module: Module, kind: SentinelKind) -> Self {
         Self(ArcId::new(SentinelInner {
+            kind,
             // TODO: properly take parent from caller of new()
             qname: QName::new(name, NestingContext::toplevel(), module),
         }))
+    }
+
+    pub fn kind(&self) -> SentinelKind {
+        self.0.kind
     }
 
     pub fn qname(&self) -> &QName {

--- a/crates/pyrefly_types/src/sentinel.rs
+++ b/crates/pyrefly_types/src/sentinel.rs
@@ -67,11 +67,15 @@ struct SentinelInner {
 }
 
 impl Sentinel {
-    pub fn new(name: Identifier, module: Module, kind: SentinelKind) -> Self {
+    pub fn new(
+        name: Identifier,
+        nesting_context: NestingContext,
+        module: Module,
+        kind: SentinelKind,
+    ) -> Self {
         Self(ArcId::new(SentinelInner {
             kind,
-            // TODO: properly take parent from caller of new()
-            qname: QName::new(name, NestingContext::toplevel(), module),
+            qname: QName::new(name, nesting_context, module),
         }))
     }
 

--- a/crates/pyrefly_types/src/sentinel.rs
+++ b/crates/pyrefly_types/src/sentinel.rs
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::fmt;
+use std::fmt::Display;
+use std::hash::Hash;
+
+use dupe::Dupe;
+use pyrefly_derive::TypeEq;
+use pyrefly_python::module::Module;
+use pyrefly_python::nesting_context::NestingContext;
+use pyrefly_python::qname::QName;
+use pyrefly_util::arc_id::ArcId;
+use pyrefly_util::visit::Visit;
+use pyrefly_util::visit::VisitMut;
+use ruff_python_ast::Identifier;
+
+use crate::equality::TypeEq;
+use crate::equality::TypeEqCtx;
+use crate::heap::TypeHeap;
+use crate::types::Type;
+
+/// Used to represent Sentinel calls. Each Sentinel is unique, so use the ArcId to separate them.
+#[derive(Clone, Dupe, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct Sentinel(ArcId<SentinelInner>);
+
+// This is a lie, we do have types in the bound position
+impl Visit<Type> for Sentinel {
+    const RECURSE_CONTAINS: bool = false;
+    fn recurse<'a>(&'a self, _: &mut dyn FnMut(&'a Type)) {}
+}
+
+impl VisitMut<Type> for Sentinel {
+    const RECURSE_CONTAINS: bool = false;
+    fn recurse_mut(&mut self, _: &mut dyn FnMut(&mut Type)) {}
+}
+
+impl Display for Sentinel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.qname.id())
+    }
+}
+
+#[derive(Debug, PartialEq, TypeEq, Eq, Ord, PartialOrd)]
+struct SentinelInner {
+    qname: QName,
+}
+
+impl Sentinel {
+    pub fn new(name: Identifier, module: Module) -> Self {
+        Self(ArcId::new(SentinelInner {
+            // TODO: properly take parent from caller of new()
+            qname: QName::new(name, NestingContext::toplevel(), module),
+        }))
+    }
+
+    pub fn qname(&self) -> &QName {
+        &self.0.qname
+    }
+
+    pub fn to_type(&self, heap: &TypeHeap) -> Type {
+        heap.mk_sentinel(self.dupe())
+    }
+
+    pub fn type_eq_inner(&self, other: &Self, ctx: &mut TypeEqCtx) -> bool {
+        self.0.type_eq(&other.0, ctx)
+    }
+}

--- a/crates/pyrefly_types/src/sentinel.rs
+++ b/crates/pyrefly_types/src/sentinel.rs
@@ -24,21 +24,6 @@ use crate::equality::TypeEqCtx;
 use crate::heap::TypeHeap;
 use crate::types::Type;
 
-#[derive(Clone, Copy, Dupe, Debug, PartialEq, Eq, Hash, Ord, PartialOrd, TypeEq)]
-pub enum SentinelKind {
-    Builtins,
-    TypingExtensions,
-}
-
-impl SentinelKind {
-    pub fn name(&self) -> &str {
-        match self {
-            Self::Builtins => "sentinel",
-            Self::TypingExtensions => "Sentinel",
-        }
-    }
-}
-
 /// Used to represent Sentinel calls. Each Sentinel is unique, so use the ArcId to separate them.
 #[derive(Clone, Dupe, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Sentinel(ArcId<SentinelInner>);
@@ -63,24 +48,13 @@ impl Display for Sentinel {
 #[derive(Debug, PartialEq, TypeEq, Eq, Ord, PartialOrd)]
 struct SentinelInner {
     qname: QName,
-    kind: SentinelKind,
 }
 
 impl Sentinel {
-    pub fn new(
-        name: Identifier,
-        nesting_context: NestingContext,
-        module: Module,
-        kind: SentinelKind,
-    ) -> Self {
+    pub fn new(name: Identifier, nesting_context: NestingContext, module: Module) -> Self {
         Self(ArcId::new(SentinelInner {
-            kind,
             qname: QName::new(name, nesting_context, module),
         }))
-    }
-
-    pub fn kind(&self) -> SentinelKind {
-        self.0.kind
     }
 
     pub fn qname(&self) -> &QName {

--- a/crates/pyrefly_types/src/stdlib.rs
+++ b/crates/pyrefly_types/src/stdlib.rs
@@ -105,7 +105,8 @@ pub struct Stdlib {
     /// After 3.14, `typing_extensions` reexports from `typing`.
     /// For 3.12 and 3.13 defined separately in both locations.
     type_alias_type: StdlibResult<ClassType>,
-    /// Defined in `typing_extensions` until 3.15, defined in `typing` since 3.15.
+    /// Defined in `typing_extensions` as Sentinel.
+    /// Defined in `builtins` as `sentinel` since 3.15.
     sentinel: StdlibResult<ClassType>,
     traceback_type: StdlibResult<ClassType>,
     builtins_type: StdlibResult<ClassType>,
@@ -259,7 +260,11 @@ impl Stdlib {
             param_spec_kwargs: lookup_concrete(standardised(3, 10), "ParamSpecKwargs"),
             type_var_tuple: lookup_concrete(standardised(3, 11), "TypeVarTuple"),
             type_alias_type: lookup_concrete(standardised(3, 12), "TypeAliasType"),
-            sentinel: lookup_concrete(standardised(3, 15), "Sentinel"),
+            // sentinel: lookup_concrete(typing_extensions, "Sentinel"),
+            sentinel: version
+                .at_least(3, 15)
+                .then(|| lookup_concrete(builtins, "sentinel"))
+                .unwrap_or_else(|| lookup_concrete(typing_extensions, "Sentinel")),
             traceback_type: lookup_concrete(types, "TracebackType"),
             function_type: lookup_concrete(types, "FunctionType"),
             method_type: lookup_concrete(types, "MethodType"),

--- a/crates/pyrefly_types/src/stdlib.rs
+++ b/crates/pyrefly_types/src/stdlib.rs
@@ -106,11 +106,8 @@ pub struct Stdlib {
     /// For 3.12 and 3.13 defined separately in both locations.
     type_alias_type: StdlibResult<ClassType>,
     /// Defined in `typing_extensions` as Sentinel.
-    /// Different attributes from `builtins` sentinel.
-    sentinel_typing_extensions: StdlibResult<ClassType>,
     /// Defined in `builtins` as `sentinel` since 3.15.
-    /// Different attributes from `typing_extensions` Sentinel.
-    sentinel_builtin: StdlibResult<ClassType>,
+    sentinel: StdlibResult<ClassType>,
     traceback_type: StdlibResult<ClassType>,
     builtins_type: StdlibResult<ClassType>,
     /// Introduced in Python 3.10.
@@ -263,9 +260,10 @@ impl Stdlib {
             param_spec_kwargs: lookup_concrete(standardised(3, 10), "ParamSpecKwargs"),
             type_var_tuple: lookup_concrete(standardised(3, 11), "TypeVarTuple"),
             type_alias_type: lookup_concrete(standardised(3, 12), "TypeAliasType"),
-            // sentinel: lookup_concrete(typing_extensions, "Sentinel"),
-            sentinel_builtin: lookup_concrete(builtins, "sentinel"),
-            sentinel_typing_extensions: lookup_concrete(typing_extensions, "Sentinel"),
+            sentinel: version
+                .at_least(3, 15)
+                .then(|| lookup_concrete(builtins, "sentinel"))
+                .unwrap_or_else(|| lookup_concrete(typing_extensions, "Sentinel")),
             traceback_type: lookup_concrete(types, "TracebackType"),
             function_type: lookup_concrete(types, "FunctionType"),
             method_type: lookup_concrete(types, "MethodType"),
@@ -590,11 +588,8 @@ impl Stdlib {
         Self::primitive(&self.type_alias_type)
     }
 
-    pub fn sentinel_builtin(&self) -> &ClassType {
-        Self::primitive(&self.sentinel_builtin)
-    }
-    pub fn sentinel_typing_extensions(&self) -> &ClassType {
-        Self::primitive(&self.sentinel_typing_extensions)
+    pub fn sentinel(&self) -> &ClassType {
+        Self::primitive(&self.sentinel)
     }
 
     pub fn traceback_type(&self) -> &ClassType {

--- a/crates/pyrefly_types/src/stdlib.rs
+++ b/crates/pyrefly_types/src/stdlib.rs
@@ -105,6 +105,8 @@ pub struct Stdlib {
     /// After 3.14, `typing_extensions` reexports from `typing`.
     /// For 3.12 and 3.13 defined separately in both locations.
     type_alias_type: StdlibResult<ClassType>,
+    /// Defined in `typing_extensions` until 3.15, defined in `typing` since 3.15.
+    sentinel: StdlibResult<ClassType>,
     traceback_type: StdlibResult<ClassType>,
     builtins_type: StdlibResult<ClassType>,
     /// Introduced in Python 3.10.
@@ -257,6 +259,7 @@ impl Stdlib {
             param_spec_kwargs: lookup_concrete(standardised(3, 10), "ParamSpecKwargs"),
             type_var_tuple: lookup_concrete(standardised(3, 11), "TypeVarTuple"),
             type_alias_type: lookup_concrete(standardised(3, 12), "TypeAliasType"),
+            sentinel: lookup_concrete(standardised(3, 15), "Sentinel"),
             traceback_type: lookup_concrete(types, "TracebackType"),
             function_type: lookup_concrete(types, "FunctionType"),
             method_type: lookup_concrete(types, "MethodType"),
@@ -579,6 +582,10 @@ impl Stdlib {
 
     pub fn type_alias_type(&self) -> &ClassType {
         Self::primitive(&self.type_alias_type)
+    }
+
+    pub fn sentinel(&self) -> &ClassType {
+        Self::primitive(&self.sentinel)
     }
 
     pub fn traceback_type(&self) -> &ClassType {

--- a/crates/pyrefly_types/src/stdlib.rs
+++ b/crates/pyrefly_types/src/stdlib.rs
@@ -106,8 +106,11 @@ pub struct Stdlib {
     /// For 3.12 and 3.13 defined separately in both locations.
     type_alias_type: StdlibResult<ClassType>,
     /// Defined in `typing_extensions` as Sentinel.
+    /// Different attributes from `builtins` sentinel.
+    sentinel_typing_extensions: StdlibResult<ClassType>,
     /// Defined in `builtins` as `sentinel` since 3.15.
-    sentinel: StdlibResult<ClassType>,
+    /// Different attributes from `typing_extensions` Sentinel.
+    sentinel_builtin: StdlibResult<ClassType>,
     traceback_type: StdlibResult<ClassType>,
     builtins_type: StdlibResult<ClassType>,
     /// Introduced in Python 3.10.
@@ -261,10 +264,8 @@ impl Stdlib {
             type_var_tuple: lookup_concrete(standardised(3, 11), "TypeVarTuple"),
             type_alias_type: lookup_concrete(standardised(3, 12), "TypeAliasType"),
             // sentinel: lookup_concrete(typing_extensions, "Sentinel"),
-            sentinel: version
-                .at_least(3, 15)
-                .then(|| lookup_concrete(builtins, "sentinel"))
-                .unwrap_or_else(|| lookup_concrete(typing_extensions, "Sentinel")),
+            sentinel_builtin: lookup_concrete(builtins, "sentinel"),
+            sentinel_typing_extensions: lookup_concrete(typing_extensions, "Sentinel"),
             traceback_type: lookup_concrete(types, "TracebackType"),
             function_type: lookup_concrete(types, "FunctionType"),
             method_type: lookup_concrete(types, "MethodType"),
@@ -589,8 +590,11 @@ impl Stdlib {
         Self::primitive(&self.type_alias_type)
     }
 
-    pub fn sentinel(&self) -> &ClassType {
-        Self::primitive(&self.sentinel)
+    pub fn sentinel_builtin(&self) -> &ClassType {
+        Self::primitive(&self.sentinel_builtin)
+    }
+    pub fn sentinel_typing_extensions(&self) -> &ClassType {
+        Self::primitive(&self.sentinel_typing_extensions)
     }
 
     pub fn traceback_type(&self) -> &ClassType {

--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -59,6 +59,7 @@ use crate::literal::Literal;
 use crate::module::ModuleType;
 use crate::param_spec::ParamSpec;
 use crate::quantified::Quantified;
+use crate::sentinel::Sentinel;
 use crate::shaped_array::ShapedArrayType;
 use crate::simplify::unions;
 use crate::special_form::SpecialForm;
@@ -858,6 +859,9 @@ pub enum Type {
     /// be immediately looked up for untyping (see `TypeAliasData::TypeAliasRef`), `UntypedAlias`
     /// stores a reference that is untyped once we actually look up the value.
     UntypedAlias(Box<TypeAliasData>),
+    // Sentinel types, documented here: https://docs.python.org/3.15/library/functions.html#sentinel
+    // First introduced in PEP 661: https://peps.python.org/pep-0661/
+    Sentinel(Sentinel),
     /// Represents the result of a super() call. The first ClassType is the point in the MRO that attribute lookup
     /// on the super instance should start at (*not* the class passed to the super() call), and the second
     /// ClassType is the second argument (implicit or explicit) to the super() call. For example, in:
@@ -919,6 +923,7 @@ impl Visit for Type {
             Type::Annotated(x, _metadata) => x.visit(f),
             Type::Unpack(x) => x.visit(f),
             Type::TypeVar(x) => x.visit(f),
+            Type::Sentinel(x) => x.visit(f),
             Type::ParamSpec(x) => x.visit(f),
             Type::TypeVarTuple(x) => x.visit(f),
             Type::SpecialForm(x) => x.visit(f),
@@ -975,6 +980,7 @@ impl VisitMut for Type {
             Type::Annotated(x, _metadata) => x.visit_mut(f),
             Type::Unpack(x) => x.visit_mut(f),
             Type::TypeVar(x) => x.visit_mut(f),
+            Type::Sentinel(x) => x.visit_mut(f),
             Type::ParamSpec(x) => x.visit_mut(f),
             Type::TypeVarTuple(x) => x.visit_mut(f),
             Type::SpecialForm(x) => x.visit_mut(f),
@@ -1919,6 +1925,7 @@ impl Type {
             Type::ParamSpec(t) => Some(t.qname()),
             Type::SelfType(cls) => Some(cls.qname()),
             Type::Literal(lit) if let Lit::Enum(e) = &lit.value => Some(e.class.qname()),
+            Type::Sentinel(s) => Some(s.qname()),
             _ => None,
         }
     }
@@ -1932,6 +1939,7 @@ impl Type {
             Type::Literal(lit) if let Lit::Str(x) = &lit.value => Some(!x.is_empty()),
             Type::Type(_) => Some(true),
             Type::None => Some(false),
+            Type::Sentinel(_) => Some(true),
             Type::Tuple(Tuple::Concrete(elements)) => Some(!elements.is_empty()),
             Type::Union(u) => {
                 let mut answer = None;

--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -14,6 +14,7 @@ use pyrefly_types::dimension::SizeExpr;
 use pyrefly_types::heap::TypeHeap;
 use pyrefly_types::lit_int::LitInt;
 use pyrefly_types::literal::LitEnum;
+use pyrefly_types::sentinel::SentinelKind;
 use pyrefly_types::shaped_array::ShapedArrayShape;
 use pyrefly_types::shaped_array::ShapedArrayType;
 use pyrefly_types::special_form::SpecialForm;
@@ -2336,9 +2337,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::TypeVar(_) => acc.push(AttributeBase1::ClassInstance(
                 self.stdlib.type_var().clone(),
             )),
-            Type::Sentinel(_) => acc.push(AttributeBase1::ClassInstance(
-                self.stdlib.sentinel().clone(),
-            )),
+            Type::Sentinel(sentinel) => {
+                acc.push(AttributeBase1::ClassInstance(match sentinel.kind() {
+                    SentinelKind::Builtins => self.stdlib.sentinel_builtin().clone(),
+                    SentinelKind::TypingExtensions => {
+                        self.stdlib.sentinel_typing_extensions().clone()
+                    }
+                }))
+            }
             Type::ParamSpec(_) => acc.push(AttributeBase1::ClassInstance(
                 self.stdlib.param_spec().clone(),
             )),

--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -2336,6 +2336,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::TypeVar(_) => acc.push(AttributeBase1::ClassInstance(
                 self.stdlib.type_var().clone(),
             )),
+            Type::Sentinel(_) => acc.push(AttributeBase1::ClassInstance(
+                self.stdlib.sentinel().clone(),
+            )),
             Type::ParamSpec(_) => acc.push(AttributeBase1::ClassInstance(
                 self.stdlib.param_spec().clone(),
             )),

--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -14,7 +14,6 @@ use pyrefly_types::dimension::SizeExpr;
 use pyrefly_types::heap::TypeHeap;
 use pyrefly_types::lit_int::LitInt;
 use pyrefly_types::literal::LitEnum;
-use pyrefly_types::sentinel::SentinelKind;
 use pyrefly_types::shaped_array::ShapedArrayShape;
 use pyrefly_types::shaped_array::ShapedArrayType;
 use pyrefly_types::special_form::SpecialForm;
@@ -2337,14 +2336,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::TypeVar(_) => acc.push(AttributeBase1::ClassInstance(
                 self.stdlib.type_var().clone(),
             )),
-            Type::Sentinel(sentinel) => {
-                acc.push(AttributeBase1::ClassInstance(match sentinel.kind() {
-                    SentinelKind::Builtins => self.stdlib.sentinel_builtin().clone(),
-                    SentinelKind::TypingExtensions => {
-                        self.stdlib.sentinel_typing_extensions().clone()
-                    }
-                }))
-            }
+            Type::Sentinel(_) => acc.push(AttributeBase1::ClassInstance(
+                self.stdlib.sentinel().clone(),
+            )),
             Type::ParamSpec(_) => acc.push(AttributeBase1::ClassInstance(
                 self.stdlib.param_spec().clone(),
             )),

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -95,6 +95,7 @@ use crate::types::literal::Lit;
 use crate::types::param_spec::ParamSpec;
 use crate::types::quantified::Quantified;
 use crate::types::quantified::QuantifiedKind;
+use crate::types::sentinel::Sentinel;
 use crate::types::special_form::SpecialForm;
 use crate::types::tuple::Tuple;
 use crate::types::type_info::TypeInfo;
@@ -1786,6 +1787,97 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 false
             }
         }
+    }
+
+    pub fn sentinel_from_call(
+        &self,
+        name: Identifier,
+        x: &ExprCall,
+        errors: &ErrorCollector,
+    ) -> Sentinel {
+        let mut iargs = x.arguments.args.iter();
+        if let Some(arg) = iargs.next() {
+            if let Expr::StringLiteral(lit) = arg {
+                if lit.value.to_str() != name.id.as_str() {
+                    self.error(
+                        errors,
+                        x.range,
+                        ErrorKind::InvalidSentinel,
+                        format!(
+                            "Sentinel must be assigned to a variable named `{}`",
+                            lit.value.to_str()
+                        ),
+                    );
+                }
+            } else {
+                self.error(
+                    errors,
+                    arg.range(),
+                    ErrorKind::InvalidSentinel,
+                    "Expected first argument of Sentinel to be a string literal".to_owned(),
+                );
+            }
+        } else {
+            self.error(
+                errors,
+                x.range,
+                ErrorKind::InvalidSentinel,
+                "Sentinel requires a name as the first argument".to_owned(),
+            );
+        }
+        if let Some(arg) = iargs.next() {
+            let args_range_end = x.arguments.args.last().map(|arg| arg.range().end());
+            let range = TextRange::new(
+                arg.range().start(),
+                // args_range_end should never be None as it should only be None if there are
+                // no args, but no reason not to have a default here anyway.
+                args_range_end.unwrap_or_else(|| arg.range().end()),
+            );
+            self.error(
+                errors,
+                range,
+                ErrorKind::InvalidSentinel,
+                "Sentinel only takes one positional argument".to_owned(),
+            );
+        }
+
+        for kw in &x.arguments.keywords {
+            match &kw.arg {
+                Some(id) => match id.id.as_str() {
+                    "repr" => {
+                        let got = self.expr_infer(&kw.value, errors);
+                        if !self
+                            .is_subset_eq(&got, &self.heap.mk_class_type(self.stdlib.str().clone()))
+                        {
+                            self.error(
+                                errors,
+                                kw.range,
+                                ErrorKind::InvalidSentinel,
+                                format!("Invalid type for Sentinel `repr` {got}"),
+                            );
+                        }
+                    }
+                    _ => {
+                        self.error(
+                            errors,
+                            kw.range,
+                            ErrorKind::InvalidSentinel,
+                            format!("Unexpected keyword argument `{}` to Sentinel", id.id),
+                        );
+                    }
+                },
+                _ => {
+                    self.error(
+                        errors,
+                        kw.range,
+                        ErrorKind::InvalidSentinel,
+                        "Cannot pass unpacked keyword arguments to Sentinel".to_owned(),
+                    );
+                }
+            }
+        }
+
+        Sentinel::new(name, self.module().dupe())
     }
 
     pub fn typevar_from_call(

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -22,7 +22,6 @@ use pyrefly_types::callable::FunctionKind;
 use pyrefly_types::dimension::SizeExpr;
 use pyrefly_types::dimension::canonicalize;
 use pyrefly_types::literal::LitStyle;
-use pyrefly_types::sentinel::SentinelKind;
 use pyrefly_types::shaped_array::IndexOp;
 use pyrefly_types::shaped_array::ShapedArrayShape;
 use pyrefly_types::shaped_array::ShapedArrayType;
@@ -1796,7 +1795,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         assignment_name: Identifier,
         nesting_context: NestingContext,
         x: &ExprCall,
-        kind: SentinelKind,
         errors: &ErrorCollector,
     ) -> Sentinel {
         let mut sentinel_name = assignment_name;
@@ -1872,7 +1870,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         }
 
-        Sentinel::new(sentinel_name, nesting_context, self.module().dupe(), kind)
+        Sentinel::new(sentinel_name, nesting_context, self.module().dupe())
     }
 
     pub fn typevar_from_call(

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -21,6 +21,7 @@ use pyrefly_types::callable::FunctionKind;
 use pyrefly_types::dimension::SizeExpr;
 use pyrefly_types::dimension::canonicalize;
 use pyrefly_types::literal::LitStyle;
+use pyrefly_types::sentinel::SentinelKind;
 use pyrefly_types::shaped_array::IndexOp;
 use pyrefly_types::shaped_array::ShapedArrayShape;
 use pyrefly_types::shaped_array::ShapedArrayType;
@@ -1793,6 +1794,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         &self,
         assignment_name: Identifier,
         x: &ExprCall,
+        kind: SentinelKind,
         errors: &ErrorCollector,
     ) -> Sentinel {
         let mut sentinel_name = assignment_name;
@@ -1868,7 +1870,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         }
 
-        Sentinel::new(sentinel_name, self.module().dupe())
+        Sentinel::new(sentinel_name, self.module().dupe(), kind)
     }
 
     pub fn typevar_from_call(

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1791,24 +1791,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
     pub fn sentinel_from_call(
         &self,
-        name: Identifier,
+        assignment_name: Identifier,
         x: &ExprCall,
         errors: &ErrorCollector,
     ) -> Sentinel {
+        let mut sentinel_name = assignment_name;
         let mut iargs = x.arguments.args.iter();
         if let Some(arg) = iargs.next() {
             if let Expr::StringLiteral(lit) = arg {
-                if lit.value.to_str() != name.id.as_str() {
-                    self.error(
-                        errors,
-                        x.range,
-                        ErrorKind::InvalidSentinel,
-                        format!(
-                            "Sentinel must be assigned to a variable named `{}`",
-                            lit.value.to_str()
-                        ),
-                    );
-                }
+                sentinel_name = Identifier::new(lit.value.to_str(), lit.range());
             } else {
                 self.error(
                     errors,
@@ -1877,7 +1868,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         }
 
-        Sentinel::new(name, self.module().dupe())
+        Sentinel::new(sentinel_name, self.module().dupe())
     }
 
     pub fn typevar_from_call(

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -16,6 +16,7 @@ use itertools::Itertools;
 use pyrefly_python::ast::Ast;
 use pyrefly_python::dunder;
 use pyrefly_python::module_name::ModuleName;
+use pyrefly_python::nesting_context::NestingContext;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_types::callable::FunctionKind;
 use pyrefly_types::dimension::SizeExpr;
@@ -1793,6 +1794,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     pub fn sentinel_from_call(
         &self,
         assignment_name: Identifier,
+        nesting_context: NestingContext,
         x: &ExprCall,
         kind: SentinelKind,
         errors: &ErrorCollector,
@@ -1870,7 +1872,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         }
 
-        Sentinel::new(sentinel_name, self.module().dupe(), kind)
+        Sentinel::new(sentinel_name, nesting_context, self.module().dupe(), kind)
     }
 
     pub fn typevar_from_call(

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1814,7 +1814,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     errors,
                     arg.range(),
                     ErrorKind::InvalidSentinel,
-                    "Expected first argument of Sentinel to be a string literal".to_owned(),
+                    "Expected first argument of sentinel to be a string literal".to_owned(),
                 );
             }
         } else {
@@ -1853,7 +1853,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 errors,
                                 kw.range,
                                 ErrorKind::InvalidSentinel,
-                                format!("Invalid type for Sentinel `repr` {got}"),
+                                format!("Invalid type for sentinel `repr` {got}"),
                             );
                         }
                     }
@@ -1862,7 +1862,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             errors,
                             kw.range,
                             ErrorKind::InvalidSentinel,
-                            format!("Unexpected keyword argument `{}` to Sentinel", id.id),
+                            format!("Unexpected keyword argument `{}` to sentinel", id.id),
                         );
                     }
                 },
@@ -1871,7 +1871,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         errors,
                         kw.range,
                         ErrorKind::InvalidSentinel,
-                        "Cannot pass unpacked keyword arguments to Sentinel".to_owned(),
+                        "Cannot pass unpacked keyword arguments to sentinel".to_owned(),
                     );
                 }
             }

--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -294,6 +294,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             {
                 self.heap.mk_never()
             }
+            (Type::Sentinel(s1), Type::Sentinel(s2)) if s1 == s2 => self.heap.mk_never(),
             (Type::ClassType(cls), Type::Literal(lit))
                 if cls.is_builtin("bool")
                     && let Lit::Bool(b) = &lit.value =>
@@ -850,7 +851,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         range,
                     );
                     match right {
-                        Type::None | Type::Ellipsis | Type::Literal(_) => {
+                        Type::None | Type::Ellipsis | Type::Literal(_) | Type::Sentinel(_) => {
                             if self.is_subset_eq(&right, &facet_ty) {
                                 t.clone()
                             } else {
@@ -872,8 +873,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     );
                     match (&facet_ty, &right) {
                         (
-                            Type::None | Type::Ellipsis | Type::Literal(_),
-                            Type::None | Type::Ellipsis | Type::Literal(_),
+                            Type::None | Type::Ellipsis | Type::Literal(_) | Type::Sentinel(_),
+                            Type::None | Type::Ellipsis | Type::Literal(_) | Type::Sentinel(_),
                         ) if self.literal_equal(&right, &facet_ty) => self.heap.mk_never(),
                         _ => t.clone(),
                     }
@@ -1410,7 +1411,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             AtomicNarrowOp::Eq(v) => {
                 let right = self.expr_infer(v, errors);
-                if matches!(right, Type::Literal(_) | Type::None | Type::Ellipsis) {
+                if matches!(
+                    right,
+                    Type::Literal(_) | Type::None | Type::Ellipsis | Type::Sentinel(_)
+                ) {
                     self.intersect(ty, &right)
                 } else {
                     ty.clone()
@@ -1418,7 +1422,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             AtomicNarrowOp::NotEq(v) => {
                 let right = self.expr_infer(v, errors);
-                if matches!(right, Type::Literal(_) | Type::None | Type::Ellipsis) {
+                if matches!(
+                    right,
+                    Type::Literal(_) | Type::None | Type::Ellipsis | Type::Sentinel(_)
+                ) {
                     self.distribute_over_union(ty, |t| match (t, &right) {
                         (_, _) if self.literal_equal(t, &right) => self.heap.mk_never(),
                         (Type::ClassType(cls), Type::Literal(lit))
@@ -2163,6 +2170,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         match (left, right) {
             (Type::None, Type::None) => true,
             (Type::Ellipsis, Type::Ellipsis) => true,
+            (Type::Sentinel(s1), Type::Sentinel(s2)) => s1 == s2,
             (Type::Literal(left), Type::Literal(right)) => left.value == right.value,
             _ => false,
         }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -5344,9 +5344,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             Binding::Delete(x) => self.check_del_statement(x, errors),
             Binding::Sentinel(x) => {
-                let (ann, name, call) = x.as_ref();
+                let (ann, name, call, kind) = x.as_ref();
                 let ty = self
-                    .sentinel_from_call(name.clone(), call, errors)
+                    .sentinel_from_call(name.clone(), call, *kind, errors)
                     .to_type(self.heap);
                 if let Some(k) = ann
                     && let AnnotationWithTarget {

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -5343,6 +5343,28 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 self.heap.mk_none()
             }
             Binding::Delete(x) => self.check_del_statement(x, errors),
+            Binding::Sentinel(x) => {
+                let (ann, name, call) = x.as_ref();
+                let ty = self
+                    .sentinel_from_call(name.clone(), call, errors)
+                    .to_type(self.heap);
+                if let Some(k) = ann
+                    && let AnnotationWithTarget {
+                        target,
+                        annotation:
+                            Annotation {
+                                ty: Some(want),
+                                qualifiers: _,
+                            },
+                    } = &*self.get_idx(*k)
+                {
+                    // Validate the annotation already on assigned name
+                    self.check_type(&ty, want, call.range, errors, &|| {
+                        TypeCheckContext::of_kind(TypeCheckKind::from_annotation_target(target))
+                    });
+                }
+                ty
+            }
         }
     }
 
@@ -5697,6 +5719,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
                 Some(*t)
             }
+            Type::Sentinel(sentinel) => Some(self.heap.mk_sentinel(sentinel)),
             Type::None => Some(self.heap.mk_none()), // Both a value and a type
             Type::Ellipsis => Some(self.heap.mk_ellipsis()), // A bit weird because of tuples, so just promote it
             Type::Any(style) => Some(style.propagate()),

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -5344,9 +5344,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             Binding::Delete(x) => self.check_del_statement(x, errors),
             Binding::Sentinel(x) => {
-                let (ann, name, nesting_context, call, kind) = x.as_ref();
+                let (ann, name, nesting_context, call) = x.as_ref();
                 let ty = self
-                    .sentinel_from_call(name.clone(), nesting_context.dupe(), call, *kind, errors)
+                    .sentinel_from_call(name.clone(), nesting_context.dupe(), call, errors)
                     .to_type(self.heap);
                 if let Some(k) = ann
                     && let AnnotationWithTarget {

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -5344,9 +5344,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             Binding::Delete(x) => self.check_del_statement(x, errors),
             Binding::Sentinel(x) => {
-                let (ann, name, call, kind) = x.as_ref();
+                let (ann, name, nesting_context, call, kind) = x.as_ref();
                 let ty = self
-                    .sentinel_from_call(name.clone(), call, *kind, errors)
+                    .sentinel_from_call(name.clone(), nesting_context.dupe(), call, *kind, errors)
                     .to_type(self.heap);
                 if let Some(k) = ann
                     && let AnnotationWithTarget {

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -2354,6 +2354,7 @@ pub enum Binding {
     /// A match statement or if/elif chain that may be type-exhaustive.
     /// Resolves to Never if ANY narrow entry narrows to Never, None otherwise.
     Exhaustive(Box<ExhaustiveBinding>),
+    Sentinel(Box<(Option<Idx<KeyAnnotation>>, Identifier, Box<ExprCall>)>),
 }
 
 impl DisplayWith<Bindings> for Binding {
@@ -2395,6 +2396,10 @@ impl DisplayWith<Bindings> for Binding {
             Self::TypeVarTuple(x) => {
                 let (a, name, call) = x.as_ref();
                 write!(f, "TypeVarTuple({}, {name}, {})", ann(a), m.display(call))
+            }
+            Self::Sentinel(x) => {
+                let (a, name, call) = x.as_ref();
+                write!(f, "Sentinel({}, {name}, {})", ann(a), m.display(call))
             }
             Self::ReturnExplicit(x) => {
                 write!(f, "ReturnExplicit({}, ", ann(&x.annot))?;
@@ -2693,6 +2698,7 @@ impl Binding {
             Binding::NameAssign(x) if x.name.as_str() == x.name.to_uppercase() => {
                 Some(SymbolKind::Constant)
             }
+            Binding::Sentinel(_) => Some(SymbolKind::Constant),
             Binding::NameAssign(x) => {
                 if x.name
                     .as_str()

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -2360,6 +2360,7 @@ pub enum Binding {
         Box<(
             Option<Idx<KeyAnnotation>>,
             Identifier,
+            NestingContext,
             Box<ExprCall>,
             SentinelKind,
         )>,
@@ -2407,7 +2408,7 @@ impl DisplayWith<Bindings> for Binding {
                 write!(f, "TypeVarTuple({}, {name}, {})", ann(a), m.display(call))
             }
             Self::Sentinel(x) => {
-                let (a, name, call, kind) = x.as_ref();
+                let (a, name, _, call, kind) = x.as_ref();
                 write!(
                     f,
                     "{}({}, {name}, {})",

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -24,6 +24,7 @@ use pyrefly_python::symbol_kind::SymbolKind;
 use pyrefly_types::callable::PlaceholderBodyKind;
 use pyrefly_types::heap::TypeHeap;
 use pyrefly_types::meta_shape_dsl::ShapeDslFunction;
+use pyrefly_types::sentinel::SentinelKind;
 use pyrefly_types::special_form::SpecialForm;
 use pyrefly_types::type_alias::TypeAlias;
 use pyrefly_types::type_alias::TypeAliasIndex;
@@ -2354,7 +2355,15 @@ pub enum Binding {
     /// A match statement or if/elif chain that may be type-exhaustive.
     /// Resolves to Never if ANY narrow entry narrows to Never, None otherwise.
     Exhaustive(Box<ExhaustiveBinding>),
-    Sentinel(Box<(Option<Idx<KeyAnnotation>>, Identifier, Box<ExprCall>)>),
+    /// Last boolean represents if the sentinel is from builtins. If false, then it is from typing_extensions.
+    Sentinel(
+        Box<(
+            Option<Idx<KeyAnnotation>>,
+            Identifier,
+            Box<ExprCall>,
+            SentinelKind,
+        )>,
+    ),
 }
 
 impl DisplayWith<Bindings> for Binding {
@@ -2398,8 +2407,14 @@ impl DisplayWith<Bindings> for Binding {
                 write!(f, "TypeVarTuple({}, {name}, {})", ann(a), m.display(call))
             }
             Self::Sentinel(x) => {
-                let (a, name, call) = x.as_ref();
-                write!(f, "Sentinel({}, {name}, {})", ann(a), m.display(call))
+                let (a, name, call, kind) = x.as_ref();
+                write!(
+                    f,
+                    "{}({}, {name}, {})",
+                    kind.name(),
+                    ann(a),
+                    m.display(call)
+                )
             }
             Self::ReturnExplicit(x) => {
                 write!(f, "ReturnExplicit({}, ", ann(&x.annot))?;

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -24,7 +24,6 @@ use pyrefly_python::symbol_kind::SymbolKind;
 use pyrefly_types::callable::PlaceholderBodyKind;
 use pyrefly_types::heap::TypeHeap;
 use pyrefly_types::meta_shape_dsl::ShapeDslFunction;
-use pyrefly_types::sentinel::SentinelKind;
 use pyrefly_types::special_form::SpecialForm;
 use pyrefly_types::type_alias::TypeAlias;
 use pyrefly_types::type_alias::TypeAliasIndex;
@@ -2362,7 +2361,6 @@ pub enum Binding {
             Identifier,
             NestingContext,
             Box<ExprCall>,
-            SentinelKind,
         )>,
     ),
 }
@@ -2408,14 +2406,8 @@ impl DisplayWith<Bindings> for Binding {
                 write!(f, "TypeVarTuple({}, {name}, {})", ann(a), m.display(call))
             }
             Self::Sentinel(x) => {
-                let (a, name, _, call, kind) = x.as_ref();
-                write!(
-                    f,
-                    "{}({}, {name}, {})",
-                    kind.name(),
-                    ann(a),
-                    m.display(call)
-                )
+                let (a, name, _, call) = x.as_ref();
+                write!(f, "sentinel({}, {name}, {})", ann(a), m.display(call))
             }
             Self::ReturnExplicit(x) => {
                 write!(f, "ReturnExplicit({}, ", ann(&x.annot))?;

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -299,6 +299,7 @@ impl<'a> BindingsBuilder<'a> {
         for kw in call.arguments.keywords.iter_mut() {
             self.ensure_expr(&mut kw.value, static_type_usage);
         }
+        let nesting_context = self.scopes.nesting_context();
         // Like legacy type var, Sentinel can only be created with a single Sentinel binding to a
         // single variable (https://peps.python.org/pep-0661/#typing). Thus we bind it in the same
         // way legacy type vars are bound.
@@ -306,6 +307,7 @@ impl<'a> BindingsBuilder<'a> {
             Binding::Sentinel(Box::new((
                 ann,
                 Ast::expr_name_identifier(name.clone()),
+                nesting_context,
                 Box::new(call.clone()),
                 sentinel_kind,
             )))

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -10,6 +10,7 @@ use pyrefly_python::ast::Ast;
 use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::nesting_context::NestingContext;
 use pyrefly_python::short_identifier::ShortIdentifier;
+use pyrefly_types::sentinel::SentinelKind;
 use ruff_python_ast::Arguments;
 use ruff_python_ast::AtomicNodeIndex;
 use ruff_python_ast::Expr;
@@ -281,7 +282,12 @@ impl<'a> BindingsBuilder<'a> {
         })
     }
 
-    fn assign_sentinel(&mut self, name: &ExprName, call: &mut ExprCall) {
+    fn assign_sentinel(
+        &mut self,
+        name: &ExprName,
+        call: &mut ExprCall,
+        sentinel_kind: SentinelKind,
+    ) {
         // Type var declarations are static types only; skip them for first-usage type inference.
         let static_type_usage = &mut Usage::StaticTypeInformation {
             is_annotation: false,
@@ -301,6 +307,7 @@ impl<'a> BindingsBuilder<'a> {
                 ann,
                 Ast::expr_name_identifier(name.clone()),
                 Box::new(call.clone()),
+                sentinel_kind,
             )))
         })
     }
@@ -623,11 +630,11 @@ impl<'a> BindingsBuilder<'a> {
                                 return;
                             }
                             SpecialExport::Sentinel => {
-                                self.assign_sentinel(name, call);
+                                self.assign_sentinel(name, call, SentinelKind::TypingExtensions);
                                 return;
                             }
                             SpecialExport::BuiltinsSentinel => {
-                                self.assign_sentinel(name, call);
+                                self.assign_sentinel(name, call, SentinelKind::Builtins);
                                 return;
                             }
                             SpecialExport::Enum

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -281,6 +281,30 @@ impl<'a> BindingsBuilder<'a> {
         })
     }
 
+    fn assign_sentinel(&mut self, name: &ExprName, call: &mut ExprCall) {
+        // Type var declarations are static types only; skip them for first-usage type inference.
+        let static_type_usage = &mut Usage::StaticTypeInformation {
+            is_annotation: false,
+        };
+        self.ensure_expr(&mut call.func, static_type_usage);
+        if let Some(expr) = call.arguments.args.iter_mut().next() {
+            self.ensure_expr(expr, static_type_usage);
+        }
+        for kw in call.arguments.keywords.iter_mut() {
+            self.ensure_expr(&mut kw.value, static_type_usage);
+        }
+        // Like legacy type var, Sentinel can only be created with a single Sentinel binding to a
+        // single variable (https://peps.python.org/pep-0661/#typing). Thus we bind it in the same
+        // way legacy type vars are bound.
+        self.bind_legacy_type_var_or_typing_alias(name, |ann| {
+            Binding::Sentinel(Box::new((
+                ann,
+                Ast::expr_name_identifier(name.clone()),
+                Box::new(call.clone()),
+            )))
+        })
+    }
+
     fn ensure_type_alias_type_args(
         &mut self,
         call: &mut ExprCall,
@@ -596,6 +620,10 @@ impl<'a> BindingsBuilder<'a> {
                             }
                             SpecialExport::TypeVarTuple => {
                                 self.assign_type_var_tuple(name, call);
+                                return;
+                            }
+                            SpecialExport::Sentinel => {
+                                self.assign_sentinel(name, call);
                                 return;
                             }
                             SpecialExport::Enum

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -626,6 +626,10 @@ impl<'a> BindingsBuilder<'a> {
                                 self.assign_sentinel(name, call);
                                 return;
                             }
+                            SpecialExport::BuiltinsSentinel => {
+                                self.assign_sentinel(name, call);
+                                return;
+                            }
                             SpecialExport::Enum
                             | SpecialExport::IntEnum
                             | SpecialExport::StrEnum => {

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -10,7 +10,6 @@ use pyrefly_python::ast::Ast;
 use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::nesting_context::NestingContext;
 use pyrefly_python::short_identifier::ShortIdentifier;
-use pyrefly_types::sentinel::SentinelKind;
 use ruff_python_ast::Arguments;
 use ruff_python_ast::AtomicNodeIndex;
 use ruff_python_ast::Expr;
@@ -282,12 +281,7 @@ impl<'a> BindingsBuilder<'a> {
         })
     }
 
-    fn assign_sentinel(
-        &mut self,
-        name: &ExprName,
-        call: &mut ExprCall,
-        sentinel_kind: SentinelKind,
-    ) {
+    fn assign_sentinel(&mut self, name: &ExprName, call: &mut ExprCall) {
         // Type var declarations are static types only; skip them for first-usage type inference.
         let static_type_usage = &mut Usage::StaticTypeInformation {
             is_annotation: false,
@@ -309,7 +303,6 @@ impl<'a> BindingsBuilder<'a> {
                 Ast::expr_name_identifier(name.clone()),
                 nesting_context,
                 Box::new(call.clone()),
-                sentinel_kind,
             )))
         })
     }
@@ -632,11 +625,11 @@ impl<'a> BindingsBuilder<'a> {
                                 return;
                             }
                             SpecialExport::Sentinel => {
-                                self.assign_sentinel(name, call, SentinelKind::TypingExtensions);
+                                self.assign_sentinel(name, call);
                                 return;
                             }
                             SpecialExport::BuiltinsSentinel => {
-                                self.assign_sentinel(name, call, SentinelKind::Builtins);
+                                self.assign_sentinel(name, call);
                                 return;
                             }
                             SpecialExport::Enum

--- a/pyrefly/lib/export/special.rs
+++ b/pyrefly/lib/export/special.rs
@@ -74,6 +74,7 @@ pub enum SpecialExport {
     UsesShapeDsl,
     ShapeDslFunction,
     ShapedArray,
+    Sentinel,
 }
 
 impl SpecialExport {
@@ -139,6 +140,7 @@ impl SpecialExport {
             "uses_shape_dsl" => Some(Self::UsesShapeDsl),
             "shape_dsl_function" => Some(Self::ShapeDslFunction),
             "shaped_array" => Some(Self::ShapedArray),
+            "Sentinel" => Some(Self::Sentinel),
             _ => None,
         }
     }
@@ -213,6 +215,7 @@ impl SpecialExport {
             Self::UsesShapeDsl => matches!(m.as_str(), "shape_extensions"),
             Self::ShapeDslFunction => matches!(m.as_str(), "shape_extensions.dsl"),
             Self::ShapedArray => matches!(m.as_str(), "shape_extensions"),
+            Self::Sentinel => matches!(m.as_str(), "typing_extensions"),
         }
     }
 

--- a/pyrefly/lib/export/special.rs
+++ b/pyrefly/lib/export/special.rs
@@ -75,6 +75,7 @@ pub enum SpecialExport {
     ShapeDslFunction,
     ShapedArray,
     Sentinel,
+    BuiltinsSentinel,
 }
 
 impl SpecialExport {
@@ -141,6 +142,7 @@ impl SpecialExport {
             "shape_dsl_function" => Some(Self::ShapeDslFunction),
             "shaped_array" => Some(Self::ShapedArray),
             "Sentinel" => Some(Self::Sentinel),
+            "sentinel" => Some(Self::BuiltinsSentinel),
             _ => None,
         }
     }
@@ -216,6 +218,7 @@ impl SpecialExport {
             Self::ShapeDslFunction => matches!(m.as_str(), "shape_extensions.dsl"),
             Self::ShapedArray => matches!(m.as_str(), "shape_extensions"),
             Self::Sentinel => matches!(m.as_str(), "typing_extensions"),
+            Self::BuiltinsSentinel => matches!(m.as_str(), "builtins"),
         }
     }
 

--- a/pyrefly/lib/query.rs
+++ b/pyrefly/lib/query.rs
@@ -425,6 +425,10 @@ fn type_shape_kind(context: &TypeShapeContext, ty: &Type) -> TypeShapeKind {
             "typing.Literal",
             vec![named_leaf(literal.value.to_string())],
         ),
+        Type::Sentinel(sentinel) => named_type_shape_kind(
+            "typing_extensions.Sentinel",
+            vec![named_leaf(format!("{}", sentinel))],
+        ),
         Type::LiteralString(_) => {
             named_type_shape_kind("typing_extensions.LiteralString", Vec::new())
         }

--- a/pyrefly/lib/query.rs
+++ b/pyrefly/lib/query.rs
@@ -425,10 +425,9 @@ fn type_shape_kind(context: &TypeShapeContext, ty: &Type) -> TypeShapeKind {
             "typing.Literal",
             vec![named_leaf(literal.value.to_string())],
         ),
-        Type::Sentinel(sentinel) => named_type_shape_kind(
-            "typing_extensions.Sentinel",
-            vec![named_leaf(format!("{}", sentinel))],
-        ),
+        Type::Sentinel(sentinel) => {
+            named_type_shape_kind("sentinel", vec![named_leaf(format!("{}", sentinel))])
+        }
         Type::LiteralString(_) => {
             named_type_shape_kind("typing_extensions.LiteralString", Vec::new())
         }

--- a/pyrefly/lib/report/cinderx/convert.rs
+++ b/pyrefly/lib/report/cinderx/convert.rs
@@ -432,6 +432,7 @@ pub(crate) fn type_to_structured(
         | Type::ParamSpec(_)
         | Type::TypeVarTuple(_)
         | Type::TypeForm(_)
+        | Type::Sentinel(_)
         | Type::ElementOfTypeVarTuple(_)
         | Type::ShapedArray(_)
         | Type::NNModule(_)

--- a/pyrefly/lib/test/mod.rs
+++ b/pyrefly/lib/test/mod.rs
@@ -67,6 +67,7 @@ mod redundant_cast;
 mod returns;
 mod scope;
 mod semantic_syntax_errors;
+mod sentinel;
 mod shape_dsl;
 mod simple;
 mod slots;

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -3230,3 +3230,90 @@ def b():
             assert_type(val, int)
 "#,
 );
+
+testcase!(
+    test_sentinel_type_narrow_to_boolean,
+    r#"
+from typing_extensions import Sentinel
+from typing import Literal, assert_type
+
+MISSING = Sentinel("MISSING")
+def f(x: bool | MISSING):
+    if x is MISSING:
+        assert_type(x, MISSING)
+    else:
+        assert_type(x, bool)
+    if x is not MISSING:
+        assert_type(x, bool)
+    else:
+        assert_type(x, MISSING)
+    "#,
+);
+
+testcase!(
+    test_sentinel_type_narrow_to_boolean_eq,
+    r#"
+from typing_extensions import Sentinel
+from typing import Literal, assert_type
+
+MISSING = Sentinel("MISSING")
+def f(x: bool | MISSING):
+    if x == MISSING:
+        assert_type(x, MISSING)
+    else:
+        assert_type(x, bool)
+    if x != MISSING:
+        assert_type(x, bool)
+    else:
+        assert_type(x, MISSING)
+    "#,
+);
+
+testcase!(
+    sentinel_narrow_from_union,
+    r#"
+from typing_extensions import Sentinel
+from typing import Literal, assert_type
+
+MISSING = Sentinel("MISSING")
+def f(x: int | bool | MISSING):
+    if x is MISSING:
+        assert_type(x, MISSING)
+    else:
+        assert_type(x, int | bool)
+    if x is not MISSING:
+        assert_type(x, int | bool)
+    else:
+        assert_type(x, MISSING)
+    "#,
+);
+
+testcase!(
+    sentinel_is_truthy,
+    r#"
+from typing_extensions import Sentinel
+from typing import Literal, assert_type
+
+MISSING = Sentinel("MISSING")
+x: MISSING | None = MISSING
+if x:
+    assert_type(x, MISSING)
+else:
+    assert_type(x, None)
+    "#,
+);
+
+testcase!(
+    sentinel_narrow_with_type_param,
+    r#"
+from typing_extensions import Sentinel
+
+MIS = Sentinel("MIS", repr="MISSING")
+
+def a[T](x: T | MIS) -> T:
+    if x is not MIS:
+        return x
+    else:
+        raise ValueError("a")
+    "#,
+);

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -3289,21 +3289,6 @@ def f(x: int | bool | MISSING):
 );
 
 testcase!(
-    sentinel_is_truthy,
-    r#"
-from typing_extensions import Sentinel
-from typing import Literal, assert_type
-
-MISSING = Sentinel("MISSING")
-x: MISSING | None = MISSING
-if x:
-    assert_type(x, MISSING)
-else:
-    assert_type(x, None)
-    "#,
-);
-
-testcase!(
     sentinel_narrow_with_type_param,
     r#"
 from typing_extensions import Sentinel

--- a/pyrefly/lib/test/sentinel.rs
+++ b/pyrefly/lib/test/sentinel.rs
@@ -234,3 +234,18 @@ MISSING = Sentinel("MISSING")
 MISSING.__name__  # E: Object of class `Sentinel` has no attribute `__name__`
     "#,
 );
+
+testcase!(
+    sentinel_is_truthy,
+    r#"
+from typing_extensions import Sentinel
+from typing import Literal, assert_type
+
+MISSING = Sentinel("MISSING")
+x: MISSING | None = MISSING
+if x:
+    assert_type(x, MISSING)
+else:
+    assert_type(x, None)
+    "#,
+);

--- a/pyrefly/lib/test/sentinel.rs
+++ b/pyrefly/lib/test/sentinel.rs
@@ -67,11 +67,35 @@ A = Sentinel(name="A")  # E: Sentinel requires a name as the first argument # E:
 );
 
 testcase!(
-    test_sentinel_construction_different_names,
+    test_sentinel_construction_different_names_allowed,
     r#"
 from typing_extensions import Sentinel
 
-A = Sentinel("B")  # E: Sentinel must be assigned to a variable named `B`
+A = Sentinel("<A>")
+    "#,
+);
+
+testcase!(
+    test_sentinel_uses_sentinel_string_literal_name_in_error_messages,
+    r#"
+from typing_extensions import Sentinel
+
+A = Sentinel("<A>")
+
+def foo(a: A):
+    b: int = a  # E: `<A>` is not assignable to `int`
+    "#,
+);
+
+testcase!(
+    test_sentinel_defaults_to_assignment_name_if_not_constructed_with_name,
+    r#"
+from typing_extensions import Sentinel
+
+A = Sentinel()  # E: Sentinel requires a name as the first argument
+
+def foo(a: A):
+    b: int = a  # E: `A` is not assignable to `int`
     "#,
 );
 

--- a/pyrefly/lib/test/sentinel.rs
+++ b/pyrefly/lib/test/sentinel.rs
@@ -203,3 +203,34 @@ def func3(x: int | Cls.IN_CLASS = Cls.IN_CLASS) -> None:
         assert_type(x, int)
     "#,
 );
+
+testcase!(
+    test_typeshed_sentinel_3_15_no_dunder_name,
+    TestEnv::new().with_version(PythonVersion::new(3, 15, 0)),
+    r#"
+from typing_extensions import Sentinel
+
+MISSING = Sentinel("MISSING")
+MISSING.__name__  # E: Object of class `Sentinel` has no attribute `__name__`
+    "#,
+);
+
+testcase!(
+    test_builtin_sentinel_3_15_has_dunder_name,
+    TestEnv::new().with_version(PythonVersion::new(3, 15, 0)),
+    r#"
+MISSING = sentinel("MISSING")
+MISSING.__name__
+    "#,
+);
+
+testcase!(
+    test_typeshed_sentinel_3_14_no_dunder_name,
+    TestEnv::new().with_version(PythonVersion::new(3, 14, 0)),
+    r#"
+from typing_extensions import Sentinel
+
+MISSING = Sentinel("MISSING")
+MISSING.__name__  # E: Object of class `Sentinel` has no attribute `__name__`
+    "#,
+);

--- a/pyrefly/lib/test/sentinel.rs
+++ b/pyrefly/lib/test/sentinel.rs
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::testcase;
+
+testcase!(
+    test_sentinel_construction_success,
+    r#"
+from typing_extensions import Sentinel
+
+A = Sentinel("A")
+    "#,
+);
+
+testcase!(
+    test_sentinel_construction_second_positional_arg,
+    r#"
+from typing_extensions import Sentinel
+
+A = Sentinel("A", 123)  # E: Sentinel only takes one positional argument
+    "#,
+);
+
+testcase!(
+    test_sentinel_construction_with_repr_success,
+    r#"
+from typing_extensions import Sentinel
+
+A = Sentinel("A", repr="some text")
+    "#,
+);
+
+testcase!(
+    test_sentinel_construction_with_repr_str_success,
+    r#"
+from typing_extensions import Sentinel
+
+text: str = "some other text"
+A = Sentinel("A", repr=text)
+    "#,
+);
+
+testcase!(
+    test_sentinel_construction_with_repr_int_error,
+    r#"
+from typing_extensions import Sentinel
+
+text = 5
+A = Sentinel("A", repr=text)  # E: Invalid type for Sentinel `repr` Literal[5]
+    "#,
+);
+
+testcase!(
+    test_sentinel_construction_name_kwarg_error,
+    r#"
+from typing_extensions import Sentinel
+
+A = Sentinel(name="A")  # E: Sentinel requires a name as the first argument # E: Unexpected keyword argument `name` to Sentinel
+    "#,
+);
+
+testcase!(
+    test_sentinel_construction_different_names,
+    r#"
+from typing_extensions import Sentinel
+
+A = Sentinel("B")  # E: Sentinel must be assigned to a variable named `B`
+    "#,
+);
+
+testcase!(
+    test_sentinel_typehint_success,
+    r#"
+from typing_extensions import Sentinel
+
+A: A = Sentinel("A")
+    "#,
+);
+
+testcase!(
+    test_sentinel_typehint_different_sentinel,
+    r#"
+from typing_extensions import Sentinel
+
+A = Sentinel("A")
+B: A = Sentinel("B")  # E: `Sentinel` is not assignable to `A`
+    "#,
+);
+
+testcase!(
+    test_sentinel_typehint_any,
+    r#"
+from typing import Any, assert_type
+from typing_extensions import Sentinel
+
+A: Any = Sentinel("A")
+assert_type(A, Any)
+    "#,
+);
+
+testcase!(
+    test_sentinel_violates_annotation,
+    r#"
+from typing_extensions import Sentinel
+
+MISSING: int = 0
+MISSING = Sentinel('MISSING')  # E: `MISSING` is not assignable to variable `MISSING` with type `int`
+    "#,
+);
+
+testcase!(
+    test_sentinel_no_args_error,
+    r#"
+from typing_extensions import Sentinel
+
+MISSING = Sentinel()  # E: Sentinel requires a name as the first argument
+    "#,
+);

--- a/pyrefly/lib/test/sentinel.rs
+++ b/pyrefly/lib/test/sentinel.rs
@@ -249,3 +249,16 @@ else:
     assert_type(x, None)
     "#,
 );
+
+testcase!(
+    test_sentinel_in_class_body_reveal_qualified_name,
+    r#"
+from typing import reveal_type
+from typing_extensions import Sentinel
+
+class Cls:
+    IN_CLASS = Sentinel("IN_CLASS")
+
+reveal_type(Cls.IN_CLASS)  # E: Cls.IN_CLASS
+    "#,
+);

--- a/pyrefly/lib/test/sentinel.rs
+++ b/pyrefly/lib/test/sentinel.rs
@@ -205,17 +205,6 @@ def func3(x: int | Cls.IN_CLASS = Cls.IN_CLASS) -> None:
 );
 
 testcase!(
-    test_typeshed_sentinel_3_15_no_dunder_name,
-    TestEnv::new().with_version(PythonVersion::new(3, 15, 0)),
-    r#"
-from typing_extensions import Sentinel
-
-MISSING = Sentinel("MISSING")
-MISSING.__name__  # E: Object of class `Sentinel` has no attribute `__name__`
-    "#,
-);
-
-testcase!(
     test_builtin_sentinel_3_15_has_dunder_name,
     TestEnv::new().with_version(PythonVersion::new(3, 15, 0)),
     r#"

--- a/pyrefly/lib/test/sentinel.rs
+++ b/pyrefly/lib/test/sentinel.rs
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use pyrefly_python::sys_info::PythonVersion;
+
+use crate::test::util::TestEnv;
 use crate::testcase;
 
 testcase!(
@@ -118,5 +121,44 @@ testcase!(
 from typing_extensions import Sentinel
 
 MISSING = Sentinel()  # E: Sentinel requires a name as the first argument
+    "#,
+);
+
+testcase!(
+    test_sentinel_typing_extensions_3_15,
+    TestEnv::new().with_version(PythonVersion::new(3, 15, 0)),
+    r#"
+from typing import Literal, assert_type
+from typing_extensions import Sentinel
+
+A = Sentinel("A")
+def foo(a: A | Literal[False]):
+    if a:
+        assert_type(a, A)
+    else:
+        assert_type(a, Literal[False])
+    "#,
+);
+
+testcase!(
+    test_sentinel_lowercase_3_15,
+    TestEnv::new().with_version(PythonVersion::new(3, 15, 0)),
+    r#"
+from typing import Literal, assert_type
+
+A = sentinel("A")
+def foo(a: A | Literal[False]):
+    if a:
+        assert_type(a, A)
+    else:
+        assert_type(a, Literal[False])
+    "#,
+);
+
+testcase!(
+    test_sentinel_lowercase_3_14_error,
+    TestEnv::new().with_version(PythonVersion::new(3, 14, 0)),
+    r#"
+A = sentinel("A")  # E: Could not find name `sentinel`
     "#,
 );

--- a/pyrefly/lib/test/sentinel.rs
+++ b/pyrefly/lib/test/sentinel.rs
@@ -186,3 +186,20 @@ testcase!(
 A = sentinel("A")  # E: Could not find name `sentinel`
     "#,
 );
+
+testcase!(
+    test_sentinel_in_class_body,
+    r#"
+from typing import assert_type
+from typing_extensions import Sentinel
+
+class Cls:
+    IN_CLASS = Sentinel("Cls.IN_CLASS")
+
+def func3(x: int | Cls.IN_CLASS = Cls.IN_CLASS) -> None:
+    if x is Cls.IN_CLASS:
+        assert_type(x, Cls.IN_CLASS)
+    else:
+        assert_type(x, int)
+    "#,
+);

--- a/pyrefly/lib/test/sentinel.rs
+++ b/pyrefly/lib/test/sentinel.rs
@@ -53,7 +53,7 @@ testcase!(
 from typing_extensions import Sentinel
 
 text = 5
-A = Sentinel("A", repr=text)  # E: Invalid type for Sentinel `repr` Literal[5]
+A = Sentinel("A", repr=text)  # E: Invalid type for sentinel `repr` Literal[5]
     "#,
 );
 
@@ -62,7 +62,7 @@ testcase!(
     r#"
 from typing_extensions import Sentinel
 
-A = Sentinel(name="A")  # E: Sentinel requires a name as the first argument # E: Unexpected keyword argument `name` to Sentinel
+A = Sentinel(name="A")  # E: Sentinel requires a name as the first argument # E: Unexpected keyword argument `name` to sentinel
     "#,
 );
 

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -362,7 +362,7 @@ impl TypeConverter<'_> {
             PyreflyType::Materialization => builtin("Unknown"),
 
             // --- Sentinel type ---
-            PyreflyType::Sentinel(_) => builtin("Sentinel"),
+            PyreflyType::Sentinel(_) => builtin("sentinel"),
         }
     }
 

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -360,6 +360,9 @@ impl TypeConverter<'_> {
 
             // --- Materialization is a solver artifact ---
             PyreflyType::Materialization => builtin("Unknown"),
+
+            // --- Sentinel type ---
+            PyreflyType::Sentinel(_) => builtin("Sentinel"),
         }
     }
 

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -892,10 +892,11 @@ An error caused by incorrect definition of a Sentinel. A few examples:
 ```python
 from typing_extensions import Sentinel
 
-# Sentinels must be assigned to a matching variable.
-A = Sentinel("B")
+# First argument passed to sentinel constructor isn't a string literal
+my_str: str = "MISSING"
+A = Sentinel(my_str)
 
-# Invalid arguments passed to Sentinel constructor
+# Invalid arguments passed to sentinel constructor
 MISSING = Sentinel("MISSING", non_existent="")
 ```
 

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -885,6 +885,20 @@ class TD(TypedDict):
     x: Option[Self]
 ```
 
+## invalid-sentinel
+
+An error caused by incorrect definition of a Sentinel. A few examples:
+
+```python
+from typing_extensions import Sentinel
+
+# Sentinels must be assigned to a matching variable.
+A = Sentinel("B")
+
+# Invalid arguments passed to Sentinel constructor
+MISSING = Sentinel("MISSING", non_existent="")
+```
+
 ## invalid-super-call
 
 `super()` has [a few restrictions](https://docs.python.org/3/library/functions.html#super) on how it is called.


### PR DESCRIPTION
# Summary

This PR adds support for PEP 661 Sentinel types.

Fixes #3207

# Test Plan

I've run this as an LSP for a bit on a bigger private repo and it seems to work, but the main testing was the tests added to `test/narrow.rs` and `test/sentinel.rs`.

# Some assumptions/things I didn't fully understand and might deserve more attention:

- I'm using NestingContext::toplevel() when creating a Sentinel struct, this is similar to TypeVar/TypeAlias/a few others, I left the same TODO in place as they had. I looked through some of the other types and couldn't find any other way it was being done, so I left it like this for now, but if anyone has any pointers to how it should be done better, please let me know and I can fix it.

- For the cinderx support, I added the sentinel to it in the TODO section of variables that get set to Any. I haven't really diven into what cinderx is and how the support for it is implemented, but if it is important to get it working I can go ahead and look into that.

- I'm using bind_legacy_type_var_or_typing_alias to bind the Sentinel type, I think this should be ok as the PEP is pretty strict in how it can be assigned. I've done some testing and only found one edge case so far that fails because of this, but I don't think Final's should be mixed with Sentinel objects like this anyway, here is the test case that fails:

```py
from typing import Any, Final
from typing_extensions import Sentinel

MISSING: Final[Any]
MISSING = Sentinel("MISSING")
```

It fails because the `Final` doesn't notice the assignment, it still thinks the variable was never assigned to.

# Status

This PR is mostly ready for review, but I'm keeping it in Draft form until #3562 is addressed, since until then I can't finalize Python 3.15 support.
