### PR TITLE
Deterministic module order in `pyrefly coverage report`

### DIFF
--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -2198,6 +2198,9 @@ impl ReportArgs {
             module_reports.retain(|r| !r.symbol_reports.is_empty());
         }
 
+        // `handles` iterate in nondeterministic `HashSet` order; path disambiguates `--module`.
+        module_reports.sort_by(|a, b| (&a.name, &a.path).cmp(&(&b.name, &b.path)));
+
         let summary = Self::calculate_summary(&module_reports);
         let full_report = FullReport {
             schema_version: format!("{}.{}", REPORT_SCHEMA_VERSION.0, REPORT_SCHEMA_VERSION.1),

--- a/test/basic.md
+++ b/test/basic.md
@@ -279,3 +279,15 @@ $ touch $TMPDIR/pyrefly.toml && \
 warning: `pyrefly report` is deprecated; use `pyrefly coverage report` instead
 [0]
 ```
+
+## `pyrefly coverage report` emits modules in a deterministic order across runs
+
+```scrut
+$ cd $TMPDIR && rm -rf detrepo && mkdir detrepo && cd detrepo && touch pyrefly.toml && \
+> for i in 1 2 3 4 5 6; do echo "def f$i() -> int: return $i" > "m$i.py"; done && \
+> $PYREFLY coverage report m1.py m2.py m3.py m4.py m5.py m6.py > a.json 2>/dev/null && \
+> $PYREFLY coverage report m1.py m2.py m3.py m4.py m5.py m6.py > b.json 2>/dev/null && \
+> diff a.json b.json && echo IDENTICAL
+IDENTICAL
+[0]
+```


### PR DESCRIPTION
# Summary

This sorts the module reports to ensure that `pyrefly coverage report` produces deterministic output.

Fixes #3639

# Test Plan

Scrut test added