### PR TITLE
Preserve TypeVar narrowing across concrete dispatch calls

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::collections::HashMap;
 use std::iter;
 use std::sync::Arc;
 
@@ -1585,11 +1586,61 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         {
             *targs = chosen_targs;
         }
-        let (ty, specialization_errors, _expected_types) = chosen_res;
+        let (ty, specialization_errors, expected_types) = chosen_res;
         if let Ok(errors) = Vec1::try_from_vec(specialization_errors) {
             self.add_specialization_errors(errors, arguments_range, call_errors, context);
         }
-        ty
+        self.refine_typevar_bound_call_result(ty, hint, args, keywords, &expected_types)
+    }
+
+    /// Preserve a narrowed `Concrete & T` witness when a concrete helper returns
+    /// the same type it accepts. Fresh concrete values remain plain `Concrete`.
+    fn refine_typevar_bound_call_result(
+        &self,
+        ty: Type,
+        hint: Option<HintRef>,
+        args: &[CallArg],
+        keywords: &[CallKeyword],
+        expected_types: &HashMap<TextRange, Type>,
+    ) -> Type {
+        let Some(hint) = hint else {
+            return ty;
+        };
+        let [hint] = hint.types() else {
+            return ty;
+        };
+        let Type::Quantified(quantified) = hint else {
+            return ty;
+        };
+        if !matches!(quantified.restriction(), Restriction::Bound(_)) {
+            return ty;
+        }
+        // Match the single value that can carry the TypeVar witness.
+        let (arg_range, value): (TextRange, &TypeOrExpr) = match (args, keywords) {
+            ([CallArg::Arg(value)], []) => (value.range(), value),
+            ([], [keyword]) => (keyword.range, &keyword.value),
+            _ => return ty,
+        };
+        if expected_types.get(&arg_range) != Some(&ty) {
+            return ty;
+        }
+        let arg_ty = match value {
+            TypeOrExpr::Type(ty, _) => (*ty).clone(),
+            TypeOrExpr::Expr(expr) => {
+                let errors = self.error_swallower();
+                self.expr_infer(expr, &errors)
+            }
+        };
+        if let Type::Intersect(intersection) = &arg_ty
+            && intersection.0.iter().any(
+                |part| matches!(part, Type::Quantified(q) if q.as_ref() == quantified.as_ref()),
+            )
+            && intersection.0.iter().any(|part| part == &ty)
+        {
+            arg_ty
+        } else {
+            ty
+        }
     }
 
     pub fn call_infer(

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -1542,6 +1542,129 @@ def test[T: int | str](value: T) -> T:
 );
 
 testcase!(
+    test_typevar_dispatch_on_concrete_class,
+    r#"
+from typing import TypeVar
+
+class A:
+    pass
+
+class B:
+    pass
+
+T = TypeVar("T", bound=A | B)
+
+def func_a(a: A) -> A:
+    return a
+
+def func_b(b: B) -> B:
+    return b
+
+def dispatch_with_type_is(x: T) -> T:
+    if type(x) is A:
+        return func_a(x)
+    elif type(x) is B:
+        return func_b(x)
+    raise NotImplementedError
+
+def dispatch_with_isinstance(x: T) -> T:
+    if isinstance(x, A):
+        return func_a(x)
+    elif isinstance(x, B):
+        return func_b(x)
+    raise NotImplementedError
+
+def bad_dispatch_with_fresh_value(x: T) -> T:
+    if isinstance(x, A):
+        return func_a(A())  # E: Returned type `A` is not assignable to declared return type `T`
+    raise NotImplementedError
+    "#,
+);
+
+testcase!(
+    test_typevar_dispatch_keyword_arg,
+    r#"
+from typing import TypeVar
+
+class A:
+    pass
+
+class B:
+    pass
+
+T = TypeVar("T", bound=A | B)
+
+def func_a(a: A) -> A:
+    return a
+
+def dispatch_kw(x: T) -> T:
+    if isinstance(x, A):
+        return func_a(a=x)
+    raise NotImplementedError
+    "#,
+);
+
+testcase!(
+    test_typevar_dispatch_single_bound,
+    r#"
+from typing import TypeVar, reveal_type
+
+class P:
+    pass
+
+class C1(P):
+    pass
+
+Tb = TypeVar("Tb", bound=P)
+
+def fc1(c: C1) -> C1:
+    return c
+
+def dispatch_single_bound(x: Tb) -> Tb:
+    if isinstance(x, C1):
+        reveal_type(x)  # E: revealed type: C1 & Tb
+        return fc1(x)
+    raise NotImplementedError
+    "#,
+);
+
+testcase!(
+    test_typevar_dispatch_negatives,
+    r#"
+from typing import TypeVar
+
+class A:
+    pass
+
+class B:
+    pass
+
+T = TypeVar("T", bound=A | B)
+
+class A3(A):
+    pass
+
+def func_a(a: A) -> A:
+    return a
+
+def fa_sub(a: A) -> A3:
+    return A3()
+
+def bad_return_subtype(x: T) -> T:
+    if isinstance(x, A):
+        return fa_sub(x)  # E: Returned type `A3` is not assignable to declared return type `T`
+    raise NotImplementedError
+
+def bad_keyword_fresh(x: T) -> T:
+    # The keyword path must enforce the same witness guard as the positional
+    # path: a fresh value passed by keyword is not the narrowed `A & T`.
+    if isinstance(x, A):
+        return func_a(a=A())  # E: Returned type `A` is not assignable to declared return type `T`
+    raise NotImplementedError
+    "#,
+);
+
+testcase!(
     test_issubclass_typevar_nondisjoint_classes,
     r#"
 from typing import reveal_type


### PR DESCRIPTION
# Summary

## What

Pyrefly rejected a dispatch-on-concrete-subclass pattern that pyright accepts. A function over a `TypeVar` bound to a union, narrowing with `isinstance`/`type(x) is C` and returning a helper's result, got a spurious `bad-return`.

```python
T = TypeVar("T", bound=A | B)
def func_a(a: A) -> A: return a

def dispatch(x: T) -> T:
    if isinstance(x, A):
        return func_a(x)   # before: bad-return (A not assignable to T)
    raise NotImplementedError
```

Fix in `pyrefly/lib/alt/call.rs` — `refine_typevar_bound_call_result`. Plus two scope expansions over the base fix: **keyword args** + **any bounded TypeVar** (not just union bounds). Tests in `pyrefly/lib/test/narrow.rs`.

## Why

Type theory: inside the body `T` is **rigid** (skolemized), constraint `T <: A | B`.

- `T <: A` — using a `T` as `A` = fine (down).
- `A <: T` — **false in general**: caller's `T` could be a strict subtype `A2 <: A`. Can't fabricate a `T` from a bare `A` (up = unsound).

Narrowing already does the right thing: `isinstance(x, A)` gives the **meet** `A & T` (`reveal_type(x)` = `A & T`), which is both `<: A` (passable to `func_a`) and `<: T` (returnable).

**The leak is at the call boundary.** `func_a: (A) -> A` is monomorphic — applying it computes codomain `A` and drops the `& T`. So `func_a(A & T)` typed as plain `A` → not assignable to `-> T` → spurious error. Narrowing the variable can't fix it; the value comes from the helper's signature, not from `x`.

## How

After computing a call's result `ty`, refine it back to the witness — but only when the argument **provably is** that witness. Gates, in order (cheap → expensive):

1. return-context hint is a single bounded `TypeVar` (`Restriction::Bound(_)`)
2. exactly one positional **or** one keyword arg (unified extraction)
3. `expected_types[arg_range] == ty` — helper's **param type == return type** (the identity shape; reuses already-computed data, previously discarded as `_expected_types`)
4. arg's type is an `Intersect` carrying **both** that same skolem `T` **and** the return type `ty` → return the intersection (`A & T`) instead of bare `A`

`A & T <: T` → checks. Expensive `expr_infer` gated behind cheap checks.

**Soundness = gates 3+4.** A function with `param == return` behaves (parametrically) like it returns its input; when the input carries `& T`, the output's precise type still carries `& T` — we *recover* the witness, not invent it. Anything else (fresh `A`, helper returning a subtype `(A)->A3`) fails a gate → stays rejected.

Honest residual: `def f(a: A) -> A: return A()` (returns fresh, not input) is accepted though mildly unsound — inherent (the signature can't say "returns its arg"), matches pyright.

**Why these two expansions are safe:** keyword `f(a=x)` ≡ positional `f(x)` (one value, one param) — zero new soundness surface. `Bound(Union)` → `Bound(_)` — gates 3+4 don't depend on the bound's shape, so per-instance soundness is identical; only applicability widens. Constrained TypeVars (`TypeVar("T", A, B)`) already worked soundly via exact-identity and need no special-casing.

## Test plan

5 testcases in `narrow.rs`:

| Test | Asserts | Type |
|---|---|---|
| `test_typevar_dispatch_on_concrete_class` | `type(x) is A` + `isinstance` dispatch OK; `func_a(A())` fresh → `bad-return` | +/− |
| `test_typevar_dispatch_keyword_arg` | `func_a(a=x)` OK | + |
| `test_typevar_dispatch_single_bound` | non-union `T: P` OK; `reveal_type(x)` = `C1 & Tb` | + (pins shape) |
| `test_typevar_dispatch_negatives` | `(A)->A3` subtype-return → rejected; `func_a(a=A())` fresh keyword → rejected | − |

Verification:

- `cargo test -p pyrefly 'test::narrow::'` → **199 passed, 0 failed**
- Full `python3 test.py` → formatting ✅, lint ✅, **5286 lib tests ✅**, conformance ✅. (jsonschema phase couldn't run locally — missing `jsonschema`/`toml` pip deps; env gap, not code.)
- `mypy_primer` ×3 runs, **~17 ecosystem projects** (pydantic, pandera, sphinx, aiohttp, starlette, tornado, werkzeug, mypy, attrs, sympy, trio, jinja, packaging, rich…) → **zero diagnostic diffs**



<!-- Describe the change in this PR -->

Fixes #3550 

