### PR TITLE
Exclude exports from `if __name__ == "__main__"`

### DIFF
--- a/crates/pyrefly_python/src/ast.rs
+++ b/crates/pyrefly_python/src/ast.rs
@@ -11,10 +11,12 @@ use std::slice;
 use pyrefly_util::visit::Visit;
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::AtomicNodeIndex;
+use ruff_python_ast::CmpOp;
 use ruff_python_ast::DictItem;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprBinOp;
 use ruff_python_ast::ExprBooleanLiteral;
+use ruff_python_ast::ExprCompare;
 use ruff_python_ast::ExprName;
 use ruff_python_ast::ExprNoneLiteral;
 use ruff_python_ast::ExprStringLiteral;
@@ -196,6 +198,43 @@ impl Ast {
             .into_iter()
             .map(|x| (x.range, x.test, x.body));
         first.chain(elses)
+    }
+
+    pub fn is_main_guard(test: &Expr) -> bool {
+        let Expr::Compare(ExprCompare {
+            left,
+            ops,
+            comparators,
+            ..
+        }) = test
+        else {
+            return false;
+        };
+
+        if ops.len() != 1 || comparators.len() != 1 {
+            return false;
+        }
+
+        let op = ops[0];
+        if !matches!(op, CmpOp::Eq | CmpOp::Is) {
+            return false;
+        }
+
+        let left = left.as_ref();
+        let right = &comparators[0];
+        (Self::is_name_dunder_name(left) && Self::is_main_string(right))
+            || (Self::is_main_string(left) && Self::is_name_dunder_name(right))
+    }
+
+    fn is_name_dunder_name(expr: &Expr) -> bool {
+        matches!(expr, Expr::Name(name) if name.id.as_str() == "__name__")
+    }
+
+    fn is_main_string(expr: &Expr) -> bool {
+        matches!(
+            expr,
+            Expr::StringLiteral(ExprStringLiteral { value, .. }) if value.to_str() == "__main__"
+        )
     }
 
     /// Iterates over parameters, returning the parameters and defaults

--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -110,6 +110,9 @@ pub struct Definition {
     /// definition, this equals `range`. Used to determine if a variable is
     /// reassigned after a given point (e.g. after a nested function definition).
     pub last_range: TextRange,
+    /// True while every definition site is inside an `if __name__ == "__main__":` body.
+    /// Such names resolve in-module but are not importable, so the export surface excludes them.
+    pub main_guard_only: bool,
 }
 
 impl Definition {
@@ -120,7 +123,8 @@ impl Definition {
         }
     }
 
-    fn merge(&mut self, other: DefinitionStyle, range: TextRange) {
+    fn merge(&mut self, other: DefinitionStyle, range: TextRange, in_main_guard: bool) {
+        self.main_guard_only &= in_main_guard;
         // To ensure binding code cannot produce invalid lookups, we ensure that
         // `self.style` and `self.range` always match.
         if other < self.style {
@@ -274,6 +278,7 @@ struct DefinitionsBuilder {
     is_init: bool,
     sys_info: SysInfo,
     inner: Definitions,
+    in_main_guard: bool,
 }
 
 fn is_private_name(name: &Name) -> bool {
@@ -327,6 +332,7 @@ impl Definitions {
             sys_info,
             is_init,
             inner: Definitions::default(),
+            in_main_guard: false,
         };
         builder.stmts(x);
 
@@ -352,6 +358,7 @@ impl Definitions {
                     needs_anywhere: false,
                     docstring_range: None,
                     last_range: TextRange::default(),
+                    main_guard_only: false,
                 },
             );
         }
@@ -373,6 +380,7 @@ impl Definitions {
         }
         for (name, def) in self.definitions.iter() {
             if !is_private_name(name)
+                && !def.main_guard_only
                 && (style == ModuleStyle::Executable
                     || matches!(
                         def.style,
@@ -427,9 +435,10 @@ impl DefinitionsBuilder {
         if x.is_empty() {
             return;
         }
+        let in_main_guard = self.in_main_guard;
         match self.inner.definitions.entry(x.clone()) {
             Entry::Occupied(mut e) => {
-                e.get_mut().merge(style, range);
+                e.get_mut().merge(style, range, in_main_guard);
             }
             Entry::Vacant(e) => {
                 e.insert(Definition {
@@ -438,6 +447,7 @@ impl DefinitionsBuilder {
                     needs_anywhere: false,
                     docstring_range: body.and_then(Docstring::range_from_stmts),
                     last_range: range,
+                    main_guard_only: in_main_guard,
                 });
             }
         }
@@ -862,8 +872,11 @@ impl DefinitionsBuilder {
             Stmt::If(x) => {
                 self.named_in_expr(&x.test);
                 let sys_info = self.sys_info;
-                for (_, body) in sys_info.pruned_if_branches(x) {
+                for (test, body) in sys_info.pruned_if_branches(x) {
+                    let outer = self.in_main_guard;
+                    self.in_main_guard = outer || test.is_some_and(Ast::is_main_guard);
                     self.stmts(body);
+                    self.in_main_guard = outer;
                 }
                 return; // We went through the relevant branches already
             }

--- a/pyrefly/lib/export/exports.rs
+++ b/pyrefly/lib/export/exports.rs
@@ -228,6 +228,7 @@ impl Exports {
                         || self_defs.deprecated.get(name) != other_defs.deprecated.get(name)
                         || self_defs.special_exports.get(name)
                             != other_defs.special_exports.get(name)
+                        || self_def.main_guard_only != other_def.main_guard_only
                     {
                         changed.0.names.entry(name.clone()).or_default().metadata = true;
                     }
@@ -348,6 +349,9 @@ impl Exports {
         let f = || {
             let mut result: SmallMap<Name, ExportLocation> = SmallMap::new();
             for (name, definition) in self.definitions.definitions.iter_hashed() {
+                if definition.main_guard_only {
+                    continue;
+                }
                 let deprecation = self.definitions.deprecated.get_hashed(name).cloned();
                 let special_export = self.definitions.special_exports.get_hashed(name).copied();
                 let is_final = self.definitions.final_names.contains_key_hashed(name);

--- a/pyrefly/lib/lsp/non_wasm/code_lens.rs
+++ b/pyrefly/lib/lsp/non_wasm/code_lens.rs
@@ -10,11 +10,9 @@ use lsp_types::Command;
 use lsp_types::Range;
 use lsp_types::Url;
 use pyrefly_build::handle::Handle;
-use ruff_python_ast::CmpOp;
+use pyrefly_python::ast::Ast;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprAttribute;
-use ruff_python_ast::ExprCompare;
-use ruff_python_ast::ExprStringLiteral;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtClassDef;
 use ruff_text_size::TextRange;
@@ -131,7 +129,7 @@ fn collect_module_entries(stmts: &[Stmt], entries: &mut Vec<CodeLensEntry>) {
                     is_unittest,
                 );
             }
-            Stmt::If(stmt_if) if is_main_guard(&stmt_if.test) => {
+            Stmt::If(stmt_if) if Ast::is_main_guard(&stmt_if.test) => {
                 entries.push(CodeLensEntry {
                     range: stmt_if.range,
                     kind: CodeLensKind::Run,
@@ -203,41 +201,4 @@ fn is_unittest_base(base: &Expr) -> bool {
         Expr::Attribute(ExprAttribute { attr, .. }) => attr.id.as_str().ends_with("TestCase"),
         _ => false,
     }
-}
-
-fn is_main_guard(test: &Expr) -> bool {
-    let Expr::Compare(ExprCompare {
-        left,
-        ops,
-        comparators,
-        ..
-    }) = test
-    else {
-        return false;
-    };
-
-    if ops.len() != 1 || comparators.len() != 1 {
-        return false;
-    }
-
-    let op = ops[0];
-    if !matches!(op, CmpOp::Eq | CmpOp::Is) {
-        return false;
-    }
-
-    let left = left.as_ref();
-    let right = &comparators[0];
-    (is_name_dunder_name(left) && is_main_string(right))
-        || (is_main_string(left) && is_name_dunder_name(right))
-}
-
-fn is_name_dunder_name(expr: &Expr) -> bool {
-    matches!(expr, Expr::Name(name) if name.id.as_str() == "__name__")
-}
-
-fn is_main_string(expr: &Expr) -> bool {
-    matches!(
-        expr,
-        Expr::StringLiteral(ExprStringLiteral { value, .. }) if value.to_str() == "__main__"
-    )
 }

--- a/pyrefly/lib/test/imports.rs
+++ b/pyrefly/lib/test/imports.rs
@@ -289,6 +289,38 @@ import foo
 "#,
 );
 
+fn env_main_guard() -> TestEnv {
+    let mut t = TestEnv::new();
+    t.add(
+        "foo",
+        r#"
+x = 1
+if __name__ == "__main__":
+    y = 2
+"#,
+    );
+    t
+}
+
+testcase!(
+    test_main_guard_not_exported,
+    env_main_guard(),
+    r#"
+from foo import x
+from foo import y  # E: Could not import `y` from `foo`
+"#,
+);
+
+testcase!(
+    test_main_guard_not_in_wildcard,
+    env_main_guard(),
+    r#"
+from foo import *
+x
+y  # E: Could not find name `y`
+"#,
+);
+
 fn env_relative_import_star() -> TestEnv {
     let mut t = TestEnv::new();
     t.add_with_path("foo", "foo/__init__.pyi", "from .bar import *");


### PR DESCRIPTION
# Summary

The problem turned out to lie a bit deeper than just `pyrefly coverage report`, because it was the export collection itself that was incorrectly including definitions from `if __name__ == "__main__"` guards. But those aren't importable at runtime, so they shouldn't be considered as import-able.

Fixes #3624 (and then some).

# Test Plan

Tests added