### PR TITLE
Allow calling classmethods on protocol classes

### DIFF
--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -688,7 +688,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             };
             Ok(param_list_owner.push(ps).items().iter().rev().collect())
         };
-        for arg in self_arg.iter().chain(args.iter()) {
+        for (arg_idx, arg) in self_arg.iter().chain(args.iter()).enumerate() {
+            // The synthesized receiver (`self`/`cls`) is arg #0 when present; mark it so
+            // the protocol-concrete-class rule exempts it (see CallContext::binding_self).
+            let receiver_ctx;
+            let arg_call_context: &CallContext = if self_arg.is_some() && arg_idx == 0 {
+                receiver_ctx = call_context.clone().with_binding_self();
+                &receiver_ctx
+            } else {
+                call_context
+            };
             let mut arg_pre = arg.pre_eval(self, arg_errors);
             while arg_pre.step() {
                 let param = if let Some(p) = rparams.last() {
@@ -757,7 +766,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             arg_errors,
                             call_errors,
                             context,
-                            call_context,
+                            arg_call_context,
                         );
                         if let Some(name) = name
                             && let Some(ty) = arg_ty
@@ -793,7 +802,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             arg_errors,
                             call_errors,
                             context,
-                            call_context,
+                            arg_call_context,
                         );
                         if bound_args.is_some() {
                             if let Some(name) = name {

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -2840,6 +2840,11 @@ pub struct CallContext {
     require_boundary_consumption: Arc<AtomicBool>,
     /// Whether deferred state from this context lineage was consumed/drained.
     boundary_consumed_and_drained: Arc<AtomicBool>,
+    /// Set only while checking a method call's synthesized `self`/`cls` receiver,
+    /// where binding a protocol class object to its own `type[Self]` is valid — so
+    /// `subset.rs` skips the protocol-concrete-class rule here. A call-position fact,
+    /// not general subset state, so `with_outside_context` clears it.
+    binding_self: bool,
 }
 
 impl Default for CallContext {
@@ -2851,6 +2856,7 @@ impl Default for CallContext {
             witness_captures: Default::default(),
             require_boundary_consumption: Arc::new(AtomicBool::new(false)),
             boundary_consumed_and_drained: Arc::new(AtomicBool::new(false)),
+            binding_self: false,
         }
     }
 }
@@ -2870,6 +2876,15 @@ impl CallContext {
         self
     }
 
+    pub(crate) fn with_binding_self(mut self) -> Self {
+        self.binding_self = true;
+        self
+    }
+
+    pub(crate) fn is_binding_self(&self) -> bool {
+        self.binding_self
+    }
+
     pub fn require_boundary_consumption(self) -> Self {
         self.require_boundary_consumption
             .store(true, Ordering::Relaxed);
@@ -2885,6 +2900,7 @@ impl CallContext {
         self.witness = Default::default();
         self.argument_side = Default::default();
         self.witness_captures = Default::default();
+        self.binding_self = false;
         self
     }
 

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -2127,7 +2127,12 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
             (Type::ClassDef(got), Type::Type(inner))
                 if let Type::ClassType(want_cls) = &**inner
                     && self.type_order.is_protocol(want_cls.class_object())
-                    && self.type_order.is_protocol(got) =>
+                    && self.type_order.is_protocol(got)
+                    // The implicit `self`/`cls` receiver of a classmethod defined on a
+                    // protocol may legitimately be the protocol class object itself;
+                    // only reject protocol class objects in non-receiver positions
+                    // (explicit `type[P]` params/assignments).
+                    && !self.active_call_context.is_binding_self() =>
             {
                 // We only allow concrete class names to be assigned to `type[T]` if `T` is a protocol
                 Err(SubsetError::TypeOfProtocolNeedsConcreteClass(

--- a/pyrefly/lib/test/protocol.rs
+++ b/pyrefly/lib/test/protocol.rs
@@ -1006,3 +1006,135 @@ class Ok(Protocol):
     y: str = "default"
 "#,
 );
+
+// https://github.com/facebook/pyrefly/issues/3375
+testcase!(
+    test_protocol_classmethod_call,
+    r#"
+from typing import Protocol, assert_type
+
+class DT[T](Protocol):
+    @classmethod
+    def make(cls, x: T) -> "DT[T]":
+        raise RuntimeError()
+
+assert_type(DT.make(5), DT[int])
+"#,
+);
+
+// https://github.com/facebook/pyrefly/issues/3375
+testcase!(
+    test_protocol_classmethod_call_non_generic,
+    r#"
+from typing import Protocol, assert_type
+
+class P(Protocol):
+    @classmethod
+    def make(cls) -> "P":
+        raise RuntimeError()
+
+assert_type(P.make(), P)
+"#,
+);
+
+// https://github.com/facebook/pyrefly/issues/3375
+testcase!(
+    test_protocol_classmethod_returns_self,
+    r#"
+from typing import Protocol, Self
+
+class P(Protocol):
+    @classmethod
+    def make(cls) -> Self:
+        raise RuntimeError()
+
+P.make()  # OK: calling a classmethod on a bare protocol class is valid
+"#,
+);
+
+// https://github.com/facebook/pyrefly/issues/3375
+testcase!(
+    test_protocol_overloaded_classmethod_call,
+    r#"
+from typing import Protocol, overload, assert_type
+
+class DT[T](Protocol):
+    @overload
+    @classmethod
+    def now(cls, x: int) -> "DT[int]": ...
+    @overload
+    @classmethod
+    def now(cls, x: str) -> "DT[str]": ...
+    @classmethod
+    def now(cls, x: int | str) -> "DT[int] | DT[str]":
+        raise RuntimeError()
+
+assert_type(DT.now(5), DT[int])
+"#,
+);
+
+// https://github.com/facebook/pyrefly/issues/3375
+// Negative test: passing a protocol class object to an EXPLICIT `type[P]`
+// parameter must still error. The fix only exempts the synthesized self/cls
+// receiver of a classmethod call, not general `type[P]` slots.
+testcase!(
+    test_type_protocol_param_still_rejected,
+    r#"
+from typing import Protocol
+
+class P(Protocol):
+    def fly(self) -> None: ...
+
+class C:
+    def fly(self) -> None: ...
+
+def f(cls: type[P]) -> None:
+    cls()
+
+f(P)  # E: Argument `type[P]` is not assignable to parameter `cls` with type `type[P]`
+f(C)  # OK
+"#,
+);
+
+// https://github.com/facebook/pyrefly/issues/3375
+// Negative test: the exemption is confined to the synthesized receiver (arg #0).
+// A classmethod's *other* parameters annotated `type[P]` must still reject a
+// protocol class object — only the implicit `cls` receiver is exempt.
+testcase!(
+    test_protocol_classmethod_non_receiver_type_param_still_rejected,
+    r#"
+from typing import Protocol
+
+class P(Protocol):
+    def fly(self) -> None: ...
+
+class C:
+    def fly(self) -> None: ...
+
+class Reg(Protocol):
+    @classmethod
+    def register(cls, other: type[P]) -> None:
+        other()
+
+Reg.register(P)  # E: Argument `type[P]` is not assignable to parameter `other` with type `type[P]`
+Reg.register(C)  # OK
+"#,
+);
+
+// https://github.com/facebook/pyrefly/issues/3375
+// The receiver exemption must not make an *abstract* protocol classmethod
+// callable: with a trivial body, `name` is abstract, so the call is still
+// rejected — only the bogus receiver `bad-argument-type` is gone, replaced by
+// the correct `abstract-method-call`.
+testcase!(
+    test_protocol_abstract_classmethod_still_rejected,
+    r#"
+from typing import Protocol
+
+class P(Protocol):
+    @classmethod
+    def name(cls) -> str: ...
+
+P.name()  # E: Cannot call abstract method `P.name`
+"#,
+);


### PR DESCRIPTION
Fixes #3375

### What

Calling a `@classmethod` on a `Protocol` class object no longer emits a spurious
`bad-argument-type` error. For example, `datetype`'s `DateTime.now(UTC)` and
`prefect`'s `...is_callback_with_parameters()` now type-check cleanly, matching
mypy, pyright, and ty.

```python
from typing import Protocol

class P(Protocol):
    @classmethod
    def make(cls) -> "P": ...

P.make()   # before: ERROR "Only concrete classes may be assigned to type[P] ..."
           # after:  OK
```

### Why

The typing spec permits classmethods as protocol members, and all three reference
checkers (mypy/pyright/ty) accept calling them on the protocol class. Pyrefly was
the lone outlier, rejecting valid code.

Root cause: the receiver of a method call is checked as a **synthesized first
argument** against the method's implicit `cls`/`self` parameter, reusing the
ordinary argument-to-parameter subtype path. For a classmethod on a bare protocol
class that check is `type[P] <: type[P]`, which tripped the rule that forbids
assigning a protocol class object to an **explicit** `type[Protocol]` slot. That
rule is correct for user-written positions (`x: type[P] = P`, `f(cls: type[P])`,
where the holder might instantiate `cls()`), but wrong for the implicit receiver —
which is always the protocol itself, and is never instantiated by the binding.

The false positive and the genuine error reduce to the **identical** `got <: want`
(in the non-generic case, literally `type[P]` vs `type[P]`), so they cannot be
distinguished by type shape — only by **call context**.

### How

Carry that one bit of context:

- **`CallContext`** (`solver.rs`) gains a `binding_self: bool` flag (builder
  `with_binding_self()`, getter `is_binding_self()`), cleared by
  `with_outside_context` since it is a call-argument-position fact, not general
  subset state.
- **`callable_infer_params`** (`callable.rs`) sets the flag **only** on the
  synthesized receiver argument (arg #0 when present); every user-provided
  argument keeps the normal context.
- **The protocol-concrete-class rule** (`subset.rs`) gains the guard
  `&& !self.active_call_context.is_binding_self()`. When checking the receiver, the
  rule stands down and the match falls through to the normal
  `(ClassDef, Type::Type(..))` arm, which `promote_silently`s the class object and
  binds/solves it correctly.

This preserves the protocol-`type[]` semantics everywhere else and avoids the
heavier alternative of changing the classmethod receiver representation (which
would ripple into `Self` resolution and bound-method display across every
classmethod). No subset-cache change is needed: this rule's `want` is
`Type::Type(...)`, which `can_be_recursive` never memoizes.

### Test plan

Seven regression tests in `pyrefly/lib/test/protocol.rs`:

| Test | Asserts |
|---|---|
| `test_protocol_classmethod_call` | generic protocol classmethod → `DT.make(5)` is `DT[int]`, no error |
| `test_protocol_classmethod_call_non_generic` | `P.make()` is `P`, no error (the `got ≡ want` case) |
| `test_protocol_classmethod_returns_self` | classmethod returning `Self` → no error |
| `test_protocol_overloaded_classmethod_call` | overloaded classmethod (datetype's `now` shape) → `DT[int]` |
| `test_type_protocol_param_still_rejected` | **negative:** `f(cls: type[P]); f(P)` still errors |
| `test_protocol_classmethod_non_receiver_type_param_still_rejected` | **negative:** a classmethod's *non-receiver* `type[P]` param still rejects `P` (exemption confined to arg #0) |
| `test_protocol_abstract_classmethod_still_rejected` | **negative:** abstract protocol classmethod still uncallable (`Cannot call abstract method`) |
