### PR TITLE
fix: show hover in notebook when kernal switches

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -3669,15 +3669,18 @@ impl Server {
             notebook_document.metadata = Some(metadata.clone());
         }
         notebook_document.version = version;
+
+        // Track existing cell contents.
+        // Track cell content even when there are no changes to cells, so that cells inside NotebookDocument struct stay updated after kernal switching.
+        for cell in &notebook_document.cells {
+            let cell_contents = original_notebook
+                .get_cell_contents(&cell.document)
+                .unwrap_or_default();
+            cell_content_map.insert(cell.document.clone(), cell_contents);
+        }
+
         // Changes to cells
         if let Some(change) = &params.change.cells {
-            // Track existing cell contents
-            for cell in &notebook_document.cells {
-                let cell_contents = original_notebook
-                    .get_cell_contents(&cell.document)
-                    .unwrap_or_default();
-                cell_content_map.insert(cell.document.clone(), cell_contents);
-            }
             // Structural changes
             if let Some(structure) = &change.structure {
                 let start = structure.array.start as usize;

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -3670,8 +3670,7 @@ impl Server {
         }
         notebook_document.version = version;
 
-        // Track existing cell contents.
-        // Track cell content even when there are no changes to cells, so that cells inside NotebookDocument struct stay updated after kernal switching.
+        // Track existing cell contents during both metdata-only (for kernel-switching) changes and cell-content changes
         for cell in &notebook_document.cells {
             let cell_contents = original_notebook
                 .get_cell_contents(&cell.document)

--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_hover.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_hover.rs
@@ -11,8 +11,7 @@ use crate::object_model::InitializeSettings;
 use crate::object_model::LspInteraction;
 use crate::util::get_test_files_root;
 
-#[test]
-fn test_notebook_hover_basic() {
+fn new_notebook_interaction() -> LspInteraction {
     let root = get_test_files_root();
     let mut interaction = LspInteraction::new();
     interaction.set_root(root.path().to_path_buf());
@@ -22,11 +21,10 @@ fn test_notebook_hover_basic() {
             ..Default::default()
         })
         .unwrap();
+    interaction
+}
 
-    // Open notebook with a single cell containing "x = 3"
-    interaction.open_notebook("notebook.ipynb", vec!["x = 3"]);
-
-    // Hover over the "x"
+fn expect_cell_content_hover(interaction: &LspInteraction) {
     interaction
         .hover_cell("notebook.ipynb", "cell1", 0, 0)
         .expect_response(json!({
@@ -36,6 +34,38 @@ fn test_notebook_hover_basic() {
             }
         }))
         .unwrap();
+}
+
+#[test]
+fn test_notebook_hover_basic() {
+    let interaction = new_notebook_interaction();
+    // Open notebook with a single cell containing "x = 3"
+    interaction.open_notebook("notebook.ipynb", vec!["x = 3"]);
+
+    // Hover over the "x"
+    expect_cell_content_hover(&interaction);
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_notebook_hover_after_kernel_change() {
+    let interaction = new_notebook_interaction();
+    // Open notebook with a single cell containing "x = 3"
+    interaction.open_notebook("notebook.ipynb", vec!["x = 3"]);
+
+    // Stimulate kernel-switch by sending metadata-only didChange event
+    interaction.change_notebook(
+        "notebook.ipynb",
+        2,
+        json!({
+        "metadata": {
+        "language_info": {"name": "python"},
+        }
+            }),
+    );
+
+    // Hover over the "x" after kernel-switch
+    expect_cell_content_hover(&interaction);
 
     interaction.shutdown().unwrap();
 }


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->
Cell content metdata was being updated when there are changes made to cells inside the notebook. LspEvent's didChange event runs the `notebook_document_did_change` fn which earlier updated the cell metdata of notebook only when there are changes made to the cell and since kernel switching doesn't cause any cell changes, the existing cells didn't get inserted into `notebookDocument` struct's cell field. this caused hover to stop working on the existing cells after kernel switching.

Fixes #3598 

# Test Plan

<!-- Describe how you tested this PR -->

- Manually verified in VS Code using a local Pyrefly build from this branch.
- created a `test.ipynb` file, created new cell in it.
- wrote `x=5` , and switched kernel and hovered over `x`

<!-- Run test.py and commit any changes to generated files -->
