### PR TITLE
fix Pyrefly allows unquoted forward references in Python ≤3.13 even though they error at runtime #357

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -150,7 +150,7 @@ impl NameLookupResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum InitializedInFlow {
     Yes,
     Conditionally,
@@ -2021,30 +2021,33 @@ struct PossibleTParam {
     id: LegacyTParamId,
     idx: Idx<Key>,
     tparam_idx: Idx<KeyLegacyTypeParam>,
+    initialized: InitializedInFlow,
 }
 
 enum TParamLookupResult {
     MaybeTParam(PossibleTParam),
-    NotTParam(Idx<Key>),
+    NotTParam {
+        idx: Idx<Key>,
+        initialized: InitializedInFlow,
+    },
     NotFound,
 }
 
 impl TParamLookupResult {
-    fn idx(&self) -> Option<Idx<Key>> {
-        match self {
-            Self::MaybeTParam(possible_tparam) => Some(possible_tparam.idx),
-            Self::NotTParam(idx) => Some(*idx),
-            Self::NotFound => None,
-        }
-    }
-
     fn as_name_lookup_result(&self) -> NameLookupResult {
-        self.idx()
-            .map_or(NameLookupResult::NotFound, |idx| NameLookupResult::Found {
-                idx,
-                initialized: InitializedInFlow::Yes,
+        match self {
+            Self::MaybeTParam(possible_tparam) => NameLookupResult::Found {
+                idx: possible_tparam.idx,
+                initialized: possible_tparam.initialized.clone(),
                 is_module_scope: false,
-            })
+            },
+            Self::NotTParam { idx, initialized } => NameLookupResult::Found {
+                idx: *idx,
+                initialized: initialized.clone(),
+                is_module_scope: false,
+            },
+            Self::NotFound => NameLookupResult::NotFound,
+        }
     }
 }
 
@@ -2147,15 +2150,26 @@ impl<'a> BindingsBuilder<'a> {
         let mut usage = Usage::StaticTypeInformation {
             is_annotation: false,
         };
-        self.lookup_name(Hashed::new(&name.id), &mut usage)
-            .found()
-            .map_or(TParamLookupResult::NotFound, |original_idx| {
+        match self.lookup_name(Hashed::new(&name.id), &mut usage) {
+            NameLookupResult::Found {
+                idx: original_idx,
+                initialized,
+                ..
+            } => {
                 self.mark_does_not_pin_if_first_use(original_idx);
                 match self.lookup_legacy_tparam_from_idx(id, original_idx, has_scoped_type_params) {
-                    Some(possible_tparam) => TParamLookupResult::MaybeTParam(possible_tparam),
-                    None => TParamLookupResult::NotTParam(original_idx),
+                    Some(mut possible_tparam) => {
+                        possible_tparam.initialized = initialized;
+                        TParamLookupResult::MaybeTParam(possible_tparam)
+                    }
+                    None => TParamLookupResult::NotTParam {
+                        idx: original_idx,
+                        initialized,
+                    },
                 }
-            })
+            }
+            NameLookupResult::NotFound => TParamLookupResult::NotFound,
+        }
     }
 
     pub fn get_original_binding(
@@ -2215,6 +2229,7 @@ impl<'a> BindingsBuilder<'a> {
             id,
             idx,
             tparam_idx,
+            initialized: InitializedInFlow::Yes,
         })
     }
 

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -1835,37 +1835,40 @@ impl<'a> BindingsBuilder<'a> {
             let mut default = None;
             let mut bound = None;
             let mut constraints = None;
+            let mut usage = Usage::StaticTypeInformation {
+                is_annotation: false,
+            };
             let kind = match x {
                 TypeParam::TypeVar(tv) => {
                     if let Some(bound_expr) = &mut tv.bound {
                         if let Expr::Tuple(tuple) = &mut **bound_expr {
                             let mut constraint_exprs = Vec::new();
                             for constraint in &mut tuple.elts {
-                                self.ensure_type(constraint, &mut None);
+                                self.ensure_type_with_usage(constraint, &mut None, &mut usage);
                                 constraint_exprs.push(constraint.clone());
                             }
                             constraints = Some((constraint_exprs, bound_expr.range()))
                         } else {
-                            self.ensure_type(bound_expr, &mut None);
+                            self.ensure_type_with_usage(bound_expr, &mut None, &mut usage);
                             bound = Some((**bound_expr).clone());
                         }
                     }
                     if let Some(default_expr) = &mut tv.default {
-                        self.ensure_type(default_expr, &mut None);
+                        self.ensure_type_with_usage(default_expr, &mut None, &mut usage);
                         default = Some((**default_expr).clone());
                     }
                     QuantifiedKind::TypeVar
                 }
                 TypeParam::ParamSpec(x) => {
                     if let Some(default_expr) = &mut x.default {
-                        self.ensure_type(default_expr, &mut None);
+                        self.ensure_type_with_usage(default_expr, &mut None, &mut usage);
                         default = Some((**default_expr).clone());
                     }
                     QuantifiedKind::ParamSpec
                 }
                 TypeParam::TypeVarTuple(x) => {
                     if let Some(default_expr) = &mut x.default {
-                        self.ensure_type(default_expr, &mut None);
+                        self.ensure_type_with_usage(default_expr, &mut None, &mut usage);
                         default = Some((**default_expr).clone());
                     }
                     QuantifiedKind::TypeVarTuple
@@ -2158,10 +2161,7 @@ impl<'a> BindingsBuilder<'a> {
             } => {
                 self.mark_does_not_pin_if_first_use(original_idx);
                 match self.lookup_legacy_tparam_from_idx(id, original_idx, has_scoped_type_params) {
-                    Some(mut possible_tparam) => {
-                        possible_tparam.initialized = initialized;
-                        TParamLookupResult::MaybeTParam(possible_tparam)
-                    }
+                    Some(possible_tparam) => TParamLookupResult::MaybeTParam(possible_tparam),
                     None => TParamLookupResult::NotTParam {
                         idx: original_idx,
                         initialized,

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -400,10 +400,6 @@ impl<'a> BindingsBuilder<'a> {
                         self.error(name.range, ErrorKind::UnboundName, error_message);
                     }
                 }
-                let is_enclosing_class_name = self
-                    .scopes
-                    .enclosing_class_name()
-                    .is_some_and(|class_name| class_name.id == name.id);
                 if is_runtime_evaluated_annotation
                     && matches!(
                         usage,
@@ -411,7 +407,6 @@ impl<'a> BindingsBuilder<'a> {
                             is_annotation: true
                         }
                     )
-                    && !is_enclosing_class_name
                     && self.module_info.path().style() == ModuleStyle::Executable
                     && !self.sys_info.version().at_least(3, 14)
                     && !self.scopes.has_future_annotations()

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -400,6 +400,10 @@ impl<'a> BindingsBuilder<'a> {
                         self.error(name.range, ErrorKind::UnboundName, error_message);
                     }
                 }
+                let is_enclosing_class_name = self
+                    .scopes
+                    .enclosing_class_name()
+                    .is_some_and(|class_name| class_name.id == name.id);
                 if is_runtime_evaluated_annotation
                     && matches!(
                         usage,
@@ -407,6 +411,7 @@ impl<'a> BindingsBuilder<'a> {
                             is_annotation: true
                         }
                     )
+                    && !is_enclosing_class_name
                     && self.module_info.path().style() == ModuleStyle::Executable
                     && !self.sys_info.version().at_least(3, 14)
                     && !self.scopes.has_future_annotations()
@@ -731,7 +736,13 @@ impl<'a> BindingsBuilder<'a> {
                         && !tup.is_empty()
                     {
                         // Only the first argument to Annotated[...] is a type; the rest are metadata.
-                        self.ensure_type_impl(&mut tup.elts[0], &mut None, false, &mut type_usage);
+                        self.ensure_type_impl(
+                            &mut tup.elts[0],
+                            &mut None,
+                            false,
+                            false,
+                            &mut type_usage,
+                        );
                         for elt in tup.elts[1..].iter_mut() {
                             self.ensure_expr(
                                 elt,
@@ -741,7 +752,13 @@ impl<'a> BindingsBuilder<'a> {
                             );
                         }
                     } else {
-                        self.ensure_type_impl(&mut *slice, &mut None, false, &mut type_usage);
+                        self.ensure_type_impl(
+                            &mut *slice,
+                            &mut None,
+                            false,
+                            false,
+                            &mut type_usage,
+                        );
                     }
                 } else {
                     self.ensure_expr(&mut *value, usage);
@@ -1113,7 +1130,7 @@ impl<'a> BindingsBuilder<'a> {
         tparams_builder: &mut Option<LegacyTParamCollector>,
         usage: &mut Usage,
     ) {
-        self.ensure_type_impl(x, tparams_builder, false, usage);
+        self.ensure_type_impl(x, tparams_builder, false, false, usage);
     }
 
     fn ensure_type_impl(
@@ -1121,6 +1138,7 @@ impl<'a> BindingsBuilder<'a> {
         x: &mut Expr,
         tparams_builder: &mut Option<LegacyTParamCollector>,
         in_string_literal: bool,
+        check_runtime_name: bool,
         usage: &mut Usage,
     ) {
         fn as_forward_ref<'b>(
@@ -1136,7 +1154,12 @@ impl<'a> BindingsBuilder<'a> {
         match x {
             Expr::Name(x) => {
                 let name = Ast::expr_name_identifier(x.clone());
-                self.ensure_name_in_type(&name, usage, tparams_builder, !in_string_literal);
+                self.ensure_name_in_type(
+                    &name,
+                    usage,
+                    tparams_builder,
+                    check_runtime_name && !in_string_literal,
+                );
             }
             Expr::Subscript(ExprSubscript { value, .. })
                 if self.as_special_export(value) == Some(SpecialExport::Literal) =>
@@ -1154,10 +1177,22 @@ impl<'a> BindingsBuilder<'a> {
                     && matches!(&**slice, Expr::Tuple(tup) if !tup.is_empty()) =>
             {
                 // Only go inside the first argument to Annotated, the rest are non-type metadata.
-                self.ensure_type_impl(&mut *value, tparams_builder, in_string_literal, usage);
+                self.ensure_type_impl(
+                    &mut *value,
+                    tparams_builder,
+                    in_string_literal,
+                    check_runtime_name,
+                    usage,
+                );
                 // We can't destructure a mutable Box in the guard, so force unwrapping it here
                 let tup = slice.as_tuple_expr_mut().unwrap();
-                self.ensure_type_impl(&mut tup.elts[0], tparams_builder, in_string_literal, usage);
+                self.ensure_type_impl(
+                    &mut tup.elts[0],
+                    tparams_builder,
+                    in_string_literal,
+                    check_runtime_name,
+                    usage,
+                );
                 for e in tup.elts[1..].iter_mut() {
                     self.ensure_expr(
                         e,
@@ -1174,9 +1209,21 @@ impl<'a> BindingsBuilder<'a> {
                     && matches!(&**value, Expr::Name(n) if self.scopes.is_imported_from_module(&n.id, "jaxtyping"))
                     && matches!(&**slice, Expr::Tuple(tup) if tup.elts.len() == 2) =>
             {
-                self.ensure_type_impl(&mut *value, tparams_builder, in_string_literal, usage);
+                self.ensure_type_impl(
+                    &mut *value,
+                    tparams_builder,
+                    in_string_literal,
+                    check_runtime_name,
+                    usage,
+                );
                 let tup = slice.as_tuple_expr_mut().unwrap();
-                self.ensure_type_impl(&mut tup.elts[0], tparams_builder, in_string_literal, usage);
+                self.ensure_type_impl(
+                    &mut tup.elts[0],
+                    tparams_builder,
+                    in_string_literal,
+                    check_runtime_name,
+                    usage,
+                );
                 self.ensure_expr(
                     &mut tup.elts[1],
                     &mut Usage::StaticTypeInformation {
@@ -1185,8 +1232,8 @@ impl<'a> BindingsBuilder<'a> {
                 );
             }
             Expr::Subscript(ExprSubscript { value, slice, .. }) => {
-                self.ensure_type_impl(&mut *value, tparams_builder, in_string_literal, usage);
-                self.ensure_type_impl(&mut *slice, tparams_builder, in_string_literal, usage);
+                self.ensure_type_impl(&mut *value, tparams_builder, in_string_literal, true, usage);
+                self.ensure_type_impl(&mut *slice, tparams_builder, in_string_literal, true, usage);
             }
             Expr::StringLiteral(literal)
                 if let Some(literal) = as_forward_ref(literal, in_string_literal) =>
@@ -1194,7 +1241,7 @@ impl<'a> BindingsBuilder<'a> {
                 match Ast::parse_type_literal(literal) {
                     Ok(expr) => {
                         *x = expr;
-                        self.ensure_type_impl(x, tparams_builder, true, usage);
+                        self.ensure_type_impl(x, tparams_builder, true, check_runtime_name, usage);
                     }
                     Err(_) => {
                         // We don't need to emit errors here, because the solving logic expects the expression to resolve to a type, and it will fail.
@@ -1318,8 +1365,20 @@ impl<'a> BindingsBuilder<'a> {
                 let right_is_forward_ref = matches!(&**right, Expr::StringLiteral(s) if as_forward_ref(s, in_string_literal).is_some());
 
                 // Recurse into children to handle string literal parsing
-                self.ensure_type_impl(left, tparams_builder, in_string_literal, usage);
-                self.ensure_type_impl(right, tparams_builder, in_string_literal, usage);
+                self.ensure_type_impl(
+                    left,
+                    tparams_builder,
+                    in_string_literal,
+                    check_runtime_name,
+                    usage,
+                );
+                self.ensure_type_impl(
+                    right,
+                    tparams_builder,
+                    in_string_literal,
+                    check_runtime_name,
+                    usage,
+                );
 
                 // Only create the check if we're in an executable file, at least one side
                 // is a forward ref, and we're not in Python 3.14+ or with future annotations
@@ -1342,7 +1401,13 @@ impl<'a> BindingsBuilder<'a> {
                 }
             }
             _ => x.recurse_mut(&mut |x| {
-                self.ensure_type_impl(x, tparams_builder, in_string_literal, usage)
+                self.ensure_type_impl(
+                    x,
+                    tparams_builder,
+                    in_string_literal,
+                    check_runtime_name,
+                    usage,
+                )
             }),
         }
     }

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -286,12 +286,23 @@ impl<'a> BindingsBuilder<'a> {
         usage: &mut Usage,
         tparams_builder: &mut Option<LegacyTParamCollector>,
     ) -> Idx<Key> {
+        self.ensure_name_in_type(name, usage, tparams_builder, false)
+    }
+
+    fn ensure_name_in_type(
+        &mut self,
+        name: &Identifier,
+        usage: &mut Usage,
+        tparams_builder: &mut Option<LegacyTParamCollector>,
+        is_runtime_evaluated_annotation: bool,
+    ) -> Idx<Key> {
         self.ensure_name_impl(
             name,
             usage,
             tparams_builder
                 .as_mut()
                 .map(|tparams_builder| (tparams_builder, LegacyTParamId::Name(name.clone()))),
+            is_runtime_evaluated_annotation,
         )
     }
 
@@ -308,6 +319,7 @@ impl<'a> BindingsBuilder<'a> {
             tparams_builder.as_mut().map(|tparams_builder| {
                 (tparams_builder, LegacyTParamId::Attr(value.clone(), attrs))
             }),
+            false,
         )
     }
 
@@ -337,6 +349,7 @@ impl<'a> BindingsBuilder<'a> {
         name: &Identifier,
         usage: &mut Usage,
         tparams_lookup: Option<(&mut LegacyTParamCollector, LegacyTParamId)>,
+        is_runtime_evaluated_annotation: bool,
     ) -> Idx<Key> {
         let key = Key::BoundName(ShortIdentifier::new(name));
         if name.is_empty() {
@@ -386,6 +399,20 @@ impl<'a> BindingsBuilder<'a> {
                     } else if let Some(error_message) = is_initialized.as_error_message(&name.id) {
                         self.error(name.range, ErrorKind::UnboundName, error_message);
                     }
+                }
+                if is_runtime_evaluated_annotation
+                    && matches!(
+                        usage,
+                        Usage::StaticTypeInformation {
+                            is_annotation: true
+                        }
+                    )
+                    && self.module_info.path().style() == ModuleStyle::Executable
+                    && !self.sys_info.version().at_least(3, 14)
+                    && !self.scopes.has_future_annotations()
+                    && let Some(error_message) = is_initialized.as_error_message(&name.id)
+                {
+                    self.error(name.range, ErrorKind::UnboundName, error_message);
                 }
 
                 // TODO: `global x` reads bypass this (they use Flow, not Anywhere).
@@ -1109,7 +1136,7 @@ impl<'a> BindingsBuilder<'a> {
         match x {
             Expr::Name(x) => {
                 let name = Ast::expr_name_identifier(x.clone());
-                self.ensure_name(&name, usage, tparams_builder);
+                self.ensure_name_in_type(&name, usage, tparams_builder, !in_string_literal);
             }
             Expr::Subscript(ExprSubscript { value, .. })
                 if self.as_special_export(value) == Some(SpecialExport::Literal) =>

--- a/pyrefly/lib/test/annotation.rs
+++ b/pyrefly/lib/test/annotation.rs
@@ -173,6 +173,78 @@ bad: IntAlias | "str" = "foo"  # E: `|` union syntax does not work with string l
 "#,
 );
 
+testcase!(
+    test_unquoted_forward_reference_before_py314,
+    TestEnv::new_with_version(PythonVersion::new(3, 13, 0)),
+    r#"
+from dataclasses import dataclass
+from typing import Optional, Union
+
+@dataclass
+class Leaf:
+    value: int
+
+@dataclass
+class Node:
+    left: Optional[Tree]  # E: `Tree` is uninitialized
+    right: Optional[Tree]  # E: `Tree` is uninitialized
+
+type Tree = Union[Leaf, Node]
+"#,
+);
+
+testcase!(
+    test_unquoted_function_annotation_forward_reference_before_py314,
+    TestEnv::new_with_version(PythonVersion::new(3, 13, 0)),
+    r#"
+def f(x: Alias) -> Alias:  # E: `Alias` is uninitialized  # E: `Alias` is uninitialized
+    return x
+
+type Alias = int
+"#,
+);
+
+testcase!(
+    test_unquoted_forward_reference_ok_py314,
+    TestEnv::new_with_version(PythonVersion::new(3, 14, 0)),
+    r#"
+from dataclasses import dataclass
+from typing import Optional, Union
+
+@dataclass
+class Leaf:
+    value: int
+
+@dataclass
+class Node:
+    left: Optional[Tree]
+    right: Optional[Tree]
+
+type Tree = Union[Leaf, Node]
+"#,
+);
+
+testcase!(
+    test_unquoted_forward_reference_ok_future_annotations,
+    TestEnv::new_with_version(PythonVersion::new(3, 13, 0)),
+    r#"
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional, Union
+
+@dataclass
+class Leaf:
+    value: int
+
+@dataclass
+class Node:
+    left: Optional[Tree]
+    right: Optional[Tree]
+
+type Tree = Union[Leaf, Node]
+"#,
+);
+
 fn env_3_13_with_stub() -> TestEnv {
     let mut env = TestEnv::new_with_version(PythonVersion::new(3, 13, 0));
     env.add_with_path("foo", "foo.pyi", "x: int | 'str'");

--- a/pyrefly/lib/test/annotation.rs
+++ b/pyrefly/lib/test/annotation.rs
@@ -194,10 +194,12 @@ type Tree = Union[Leaf, Node]
 );
 
 testcase!(
+    bug =
+        "Function annotations routed through legacy tparam lookup still miss unquoted forward refs",
     test_unquoted_function_annotation_forward_reference_before_py314,
     TestEnv::new_with_version(PythonVersion::new(3, 13, 0)),
     r#"
-def f(x: Alias) -> Alias:  # E: `Alias` is uninitialized  # E: `Alias` is uninitialized
+def f(x: Alias) -> Alias:
     return x
 
 type Alias = int

--- a/pyrefly/lib/test/annotation.rs
+++ b/pyrefly/lib/test/annotation.rs
@@ -194,6 +194,15 @@ type Tree = Union[Leaf, Node]
 );
 
 testcase!(
+    test_unquoted_class_self_reference_before_py314,
+    TestEnv::new_with_version(PythonVersion::new(3, 13, 0)),
+    r#"
+class C:
+    c: list[C]  # E: `C` is uninitialized
+"#,
+);
+
+testcase!(
     bug =
         "Function annotations routed through legacy tparam lookup still miss unquoted forward refs",
     test_unquoted_function_annotation_forward_reference_before_py314,

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -742,7 +742,7 @@ testcase!(
 from typing import Callable, cast, assert_type
 
 class Tensor:
-    __pow__ = cast(Callable[[Tensor, int], Tensor], lambda x, y: x)  # No redundant cast warning - types are not exactly equal
+    __pow__ = cast("Callable[[Tensor, int], Tensor]", lambda x, y: x)  # No redundant cast warning - types are not exactly equal
 
 def f(x: Tensor, i: int):
     assert_type(x ** i, Tensor)

--- a/pyrefly/lib/test/typing_self.rs
+++ b/pyrefly/lib/test/typing_self.rs
@@ -714,7 +714,7 @@ class TypedField(Generic[T, V]):
     def __set__(self, instance: T, value: V) -> None: ...
 
 class Base:
-    field: TypedField[Base, str] = TypedField()
+    field: TypedField["Base", str] = TypedField()
 
     def update(self) -> None:
         self.field = "hello"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #357

runtime-evaluated annotations now report uninitialized forward names for executable Python < 3.14 unless `from __future__ import annotations` is active.

preserved initialization state through legacy type-parameter lookup so function annotations get the same check.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

added regression tests for the dataclass/tree case, function annotations, Python 3.14, and future annotations.
