### PR TITLE
stubgen: emit synthesized `__init__` for dataclasses (#3586)

### DIFF
--- a/pyrefly/lib/stubgen/extract.rs
+++ b/pyrefly/lib/stubgen/extract.rs
@@ -19,6 +19,8 @@ use pyrefly_python::module::Module;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_python::sys_info::SysInfo;
 use pyrefly_types::callable::Param;
+use pyrefly_types::callable::Params;
+use pyrefly_types::callable::Required;
 use pyrefly_types::display::TypeDisplayContext;
 use pyrefly_types::types::Type;
 use ruff_python_ast::Expr;
@@ -35,6 +37,8 @@ use crate::alt::answers::Answers;
 use crate::alt::types::decorated_function::DecoratedFunction;
 use crate::binding::binding::Key;
 use crate::binding::binding::KeyClassField;
+use crate::binding::binding::KeyClassMetadata;
+use crate::binding::binding::KeyClassSynthesizedFields;
 use crate::binding::binding::KeyDecoratedFunction;
 use crate::binding::bindings::Bindings;
 use crate::export::definitions::Definitions;
@@ -570,6 +574,147 @@ fn merge_instance_field_stubs(
     }
 }
 
+/// Returns `true` when the class is a dataclass or pydantic model, using
+/// the resolved `ClassMetadata` from the type checker rather than fragile
+/// AST pattern matching on decorator/base-class names.
+fn is_dataclass_or_pydantic_model(class_def: &StmtClassDef, ctx: &ExtractionContext) -> bool {
+    let Some(def_index) = ctx.bindings.class_def_index(class_def) else {
+        return false;
+    };
+    let key = KeyClassMetadata(def_index);
+    let Some(idx) = ctx.bindings.key_to_idx_hashed_opt(Hashed::new(&key)) else {
+        return false;
+    };
+    let Some(metadata) = ctx.answers.get_idx(idx) else {
+        return false;
+    };
+    metadata.dataclass_metadata().is_some() || metadata.is_pydantic_model()
+}
+
+/// Extract a synthesized `__init__` stub for dataclass and pydantic model
+/// classes that generate `__init__` at type-check time rather than declaring
+/// it in source.
+fn extract_synthesized_init_stub(
+    class_def: &StmtClassDef,
+    ctx: &mut ExtractionContext,
+) -> Option<StubFunction> {
+    let def_index = ctx.bindings.class_def_index(class_def)?;
+    let key = KeyClassSynthesizedFields(def_index);
+    let idx = ctx.bindings.key_to_idx_hashed_opt(Hashed::new(&key))?;
+    let synth_fields = ctx.answers.get_idx(idx)?;
+    let init_field = synth_fields.get(&Name::new("__init__"))?;
+    let init_ty = init_field.inner.ty();
+    let func = match &init_ty {
+        Type::Function(f) => f,
+        _ => return None,
+    };
+    let params = match &func.signature.params {
+        Params::List(param_list) => param_list.items(),
+        _ => return None,
+    };
+    Some(StubFunction {
+        name: "__init__".to_owned(),
+        is_async: false,
+        type_params: None,
+        decorators: Vec::new(),
+        params: synthesized_params_to_stub(params, ctx),
+        return_type: Some("None".to_owned()),
+        docstring: None,
+    })
+}
+
+/// Convert resolved `Param`s from a synthesized method into `StubParam`s.
+fn synthesized_params_to_stub(params: &[Param], ctx: &mut ExtractionContext) -> Vec<StubParam> {
+    let mut result = Vec::new();
+    let mut seen_kwonly = false;
+    let mut seen_posonly = false;
+    let has_varargs = params.iter().any(|p| matches!(p, Param::Varargs(..)));
+    for param in params {
+        if seen_posonly && !matches!(param, Param::PosOnly(..)) {
+            result.push(StubParam {
+                prefix: "",
+                name: "/".to_owned(),
+                annotation: None,
+                default: None,
+            });
+            seen_posonly = false;
+        }
+        match param {
+            Param::PosOnly(..) => {
+                seen_posonly = true;
+                result.push(StubParam {
+                    prefix: "",
+                    name: param.name().map_or("_".to_owned(), |n| n.to_string()),
+                    annotation: format_param_type(param, ctx),
+                    default: required_to_default(param),
+                });
+            }
+            Param::Pos(name, ..) => {
+                result.push(StubParam {
+                    prefix: "",
+                    name: name.to_string(),
+                    annotation: format_param_type(param, ctx),
+                    default: required_to_default(param),
+                });
+            }
+            Param::Varargs(..) => {
+                result.push(StubParam {
+                    prefix: "*",
+                    name: param.name().map_or("args".to_owned(), |n| n.to_string()),
+                    annotation: format_param_type(param, ctx),
+                    default: None,
+                });
+            }
+            Param::KwOnly(name, ..) => {
+                if !seen_kwonly && !has_varargs {
+                    result.push(StubParam {
+                        prefix: "",
+                        name: "*".to_owned(),
+                        annotation: None,
+                        default: None,
+                    });
+                }
+                seen_kwonly = true;
+                result.push(StubParam {
+                    prefix: "",
+                    name: name.to_string(),
+                    annotation: format_param_type(param, ctx),
+                    default: required_to_default(param),
+                });
+            }
+            Param::Kwargs(..) => {
+                result.push(StubParam {
+                    prefix: "**",
+                    name: param.name().map_or("kwargs".to_owned(), |n| n.to_string()),
+                    annotation: format_param_type(param, ctx),
+                    default: None,
+                });
+            }
+        }
+    }
+    if seen_posonly {
+        result.push(StubParam {
+            prefix: "",
+            name: "/".to_owned(),
+            annotation: None,
+            default: None,
+        });
+    }
+    result
+}
+
+/// Map a `Param`'s requiredness to a stub default (`= ...` for optional, `None` for required).
+fn required_to_default(param: &Param) -> Option<String> {
+    let required = match param {
+        Param::PosOnly(_, _, r) | Param::Pos(_, _, r) | Param::KwOnly(_, _, r) => r,
+        Param::Varargs(..) | Param::Kwargs(..) => return None,
+    };
+    match required {
+        Required::Required => None,
+        Required::Optional(_) => Some("...".to_owned()),
+    }
+}
+
 fn extract_class(class_def: &StmtClassDef, ctx: &mut ExtractionContext) -> Option<StubClass> {
     let name = class_def.name.id.as_str();
     if !should_include_name(name, ctx.config, false, ctx.dunder_all) {
@@ -619,7 +764,16 @@ fn extract_class(class_def: &StmtClassDef, ctx: &mut ExtractionContext) -> Optio
         .as_ref()
         .map(|tp| source_text(ctx.module_info, tp.range()).to_owned());
 
-    let body = extract_stmts(&class_def.body, ctx, true);
+    let mut body = extract_stmts(&class_def.body, ctx, true);
+    let has_explicit_init = body
+        .iter()
+        .any(|item| matches!(item, StubItem::Function(f) if f.name == "__init__"));
+    if !has_explicit_init
+        && is_dataclass_or_pydantic_model(class_def, ctx)
+        && let Some(init_stub) = extract_synthesized_init_stub(class_def, ctx)
+    {
+        body.push(StubItem::Function(init_stub));
+    }
     let extra = extract_instance_attr_stubs_from_class_fields(class_def, &body, ctx);
     let body = merge_instance_field_stubs(extra, body);
 

--- a/pyrefly/lib/stubgen/mod.rs
+++ b/pyrefly/lib/stubgen/mod.rs
@@ -45,6 +45,57 @@ mod tests {
         let mut t = TestEnv::new();
         t.add(&path.display().to_string(), input);
         let includes = Globs::new(vec![format!("{}/**/*", tdir.path().display())]).unwrap();
+        run_stubgen_inner(&mut t, includes, config)
+    }
+
+    /// Pydantic shim providing `@dataclass_transform` on `BaseModel` so the
+    /// type checker synthesizes `__init__` for pydantic model subclasses.
+    const PYDANTIC_SHIM: &str = r#"from typing import dataclass_transform
+
+def Field(**kwargs): ...
+
+def computed_field(fn=None, **_kw):
+    return fn
+
+@dataclass_transform(
+    kw_only_default=False,
+    field_specifiers=(Field,),
+)
+class BaseModel:
+    pass
+"#;
+
+    /// Like `run_stubgen`, but injects a minimal pydantic shim so that
+    /// `BaseModel` subclasses get synthesized `__init__` in the stub output.
+    fn run_stubgen_pydantic(input: &str) -> String {
+        let config = ExtractConfig {
+            include_private: false,
+            include_docstrings: false,
+        };
+        let tdir = tempfile::tempdir().unwrap();
+
+        // Write the pydantic shim as a real package on disk.
+        let pydantic_dir = tdir.path().join("pydantic");
+        fs_anyhow::create_dir_all(&pydantic_dir).unwrap();
+        let pydantic_init = pydantic_dir.join("__init__.py");
+        fs_anyhow::write(&pydantic_init, PYDANTIC_SHIM).unwrap();
+
+        // Write the test input alongside the shim.
+        let path = tdir.path().join("input.py");
+        fs_anyhow::write(&path, input).unwrap();
+
+        let mut t = TestEnv::new();
+        t.add(&path.display().to_string(), input);
+        t.add_real_path("pydantic", pydantic_init);
+
+        // Only process the input file — not the pydantic shim.
+        let includes = Globs::new(vec![path.display().to_string()]).unwrap();
+        run_stubgen_inner(&mut t, includes, &config)
+    }
+
+    /// Shared stubgen runner: sets up `FilteredGlobs`, `State`, and
+    /// `Transaction`, then extracts and emits stubs for the matched files.
+    fn run_stubgen_inner(t: &mut TestEnv, includes: Globs, config: &ExtractConfig) -> String {
         let f_globs = Box::new(FilteredGlobs::new(
             includes,
             Globs::empty(),
@@ -87,6 +138,18 @@ mod tests {
 
     /// Run a snapshot test for a specific test case directory.
     fn assert_stubgen_snapshot(test_name: &str) {
+        assert_stubgen_snapshot_with(test_name, run_stubgen);
+    }
+
+    /// Like `assert_stubgen_snapshot` but injects the pydantic shim so
+    /// `BaseModel` subclasses get synthesized `__init__` in the output.
+    fn assert_stubgen_pydantic_snapshot(test_name: &str) {
+        assert_stubgen_snapshot_with(test_name, run_stubgen_pydantic);
+    }
+
+    /// Shared snapshot runner: reads `input.py`, produces a stub via
+    /// `stub_fn`, and compares against `expected.pyi`.
+    fn assert_stubgen_snapshot_with(test_name: &str, stub_fn: impl Fn(&str) -> String) {
         let test_dir = get_test_dir().join(test_name);
         let input_path = test_dir.join("input.py");
         let expected_path = test_dir.join("expected.pyi");
@@ -98,7 +161,7 @@ mod tests {
         );
 
         let input = fs_anyhow::read_to_string(&input_path).unwrap();
-        let actual = run_stubgen(&input);
+        let actual = stub_fn(&input);
 
         if std::env::var("STUBGEN_UPDATE_SNAPSHOTS").is_ok() {
             fs_anyhow::create_dir_all(&test_dir).unwrap();
@@ -276,6 +339,16 @@ class A:
             .trim(),
             actual.trim(),
         );
+    }
+
+    #[test]
+    fn test_stubgen_dataclass() {
+        assert_stubgen_snapshot("dataclass");
+    }
+
+    #[test]
+    fn test_stubgen_pydantic() {
+        assert_stubgen_pydantic_snapshot("pydantic");
     }
 
     /// Instance attrs from `__init__` are emitted in alphabetical order by name (not assignment

--- a/pyrefly/lib/test/stubgen/dataclass/expected.pyi
+++ b/pyrefly/lib/test/stubgen/dataclass/expected.pyi
@@ -1,0 +1,56 @@
+# @generated
+from dataclasses import dataclass, field, InitVar
+from typing import ClassVar
+
+
+@dataclass
+class OptionalName:
+    name: str | None
+
+    def __init__(self, name: str | None = ...) -> None: ...
+
+
+@dataclass
+class Mixed:
+    required: int
+    literal_default: str = "x"
+    field_with_default: int
+    field_with_none: str | None
+    items: list[str]
+    complex_factory: list[int]
+    field_no_default: int
+    field_ellipsis: int
+
+    def __init__(self, required: int, literal_default: str = ..., field_with_default: int = ..., field_with_none: str | None = ..., items: list[str] = ..., complex_factory: list[int] = ..., field_no_default: int, *, field_ellipsis: int) -> None: ...
+
+
+@dataclass
+class WithInitFalse:
+    path: str
+    cached: dict[str, str]
+
+    def __init__(self, path: str) -> None: ...
+
+
+@dataclass
+class WithInitVarAndClassVar:
+    sentinel: ClassVar[str] = "x"
+    raw: InitVar[bytes | None]
+    text: str
+
+    def __init__(self, raw: bytes | None, text: str = ...) -> None: ...
+
+
+@dataclass(kw_only=True)
+class AllKwOnly:
+    a: int
+    b: str = "y"
+
+    def __init__(self, *, a: int, b: str = ...) -> None: ...
+
+
+@dataclass
+class CustomInit:
+    x: int
+
+    def __init__(self, x: int, *, tag: str = "") -> None: ...

--- a/pyrefly/lib/test/stubgen/dataclass/input.py
+++ b/pyrefly/lib/test/stubgen/dataclass/input.py
@@ -1,0 +1,60 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass, field, InitVar
+from typing import ClassVar
+
+
+# The original #3221 reproducer: a non-literal `field(default=None)` should still produce a
+# default in the synthesized `__init__`, so `A()` is accepted by checkers against the stub.
+@dataclass
+class OptionalName:
+    name: str | None = field(default=None)
+
+
+# Mixed field defaults: literal, `field(default=...)`, `field(default_factory=...)`, bare
+# `field()`, and a trailing `field(..., kw_only=True)` to force keyword-only positioning.
+@dataclass
+class Mixed:
+    required: int
+    literal_default: str = "x"
+    field_with_default: int = field(default=0, metadata={"a": 1}, repr=True)
+    field_with_none: str | None = field(default=None)
+    items: list[str] = field(default_factory=list, metadata={"k": 1})
+    complex_factory: list[int] = field(default_factory=lambda: [1, 2, 3])
+    field_no_default: int = field()
+    field_ellipsis: int = field(..., kw_only=True)
+
+
+# `init=False` keeps the attribute typed on the class but drops it from `__init__`.
+@dataclass
+class WithInitFalse:
+    path: str
+    cached: dict[str, str] = field(default_factory=dict, init=False)
+
+
+# `InitVar` participates in `__init__` (unwrapped to its inner type) but does not become a
+# stored attribute. `ClassVar` stays on the class body and is omitted from `__init__`.
+@dataclass
+class WithInitVarAndClassVar:
+    sentinel: ClassVar[str] = "x"
+    raw: InitVar[bytes | None]
+    text: str = field(default="")
+
+
+# `@dataclass(kw_only=True)` makes every constructor parameter keyword-only.
+@dataclass(kw_only=True)
+class AllKwOnly:
+    a: int
+    b: str = "y"
+
+
+# A user-defined `__init__` must be kept verbatim; stubgen must not synthesize a replacement.
+@dataclass
+class CustomInit:
+    x: int
+
+    def __init__(self, x: int, *, tag: str = "") -> None:
+        self.x = x

--- a/pyrefly/lib/test/stubgen/pydantic/expected.pyi
+++ b/pyrefly/lib/test/stubgen/pydantic/expected.pyi
@@ -1,0 +1,54 @@
+# @generated
+import functools
+from pydantic import BaseModel, computed_field, Field
+
+
+class Mixed(BaseModel):
+    required: int
+    literal_default: int = 7
+    field_with_default: int
+    field_with_none: str | None
+    items: list[str]
+    complex_factory: list[int]
+    field_bare: int
+    field_ellipsis: int
+    field_ellipsis_only: int
+
+    def __init__(self, required: int, literal_default: int = ..., field_with_default: int = ..., field_with_none: str | None = ..., items: list[str] = ..., complex_factory: list[int] = ..., field_bare: int, field_ellipsis: int, field_ellipsis_only: int) -> None: ...
+
+
+class WithInitFalse(BaseModel):
+    id: int
+    digest: bytes
+
+    def __init__(self, id: int) -> None: ...
+
+
+class WithValidationAlias(BaseModel):
+    internal_id: int
+
+    def __init__(self, internal_id: int) -> None: ...
+
+
+class WithKwOnly(BaseModel):
+    req: int
+    opt: str
+
+    def __init__(self, req: int, *, opt: str = ...) -> None: ...
+
+
+class WithComputed(BaseModel):
+    width: int
+    height: int
+
+    @computed_field
+    @property
+    def area(self) -> int: ...
+
+    def __init__(self, width: int, height: int) -> None: ...
+
+
+class CustomInit(BaseModel):
+    name: str
+
+    def __init__(self, name: str, *, eager: bool = False) -> None: ...

--- a/pyrefly/lib/test/stubgen/pydantic/input.py
+++ b/pyrefly/lib/test/stubgen/pydantic/input.py
@@ -1,0 +1,61 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+
+from pydantic import BaseModel, computed_field, Field
+
+
+# Mixed Pydantic `Field` defaults: literal, `default=`, `default_factory=` (simple + complex),
+# `Field(...)` for required fields, bare `Field()`, plus a kwargs-only field.
+class Mixed(BaseModel):
+    required: int
+    literal_default: int = 7
+    field_with_default: int = Field(default=0)
+    field_with_none: str | None = Field(default=None)
+    items: list[str] = Field(default_factory=list, min_length=0)
+    complex_factory: list[int] = Field(default_factory=functools.partial(list, [0]))
+    field_bare: int = Field()
+    field_ellipsis: int = Field(..., description="req")
+    field_ellipsis_only: int = Field(...)
+
+
+# `init=False` keeps the attribute on the model but drops it from `__init__`, matching the
+# runtime constructor surface.
+class WithInitFalse(BaseModel):
+    id: int
+    digest: bytes = Field(default=b"", init=False)
+
+
+# Pydantic `validation_alias` (without `validate_by_name`) means the field is only populated
+# via the alias keyword; the alias appears as a keyword-only parameter on `__init__`.
+class WithValidationAlias(BaseModel):
+    internal_id: int = Field(validation_alias="id")
+
+
+# `Field(kw_only=True)` forces a field (and any later fields) to be keyword-only.
+class WithKwOnly(BaseModel):
+    req: int = Field(kw_only=False)
+    opt: str = Field(default="z", kw_only=True)
+
+
+# `@computed_field` exposes a read-only attribute that is not a constructor parameter; it
+# should appear in the stub as a plain `@property`.
+class WithComputed(BaseModel):
+    width: int
+    height: int
+
+    @computed_field
+    @property
+    def area(self) -> int:
+        return self.width * self.height
+
+
+# A user-defined `__init__` must be kept verbatim; stubgen must not synthesize a replacement.
+class CustomInit(BaseModel):
+    name: str
+
+    def __init__(self, name: str, *, eager: bool = False) -> None:
+        super().__init__(name=name)


### PR DESCRIPTION
Summary:

closes https://github.com/facebook/pyrefly/issues/3221

Dataclasses (and similar patterns like NamedTuples) generate their
`__init__` at type-check time rather than declaring it in source.
Previously, stubgen would omit the `__init__` entirely for these
classes, producing stubs that lost the constructor signature.

Look up `KeyClassSynthesizedFields` in the answers to find the
synthesized `__init__` type (a `Type::Function` with the full
`Callable` signature), then convert its `Param` list into stub
parameters. Only emitted when no explicit `__init__` exists in the
source.

Differential Revision: D106327984


