### PR TITLE
Preserve class tparams when binding a classmethod to a callable

### DIFF
--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -2233,7 +2233,28 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         m: &BoundMethod,
         is_subset: &mut dyn FnMut(&Type, &Type) -> bool,
     ) -> Option<Type> {
-        self.bind_bound_method_type(&m.func, &m.obj, false, is_subset)
+        // Skip instantiation when binding a classmethod whose tparams reference the class's own
+        // tparams, otherwise those class tparams would be erased to `Unknown` in the resulting callable.
+        let skip_instantiation = if let Type::ClassDef(cls) = &m.obj {
+            let class_tparams = self.get_class_tparams(cls);
+            let class_tparams = class_tparams.iter().collect::<SmallSet<_>>();
+            let uses_class_tparam =
+                |tparams: &TParams| tparams.iter().any(|tp| class_tparams.contains(tp));
+            !class_tparams.is_empty()
+                && match &m.func {
+                    BoundMethodType::Function(_) => false,
+                    BoundMethodType::Forall(forall) => uses_class_tparam(&forall.tparams),
+                    BoundMethodType::Overload(overload) => {
+                        overload.signatures.iter().any(|sig| match sig {
+                            OverloadType::Function(_) => false,
+                            OverloadType::Forall(forall) => uses_class_tparam(&forall.tparams),
+                        })
+                    }
+                }
+        } else {
+            false
+        };
+        self.bind_bound_method_type(&m.func, &m.obj, skip_instantiation, is_subset)
     }
 
     pub fn bind_dunder_new(&self, t: &Type, cls: ClassType) -> Option<Type> {

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -1421,7 +1421,6 @@ assert_type(r8([""], [""]), Class8[str])  # E: assert_type(Class8[Unknown], Clas
 );
 
 testcase!(
-    bug = "Generic classmethod callable loses class type params",
     test_generic_classmethod_to_callable_preserves_class_tparams,
     r#"
 from typing import Callable, Generic, ParamSpec, TypeVar, assert_type
@@ -1441,7 +1440,7 @@ class Factory(Generic[T]):
     def make(cls, x: list[T], y: list[T]) -> Box[T]: ...
 
 r = accepts_callable(Factory.make)
-assert_type(r([""], [""]), Box[str])  # E: assert_type(Box[Unknown], Box[str]) failed
+assert_type(r([""], [""]), Box[str])
 "#,
 );
 

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -1421,6 +1421,31 @@ assert_type(r8([""], [""]), Class8[str])  # E: assert_type(Class8[Unknown], Clas
 );
 
 testcase!(
+    bug = "Generic classmethod callable loses class type params",
+    test_generic_classmethod_to_callable_preserves_class_tparams,
+    r#"
+from typing import Callable, Generic, ParamSpec, TypeVar, assert_type
+
+P = ParamSpec("P")
+R = TypeVar("R")
+T = TypeVar("T")
+
+def accepts_callable(cb: Callable[P, R]) -> Callable[P, R]:
+    return cb
+
+class Box(Generic[T]):
+    pass
+
+class Factory(Generic[T]):
+    @classmethod
+    def make(cls, x: list[T], y: list[T]) -> Box[T]: ...
+
+r = accepts_callable(Factory.make)
+assert_type(r([""], [""]), Box[str])  # E: assert_type(Box[Unknown], Box[str]) failed
+"#,
+);
+
+testcase!(
     test_callable_instance_with_unknown_base,
     r#"
 class MyModel(BaseClass):  # E: Could not find name `BaseClass`


### PR DESCRIPTION
# Summary

While investigating #2450 (https://github.com/facebook/pyrefly/issues/2450#issuecomment-4558292038), I noticed that generics handling via classmethod + paramspec is lossy -- the inferred type carries an `Unknown` type instead of a generic type. This diff attempts to fix the gap.

[sandbox](
https://pyrefly.org/sandbox/?project=N4IgZglgNgpgziAXKOBDAdgEwEYHsAeAdAA4CeS4ATrgLYAEALqcROgOZ0Q3G6UN0BhVFCipssADR0A4jHQxKEAMZSACqkqoaAZWIwVdACrMYANQ1TUcOAoYB9JnqmUYANxjCHJgDrpfqugBeOnVNHT0lAApvEFUYgEpfACUgoxNzSmiQJITfQ1TjPQysw1y-LBgwOlQlJRhiBjg7JWFRcRhIpWxEQVaxWABtVSkkgF14ugBaAD5ekX6YIZHRxF86dboXBgBXSnQ6Lt9fJVFrOgAhAkjZeUUlAcNx1f2N4is4I-QT97oAMRqGLxSNc5AplA8nmsNgABb7WGgwBgAC1wmCh60wlToNFQAGsOic4FJ8D0oBA4AwIVJSKTyZTHhMZhcCBCeoR2Z9KKkanUGk0WvN2pF-kpAZRSIQcfjEugXO5PI4OpQJnQAMR0MguMBQGl0SIkuhkikDACq6Fx6FwAHd0KNqbTjWaLdbbYzZpd8KbzZabaNPu9bF49JFMgMYjE7XQwyAI-EpB6BhTKON1uqlLsXOgGDq6GBUNAPuVfJiqlKYHYwNsvgwILh0BD9Q76ZHdUbm27mZ7HmyOeVKAAmbm1eqNZp9IVlitV0W19AyuUeKBBpX9lXqzWVHU9BsGttUuitukQjsJx7%2B6yBxUh-uRaMRqR3kDjeMspPjXwgCQgbY1qBwEjkIgIDqiav4QEwubTjWdaFsWWJgLwOL2Og2w0NgCiNpwWYdkmzwbJsiK7PsYAxAAcqh6GUD0wD4AAvuG6CfiAG7ahKgI0FAFDqqopBajmaBYHg%2BAHHWkBsLsqDQeghC%2BOq2gwDAdBIgwDDEHAiAAPQaSxOqELwbAaXIGmYLgShwBpSiiRA4maFJGm5rw1SuPmbSwCJ6BiRJUl0LgDSzv%2BvhkMidaTO4lBwLOqQxAAzIQACM-YMSAtFfgCEDuL80AwBQAk4AQAHJUAA)

P.S. This was insufficient for the original constructor issue, as the code path was not shared after all. Nonetheless worth fixing


# Test Plan

Regression test + test.py
