### PR TITLE
fix(lsp): display ** prefix for ParamSpec in hover type parameter lists

### DIFF
--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -2103,6 +2103,34 @@ pub mod tests {
         );
     }
 
+n    #[test]
+    fn test_display_param_spec() {
+        let tparams = fake_tparams(vec![
+            fake_tparam(0, "T", QuantifiedKind::TypeVar),
+            fake_tparam(1, "P", QuantifiedKind::ParamSpec),
+            fake_tparam(2, "R", QuantifiedKind::TypeVar),
+        ]);
+        let method = fake_generic_bound_method(
+            "foo",
+            "MyClass",
+            "my.module",
+            tparams,
+        );
+        let mut ctx = TypeDisplayContext::new(&[&method]);
+        assert_eq!(
+            ctx.display(&method).to_string(),
+            "[T, **P, R](self: Any, x: Any, y: Any) -> None"
+        );
+        ctx.set_lsp_display_mode(LspDisplayMode::Hover);
+        assert_eq!(
+            ctx.display(&method).to_string(),
+            r#"def foo[T, **P, R](
+    self: Any,
+    x: Any,
+    y: Any
+) -> None: ..."#
+        );
+    }
     #[test]
     fn test_display_overload() {
         let class = fake_class("TestClass", "test", 0);

--- a/crates/pyrefly_types/src/quantified.rs
+++ b/crates/pyrefly_types/src/quantified.rs
@@ -368,6 +368,9 @@ impl Quantified {
     /// in the format used for type parameter lists (e.g. `T: int = str`).
     pub fn display_with_bounds(&self) -> impl Display + '_ {
         Fmt(move |f| {
+            if self.is_param_spec() {
+                write!(f, "**")?;
+            }
             write!(f, "{}", self.name)?;
             match self.restriction() {
                 Restriction::Bound(t) => write!(f, ": {}", t)?,


### PR DESCRIPTION
## Summary

When hovering over a generic function that uses ParamSpec (e.g., **P), the type parameter list in the hover was showing [T, P, R] instead of [T, **P, R] - the ** prefix was missing.

## Changes

- **quantified.rs**: Added `**` prefix in `Quantified::display_with_bounds()` for ParamSpec type parameters, matching Python syntax where ParamSpec is declared as `**P`.
- **display.rs**: Added test `test_display_param_spec` to verify the fix works in both default and LSP hover display modes.

## Testing

Added a unit test that creates a generic bound method with type parameters [T, **P, R] and verifies:
- Default display: [T, **P, R](self: Any, x: Any, y: Any) -> None
- LSP hover display: def foo[T, **P, R](...) -> None: ...

Fixes #3568