### PR TITLE
Report invalid-variance errors on the offending overload

### DIFF
--- a/pyrefly/lib/alt/class/variance_inference.rs
+++ b/pyrefly/lib/alt/class/variance_inference.rs
@@ -18,19 +18,26 @@ use pyrefly_types::dimension::SizeExpr;
 use pyrefly_types::heap::TypeHeap;
 use pyrefly_types::tensor::TensorShape;
 use ruff_python_ast::name::Name;
+use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
+use starlark_map::Hashed;
 use starlark_map::small_map::SmallMap;
 
 use crate::alt::answers::LookupAnswer;
 use crate::alt::answers_solver::AnswersSolver;
 use crate::alt::class::class_field::ClassField;
 use crate::alt::types::class_bases::ClassBases;
+use crate::binding::binding::KeyUndecoratedFunctionRange;
+use crate::types::callable::Callable;
+use crate::types::callable::FuncMetadata;
+use crate::types::callable::FunctionKind;
 use crate::types::callable::Params;
 use crate::types::class::Class;
 use crate::types::quantified::Quantified;
 use crate::types::tuple::Tuple;
 use crate::types::type_var::PreInferenceVariance;
 use crate::types::type_var::Variance;
+use crate::types::types::OverloadType;
 use crate::types::types::TParams;
 use crate::types::types::Type;
 
@@ -354,34 +361,35 @@ fn check_typevar(
     }
 }
 
-/// Check method for variance violations (shallow - only direct TypeVars in params/return).
-fn check_method_shallow(typ: &Type, range: TextRange, violations: &mut Vec<VarianceViolation>) {
-    typ.visit_toplevel_callable(|callable| {
-        // Check return type (covariant position)
-        if let Type::Quantified(q) = &callable.ret {
-            check_typevar(
-                q.name(),
-                Variance::Covariant,
-                q.variance(),
-                range,
-                violations,
-            );
-        }
-        // Check parameters (contravariant position)
-        if let Params::List(param_list) = &callable.params {
-            for param in param_list.items().iter() {
-                if let Type::Quantified(q) = param.as_type() {
-                    check_typevar(
-                        q.name(),
-                        Variance::Contravariant,
-                        q.variance(),
-                        range,
-                        violations,
-                    );
-                }
+/// Check a single callable signature for variance violations at `range`.
+/// The return type is a covariant position; parameters are contravariant.
+fn check_callable_variance(
+    callable: &Callable,
+    range: TextRange,
+    violations: &mut Vec<VarianceViolation>,
+) {
+    if let Type::Quantified(q) = &callable.ret {
+        check_typevar(
+            q.name(),
+            Variance::Covariant,
+            q.variance(),
+            range,
+            violations,
+        );
+    }
+    if let Params::List(param_list) = &callable.params {
+        for param in param_list.items().iter() {
+            if let Type::Quantified(q) = param.as_type() {
+                check_typevar(
+                    q.name(),
+                    Variance::Contravariant,
+                    q.variance(),
+                    range,
+                    violations,
+                );
             }
         }
-    });
+    }
 }
 
 fn initial_inference_status(gp: &Quantified) -> InferenceStatus {
@@ -666,10 +674,54 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 let range = class_fields
                     .and_then(|f| f.field_decl_range(name))
                     .unwrap_or_else(|| class.range());
-                check_method_shallow(ty, range, &mut violations);
+                self.check_method_shallow(ty, range, &mut violations);
             }
         }
 
         violations
+    }
+
+    /// The `def`-name range of `metadata`'s function, via `KeyUndecoratedFunctionRange`.
+    /// `None` when there's no `def_index` (synthesized/metadata-only); the caller then
+    /// falls back to the field range. Current-module only: variance checks a class's own
+    /// fields, so `def_index` is always local — we don't resolve cross-module `FuncId`s.
+    fn func_def_range(&self, metadata: &FuncMetadata) -> Option<TextRange> {
+        let def_index = match &metadata.kind {
+            FunctionKind::Def(func_id) | FunctionKind::ShapeDsl(func_id, ..) => func_id.def_index?,
+            _ => return None,
+        };
+        let idx = self
+            .bindings()
+            .key_to_idx_hashed_opt(Hashed::new(&KeyUndecoratedFunctionRange(def_index)))?;
+        Some(self.get_idx(idx).0.range())
+    }
+
+    /// Check a method's signatures for variance violations (shallow: direct
+    /// TypeVars in params/return only, not nested Callables).
+    ///
+    /// Each overload arm is reported at its own `def` range, taken from that arm's
+    /// own metadata — not the merged group metadata, which points at the
+    /// implementation or first overload — so the error lands on the offending
+    /// overload. Other callable shapes report at `field_range`.
+    fn check_method_shallow(
+        &self,
+        ty: &Type,
+        field_range: TextRange,
+        violations: &mut Vec<VarianceViolation>,
+    ) {
+        if let Type::Overload(overload) = ty {
+            for signature in overload.signatures.iter() {
+                let (callable, metadata) = match signature {
+                    OverloadType::Function(func) => (&func.signature, &func.metadata),
+                    OverloadType::Forall(forall) => (&forall.body.signature, &forall.body.metadata),
+                };
+                let range = self.func_def_range(metadata).unwrap_or(field_range);
+                check_callable_variance(callable, range, violations);
+            }
+            return;
+        }
+        ty.visit_toplevel_callable(|callable| {
+            check_callable_variance(callable, field_range, violations);
+        });
     }
 }

--- a/pyrefly/lib/test/variance_inference.rs
+++ b/pyrefly/lib/test/variance_inference.rs
@@ -694,7 +694,6 @@ class Box(Protocol[T_co]):
 );
 
 testcase!(
-    bug = "The reported error is correct but is on the wrong line",
     test_variance_error_in_overload,
     r#"
 from typing import Any, Generic, overload, TypeVar
@@ -703,9 +702,147 @@ T_co = TypeVar("T_co", covariant=True)
 
 class C(Generic[T_co]):
     @overload
-    def f(self, x: int) -> int: ...  # E: `T_co` is covariant but is used in contravariant position
+    def f(self, x: int) -> int: ...
     @overload
-    def f(self, x: T_co) -> str: ...
+    def f(self, x: T_co) -> str: ...  # E: `T_co` is covariant but is used in contravariant position
     def f(self, x: Any) -> Any: ...
+    "#,
+);
+
+testcase!(
+    test_variance_error_in_overload_issue_3536,
+    r#"
+from typing import Generic, overload, TypeVar
+
+_T_co = TypeVar("_T_co", covariant=True)
+
+class Foo(Generic[_T_co]):
+    @overload
+    def foo(self) -> None: ...
+    @overload
+    def foo(self, instance: _T_co) -> None: ...  # E: `_T_co` is covariant but is used in contravariant position
+    def foo(self, instance: _T_co | None = ...) -> None: ...
+    "#,
+);
+
+// Overloads without an implementation are built from the final `@overload`
+// definition itself, which is a different construction path from overloads with
+// a concrete implementation.
+testcase!(
+    test_variance_error_in_overload_protocol_no_implementation,
+    r#"
+from typing import Protocol, TypeVar, overload
+
+T_co = TypeVar("T_co", covariant=True)
+
+class P(Protocol[T_co]):
+    @overload
+    def f(self, x: int) -> None: ...
+    @overload
+    def f(self, x: T_co) -> None: ...  # E: `T_co` is covariant but is used in contravariant position
+    "#,
+);
+
+// The error must track the *offending* overload, not a fixed index: here the
+// violation is in the FIRST arm, so the error belongs there.
+testcase!(
+    test_variance_error_in_overload_first_arm,
+    r#"
+from typing import Generic, overload, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+
+class C(Generic[T_co]):
+    @overload
+    def f(self, x: T_co) -> None: ...  # E: `T_co` is covariant but is used in contravariant position
+    @overload
+    def f(self, x: int) -> None: ...
+    def f(self, x: object) -> None: ...
+    "#,
+);
+
+// Each violating overload is reported independently, on its own line.
+testcase!(
+    test_variance_error_in_overload_both_arms,
+    r#"
+from typing import Generic, overload, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+
+class C(Generic[T_co]):
+    @overload
+    def f(self, x: T_co) -> None: ...  # E: `T_co` is covariant but is used in contravariant position
+    @overload
+    def f(self, x: T_co, y: int) -> None: ...  # E: `T_co` is covariant but is used in contravariant position
+    def f(self, x: T_co, y: int = ...) -> None: ...
+    "#,
+);
+
+// Return position is covariant: a contravariant TypeVar there is the violation,
+// and it must land on the arm that returns it (the second), not the first.
+testcase!(
+    test_variance_error_in_overload_contravariant_return,
+    r#"
+from typing import Generic, overload, TypeVar
+
+T_contra = TypeVar("T_contra", contravariant=True)
+
+class C(Generic[T_contra]):
+    @overload
+    def f(self, x: T_contra) -> None: ...
+    @overload
+    def f(self, x: int) -> T_contra: ...  # E: `T_contra` is contravariant but is used in covariant position
+    def f(self, x: object) -> T_contra | None: ...
+    "#,
+);
+
+// The offending arm is itself generic (an `OverloadType::Forall`), exercising
+// the Forall branch of the per-signature range lookup.
+testcase!(
+    test_variance_error_in_overload_generic_arm,
+    r#"
+from typing import Generic, overload, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+U = TypeVar("U")
+
+class C(Generic[T_co]):
+    @overload
+    def f(self, x: int) -> None: ...
+    @overload
+    def f(self, x: T_co, y: U) -> U: ...  # E: `T_co` is covariant but is used in contravariant position
+    def f(self, x: object, y: object = ...) -> object: ...
+    "#,
+);
+
+// Negative: correct positions across overloads must not over-report.
+testcase!(
+    test_variance_overload_no_false_positive,
+    r#"
+from typing import Generic, overload, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+T_contra = TypeVar("T_contra", contravariant=True)
+
+class C(Generic[T_co, T_contra]):
+    @overload
+    def f(self, x: T_contra) -> T_co: ...
+    @overload
+    def f(self, x: int) -> T_co: ...
+    def f(self, x: object) -> T_co: ...
+    "#,
+);
+
+// Regression guard: single (non-overloaded) methods still go through the
+// unchanged `visit_toplevel_callable` path and are still flagged.
+testcase!(
+    test_variance_error_in_single_method,
+    r#"
+from typing import Generic, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+
+class C(Generic[T_co]):
+    def f(self, x: T_co) -> None: ...  # E: `T_co` is covariant but is used in contravariant position
     "#,
 );


### PR DESCRIPTION
Fixes #3536

### What

For an overloaded method on a generic class, the `invalid-variance` error
(covariant/contravariant TypeVar used in the wrong position) was always
reported on the **first** overload, regardless of which signature actually
misused the TypeVar. This moves the error onto the offending overload.

```python
from typing import Generic, TypeVar, overload

_T_co = TypeVar("_T_co", covariant=True)

class Foo(Generic[_T_co]):
    @overload
    def foo(self) -> None: ...                    # <- error was reported here
    @overload
    def foo(self, instance: _T_co) -> None: ...   # <- error belongs here (covariant TypeVar in a parameter)
    def foo(self, instance: _T_co | None = ...) -> None: ...
```

Before: error on the first overload. After: error on the signature that uses
`_T_co` in a contravariant position — matching pyright (`Covariant type variable
cannot be used in parameter type`) and mypy (`Cannot use a covariant type
variable as a parameter`), both of which point at the second overload.

### Why

The violation was *detected* on the correct signature; only its reported
location was wrong. `check_class_violations` looked up a single
`field_decl_range` for the whole member and `check_method_shallow` reused that
one range for every signature in the `Type::Overload`, so all overload
violations landed on the first `def`.

The per-overload `def` ranges do exist while the overload type is built
(`extract_signatures` returns `Vec1<(TextRange, OverloadType)>`), but they are
dropped when the `Type::Overload` is constructed. Pyrefly types are
position-free by design (they are interned, hashed, and compared for
incremental reuse, so they cannot carry source ranges).

### How

Recover each overload arm's range at check time from the identity the type
still carries, instead of putting positions back into the type:

- `check_method_shallow` now special-cases `Type::Overload` and resolves a range
  **per signature** from that signature's **own** inner `FuncMetadata`
  (`def_index` → existing `KeyUndecoratedFunctionRange` binding →
  `ShortIdentifier::range()`) - the same `def_index → def range` bridge the LSP
  already uses in `resolve_func_def_range`.
- It reads each arm's own metadata, **not** the merged overload-group metadata,
  which points at the implementation (with an implementation) or the first
  overload (without one).
- All other callable shapes keep flowing through `visit_toplevel_callable` with
  the field range - single-def methods were already located correctly, so their
  behavior is unchanged.
- The lookup is `Option`-returning and local to the current module (variance
  only checks a class's own fields, so the `def_index` is always local).
  Synthesized/metadata-only callables with no `def_index` fall back to the field
  range.

No change to the `Type` representation; no new bindings.

### Test plan

New/updated tests in `pyrefly/lib/test/variance_inference.rs`:

- Un-`bug`-marked `test_variance_error_in_overload` (the existing
  known-wrong-location test), with the expectation moved to the offending arm.
- `test_variance_error_in_overload_issue_3536` — the exact repro from the issue.
- `test_variance_error_in_overload_first_arm` — violation in the *first* arm, to
  prove the error tracks the offender rather than a fixed index.
- `test_variance_error_in_overload_both_arms` — both arms violate; each is
  reported on its own line.
- `test_variance_error_in_overload_contravariant_return` — contravariant TypeVar
  in a return (covariant) position, located on the returning arm.
- `test_variance_error_in_overload_generic_arm` — the offending arm is itself
  generic (`OverloadType::Forall`), exercising the Forall branch of the lookup.
- `test_variance_overload_no_false_positive` — correct positions across overloads
  must not over-report.
- `test_variance_error_in_single_method` — regression guard that single
  (non-overloaded) methods are still flagged.

Verification:

- `cargo test -p pyrefly --lib` — full suite green (5293 passed, 0 failed).
- `python3 test.py --no-test --no-conformance --no-jsonschema` — format + lint clean.
- Snippet confirmed against the release binary: `invalid-variance` now reported on
  the offending overload, matching pyright and mypy.
- `mypy_primer` (wide local scope, 26 typing-heavy projects incl. pydantic, attrs,
  trio, anyio, sympy, pandera, scipy, sphinx, mypy): **no diff** — no regressions
  and no spurious changes, as expected for a fix that only relocates an existing
  diagnostic.