### PR TITLE
Prepare semantic tokens to include syntax highlighting

### DIFF
--- a/crates/pyrefly_python/src/ast.rs
+++ b/crates/pyrefly_python/src/ast.rs
@@ -40,7 +40,6 @@ use ruff_python_ast::visitor::source_order::SourceOrderVisitor;
 use ruff_python_ast::visitor::source_order::TraversalSignal;
 use ruff_python_parser::ParseError;
 use ruff_python_parser::ParseOptions;
-use ruff_python_parser::Parsed;
 use ruff_python_parser::UnsupportedSyntaxError;
 use ruff_python_parser::parse_expression_range;
 use ruff_python_parser::parse_unchecked;
@@ -104,26 +103,17 @@ impl Ast {
         version: PythonVersion,
         source_type: PySourceType,
     ) -> (ModModule, Vec<ParseError>, Vec<UnsupportedSyntaxError>) {
-        let res = Ast::parse_full_with_version(contents, version, source_type);
-        let parse_errors = res.errors().to_owned();
-        let unsupported_syntax_errors = res.unsupported_syntax_errors().to_owned();
-        (res.into_syntax(), parse_errors, unsupported_syntax_errors)
-    }
-
-    pub fn parse_full_with_version(
-        contents: &str,
-        version: PythonVersion,
-        source_type: PySourceType,
-    ) -> Parsed<ModModule> {
         // PySourceType of Python vs Stub doesn't actually change the parsing
         let options = ParseOptions::from(source_type).with_target_version(RuffPythonVersion {
             major: version.major as u8,
             minor: version.minor as u8,
         });
-
-        parse_unchecked(contents, options)
+        let res = parse_unchecked(contents, options)
             .try_into_module()
-            .expect("PySourceType should parse into a module")
+            .unwrap();
+        let parse_errors = res.errors().to_owned();
+        let unsupported_syntax_errors = res.unsupported_syntax_errors().to_owned();
+        (res.into_syntax(), parse_errors, unsupported_syntax_errors)
     }
 
     pub fn parse_expr(contents: &str, pos: TextSize) -> anyhow::Result<Expr> {

--- a/crates/pyrefly_python/src/ast.rs
+++ b/crates/pyrefly_python/src/ast.rs
@@ -36,11 +36,11 @@ use ruff_python_ast::StringLiteral;
 use ruff_python_ast::StringLiteralFlags;
 use ruff_python_ast::StringLiteralValue;
 use ruff_python_ast::name::Name;
-use ruff_python_ast::token::Tokens;
 use ruff_python_ast::visitor::source_order::SourceOrderVisitor;
 use ruff_python_ast::visitor::source_order::TraversalSignal;
 use ruff_python_parser::ParseError;
 use ruff_python_parser::ParseOptions;
+use ruff_python_parser::Parsed;
 use ruff_python_parser::UnsupportedSyntaxError;
 use ruff_python_parser::parse_expression_range;
 use ruff_python_parser::parse_unchecked;
@@ -104,24 +104,17 @@ impl Ast {
         version: PythonVersion,
         source_type: PySourceType,
     ) -> (ModModule, Vec<ParseError>, Vec<UnsupportedSyntaxError>) {
-        // PySourceType of Python vs Stub doesn't actually change the parsing
-        let options = ParseOptions::from(source_type).with_target_version(RuffPythonVersion {
-            major: version.major as u8,
-            minor: version.minor as u8,
-        });
-        let res = parse_unchecked(contents, options)
-            .try_into_module()
-            .unwrap();
+        let res = Ast::parse_full_with_version(contents, version, source_type);
         let parse_errors = res.errors().to_owned();
         let unsupported_syntax_errors = res.unsupported_syntax_errors().to_owned();
         (res.into_syntax(), parse_errors, unsupported_syntax_errors)
     }
 
-    pub fn lex_with_version(
+    pub fn parse_full_with_version(
         contents: &str,
         version: PythonVersion,
         source_type: PySourceType,
-    ) -> Tokens {
+    ) -> Parsed<ModModule> {
         // PySourceType of Python vs Stub doesn't actually change the parsing
         let options = ParseOptions::from(source_type).with_target_version(RuffPythonVersion {
             major: version.major as u8,
@@ -130,9 +123,7 @@ impl Ast {
 
         parse_unchecked(contents, options)
             .try_into_module()
-            .unwrap()
-            .tokens()
-            .clone()
+            .expect("PySourceType should parse into a module")
     }
 
     pub fn parse_expr(contents: &str, pos: TextSize) -> anyhow::Result<Expr> {

--- a/crates/pyrefly_python/src/ast.rs
+++ b/crates/pyrefly_python/src/ast.rs
@@ -40,6 +40,7 @@ use ruff_python_ast::visitor::source_order::SourceOrderVisitor;
 use ruff_python_ast::visitor::source_order::TraversalSignal;
 use ruff_python_parser::ParseError;
 use ruff_python_parser::ParseOptions;
+use ruff_python_parser::Parsed;
 use ruff_python_parser::UnsupportedSyntaxError;
 use ruff_python_parser::parse_expression_range;
 use ruff_python_parser::parse_unchecked;
@@ -95,14 +96,24 @@ impl Ast {
         contents: &str,
         source_type: PySourceType,
     ) -> (ModModule, Vec<ParseError>, Vec<UnsupportedSyntaxError>) {
-        Ast::parse_with_version(contents, PythonVersion::default(), source_type)
+        let (parsed, parse_errors, unsupported_syntax_errors) =
+            Ast::parse_with_version(contents, PythonVersion::default(), source_type);
+        (
+            parsed.into_syntax(),
+            parse_errors,
+            unsupported_syntax_errors,
+        )
     }
 
     pub fn parse_with_version(
         contents: &str,
         version: PythonVersion,
         source_type: PySourceType,
-    ) -> (ModModule, Vec<ParseError>, Vec<UnsupportedSyntaxError>) {
+    ) -> (
+        Parsed<ModModule>,
+        Vec<ParseError>,
+        Vec<UnsupportedSyntaxError>,
+    ) {
         // PySourceType of Python vs Stub doesn't actually change the parsing
         let options = ParseOptions::from(source_type).with_target_version(RuffPythonVersion {
             major: version.major as u8,
@@ -113,7 +124,7 @@ impl Ast {
             .unwrap();
         let parse_errors = res.errors().to_owned();
         let unsupported_syntax_errors = res.unsupported_syntax_errors().to_owned();
-        (res.into_syntax(), parse_errors, unsupported_syntax_errors)
+        (res, parse_errors, unsupported_syntax_errors)
     }
 
     pub fn parse_expr(contents: &str, pos: TextSize) -> anyhow::Result<Expr> {

--- a/crates/pyrefly_python/src/ast.rs
+++ b/crates/pyrefly_python/src/ast.rs
@@ -36,6 +36,7 @@ use ruff_python_ast::StringLiteral;
 use ruff_python_ast::StringLiteralFlags;
 use ruff_python_ast::StringLiteralValue;
 use ruff_python_ast::name::Name;
+use ruff_python_ast::token::Tokens;
 use ruff_python_ast::visitor::source_order::SourceOrderVisitor;
 use ruff_python_ast::visitor::source_order::TraversalSignal;
 use ruff_python_parser::ParseError;
@@ -114,6 +115,24 @@ impl Ast {
         let parse_errors = res.errors().to_owned();
         let unsupported_syntax_errors = res.unsupported_syntax_errors().to_owned();
         (res.into_syntax(), parse_errors, unsupported_syntax_errors)
+    }
+
+    pub fn lex_with_version(
+        contents: &str,
+        version: PythonVersion,
+        source_type: PySourceType,
+    ) -> Tokens {
+        // PySourceType of Python vs Stub doesn't actually change the parsing
+        let options = ParseOptions::from(source_type).with_target_version(RuffPythonVersion {
+            major: version.major as u8,
+            minor: version.minor as u8,
+        });
+
+        parse_unchecked(contents, options)
+            .try_into_module()
+            .unwrap()
+            .tokens()
+            .clone()
     }
 
     pub fn parse_expr(contents: &str, pos: TextSize) -> anyhow::Result<Expr> {

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -1191,17 +1191,21 @@ pub fn dispatch_lsp_events(server: &Server, reader: &mut MessageReader) {
     let _ = server.lsp_queue().send(LspEvent::Exit);
 }
 
-pub fn capabilities(
-    indexing_mode: IndexingMode,
-    initialization_params: &InitializeParams,
-) -> ServerCapabilitiesWithTypeHierarchy {
-    let augments_syntax_tokens = initialization_params
+fn client_augments_syntax_tokens(initialization_params: &InitializeParams) -> bool {
+    initialization_params
         .capabilities
         .text_document
         .as_ref()
         .and_then(|c| c.semantic_tokens.as_ref())
         .and_then(|c| c.augments_syntax_tokens)
-        .unwrap_or(false);
+        .unwrap_or(false)
+}
+
+pub fn capabilities(
+    indexing_mode: IndexingMode,
+    initialization_params: &InitializeParams,
+) -> ServerCapabilitiesWithTypeHierarchy {
+    let augments_syntax_tokens = client_augments_syntax_tokens(initialization_params);
 
     // Parse syncNotebooks from initialization options, defaults to true
     let sync_notebooks = initialization_params
@@ -1286,6 +1290,9 @@ pub fn capabilities(
             // syntax highlighting for tokens we don't provide, it will be a regression
             // (e.g. users might lose keyword highlighting).
             // Therefore, we should not produce semantic tokens if the client doesn't support `augments_syntax_tokens`.
+            // We now have an implementation path for a full semantic token stream that fills in
+            // syntax tokens, but we do not advertise that capability to non-augmenting clients yet.
+            // Keep the provider gate here until that full-stream behavior is ready to expose.
             Some(SemanticTokensServerCapabilities::SemanticTokensOptions(
                 SemanticTokensOptions {
                     legend: SemanticTokensLegends::lsp_semantic_token_legends(),
@@ -5085,10 +5092,11 @@ impl Server {
         let uri = &params.text_document.uri;
         let maybe_cell_idx = self.maybe_get_code_cell_index(uri);
         let handle = self.make_handle_if_enabled(uri, Some(SemanticTokensFullRequest::METHOD))?;
+        let include_syntax_tokens = !client_augments_syntax_tokens(&self.initialize_params);
         Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
             result_id: None,
             data: transaction
-                .semantic_tokens(&handle, None, maybe_cell_idx)
+                .semantic_tokens(&handle, None, maybe_cell_idx, include_syntax_tokens)
                 .unwrap_or_default(),
         })))
     }
@@ -5105,10 +5113,11 @@ impl Server {
             .get_module_info(&handle)
             .ok_or(EmptyResponseReason::ModuleInfoNotFound)?;
         let range = self.from_lsp_range(uri, &module_info, params.range);
+        let include_syntax_tokens = !client_augments_syntax_tokens(&self.initialize_params);
         Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
             result_id: None,
             data: transaction
-                .semantic_tokens(&handle, Some(range), maybe_cell_idx)
+                .semantic_tokens(&handle, Some(range), maybe_cell_idx, include_syntax_tokens)
                 .unwrap_or_default(),
         })))
     }

--- a/pyrefly/lib/lsp/wasm/semantic_tokens.rs
+++ b/pyrefly/lib/lsp/wasm/semantic_tokens.rs
@@ -7,6 +7,7 @@
 
 use lsp_types::SemanticToken;
 use pyrefly_build::handle::Handle;
+use pyrefly_python::ast::Ast;
 use ruff_text_size::TextRange;
 
 use crate::binding::binding::Key;
@@ -23,12 +24,22 @@ impl Transaction<'_> {
         handle: &Handle,
         limit_range: Option<TextRange>,
         limit_cell_idx: Option<usize>,
+        include_syntax_tokens: bool,
     ) -> Option<Vec<SemanticToken>> {
         let module_info = self.get_module_info(handle)?;
         let ast = self.get_ast(handle)?;
         let legends = SemanticTokensLegends::new();
         let disabled_ranges = disabled_ranges_for_module(ast.as_ref(), *handle.sys_info());
         let mut builder = SemanticTokenBuilder::new(limit_range, disabled_ranges);
+
+        if include_syntax_tokens {
+            let tokens = Ast::lex_with_version(
+                module_info.contents(),
+                handle.sys_info().version(),
+                module_info.source_type(),
+            );
+            builder.process_syntax_tokens(&tokens);
+        }
 
         builder.process_ast(
             &ast,
@@ -48,6 +59,7 @@ impl Transaction<'_> {
         Some(legends.convert_tokens_into_lsp_semantic_tokens(
             &builder.all_tokens_sorted(),
             module_info,
+            limit_range,
             limit_cell_idx,
         ))
     }

--- a/pyrefly/lib/lsp/wasm/semantic_tokens.rs
+++ b/pyrefly/lib/lsp/wasm/semantic_tokens.rs
@@ -7,7 +7,6 @@
 
 use lsp_types::SemanticToken;
 use pyrefly_build::handle::Handle;
-use pyrefly_python::ast::Ast;
 use ruff_text_size::TextRange;
 
 use crate::binding::binding::Key;
@@ -33,11 +32,9 @@ impl Transaction<'_> {
         let mut builder = SemanticTokenBuilder::new(limit_range, disabled_ranges);
 
         if include_syntax_tokens {
-            let tokens = Ast::lex_with_version(
-                module_info.contents(),
-                handle.sys_info().version(),
-                module_info.source_type(),
-            );
+            let tokens = self
+                .get_syntax_tokens(handle)
+                .expect("syntax tokens must be cached with the AST");
             builder.process_syntax_tokens(&tokens);
         }
 

--- a/pyrefly/lib/lsp/wasm/semantic_tokens.rs
+++ b/pyrefly/lib/lsp/wasm/semantic_tokens.rs
@@ -26,15 +26,14 @@ impl Transaction<'_> {
         include_syntax_tokens: bool,
     ) -> Option<Vec<SemanticToken>> {
         let module_info = self.get_module_info(handle)?;
-        let ast = self.get_ast(handle)?;
+        let parsed = self.get_parsed_module(handle)?;
+        let ast = parsed.module();
         let legends = SemanticTokensLegends::new();
         let disabled_ranges = disabled_ranges_for_module(ast.as_ref(), *handle.sys_info());
         let mut builder = SemanticTokenBuilder::new(limit_range, disabled_ranges);
 
         if include_syntax_tokens {
-            let tokens = self
-                .get_syntax_tokens(handle)
-                .expect("syntax tokens must be cached with the AST");
+            let tokens = parsed.tokens();
             builder.process_syntax_tokens(&tokens);
         }
 

--- a/pyrefly/lib/module/parse.rs
+++ b/pyrefly/lib/module/parse.rs
@@ -9,6 +9,8 @@ use pyrefly_python::ast::Ast;
 use pyrefly_python::sys_info::PythonVersion;
 use ruff_python_ast::ModModule;
 use ruff_python_ast::PySourceType;
+use ruff_python_ast::token::Tokens;
+use ruff_python_parser::Parsed;
 
 use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
@@ -19,9 +21,28 @@ pub fn module_parse(
     source_type: PySourceType,
     errors: &ErrorCollector,
 ) -> ModModule {
-    let (module, parse_errors, unsupported_syntax_errors) =
-        Ast::parse_with_version(contents, version, source_type);
-    for err in parse_errors {
+    parse_with_errors(contents, version, source_type, errors).into_syntax()
+}
+
+pub fn module_parse_with_tokens(
+    contents: &str,
+    version: PythonVersion,
+    source_type: PySourceType,
+    errors: &ErrorCollector,
+) -> (ModModule, Tokens) {
+    let parsed = parse_with_errors(contents, version, source_type, errors);
+    let tokens = parsed.tokens().clone();
+    (parsed.into_syntax(), tokens)
+}
+
+fn parse_with_errors(
+    contents: &str,
+    version: PythonVersion,
+    source_type: PySourceType,
+    errors: &ErrorCollector,
+) -> Parsed<ModModule> {
+    let parsed = Ast::parse_full_with_version(contents, version, source_type);
+    for err in parsed.errors() {
         errors
             .error_builder(
                 err.location,
@@ -30,10 +51,10 @@ pub fn module_parse(
             )
             .emit();
     }
-    for err in unsupported_syntax_errors {
+    for err in parsed.unsupported_syntax_errors() {
         errors
             .error_builder(err.range, ErrorKind::InvalidSyntax, format!("{err}"))
             .emit();
     }
-    module
+    parsed
 }

--- a/pyrefly/lib/module/parse.rs
+++ b/pyrefly/lib/module/parse.rs
@@ -5,14 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use pyrefly_python::ast::Ast;
 use pyrefly_python::sys_info::PythonVersion;
 use ruff_python_ast::ModModule;
 use ruff_python_ast::PySourceType;
-use ruff_python_ast::PythonVersion as RuffPythonVersion;
 use ruff_python_ast::token::Tokens;
-use ruff_python_parser::ParseOptions;
-use ruff_python_parser::Parsed;
-use ruff_python_parser::parse_unchecked;
 
 use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
@@ -23,26 +20,9 @@ pub fn module_parse(
     source_type: PySourceType,
     errors: &ErrorCollector,
 ) -> (ModModule, Tokens) {
-    let parsed = parse_with_errors(contents, version, source_type, errors);
-    let tokens = parsed.tokens().clone();
-    (parsed.into_syntax(), tokens)
-}
-
-fn parse_with_errors(
-    contents: &str,
-    version: PythonVersion,
-    source_type: PySourceType,
-    errors: &ErrorCollector,
-) -> Parsed<ModModule> {
-    // PySourceType of Python vs Stub doesn't actually change the parsing.
-    let options = ParseOptions::from(source_type).with_target_version(RuffPythonVersion {
-        major: version.major as u8,
-        minor: version.minor as u8,
-    });
-    let parsed = parse_unchecked(contents, options)
-        .try_into_module()
-        .expect("PySourceType should parse into a module");
-    for err in parsed.errors() {
+    let (parsed, parse_errors, unsupported_syntax_errors) =
+        Ast::parse_with_version(contents, version, source_type);
+    for err in parse_errors {
         errors
             .error_builder(
                 err.location,
@@ -51,10 +31,13 @@ fn parse_with_errors(
             )
             .emit();
     }
-    for err in parsed.unsupported_syntax_errors() {
+    for err in unsupported_syntax_errors {
         errors
             .error_builder(err.range, ErrorKind::InvalidSyntax, format!("{err}"))
             .emit();
     }
-    parsed
+
+    let tokens = parsed.tokens().clone();
+
+    (parsed.into_syntax(), tokens)
 }

--- a/pyrefly/lib/module/parse.rs
+++ b/pyrefly/lib/module/parse.rs
@@ -5,26 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use pyrefly_python::ast::Ast;
 use pyrefly_python::sys_info::PythonVersion;
 use ruff_python_ast::ModModule;
 use ruff_python_ast::PySourceType;
+use ruff_python_ast::PythonVersion as RuffPythonVersion;
 use ruff_python_ast::token::Tokens;
+use ruff_python_parser::ParseOptions;
 use ruff_python_parser::Parsed;
+use ruff_python_parser::parse_unchecked;
 
 use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
 
 pub fn module_parse(
-    contents: &str,
-    version: PythonVersion,
-    source_type: PySourceType,
-    errors: &ErrorCollector,
-) -> ModModule {
-    parse_with_errors(contents, version, source_type, errors).into_syntax()
-}
-
-pub fn module_parse_with_tokens(
     contents: &str,
     version: PythonVersion,
     source_type: PySourceType,
@@ -41,7 +34,14 @@ fn parse_with_errors(
     source_type: PySourceType,
     errors: &ErrorCollector,
 ) -> Parsed<ModModule> {
-    let parsed = Ast::parse_full_with_version(contents, version, source_type);
+    // PySourceType of Python vs Stub doesn't actually change the parsing.
+    let options = ParseOptions::from(source_type).with_target_version(RuffPythonVersion {
+        major: version.major as u8,
+        minor: version.minor as u8,
+    });
+    let parsed = parse_unchecked(contents, options)
+        .try_into_module()
+        .expect("PySourceType should parse into a module");
     for err in parsed.errors() {
         errors
             .error_builder(

--- a/pyrefly/lib/playground.rs
+++ b/pyrefly/lib/playground.rs
@@ -578,7 +578,7 @@ impl Playground {
         Some(SemanticTokensResult::Tokens(SemanticTokens {
             result_id: None,
             data: transaction
-                .semantic_tokens(handle, range, None)
+                .semantic_tokens(handle, range, None, true)
                 .unwrap_or_default(),
         }))
     }

--- a/pyrefly/lib/state/module.rs
+++ b/pyrefly/lib/state/module.rs
@@ -40,6 +40,7 @@ use dupe::Dupe;
 use pyrefly_util::lock::Condvar;
 use pyrefly_util::lock::Mutex;
 use ruff_python_ast::ModModule;
+use ruff_python_ast::token::Tokens;
 
 use crate::alt::answers::Answers;
 use crate::alt::answers::LookupAnswer;
@@ -146,6 +147,10 @@ impl ModuleStateMut {
 
     pub fn get_ast(&self) -> Option<Arc<ModModule>> {
         self.steps.ast.load_full()
+    }
+
+    pub fn get_syntax_tokens(&self) -> Option<Arc<Tokens>> {
+        self.steps.syntax_tokens.load_full()
     }
 
     pub fn get_exports(&self) -> Option<Arc<Exports>> {
@@ -367,6 +372,7 @@ impl PostComputeGuard<'_> {
             "evict_ast called before answers computed"
         );
         self.state.steps.ast.store(None);
+        self.state.steps.syntax_tokens.store(None);
     }
 
     /// Evict answers after computing solutions (if not needed for retention).
@@ -464,6 +470,7 @@ impl CleanGuard<'_> {
 pub trait ModuleStateReader {
     fn get_load(&self) -> Option<Arc<Load>>;
     fn get_ast(&self) -> Option<Arc<ModModule>>;
+    fn get_syntax_tokens(&self) -> Option<Arc<Tokens>>;
     fn get_answers(&self) -> Option<Arc<(Bindings, Arc<Answers>)>>;
     fn get_solutions(&self) -> Option<Arc<Solutions>>;
     fn module_ranges(&self) -> Option<Arc<ModuleRanges>>;
@@ -476,6 +483,10 @@ impl ModuleStateReader for ModuleState {
 
     fn get_ast(&self) -> Option<Arc<ModModule>> {
         self.steps.ast.dupe()
+    }
+
+    fn get_syntax_tokens(&self) -> Option<Arc<Tokens>> {
+        self.steps.syntax_tokens.dupe()
     }
 
     fn get_answers(&self) -> Option<Arc<(Bindings, Arc<Answers>)>> {
@@ -505,6 +516,10 @@ impl ModuleStateReader for ModuleStateMut {
 
     fn get_ast(&self) -> Option<Arc<ModModule>> {
         self.get_ast()
+    }
+
+    fn get_syntax_tokens(&self) -> Option<Arc<Tokens>> {
+        self.get_syntax_tokens()
     }
 
     fn get_answers(&self) -> Option<Arc<(Bindings, Arc<Answers>)>> {

--- a/pyrefly/lib/state/module.rs
+++ b/pyrefly/lib/state/module.rs
@@ -40,7 +40,6 @@ use dupe::Dupe;
 use pyrefly_util::lock::Condvar;
 use pyrefly_util::lock::Mutex;
 use ruff_python_ast::ModModule;
-use ruff_python_ast::token::Tokens;
 
 use crate::alt::answers::Answers;
 use crate::alt::answers::LookupAnswer;
@@ -58,6 +57,7 @@ use crate::state::load::Load;
 use crate::state::require::AtomicRequire;
 use crate::state::require::Require;
 use crate::state::steps::Context;
+use crate::state::steps::ParsedModule;
 use crate::state::steps::Step;
 use crate::state::steps::Steps;
 use crate::state::steps::StepsMut;
@@ -146,11 +146,11 @@ impl ModuleStateMut {
     }
 
     pub fn get_ast(&self) -> Option<Arc<ModModule>> {
-        self.steps.ast.load_full()
+        self.steps.parsed.load_full().map(|parsed| parsed.module())
     }
 
-    pub fn get_syntax_tokens(&self) -> Option<Arc<Tokens>> {
-        self.steps.syntax_tokens.load_full()
+    pub fn get_parsed_module(&self) -> Option<Arc<ParsedModule>> {
+        self.steps.parsed.load_full()
     }
 
     pub fn get_exports(&self) -> Option<Arc<Exports>> {
@@ -371,8 +371,7 @@ impl PostComputeGuard<'_> {
             self.state.steps.current_step.load() >= Some(Step::Answers),
             "evict_ast called before answers computed"
         );
-        self.state.steps.ast.store(None);
-        self.state.steps.syntax_tokens.store(None);
+        self.state.steps.parsed.store(None);
     }
 
     /// Evict answers after computing solutions (if not needed for retention).
@@ -470,7 +469,7 @@ impl CleanGuard<'_> {
 pub trait ModuleStateReader {
     fn get_load(&self) -> Option<Arc<Load>>;
     fn get_ast(&self) -> Option<Arc<ModModule>>;
-    fn get_syntax_tokens(&self) -> Option<Arc<Tokens>>;
+    fn get_parsed_module(&self) -> Option<Arc<ParsedModule>>;
     fn get_answers(&self) -> Option<Arc<(Bindings, Arc<Answers>)>>;
     fn get_solutions(&self) -> Option<Arc<Solutions>>;
     fn module_ranges(&self) -> Option<Arc<ModuleRanges>>;
@@ -482,11 +481,11 @@ impl ModuleStateReader for ModuleState {
     }
 
     fn get_ast(&self) -> Option<Arc<ModModule>> {
-        self.steps.ast.dupe()
+        self.steps.parsed.as_ref().map(|parsed| parsed.module())
     }
 
-    fn get_syntax_tokens(&self) -> Option<Arc<Tokens>> {
-        self.steps.syntax_tokens.dupe()
+    fn get_parsed_module(&self) -> Option<Arc<ParsedModule>> {
+        self.steps.parsed.dupe()
     }
 
     fn get_answers(&self) -> Option<Arc<(Bindings, Arc<Answers>)>> {
@@ -518,8 +517,8 @@ impl ModuleStateReader for ModuleStateMut {
         self.get_ast()
     }
 
-    fn get_syntax_tokens(&self) -> Option<Arc<Tokens>> {
-        self.get_syntax_tokens()
+    fn get_parsed_module(&self) -> Option<Arc<ParsedModule>> {
+        self.get_parsed_module()
     }
 
     fn get_answers(&self) -> Option<Arc<(Bindings, Arc<Answers>)>> {

--- a/pyrefly/lib/state/semantic_tokens.rs
+++ b/pyrefly/lib/state/semantic_tokens.rs
@@ -30,8 +30,11 @@ use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtImport;
 use ruff_python_ast::StmtImportFrom;
 use ruff_python_ast::name::Name;
+use ruff_python_ast::token::TokenKind;
+use ruff_python_ast::token::Tokens;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
+use ruff_text_size::TextSize;
 
 use crate::binding::binding::Key;
 
@@ -123,39 +126,41 @@ impl SemanticTokensLegends {
         &self,
         tokens: &[SemanticTokenWithFullRange],
         module_info: Module,
+        limit_range: Option<TextRange>,
         limit_cell_idx: Option<usize>,
     ) -> Vec<SemanticToken> {
         let mut previous_line = 0;
         let mut previous_col = 0;
         let mut lsp_semantic_tokens = Vec::new();
+        let source = module_info.contents().as_str();
         for token in tokens {
-            let cell_idx = module_info.to_cell_for_lsp(token.range.start());
-            // Skip tokens in different cells if we're filtering for a particular cell
-            if cell_idx != limit_cell_idx {
-                continue;
-            }
-            let start_pos = module_info.to_lsp_position(token.range.start());
-            let end_pos = module_info.to_lsp_position(token.range.end());
-            let length = if start_pos.line == end_pos.line {
-                end_pos.character.saturating_sub(start_pos.character)
-            } else {
-                // LSP semantic tokens must be expressed within a single line; we currently
-                // generate only single-line ranges, so treat any multi-line span as invalid
-                // and skip it. (Today this effectively never happens, but the guard keeps us
-                // from emitting malformed data if it does.)
-                debug_assert!(
-                    false,
-                    "Unexpected multi-line semantic token range (from line {} to line {}, with token type {:?})",
-                    start_pos.line, end_pos.line, token.token_type,
+            let mut push_segment = |segment_range: TextRange| {
+                if segment_range.is_empty() {
+                    return;
+                }
+                if !range_overlaps(limit_range, segment_range) {
+                    return;
+                }
+                let cell_idx = module_info.to_cell_for_lsp(segment_range.start());
+                // Skip tokens in different cells if we're filtering for a particular cell
+                if cell_idx != limit_cell_idx {
+                    return;
+                }
+                let start_pos = module_info.to_lsp_position(segment_range.start());
+                let end_pos = module_info.to_lsp_position(segment_range.end());
+                debug_assert_eq!(
+                    start_pos.line, end_pos.line,
+                    "Semantic token segment should be on a single line"
                 );
-                0
-            };
-            if length == 0 {
-                continue;
-            }
-            let current_line = start_pos.line;
-            let current_col = start_pos.character;
-            let (delta_line, delta_start) = {
+                if start_pos.line != end_pos.line {
+                    return;
+                }
+                let length = end_pos.character.saturating_sub(start_pos.character);
+                if length == 0 {
+                    return;
+                }
+                let current_line = start_pos.line;
+                let current_col = start_pos.character;
                 let delta_line = current_line - previous_line;
                 let delta_start = if previous_line == current_line {
                     current_col - previous_col
@@ -164,21 +169,37 @@ impl SemanticTokensLegends {
                 };
                 previous_line = current_line;
                 previous_col = current_col;
-                (delta_line, delta_start)
+                let token_type = *self.token_types_index.get(&token.token_type).unwrap();
+                let mut token_modifiers_bitset = 0;
+                for modifier in &token.token_modifiers {
+                    let index = *self.token_modifiers_index.get(modifier).unwrap();
+                    token_modifiers_bitset |= 1 << index;
+                }
+                lsp_semantic_tokens.push(SemanticToken {
+                    delta_line,
+                    delta_start,
+                    length,
+                    token_type,
+                    token_modifiers_bitset,
+                });
             };
-            let token_type = *self.token_types_index.get(&token.token_type).unwrap();
-            let mut token_modifiers_bitset = 0;
-            for modifier in &token.token_modifiers {
-                let index = *self.token_modifiers_index.get(modifier).unwrap();
-                token_modifiers_bitset |= 1 << index;
+            let mut segment_start = token.range.start();
+            let start = token.range.start().to_usize();
+            let end = token.range.end().to_usize();
+            let token_source = &source[start..end];
+            for line in token_source.split_inclusive('\n') {
+                let line_without_lf = line.strip_suffix('\n').unwrap_or(line);
+                let line_without_ending = line_without_lf
+                    .strip_suffix('\r')
+                    .unwrap_or(line_without_lf);
+                let segment_end = segment_start
+                    + TextSize::try_from(line_without_ending.len())
+                        .expect("semantic token segment length must fit in TextSize");
+                let segment_range = TextRange::new(segment_start, segment_end);
+                segment_start += TextSize::try_from(line.len())
+                    .expect("semantic token line length must fit in TextSize");
+                push_segment(segment_range);
             }
-            lsp_semantic_tokens.push(SemanticToken {
-                delta_line,
-                delta_start,
-                length,
-                token_type,
-                token_modifiers_bitset,
-            });
         }
         lsp_semantic_tokens.dedup_by(|current, previous| {
             current.delta_line == 0 && current.delta_start == 0 && current.length == previous.length
@@ -199,6 +220,37 @@ impl SemanticTokensLegends {
         modifiers.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         modifiers
     }
+}
+
+fn syntax_token_type(kind: TokenKind) -> Option<SemanticTokenType> {
+    if kind.is_keyword() {
+        Some(SemanticTokenType::KEYWORD)
+    } else if kind.is_operator() {
+        Some(SemanticTokenType::OPERATOR)
+    } else {
+        match kind {
+            TokenKind::Comment => Some(SemanticTokenType::COMMENT),
+            TokenKind::String
+            | TokenKind::FStringStart
+            | TokenKind::FStringMiddle
+            | TokenKind::FStringEnd
+            | TokenKind::TStringStart
+            | TokenKind::TStringMiddle
+            | TokenKind::TStringEnd => Some(SemanticTokenType::STRING),
+            TokenKind::Int | TokenKind::Float | TokenKind::Complex => {
+                Some(SemanticTokenType::NUMBER)
+            }
+            _ => None,
+        }
+    }
+}
+
+fn range_overlaps(limit_range: Option<TextRange>, range: TextRange) -> bool {
+    limit_range.is_none_or(|limit| {
+        limit
+            .intersect(range)
+            .is_some_and(|intersection| !intersection.is_empty())
+    })
 }
 
 pub struct SemanticTokenWithFullRange {
@@ -233,7 +285,7 @@ impl SemanticTokenBuilder {
         token_type: SemanticTokenType,
         token_modifiers: Vec<SemanticTokenModifier>,
     ) {
-        if self.limit_range.is_none_or(|x| x.contains_range(range)) {
+        if range_overlaps(self.limit_range, range) {
             self.tokens.push(SemanticTokenWithFullRange {
                 range,
                 token_type,
@@ -246,6 +298,14 @@ impl SemanticTokenBuilder {
         self.disabled_ranges
             .iter()
             .any(|disabled| disabled.contains_range(range))
+    }
+
+    pub fn process_syntax_tokens(&mut self, tokens: &Tokens) {
+        for token in tokens.iter() {
+            if let Some(token_type) = syntax_token_type(token.kind()) {
+                self.push_if_in_range(token.range(), token_type, Vec::new());
+            }
+        }
     }
 
     fn process_arguments(&mut self, args: &Arguments) {

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -62,6 +62,7 @@ use pyrefly_util::thread_pool::ThreadCount;
 use pyrefly_util::thread_pool::ThreadPool;
 use pyrefly_util::uniques::UniqueFactory;
 use ruff_python_ast::name::Name;
+use ruff_python_ast::token::Tokens;
 use ruff_text_size::TextRange;
 use starlark_map::Hashed;
 use starlark_map::small_map::SmallMap;
@@ -859,6 +860,10 @@ impl<'a> Transaction<'a> {
 
     pub fn get_ast(&self, handle: &Handle) -> Option<Arc<ruff_python_ast::ModModule>> {
         self.with_module_inner(handle, |x| x.get_ast())
+    }
+
+    pub fn get_syntax_tokens(&self, handle: &Handle) -> Option<Arc<Tokens>> {
+        self.with_module_inner(handle, |x| x.get_syntax_tokens())
     }
 
     pub fn get_config(&self, handle: &Handle) -> Option<ArcId<ConfigFile>> {

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -62,7 +62,6 @@ use pyrefly_util::thread_pool::ThreadCount;
 use pyrefly_util::thread_pool::ThreadPool;
 use pyrefly_util::uniques::UniqueFactory;
 use ruff_python_ast::name::Name;
-use ruff_python_ast::token::Tokens;
 use ruff_text_size::TextRange;
 use starlark_map::Hashed;
 use starlark_map::small_map::SmallMap;
@@ -132,6 +131,7 @@ use crate::state::module::ModuleStateReader;
 use crate::state::require::Require;
 use crate::state::require::RequireLevels;
 use crate::state::steps::Context;
+use crate::state::steps::ParsedModule;
 use crate::state::steps::PysaContext;
 use crate::state::steps::Step;
 use crate::state::steps::StepsMut;
@@ -862,8 +862,8 @@ impl<'a> Transaction<'a> {
         self.with_module_inner(handle, |x| x.get_ast())
     }
 
-    pub fn get_syntax_tokens(&self, handle: &Handle) -> Option<Arc<Tokens>> {
-        self.with_module_inner(handle, |x| x.get_syntax_tokens())
+    pub(crate) fn get_parsed_module(&self, handle: &Handle) -> Option<Arc<ParsedModule>> {
+        self.with_module_inner(handle, |x| x.get_parsed_module())
     }
 
     pub fn get_config(&self, handle: &Handle) -> Option<ArcId<ConfigFile>> {

--- a/pyrefly/lib/state/steps.rs
+++ b/pyrefly/lib/state/steps.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
@@ -31,7 +32,7 @@ use crate::config::base::RecursionLimitConfig;
 use crate::error::style::ErrorStyle;
 use crate::export::exports::Exports;
 use crate::export::exports::LookupExport;
-use crate::module::parse::module_parse_with_tokens;
+use crate::module::parse::module_parse;
 use crate::solver::solver::Solver;
 use crate::state::load::Load;
 use crate::state::memory::MemoryFilesLookup;
@@ -70,15 +71,47 @@ pub struct Context<'a, Lookup> {
     pub timing: Option<&'a TransactionTimingCounters>,
 }
 
+/// AST and lexer tokens produced by the same parser invocation.
+#[derive(Debug, Dupe, Clone)]
+pub struct ParsedModule {
+    module: Arc<ModModule>,
+    tokens: Arc<Tokens>,
+}
+
+impl ParsedModule {
+    pub fn module(&self) -> Arc<ModModule> {
+        self.module.dupe()
+    }
+
+    pub fn tokens(&self) -> Arc<Tokens> {
+        self.tokens.dupe()
+    }
+}
+
+impl From<(ModModule, Tokens)> for ParsedModule {
+    fn from(value: (ModModule, Tokens)) -> Self {
+        Self {
+            module: Arc::new(value.0),
+            tokens: Arc::new(value.1),
+        }
+    }
+}
+
+impl Deref for ParsedModule {
+    type Target = ModModule;
+
+    fn deref(&self) -> &Self::Target {
+        self.module.as_ref()
+    }
+}
+
 #[derive(Debug, Default, Dupe, Clone)]
 pub struct Steps {
     /// The last step that was computed.
     /// None means no steps have been computed yet.
     pub last_step: Option<Step>,
     pub load: Option<Arc<Load>>,
-    pub ast: Option<Arc<ModModule>>,
-    /// Tokens from the same parser invocation as `ast`.
-    pub syntax_tokens: Option<Arc<Tokens>>,
+    pub parsed: Option<Arc<ParsedModule>>,
     pub exports: Option<Arc<Exports>>,
     pub answers: Option<Arc<(Bindings, Arc<Answers>)>>,
     pub solutions: Option<Arc<Solutions>>,
@@ -206,6 +239,19 @@ macro_rules! compute_step {
         let res = paste! { Step::[<step_ $output>] }($ctx, $($input,)*);
         $steps.$output.store(Some(res));
     }};
+    // AST inputs are stored as part of the parsed module cache.
+    (@exec $steps:ident, $ctx:ident, $output:ident, [$($acc:ident)*] ast ? $(, $($rest:tt)*)?) => {{
+        let ast = $steps.parsed.load_full().map(|parsed| parsed.module());
+        compute_step!(@exec $steps, $ctx, $output, [$($acc)* ast] $($($rest)*)?);
+    }};
+    (@exec $steps:ident, $ctx:ident, $output:ident, [$($acc:ident)*] ast $(, $($rest:tt)*)?) => {{
+        let ast = $steps
+            .parsed
+            .load_full()
+            .expect("parsed module must exist after the AST step")
+            .module();
+        compute_step!(@exec $steps, $ctx, $output, [$($acc)* ast] $($($rest)*)?);
+    }};
     // Optional input (name?): load as Option (no unwrap).
     (@exec $steps:ident, $ctx:ident, $output:ident, [$($acc:ident)*] $input:ident ? $(, $($rest:tt)*)?) => {{
         let $input = $steps.$input.load_full();
@@ -231,9 +277,7 @@ macro_rules! compute_step {
 pub struct StepsMut {
     pub current_step: AtomicStep,
     pub load: ArcSwapOption<Load>,
-    pub ast: ArcSwapOption<ModModule>,
-    /// Tokens from the same parser invocation as `ast`.
-    pub syntax_tokens: ArcSwapOption<Tokens>,
+    pub parsed: ArcSwapOption<ParsedModule>,
     pub exports: ArcSwapOption<Exports>,
     pub answers: ArcSwapOption<(Bindings, Arc<Answers>)>,
     pub solutions: ArcSwapOption<Solutions>,
@@ -252,8 +296,7 @@ impl StepsMut {
         Self {
             current_step: AtomicStep::new(steps.last_step),
             load: ArcSwapOption::new(steps.load.dupe()),
-            ast: ArcSwapOption::new(steps.ast.dupe()),
-            syntax_tokens: ArcSwapOption::new(steps.syntax_tokens.dupe()),
+            parsed: ArcSwapOption::new(steps.parsed.dupe()),
             exports: ArcSwapOption::new(steps.exports.dupe()),
             answers: ArcSwapOption::new(steps.answers.dupe()),
             solutions: ArcSwapOption::new(steps.solutions.dupe()),
@@ -268,8 +311,7 @@ impl StepsMut {
         Self {
             current_step: AtomicStep::new(None),
             load: ArcSwapOption::empty(),
-            ast: ArcSwapOption::empty(),
-            syntax_tokens: ArcSwapOption::empty(),
+            parsed: ArcSwapOption::empty(),
             exports: ArcSwapOption::empty(),
             answers: ArcSwapOption::empty(),
             solutions: ArcSwapOption::empty(),
@@ -286,8 +328,7 @@ impl StepsMut {
         Self {
             current_step: AtomicStep::new(Some(Step::Load)),
             load: ArcSwapOption::from(Some(load)),
-            ast: ArcSwapOption::empty(),
-            syntax_tokens: ArcSwapOption::empty(),
+            parsed: ArcSwapOption::empty(),
             exports: ArcSwapOption::empty(),
             answers: ArcSwapOption::empty(),
             solutions: ArcSwapOption::empty(),
@@ -325,12 +366,7 @@ impl StepsMut {
     pub fn compute<Lookup: LookupExport + LookupAnswer>(&self, step: Step, ctx: &Context<Lookup>) {
         match step {
             Step::Load => compute_step!(self, ctx, load =),
-            Step::Ast => {
-                let load = self.load.load_full().unwrap();
-                let (ast, syntax_tokens) = Step::step_ast(ctx, load);
-                self.syntax_tokens.store(Some(syntax_tokens));
-                self.ast.store(Some(ast));
-            }
+            Step::Ast => compute_step!(self, ctx, parsed = load),
             Step::Exports => compute_step!(self, ctx, exports = load, ast),
             Step::Answers => compute_step!(self, ctx, answers = load, ast, exports),
             Step::Solutions => compute_step!(self, ctx, solutions = load, ast?, answers),
@@ -346,13 +382,12 @@ impl StepsMut {
     /// on another variable (e.g. `checked` epoch) to make these writes visible.
     pub fn reset_for_rebuild(&self, clear_ast: bool) {
         if clear_ast {
-            self.ast.store(None);
-            self.syntax_tokens.store(None);
+            self.parsed.store(None);
         }
 
         // Determine the new last_step value based on what data remains.
         // This must be computed AFTER clearing/storing data above.
-        let new_last_step = if clear_ast || self.ast.load_full().is_none() {
+        let new_last_step = if clear_ast || self.parsed.load_full().is_none() {
             if self.load.load_full().is_some() {
                 Some(Step::Load)
             } else {
@@ -378,8 +413,7 @@ impl StepsMut {
         Steps {
             last_step: self.current_step.load(),
             load: self.load.into_inner(),
-            ast: self.ast.into_inner(),
-            syntax_tokens: self.syntax_tokens.into_inner(),
+            parsed: self.parsed.into_inner(),
             exports: self.exports.into_inner(),
             answers: self.answers.into_inner(),
             solutions: self.solutions.into_inner(),
@@ -420,14 +454,16 @@ impl Step {
     }
 
     #[inline(never)]
-    fn step_ast<Lookup>(ctx: &Context<Lookup>, load: Arc<Load>) -> (Arc<ModModule>, Arc<Tokens>) {
-        let (ast, tokens) = module_parse_with_tokens(
-            load.module_info.contents(),
-            ctx.sys_info.version(),
-            load.module_info.source_type(),
-            &load.errors,
-        );
-        (Arc::new(ast), Arc::new(tokens))
+    fn step_parsed<Lookup>(ctx: &Context<Lookup>, load: Arc<Load>) -> Arc<ParsedModule> {
+        Arc::new(
+            module_parse(
+                load.module_info.contents(),
+                ctx.sys_info.version(),
+                load.module_info.source_type(),
+                &load.errors,
+            )
+            .into(),
+        )
     }
 
     #[inline(never)]

--- a/pyrefly/lib/state/steps.rs
+++ b/pyrefly/lib/state/steps.rs
@@ -20,6 +20,7 @@ use pyrefly_python::module_path::ModulePath;
 use pyrefly_python::sys_info::SysInfo;
 use pyrefly_util::uniques::UniqueFactory;
 use ruff_python_ast::ModModule;
+use ruff_python_ast::token::Tokens;
 
 use crate::alt::answers::Answers;
 use crate::alt::answers::LookupAnswer;
@@ -30,7 +31,7 @@ use crate::config::base::RecursionLimitConfig;
 use crate::error::style::ErrorStyle;
 use crate::export::exports::Exports;
 use crate::export::exports::LookupExport;
-use crate::module::parse::module_parse;
+use crate::module::parse::module_parse_with_tokens;
 use crate::solver::solver::Solver;
 use crate::state::load::Load;
 use crate::state::memory::MemoryFilesLookup;
@@ -76,6 +77,8 @@ pub struct Steps {
     pub last_step: Option<Step>,
     pub load: Option<Arc<Load>>,
     pub ast: Option<Arc<ModModule>>,
+    /// Tokens from the same parser invocation as `ast`.
+    pub syntax_tokens: Option<Arc<Tokens>>,
     pub exports: Option<Arc<Exports>>,
     pub answers: Option<Arc<(Bindings, Arc<Answers>)>>,
     pub solutions: Option<Arc<Solutions>>,
@@ -229,6 +232,8 @@ pub struct StepsMut {
     pub current_step: AtomicStep,
     pub load: ArcSwapOption<Load>,
     pub ast: ArcSwapOption<ModModule>,
+    /// Tokens from the same parser invocation as `ast`.
+    pub syntax_tokens: ArcSwapOption<Tokens>,
     pub exports: ArcSwapOption<Exports>,
     pub answers: ArcSwapOption<(Bindings, Arc<Answers>)>,
     pub solutions: ArcSwapOption<Solutions>,
@@ -248,6 +253,7 @@ impl StepsMut {
             current_step: AtomicStep::new(steps.last_step),
             load: ArcSwapOption::new(steps.load.dupe()),
             ast: ArcSwapOption::new(steps.ast.dupe()),
+            syntax_tokens: ArcSwapOption::new(steps.syntax_tokens.dupe()),
             exports: ArcSwapOption::new(steps.exports.dupe()),
             answers: ArcSwapOption::new(steps.answers.dupe()),
             solutions: ArcSwapOption::new(steps.solutions.dupe()),
@@ -263,6 +269,7 @@ impl StepsMut {
             current_step: AtomicStep::new(None),
             load: ArcSwapOption::empty(),
             ast: ArcSwapOption::empty(),
+            syntax_tokens: ArcSwapOption::empty(),
             exports: ArcSwapOption::empty(),
             answers: ArcSwapOption::empty(),
             solutions: ArcSwapOption::empty(),
@@ -280,6 +287,7 @@ impl StepsMut {
             current_step: AtomicStep::new(Some(Step::Load)),
             load: ArcSwapOption::from(Some(load)),
             ast: ArcSwapOption::empty(),
+            syntax_tokens: ArcSwapOption::empty(),
             exports: ArcSwapOption::empty(),
             answers: ArcSwapOption::empty(),
             solutions: ArcSwapOption::empty(),
@@ -317,7 +325,12 @@ impl StepsMut {
     pub fn compute<Lookup: LookupExport + LookupAnswer>(&self, step: Step, ctx: &Context<Lookup>) {
         match step {
             Step::Load => compute_step!(self, ctx, load =),
-            Step::Ast => compute_step!(self, ctx, ast = load),
+            Step::Ast => {
+                let load = self.load.load_full().unwrap();
+                let (ast, syntax_tokens) = Step::step_ast(ctx, load);
+                self.syntax_tokens.store(Some(syntax_tokens));
+                self.ast.store(Some(ast));
+            }
             Step::Exports => compute_step!(self, ctx, exports = load, ast),
             Step::Answers => compute_step!(self, ctx, answers = load, ast, exports),
             Step::Solutions => compute_step!(self, ctx, solutions = load, ast?, answers),
@@ -334,6 +347,7 @@ impl StepsMut {
     pub fn reset_for_rebuild(&self, clear_ast: bool) {
         if clear_ast {
             self.ast.store(None);
+            self.syntax_tokens.store(None);
         }
 
         // Determine the new last_step value based on what data remains.
@@ -365,6 +379,7 @@ impl StepsMut {
             last_step: self.current_step.load(),
             load: self.load.into_inner(),
             ast: self.ast.into_inner(),
+            syntax_tokens: self.syntax_tokens.into_inner(),
             exports: self.exports.into_inner(),
             answers: self.answers.into_inner(),
             solutions: self.solutions.into_inner(),
@@ -405,13 +420,14 @@ impl Step {
     }
 
     #[inline(never)]
-    fn step_ast<Lookup>(ctx: &Context<Lookup>, load: Arc<Load>) -> Arc<ModModule> {
-        Arc::new(module_parse(
+    fn step_ast<Lookup>(ctx: &Context<Lookup>, load: Arc<Load>) -> (Arc<ModModule>, Arc<Tokens>) {
+        let (ast, tokens) = module_parse_with_tokens(
             load.module_info.contents(),
             ctx.sys_info.version(),
             load.module_info.source_type(),
             &load.errors,
-        ))
+        );
+        (Arc::new(ast), Arc::new(tokens))
     }
 
     #[inline(never)]

--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_tokens.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_tokens.rs
@@ -11,17 +11,33 @@ use crate::object_model::InitializeSettings;
 use crate::object_model::LspInteraction;
 use crate::util::get_test_files_root;
 
+fn initialize_settings() -> InitializeSettings {
+    InitializeSettings {
+        capabilities: Some(json!({
+            "textDocument": {
+                "semanticTokens": {
+                    "requests": {
+                        "full": true,
+                        "range": true,
+                    },
+                    "tokenTypes": [],
+                    "tokenModifiers": [],
+                    "formats": ["relative"],
+                    "augmentsSyntaxTokens": true,
+                },
+            },
+        })),
+        configuration: Some(None),
+        ..Default::default()
+    }
+}
+
 #[test]
 fn test_semantic_tokens_full() {
     let root = get_test_files_root();
     let mut interaction = LspInteraction::new();
     interaction.set_root(root.path().to_path_buf());
-    interaction
-        .initialize(InitializeSettings {
-            configuration: Some(None),
-            ..Default::default()
-        })
-        .unwrap();
+    interaction.initialize(initialize_settings()).unwrap();
     interaction.open_notebook("notebook.ipynb", vec!["x = 1", "x2 = 1"]);
 
     interaction
@@ -41,12 +57,7 @@ fn test_semantic_tokens_ranged() {
     let root = get_test_files_root();
     let mut interaction = LspInteraction::new();
     interaction.set_root(root.path().to_path_buf());
-    interaction
-        .initialize(InitializeSettings {
-            configuration: Some(None),
-            ..Default::default()
-        })
-        .unwrap();
+    interaction.initialize(initialize_settings()).unwrap();
     interaction.open_notebook("notebook.ipynb", vec!["x = 1\nx2 = 1"]);
 
     // Request ranged semantic tokens for just the first line in the first cell

--- a/pyrefly/lib/test/lsp/semantic_tokens.rs
+++ b/pyrefly/lib/test/lsp/semantic_tokens.rs
@@ -29,6 +29,14 @@ fn utf16_to_byte_index(line: &str, utf16_offset: usize) -> usize {
 }
 
 fn assert_full_semantic_tokens(files: &[(&'static str, &str)], expected: &str) {
+    assert_full_semantic_tokens_with_syntax(files, false, expected);
+}
+
+fn assert_full_semantic_tokens_with_syntax(
+    files: &[(&'static str, &str)],
+    include_syntax_tokens: bool,
+    expected: &str,
+) {
     let (handles, state) = mk_multi_file_state_assert_no_errors(files, Require::Exports);
     let mut report = String::new();
     for (name, code) in files {
@@ -38,7 +46,7 @@ fn assert_full_semantic_tokens(files: &[(&'static str, &str)], expected: &str) {
         let handle = handles.get(name).unwrap();
         let tokens = state
             .transaction()
-            .semantic_tokens(handle, None, None)
+            .semantic_tokens(handle, None, None, include_syntax_tokens)
             .unwrap();
 
         let mut start_line: usize = 0;
@@ -134,6 +142,150 @@ token-type: variable
 line: 3, column: 11, length: 8, text: ALL_CAPS
 token-type: variable, token-modifiers: [readonly]
 "#,
+    );
+}
+
+#[test]
+fn syntax_tokens_test() {
+    let code = r#"# comment
+def foo(x):
+    if x == 1:
+        return "yes"
+"#;
+    assert_full_semantic_tokens_with_syntax(
+        &[("main", code)],
+        true,
+        r#"
+# main.py
+line: 0, column: 0, length: 9, text: # comment
+token-type: comment
+
+line: 1, column: 0, length: 3, text: def
+token-type: keyword
+
+line: 1, column: 4, length: 3, text: foo
+token-type: function
+
+line: 1, column: 7, length: 1, text: (
+token-type: operator
+
+line: 1, column: 8, length: 1, text: x
+token-type: parameter
+
+line: 1, column: 9, length: 1, text: )
+token-type: operator
+
+line: 1, column: 10, length: 1, text: :
+token-type: operator
+
+line: 2, column: 4, length: 2, text: if
+token-type: keyword
+
+line: 2, column: 7, length: 1, text: x
+token-type: parameter
+
+line: 2, column: 9, length: 2, text: ==
+token-type: operator
+
+line: 2, column: 12, length: 1, text: 1
+token-type: number
+
+line: 2, column: 13, length: 1, text: :
+token-type: operator
+
+line: 3, column: 8, length: 6, text: return
+token-type: keyword
+
+line: 3, column: 15, length: 5, text: "yes"
+token-type: string
+"#,
+    );
+}
+
+#[test]
+fn soft_keyword_syntax_tokens_test() {
+    let code = r#"match = 1
+case = match
+type = case
+match match:
+    case _:
+        pass
+"#;
+    assert_full_semantic_tokens_with_syntax(
+        &[("main", code)],
+        true,
+        r#"
+# main.py
+line: 0, column: 0, length: 5, text: match
+token-type: variable
+
+line: 0, column: 6, length: 1, text: =
+token-type: operator
+
+line: 0, column: 8, length: 1, text: 1
+token-type: number
+
+line: 1, column: 0, length: 4, text: case
+token-type: variable
+
+line: 1, column: 5, length: 1, text: =
+token-type: operator
+
+line: 1, column: 7, length: 5, text: match
+token-type: variable
+
+line: 2, column: 0, length: 4, text: type
+token-type: variable
+
+line: 2, column: 5, length: 1, text: =
+token-type: operator
+
+line: 2, column: 7, length: 4, text: case
+token-type: variable
+
+line: 3, column: 0, length: 5, text: match
+token-type: keyword
+
+line: 3, column: 6, length: 5, text: match
+token-type: variable
+
+line: 3, column: 11, length: 1, text: :
+token-type: operator
+
+line: 4, column: 4, length: 4, text: case
+token-type: keyword
+
+line: 4, column: 10, length: 1, text: :
+token-type: operator
+
+line: 5, column: 8, length: 4, text: pass
+token-type: keyword
+"#,
+    );
+}
+
+#[test]
+fn multiline_syntax_token_test() {
+    let code = r##"x = """one
+two"""
+"##;
+    assert_full_semantic_tokens_with_syntax(
+        &[("main", code)],
+        true,
+        r##"
+# main.py
+line: 0, column: 0, length: 1, text: x
+token-type: variable
+
+line: 0, column: 2, length: 1, text: =
+token-type: operator
+
+line: 0, column: 4, length: 6, text: """one
+token-type: string
+
+line: 1, column: 0, length: 6, text: two"""
+token-type: string
+"##,
     );
 }
 


### PR DESCRIPTION


# Summary

<!-- Describe the change in this PR -->

Pyrefly's semantic pipeline currently models only identifier-level tokens. Future support for a full semantic stream therefore requires a syntax-token source covering keywords, comments, strings, numbers, and operators.

This change introduces a lightweight syntax path derived from Ruff's parse results and configures the LSP encoder to split multiline ranges into line-local tokens. To ensure the new path remains unadvertised, this server capability is gated to clients that already augment syntax tokens.

This enables proper representation of triple-quoted strings and preserves current semantic-overlay behavior during the gated rollout.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

- `python3 test.py --no-test --no-conformance --no-jsonschema`
- `cargo test`