### PR TITLE
Fix ParamSpec prefix params incorrectly demoted to positional-only

### DIFF
--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -240,7 +240,7 @@ impl ParamList {
         } else {
             Cow::Owned(ParamList(
                 pre.iter()
-                    .map(|p| p.to_param())
+                    .map(|p| p.to_subset_param())
                     .chain(self.0.iter().cloned())
                     .collect(),
             ))

--- a/pyrefly/lib/test/callable_residuals.rs
+++ b/pyrefly/lib/test/callable_residuals.rs
@@ -307,7 +307,6 @@ assert_type(b.fn(1), int)
 );
 
 testcase!(
-    bug = "ParamSpec prefix params incorrectly demoted to positional-only",
     test_callable_class_wrapper,
     r#"
 from typing import Callable, assert_type, reveal_type
@@ -328,7 +327,6 @@ assert_type(wrapper(1), int)
 );
 
 testcase!(
-    bug = "ParamSpec prefix params incorrectly demoted to positional-only",
     test_callable_class_wrapper_with_helper,
     r#"
 from typing import Callable, assert_type, reveal_type
@@ -352,7 +350,7 @@ assert_type(wrapper(1), int)
 );
 
 testcase!(
-    bug = "Need better display for callback protocol residuals in class targs; ParamSpec prefix params incorrectly demoted to positional-only",
+    bug = "Need better display for callback protocol residuals in class targs",
     test_callable_class_wrapper_display_without_field,
     r#"
 from typing import Callable, reveal_type

--- a/pyrefly/lib/test/callable_residuals.rs
+++ b/pyrefly/lib/test/callable_residuals.rs
@@ -307,6 +307,7 @@ assert_type(b.fn(1), int)
 );
 
 testcase!(
+    bug = "ParamSpec prefix params incorrectly demoted to positional-only",
     test_callable_class_wrapper,
     r#"
 from typing import Callable, assert_type, reveal_type
@@ -321,12 +322,13 @@ class Wrapper[**P, R]:
 def f[S](x: S) -> S: ...
 wrapper = Wrapper(f)
 reveal_type(wrapper.fn)  # E: revealed type: [R](x: R) -> R
-reveal_type(wrapper.__call__)  # E: [R](self: Wrapper[[x: R], R], /, x: R) -> R
+reveal_type(wrapper.__call__)  # E: [R](self: Wrapper[[x: R], R], x: R) -> R
 assert_type(wrapper(1), int)
 "#,
 );
 
 testcase!(
+    bug = "ParamSpec prefix params incorrectly demoted to positional-only",
     test_callable_class_wrapper_with_helper,
     r#"
 from typing import Callable, assert_type, reveal_type
@@ -344,13 +346,13 @@ def wrap[**P, R](f: Callable[P, R]) -> Wrapper[P, R]:
 def f[S](x: S) -> S: ...
 wrapper = wrap(f)
 reveal_type(wrapper.fn)  # E: revealed type: [R](x: R) -> R
-reveal_type(wrapper.__call__)  # E: [R](self: Wrapper[[x: R], R], /, x: R) -> R
+reveal_type(wrapper.__call__)  # E: [R](self: Wrapper[[x: R], R], x: R) -> R
 assert_type(wrapper(1), int)
 "#,
 );
 
 testcase!(
-    bug = "Need better display for callback protocol residuals in class targs",
+    bug = "Need better display for callback protocol residuals in class targs; ParamSpec prefix params incorrectly demoted to positional-only",
     test_callable_class_wrapper_display_without_field,
     r#"
 from typing import Callable, reveal_type
@@ -362,7 +364,7 @@ class Wrapper[**P, R]:
 def f[S](x: S) -> S: ...
 wrapper = Wrapper(f)
 reveal_type(wrapper)  # E: revealed type: Wrapper[[x: GenericResidual@R], GenericResidual@R]
-reveal_type(wrapper.__call__)  # E: [R](self: Wrapper[[x: R], R], /, x: R) -> R
+reveal_type(wrapper.__call__)  # E: [R](self: Wrapper[[x: R], R], x: R) -> R
 "#,
 );
 

--- a/pyrefly/lib/test/paramspec.rs
+++ b/pyrefly/lib/test/paramspec.rs
@@ -873,3 +873,52 @@ def forward(g: Callable[Q, None], *args: Q.args, **kwargs: Q.kwargs) -> None:
     call_fn(g, x=1, *args, **kwargs)
 "#,
 );
+
+// Reproduces pyinfra's @operation decorator pattern: a Protocol whose __call__
+// mixes explicit "global" params with *args: P.args / **kwargs: P.kwargs, and
+// the decorator returns cast(Protocol[P], wrapped_func). Mypy 1.17 handles
+// this correctly; pyrefly currently resolves the P-bound params (from the
+// original function) but drops the Protocol's own explicit params (_sudo, name).
+testcase!(
+    bug = "Protocol's explicit params are lost when ParamSpec is resolved through cast()",
+    test_paramspec_protocol_cast_preserves_binding,
+    r#"
+from typing import Protocol, Generic, Callable, Iterator, cast
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+
+class OperationResult:
+    changed: bool
+
+class OperationProtocol(Generic[P], Protocol):
+    def __call__(
+        self,
+        _sudo: bool = False,
+        name: str | None = None,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> OperationResult: ...
+
+def make_operation(func: Callable[P, Iterator[str]]) -> OperationProtocol[P]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> OperationResult:
+        return OperationResult()
+    return cast(OperationProtocol[P], wrapper)
+
+def _service_impl(service_name: str, running: bool = True) -> Iterator[str]:
+    yield "test"
+
+service = make_operation(_service_impl)
+
+# P-bound params work correctly:
+service(service_name="nginx")
+service(service_name="nginx", running=True)
+
+# Protocol's explicit params are incorrectly rejected:
+service(service_name="nginx", _sudo=True)  # E: Unexpected keyword argument `_sudo`
+service(service_name="nginx", running=True, _sudo=True, name="Start nginx")  # E: Unexpected keyword argument `_sudo` # E: Unexpected keyword argument `name`
+
+# Correctly rejected — not on the Protocol or in P:
+service(nonexistent_param=True)  # E: Missing argument `service_name` # E: Unexpected keyword argument `nonexistent_param`
+"#,
+);

--- a/pyrefly/lib/test/paramspec.rs
+++ b/pyrefly/lib/test/paramspec.rs
@@ -877,10 +877,8 @@ def forward(g: Callable[Q, None], *args: Q.args, **kwargs: Q.kwargs) -> None:
 // Reproduces pyinfra's @operation decorator pattern: a Protocol whose __call__
 // mixes explicit "global" params with *args: P.args / **kwargs: P.kwargs, and
 // the decorator returns cast(Protocol[P], wrapped_func). Mypy 1.17 handles
-// this correctly; pyrefly currently resolves the P-bound params (from the
-// original function) but drops the Protocol's own explicit params (_sudo, name).
+// this correctly.
 testcase!(
-    bug = "Protocol's explicit params are lost when ParamSpec is resolved through cast()",
     test_paramspec_protocol_cast_preserves_binding,
     r#"
 from typing import Protocol, Generic, Callable, Iterator, cast
@@ -914,9 +912,9 @@ service = make_operation(_service_impl)
 service(service_name="nginx")
 service(service_name="nginx", running=True)
 
-# Protocol's explicit params are incorrectly rejected:
-service(service_name="nginx", _sudo=True)  # E: Unexpected keyword argument `_sudo`
-service(service_name="nginx", running=True, _sudo=True, name="Start nginx")  # E: Unexpected keyword argument `_sudo` # E: Unexpected keyword argument `name`
+# Protocol's explicit params also work:
+service(service_name="nginx", _sudo=True)
+service(service_name="nginx", running=True, _sudo=True, name="Start nginx")
 
 # Correctly rejected — not on the Protocol or in P:
 service(nonexistent_param=True)  # E: Missing argument `service_name` # E: Unexpected keyword argument `nonexistent_param`


### PR DESCRIPTION
# Summary

When I am using the [`pyinfra` library](https://docs.pyinfra.com/en/3.x/using-operations.html#global-arguments) , it fails pyrefly type check with these errors:
```
ERROR Unexpected keyword argument `name` in function `pyinfra.api.arguments_typed.PyinfraOperation.__call__` [unexpected-keyword]
ERROR Unexpected keyword argument `_sudo` in function `pyinfra.api.arguments_typed.PyinfraOperation.__call__` [unexpected-keyword]
```
and similar ones. MyPy correctly recognizes the types here successfully.

prepend_types() was converting PrefixParam::Pos to Param::PosOnly via to_param(), making keyword-passable params from function definitions positional-only after ParamSpec expansion. This caused keyword arguments like _sudo=True to be rejected as "unexpected keyword" when calling through a Protocol with explicit params before *args: P.args.

Switch to to_subset_param() which preserves the Pos vs PosOnly distinction. PrefixParam::Pos is only ever created from function definitions (not from Concatenate syntax, which always uses PosOnly), so this change is safe for all callers.

Repro file is here

https://gist.github.com/thatfunkymunki/c0c8a57d60f0f02217b918ef6a377189

observe additional unexpected kwarg errors in pyrefly vs mypy

### pyrefly
```
PS C:\Users\munki> uvx pyrefly check repro.py 
ERROR Unexpected keyword argument `_bar` in function `FooProtocol.__call__` [unexpected-keyword]                                                                                                                                   
  --> repro.py:24:16
   |
24 | foo(biz="ccc", _bar=True)
   |                ^^^^
   |
ERROR Unexpected keyword argument `_bar` in function `FooProtocol.__call__` [unexpected-keyword]
  --> repro.py:25:26
   |
25 | foo(biz="ddd", baf=True, _bar=True, baz="abcdef")
   |                          ^^^^
   |
ERROR Unexpected keyword argument `baz` in function `FooProtocol.__call__` [unexpected-keyword]
  --> repro.py:25:37
   |
25 | foo(biz="ddd", baf=True, _bar=True, baz="abcdef")
   |                                     ^^^
   |
ERROR Unexpected keyword argument `nonexistent_param` in function `FooProtocol.__call__` [unexpected-keyword]
  --> repro.py:27:5
   |
27 | foo(nonexistent_param=True)
   |     ^^^^^^^^^^^^^^^^^
   |
 INFO 4 errors
No `pyrefly.toml` found — using preset `basic`.
Run `pyrefly init` to continue setting up Pyrefly.
Docs: https://pyrefly.org/getting-started-cli
```
### mypy
```
PS C:\Users\munki> uvx mypy --strict repro.py
repro.py:27: error: Unexpected keyword argument "nonexistent_param" for "__call__" of "FooProtocol"  [call-arg]                                                                                                                    
Found 1 error in 1 file (checked 1 source file)

```
# Test Plan

Created a failing test and confirmed that it passes with my changes. I also observed that some of the existing tests were expecting incorrect result which was also resolved with the changes.