### PR TITLE
Fix TSP getComputedType to preserve declarations for callees (pylance-release#8020)

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -6315,7 +6315,11 @@ impl TspInterface for Server {
         let module_info = transaction.get_module_info(&handle)?;
         let position =
             module_info.from_lsp_position(lsp_types::Position { line, character }, notebook_cell);
-        transaction.get_type_at(&handle, position)
+        // For TSP, return the raw declared type without coercing callees in
+        // call position. This keeps the function's `Declaration::Regular`
+        // intact on the wire, which TSP clients need to re-resolve the
+        // signature (parameters, overloads) from source.
+        transaction.get_type_at_preserving_declaration(&handle, position)
     }
 
     fn resolve_func_def_range(

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -984,6 +984,16 @@ impl<'a> Transaction<'a> {
         position: TextSize,
         for_display: bool,
     ) -> Option<Type> {
+        self.get_type_at_impl_with_options(handle, position, for_display, true)
+    }
+
+    fn get_type_at_impl_with_options(
+        &self,
+        handle: &Handle,
+        position: TextSize,
+        for_display: bool,
+        coerce_callees: bool,
+    ) -> Option<Type> {
         match self.identifier_at(handle, position) {
             Some(IdentifierWithContext {
                 identifier: id,
@@ -1001,20 +1011,24 @@ impl<'a> Transaction<'a> {
                     return None;
                 }
                 let mut ty = self.get_type_for_surface(handle, &key, for_display)?;
-                let call_args_range = self.callee_at(handle, position).and_then(
-                    |ExprCall {
-                         func, arguments, ..
-                     }| (func.range() == id.range).then_some(arguments.range),
-                );
-                if let Some(arguments_range) = call_args_range {
-                    if let Some(ret) = self.get_chosen_overload_trace_for_surface(
-                        handle,
-                        arguments_range,
-                        for_display,
-                    ) {
-                        return Some(ret);
+                if coerce_callees {
+                    let call_args_range = self.callee_at(handle, position).and_then(
+                        |ExprCall {
+                             func, arguments, ..
+                         }| {
+                            (func.range() == id.range).then_some(arguments.range)
+                        },
+                    );
+                    if let Some(arguments_range) = call_args_range {
+                        if let Some(ret) = self.get_chosen_overload_trace_for_surface(
+                            handle,
+                            arguments_range,
+                            for_display,
+                        ) {
+                            return Some(ret);
+                        }
+                        ty = self.coerce_type_to_callable(handle, ty);
                     }
-                    ty = self.coerce_type_to_callable(handle, ty);
                 }
                 Some(ty)
             }
@@ -1183,6 +1197,24 @@ impl<'a> Transaction<'a> {
 
     pub fn get_type_at_for_display(&self, handle: &Handle, position: TextSize) -> Option<Type> {
         self.get_type_at_impl(handle, position, true)
+    }
+
+    /// Like `get_type_at`, but returns the raw bound type of an identifier
+    /// without coercing-to-callable or substituting in the chosen-overload
+    /// trace when the identifier appears in a call position.
+    ///
+    /// This preserves the declaration link (e.g. for `print` in `print(...)`,
+    /// returns the underlying `Function`/`Overload` referencing `builtins.pyi`
+    /// rather than a synthesized `Callable` for the matched overload). It is
+    /// intended for clients (such as the TSP `getComputedType` endpoint) that
+    /// re-resolve declarations on their side and need the wire type to carry
+    /// the original source declaration.
+    pub fn get_type_at_preserving_declaration(
+        &self,
+        handle: &Handle,
+        position: TextSize,
+    ) -> Option<Type> {
+        self.get_type_at_impl_with_options(handle, position, false, false)
     }
 
     fn get_result_type_at_impl(

--- a/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
@@ -921,3 +921,156 @@ fn test_get_computed_type_literal_bool_has_literal_value() {
 
     tsp.shutdown();
 }
+
+// =======================================================================
+// Regression: identifiers in call position preserve the original declaration
+//
+// `typeServer/getComputedType` must return the raw declared type for an
+// identifier even when that identifier appears in a call position. The LSP
+// `get_type_at` path coerces callees (substitutes the chosen-overload trace
+// or applies `coerce_type_to_callable`), which strips the original
+// `Declaration::Regular` link. TSP clients (e.g. Pylance) rely on the
+// declaration to re-resolve signatures on their side, so the TSP endpoint
+// uses `get_type_at_preserving_declaration` instead.
+//
+// Pylance bug: https://github.com/microsoft/pylance-release/issues/8020
+// =======================================================================
+
+#[test]
+fn test_get_computed_type_builtin_print_at_call_position_preserves_declaration() {
+    // Regression for pylance-release#8020. Querying `print` inside a call
+    // expression must return the underlying Function with a Regular
+    // declaration pointing at `builtins.pyi`, not a synthesized Callable
+    // and not the return type of the matched overload.
+    let (mut tsp, file_uri, snapshot) = setup_project("print(\"foo\", sep=\"x\")\n");
+
+    let result = get_computed_type_ok(&mut tsp, &file_uri, 0, 0, snapshot);
+
+    let kind = result
+        .get("kind")
+        .and_then(|v| v.as_u64())
+        .expect("Expected kind on print");
+    assert!(
+        kind == TypeKind::Function as u64 || kind == TypeKind::Overloaded as u64,
+        "Expected Function or Overloaded for `print` in call position, got kind={kind} (result={result})"
+    );
+
+    // The first function-shaped result (the type itself, or the first
+    // overload entry) must carry a Regular declaration that points back
+    // to a real source file (typeshed's builtins.pyi).
+    let function_like = if kind == TypeKind::Overloaded as u64 {
+        result
+            .get("overloads")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .cloned()
+            .expect("Expected at least one entry in overloads array")
+    } else {
+        result.clone()
+    };
+
+    let decl = function_like
+        .get("declaration")
+        .expect("Expected declaration on `print`");
+
+    // DeclarationKind::Regular = 0
+    let decl_kind = decl.get("kind").and_then(|v| v.as_u64());
+    assert_eq!(
+        decl_kind,
+        Some(0),
+        "Expected Regular declaration (kind=0) for `print`, got {decl_kind:?}. \
+         A Synthesized declaration here means the callee was coerced and the \
+         original typeshed declaration was lost."
+    );
+
+    let uri = decl
+        .get("node")
+        .and_then(|n| n.get("uri"))
+        .and_then(|v| v.as_str());
+    assert!(
+        uri.is_some_and(|u| u.contains("builtins.pyi")),
+        "Expected declaration URI to point at builtins.pyi for `print`, got: {uri:?}"
+    );
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_computed_type_overloaded_callee_returns_overloaded_not_return_type() {
+    // Querying an overloaded function at a call site must return the full
+    // Overloaded type (so clients see every signature), not the return type
+    // of the matched overload.
+    let code = "\
+from typing import overload
+
+@overload
+def process(value: int) -> str: ...
+@overload
+def process(value: str) -> int: ...
+def process(value):
+    return value
+
+process(1)
+";
+    let (mut tsp, file_uri, snapshot) = setup_project(code);
+
+    // Line 9 (0-indexed): `process(1)` — query the `process` identifier.
+    let result = get_computed_type_ok(&mut tsp, &file_uri, 9, 0, snapshot);
+    assert_kind(&result, TypeKind::Overloaded);
+
+    let overloads = result
+        .get("overloads")
+        .and_then(|v| v.as_array())
+        .expect("Expected overloads array on `process` at call site");
+    assert_eq!(
+        overloads.len(),
+        2,
+        "Expected 2 overload signatures for `process`, got {}",
+        overloads.len()
+    );
+}
+
+#[test]
+fn test_get_computed_type_local_def_callee_preserves_declaration() {
+    // Querying a locally-defined function at its call site must return a
+    // Function with a Regular declaration that names the function and
+    // points back at the source file.
+    let code = "\
+def greet(name: str) -> str:
+    return name
+
+greet(\"world\")
+";
+    let (mut tsp, file_uri, snapshot) = setup_project(code);
+
+    // Line 3 (0-indexed): `greet("world")` — query the `greet` identifier.
+    let result = get_computed_type_ok(&mut tsp, &file_uri, 3, 0, snapshot);
+    assert_kind(&result, TypeKind::Function);
+
+    let decl = result
+        .get("declaration")
+        .expect("Expected declaration on `greet` at call site");
+
+    // DeclarationKind::Regular = 0
+    let decl_kind = decl.get("kind").and_then(|v| v.as_u64());
+    assert_eq!(
+        decl_kind,
+        Some(0),
+        "Expected Regular declaration (kind=0) for `greet`, got {decl_kind:?}"
+    );
+
+    let name = decl.get("name").and_then(|v| v.as_str());
+    assert_eq!(name, Some("greet"), "Expected declaration name 'greet'");
+
+    let uri = decl
+        .get("node")
+        .and_then(|n| n.get("uri"))
+        .and_then(|v| v.as_str());
+    assert_eq!(
+        uri,
+        Some(file_uri.as_str()),
+        "Expected declaration URI to match the source file"
+    );
+
+    tsp.shutdown();
+}


### PR DESCRIPTION
## Summary

Fixes [microsoft/pylance-release#8020](https://github.com/microsoft/pylance-release/issues/8020) — _[TSP] Parameter hints don't work with TSP_.

When Pyrefly is used as a TSP server (e.g. with Pylance as the TSP client), parameter hints / signature help on a call like `print("foo", sep=)` never appear. The TSP client relies on `typeServer/getComputedType` to return the function's declared type so it can re-resolve the signature(s) (parameters, overloads, defaults) from source on its side. Today, the TSP endpoint funnels the request through `Transaction::get_type_at`, which — when the identifier is in call position — does one of two things:

1. Substitutes the **return type of the chosen overload** (via `get_chosen_overload_trace_for_surface`), or
2. Coerces the type to a synthesized `Callable` (`coerce_type_to_callable`).

Both paths discard the original `Declaration::Regular` link that points back at the function's source (e.g. `builtins.pyi` for `print`). With no `Regular` declaration on the wire, the TSP client has nothing to resolve back to and signature help silently fails.

This behavior is correct for the LSP hover path (you want the call's effective type / return type for hover), but wrong for TSP `getComputedType`, which is specified to return the raw declared type of the queried node.

## Fix

Split `get_type_at_impl` into a parameterized helper and add a public `get_type_at_preserving_declaration` entry point that skips the callee-coercion branch entirely. The TSP `getComputedType` handler in `lsp/non_wasm/server.rs` now calls the new method, while existing LSP consumers continue to use `get_type_at` and see no behavior change.

The change in `pyrefly/lib/state/lsp.rs` is purely a refactor + new flag:

- `get_type_at_impl` now delegates to `get_type_at_impl_with_options(..., coerce_callees: true)` — preserving today's LSP behavior.
- The new `get_type_at_impl_with_options` gates the call-position rewrite (chosen-overload trace + `coerce_type_to_callable`) on the `coerce_callees` flag.
- `get_type_at_preserving_declaration` is a thin public wrapper that passes `coerce_callees: false` (and `for_display: false`, since TSP serializes the type rather than rendering it).

## Tests

Three new regression tests in `pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs`, all driving the real TSP endpoint via `get_computed_type_ok`:

1. **`test_get_computed_type_builtin_print_at_call_position_preserves_declaration`** — the direct repro for #8020. Sends `print("foo", sep="x")`, queries the `print` identifier at the call site, and asserts the result is a `Function`/`Overloaded` whose first declaration is `DeclarationKind::Regular` (kind = 0) with a `node.uri` pointing at `builtins.pyi`. Before the fix this came back as a synthesized `Callable` / return-type with no usable declaration, which is exactly what broke Pylance's parameter hints.

2. **`test_get_computed_type_overloaded_callee_returns_overloaded_not_return_type`** — defines a two-overload `process` and queries it at `process(1)`. Asserts the returned kind is `Overloaded` and the `overloads` array has both signatures. Pre-fix, the chosen-overload trace collapsed this to the matched overload's return type (`str`), which would prevent the client from showing the alternate signature in signature help.

3. **`test_get_computed_type_local_def_callee_preserves_declaration`** — covers the non-builtin path: defines `greet` locally and queries it at `greet("world")`. Asserts kind is `Function`, the declaration is `Regular`, the declaration `name` is `"greet"`, and the declaration's `node.uri` matches the source file. This guards against regressions where coercion would still fire for user-defined functions.

Together these lock in: (a) the fix actually resolves #8020 for the canonical `print(...)` case, (b) overloads are preserved end-to-end for call sites, and (c) the behavior is correct for user code, not just typeshed.

## Risk

Scoped to the TSP `getComputedType` handler — all existing LSP callers continue to go through `get_type_at` unchanged.
