### PR TITLE
configuration.mdx: Add missing backticks

### DIFF
--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -1098,13 +1098,13 @@ you've configured yourself, either through CLI flags or a config file.
 We look for an interpreter with the following logic:
 
 1. Use [`python-interpreter-path`](#python-interpreter-path),
-   [`fallback-python-interpreter-name](#fallback-python-interpreter-name), or
+   [`fallback-python-interpreter-name`](#fallback-python-interpreter-name), or
    [`conda-environment`](#conda-environment) if any are set by a flag.
    More than one cannot be set in flags at the same time.
 2. Determine if there's an active `venv` or `conda` environment. If both are active at
    the same time, we take `venv` over `conda`.
 3. Use [`python-interpreter-path`](#python-interpreter-path),
-   [`fallback-python-interpreter-name](#fallback-python-interpreter-name), or
+   [`fallback-python-interpreter-name`](#fallback-python-interpreter-name), or
    [`conda-environment`](#conda-environment) if either are set in a config file.
    Both cannot be set in a config at the same time.
 4. Find a `venv` at the root of the project by searching for something that looks like a
@@ -1155,7 +1155,7 @@ directories under `src/`, so therefore, we will recursively match everything und
 Examples:
 
 - `src/**/*.py`: only match `.py` files under `src/`
-- `src`, `src/`, `src/*`, `src/**`, and `src/**/*`: match all `.py` and `.pyi` files under `src/
+- `src`, `src/`, `src/*`, `src/**`, and `src/**/*`: match all `.py` and `.pyi` files under `src/`
 - `?.py` and `[A-z].py`: match any file that looks like `<letter>.py`
 - `src/path/to/my/file.py`: only match `src/path/to/my/file.py`
 - `src/**/tests`, `src/**/tests/`, `src/**/tests/**`, and `src/**/tests/**/*`: match all `.py` and `.pyi` files in `src/`


### PR DESCRIPTION
# Summary

I spotted a couple of links that were a bit garbled due to missing one of two backticks, and after I fixed those, I found and fixed one unpaired backtick in the rendered page outside the code blocks (which I didn't really check, because even paired backticks show up in code blocks, and anyway this doesn't screw up the page formatting).

I might have missed some though, because there are a lot of backticks in code blocks.

# Test Plan

I tested this using github's "preview" tab (with **diff** mode **OFF**) and my eyes (diff mode rendering gets garbled by the unpaired backticks in the old markdown). Further testing will involve reading the generated documentation.

If `test.py` was effective in such matters, surely it would already have caught these?
