### PR TITLE
Add per-target `config` and `root` fields to build system response (#3627)

### DIFF
--- a/crates/pyrefly_build/src/query/mod.rs
+++ b/crates/pyrefly_build/src/query/mod.rs
@@ -269,15 +269,25 @@ pub trait SourceDbQuerier: Send + Sync + fmt::Debug {
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 pub(crate) struct PythonLibraryManifest {
+    #[serde(default)]
     pub deps: SmallSet<Target>,
     pub srcs: SmallMap<ModuleName, Vec1<InternedPath>>,
     #[serde(default)]
     pub relative_to: Option<PathBuf>,
     #[serde(flatten)]
     pub sys_info: SysInfo,
+    #[serde(default)]
     pub buildfile_path: PathBuf,
     #[serde(default, skip)]
     pub packages: SmallMap<ModuleName, Vec1<InternedPath>>,
+    /// Per-target override of the top-level `root`. Used for both absolutizing
+    /// `srcs` paths and as the import resolution root for files in this target.
+    #[serde(default)]
+    pub root: Option<PathBuf>,
+    /// Per-target config overrides stored as raw JSON to avoid a circular
+    /// dependency between `pyrefly_build` and `pyrefly_config`.
+    #[serde(default)]
+    pub config: Option<serde_json::Value>,
 }
 
 impl PythonLibraryManifest {
@@ -410,7 +420,8 @@ impl TargetManifestDatabase {
                 TargetManifest::Alias { .. } => continue,
                 TargetManifest::Library(lib) => {
                     lib.replace_alias_deps(&aliases);
-                    lib.rewrite_relative_to_root(&self.root);
+                    let root = lib.root.clone().unwrap_or_else(|| self.root.clone());
+                    lib.rewrite_relative_to_root(&root);
                 }
             }
         }
@@ -728,6 +739,8 @@ mod tests {
                 sys_info: SysInfo::new(PythonVersion::new(3, 12, 0), PythonPlatform::linux()),
                 buildfile_path: PathBuf::from(buildfile),
                 packages: map_implicit_packages(implicit_packages, None),
+                root: None,
+                config: None,
             })
         }
     }
@@ -748,6 +761,8 @@ mod tests {
                 sys_info: SysInfo::new(PythonVersion::new(3, 12, 0), PythonPlatform::linux()),
                 buildfile_path: PathBuf::from(root).join(buildfile),
                 packages: map_implicit_packages(inits, Some(root)),
+                root: None,
+                config: None,
             }
         }
     }
@@ -1391,5 +1406,98 @@ mod tests {
             "Expected packages to contain 'foo', but got: {:?}",
             manifest.packages.keys().collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn test_per_target_config_and_root() {
+        let json = r#"
+{
+  "db": {
+    "//pkg:basic": {
+      "srcs": {
+        "foo": ["foo.py"]
+      },
+      "root": "/src/Package",
+      "config": {
+        "preset": "basic",
+        "errors": { "missing-import": "warn" }
+      },
+      "python_version": "3.12",
+      "python_platform": "linux"
+    },
+    "//pkg:strict": {
+      "srcs": {
+        "bar": ["bar.py"]
+      },
+      "root": "/src/Package",
+      "config": {
+        "preset": "strict"
+      },
+      "python_version": "3.12",
+      "python_platform": "linux"
+    }
+  },
+  "root": "/src"
+}
+        "#;
+        let parsed: TargetManifestDatabase = serde_json::from_str(json).unwrap();
+
+        let (db, _) = parsed.produce_map();
+
+        let basic = db
+            .get(&Target::from_string("//pkg:basic".to_owned()))
+            .unwrap();
+        assert_eq!(basic.root, Some(PathBuf::from("/src/Package")));
+        assert!(basic.config.is_some());
+        // Paths should be absolutized against per-target root, not top-level root
+        assert_eq!(
+            basic
+                .srcs
+                .get(&ModuleName::from_str("foo"))
+                .unwrap()
+                .first(),
+            &InternedPath::new(PathBuf::from("/src/Package/foo.py"))
+        );
+
+        let strict = db
+            .get(&Target::from_string("//pkg:strict".to_owned()))
+            .unwrap();
+        assert_eq!(strict.root, Some(PathBuf::from("/src/Package")));
+        assert!(strict.config.is_some());
+        assert_eq!(
+            strict
+                .srcs
+                .get(&ModuleName::from_str("bar"))
+                .unwrap()
+                .first(),
+            &InternedPath::new(PathBuf::from("/src/Package/bar.py"))
+        );
+    }
+
+    #[test]
+    fn test_optional_deps_and_buildfile_path() {
+        let json = r#"
+{
+  "db": {
+    "//pkg:minimal": {
+      "srcs": {
+        "main": ["main.py"]
+      },
+      "python_version": "3.12",
+      "python_platform": "linux"
+    }
+  },
+  "root": "/src"
+}
+        "#;
+        let parsed: TargetManifestDatabase = serde_json::from_str(json).unwrap();
+        let (db, _) = parsed.produce_map();
+        let minimal = db
+            .get(&Target::from_string("//pkg:minimal".to_owned()))
+            .unwrap();
+        assert!(minimal.deps.is_empty());
+        assert_eq!(minimal.buildfile_path, PathBuf::from("/src"));
+        assert!(minimal.config.is_none());
+        assert!(minimal.root.is_none());
     }
 }

--- a/crates/pyrefly_build/src/source_db/buck_check.rs
+++ b/crates/pyrefly_build/src/source_db/buck_check.rs
@@ -208,6 +208,14 @@ impl SourceDatabase for BuckCheckSourceDatabase {
     fn get_generated_files(&self) -> SmallSet<InternedPath> {
         SmallSet::new()
     }
+
+    fn get_target_config_raw(&self, _: Option<&Path>) -> Option<serde_json::Value> {
+        None
+    }
+
+    fn get_target_root(&self, _: Option<&Path>) -> Option<PathBuf> {
+        None
+    }
 }
 
 impl BuckCheckSourceDatabase {

--- a/crates/pyrefly_build/src/source_db/map_db.rs
+++ b/crates/pyrefly_build/src/source_db/map_db.rs
@@ -8,6 +8,7 @@
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::path::Path;
+use std::path::PathBuf;
 
 use dupe::Dupe as _;
 use pyrefly_python::module_name::ModuleName;
@@ -111,5 +112,13 @@ impl SourceDatabase for MapDatabase {
 
     fn get_generated_files(&self) -> SmallSet<InternedPath> {
         SmallSet::new()
+    }
+
+    fn get_target_config_raw(&self, _: Option<&Path>) -> Option<serde_json::Value> {
+        None
+    }
+
+    fn get_target_root(&self, _: Option<&Path>) -> Option<PathBuf> {
+        None
     }
 }

--- a/crates/pyrefly_build/src/source_db/mod.rs
+++ b/crates/pyrefly_build/src/source_db/mod.rs
@@ -139,4 +139,8 @@ pub trait SourceDatabase: Send + Sync + fmt::Debug {
     fn get_target(&self, origin: Option<&Path>) -> Option<Target>;
     /// Get any generated files for which we might have to override the config finder.
     fn get_generated_files(&self) -> SmallSet<InternedPath>;
+    /// Get the raw JSON config overrides for the target that owns the given file.
+    fn get_target_config_raw(&self, origin: Option<&Path>) -> Option<serde_json::Value>;
+    /// Get the per-target root for the target that owns the given file.
+    fn get_target_root(&self, origin: Option<&Path>) -> Option<PathBuf>;
 }

--- a/crates/pyrefly_build/src/source_db/query_source_db.rs
+++ b/crates/pyrefly_build/src/source_db/query_source_db.rs
@@ -492,6 +492,20 @@ impl SourceDatabase for QuerySourceDatabase {
             .flatten()
             .collect()
     }
+
+    fn get_target_config_raw(&self, origin: Option<&Path>) -> Option<serde_json::Value> {
+        let target = self.get_target(origin)?;
+        let read = self.inner.read();
+        let manifest = read.db.get(&target)?;
+        manifest.config.clone()
+    }
+
+    fn get_target_root(&self, origin: Option<&Path>) -> Option<PathBuf> {
+        let target = self.get_target(origin)?;
+        let read = self.inner.read();
+        let manifest = read.db.get(&target)?;
+        manifest.root.clone()
+    }
 }
 
 #[cfg(test)]

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -875,24 +875,26 @@ impl ConfigFile {
         SysInfo::new(self.python_version(), self.python_platform().clone())
     }
 
-    pub fn errors(&self, path: &Path) -> &ErrorDisplayConfig {
-        self.get_from_sub_configs(ConfigBase::get_errors, path)
-            .unwrap_or_else(||
-                 // we can use unwrap here, because the value in the root config must
-                 // be set in `ConfigFile::configure()`.
-                 self.root.errors.as_ref().unwrap())
+    pub fn errors(&self, path: &Path) -> ErrorDisplayConfig {
+        if let Some(e) = self.get_from_sub_configs(ConfigBase::get_errors, path) {
+            return e.clone();
+        }
+        if let Some(e) = self.get_from_target_config(|c| c.errors.clone(), path) {
+            return e;
+        }
+        self.root.errors.clone().unwrap()
     }
 
     pub fn replace_imports_with_any(&self, path: Option<&Path>, module: ModuleName) -> bool {
         let wildcards = path
             .and_then(|path| {
                 self.get_from_sub_configs(ConfigBase::get_replace_imports_with_any, path)
+                    .map(|w| w.to_vec())
+                    .or_else(|| {
+                        self.get_from_target_config(|c| c.replace_imports_with_any.clone(), path)
+                    })
             })
-            .unwrap_or_else(||
-             // we can use unwrap here, because the value in the root config must
-             // be set in `ConfigFile::configure()`.
-             self.root.replace_imports_with_any.as_deref().unwrap());
-        // Need to filter out any files that would be a not case.
+            .unwrap_or_else(|| self.root.replace_imports_with_any.clone().unwrap());
         let found_match = wildcards.iter().find_map(|w| {
             if w.matches(module) == Match::Negative {
                 Some(false)
@@ -909,11 +911,12 @@ impl ConfigFile {
         let wildcards = path
             .and_then(|path| {
                 self.get_from_sub_configs(ConfigBase::get_ignore_missing_imports, path)
+                    .map(|w| w.to_vec())
+                    .or_else(|| {
+                        self.get_from_target_config(|c| c.ignore_missing_imports.clone(), path)
+                    })
             })
-            .unwrap_or_else(||
-             // we can use unwrap here, because the value in the root config must
-             // be set in `ConfigFile::configure()`.
-             self.root.ignore_missing_imports.as_deref().unwrap());
+            .unwrap_or_else(|| self.root.ignore_missing_imports.clone().unwrap());
         let found_match = wildcards.iter().find_map(|w| {
             if w.matches(module) == Match::Negative {
                 Some(false)
@@ -928,65 +931,60 @@ impl ConfigFile {
 
     pub fn check_unannotated_defs(&self, path: &Path) -> bool {
         self.get_from_sub_configs(ConfigBase::get_check_unannotated_defs, path)
+            .or_else(|| self.get_from_target_config(|c| c.check_unannotated_defs, path))
             .unwrap_or_else(|| self.root.check_unannotated_defs.unwrap())
     }
 
     pub fn infer_return_types(&self, path: &Path) -> InferReturnTypes {
         self.get_from_sub_configs(ConfigBase::get_infer_return_types, path)
+            .or_else(|| self.get_from_target_config(|c| c.infer_return_types, path))
             .unwrap_or_else(|| self.root.infer_return_types.unwrap())
     }
 
     pub fn disable_type_errors_in_ide(&self, path: &Path) -> bool {
         self.get_from_sub_configs(ConfigBase::get_disable_type_errors_in_ide, path)
+            .or_else(|| self.get_from_target_config(|c| c.disable_type_errors_in_ide, path))
             .unwrap_or_else(|| self.root.disable_type_errors_in_ide.unwrap_or_default())
     }
 
     fn ignore_errors_in_generated_code(&self, path: &Path) -> bool {
         self.get_from_sub_configs(ConfigBase::get_ignore_errors_in_generated_code, path)
-            .unwrap_or_else(||
-                 // we can use unwrap here, because the value in the root config must
-                 // be set in `ConfigFile::configure()`.
-                 self.root.ignore_errors_in_generated_code.unwrap())
+            .or_else(|| self.get_from_target_config(|c| c.ignore_errors_in_generated_code, path))
+            .unwrap_or_else(|| self.root.ignore_errors_in_generated_code.unwrap())
     }
 
     pub fn infer_with_first_use(&self, path: &Path) -> bool {
         self.get_from_sub_configs(ConfigBase::get_infer_with_first_use, path)
-            .unwrap_or_else(||
-                 // we can use unwrap here, because the value in the root config must
-                 // be set in `ConfigFile::configure()`.
-                 self.root.infer_with_first_use.unwrap())
+            .or_else(|| self.get_from_target_config(|c| c.infer_with_first_use, path))
+            .unwrap_or_else(|| self.root.infer_with_first_use.unwrap())
     }
 
     pub fn tensor_shapes(&self, path: &Path) -> bool {
         self.get_from_sub_configs(ConfigBase::get_tensor_shapes, path)
-            .unwrap_or_else(||
-                 // we can use unwrap here, because the value in the root config must
-                 // be set in `ConfigFile::configure()`.
-                 self.root.tensor_shapes.unwrap())
+            .or_else(|| self.get_from_target_config(|c| c.tensor_shapes, path))
+            .unwrap_or_else(|| self.root.tensor_shapes.unwrap())
     }
 
     pub fn strict_callable_subtyping(&self, path: &Path) -> bool {
         self.get_from_sub_configs(ConfigBase::get_strict_callable_subtyping, path)
-            .unwrap_or_else(||
-                 // we can use unwrap here, because the value in the root config must
-                 // be set in `ConfigFile::configure()`.
-                 self.root.strict_callable_subtyping.unwrap())
+            .or_else(|| self.get_from_target_config(|c| c.strict_callable_subtyping, path))
+            .unwrap_or_else(|| self.root.strict_callable_subtyping.unwrap())
     }
 
     pub fn spec_compliant_overloads(&self, path: &Path) -> bool {
         self.get_from_sub_configs(ConfigBase::get_spec_compliant_overloads, path)
-            .unwrap_or_else(||
-                 // we can use unwrap here, because the value in the root config must
-                 // be set in `ConfigFile::configure()`.
-                 self.root.spec_compliant_overloads.unwrap())
+            .or_else(|| self.get_from_target_config(|c| c.spec_compliant_overloads, path))
+            .unwrap_or_else(|| self.root.spec_compliant_overloads.unwrap())
     }
 
-    pub fn enabled_ignores(&self, path: &Path) -> &SmallSet<Tool> {
-        self.get_from_sub_configs(ConfigBase::get_enabled_ignores, path)
-            .unwrap_or_else(||
-                 // we can use unwrap here, because the value in the root config must
-                 // be set in `ConfigFile::configure()`.
-                 self.root.enabled_ignores.as_ref().unwrap())
+    pub fn enabled_ignores(&self, path: &Path) -> SmallSet<Tool> {
+        if let Some(e) = self.get_from_sub_configs(ConfigBase::get_enabled_ignores, path) {
+            return e.clone();
+        }
+        if let Some(e) = self.get_from_target_config(|c| c.enabled_ignores.clone(), path) {
+            return e;
+        }
+        self.root.enabled_ignores.clone().unwrap()
     }
 
     /// Get the recursion limit configuration.
@@ -995,11 +993,11 @@ impl ConfigFile {
         ConfigBase::get_recursion_limit_config(&self.root)
     }
 
-    pub fn get_error_config(&self, path: &Path) -> ErrorConfig<'_> {
+    pub fn get_error_config(&self, path: &Path) -> ErrorConfig {
         ErrorConfig::new(
             self.errors(path),
             self.ignore_errors_in_generated_code(path),
-            self.enabled_ignores(path).clone(),
+            self.enabled_ignores(path),
         )
     }
 
@@ -1017,6 +1015,20 @@ impl ConfigFile {
             }
             None
         })
+    }
+
+    /// Look up a per-file config setting from the build system target that owns
+    /// the given file. Returns `None` if there is no source database, the file
+    /// doesn't belong to any target, or the target has no config override.
+    fn get_from_target_config<T>(
+        &self,
+        getter: impl FnOnce(&ConfigBase) -> Option<T>,
+        path: &Path,
+    ) -> Option<T> {
+        let source_db = self.source_db.as_ref()?;
+        let raw = source_db.get_target_config_raw(Some(path))?;
+        let config_base: ConfigBase = serde_json::from_value(raw).ok()?;
+        getter(&config_base)
     }
 
     pub fn handle_from_module_path(&self, module_path: ModulePath) -> Handle {

--- a/crates/pyrefly_config/src/error.rs
+++ b/crates/pyrefly_config/src/error.rs
@@ -156,15 +156,15 @@ impl<'de> Deserialize<'de> for ErrorDisplayConfig {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct ErrorConfig<'a> {
-    pub display_config: &'a ErrorDisplayConfig,
+pub struct ErrorConfig {
+    pub display_config: ErrorDisplayConfig,
     pub ignore_errors_in_generated_code: bool,
     pub enabled_ignores: SmallSet<Tool>,
 }
 
-impl<'a> ErrorConfig<'a> {
+impl ErrorConfig {
     pub fn new(
-        display_config: &'a ErrorDisplayConfig,
+        display_config: ErrorDisplayConfig,
         ignore_errors_in_generated_code: bool,
         enabled_ignores: SmallSet<Tool>,
     ) -> Self {

--- a/pyrefly/lib/error/collector.rs
+++ b/pyrefly/lib/error/collector.rs
@@ -450,7 +450,7 @@ mod tests {
         assert_eq!(
             errors
                 .collect(&ErrorConfig::new(
-                    &ErrorDisplayConfig::default(),
+                    ErrorDisplayConfig::default(),
                     false,
                     Tool::default_enabled(),
                 ))
@@ -504,7 +504,7 @@ mod tests {
             (ErrorKind::BadAssignment, Severity::Ignore),
             (ErrorKind::NotIterable, Severity::Ignore),
         ]));
-        let config = ErrorConfig::new(&display_config, false, Tool::default_enabled());
+        let config = ErrorConfig::new(display_config, false, Tool::default_enabled());
 
         assert_eq!(
             errors.collect(&config).ordinary.map(|x| x.msg()),
@@ -528,13 +528,13 @@ mod tests {
         );
 
         let display_config = ErrorDisplayConfig::default();
-        let config0 = ErrorConfig::new(&display_config, false, Tool::default_enabled());
+        let config0 = ErrorConfig::new(display_config.clone(), false, Tool::default_enabled());
         assert_eq!(
             errors.collect(&config0).ordinary.map(|x| x.msg()),
             vec!["a"]
         );
 
-        let config1 = ErrorConfig::new(&display_config, true, Tool::default_enabled());
+        let config1 = ErrorConfig::new(display_config, true, Tool::default_enabled());
         assert!(
             errors
                 .collect(&config1)
@@ -567,7 +567,7 @@ mod tests {
         assert_eq!(
             errors
                 .collect(&ErrorConfig::new(
-                    &ErrorDisplayConfig::default(),
+                    ErrorDisplayConfig::default(),
                     false,
                     Tool::default_enabled(),
                 ))

--- a/pyrefly/lib/playground.rs
+++ b/pyrefly/lib/playground.rs
@@ -115,6 +115,14 @@ impl SourceDatabase for PlaygroundSourceDatabase {
     fn get_generated_files(&self) -> SmallSet<InternedPath> {
         SmallSet::new()
     }
+
+    fn get_target_config_raw(&self, _: Option<&Path>) -> Option<serde_json::Value> {
+        None
+    }
+
+    fn get_target_root(&self, _: Option<&Path>) -> Option<PathBuf> {
+        None
+    }
 }
 
 #[derive(Serialize)]

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -917,10 +917,71 @@ The command should output a JSON file with the following structure:
 
 Where:
 
-- `root` is the absolute path the root of the repository.
+- `root` is the absolute path to the root of the repository. Source paths in
+  `srcs` are relative to this root (or to the per-target `root`, if set).
 - `db` is a map from target names to either:
     - library target definitions (e.g. `//colorama:py` and `//colorama:py-stubs` here)
     - target aliases (e.g. `//colorama:colorama` here)
+
+Each library target definition has the following fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `srcs` | yes | Map from qualified module names to lists of relative source file paths. |
+| `python_version` | yes | Python version string (e.g. `"3.12"`). |
+| `python_platform` | yes | Python platform string (e.g. `"linux"`). |
+| `deps` | no | List of target names this target depends on. Defaults to `[]`. |
+| `buildfile_path` | no | Relative path to the build file that defines this target. Defaults to `""`. |
+| `root` | no | Absolute path override for absolutizing this target's `srcs` paths. When omitted, the top-level `root` is used. |
+| `config` | no | JSON object with per-target type checking config overrides (e.g. `errors`, `preset`). These are applied in the resolution chain between sub-configs and the root config. |
+
+Here is an example with per-target `config` and `root`:
+
+```json
+{
+    "root": "/src",
+    "db": {
+        "//Project:MyLib": {
+            "srcs": {
+                "Foo": ["Foo.py"],
+                "Bar": ["sub1/Bar.py"]
+            },
+            "root": "/src/Project",
+            "config": {
+                "errors": { "missing-import": "warn" }
+            },
+            "python_version": "3.12",
+            "python_platform": "linux"
+        },
+        "//Project:MyPkg": {
+            "srcs": {
+                "MyPkg": ["MyPkg/__init__.py"],
+                "MyPkg.Utils": ["MyPkg/Utils.py"]
+            },
+            "deps": ["//Project:MyLib"],
+            "root": "/src/Project",
+            "config": { "preset": "strict" },
+            "python_version": "3.12",
+            "python_platform": "linux"
+        },
+        "//Project/test:test": {
+            "srcs": {
+                "test.lib": ["test/lib.py"],
+                "test.test": ["test/test.py"]
+            },
+            "deps": ["//Project:MyLib", "//Project:MyPkg"],
+            "python_version": "3.12",
+            "python_platform": "linux"
+        }
+    }
+}
+```
+
+In this example, `MyLib` and `MyPkg` set `root` to `/src/Project`, so their
+`srcs` paths are absolutized relative to that directory (e.g. `Foo.py` becomes
+`/src/Project/Foo.py`). The test target omits `root`, so its paths are
+absolutized relative to the top-level `root` (`/src`). `MyLib` also omits `deps`
+and `buildfile_path`, which default to empty.
 
 For reference, the command invoked as part of the Buck2 integration is:
 


### PR DESCRIPTION
Summary:

External users with custom build systems (e.g., Arista Networks) need the
build system to be the single source of truth for both import resolution
and type checking settings. Currently the build system JSON response can
provide `srcs` and `deps` per target, but has no way to communicate
per-target type checking configuration or per-target source roots.

This adds two new optional fields to `PythonLibraryManifest`:
- `config`: raw JSON config overrides (errors, preset, etc.) that are
  deserialized into `ConfigBase` by `pyrefly_config` at resolution time.
  Stored as `serde_json::Value` to avoid a circular crate dependency.
- `root`: per-target override of the top-level root, used for both
  absolutizing `srcs` paths and as the import resolution root.

Also makes `deps` and `buildfile_path` optional via `#[serde(default)]`
so build systems that don't map cleanly to per-target deps can omit them.

The config resolution chain becomes:
  sub-config -> target config -> root config -> preset defaults

`ErrorConfig` is simplified to own its `ErrorDisplayConfig` (removing the
lifetime parameter) so that target configs deserialized from JSON can
participate in the resolution chain without lifetime issues.

Differential Revision: D107113346


