### PR TITLE
Make `is_subset_overload` revert specialization errors

### DIFF
--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -1571,8 +1571,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         };
         if let Some(targs) = ctor_targs {
-            let mut residual_vars = call_context.overload_captured_vars();
-            residual_vars.extend(call_context.generic_captured_vars());
+            let residual_vars = call_context.captured_vars();
             self.solver().generalize_class_targs(targs, &residual_vars);
         }
         let mut errors = self

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -1571,9 +1571,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         };
         if let Some(targs) = ctor_targs {
-            let overload_capture_vars = call_context.overload_captured_vars();
-            self.solver()
-                .generalize_class_targs(targs, &overload_capture_vars);
+            let mut residual_vars = call_context.overload_captured_vars();
+            residual_vars.extend(call_context.generic_captured_vars());
+            self.solver().generalize_class_targs(targs, &residual_vars);
         }
         let mut errors = self
             .solver()

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -140,6 +140,10 @@ struct GenericWitnessCapture {
 pub(crate) struct OverloadBranchCapture {
     branch_index: usize,
     values: SmallMap<Var, Variable>,
+    /// Vars that had a generic residual at snapshot time. Used by
+    /// `materialize_overload_residual_branch_value` to decide whether
+    /// to produce a `callable_residual_generic`.
+    generic_residual_vars: SmallSet<Var>,
 }
 
 type OverloadWitnessCapturesByHash = SmallMap<u64, Vec<OverloadBranchCapture>>;
@@ -736,15 +740,22 @@ impl Solver {
         &self,
         branch_index: usize,
         vars: &[Var],
+        generic_captured_vars: &SmallSet<Var>,
     ) -> OverloadBranchCapture {
         let variables = self.variables.lock();
         let values: SmallMap<Var, Variable> = vars
             .iter()
             .map(|var| (*var, variables.get(*var).clone()))
             .collect();
+        let generic_residual_vars: SmallSet<Var> = vars
+            .iter()
+            .copied()
+            .filter(|var| generic_captured_vars.contains(var))
+            .collect();
         OverloadBranchCapture {
             branch_index,
             values,
+            generic_residual_vars,
         }
     }
 
@@ -1287,6 +1298,7 @@ impl Solver {
             false,
             &mut |_got, _want| Ok(()),
             &mut SmallMap::new(),
+            &[],
         );
 
         callable
@@ -1554,25 +1566,10 @@ impl Solver {
         witness: &ResidualWitnessContext,
         call_context: &CallContext,
     ) {
-        let witness_vars = witness.capture_candidate_vars();
-
-        // Dual-write: keep variable-backed path (will be removed in a follow-up)
-        // alongside the new payload-backed path.
-        let lock = self.variables.lock();
-        for &var in witness_vars.iter() {
-            let mut variable = lock.get_mut(var);
-            if let Variable::Quantified { residuals, .. } = &mut *variable
-                && !residuals.contains(&witness.identity)
-            {
-                residuals.push(witness.identity.clone());
-            }
-        }
-        drop(lock);
-
         call_context.persist_generic_witness_capture(GenericWitnessCapture {
             witness_hash: witness.identity.witness_hash,
             target_vars: witness.identity.target_vars.clone(),
-            witness_vars,
+            witness_vars: witness.capture_candidate_vars(),
         });
     }
 
@@ -1588,18 +1585,20 @@ impl Solver {
         *right = left.clone();
     }
 
-    fn materialize_overload_residual_branch_value(&self, value: &Variable) -> Type {
+    fn materialize_overload_residual_branch_value(
+        &self,
+        value: &Variable,
+        has_generic_residual: bool,
+    ) -> Type {
         match value {
             Variable::Answer(ty) | Variable::ResidualAnswer { ty, .. } => ty.clone(),
             Variable::Quantified {
-                quantified,
-                bounds,
-                residuals,
+                quantified, bounds, ..
             } => {
                 if let Some(bound) = self.solve_bounds(bounds.clone()) {
                     return bound;
                 }
-                if residuals.len() == 1 {
+                if has_generic_residual {
                     return Type::callable_residual_generic(quantified.clone());
                 }
                 quantified.as_gradual_type()
@@ -1641,7 +1640,9 @@ impl Solver {
             .filter(|capture| surviving_branch_indices.contains(&capture.branch_index))
             .filter_map(|capture| {
                 let value = capture.values.get(&var)?;
-                let mut ty = self.materialize_overload_residual_branch_value(value);
+                let has_generic_residual = capture.generic_residual_vars.contains(&var);
+                let mut ty =
+                    self.materialize_overload_residual_branch_value(value, has_generic_residual);
                 ty.flatten_overload_residual_markers(&self.heap);
                 Some(OverloadBranchProjection {
                     branch_index: capture.branch_index,
@@ -1822,7 +1823,7 @@ impl Solver {
         type_order: TypeOrder<Ans>,
         call_context: Option<&CallContext>,
     ) -> Result<(), Vec1<TypeVarSpecializationError>> {
-        let (vs, mut overload_witness_captures, _generic_witness_captures) =
+        let (vs, mut overload_witness_captures, generic_witness_captures) =
             if let Some(cc) = call_context {
                 let tracked_fresh_vars = cc.take_deferred_quantified_vars();
                 let overload_witness_captures = cc.take_overload_witness_captures();
@@ -1861,6 +1862,7 @@ impl Solver {
             infer_with_first_use,
             &mut |got, want| subset.is_subset_eq_probe_for_pruning(got, want),
             &mut overload_witness_captures,
+            &generic_witness_captures,
         )
     }
 
@@ -1878,6 +1880,31 @@ impl Solver {
         self.finish_quantified(vs, self.infer_with_first_use, type_order, None)
     }
 
+    /// Find the unique generic witness capture whose `witness_vars` share a
+    /// union-find root with `v`. Returns `None` if zero or multiple captures match
+    /// (ambiguous matches cannot produce a residual).
+    fn find_unique_generic_witness(
+        &self,
+        v: Var,
+        captures: &[GenericWitnessCapture],
+        root_map: &SmallMap<Var, Var>,
+    ) -> Option<SmallSet<Var>> {
+        let v_root = root_map.get(&v).copied().unwrap_or(v);
+        let mut found = None;
+        for c in captures {
+            if c.witness_vars
+                .iter()
+                .any(|wv| root_map.get(wv).copied().unwrap_or(*wv) == v_root)
+            {
+                if found.is_some() {
+                    return None;
+                }
+                found = Some(c.target_vars.clone());
+            }
+        }
+        found
+    }
+
     /// Core quantified-finishing implementation.
     ///
     /// The injected `is_subset` callback controls whether/how overload branch
@@ -1888,6 +1915,7 @@ impl Solver {
         infer_with_first_use: bool,
         is_subset: &mut dyn FnMut(&Type, &Type) -> Result<(), SubsetError>,
         overload_witness_captures: &mut OverloadWitnessCapturesByHash,
+        generic_witness_captures: &[GenericWitnessCapture],
     ) -> Result<(), Vec1<TypeVarSpecializationError>> {
         let mut err = Vec::new();
         let has_overload_captures = !overload_witness_captures.is_empty();
@@ -2011,6 +2039,21 @@ impl Solver {
             map
         };
 
+        // Precompute union-find roots for all vars that appear in generic
+        // residual captures, so we can match vars by equivalence class without
+        // holding a mutable borrow during the main loop.
+        let root_map: SmallMap<Var, Var> = if !generic_witness_captures.is_empty() {
+            let lock = self.variables.lock();
+            let all_vars = vs.0.iter().copied().chain(
+                generic_witness_captures
+                    .iter()
+                    .flat_map(|c| c.witness_vars.iter().copied()),
+            );
+            all_vars.map(|v| (v, lock.get_root(v))).collect()
+        } else {
+            SmallMap::new()
+        };
+
         let mut reported_all_pruned_witnesses = SmallSet::new();
         let lock = self.variables.lock();
         for &v in &vs.0 {
@@ -2018,7 +2061,7 @@ impl Solver {
             if let Variable::Quantified {
                 quantified: q,
                 bounds,
-                residuals,
+                ..
             } = &mut *e
             {
                 let solved_bound = self.solve_bounds(mem::take(bounds));
@@ -2066,11 +2109,7 @@ impl Solver {
                         });
                     }
                 }
-                let residual_candidate = if solved_bound.is_none() && residuals.len() == 1 {
-                    residuals.first().cloned()
-                } else {
-                    None
-                };
+
                 *e = if let Some(bound) = solved_bound {
                     Variable::Answer(bound)
                 } else if overload_all_pruned {
@@ -2093,7 +2132,9 @@ impl Solver {
                         &overload_pruning_by_witness,
                     );
                     Variable::ResidualAnswer { target_vars, ty }
-                } else if let Some(ResidualIdentity { target_vars, .. }) = residual_candidate {
+                } else if let Some(target_vars) =
+                    self.find_unique_generic_witness(v, generic_witness_captures, &root_map)
+                {
                     Variable::ResidualAnswer {
                         target_vars,
                         ty: Type::callable_residual_generic(q.clone()),
@@ -2149,7 +2190,7 @@ impl Solver {
     pub fn generalize_class_targs(
         &self,
         targs: &mut TArgs,
-        vars_with_overload_residuals: &SmallSet<Var>,
+        vars_with_residual_captures: &SmallSet<Var>,
     ) {
         // Expanding targs might require the variables lock, so do that first.
         targs.as_mut().iter_mut().for_each(|t| self.expand_mut(t));
@@ -2160,12 +2201,12 @@ impl Solver {
                 if let Variable::Quantified {
                     quantified: q,
                     bounds,
-                    residuals,
+                    ..
                 } = &mut *e
                     && *q == *param
                 {
-                    let has_overload_residuals = vars_with_overload_residuals.contains(v);
-                    if bounds.is_empty() && residuals.is_empty() && !has_overload_residuals {
+                    let has_residual_captures = vars_with_residual_captures.contains(v);
+                    if bounds.is_empty() && !has_residual_captures {
                         *t = param.clone().to_type(&self.heap);
                     } else if !bounds.is_empty() {
                         // If the variable has bounds, finalize its type now.

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -123,6 +123,18 @@ struct ResidualIdentity {
     target_vars: SmallSet<Var>,
 }
 
+/// Per-call capture of generic witness information, stored on `CallContext`.
+/// Each entry records a single Forall instantiation's witness vars and the
+/// target vars that are allowed to observe the residualized answer.
+#[derive(Clone, Debug)]
+struct GenericWitnessCapture {
+    witness_hash: u64,
+    target_vars: SmallSet<Var>,
+    /// Union of origin_vars and deferred_vars from the witness — the quantified
+    /// vars constrained by this Forall instantiation.
+    witness_vars: SmallSet<Var>,
+}
+
 /// Full per-branch capture used transiently during overload probing.
 #[derive(Clone, Debug)]
 pub(crate) struct OverloadBranchCapture {
@@ -1537,13 +1549,17 @@ impl Solver {
         }
     }
 
-    pub(crate) fn record_generic_residuals_for_witness(&self, witness: &ResidualWitnessContext) {
+    pub(crate) fn record_generic_residuals_for_witness(
+        &self,
+        witness: &ResidualWitnessContext,
+        call_context: &CallContext,
+    ) {
+        let witness_vars = witness.capture_candidate_vars();
+
+        // Dual-write: keep variable-backed path (will be removed in a follow-up)
+        // alongside the new payload-backed path.
         let lock = self.variables.lock();
-        for &var in witness
-            .origin_vars
-            .iter()
-            .chain(witness.deferred_vars.iter())
-        {
+        for &var in witness_vars.iter() {
             let mut variable = lock.get_mut(var);
             if let Variable::Quantified { residuals, .. } = &mut *variable
                 && !residuals.contains(&witness.identity)
@@ -1551,6 +1567,13 @@ impl Solver {
                 residuals.push(witness.identity.clone());
             }
         }
+        drop(lock);
+
+        call_context.persist_generic_witness_capture(GenericWitnessCapture {
+            witness_hash: witness.identity.witness_hash,
+            target_vars: witness.identity.target_vars.clone(),
+            witness_vars,
+        });
     }
 
     fn merge_residual_candidates(
@@ -1799,33 +1822,36 @@ impl Solver {
         type_order: TypeOrder<Ans>,
         call_context: Option<&CallContext>,
     ) -> Result<(), Vec1<TypeVarSpecializationError>> {
-        let (vs, mut overload_witness_captures) = if let Some(cc) = call_context {
-            let tracked_fresh_vars = cc.take_deferred_quantified_vars();
-            let overload_witness_captures = cc.take_overload_witness_captures();
-            cc.mark_boundary_consumed_and_drained();
-            let overload_capture_vars: SmallSet<Var> = overload_witness_captures
-                .values()
-                .flat_map(|branch_captures| branch_captures.iter())
-                .flat_map(|capture| capture.values.keys().copied())
-                .collect();
-            let mut roots: SmallSet<Var> = vs.0.into_iter().collect();
-            roots.extend(tracked_fresh_vars.0);
-            // Solve boundaries explicitly own fresh quantified tracking. We finish
-            // the exact boundary set (explicit roots + fresh vars + overload capture vars),
-            // rather than using reachability expansion that can miss or overreach.
-            let mut all_boundary_vars: Vec<Var> = roots.into_iter().collect();
-            // Overload pruning must include solved vars even if they
-            // already collapsed to `Answer` before boundary finishing.
-            all_boundary_vars.extend(overload_capture_vars);
-            all_boundary_vars.sort_unstable();
-            all_boundary_vars.dedup();
-            (
-                QuantifiedHandle(all_boundary_vars),
-                overload_witness_captures,
-            )
-        } else {
-            (vs, SmallMap::new())
-        };
+        let (vs, mut overload_witness_captures, _generic_witness_captures) =
+            if let Some(cc) = call_context {
+                let tracked_fresh_vars = cc.take_deferred_quantified_vars();
+                let overload_witness_captures = cc.take_overload_witness_captures();
+                let generic_witness_captures = cc.take_generic_witness_captures();
+                cc.mark_boundary_consumed_and_drained();
+                let overload_capture_vars: SmallSet<Var> = overload_witness_captures
+                    .values()
+                    .flat_map(|branch_captures| branch_captures.iter())
+                    .flat_map(|capture| capture.values.keys().copied())
+                    .collect();
+                let mut roots: SmallSet<Var> = vs.0.into_iter().collect();
+                roots.extend(tracked_fresh_vars.0);
+                // Solve boundaries explicitly own fresh quantified tracking. We finish
+                // the exact boundary set (explicit roots + fresh vars + overload capture vars),
+                // rather than using reachability expansion that can miss or overreach.
+                let mut all_boundary_vars: Vec<Var> = roots.into_iter().collect();
+                // Overload pruning must include solved vars even if they
+                // already collapsed to `Answer` before boundary finishing.
+                all_boundary_vars.extend(overload_capture_vars);
+                all_boundary_vars.sort_unstable();
+                all_boundary_vars.dedup();
+                (
+                    QuantifiedHandle(all_boundary_vars),
+                    overload_witness_captures,
+                    generic_witness_captures,
+                )
+            } else {
+                (vs, SmallMap::new(), Vec::new())
+            };
         if vs.0.is_empty() {
             return Ok(());
         }
@@ -2751,6 +2777,9 @@ pub struct CallContext {
     /// Invariant: capture entries are scoped to this call-context lineage and
     /// must not leak across `with_outside_context` boundaries.
     overload_witness_captures: Arc<Mutex<OverloadWitnessCapturesByHash>>,
+    /// Per-call generic witness captures, written during subset checking and
+    /// consumed in `finish_quantified`.
+    generic_witness_captures: Arc<Mutex<Vec<GenericWitnessCapture>>>,
     /// Whether this context must be consumed at a solve boundary.
     require_boundary_consumption: Arc<AtomicBool>,
     /// Whether deferred state from this context lineage was consumed/drained.
@@ -2764,6 +2793,7 @@ impl Default for CallContext {
             argument_side: ArgumentSide::default(),
             deferred_quantified_vars: Arc::new(Mutex::new(SmallSet::new())),
             overload_witness_captures: Arc::new(Mutex::new(SmallMap::new())),
+            generic_witness_captures: Arc::new(Mutex::new(Vec::new())),
             require_boundary_consumption: Arc::new(AtomicBool::new(false)),
             boundary_consumed_and_drained: Arc::new(AtomicBool::new(false)),
         }
@@ -2800,6 +2830,7 @@ impl CallContext {
         self.witness = Default::default();
         self.argument_side = Default::default();
         self.overload_witness_captures = Default::default();
+        self.generic_witness_captures = Default::default();
         self
     }
 
@@ -2873,6 +2904,35 @@ impl CallContext {
             .collect()
     }
 
+    fn persist_generic_witness_capture(&self, capture: GenericWitnessCapture) {
+        let mut captures = self.generic_witness_captures.lock();
+        // Dedup: if an existing entry has the same (witness_hash, target_vars),
+        // merge witness_vars into it instead of pushing a new entry.
+        for existing in captures.iter_mut() {
+            if existing.witness_hash == capture.witness_hash
+                && existing.target_vars == capture.target_vars
+            {
+                existing.witness_vars.extend(capture.witness_vars);
+                return;
+            }
+        }
+        captures.push(capture);
+    }
+
+    fn take_generic_witness_captures(&self) -> Vec<GenericWitnessCapture> {
+        let mut captures = self.generic_witness_captures.lock();
+        mem::take(&mut *captures)
+    }
+
+    /// Returns the union of all `witness_vars` across all captures, without draining.
+    pub fn generic_captured_vars(&self) -> SmallSet<Var> {
+        let captures = self.generic_witness_captures.lock();
+        captures
+            .iter()
+            .flat_map(|c| c.witness_vars.iter().copied())
+            .collect()
+    }
+
     fn mark_boundary_consumed_and_drained(&self) {
         self.boundary_consumed_and_drained
             .store(true, Ordering::Relaxed);
@@ -2902,6 +2962,10 @@ impl Drop for CallContext {
             assert!(
                 self.overload_witness_captures.lock().is_empty(),
                 "CallContext dropped with overload witness captures still pending",
+            );
+            assert!(
+                self.generic_witness_captures.lock().is_empty(),
+                "CallContext dropped with generic witness captures still pending",
             );
         }
     }

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -140,6 +140,14 @@ pub(crate) struct OverloadBranchCapture {
 
 type OverloadWitnessCapturesByHash = SmallMap<u64, Vec<OverloadBranchCapture>>;
 
+/// Witness captures collected during subset checking and consumed at solve
+/// boundaries.
+#[derive(Debug, Default)]
+struct WitnessCaptures {
+    overload: OverloadWitnessCapturesByHash,
+    generic: Vec<GenericWitnessCapture>,
+}
+
 /// Witness-keyed pruning decisions threaded through finishing.
 #[derive(Clone, Debug, Default)]
 struct OverloadWitnessPruningDecision {
@@ -1284,8 +1292,7 @@ impl Solver {
             vs,
             false,
             &mut |_got, _want| Ok(()),
-            &mut SmallMap::new(),
-            &[],
+            &mut WitnessCaptures::default(),
         );
 
         callable
@@ -1798,36 +1805,34 @@ impl Solver {
         type_order: TypeOrder<Ans>,
         call_context: Option<&CallContext>,
     ) -> Result<(), Vec1<TypeVarSpecializationError>> {
-        let (vs, mut overload_witness_captures, generic_witness_captures) =
-            if let Some(cc) = call_context {
-                let tracked_fresh_vars = cc.take_deferred_quantified_vars();
-                let overload_witness_captures = cc.take_overload_witness_captures();
-                let generic_witness_captures = cc.take_generic_witness_captures();
-                cc.mark_boundary_consumed_and_drained();
-                let overload_capture_vars: SmallSet<Var> = overload_witness_captures
-                    .values()
-                    .flat_map(|branch_captures| branch_captures.iter())
-                    .flat_map(|capture| capture.values.keys().copied())
-                    .collect();
-                let mut roots: SmallSet<Var> = vs.0.into_iter().collect();
-                roots.extend(tracked_fresh_vars.0);
-                // Solve boundaries explicitly own fresh quantified tracking. We finish
-                // the exact boundary set (explicit roots + fresh vars + overload capture vars),
-                // rather than using reachability expansion that can miss or overreach.
-                let mut all_boundary_vars: Vec<Var> = roots.into_iter().collect();
-                // Overload pruning must include solved vars even if they
-                // already collapsed to `Answer` before boundary finishing.
-                all_boundary_vars.extend(overload_capture_vars);
-                all_boundary_vars.sort_unstable();
-                all_boundary_vars.dedup();
-                (
-                    QuantifiedHandle(all_boundary_vars),
-                    overload_witness_captures,
-                    generic_witness_captures,
-                )
-            } else {
-                (vs, SmallMap::new(), Vec::new())
+        let (vs, mut captures) = if let Some(cc) = call_context {
+            let tracked_fresh_vars = cc.take_deferred_quantified_vars();
+            let captures = WitnessCaptures {
+                overload: cc.take_overload_witness_captures(),
+                generic: cc.take_generic_witness_captures(),
             };
+            cc.mark_boundary_consumed_and_drained();
+            let overload_capture_vars: SmallSet<Var> = captures
+                .overload
+                .values()
+                .flat_map(|branch_captures| branch_captures.iter())
+                .flat_map(|capture| capture.values.keys().copied())
+                .collect();
+            let mut roots: SmallSet<Var> = vs.0.into_iter().collect();
+            roots.extend(tracked_fresh_vars.0);
+            // Solve boundaries explicitly own fresh quantified tracking. We finish
+            // the exact boundary set (explicit roots + fresh vars + overload capture vars),
+            // rather than using reachability expansion that can miss or overreach.
+            let mut all_boundary_vars: Vec<Var> = roots.into_iter().collect();
+            // Overload pruning must include solved vars even if they
+            // already collapsed to `Answer` before boundary finishing.
+            all_boundary_vars.extend(overload_capture_vars);
+            all_boundary_vars.sort_unstable();
+            all_boundary_vars.dedup();
+            (QuantifiedHandle(all_boundary_vars), captures)
+        } else {
+            (vs, WitnessCaptures::default())
+        };
         if vs.0.is_empty() {
             return Ok(());
         }
@@ -1836,8 +1841,7 @@ impl Solver {
             vs,
             infer_with_first_use,
             &mut |got, want| subset.is_subset_eq_probe_for_pruning(got, want),
-            &mut overload_witness_captures,
-            &generic_witness_captures,
+            &mut captures,
         )
     }
 
@@ -1889,11 +1893,10 @@ impl Solver {
         vs: QuantifiedHandle,
         infer_with_first_use: bool,
         is_subset: &mut dyn FnMut(&Type, &Type) -> Result<(), SubsetError>,
-        overload_witness_captures: &mut OverloadWitnessCapturesByHash,
-        generic_witness_captures: &[GenericWitnessCapture],
+        captures: &mut WitnessCaptures,
     ) -> Result<(), Vec1<TypeVarSpecializationError>> {
         let mut err = Vec::new();
-        let has_overload_captures = !overload_witness_captures.is_empty();
+        let has_overload_captures = !captures.overload.is_empty();
         let mut solved_quantified_names_by_var: SmallMap<Var, Name> = SmallMap::new();
         let lock = self.variables.lock();
         for &v in &vs.0 {
@@ -1947,7 +1950,7 @@ impl Solver {
             drop(lock);
             self.compute_overload_pruning_by_witness(
                 &solved_vars,
-                overload_witness_captures,
+                &mut captures.overload,
                 is_subset,
             )
         } else {
@@ -1995,7 +1998,7 @@ impl Solver {
         // should not produce an overload residual.
         let var_to_witness: SmallMap<Var, Option<u64>> = {
             let mut map: SmallMap<Var, Option<u64>> = SmallMap::new();
-            for (&wh, captures) in overload_witness_captures.iter() {
+            for (&wh, captures) in captures.overload.iter() {
                 for capture in captures {
                     for &v in capture.values.keys() {
                         match map.entry(v) {
@@ -2017,10 +2020,11 @@ impl Solver {
         // Precompute union-find roots for all vars that appear in generic
         // residual captures, so we can match vars by equivalence class without
         // holding a mutable borrow during the main loop.
-        let root_map: SmallMap<Var, Var> = if !generic_witness_captures.is_empty() {
+        let root_map: SmallMap<Var, Var> = if !captures.generic.is_empty() {
             let lock = self.variables.lock();
             let all_vars = vs.0.iter().copied().chain(
-                generic_witness_captures
+                captures
+                    .generic
                     .iter()
                     .flat_map(|c| c.witness_vars.iter().copied()),
             );
@@ -2090,25 +2094,23 @@ impl Solver {
                 } else if overload_all_pruned {
                     Variable::Answer(Type::never())
                 } else if let Some(witness_hash) = witness_hash {
-                    let captures =
-                        overload_witness_captures
-                            .get(&witness_hash)
-                            .unwrap_or_else(|| {
-                                unreachable!("overload materialization requires witness captures")
-                            });
-                    let target_vars: SmallSet<Var> = captures
+                    let overload_captures =
+                        captures.overload.get(&witness_hash).unwrap_or_else(|| {
+                            unreachable!("overload materialization requires witness captures")
+                        });
+                    let target_vars: SmallSet<Var> = overload_captures
                         .iter()
                         .flat_map(|c| c.values.keys().copied())
                         .collect();
                     let ty = self.materialize_overload_residual(
                         witness_hash,
                         v,
-                        captures,
+                        overload_captures,
                         &overload_pruning_by_witness,
                     );
                     Variable::ResidualAnswer { target_vars, ty }
                 } else if let Some(target_vars) =
-                    self.find_unique_generic_witness(v, generic_witness_captures, &root_map)
+                    self.find_unique_generic_witness(v, &captures.generic, &root_map)
                 {
                     Variable::ResidualAnswer {
                         target_vars,

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -115,14 +115,6 @@ impl Bounds {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct ResidualIdentity {
-    witness_hash: u64,
-    /// Vars that are allowed to observe the residualized answer for this candidate.
-    /// This is captured during subset checks and threaded into `Variable::ResidualAnswer`.
-    target_vars: SmallSet<Var>,
-}
-
 /// Per-call capture of generic witness information, stored on `CallContext`.
 /// Each entry records a single Forall instantiation's witness vars and the
 /// target vars that are allowed to observe the residualized answer.
@@ -198,9 +190,6 @@ enum Variable {
     Quantified {
         quantified: Quantified,
         bounds: Bounds,
-        /// Residual candidates captured during subset checks.
-        /// Kept separate from concrete bounds to avoid accidental coupling.
-        residuals: Vec<ResidualIdentity>,
     },
     /// A variable caused by general recursion, e.g. `x = f(); def f(): return x`.
     Recursive,
@@ -233,7 +222,6 @@ impl Display for Variable {
             | Variable::Quantified {
                 quantified: q,
                 bounds: _,
-                residuals: _,
             } => {
                 let label = if matches!(self, Variable::PartialQuantified(_)) {
                     "PartialQuantified"
@@ -1224,7 +1212,6 @@ impl Solver {
                 Variable::Quantified {
                     quantified: (*q).clone(),
                     bounds: Bounds::new(),
-                    residuals: Vec::new(),
                 },
             );
         }
@@ -1567,22 +1554,10 @@ impl Solver {
         call_context: &CallContext,
     ) {
         call_context.persist_generic_witness_capture(GenericWitnessCapture {
-            witness_hash: witness.identity.witness_hash,
-            target_vars: witness.identity.target_vars.clone(),
+            witness_hash: witness.witness_hash,
+            target_vars: witness.target_vars.clone(),
             witness_vars: witness.capture_candidate_vars(),
         });
-    }
-
-    fn merge_residual_candidates(
-        left: &mut Vec<ResidualIdentity>,
-        right: &mut Vec<ResidualIdentity>,
-    ) {
-        for residual in mem::take(right) {
-            if !left.contains(&residual) {
-                left.push(residual);
-            }
-        }
-        *right = left.clone();
     }
 
     fn materialize_overload_residual_branch_value(
@@ -2176,7 +2151,6 @@ impl Solver {
                     Variable::Quantified {
                         quantified: param.clone(),
                         bounds: Bounds::new(),
-                        residuals: Vec::new(),
                     },
                 );
             }
@@ -2774,8 +2748,9 @@ pub(crate) enum SubsetCacheContext {
 }
 
 // The context in which we are collecting residuals.
-// - The `identity` is the particular Forall type that appeared as an argument
-//   in a higher-order call
+// - The `witness_hash` identifies the particular Forall type that appeared as
+//   an argument in a higher-order call
+// - The `target_vars` are vars allowed to observe the residualized answer
 // - The `origin_vars` are `Vars` that correspond to scoped type parameters
 //   inside of that argument (the "origin" of the generic behavior)
 // - The `deferred_vars` are `Vars` that correspond to call-scope vars from
@@ -2786,7 +2761,9 @@ pub(crate) enum SubsetCacheContext {
 // TODO(stroxler): Rethink the names of fields here. It would be difficult to restack.
 #[derive(Clone, Debug)]
 pub struct ResidualWitnessContext {
-    identity: ResidualIdentity,
+    witness_hash: u64,
+    /// Vars that are allowed to observe the residualized answer for this candidate.
+    target_vars: SmallSet<Var>,
     argument_side: ArgumentSide,
     origin_vars: SmallSet<Var>,
     deferred_vars: SmallSet<Var>,
@@ -2794,7 +2771,7 @@ pub struct ResidualWitnessContext {
 
 impl ResidualWitnessContext {
     pub(crate) fn witness_hash(&self) -> u64 {
-        self.identity.witness_hash
+        self.witness_hash
     }
 
     fn capture_candidate_vars(&self) -> SmallSet<Var> {
@@ -2912,7 +2889,7 @@ impl CallContext {
             // witness/polarity-sensitive side effects isolated. Most checks run
             // under Default context and keep prior cache behavior.
             SubsetCacheContext::Witness {
-                witness_hash: witness.identity.witness_hash,
+                witness_hash: witness.witness_hash,
                 argument_side: self.argument_side,
             }
         } else {
@@ -3119,10 +3096,8 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
             want.collect_maybe_placeholder_vars().into_iter().collect();
         target_vars.extend(vars.0.iter().copied());
         ResidualWitnessContext {
-            identity: ResidualIdentity {
-                witness_hash: Self::type_witness_hash(got),
-                target_vars,
-            },
+            witness_hash: Self::type_witness_hash(got),
+            target_vars,
             argument_side,
             origin_vars: vars.0.iter().copied().collect(),
             deferred_vars: SmallSet::new(),
@@ -3199,10 +3174,8 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
         let target_vars: SmallSet<Var> = eligible_vars.iter().copied().collect();
         let origin_vars = target_vars.clone();
         ResidualWitnessContext {
-            identity: ResidualIdentity {
-                witness_hash: Self::type_witness_hash(got),
-                target_vars,
-            },
+            witness_hash: Self::type_witness_hash(got),
+            target_vars,
             argument_side,
             origin_vars,
             deferred_vars: SmallSet::new(),
@@ -3230,8 +3203,8 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
         if !witness.origin_vars.contains(&origin_var) {
             return;
         }
-        let witness_hash = witness.identity.witness_hash;
-        let target_vars = witness.identity.target_vars.clone();
+        let witness_hash = witness.witness_hash;
+        let target_vars = witness.target_vars.clone();
         let deferred_vars = self.witness_deferred_vars.entry(witness_hash).or_default();
         for var in other.collect_maybe_placeholder_vars() {
             if target_vars.contains(&var) {
@@ -3377,29 +3350,11 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                             Variable::Quantified {
                                 quantified: _,
                                 bounds: v1_bounds,
-                                residuals: v1_residuals,
-                            },
-                            Variable::Quantified {
-                                quantified: _,
-                                bounds: v2_bounds,
-                                residuals: v2_residuals,
-                            },
-                        ) => {
-                            v1_bounds.extend(mem::take(v2_bounds));
-                            *v2_bounds = v1_bounds.clone();
-                            Solver::merge_residual_candidates(v1_residuals, v2_residuals);
-                        }
-                        (
-                            Variable::Quantified {
-                                quantified: _,
-                                bounds: v1_bounds,
-                                ..
                             }
                             | Variable::Unwrap(v1_bounds),
                             Variable::Quantified {
                                 quantified: _,
                                 bounds: v2_bounds,
-                                ..
                             }
                             | Variable::Unwrap(v2_bounds),
                         ) => {

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -586,7 +586,6 @@ impl Solver {
             Variable::Quantified {
                 quantified: q,
                 bounds: _,
-                ..
             } => {
                 // A Variable::Quantified should always be finished (see `finish_quantified`) by
                 // the code that creates it, because we need to know when we're done collecting
@@ -856,7 +855,6 @@ impl Solver {
                                     Variable::Quantified {
                                         quantified: q,
                                         bounds,
-                                        ..
                                     } => self
                                         .solve_bounds(mem::take(bounds))
                                         .unwrap_or_else(|| q.as_gradual_type()),
@@ -904,7 +902,6 @@ impl Solver {
                             Variable::Quantified {
                                 quantified: _,
                                 bounds,
-                                ..
                             }
                             | Variable::Unwrap(bounds)
                                 if policy == VarExpansionPolicy::ExpandWithBounds
@@ -976,7 +973,6 @@ impl Solver {
                     Variable::Quantified {
                         quantified: q,
                         bounds,
-                        ..
                     } => self
                         .solve_bounds(mem::take(bounds))
                         .unwrap_or_else(|| q.as_gradual_type()),
@@ -1447,7 +1443,6 @@ impl Solver {
             Variable::Quantified {
                 quantified: _,
                 bounds,
-                ..
             }
             | Variable::Unwrap(bounds) => (
                 bounds.lower.first().cloned(),
@@ -1476,7 +1471,6 @@ impl Solver {
             Variable::Quantified {
                 quantified: _,
                 bounds,
-                ..
             }
             | Variable::Unwrap(bounds) => self.add_bound(&mut bounds.lower, new_bound),
             _ => {}
@@ -1496,7 +1490,6 @@ impl Solver {
             Variable::Quantified {
                 quantified: _,
                 bounds,
-                ..
             }
             | Variable::Unwrap(bounds) => (
                 bounds.upper.first().cloned(),
@@ -1525,7 +1518,6 @@ impl Solver {
             Variable::Quantified {
                 quantified: _,
                 bounds,
-                ..
             }
             | Variable::Unwrap(bounds) => self.add_bound(&mut bounds.upper, new_bound),
             _ => {}
@@ -1584,9 +1576,7 @@ impl Solver {
     ) -> Type {
         match value {
             Variable::Answer(ty) | Variable::ResidualAnswer { ty, .. } => ty.clone(),
-            Variable::Quantified {
-                quantified, bounds, ..
-            } => {
+            Variable::Quantified { quantified, bounds } => {
                 if let Some(bound) = self.solve_bounds(bounds.clone()) {
                     return bound;
                 }
@@ -1919,7 +1909,6 @@ impl Solver {
                 Variable::Quantified {
                     quantified: q,
                     bounds,
-                    ..
                 } => {
                     if let Some(e) = self.instantiation_errors.read().get(&v) {
                         err.push(e.clone());
@@ -2047,7 +2036,6 @@ impl Solver {
             if let Variable::Quantified {
                 quantified: q,
                 bounds,
-                ..
             } = &mut *e
             {
                 let solved_bound = self.solve_bounds(mem::take(bounds));
@@ -2184,7 +2172,6 @@ impl Solver {
                 if let Variable::Quantified {
                     quantified: q,
                     bounds,
-                    ..
                 } = &mut *e
                     && *q == *param
                 {
@@ -3400,12 +3387,10 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                             Variable::Quantified {
                                 quantified: q1,
                                 bounds: _,
-                                ..
                             },
                             Variable::Quantified {
                                 quantified: q2,
                                 bounds: _,
-                                ..
                             },
                         )
                         | (Variable::PartialQuantified(q1), Variable::PartialQuantified(q2)) => {
@@ -3460,7 +3445,6 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                             Variable::Quantified {
                                 quantified: _,
                                 bounds: _,
-                                ..
                             },
                         ) => {
                             drop(variable1);
@@ -3505,7 +3489,6 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                     Variable::Quantified {
                         quantified: q,
                         bounds: _,
-                        ..
                     } if q.kind() == QuantifiedKind::ParamSpec => {
                         // TODO(https://github.com/facebook/pyrefly/issues/105): figure out what to
                         // do with ParamSpec.
@@ -3638,7 +3621,6 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                     Variable::Quantified {
                         quantified: q,
                         bounds,
-                        ..
                     } => {
                         let q = q.clone();
                         let upper_bound = self.solver.get_current_bound(bounds.upper.clone());

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -141,11 +141,33 @@ pub struct OverloadBranchCapture {
 type OverloadWitnessCapturesByHash = SmallMap<u64, Vec<OverloadBranchCapture>>;
 
 /// Witness captures collected during subset checking and consumed at solve
-/// boundaries.
+/// boundaries. Used both as live storage on `CallContext` and as owned data
+/// after draining.
 #[derive(Debug, Default)]
 struct WitnessCaptures {
     overload: OverloadWitnessCapturesByHash,
     generic: Vec<GenericWitnessCapture>,
+}
+
+impl WitnessCaptures {
+    fn is_empty(&self) -> bool {
+        self.overload.is_empty() && self.generic.is_empty()
+    }
+
+    fn captured_vars(&self) -> SmallSet<Var> {
+        let mut vars: SmallSet<Var> = self
+            .overload
+            .values()
+            .flat_map(|captures| captures.iter())
+            .flat_map(|capture| capture.values.keys().copied())
+            .collect();
+        vars.extend(
+            self.generic
+                .iter()
+                .flat_map(|c| c.witness_vars.iter().copied()),
+        );
+        vars
+    }
 }
 
 /// Witness-keyed pruning decisions threaded through finishing.
@@ -1795,10 +1817,7 @@ impl Solver {
     ) -> Result<(), Vec1<TypeVarSpecializationError>> {
         let (vs, mut captures) = if let Some(cc) = call_context {
             let tracked_fresh_vars = cc.take_deferred_quantified_vars();
-            let captures = WitnessCaptures {
-                overload: cc.take_overload_witness_captures(),
-                generic: cc.take_generic_witness_captures(),
-            };
+            let captures = cc.take_witness_captures();
             cc.mark_boundary_consumed_and_drained();
             let overload_capture_vars: SmallSet<Var> = captures
                 .overload
@@ -2820,12 +2839,9 @@ pub struct CallContext {
     witness: Option<ResidualWitnessContext>,
     argument_side: ArgumentSide,
     deferred_quantified_vars: Arc<Mutex<SmallSet<Var>>>,
-    /// Invariant: capture entries are scoped to this call-context lineage and
-    /// must not leak across `with_outside_context` boundaries.
-    overload_witness_captures: Arc<Mutex<OverloadWitnessCapturesByHash>>,
-    /// Per-call generic witness captures, written during subset checking and
-    /// consumed in `finish_quantified`.
-    generic_witness_captures: Arc<Mutex<Vec<GenericWitnessCapture>>>,
+    /// Witness captures scoped to this call-context lineage. Must not leak
+    /// across `with_outside_context` boundaries.
+    witness_captures: Arc<Mutex<WitnessCaptures>>,
     /// Whether this context must be consumed at a solve boundary.
     require_boundary_consumption: Arc<AtomicBool>,
     /// Whether deferred state from this context lineage was consumed/drained.
@@ -2838,8 +2854,7 @@ impl Default for CallContext {
             witness: None,
             argument_side: ArgumentSide::default(),
             deferred_quantified_vars: Arc::new(Mutex::new(SmallSet::new())),
-            overload_witness_captures: Arc::new(Mutex::new(SmallMap::new())),
-            generic_witness_captures: Arc::new(Mutex::new(Vec::new())),
+            witness_captures: Default::default(),
             require_boundary_consumption: Arc::new(AtomicBool::new(false)),
             boundary_consumed_and_drained: Arc::new(AtomicBool::new(false)),
         }
@@ -2875,8 +2890,7 @@ impl CallContext {
         // this scope must still be finished when the outer boundary drains.
         self.witness = Default::default();
         self.argument_side = Default::default();
-        self.overload_witness_captures = Default::default();
-        self.generic_witness_captures = Default::default();
+        self.witness_captures = Default::default();
         self
     }
 
@@ -2934,9 +2948,9 @@ impl CallContext {
         )
     }
 
-    fn take_overload_witness_captures(&self) -> OverloadWitnessCapturesByHash {
-        let mut overload_witness_captures = self.overload_witness_captures.lock();
-        mem::take(&mut *overload_witness_captures)
+    fn take_witness_captures(&self) -> WitnessCaptures {
+        let mut captures = self.witness_captures.lock();
+        mem::take(&mut *captures)
     }
 
     /// Persist overload probe captures. Finishing consumes these captures as the
@@ -2946,24 +2960,13 @@ impl CallContext {
         witness_hash: u64,
         branch_captures: Vec<OverloadBranchCapture>,
     ) {
-        let mut captures = self.overload_witness_captures.lock();
-        captures.insert(witness_hash, branch_captures);
-    }
-
-    /// Returns the set of vars that appear in overload witness captures
-    /// without draining them.
-    pub fn overload_captured_vars(&self) -> SmallSet<Var> {
-        let captures = self.overload_witness_captures.lock();
-        captures
-            .values()
-            .flat_map(|captures| captures.iter())
-            .flat_map(|capture| capture.values.keys().copied())
-            .collect()
+        let mut captures = self.witness_captures.lock();
+        captures.overload.insert(witness_hash, branch_captures);
     }
 
     /// Record generic residual information from a completed witness check.
     pub fn record_generic_residuals(&self, witness: &ResidualWitnessContext) {
-        let mut captures = self.generic_witness_captures.lock();
+        let mut captures = self.witness_captures.lock();
         let capture = GenericWitnessCapture {
             witness_hash: witness.witness_hash,
             target_vars: witness.target_vars.clone(),
@@ -2971,7 +2974,7 @@ impl CallContext {
         };
         // Dedup: if an existing entry has the same (witness_hash, target_vars),
         // merge witness_vars into it instead of pushing a new entry.
-        for existing in captures.iter_mut() {
+        for existing in captures.generic.iter_mut() {
             if existing.witness_hash == capture.witness_hash
                 && existing.target_vars == capture.target_vars
             {
@@ -2979,18 +2982,20 @@ impl CallContext {
                 return;
             }
         }
-        captures.push(capture);
+        captures.generic.push(capture);
     }
 
-    fn take_generic_witness_captures(&self) -> Vec<GenericWitnessCapture> {
-        let mut captures = self.generic_witness_captures.lock();
-        mem::take(&mut *captures)
+    /// Returns the union of all captured vars across both overload and generic
+    /// witness captures, without draining.
+    pub fn captured_vars(&self) -> SmallSet<Var> {
+        self.witness_captures.lock().captured_vars()
     }
 
-    /// Returns the union of all `witness_vars` across all captures, without draining.
+    /// Returns the union of generic witness vars only, without draining.
     pub fn generic_captured_vars(&self) -> SmallSet<Var> {
-        let captures = self.generic_witness_captures.lock();
+        let captures = self.witness_captures.lock();
         captures
+            .generic
             .iter()
             .flat_map(|c| c.witness_vars.iter().copied())
             .collect()
@@ -3023,12 +3028,8 @@ impl Drop for CallContext {
                 "CallContext dropped with deferred quantified vars still pending",
             );
             assert!(
-                self.overload_witness_captures.lock().is_empty(),
-                "CallContext dropped with overload witness captures still pending",
-            );
-            assert!(
-                self.generic_witness_captures.lock().is_empty(),
-                "CallContext dropped with generic witness captures still pending",
+                self.witness_captures.lock().is_empty(),
+                "CallContext dropped with witness captures still pending",
             );
         }
     }

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -129,7 +129,7 @@ struct GenericWitnessCapture {
 
 /// Full per-branch capture used transiently during overload probing.
 #[derive(Clone, Debug)]
-pub(crate) struct OverloadBranchCapture {
+pub struct OverloadBranchCapture {
     branch_index: usize,
     values: SmallMap<Var, Variable>,
     /// Vars that had a generic residual at snapshot time. Used by
@@ -1555,18 +1555,6 @@ impl Solver {
         }
     }
 
-    pub(crate) fn record_generic_residuals_for_witness(
-        &self,
-        witness: &ResidualWitnessContext,
-        call_context: &CallContext,
-    ) {
-        call_context.persist_generic_witness_capture(GenericWitnessCapture {
-            witness_hash: witness.witness_hash,
-            target_vars: witness.target_vars.clone(),
-            witness_vars: witness.capture_candidate_vars(),
-        });
-    }
-
     fn materialize_overload_residual_branch_value(
         &self,
         value: &Variable,
@@ -2772,6 +2760,44 @@ pub struct ResidualWitnessContext {
 }
 
 impl ResidualWitnessContext {
+    fn type_witness_hash(ty: &Type) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        ty.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Build a witness for a Forall instantiation during subset checking.
+    pub fn for_forall(
+        got: &Type,
+        vars: &QuantifiedHandle,
+        want: &Type,
+        argument_side: ArgumentSide,
+    ) -> Self {
+        let mut target_vars: SmallSet<Var> =
+            want.collect_maybe_placeholder_vars().into_iter().collect();
+        target_vars.extend(vars.0.iter().copied());
+        Self {
+            witness_hash: Self::type_witness_hash(got),
+            target_vars,
+            argument_side,
+            origin_vars: vars.0.iter().copied().collect(),
+            deferred_vars: SmallSet::new(),
+        }
+    }
+
+    /// Build a witness for an overload residual during subset checking.
+    pub fn for_overload(got: &Type, eligible_vars: &[Var], argument_side: ArgumentSide) -> Self {
+        let target_vars: SmallSet<Var> = eligible_vars.iter().copied().collect();
+        let origin_vars = target_vars.clone();
+        Self {
+            witness_hash: Self::type_witness_hash(got),
+            target_vars,
+            argument_side,
+            origin_vars,
+            deferred_vars: SmallSet::new(),
+        }
+    }
+
     pub(crate) fn witness_hash(&self) -> u64 {
         self.witness_hash
     }
@@ -2913,6 +2939,17 @@ impl CallContext {
         mem::take(&mut *overload_witness_captures)
     }
 
+    /// Persist overload probe captures. Finishing consumes these captures as the
+    /// authoritative pruning source.
+    pub fn persist_overload_witness_captures(
+        &self,
+        witness_hash: u64,
+        branch_captures: Vec<OverloadBranchCapture>,
+    ) {
+        let mut captures = self.overload_witness_captures.lock();
+        captures.insert(witness_hash, branch_captures);
+    }
+
     /// Returns the set of vars that appear in overload witness captures
     /// without draining them.
     pub fn overload_captured_vars(&self) -> SmallSet<Var> {
@@ -2924,8 +2961,14 @@ impl CallContext {
             .collect()
     }
 
-    fn persist_generic_witness_capture(&self, capture: GenericWitnessCapture) {
+    /// Record generic residual information from a completed witness check.
+    pub fn record_generic_residuals(&self, witness: &ResidualWitnessContext) {
         let mut captures = self.generic_witness_captures.lock();
+        let capture = GenericWitnessCapture {
+            witness_hash: witness.witness_hash,
+            target_vars: witness.target_vars.clone(),
+            witness_vars: witness.capture_candidate_vars(),
+        };
         // Dedup: if an existing entry has the same (witness_hash, target_vars),
         // merge witness_vars into it instead of pushing a new entry.
         for existing in captures.iter_mut() {
@@ -3035,12 +3078,6 @@ pub struct Subset<'a, Ans: LookupAnswer> {
 }
 
 impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
-    fn type_witness_hash(ty: &Type) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        ty.hash(&mut hasher);
-        hasher.finish()
-    }
-
     fn snapshot_witness_deferred_vars(&self) -> SmallMap<u64, SmallSet<Var>> {
         self.witness_deferred_vars.clone()
     }
@@ -3083,27 +3120,6 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
         self.restore_witness_deferred_vars(deferred_vars);
         self.coinductive_assumptions_used = coinductive_assumptions_used;
         result
-    }
-
-    pub(crate) fn make_forall_witness(
-        &mut self,
-        got: &Type,
-        vars: &QuantifiedHandle,
-        want: &Type,
-    ) -> ResidualWitnessContext {
-        let argument_side = self.active_call_context.argument_side();
-        // Residual reads may happen through either side: call-visible vars from
-        // `want`, or fresh vars created by this Forall instantiation.
-        let mut target_vars: SmallSet<Var> =
-            want.collect_maybe_placeholder_vars().into_iter().collect();
-        target_vars.extend(vars.0.iter().copied());
-        ResidualWitnessContext {
-            witness_hash: Self::type_witness_hash(got),
-            target_vars,
-            argument_side,
-            origin_vars: vars.0.iter().copied().collect(),
-            deferred_vars: SmallSet::new(),
-        }
     }
 
     pub fn is_consistent(&mut self, got: &Type, want: &Type) -> Result<(), SubsetError> {
@@ -3154,34 +3170,6 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
         witness_hash: u64,
     ) -> Option<SmallSet<Var>> {
         self.witness_deferred_vars.shift_remove(&witness_hash)
-    }
-
-    /// Persist overload probe captures in the call context.
-    /// Finishing consumes these captures as the authoritative pruning source.
-    pub(crate) fn persist_overload_witness_captures(
-        &self,
-        witness_hash: u64,
-        branch_captures: Vec<OverloadBranchCapture>,
-    ) {
-        let mut captures = self.active_call_context.overload_witness_captures.lock();
-        captures.insert(witness_hash, branch_captures);
-    }
-
-    pub(crate) fn make_overload_witness(
-        &mut self,
-        got: &Type,
-        eligible_vars: &[Var],
-        argument_side: ArgumentSide,
-    ) -> ResidualWitnessContext {
-        let target_vars: SmallSet<Var> = eligible_vars.iter().copied().collect();
-        let origin_vars = target_vars.clone();
-        ResidualWitnessContext {
-            witness_hash: Self::type_witness_hash(got),
-            target_vars,
-            argument_side,
-            origin_vars,
-            deferred_vars: SmallSet::new(),
-        }
     }
 
     pub(crate) fn active_overload_residual_witness(&self) -> Option<ResidualWitnessContext> {

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -1284,8 +1284,7 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                     self.with_active_call_context(
                         self.active_call_context
                             .clone()
-                            .with_residual_witness(synthesized)
-                            .with_argument_side(argument_side),
+                            .with_residual_witness(synthesized),
                         |me| {
                             let (witness, captured_vars) =
                             me.witness_and_captured_vars_for_overload().expect(
@@ -2288,8 +2287,7 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                 let (result, mut maybe_witness) = self.with_active_call_context(
                     self.active_call_context
                         .clone()
-                        .with_residual_witness(witness)
-                        .with_argument_side(argument_side),
+                        .with_residual_witness(witness),
                     |me| {
                         (
                             me.is_subset_eq(&got, want),

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -1227,14 +1227,16 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
         let pre_probe_snapshot = self.solver.snapshot_vars(captured_vars);
         let mut matched_any_branch = false;
         let mut successful_branch_captures = Vec::new();
+        let generic_captured_vars = self.active_call_context.generic_captured_vars();
         for (branch_index, l) in overload.signatures.iter().enumerate() {
             let probe_snapshot = self.solver.snapshot_vars(captured_vars);
             if self.is_subset_eq(&l.as_type(), want).is_ok() {
                 matched_any_branch = true;
-                successful_branch_captures.push(
-                    self.solver
-                        .extract_overload_branch_capture(branch_index, captured_vars),
-                );
+                successful_branch_captures.push(self.solver.extract_overload_branch_capture(
+                    branch_index,
+                    captured_vars,
+                    &generic_captured_vars,
+                ));
             }
             self.solver.restore_vars(probe_snapshot);
         }

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -30,6 +30,7 @@ use pyrefly_types::typed_dict::TypedDict;
 use pyrefly_types::typed_dict::TypedDictField;
 use pyrefly_types::types::Forall;
 use pyrefly_types::types::Overload;
+use pyrefly_types::types::OverloadType;
 use pyrefly_types::types::Var;
 use pyrefly_util::owner::Owner;
 use ruff_python_ast::name::Name;
@@ -1278,8 +1279,25 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                     .filter(|v| self.solver.var_is_quantified(*v))
                     .collect();
                 if eligible_vars.is_empty() {
-                    any(overload.signatures.iter(), |l| {
-                        self.is_subset_eq(&l.as_type(), want)
+                    any(overload.signatures.iter(), |l| match l {
+                        OverloadType::Function(_) => self.is_subset_eq(&l.as_type(), want),
+                        OverloadType::Forall(forall) => {
+                            let fresh_forall = self.instantiate_fresh_forall(
+                                Forall {
+                                    tparams: forall.tparams.clone(),
+                                    body: Forallable::Function(forall.body.clone()),
+                                },
+                                want,
+                            );
+                            let vars = fresh_forall.handle.vars().to_vec();
+                            match self
+                                .solver
+                                .with_snapshot(&vars, || self.is_subset_forall(fresh_forall, want))
+                            {
+                                SubsetWithSnapshotResult::Ok => Ok(()),
+                                SubsetWithSnapshotResult::Err(e) => Err(e),
+                            }
+                        }
                     })
                     .is_ok()
                 } else {

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -28,6 +28,7 @@ use pyrefly_types::typed_dict::ExtraItem;
 use pyrefly_types::typed_dict::ExtraItems;
 use pyrefly_types::typed_dict::TypedDict;
 use pyrefly_types::typed_dict::TypedDictField;
+use pyrefly_types::types::Forall;
 use pyrefly_types::types::Overload;
 use pyrefly_types::types::Var;
 use pyrefly_util::owner::Owner;
@@ -40,6 +41,7 @@ use crate::alt::callable::CallArg;
 use crate::alt::expr::TypeOrExpr;
 use crate::solver::solver::ArgumentSide;
 use crate::solver::solver::OpenTypedDictSubsetError;
+use crate::solver::solver::QuantifiedHandle;
 use crate::solver::solver::ResidualWitnessContext;
 use crate::solver::solver::Subset;
 use crate::solver::solver::SubsetCacheEntry;
@@ -143,6 +145,12 @@ fn any<T>(
         }
     }
     Err(err.unwrap_or(SubsetError::Other))
+}
+
+struct FreshForall {
+    handle: QuantifiedHandle,
+    ty: Type,
+    witness: ResidualWitnessContext,
 }
 
 impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
@@ -1368,6 +1376,72 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
         Err(SubsetError::Other)
     }
 
+    fn instantiate_fresh_forall(&self, forall: Forall<Forallable>, want: &Type) -> FreshForall {
+        let (vs, got) = self.type_order.instantiate_fresh_forall(forall.clone());
+        let witness = ResidualWitnessContext::for_forall(
+            &Type::Forall(Box::new(forall)),
+            &vs,
+            want,
+            self.active_call_context.argument_side(),
+        );
+        FreshForall {
+            handle: vs,
+            ty: got,
+            witness,
+        }
+    }
+
+    fn is_subset_forall(&mut self, got: FreshForall, want: &Type) -> Result<(), SubsetError> {
+        self.active_call_context
+            .register_fresh_quantified_vars(got.handle.vars());
+        let (result, mut maybe_witness) = self.with_active_call_context(
+            self.active_call_context
+                .clone()
+                .with_residual_witness(got.witness),
+            |me| {
+                (
+                    me.is_subset_eq(&got.ty, want),
+                    me.active_call_context.take_residual_witness(),
+                )
+            },
+        );
+        // Either defer finishing to the active
+        // call boundary (when inside call analysis) or finish eagerly
+        // for ad-hoc subset checks outside calls.
+        let in_call_analysis = !matches!(
+            self.active_call_context.argument_side(),
+            ArgumentSide::NotAnalyzingACall
+        );
+        if result.is_ok()
+            && in_call_analysis
+            && let Some(witness) = maybe_witness.as_mut()
+        {
+            if let Some(deferred_vars) = self.take_witness_deferred_vars(witness.witness_hash()) {
+                witness.extend_deferred_vars(deferred_vars);
+            }
+            self.active_call_context.record_generic_residuals(witness);
+        }
+        if in_call_analysis {
+            result
+        } else {
+            // Even when subset checking fails, finish the fresh vars
+            // to avoid leaking Quantified placeholders in ad-hoc paths.
+            let finish_result = self
+                .solver
+                .finish_quantified(
+                    got.handle,
+                    self.solver.infer_with_first_use,
+                    self.type_order,
+                    None,
+                )
+                .map_err(SubsetError::TypeVarSpecialization);
+            match result {
+                Ok(()) => finish_result,
+                Err(e) => Err(e),
+            }
+        }
+    }
+
     fn can_be_recursive(&self, t1: &Type, t2: &Type) -> bool {
         match (t1, t2) {
             // We only care if the RHS is a protocol
@@ -2273,58 +2347,8 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                     .mk_class_type(self.type_order.stdlib().none_type().clone()),
             ),
             (Type::Forall(forall), _) => {
-                let forall_type = Type::Forall(forall.clone());
-                // Instantiate once, then either defer finishing to the active
-                // call boundary (when inside call analysis) or finish eagerly
-                // for ad-hoc subset checks outside calls.
-                let (vs, got) = self.type_order.instantiate_fresh_forall((**forall).clone());
-                self.active_call_context
-                    .register_fresh_quantified_vars(vs.vars());
-                let argument_side = self.active_call_context.argument_side();
-                let in_call_analysis = !matches!(argument_side, ArgumentSide::NotAnalyzingACall);
-                let witness =
-                    ResidualWitnessContext::for_forall(&forall_type, &vs, want, argument_side);
-                let (result, mut maybe_witness) = self.with_active_call_context(
-                    self.active_call_context
-                        .clone()
-                        .with_residual_witness(witness),
-                    |me| {
-                        (
-                            me.is_subset_eq(&got, want),
-                            me.active_call_context.take_residual_witness(),
-                        )
-                    },
-                );
-                if result.is_ok()
-                    && !matches!(argument_side, ArgumentSide::NotAnalyzingACall)
-                    && let Some(witness) = maybe_witness.as_mut()
-                {
-                    if let Some(deferred_vars) =
-                        self.take_witness_deferred_vars(witness.witness_hash())
-                    {
-                        witness.extend_deferred_vars(deferred_vars);
-                    }
-                    self.active_call_context.record_generic_residuals(witness);
-                }
-                if in_call_analysis {
-                    result
-                } else {
-                    // Even when subset checking fails, finish the fresh vars
-                    // to avoid leaking Quantified placeholders in ad-hoc paths.
-                    let finish_result = self
-                        .solver
-                        .finish_quantified(
-                            vs,
-                            self.solver.infer_with_first_use,
-                            self.type_order,
-                            None,
-                        )
-                        .map_err(SubsetError::TypeVarSpecialization);
-                    match result {
-                        Ok(()) => finish_result,
-                        Err(e) => Err(e),
-                    }
-                }
+                let got = self.instantiate_fresh_forall((**forall).clone(), want);
+                self.is_subset_forall(got, want)
             }
             (_, Type::Forall(forall)) => self.is_subset_eq(got, &forall.body.clone().as_type()),
             (Type::TypeVar(l), Type::TypeVar(u)) => {

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -2300,7 +2300,8 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                     {
                         witness.extend_deferred_vars(deferred_vars);
                     }
-                    self.solver.record_generic_residuals_for_witness(witness);
+                    self.solver
+                        .record_generic_residuals_for_witness(witness, &self.active_call_context);
                 }
                 if in_call_analysis {
                     result

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -1245,7 +1245,7 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
             if successful_branch_captures.is_empty() {
                 unreachable!("successful overload probe must produce a branch capture");
             }
-            self.persist_overload_witness_captures(
+            self.active_call_context.persist_overload_witness_captures(
                 witness.witness_hash(),
                 successful_branch_captures,
             );
@@ -1276,8 +1276,11 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                     .is_ok()
                 } else {
                     let overload_type = Type::Overload(overload.clone());
-                    let synthesized =
-                        self.make_overload_witness(&overload_type, &eligible_vars, argument_side);
+                    let synthesized = ResidualWitnessContext::for_overload(
+                        &overload_type,
+                        &eligible_vars,
+                        argument_side,
+                    );
                     self.with_active_call_context(
                         self.active_call_context
                             .clone()
@@ -2280,7 +2283,8 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                     .register_fresh_quantified_vars(vs.vars());
                 let argument_side = self.active_call_context.argument_side();
                 let in_call_analysis = !matches!(argument_side, ArgumentSide::NotAnalyzingACall);
-                let witness = self.make_forall_witness(&forall_type, &vs, want);
+                let witness =
+                    ResidualWitnessContext::for_forall(&forall_type, &vs, want, argument_side);
                 let (result, mut maybe_witness) = self.with_active_call_context(
                     self.active_call_context
                         .clone()
@@ -2302,8 +2306,7 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                     {
                         witness.extend_deferred_vars(deferred_vars);
                     }
-                    self.solver
-                        .record_generic_residuals_for_witness(witness, &self.active_call_context);
+                    self.active_call_context.record_generic_residuals(witness);
                 }
                 if in_call_analysis {
                     result

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -1959,3 +1959,23 @@ def g(x: float):
     f(x)  # E: No matching overload
     "#,
 );
+
+testcase!(
+    test_callback_protocol_with_overloads_and_bounded_typevar,
+    r#"
+from typing import Callable, Protocol, overload
+
+class Base: ...
+
+class HasCall(Protocol):
+    @overload
+    def __call__[T: Base](self, arg: T) -> T: ...
+    @overload
+    def __call__(self, arg: float) -> float: ...
+
+def takes(f: Callable[[float], float]) -> None: ...
+
+def repro(p: HasCall):
+    takes(p)
+    "#,
+);


### PR DESCRIPTION
Summary: Specialization errors from overload branches we didn't select should be reverted.

Differential Revision: D106459333


