### PR TITLE
Recognize walrus targets in decorator expressions

### DIFF
--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -880,11 +880,11 @@ impl<'a> BindingsBuilder<'a> {
             None
         };
 
+        let decorators = self.decorators(mem::take(&mut x.decorator_list), def_idx.usage());
+
         self.scopes.push(Scope::annotation(x.range));
         let (return_ann_with_range, legacy_tparams) =
             self.function_header(&mut x, &func_name, class_key, def_idx.usage(), parent);
-
-        let decorators = self.decorators(mem::take(&mut x.decorator_list), def_idx.usage());
 
         let docstring_range = Docstring::range_from_stmts(x.body.as_slice());
         let (stub_or_impl, placeholder_body_kind, is_return_inferred, self_assignments) = self

--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -596,10 +596,14 @@ impl DefinitionsBuilder {
                 decorator_list,
                 ..
             }) => {
-                if let Some(decoration) = decorator_list
-                    .iter()
-                    .find_map(|d| parse_deprecation(&d.expression))
-                {
+                let mut deprecated_decoration = None;
+                for d in decorator_list {
+                    self.named_in_expr(&d.expression);
+                    if deprecated_decoration.is_none() {
+                        deprecated_decoration = parse_deprecation(&d.expression);
+                    }
+                }
+                if let Some(decoration) = deprecated_decoration {
                     self.inner.deprecated.insert(name.id.clone(), decoration);
                 }
                 self.add_identifier_with_body(
@@ -801,6 +805,7 @@ impl DefinitionsBuilder {
                 let mut is_overload = false;
                 let mut deprecated_decoration = None;
                 for d in decorator_list {
+                    self.named_in_expr(&d.expression);
                     is_overload = is_overload || is_overload_decorator(d);
                     if deprecated_decoration.is_none() {
                         deprecated_decoration = parse_deprecation(&d.expression);
@@ -1088,6 +1093,10 @@ match (x7 := 42):
     case int(): pass
 (x8 := 42)[y] = 42
 assert (x9 := 42), (x10 := "oops")
+@decorator(x12 := 42)
+def foo(): pass
+@decorator(x13 := 42)
+class Foo: pass
 # Named expressions inside type aliases and lambdas should not appear in definitions.
 type y = (x11 := int)
 lambda x: (z2 := 42)
@@ -1101,7 +1110,8 @@ lambda x: (z2 := 42)
         assert_definition_names(
             &defs,
             &[
-                "x0", "y", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "z",
+                "x0", "y", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x12",
+                "foo", "x13", "Foo", "z",
             ],
         );
     }

--- a/pyrefly/lib/test/decorators.rs
+++ b/pyrefly/lib/test/decorators.rs
@@ -85,6 +85,25 @@ assert_type(decorated, Callable[[int], list[set[str]]])
 );
 
 testcase!(
+    test_walrus_in_decorator,
+    r#"
+from typing import assert_type, Callable, Literal
+
+def decorator[T](x: object) -> Callable[[T], T]: ...
+
+@decorator(x := 42)
+def foo() -> None: ...
+
+assert_type(x, Literal[42])
+
+@decorator(y := "bar")
+class Bar: ...
+
+assert_type(y, Literal["bar"])
+    "#,
+);
+
+testcase!(
     test_parameter_type_inferred_from_decorator,
     r#"
 from typing import Callable, reveal_type


### PR DESCRIPTION
Resolves https://github.com/facebook/pyrefly/issues/3300

This diff records `named-expression` targets while collecting definitions from function and class decorator
expressions, so names introduced by `@decorator(x := ...)` are visible after the decorated definition.

Function decorators are also bound before entering the function annotation scope, matching where Python
evaluates decorators and matching the existing class decorator behavior. This prevents walrus targets in
decorators from being treated as unknown or uninitialized in the enclosing scope.
