### PR TITLE
Fix Pyrefly typo in release notes

### DIFF
--- a/release_notes/release-notes-v0.64.0.md
+++ b/release_notes/release-notes-v0.64.0.md
@@ -63,7 +63,7 @@ Upgrading the version of Pyrefly you're using or a third-party library you depen
 
 This will add  `# pyrefly: ignore` comments to your code, enabling you to silence errors and return to fix them later. This can make the process of upgrading a large codebase much more manageable.
 
-Read more about error suppressions in the \[Pyefly documentation\](https://pyrefly.org/en/docs/error-suppressions/)
+Read more about error suppressions in the \[Pyrefly documentation\](https://pyrefly.org/en/docs/error-suppressions/)
 
 ---
 

--- a/release_notes/release_notes_template.md
+++ b/release_notes/release_notes_template.md
@@ -50,7 +50,7 @@ Upgrading the version of Pyrefly you're using or a third-party library you depen
 
 This will add  `# pyrefly: ignore` comments to your code, enabling you to silence errors and return to fix them later. This can make the process of upgrading a large codebase much more manageable.
 
-Read more about error suppressions in the \[Pyefly documentation\](https://pyrefly.org/en/docs/error-suppressions/)
+Read more about error suppressions in the \[Pyrefly documentation\](https://pyrefly.org/en/docs/error-suppressions/)
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix two `Pyefly` typos in the release notes template and v0.64.0 notes.

## Testing
- Ran `git diff --check`.