### PR TITLE
Trim dependency debug info in dev builds to shrink `target/`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,10 @@ and inspect variables. Many code editors,
 for breakpoints and variable watch. You can also use the command line debuggers
 like [lldb](https://docs.rs/lldb/latest/lldb/#installation):
 
+`dev` builds carry only line tables to keep `target/` small. When you need to step
+through code in a debugger, build with the `dbg` profile (`cargo build --profile dbg`)
+for full debug info.
+
 ## Making a Pull Request
 
 Contributing a pull request (PR) is the main way to propose changes to Pyrefly. To ensure your PR is reviewed efficiently and has the best chance of being accepted, please make sure you have done the following:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,14 @@ lto = true
 codegen-units = 1
 strip = "debuginfo"
 
+# Dev keeps only line tables; use the `dbg` profile for full debug info.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dbg]
+inherits = "dev"
+debug = "full"
+
 [workspace]
 members = [
   "crates/pyrefly_build",


### PR DESCRIPTION
# Summary

Most of `target/debug` is debug info, which usually isn't of interest when doing a `dev` build. 
This removes this debug info in `dev` builds, and instead adds a new `dbg` profile for debugging purposes.

# Test Plan

Running `cargo build -q -p pyrefly` before and after in a clean env showed that `target/debug` went from 4.3G to 2.6G. So that's a -1.7G / -39% reduction.