### PR TITLE
Don't pin an empty container's element from a covariant read

### DIFF
--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -634,7 +634,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         return true;
                     };
                     for t in param_types {
-                        if !self.is_equivalent(first, t) {
+                        if !self.probe(first, t, &placeholder_vars, |s| s.is_equivalent(first, t)) {
                             return true;
                         }
                     }
@@ -689,9 +689,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
             }
             let selected_overload = if spec_compliant {
-                self.disambiguate_overloads_spec_compliant(&matched_overloads)
+                self.disambiguate_overloads_spec_compliant(&matched_overloads, &placeholder_vars)
             } else {
-                self.disambiguate_overloads(&matched_overloads)
+                self.disambiguate_overloads(&matched_overloads, &placeholder_vars)
             };
             if let Some(idx) = selected_overload {
                 let overload = matched_overloads
@@ -744,6 +744,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     fn disambiguate_overloads_spec_compliant(
         &self,
         matched_overloads: &[CalledOverload<'_>],
+        placeholder_vars: &[Var],
     ) -> Option<usize> {
         // Step 5, part 2: are all remaining return types equivalent to one another?
         // If not, the call is ambiguous.
@@ -751,14 +752,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let first_overload = matched_overloads
             .next()
             .expect("Expected at least one overload");
-        if matched_overloads.any(|o| !self.is_equivalent(&first_overload.res, &o.res)) {
+        if matched_overloads.any(|o| {
+            !self.probe(&first_overload.res, &o.res, placeholder_vars, |s| {
+                s.is_equivalent(&first_overload.res, &o.res)
+            })
+        }) {
             return None;
         }
         // Step 6: if there are still multiple matches, pick the first one.
         Some(0)
     }
 
-    fn disambiguate_overloads(&self, matched_overloads: &[CalledOverload<'_>]) -> Option<usize> {
+    fn disambiguate_overloads(
+        &self,
+        matched_overloads: &[CalledOverload<'_>],
+        placeholder_vars: &[Var],
+    ) -> Option<usize> {
         // When a call to an overloaded function may match multiple overloads, the spec says to
         // return Any when the return types are not all equivalent.
         // However, neither mypy nor pyright fully follows this part of the spec, and many
@@ -776,14 +785,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // First, find a candidate return type.
         let mut candidate = 0;
         for (i, o) in matched_overloads.iter().enumerate().skip(1) {
-            if !self.is_subset_eq(&o.res.materialize(), &matched_overloads[candidate].res) {
+            let got = o.res.materialize();
+            let want = &matched_overloads[candidate].res;
+            if !self.probe(&got, want, placeholder_vars, |s| s.is_subset_eq(&got, want)) {
                 candidate = i;
             }
         }
         // We've already checked every return type after the candidate.
         // Check every return type before the candidate.
         for o in matched_overloads.iter().take(candidate) {
-            if !self.is_subset_eq(&o.res.materialize(), &matched_overloads[candidate].res) {
+            let got = o.res.materialize();
+            let want = &matched_overloads[candidate].res;
+            if !self.probe(&got, want, placeholder_vars, |s| s.is_subset_eq(&got, want)) {
                 return None;
             }
         }
@@ -821,6 +834,36 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         }
         placeholder_vars
+    }
+
+    /// Compare two candidate overloads without committing side effects.
+    /// `is_equivalent`/`is_subset_eq` can pin/unify vars, but disambiguation must only
+    /// observe, so we snapshot the operands' vars (expanded) plus the call's placeholder
+    /// vars, compare, then restore. Without this, `sum([])` leaks a pin onto the empty
+    /// list's element var. See facebook/pyrefly#1584. Like the solver's
+    /// `is_subset_eq_probe_for_pruning`, this covers syntactically-reachable vars only, not
+    /// bound-only vars; no leak through that gap is known.
+    fn probe<F: FnOnce(&Self) -> bool>(
+        &self,
+        left: &Type,
+        right: &Type,
+        placeholder_vars: &[Var],
+        compare: F,
+    ) -> bool {
+        let mut vars = placeholder_vars.to_vec();
+        for operand in [left, right] {
+            let mut expanded = operand.clone();
+            self.solver().expand_mut(&mut expanded);
+            for var in expanded.collect_all_vars() {
+                if !vars.contains(&var) {
+                    vars.push(var);
+                }
+            }
+        }
+        let snapshot = self.solver().snapshot_vars(&vars);
+        let result = compare(self);
+        self.solver().restore_vars(snapshot);
+        result
     }
 
     fn call_overload<'c>(

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -3558,7 +3558,7 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                             }
                         }
                         // Widen None to None | Any for PartialQuantified, matching
-                        // the PartialContained behavior (see comment there).
+                        // the PartialContained write arm below.
                         let variables = self.solver.variables.lock();
                         let v1_current = variables.get(*v1);
                         if let Variable::Answer(t) | Variable::ResidualAnswer { ty: t, .. } =
@@ -3575,19 +3575,13 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                         Ok(())
                     }
                     Variable::PartialContained(_) => {
+                        // A covariant read (upper bound) tells us only that whatever the
+                        // empty container holds must be `<: t2`; it does not tell us the
+                        // element type. Leave the placeholder unsolved so it is pinned only
+                        // by writes (lower bounds), invariant params, or generic type-var
+                        // inference -- and otherwise defaults to `Any`. See
+                        // facebook/pyrefly#1584.
                         drop(v1_ref);
-                        // When an empty container's element is pinned to None, widen to
-                        // None | Any. A bare None in the first use almost always means the
-                        // container will later hold some other (unknown) type, analogous
-                        // to how `self.x = None` is inferred as `None | Any` for attributes.
-                        let answer = if t2.is_none() {
-                            self.solver
-                                .heap
-                                .mk_union(vec![t2.clone(), Type::any_implicit()])
-                        } else {
-                            t2.clone()
-                        };
-                        variables.update(*v1, Variable::Answer(answer));
                         Ok(())
                     }
                     Variable::Recursive => {
@@ -3667,7 +3661,7 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                                 .insert(*v2, specialization_error);
                         }
                         // Widen None to None | Any for PartialQuantified, matching
-                        // the PartialContained behavior (see comment there).
+                        // the PartialContained write arm below.
                         let variables = self.solver.variables.lock();
                         if answer.is_none() {
                             let widened = self
@@ -3685,8 +3679,13 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                             .clone()
                             .promote_implicit_literals(self.type_order.stdlib());
                         drop(v2_ref);
-                        // Widen None to None | Any (see comment at the other
-                        // PartialContained pinning site above).
+                        // This lower-bound (write) arm is the only place an empty
+                        // container's element is pinned -- the upper-bound (read) arm
+                        // above intentionally does not pin (see facebook/pyrefly#1584).
+                        // When the first write is `None`, widen to `None | Any`: a bare
+                        // `None` first use almost always means the container will later
+                        // hold some other (unknown) type, analogous to how `self.x = None`
+                        // is inferred as `None | Any` for attributes.
                         let answer = if t1_p.is_none() {
                             self.solver.heap.mk_union(vec![t1_p, Type::any_implicit()])
                         } else {

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -3505,82 +3505,13 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                                 self.is_subset_eq(got, want)
                             })
                     }
-                    Variable::PartialQuantified(q) => {
-                        let name = q.name.clone();
-                        let restriction = q.restriction().clone();
-                        let bound = q.upper_bound(self.type_order.stdlib(), &self.solver.heap);
-                        drop(v1_ref);
-
-                        // For constrained TypeVars, promote to the matching constraint type
-                        // rather than pinning to the raw argument type.
-                        if let Restriction::Constraints(ref constraints) = restriction {
-                            variables.update(*v1, Variable::Answer(t2.clone()));
-                            drop(variables);
-                            if let Some(constraint) = self.find_matching_constraint(t2, constraints)
-                            {
-                                let constraint = constraint.clone();
-                                self.solver
-                                    .variables
-                                    .lock()
-                                    .update(*v1, Variable::Answer(constraint));
-                            } else if let Err(e) = self.is_subset_eq(t2, &bound) {
-                                // No individual constraint matched, but the type may still
-                                // be assignable to the constraint union (e.g. an abstract
-                                // `AnyStr` satisfies `str | bytes`). Only error if it fails
-                                // the union bound check too.
-                                self.solver.instantiation_errors.write().insert(
-                                    *v1,
-                                    TypeVarSpecializationError {
-                                        name,
-                                        got: t2.clone(),
-                                        want: bound,
-                                        error_kind: ErrorKind::BadSpecialization,
-                                        message_override: None,
-                                        error: e,
-                                    },
-                                );
-                            }
-                        } else {
-                            variables.update(*v1, Variable::Answer(t2.clone()));
-                            drop(variables);
-                            if let Err(e) = self.is_subset_eq(t2, &bound) {
-                                self.solver.instantiation_errors.write().insert(
-                                    *v1,
-                                    TypeVarSpecializationError {
-                                        name,
-                                        got: t2.clone(),
-                                        want: bound,
-                                        error_kind: ErrorKind::BadSpecialization,
-                                        message_override: None,
-                                        error: e,
-                                    },
-                                );
-                            }
-                        }
-                        // Widen None to None | Any for PartialQuantified, matching
-                        // the PartialContained write arm below.
-                        let variables = self.solver.variables.lock();
-                        let v1_current = variables.get(*v1);
-                        if let Variable::Answer(t) | Variable::ResidualAnswer { ty: t, .. } =
-                            &*v1_current
-                            && t.is_none()
-                        {
-                            let widened = self
-                                .solver
-                                .heap
-                                .mk_union(vec![t.clone(), Type::any_implicit()]);
-                            drop(v1_current);
-                            variables.update(*v1, Variable::Answer(widened));
-                        }
-                        Ok(())
-                    }
-                    Variable::PartialContained(_) => {
-                        // A covariant read (upper bound) tells us only that whatever the
-                        // empty container holds must be `<: t2`; it does not tell us the
-                        // element type. Leave the placeholder unsolved so it is pinned only
-                        // by writes (lower bounds), invariant params, or generic type-var
-                        // inference -- and otherwise defaults to `Any`. See
-                        // facebook/pyrefly#1584.
+                    Variable::PartialContained(_) | Variable::PartialQuantified(_) => {
+                        // A covariant read (upper bound) constrains the element to `<: t2` but
+                        // does not determine it, so leave the placeholder unsolved -- for both
+                        // literals (`[]`, `{}` -> PartialContained) and constructor calls (`set()`,
+                        // `dict()`, `list()` -> PartialQuantified). The element is pinned only via
+                        // the lower arm (writes, invariant params, generic inference); otherwise it
+                        // defaults to `Any`. See facebook/pyrefly#1584.
                         drop(v1_ref);
                         Ok(())
                     }

--- a/pyrefly/lib/test/delayed_inference.rs
+++ b/pyrefly/lib/test/delayed_inference.rs
@@ -75,6 +75,20 @@ assert_type(g, list[int])
 "#,
 );
 
+// Constructor (`set()`, PartialQuantified) sibling-arg inference: the covariant
+// read of `xs` must not pin, but solving `T` against `y=1` (`int <: T`) MUST, via
+// the lower-bound arm. See facebook/pyrefly#1485 and #1584.
+testcase!(
+    test_empty_set_generic_cross_arg,
+    r#"
+from typing import Iterable, assert_type
+def gen[T](xs: Iterable[T], y: T) -> None: ...
+s = set()
+gen(s, 1)
+assert_type(s, set[int])
+"#,
+);
+
 // Intended behavior change (#1584): a concrete covariant read no longer pins
 // the empty container's element type; it stays unsolved and defaults to Any.
 testcase!(
@@ -88,20 +102,17 @@ assert_type(d, list[Any])
 "#,
 );
 
-// The #1584 fix covers empty container *literals* (`[]`, `{}`), which use the
-// `PartialContained` first-use placeholder. `set()` is a constructor *call*, so
-// its element goes through a different (generic) placeholder path and is NOT
-// covered: a covariant read still pins it. Tracked here so the gap isn't
-// silently assumed handled (pyright leaves it `set[Unknown]`).
+// #1584 extended from literals to constructor calls: `set()`'s element is a
+// `PartialQuantified` placeholder, but a covariant read still must not pin it ->
+// stays `Any` (pyright: `set[Unknown]`). See facebook/pyrefly#1584.
 testcase!(
-    bug = "covariant read of set() still pins its element (constructor path, not PartialContained)",
-    test_empty_set_covariant_read_still_pins,
+    test_empty_set_covariant_read_stays_any,
     r#"
-from typing import Iterable, assert_type
+from typing import Iterable, assert_type, Any
 def take_iter(z: Iterable[int]) -> None: ...
 s = set()
 take_iter(s)
-assert_type(s, set[int])
+assert_type(s, set[Any])
 "#,
 );
 
@@ -139,6 +150,37 @@ d = {}
 def take_map(z: Mapping[str, int]) -> None: ...
 take_map(d)
 assert_type(d, dict[str, Any])
+"#,
+);
+
+// `dict()` constructor (PartialQuantified key/value). Read as `Mapping[str, int]`:
+// the value param is covariant -> read does not pin -> `Any`; the key param is
+// invariant -> pinned to `str` via the lower arm. Cf. the `{}` literal in
+// `test_empty_dict_covariant_read_value_unpinned`. See facebook/pyrefly#1584.
+testcase!(
+    test_empty_dict_constructor_covariant_read,
+    r#"
+from typing import Mapping, assert_type, Any
+d = dict()
+def take_map(z: Mapping[str, int]) -> None: ...
+take_map(d)
+assert_type(d, dict[str, Any])
+"#,
+);
+
+// Covariant read of a BOUNDED first-use placeholder: passes `str` (violates bound
+// `int`) yet neither pins nor errors -> `list[Any]`, matching pyright. Guards that
+// removing the old upper-arm bound validation surfaced no spurious
+// `BadSpecialization`. See facebook/pyrefly#1584.
+testcase!(
+    test_bounded_generic_covariant_read_no_pin,
+    r#"
+from typing import Iterable, assert_type, Any
+def make[T: int](x: T | None) -> list[T]: ...
+xs = make(None)
+def take_str_iter(z: Iterable[str]) -> None: ...
+take_str_iter(xs)  # str violates bound int; covariant read must not pin or error
+assert_type(xs, list[Any])
 "#,
 );
 

--- a/pyrefly/lib/test/delayed_inference.rs
+++ b/pyrefly/lib/test/delayed_inference.rs
@@ -39,6 +39,110 @@ assert_type(x, list[Any])
 );
 
 testcase!(
+    test_sum_empty_list,
+    r#"
+from typing import assert_type, Any
+x = []
+y = sum(x)
+assert_type(x, list[Any])
+assert_type(y, int)
+"#,
+);
+
+testcase!(
+    test_empty_list_invariant_param,
+    r#"
+from typing import assert_type
+c = []
+def f(z: list[int]) -> None: ...
+f(c)
+assert_type(c, list[int])
+"#,
+);
+
+// CRITICAL: cross-argument generic inference must still pin the element type.
+// A bare covariant read (e.g. `sum(x)`) must NOT pin an empty container's
+// element, but solving a generic type-var against a sibling argument's value
+// MUST. See facebook/pyrefly#1485 and #1584.
+testcase!(
+    test_empty_list_generic_cross_arg,
+    r#"
+from typing import Iterable, assert_type
+def gen[T](xs: Iterable[T], y: T) -> None: ...
+g = []
+gen(g, 1)
+assert_type(g, list[int])
+"#,
+);
+
+// Intended behavior change (#1584): a concrete covariant read no longer pins
+// the empty container's element type; it stays unsolved and defaults to Any.
+testcase!(
+    test_empty_list_covariant_read_stays_any,
+    r#"
+from typing import Iterable, assert_type, Any
+d = []
+def take_iter(z: Iterable[int]) -> None: ...
+take_iter(d)
+assert_type(d, list[Any])
+"#,
+);
+
+// The #1584 fix covers empty container *literals* (`[]`, `{}`), which use the
+// `PartialContained` first-use placeholder. `set()` is a constructor *call*, so
+// its element goes through a different (generic) placeholder path and is NOT
+// covered: a covariant read still pins it. Tracked here so the gap isn't
+// silently assumed handled (pyright leaves it `set[Unknown]`).
+testcase!(
+    bug = "covariant read of set() still pins its element (constructor path, not PartialContained)",
+    test_empty_set_covariant_read_still_pins,
+    r#"
+from typing import Iterable, assert_type
+def take_iter(z: Iterable[int]) -> None: ...
+s = set()
+take_iter(s)
+assert_type(s, set[int])
+"#,
+);
+
+// A covariant read as the FIRST use no longer pins (the #1584 fix). Like any
+// non-pinning first use -- e.g. `print(x)` in
+// `test_inference_when_first_use_does_not_determine_type` -- it still consumes
+// first-use inference, so a *later* write does not pin either; the element
+// defaults to `Any`. This is pyrefly's pre-existing first-use design, not
+// specific to #1584. (Before the fix the read instead pinned `list[str]`, making
+// the `append(1)` a false positive -- so this is strictly an improvement, though
+// pyright is more precise at `list[int]`.)
+testcase!(
+    test_empty_list_covariant_read_then_write,
+    r#"
+from typing import Iterable, assert_type, Any
+x = []
+def take_iter(z: Iterable[str]) -> None: ...
+take_iter(x)
+x.append(1)
+assert_type(x, list[Any])
+"#,
+);
+
+// `{}` is a container literal (PartialContained), so the #1584 fix applies to its
+// *value* (covariant in Mapping -> no longer pinned -> Any). The *key* is still
+// pinned to `str` because Mapping's key parameter is invariant and constrains via
+// the lower-bound (write) path -- the same intended invariant pinning as
+// `test_empty_list_check`. (pyright/mypy leave both Unknown/Any; pyrefly
+// deliberately infers from invariant positions.)
+testcase!(
+    test_empty_dict_covariant_read_value_unpinned,
+    r#"
+from typing import Mapping, assert_type, Any
+d = {}
+def take_map(z: Mapping[str, int]) -> None: ...
+take_map(d)
+assert_type(d, dict[str, Any])
+"#,
+);
+
+testcase!(
     test_simple_int_operation_in_loop,
     r#"
 from typing import assert_type, Literal

--- a/pyrefly/lib/test/inference.rs
+++ b/pyrefly/lib/test/inference.rs
@@ -203,6 +203,19 @@ x2 = {}
 "#,
 );
 
+// A bare covariant read no longer pins an empty container's element type, so
+// the container stays unsolved and the ImplicitAny diagnostic fires. Before the
+// fix for facebook/pyrefly#1584, `sum(x)` pinned the element to typeshed's
+// literal-int union, which silently suppressed this diagnostic.
+testcase!(
+    test_implicit_any_empty_container_covariant_read,
+    TestEnv::new().enable_implicit_any_error(),
+    r#"
+x = [] # E: Cannot infer type of empty container
+sum(x)
+"#,
+);
+
 testcase!(
     test_explicit_any_default_disabled,
     r#"

--- a/pyrefly/lib/test/literal.rs
+++ b/pyrefly/lib/test/literal.rs
@@ -362,7 +362,6 @@ def f(x: int):
 );
 
 testcase!(
-    bug = "Bad interaction between overload resolution and partial type inference",
     test_partial_inference_literalstring_join,
     r#"
 from typing import assert_type, LiteralString, reveal_type
@@ -371,8 +370,10 @@ def f(x1: list[str], x2: list[LiteralString]):
     x3 = []
     assert_type(", ".join(x1), str)
     assert_type(", ".join(x2), LiteralString)
-    # This is wrong: we should not assume `join`'s `LiteralString` overload is matched.
-    reveal_type(", ".join(x3))  # E: revealed type: LiteralString
+    # `x3` is an empty list whose element type is only read (covariant) by `join`,
+    # so it stays unsolved (defaults to `Any`) rather than being pinned to
+    # `join`'s `LiteralString` overload param. See facebook/pyrefly#1584.
+    reveal_type(", ".join(x3))  # E: revealed type: str
     "#,
 );
 


### PR DESCRIPTION
Fixes #1584

### What
Passing an empty list to `sum` (or any covariant reader) no longer pins the list's element type to the parameter's element.

```python
x = []
y = sum(x)
reveal_type(x)
# before: list[Literal[-20, -19, …, 24, 25] | bool]   (typeshed's sum-overload union)
# after:  list[Unknown]                                (y is int, unchanged)
```

### Why
`x = []` is a list whose element type isn't known yet. pyrefly's first-use inference looks at the first use to infer it — but it was treating a *covariant read* as evidence. Passing `x` where `Iterable[E]` is expected only asserts "whatever is in the list is `<: E`"; it says nothing about what the list **contains** (you can't write into an `Iterable`). So pinning the element to `E` is unsound — and for `sum`, `E` is typeshed's artificial `bool | _LiteralInteger` (= `Literal[-20..25]`) hack, which is how the nonsense union ended up on `x`. pyright, mypy, and ty all leave the element unsolved (`list[Unknown]` / `list[Any]`) — they are the conformance bar.

An empty container's element should come only from **lower** bounds: values written in (`append`), the equality an **invariant** parameter (`list[E]`) forces, or a generic type var solved against a value. Two code paths were pinning it from a read; both are fixed under that one principle.

### How
- **`pyrefly/lib/solver/solver.rs`** — in `is_subset_eq_var`, the `PartialContained` **upper-bound** arm (a covariant read) no longer pins; it leaves the placeholder unsolved. The **lower-bound** arm (writes / invariance) is untouched, so `append` and `list[int]`-style params still pin.
- **`pyrefly/lib/alt/overload.rs`** — `is_equivalent`/`is_subset_eq` are *side-effecting* (they record bounds and pin/unify vars). Overload disambiguation ran them **outside** any snapshot, leaking a pin onto the element while choosing which `sum` overload to materialize. A new `probe` helper runs those comparisons under `snapshot_vars`/`restore_vars` so disambiguation only observes; the authoritative pin still happens in the selected overload's contextual call.

**Deliberately unchanged:** writes (`append`), invariant parameters, and generic cross-argument inference (`gen[T](Iterable[T], y: T); gen([], 1)` → `list[int]`) all still pin via lower bounds. **Scope:** the fix covers empty container *literals* (`[]`, `{}`); `set()` is a constructor call on a different placeholder path and is left as a documented `bug`-marked gap.

### Test plan
| Test | Protects |
|------|----------|
| `delayed_inference::test_sum_empty_list` | the repro: `x` is `list[Any]`, `y` is `int` |
| `delayed_inference::test_empty_list_invariant_param` | invariant `list[int]` param still pins `list[int]` |
| `delayed_inference::test_empty_list_generic_cross_arg` | generic cross-arg `gen([], 1)` still pins `list[int]` (regression guard) |
| `delayed_inference::test_empty_list_covariant_read_stays_any` | covariant read → `list[Any]` (intended change) |
| `delayed_inference::test_empty_list_covariant_read_then_write` | read-then-write → `list[Any]` (existing first-use limitation; was a false positive before) |
| `delayed_inference::test_empty_dict_covariant_read_value_unpinned` | `{}` value unpinned, key pinned via Mapping's invariant key |
| `delayed_inference::test_empty_set_covariant_read_still_pins` | `bug=` marker documenting the `set()` constructor-path gap |
| `inference::test_implicit_any_empty_container_covariant_read` | with `ImplicitAnyEmptyContainer` enabled, the diagnostic now fires |
| `literal::test_partial_inference_literalstring_join` | `bug=` removed: `", ".join([])` now `str`, not `LiteralString` |

- Full lib suite: **passing, 0 failed**.
- Conformance: regenerated, **0 moved results**.
- Format + lint: clean.
- mypy_primer (broad ecosystem set: pydantic, pandas, pandera, attrs, rich, sympy, aiohttp, sphinx, tornado, trio, werkzeug, black, mypy, comtypes, spark, discord.py, …): **0 errors added, 0 removed** — only 2 cosmetic element-type display shifts within pre-existing errors (`attrs` `dict[str, object]`→`dict[str, Unknown]`; `discord.py` `list[int]`→`list[@_]`).
