### PR TITLE
Narrow TypedDict values on isinstance(x, dict) checks

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -442,11 +442,48 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
+    /// The runtime class an `isinstance` check sees, for types whose runtime identity differs from
+    /// their static type. Only `TypedDict`s qualify: not statically a `dict` subtype (mutability),
+    /// yet a plain `dict` at runtime. `None` otherwise — static type already matches runtime class.
+    fn runtime_class_for_isinstance(&self, ty: &Type) -> Option<&Class> {
+        match ty {
+            Type::TypedDict(_) | Type::PartialTypedDict(_) => Some(self.stdlib.dict_object()),
+            _ => None,
+        }
+    }
+
+    /// Decide `isinstance(left, target)` by `left`'s runtime class when it diverges from `left`'s
+    /// static type — `isinstance` is a runtime-class test, but `intersect`/`subtract` approximate
+    /// it with assignability. `Some(true/false)` = definitely is/isn't; `None` = defer to that
+    /// assignability path. Protocol targets defer too, preserving structural `isinstance`.
+    fn known_runtime_isinstance_result(&self, left: &Type, target: &Type) -> Option<bool> {
+        let runtime_class = self.runtime_class_for_isinstance(left)?;
+        let Type::ClassType(target) = target else {
+            return None;
+        };
+        if self
+            .get_metadata_for_class(target.class_object())
+            .is_protocol()
+        {
+            return None;
+        }
+        Some(self.has_superclass(runtime_class, target.class_object()))
+    }
+
     fn narrow_isinstance(&self, left: &Type, right: &Type) -> Type {
         let mut res = Vec::new();
         for right in self.as_class_info(right.clone()) {
             res.push(self.distribute_over_union(left, |l| {
                 if let Some((tparams, right)) = self.unwrap_isinstance_target(l, &right) {
+                    // When `l`'s runtime class diverges from its static type (e.g. a TypedDict is a
+                    // `dict` at runtime), use the runtime-instance answer rather than assignability.
+                    if let Some(is_inst) = self.known_runtime_isinstance_result(l, &right) {
+                        return if is_inst {
+                            l.clone()
+                        } else {
+                            self.heap.mk_never()
+                        };
+                    }
                     let (vs, right) = self
                         .solver()
                         .fresh_quantified(&tparams, right, self.uniques);
@@ -500,6 +537,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     continue;
                 }
                 if let Some((tparams, right)) = self.unwrap_isinstance_target(&result, right) {
+                    // Mirror of the positive branch: when the runtime class is known (e.g. a
+                    // TypedDict is always a `dict`), the negative branch removes it iff it is
+                    // definitely an instance; otherwise it can never be one, so keep it.
+                    if let Some(is_inst) = self.known_runtime_isinstance_result(&result, &right) {
+                        if is_inst {
+                            result = self.heap.mk_never();
+                        }
+                        continue;
+                    }
                     let (vs, right) = self
                         .solver()
                         .fresh_quantified(&tparams, right, self.uniques);

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -2310,6 +2310,100 @@ def g(x, y: tuple[type[int], type[str]]):
 );
 
 testcase!(
+    test_isinstance_dict_narrows_typed_dict,
+    r#"
+from typing import TypedDict
+class Config[T](TypedDict): pass
+def initialize[T](spec: T | type[T] | Config[T], /) -> T:
+    if isinstance(spec, type):
+        raise NotImplementedError
+    if isinstance(spec, dict):
+        raise NotImplementedError
+    return spec
+"#,
+);
+
+testcase!(
+    test_isinstance_dict_narrows_typed_dict_branches,
+    r#"
+from typing import TypedDict, assert_type
+class Config(TypedDict): pass
+def f(spec: int | Config) -> None:
+    if isinstance(spec, dict):
+        assert_type(spec, Config)
+    else:
+        assert_type(spec, int)
+"#,
+);
+
+testcase!(
+    test_isinstance_typed_dict_mutablemapping_and_mapping,
+    r#"
+from typing import TypedDict, Mapping, MutableMapping, assert_type
+class Config(TypedDict): pass
+def f(spec: int | Config) -> None:
+    if isinstance(spec, MutableMapping):
+        assert_type(spec, Config)
+    else:
+        assert_type(spec, int)
+def g(spec: int | Config) -> None:
+    # Mapping already worked (a TypedDict is assignable to read-only Mapping);
+    # this is the no-regression check.
+    if isinstance(spec, Mapping):
+        assert_type(spec, Config)
+    else:
+        assert_type(spec, int)
+"#,
+);
+
+testcase!(
+    test_isinstance_typed_dict_unrelated_class_does_not_narrow,
+    r#"
+from typing import TypedDict, assert_type, Never
+class Config(TypedDict): pass
+def f(spec: Config) -> None:
+    # A TypedDict is not an int at runtime, so the positive branch is Never
+    # and the negative branch keeps the full TypedDict.
+    if isinstance(spec, int):
+        assert_type(spec, Never)
+    else:
+        assert_type(spec, Config)
+"#,
+);
+
+testcase!(
+    test_isinstance_dict_non_typeddict_unchanged,
+    r#"
+from typing import assert_type, Never
+def f(x: int | str) -> None:
+    # Guards against an over-broad change: non-TypedDict narrowing is untouched.
+    if isinstance(x, dict):
+        assert_type(x, Never)
+    else:
+        assert_type(x, int | str)
+"#,
+);
+
+testcase!(
+    test_isinstance_typed_dict_runtime_checkable_protocol,
+    r#"
+from typing import TypedDict, Protocol, runtime_checkable, Iterable, assert_type
+@runtime_checkable
+class HasKeys(Protocol):
+    def keys(self) -> Iterable[str]: ...
+class Config(TypedDict): pass
+def f(spec: int | Config) -> None:
+    # A TypedDict structurally satisfies a method protocol it implements (dict has
+    # `keys()`), so the `dict`-runtime-class shortcut must NOT fire for protocol
+    # targets: it defers to structural narrowing, which keeps Config positive.
+    if isinstance(spec, HasKeys):
+        assert_type(spec, Config)
+    else:
+        assert_type(spec, int)
+"#,
+);
+
+testcase!(
     test_typeguard_argument_number,
     r#"
 from typing import TypeGuard


### PR DESCRIPTION
Fixes #3075

### What
`isinstance(x, dict)` (and `MutableMapping`) now narrows a `TypedDict` like a real `dict`, because at runtime it is one. Before, the positive branch dropped the TypedDict and the negative branch kept it, producing false errors on sound code:

```python
from typing import TypedDict
class Config[T](TypedDict): pass

def initialize[T](spec: T | type[T] | Config[T], /) -> T:
    if isinstance(spec, type): raise NotImplementedError
    if isinstance(spec, dict): raise NotImplementedError
    return spec
    # before: ERROR Returned type `Config[T] | T` is not assignable to `T` [bad-return]
    # after:  ok (spec is `T`)
```

### Why
`isinstance` narrowing decided instance-hood with the **assignability** relation (`is_subset_eq`), but `isinstance` is a **runtime-class** test. A `TypedDict` is deliberately *not assignable* to a mutable `dict[...]` (mutability/variance), yet every TypedDict value is a plain `dict` at runtime — so the assignability answer is wrong here. The positive branch collapsed the TypedDict to `Never`; the negative kept it.

pyright narrows this correctly. mypy doesn't narrow it either, but its own docs concede TypedDicts are runtime dicts, and `ty`'s positive branch already keeps `Config & dict` (it agrees a TypedDict is a dict). Runtime semantics + pyright + the maintainer's confirmation on the issue are the bar here, not the conformance majority.

### How
- **`pyrefly/lib/alt/narrow.rs`**
  - `runtime_class_for_isinstance(ty)` — maps a type whose runtime identity differs from its static type to that runtime class. Only `TypedDict`/`PartialTypedDict` qualify → `dict`.
  - `known_runtime_isinstance_result(left, target)` — when `left` has such a runtime class, answers the check with the nominal `has_superclass` relation against it; protocol targets return `None` (defer to structural narrowing).
  - Both `narrow_isinstance` (positive) and `narrow_is_not_instance` (negative) consult this before the assignability path.
- **Deliberately untouched:** `is_subset_eq` / `intersect` / `subtract` — general assignability is unchanged; `issubclass` (a TypedDict value isn't a class object); `type(x) != dict` negative narrowing (already intentionally limited).

### Test plan
`pyrefly/lib/test/narrow.rs`:

| test | protects |
|------|----------|
| `test_isinstance_dict_narrows_typed_dict` | the issue repro — `return spec` is clean |
| `test_isinstance_dict_narrows_typed_dict_branches` | positive → `Config`, negative → `int` |
| `test_isinstance_typed_dict_mutablemapping_and_mapping` | `MutableMapping` narrows; `Mapping` no-regression |
| `test_isinstance_typed_dict_unrelated_class_does_not_narrow` | `isinstance(td, int)` → positive `Never`, negative keeps the TypedDict |
| `test_isinstance_dict_non_typeddict_unchanged` | `int | str` vs `dict` unchanged (no over-broad change) |
| `test_isinstance_typed_dict_runtime_checkable_protocol` | protocol target defers → keeps `Config` in positive branch |

- `cargo test -p pyrefly test::narrow` → **201 passed**.
- Format + lint (`test.py --no-test --no-conformance --no-jsonschema`) → clean.
- `mypy_primer` (~43 projects: pydantic, pandera, pandas, sympy, jax, scipy, xarray, sphinx, …): **1 diff — a removed false positive in `prefect`** (this exact bug in the wild), **0 regressions**.
