### PR TITLE
fix(narrow): narrow TypedDict unions on subscript membership tests

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -879,6 +879,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                 }))
             }
+            AtomicNarrowOp::In(_) | AtomicNarrowOp::NotIn(_) => {
+                Some(self.distribute_over_union(base, |t| {
+                    let base_info = TypeInfo::of_ty(t.clone());
+                    let facet_ty = self.get_facet_chain_type(
+                        &base_info,
+                        &FacetChain::new(Vec1::new(facet.clone())),
+                        range,
+                    );
+                    let narrowed_facet = self.atomic_narrow(&facet_ty, op, range, errors);
+                    if narrowed_facet.is_never() {
+                        self.heap.mk_never()
+                    } else {
+                        t.clone()
+                    }
+                }))
+            }
             _ => None,
         }
     }

--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -879,7 +879,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                 }))
             }
-            AtomicNarrowOp::In(_) | AtomicNarrowOp::NotIn(_) => {
+            AtomicNarrowOp::In(v) | AtomicNarrowOp::NotIn(v) => {
+                // Parent narrowing is only reliable for enumerable membership tests
+                // like `x.kind in ("a", "b")`; a general mapping only gives us a
+                // key type, not a closed set of possible runtime values.
+                self.literal_membership_exprs(v, errors)?;
                 Some(self.distribute_over_union(base, |t| {
                     let base_info = TypeInfo::of_ty(t.clone());
                     let facet_ty = self.get_facet_chain_type(
@@ -1778,7 +1782,20 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     range,
                     errors,
                 );
-                let mut narrowed = type_info.with_narrow(resolved_chain.facets(), ty);
+                let non_literal_membership = match &op_for_narrow {
+                    AtomicNarrowOp::In(v) | AtomicNarrowOp::NotIn(v) => {
+                        self.literal_membership_exprs(v, errors).is_none()
+                    }
+                    _ => false,
+                };
+                // A general mapping's key type is not a closed set of runtime
+                // members. Do not turn `x in some_mapping` into `x: Never` when
+                // `x` and the static key type are disjoint.
+                let mut narrowed = if ty.is_never() && non_literal_membership {
+                    type_info.clone()
+                } else {
+                    type_info.with_narrow(resolved_chain.facets(), ty)
+                };
                 // For certain types of narrows, we can also narrow the parent of the current subject
                 // If `.get()` on a dict or TypedDict is falsy, the key may not be present at all
                 // We should invalidate any existing narrows

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -2514,6 +2514,150 @@ def test(x: UserDict | AdminDict):
 );
 
 testcase!(
+    test_discriminated_union_key_membership,
+    r#"
+from typing import Literal, TypedDict, assert_type
+
+class InstantEvent(TypedDict):
+    name: str
+    ph: Literal["I"]
+    s: Literal["p"]
+
+class PauseEvent(TypedDict):
+    name: str
+    cat: str
+    ph: Literal["X"]
+    ts: int
+
+class CounterEvent(TypedDict):
+    name: str
+    ph: Literal["C"]
+    ts: int
+
+class ProcessMeta(TypedDict):
+    name: Literal["process_name"]
+    ph: Literal["M"]
+
+TraceEvent = PauseEvent | CounterEvent | ProcessMeta | InstantEvent
+TimedEvent = PauseEvent | CounterEvent | InstantEvent
+
+def test_in(events: list[TraceEvent]) -> None:
+    timed: list[TimedEvent] = []
+    for event in events:
+        if event["ph"] in ("X", "C", "I"):
+            assert_type(event, TimedEvent)
+            timed.append(event)
+        else:
+            assert_type(event, ProcessMeta)
+
+def test_not_in(event: TraceEvent) -> None:
+    if event["ph"] not in ("M",):
+        assert_type(event, TimedEvent)
+    else:
+        assert_type(event, ProcessMeta)
+    "#,
+);
+
+testcase!(
+    test_discriminated_union_key_membership_non_literal_container,
+    r#"
+from typing import Literal, TypedDict, assert_type
+
+class XEvent(TypedDict):
+    ph: Literal["X"]
+
+class MEvent(TypedDict):
+    ph: Literal["M"]
+
+Event = XEvent | MEvent
+
+def test(event: Event, keys: list[str]) -> None:
+    # `keys` is not a statically-enumerable container, so membership cannot
+    # eliminate any union member: both branches keep the full union.
+    if event["ph"] in keys:
+        assert_type(event, Event)
+    else:
+        assert_type(event, Event)
+    "#,
+);
+
+testcase!(
+    test_discriminated_union_key_membership_non_literal_discriminant,
+    r#"
+from typing import Literal, TypedDict, assert_type
+
+class XEvent(TypedDict):
+    ph: Literal["X"]
+
+class AnyPhEvent(TypedDict):
+    ph: str
+
+Event = XEvent | AnyPhEvent
+
+def test(event: Event) -> None:
+    if event["ph"] in ("X",):
+        # AnyPhEvent's `str` discriminant might be "X", so it cannot be dropped.
+        assert_type(event, Event)
+    else:
+        # XEvent's "X" is excluded; AnyPhEvent survives (its `str` might not be "X").
+        assert_type(event, AnyPhEvent)
+    "#,
+);
+
+testcase!(
+    test_discriminated_union_key_membership_exhaustive,
+    r#"
+from typing import Literal, Never, TypedDict, assert_type
+
+class XEvent(TypedDict):
+    ph: Literal["X"]
+
+class MEvent(TypedDict):
+    ph: Literal["M"]
+
+Event = XEvent | MEvent
+
+def test(event: Event) -> None:
+    if event["ph"] in ("X", "M"):
+        # Every member's discriminant is covered, so nothing is eliminated.
+        assert_type(event, Event)
+    else:
+        # The complement is empty: this branch is unreachable.
+        assert_type(event, Never)
+    "#,
+);
+
+testcase!(
+    test_discriminated_union_key_membership_enum,
+    r#"
+from typing import Literal, TypedDict, assert_type
+from enum import Enum
+
+class Phase(Enum):
+    X = "x"
+    C = "c"
+    M = "m"
+
+class PauseEvent(TypedDict):
+    ph: Literal[Phase.X]
+
+class CounterEvent(TypedDict):
+    ph: Literal[Phase.C]
+
+class ProcessMeta(TypedDict):
+    ph: Literal[Phase.M]
+
+Event = PauseEvent | CounterEvent | ProcessMeta
+
+def test(event: Event) -> None:
+    if event["ph"] in (Phase.X, Phase.C):
+        assert_type(event, PauseEvent | CounterEvent)
+    else:
+        assert_type(event, ProcessMeta)
+    "#,
+);
+
+testcase!(
     test_discriminated_union_attr,
     r#"
 from typing import assert_type, Literal

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -2658,6 +2658,36 @@ def test(event: Event) -> None:
 );
 
 testcase!(
+    test_repro_mapping_membership_does_not_collapse_base,
+    r#"
+from typing import reveal_type
+
+class C:
+    arg: bytes
+    origin: type
+
+def test(c: C, d: dict[str, int]) -> None:
+    if c.arg in d:
+        reveal_type(c)  # E: revealed type: C
+        reveal_type(c.arg)  # E: revealed type: bytes
+    "#,
+);
+
+testcase!(
+    test_in_general_mapping_preserves_disjoint_facet_value,
+    r#"
+from typing import assert_type
+
+class C:
+    key: bytes
+
+def test(c: C, d: dict[str, int]) -> None:
+    if c.key in d:
+        assert_type(c.key, bytes)
+    "#,
+);
+
+testcase!(
     test_discriminated_union_attr,
     r#"
 from typing import assert_type, Literal
@@ -3244,6 +3274,30 @@ def example(variable: str | None) -> str:
         return "Not Found"
 
     return variable
+"#,
+);
+
+testcase!(
+    test_in_facet_narrow_does_not_make_ignored_subscript_never,
+    r#"
+from typing import Any, Optional
+
+class TypeVar:
+    pass
+
+class AnnotationInfo:
+    def __init__(self, raw_annotation: TypeVar) -> None:
+        self.origin = self.arg = None
+        self.optional = False
+        self.origin = list  # type: ignore
+        self.arg = raw_annotation  # type: ignore
+
+def f(annot_info: AnnotationInfo, param_dict: dict[TypeVar, type[Any]]) -> None:
+    if isinstance(annot_info.arg, TypeVar):
+        if annot_info.arg in param_dict:
+            raw_annot = annot_info.origin[param_dict[annot_info.arg]]  # type: ignore
+            if annot_info.optional:
+                raw_annot = Optional[raw_annot]
 "#,
 );
 


### PR DESCRIPTION
# Summary

## What
Narrow discriminated `TypedDict` unions when the discriminant is tested with a membership check (event[key] in (...) / not in (...)), not just with equality/identity.

Given a union where each member pins a shared key to a distinct literal:

```python
TraceEvent = PauseEvent | CounterEvent | ProcessMeta | InstantEvent  # ph: "X" | "C" | "M" | "I"

if event["ph"] in ("X", "C", "I"):
    timed.append(event)   # event now narrows to PauseEvent | CounterEvent | InstantEvent
```
ProcessMeta (ph: Literal["M"]) is now correctly dropped inside the branch, and the union is fully restored in the else.

## Why
Subscript narrowing does two jobs: it narrows the facet value (`event["ph"]`), and it narrows the parent by eliminating union members whose discriminant can't match. The parent step (`atomic_narrow_for_facet`) handled ==/!=/is/is not but left in/not in to narrow nothing. So equality discriminants worked while membership discriminants silently left the full union in place - impossible members survived the branch, and downstream assignments (list.append, returns, etc.) failed to type-check even though the code is sound.

## How
The in/not in arm now narrows each union member's discriminant facet through the same `atomic_narrow` routine already used for the facet value, and drops any member whose facet collapses to `Never` - a member that can't satisfy the test is impossible in that branch.

Fixes #3603 

# Test Plan

`cargo test -p pyrefly test::narrow` - full narrowing module green
`python3 test.py --no-test --no-conformance --no-jsonschema`  - cargo fmt + clippy clean

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
