### PR TITLE
Fix callHierarchy/incomingCalls returning no callers for cross-file c…

### DIFF
--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3984,7 +3984,6 @@ fn compute_transitive_rdeps_for_definition_impl<T: RdepTransaction>(
                 sys_info,
             );
             let rdeps = transaction.transitive_rdeps(definition_handle.dupe());
-            transaction.run_for_handles(&[definition_handle], Require::Everything)?;
             rdeps
         }
     };
@@ -4002,10 +4001,12 @@ fn compute_transitive_rdeps_for_definition_impl<T: RdepTransaction>(
     {
         transitive_rdeps.remove(&fs_counterpart_of_in_memory_handles);
     }
-    let candidate_handles = transitive_rdeps
+    let candidate_handles: Vec<Handle> = transitive_rdeps
         .into_iter()
         .sorted_by_key(|h| h.path().dupe())
-        .collect::<Vec<_>>();
+        .collect();
+
+    transaction.run_for_handles(&candidate_handles, Require::Everything)?;
 
     Ok(candidate_handles)
 }

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -4815,7 +4815,6 @@ fn compute_transitive_rdeps_for_definition_impl<T: RdepTransaction>(
                 sys_info,
             );
             let rdeps = transaction.transitive_rdeps(definition_handle.dupe());
-            transaction.run_for_handles(&[definition_handle], Require::Everything)?;
             rdeps
         }
     };
@@ -4833,10 +4832,12 @@ fn compute_transitive_rdeps_for_definition_impl<T: RdepTransaction>(
     {
         transitive_rdeps.remove(&fs_counterpart_of_in_memory_handles);
     }
-    let candidate_handles = transitive_rdeps
+    let candidate_handles: Vec<Handle> = transitive_rdeps
         .into_iter()
         .sorted_by_key(|h| h.path().dupe())
-        .collect::<Vec<_>>();
+        .collect();
+
+    transaction.run_for_handles(&candidate_handles, Require::Everything)?;
 
     Ok(candidate_handles)
 }


### PR DESCRIPTION
Fixes #3636 

# Summary

When `didOpen` triggers `populate_all_project_files_in_config`, discovered project files are processed at `Require::Indexing` level. 

Later, when `callHierarchy/incomingCalls` processes the reverse dependencies to find call sites, the `process_fn` closure needs the AST of the caller module containing the callsite. Since the populated files are at Require::Indexing level (thus no AST), calling `get_ast` on their handles returns `None`, and the caller is silently dropped from the results.

This patch fixes the issue by running all candidates to `Require::Everything`, after computing candidate handles and before returning them in `compute_transitive_rdeps_for_definition_impl`.