### PR TITLE
Treat `__getattribute__` param as implicitly typed in `pyrefly coverage report`

### DIFF
--- a/pyrefly/lib/commands/report.rs
+++ b/pyrefly/lib/commands/report.rs
@@ -1463,8 +1463,8 @@ impl ReportArgs {
             // __exit__/__aexit__(self, exc_type, exc_val, exc_tb)
             "__exit__" | "__aexit__" => non_self_param_pos <= 2,
             // First non-self param is protocol-fixed (str, int, or memoryview)
-            "__getattr__" | "__delattr__" | "__setattr__" | "__format__" | "__buffer__"
-            | "__release_buffer__" => non_self_param_pos == 0,
+            "__getattr__" | "__getattribute__" | "__delattr__" | "__setattr__" | "__format__"
+            | "__buffer__" | "__release_buffer__" => non_self_param_pos == 0,
             // __set_name__(self, owner, name: str) — name at position 1
             "__set_name__" => non_self_param_pos == 1,
             _ => false,

--- a/pyrefly/lib/test/report/test_files/dunder_params.expected.json
+++ b/pyrefly/lib/test/report/test_files/dunder_params.expected.json
@@ -4,16 +4,18 @@
   "names": [
     "test.WithExit.__exit__",
     "test.WithGetattr.__getattr__",
+    "test.WithGetattribute.__getattribute__",
     "test.WithSetattr.__setattr__",
     "test.AnnotatedExit.__exit__",
     "test.WithNewRenamed.__new__",
     "test.AnnotatedExit",
     "test.WithExit",
     "test.WithGetattr",
+    "test.WithGetattribute",
     "test.WithNewRenamed",
     "test.WithSetattr"
   ],
-  "line_count": 36,
+  "line_count": 41,
   "symbol_reports": [
     {
       "kind": "function",
@@ -41,7 +43,7 @@
     },
     {
       "kind": "function",
-      "name": "test.WithSetattr.__setattr__",
+      "name": "test.WithGetattribute.__getattribute__",
       "n_typable": 1,
       "n_typed": 0,
       "n_any": 0,
@@ -53,13 +55,25 @@
     },
     {
       "kind": "function",
+      "name": "test.WithSetattr.__setattr__",
+      "n_typable": 1,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 1,
+      "location": {
+        "line": 29,
+        "column": 5
+      }
+    },
+    {
+      "kind": "function",
       "name": "test.AnnotatedExit.__exit__",
       "n_typable": 1,
       "n_typed": 1,
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 29,
+        "line": 34,
         "column": 5
       }
     },
@@ -71,7 +85,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 34,
+        "line": 39,
         "column": 5
       }
     },
@@ -83,7 +97,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 28,
+        "line": 33,
         "column": 1
       }
     },
@@ -113,13 +127,25 @@
     },
     {
       "kind": "class",
+      "name": "test.WithGetattribute",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 23,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
       "name": "test.WithNewRenamed",
       "n_typable": 0,
       "n_typed": 0,
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 33,
+        "line": 38,
         "column": 1
       }
     },
@@ -131,23 +157,23 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 23,
+        "line": 28,
         "column": 1
       }
     }
   ],
   "type_ignores": [],
-  "n_typable": 6,
+  "n_typable": 7,
   "n_typed": 3,
   "n_any": 0,
-  "n_untyped": 3,
-  "coverage": 50.0,
-  "strict_coverage": 50.0,
+  "n_untyped": 4,
+  "coverage": 42.857142857142854,
+  "strict_coverage": 42.857142857142854,
   "n_functions": 0,
-  "n_methods": 5,
+  "n_methods": 6,
   "n_function_params": 0,
   "n_method_params": 2,
-  "n_classes": 5,
+  "n_classes": 6,
   "n_attrs": 0,
   "n_properties": 0,
   "n_type_ignores": 0

--- a/pyrefly/lib/test/report/test_files/dunder_params.py
+++ b/pyrefly/lib/test/report/test_files/dunder_params.py
@@ -5,7 +5,7 @@
 
 # Tests for dunder methods with implicit parameter types.
 # __exit__ params (exc_type, exc_val, exc_tb) are protocol-fixed → 0 slots.
-# __getattr__ param 0 (name: str) is implicit → 0 slots.
+# __getattr__/__getattribute__ param 0 (name: str) is implicit → 0 slots.
 # __setattr__ param 0 (name: str) is implicit, param 1 (value) is not.
 # Explicit annotations on implicit slots are still excluded.
 
@@ -17,6 +17,11 @@ class WithExit:
 
 class WithGetattr:
     def __getattr__(self, name):
+        return None
+
+
+class WithGetattribute:
+    def __getattribute__(self, name):
         return None
 
 


### PR DESCRIPTION
# Summary

This adds `__getattribute__` to the list of dunder methods whose parameter should be treated as implicitly typed (it's always `str`, after all).

Fixes #3640

# Test Plan

Updated the relevant test file.