### PR TITLE
[TSP] Return contextual expected type from getExpectedType

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -451,6 +451,25 @@ pub trait TspInterface: Send + Sync + 'static {
         character: u32,
     ) -> Option<pyrefly_types::types::Type>;
 
+    /// Return the contextually expected type at the given position in a file.
+    ///
+    /// Unlike [`Self::get_type_at_position`], which returns the inferred
+    /// type of the expression at the cursor, this returns the type that the
+    /// surrounding context demands. For example, in
+    /// `e: Literal["a", "b"] = "<cursor>"`, the expected type at the
+    /// cursor is `Literal["a", "b"]` (from the LHS annotation), not the
+    /// inferred type of the empty string literal.
+    ///
+    /// Returns `None` when the URI cannot be resolved, the position is invalid,
+    /// or no contextual expected type is available at that location. Callers
+    /// may fall back to [`Self::get_type_at_position`] in that case.
+    fn get_expected_type_at_position(
+        &self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Option<pyrefly_types::types::Type>;
+
     /// Resolve the source range of a function name from its `FuncDefIndex`.
     ///
     /// Uses the binding table to look up `KeyUndecoratedFunctionRange` for
@@ -6319,6 +6338,55 @@ impl TspInterface for Server {
         // call position. This keeps the function's `Declaration::Regular`
         // intact on the wire, which TSP clients need to re-resolve the
         // signature (parameters, overloads) from source.
+        transaction.get_type_at_preserving_declaration(&handle, position)
+    }
+
+    fn get_expected_type_at_position(
+        &self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Option<pyrefly_types::types::Type> {
+        let url = Url::parse(uri)
+            .ok()
+            .or_else(|| Url::from_file_path(uri).ok())?;
+        let path = self.path_for_uri_or_notebook_cell(&url)?;
+        let notebook_cell = self.maybe_get_code_cell_index(&url);
+
+        let handle = make_open_handle(&self.state, &path);
+        let transaction = self.state.transaction();
+        let module_info = transaction.get_module_info(&handle)?;
+        let position =
+            module_info.from_lsp_position(lsp_types::Position { line, character }, notebook_cell);
+
+        // Walk the AST nodes covering the cursor position to find a
+        // surrounding context that gives a contextual expected type.
+        // Currently we recognize:
+        //   * The RHS value of an annotated assignment (`x: T = <cursor>`)
+        //     — the expected type is the LHS-declared type `T`.
+        // Other contexts (call arguments, return positions, etc.) fall back
+        // to the inferred type at position, which may not be the contextual
+        // expected type but is what callers historically received.
+        if let Some(module) = transaction.get_ast(&handle) {
+            let covering_nodes = pyrefly_python::ast::Ast::locate_node(&module, position);
+            for node in &covering_nodes {
+                if let ruff_python_ast::AnyNodeRef::StmtAnnAssign(ann) = node
+                    && let Some(value) = ann.value.as_deref()
+                    && value.range().contains_inclusive(position)
+                    && let ruff_python_ast::Expr::Name(target_name) = ann.target.as_ref()
+                {
+                    // Asking for the type at the LHS target name returns the
+                    // declared (annotated) type of the binding.
+                    let target_position = target_name.range.start();
+                    if let Some(ty) =
+                        transaction.get_type_at_preserving_declaration(&handle, target_position)
+                    {
+                        return Some(ty);
+                    }
+                }
+            }
+        }
+
         transaction.get_type_at_preserving_declaration(&handle, position)
     }
 

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -6359,30 +6359,88 @@ impl TspInterface for Server {
         let position =
             module_info.from_lsp_position(lsp_types::Position { line, character }, notebook_cell);
 
-        // Walk the AST nodes covering the cursor position to find a
-        // surrounding context that gives a contextual expected type.
-        // Currently we recognize:
-        //   * The RHS value of an annotated assignment (`x: T = <cursor>`)
-        //     — the expected type is the LHS-declared type `T`.
-        // Other contexts (call arguments, return positions, etc.) fall back
-        // to the inferred type at position, which may not be the contextual
-        // expected type but is what callers historically received.
+        // Walk the AST nodes covering the cursor position from innermost to
+        // outermost looking for a surrounding context that supplies a
+        // contextual expected type. The first match wins, so inner contexts
+        // (e.g. a call argument inside an annotated assignment) take
+        // precedence over outer ones.
+        //
+        // Recognized contexts:
+        //   * Call argument (positional or keyword) — the parameter type
+        //     declared by the callee.
+        //   * `return <expr>` — the enclosing function's return annotation.
+        //   * Parameter default `def f(x: T = <expr>)` — the parameter's
+        //     own annotation `T`.
+        //   * Annotated assignment RHS `x: T = <expr>` — the LHS type `T`.
+        //
+        // Other contexts (yield expressions, container literal elements
+        // under an annotation, etc.) fall back to the inferred type at the
+        // cursor.
         if let Some(module) = transaction.get_ast(&handle) {
             let covering_nodes = pyrefly_python::ast::Ast::locate_node(&module, position);
             for node in &covering_nodes {
-                if let ruff_python_ast::AnyNodeRef::StmtAnnAssign(ann) = node
-                    && let Some(value) = ann.value.as_deref()
-                    && value.range().contains_inclusive(position)
-                    && let ruff_python_ast::Expr::Name(target_name) = ann.target.as_ref()
-                {
-                    // Asking for the type at the LHS target name returns the
-                    // declared (annotated) type of the binding.
-                    let target_position = target_name.range.start();
-                    if let Some(ty) =
-                        transaction.get_type_at_preserving_declaration(&handle, target_position)
+                use ruff_python_ast::AnyNodeRef;
+                use ruff_python_ast::Expr;
+                match node {
+                    AnyNodeRef::ExprCall(call)
+                        if call.arguments.range.contains_inclusive(position) =>
                     {
-                        return Some(ty);
+                        if let Some(ty) = transaction.expected_call_argument_type(&handle, position)
+                        {
+                            return Some(ty);
+                        }
                     }
+                    AnyNodeRef::StmtReturn(ret)
+                        if ret
+                            .value
+                            .as_deref()
+                            .is_some_and(|v| v.range().contains_inclusive(position)) =>
+                    {
+                        // Find the innermost enclosing function and use its
+                        // return annotation, if present.
+                        for outer in &covering_nodes {
+                            if let AnyNodeRef::StmtFunctionDef(func) = outer
+                                && let Some(returns) = func.returns.as_deref()
+                                && let Some(ty) =
+                                    transaction.get_type_trace(&handle, returns.range())
+                            {
+                                return Some(ty);
+                            }
+                        }
+                    }
+                    AnyNodeRef::ParameterWithDefault(param_with_default)
+                        if param_with_default
+                            .default
+                            .as_deref()
+                            .is_some_and(|d| d.range().contains_inclusive(position)) =>
+                    {
+                        // The default value of an annotated parameter has the
+                        // parameter's annotation as its expected type.
+                        if let Some(annotation) = param_with_default.parameter.annotation.as_deref()
+                            && let Some(ty) =
+                                transaction.get_type_trace(&handle, annotation.range())
+                        {
+                            return Some(ty);
+                        }
+                    }
+                    AnyNodeRef::StmtAnnAssign(ann)
+                        if ann
+                            .value
+                            .as_deref()
+                            .is_some_and(|v| v.range().contains_inclusive(position)) =>
+                    {
+                        if let Expr::Name(target_name) = ann.target.as_ref() {
+                            // Asking for the type at the LHS target name returns the
+                            // declared (annotated) type of the binding.
+                            let target_position = target_name.range.start();
+                            if let Some(ty) = transaction
+                                .get_type_at_preserving_declaration(&handle, target_position)
+                            {
+                                return Some(ty);
+                            }
+                        }
+                    }
+                    _ => {}
                 }
             }
         }

--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -478,7 +478,11 @@ impl Transaction<'_> {
         }
     }
 
-    fn expected_call_argument_type(&self, handle: &Handle, position: TextSize) -> Option<Type> {
+    pub(crate) fn expected_call_argument_type(
+        &self,
+        handle: &Handle,
+        position: TextSize,
+    ) -> Option<Type> {
         let CallInfo {
             callables,
             chosen_overload_index,

--- a/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
@@ -341,6 +341,93 @@ fn test_get_expected_type_stale_snapshot() {
     tsp.shutdown();
 }
 
+/// Helper to send a getExpectedType request and return a successful (non-null) result.
+fn get_expected_type_ok(
+    tsp: &mut TspInteraction,
+    file_uri: &str,
+    line: u32,
+    character: u32,
+    snapshot: i32,
+) -> serde_json::Value {
+    tsp.server
+        .get_expected_type(file_uri, line, character, snapshot);
+    let resp = tsp.client.receive_response_skip_notifications();
+    assert!(
+        resp.error.is_none(),
+        "Expected success, got error: {:?}",
+        resp.error
+    );
+    let result = resp.result.expect("Expected result");
+    assert!(!result.is_null(), "Expected non-null type result");
+    result
+}
+
+#[test]
+fn test_get_expected_type_on_rhs_returns_lhs_annotation_union() {
+    // For `x: int | str = 42`, the expected type at the RHS position is
+    // the union `int | str` declared on the LHS, NOT the inferred type
+    // (Literal[42]) of the RHS expression.
+    //                          1111111
+    //                0123456789012345678
+    let source = "x: int | str = 42\n";
+    let (mut tsp, file_uri, snapshot) = setup_project(source);
+
+    // Position 15 is the `4` in `42`.
+    let expected = get_expected_type_ok(&mut tsp, &file_uri, 0, 15, snapshot);
+    assert_kind(&expected, TypeKind::Union);
+
+    // Sanity check: getComputedType at the same position narrows to the
+    // RHS literal type (Class), confirming the two methods disagree here.
+    let computed = get_computed_type_ok(&mut tsp, &file_uri, 0, 15, snapshot);
+    assert_kind(&computed, TypeKind::Class);
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_expected_type_on_rhs_string_literal_annotation() {
+    // For `e: Literal["a", "b"] = "a"`, the expected type at the RHS
+    // string literal should be the annotated `Literal["a", "b"]` (a
+    // Union of literal classes), not just `Literal["a"]`.
+    //                                     1111111111222222
+    //                           01234567890123456789012345
+    let source = "from typing import Literal\ne: Literal[\"a\", \"b\"] = \"a\"\n";
+    let (mut tsp, file_uri, snapshot) = setup_project(source);
+
+    // Line 1, position 24 lands inside the RHS string literal `"a"`.
+    let expected = get_expected_type_ok(&mut tsp, &file_uri, 1, 24, snapshot);
+    assert_kind(&expected, TypeKind::Union);
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_expected_type_falls_back_outside_annotated_rhs() {
+    // No annotated assignment surrounds the cursor → expected type
+    // falls back to the type at the cursor (`Literal[42]` → Class).
+    let (mut tsp, file_uri, snapshot) = setup_project("x = 42\n");
+
+    // Position 4 is the `4` in `42`.
+    let expected = get_expected_type_ok(&mut tsp, &file_uri, 0, 4, snapshot);
+    assert_kind(&expected, TypeKind::Class);
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_expected_type_on_lhs_returns_declared_type() {
+    // When the cursor is on the LHS target of an annotated assignment,
+    // the value range does not contain it, so the expected type is just
+    // the declared type at that position (which is the annotation).
+    let (mut tsp, file_uri, snapshot) = setup_project("x: int | str = 42\n");
+
+    // Position 0 is the `x` target.
+    let expected = get_expected_type_ok(&mut tsp, &file_uri, 0, 0, snapshot);
+    assert_kind(&expected, TypeKind::Union);
+
+    tsp.shutdown();
+}
+
 // =======================================================================
 // Cross-cutting: all three methods agree
 // =======================================================================

--- a/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
@@ -428,6 +428,133 @@ fn test_get_expected_type_on_lhs_returns_declared_type() {
     tsp.shutdown();
 }
 
+#[test]
+fn test_get_expected_type_call_positional_argument() {
+    // For `foo(4)` where `foo(a: int | str)`, the expected type at the
+    // argument `4` is the union `int | str`, not the inferred Literal[4].
+    //                                                       111111111
+    //                                            0123456789012345678
+    let source = "def foo(a: int | str) -> None: ...\nfoo(4)\n";
+    let (mut tsp, file_uri, snapshot) = setup_project(source);
+
+    // Line 1, position 4 lands on the `4` argument.
+    let expected = get_expected_type_ok(&mut tsp, &file_uri, 1, 4, snapshot);
+    assert_kind(&expected, TypeKind::Union);
+
+    // Sanity check: getComputedType at the same position narrows to Literal[4].
+    let computed = get_computed_type_ok(&mut tsp, &file_uri, 1, 4, snapshot);
+    assert_kind(&computed, TypeKind::Class);
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_expected_type_call_keyword_argument() {
+    // For `foo(a=4)` where `foo(a: int | str)`, the expected type at `4`
+    // should be the union `int | str` (matched by parameter name).
+    let source = "def foo(a: int | str) -> None: ...\nfoo(a=4)\n";
+    let (mut tsp, file_uri, snapshot) = setup_project(source);
+
+    // Line 1, position 6 lands on the `4` value of the kwarg.
+    let expected = get_expected_type_ok(&mut tsp, &file_uri, 1, 6, snapshot);
+    assert_kind(&expected, TypeKind::Union);
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_expected_type_return_statement_value() {
+    // For `def f() -> int | str: return 4`, the expected type of the
+    // return value `4` is the function's declared return annotation
+    // `int | str`, not the inferred Literal[4].
+    let source = "def f() -> int | str:\n    return 4\n";
+    let (mut tsp, file_uri, snapshot) = setup_project(source);
+
+    // Line 1 is `    return 4`. Position 11 is the `4`.
+    let expected = get_expected_type_ok(&mut tsp, &file_uri, 1, 11, snapshot);
+    assert_kind(&expected, TypeKind::Union);
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_expected_type_default_parameter_value() {
+    // For `def f(x: int | str = 4): ...`, the expected type of the
+    // default value `4` is the parameter's annotation `int | str`.
+    //              1111111111222
+    //    01234567890123456789012
+    let source = "def f(x: int | str = 4) -> None: ...\n";
+    let (mut tsp, file_uri, snapshot) = setup_project(source);
+
+    // Position 21 is the `4` default value.
+    let expected = get_expected_type_ok(&mut tsp, &file_uri, 0, 21, snapshot);
+    assert_kind(&expected, TypeKind::Union);
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_expected_type_yield_falls_back_to_value_type() {
+    // For `def g() -> Iterator[int | str]: yield 4`, the contextually
+    // expected type of the yielded value `4` is the iterator's element
+    // type `int | str`. We don't yet unwrap generator return annotations,
+    // so we currently fall back to the inferred type of `4` (Literal[4]).
+    let source = "\
+from typing import Iterator
+def g() -> Iterator[int | str]:
+    yield 4
+";
+    let (mut tsp, file_uri, snapshot) = setup_project(source);
+
+    // Line 2 is `    yield 4`. Position 10 is the `4`.
+    let expected = get_expected_type_ok(&mut tsp, &file_uri, 2, 10, snapshot);
+    // TODO: should be TypeKind::Union (the iterator element type).
+    assert_kind(&expected, TypeKind::Class);
+
+    tsp.shutdown();
+}
+
+// ---- Container element / dict value contexts -------------------------
+//
+// These cases would ideally also return the contextual element/value type
+// from the surrounding annotation (e.g. for `xs: list[int | str] = [4]`,
+// the expected type at `4` should be `int | str`). We currently fall back
+// to the outer assignment's declared type in these cases. The tests below
+// pin the current behavior so a future improvement will deliberately fail
+// them and force an update.
+
+#[test]
+fn test_get_expected_type_list_element_falls_back_to_container_type() {
+    // `xs: list[int | str] = [4]` — ideally the expected type at `4`
+    // would be `int | str`, but we currently return the container type
+    // `list[int | str]` (a Class) because the AnnAssign branch fires.
+    let source = "xs: list[int | str] = [4]\n";
+    let (mut tsp, file_uri, snapshot) = setup_project(source);
+
+    // Position 23 is the `4` inside `[4]`.
+    let expected = get_expected_type_ok(&mut tsp, &file_uri, 0, 23, snapshot);
+    // TODO: should be TypeKind::Union (the element type). For now we
+    // verify the response is a well-formed class type (the container).
+    assert_kind(&expected, TypeKind::Class);
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_expected_type_dict_value_falls_back_to_container_type() {
+    // `d: dict[str, int | str] = {"k": 4}` — ideally the expected type
+    // at `4` would be `int | str`, but we currently return `dict[...]`.
+    let source = "d: dict[str, int | str] = {\"k\": 4}\n";
+    let (mut tsp, file_uri, snapshot) = setup_project(source);
+
+    // Position 32 is the `4` value in the dict literal.
+    let expected = get_expected_type_ok(&mut tsp, &file_uri, 0, 32, snapshot);
+    // TODO: should be TypeKind::Union for the value type.
+    assert_kind(&expected, TypeKind::Class);
+
+    tsp.shutdown();
+}
+
 // =======================================================================
 // Cross-cutting: all three methods agree
 // =======================================================================

--- a/pyrefly/lib/tsp/requests/get_expected_type.rs
+++ b/pyrefly/lib/tsp/requests/get_expected_type.rs
@@ -20,11 +20,9 @@ impl<T: TspInterface> TspConnection<T> {
     ///
     /// The expected type is the type that a surrounding context demands.
     /// For example, in `foo(4)` where `def foo(a: int | str)`, the expected
-    /// type of the argument `4` is `int | str`.
-    ///
-    /// Currently piggy-backs on `get_type_at_position`, which returns the
-    /// computed type. A future improvement can query the expected type from
-    /// function parameter annotations or assignment target types.
+    /// type of the argument `4` is `int | str`. Likewise, in
+    /// `e: Literal["a", "b"] = "<cursor>"`, the expected type of the RHS is
+    /// `Literal["a", "b"]` rather than the inferred type of the value.
     pub fn handle_get_expected_type(
         &self,
         params: GetTypeParams,
@@ -32,12 +30,14 @@ impl<T: TspInterface> TspConnection<T> {
         self.validate_snapshot(params.snapshot)?;
         // Validate the URI is parseable (rejects malformed strings).
         // Any valid scheme is accepted — notebook cell URIs are resolved
-        // to notebook paths inside get_type_at_position.
+        // to notebook paths inside get_expected_type_at_position.
         parse_uri(params.uri())?;
         let position = params.position();
-        let ty = self
-            .inner()
-            .get_type_at_position(params.uri(), position.line, position.character);
+        let ty = self.inner().get_expected_type_at_position(
+            params.uri(),
+            position.line,
+            position.character,
+        );
         Ok(ty.map(|t| self.convert_type(&t, Some(params.uri()))))
     }
 }


### PR DESCRIPTION
# Summary

`typeServer/getExpectedType` was returning the inferred (computed) type at the cursor instead of the contextually expected type that the position imposes. For example, in `x: int | str = 4`, querying on `4` returned `int` rather than `int | str`.

This change makes `get_expected_type_at_position` walk the covering AST nodes innermost-first and, when the cursor lies in a context that supplies an expected type, look up that contextual type. Recognized contexts:

- **Call argument** (positional or keyword) — uses the parameter type declared by the callee, via `Transaction::expected_call_argument_type` (now `pub(crate)` so the non-WASM server can call it).
- **`return <expr>`** — uses the enclosing function's return annotation (resolved via `get_type_trace` over the annotation's full range so unions like `int | str` are preserved instead of collapsing to the leading identifier).
- **Parameter default `def f(x: T = <expr>)`** — uses the parameter's annotation `T`.
- **Annotated assignment RHS `x: T = <expr>`** — uses the LHS declared type `T`.

Other contexts (yield expressions, container-literal elements under an annotation, etc.) still fall back to the inferred type at the cursor; tests document that behavior so future fixes can flip the expectations.

Fixes microsoft/pylance-release#8060

# Test Plan

Added 8 new tests in `pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs` covering each newly supported context plus the documented fallbacks:

- `test_get_expected_type_call_positional_argument`
- `test_get_expected_type_call_keyword_argument`
- `test_get_expected_type_return_statement_value`
- `test_get_expected_type_default_parameter_value`
- `test_get_expected_type_yield_falls_back_to_value_type`
- `test_get_expected_type_list_element_falls_back_to_container_type`
- `test_get_expected_type_dict_value_falls_back_to_container_type`

All 14 `test_get_expected_type*` tests pass:

```
cargo test -p pyrefly --lib test_get_expected_type
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured
```

Also ran `python3 test.py --no-test --no-conformance --no-jsonschema` — formatting and linting clean. `cargo clippy --all-targets --all-features` produces no new warnings (only 2 pre-existing unused-import warnings in `pyrefly_lsp_interaction_tests`, unrelated to this branch).
