### PR TITLE
fix new rule - missing super() call  #3681

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -263,6 +263,8 @@ pub enum ErrorKind {
     MissingSource,
     /// We are using bundled stubs for a package but the source code is missing.
     MissingSourceForStubs,
+    /// A constructor-like method overrides a parent class method but does not call `super()`.
+    MissingSuperCall,
     /// The first string argument to a functional type definition does not match the bound name.
     NameMismatch,
     /// The attribute exists but does not support this access pattern.
@@ -475,6 +477,7 @@ impl ErrorKind {
             ErrorKind::IncompatibleComparison => Severity::Ignore,
             ErrorKind::InvalidDecorator => Severity::Warn,
             ErrorKind::MissingOverrideDecorator => Severity::Ignore,
+            ErrorKind::MissingSuperCall => Severity::Ignore,
             ErrorKind::MissingSource => Severity::Ignore,
             ErrorKind::NameMismatch => Severity::Warn,
             ErrorKind::NonExhaustiveMatch => Severity::Warn,

--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -709,6 +709,8 @@ pub struct FuncFlags {
     /// which lets override-consistency logic relax inferred placeholder returns
     /// without overriding what the user explicitly declared.
     pub is_return_inferred: bool,
+    /// Whether the function body directly calls `super(...).<this function>(...)`.
+    pub calls_super_method: bool,
     /// A function decorated with `typing.dataclass_transform(...)`, turning it into a
     /// `dataclasses.dataclass`-like decorator. Stores the keyword values passed to the
     /// `dataclass_transform` call. See

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1056,6 +1056,19 @@ impl ClassField {
         }
     }
 
+    fn calls_super_method(&self) -> bool {
+        match &self.0 {
+            ClassFieldInner::Method { ty, .. } => {
+                ty.visit_toplevel_func_metadata(&|meta| meta.flags.calls_super_method)
+            }
+            _ => false,
+        }
+    }
+
+    fn requires_super_method_call(name: &Name) -> bool {
+        name == &dunder::INIT || name == &dunder::NEW || name == &dunder::INIT_SUBCLASS
+    }
+
     /// Check if this field is read-only for any reason.
     fn is_read_only(&self) -> bool {
         match &self.0 {
@@ -3167,6 +3180,48 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         true
     }
 
+    fn check_missing_super_call_for_field(
+        &self,
+        cls: &Class,
+        field_name: &Name,
+        class_field: &ClassField,
+        bases: &ClassBases,
+        range: TextRange,
+        errors: &ErrorCollector,
+    ) {
+        if !(ClassField::requires_super_method_call(field_name)
+            && class_field.can_have_override_decorator()
+            && !class_field.calls_super_method())
+        {
+            return;
+        }
+        for parent in bases.iter() {
+            let parent_cls = parent.class_object();
+            if self.get_metadata_for_class(parent_cls).has_base_any() {
+                return;
+            }
+            let Some(want_field) =
+                self.get_class_member_with_defining_class(parent_cls, field_name)
+            else {
+                continue;
+            };
+            if want_field.defining_class.is_builtin("object") {
+                continue;
+            }
+            self.error(
+                errors,
+                range,
+                ErrorKind::MissingSuperCall,
+                format!(
+                    "Method `{}.{}` does not call the method of the same name in a parent class",
+                    cls.name(),
+                    field_name,
+                ),
+            );
+            return;
+        }
+    }
+
     pub fn check_consistent_override_for_field(
         &self,
         cls: &Class,
@@ -3176,18 +3231,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         errors: &ErrorCollector,
     ) {
         let is_explicit_override = class_field.is_override();
-        if matches!(class_field.1, IsInherited::No) && !is_explicit_override {
-            return;
-        }
         let metadata = self.get_metadata_for_class(cls);
-        if !self.should_check_field_for_override_consistency(
-            field_name,
-            &metadata,
-            is_explicit_override,
-        ) {
-            return;
-        }
-
         let Some(cls_fields) = self.get_class_fields(cls) else {
             return;
         };
@@ -3196,6 +3240,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         } else {
             return;
         };
+
+        self.check_missing_super_call_for_field(cls, field_name, class_field, bases, range, errors);
+
+        if matches!(class_field.1, IsInherited::No) && !is_explicit_override {
+            return;
+        }
+        if !self.should_check_field_for_override_consistency(
+            field_name,
+            &metadata,
+            is_explicit_override,
+        ) {
+            return;
+        }
 
         let mut got_attribute = None;
         let mut parent_attr_found = false;

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -437,6 +437,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         stub_or_impl: FunctionStubOrImpl,
         placeholder_body_kind: Option<PlaceholderBodyKind>,
         is_return_inferred: bool,
+        calls_super_method: bool,
         class_key: Option<&Idx<KeyClass>>,
         decorators: &[Idx<KeyDecorator>],
         legacy_tparams: &[Idx<KeyLegacyTypeParam>],
@@ -465,6 +466,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             is_async: def.is_async,
             placeholder_body_kind,
             is_return_inferred,
+            calls_super_method,
             ..Default::default()
         };
         let mut found_class_property = false;

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -5417,6 +5417,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             x.stub_or_impl,
             x.placeholder_body_kind,
             x.is_return_inferred,
+            x.calls_super_method,
             x.class_key.as_ref(),
             &x.decorators,
             &x.legacy_tparams,

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -136,7 +136,7 @@ assert_words!(BindingYield, 4);
 assert_words!(BindingYieldFrom, 4);
 assert_words!(BindingDecorator, 10);
 assert_bytes!(BindingDecoratedFunction, 20);
-assert_words!(BindingUndecoratedFunction, 20);
+assert_words!(BindingUndecoratedFunction, 21);
 
 #[derive(Clone, Dupe, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AnyIdx {
@@ -1865,6 +1865,8 @@ pub struct BindingUndecoratedFunction {
     /// inferred from the body (i.e. the corresponding `ReturnType` binding will
     /// use `ReturnTypeKind::ShouldInferType`).
     pub is_return_inferred: bool,
+    /// `true` when the body directly calls `super(...).<this function>(...)`.
+    pub calls_super_method: bool,
     pub class_key: Option<Idx<KeyClass>>,
     pub legacy_tparams: Box<[Idx<KeyLegacyTypeParam>]>,
     pub decorators: Box<[Idx<KeyDecorator>]>,

--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -32,6 +32,9 @@ use ruff_python_ast::StmtFunctionDef;
 use ruff_python_ast::StmtRaise;
 use ruff_python_ast::StmtReturn;
 use ruff_python_ast::name::Name;
+use ruff_python_ast::visitor::source_order::SourceOrderVisitor;
+use ruff_python_ast::visitor::source_order::walk_expr;
+use ruff_python_ast::visitor::source_order::walk_stmt;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use starlark_map::small_map::SmallMap;
@@ -84,6 +87,70 @@ struct Decorators {
     is_override: bool,
     is_classmethod: bool,
     decorators: Box<[Idx<KeyDecorator>]>,
+}
+
+struct SuperMethodCallFinder<'a> {
+    method_name: &'a Name,
+    found: bool,
+}
+
+impl<'a> SuperMethodCallFinder<'a> {
+    fn is_super_call(expr: &Expr) -> bool {
+        let Expr::Call(call) = expr else {
+            return false;
+        };
+        let Expr::Name(name) = call.func.as_ref() else {
+            return false;
+        };
+        name.id.as_str() == "super"
+    }
+
+    fn is_super_method_call(&self, expr: &Expr) -> bool {
+        let Expr::Call(call) = expr else {
+            return false;
+        };
+        let Expr::Attribute(attr) = call.func.as_ref() else {
+            return false;
+        };
+        attr.attr.id == *self.method_name && Self::is_super_call(attr.value.as_ref())
+    }
+
+    fn find(method_name: &'a Name, body: &[Stmt]) -> bool {
+        let mut finder = Self {
+            method_name,
+            found: false,
+        };
+        for stmt in body {
+            finder.visit_stmt(stmt);
+            if finder.found {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+impl<'a, 'b> SourceOrderVisitor<'a> for SuperMethodCallFinder<'b> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        if self.found {
+            return;
+        }
+        match stmt {
+            Stmt::FunctionDef(_) | Stmt::ClassDef(_) => {}
+            _ => walk_stmt(self, stmt),
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        if self.found {
+            return;
+        }
+        if self.is_super_method_call(expr) {
+            self.found = true;
+        } else {
+            walk_expr(self, expr);
+        }
+    }
 }
 
 pub struct SelfAssignments {
@@ -889,6 +956,7 @@ impl<'a> BindingsBuilder<'a> {
             self.function_header(&mut x, &func_name, class_key, def_idx.usage(), parent);
 
         let docstring_range = Docstring::range_from_stmts(x.body.as_slice());
+        let calls_super_method = SuperMethodCallFinder::find(&func_name.id, &x.body);
         let (stub_or_impl, placeholder_body_kind, is_return_inferred, self_assignments) = self
             .function_body(
                 &mut x.parameters,
@@ -917,6 +985,7 @@ impl<'a> BindingsBuilder<'a> {
                 stub_or_impl,
                 placeholder_body_kind,
                 is_return_inferred,
+                calls_super_method,
                 class_key,
                 decorators: decorators.decorators,
                 legacy_tparams: legacy_tparams.into_boxed_slice(),

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -1306,6 +1306,62 @@ class Derived(Base):
 );
 
 testcase!(
+    test_missing_super_call_init,
+    TestEnv::new().enable_missing_super_call_error(),
+    r#"
+class Base:
+    def __init__(self) -> None:
+        self.value: int = 1
+
+class Child(Base):
+    def __init__(self) -> None:  # E: Method `Child.__init__` does not call the method of the same name in a parent class
+        pass
+    "#,
+);
+
+testcase!(
+    test_missing_super_call_special_methods,
+    TestEnv::new().enable_missing_super_call_error(),
+    r#"
+from typing import Self
+
+class Base:
+    def __new__(cls) -> Self:
+        return super().__new__(cls)
+
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
+
+class CallsSuper(Base):
+    def __new__(cls) -> Self:
+        return super().__new__(cls)
+
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
+
+class MissingSuper(Base):
+    def __new__(cls) -> Self:  # E: Method `MissingSuper.__new__` does not call the method of the same name in a parent class
+        return object.__new__(cls)
+
+    def __init_subclass__(cls) -> None:  # E: Method `MissingSuper.__init_subclass__` does not call the method of the same name in a parent class
+        pass
+    "#,
+);
+
+testcase!(
+    test_missing_super_call_disabled_by_default,
+    r#"
+class Base:
+    def __init__(self) -> None:
+        self.value: int = 1
+
+class Child(Base):
+    def __init__(self) -> None:
+        pass
+    "#,
+);
+
+testcase!(
     test_raise_not_implemented_infers_never_but_allows_override,
     r#"
 from typing import Never, assert_type

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -115,6 +115,7 @@ pub struct TestEnv {
     implicit_abstract_class_error: bool,
     open_unpacking_error: bool,
     missing_override_decorator_error: bool,
+    missing_super_call_error: bool,
     not_required_key_access_error: bool,
     pytorch_efficiency_lint_error: bool,
     incompatible_comparison_error: bool,
@@ -149,6 +150,7 @@ impl TestEnv {
             implicit_abstract_class_error: false,
             open_unpacking_error: false,
             missing_override_decorator_error: false,
+            missing_super_call_error: false,
             not_required_key_access_error: false,
             pytorch_efficiency_lint_error: false,
             incompatible_comparison_error: false,
@@ -289,6 +291,11 @@ impl TestEnv {
 
     pub fn enable_missing_override_decorator_error(mut self) -> Self {
         self.missing_override_decorator_error = true;
+        self
+    }
+
+    pub fn enable_missing_super_call_error(mut self) -> Self {
+        self.missing_super_call_error = true;
         self
     }
 
@@ -443,6 +450,9 @@ impl TestEnv {
         }
         if self.missing_override_decorator_error {
             errors.set_error_severity(ErrorKind::MissingOverrideDecorator, Severity::Error);
+        }
+        if self.missing_super_call_error {
+            errors.set_error_severity(ErrorKind::MissingSuperCall, Severity::Error);
         }
         if self.not_required_key_access_error {
             errors.set_error_severity(ErrorKind::NotRequiredKeyAccess, Severity::Error);

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -1111,6 +1111,29 @@ happen if you install the `types-requests` package but forget to install `reques
 
 Pyrefly has bundled stubs for a package, but no corresponding source package was found.
 
+## missing-super-call
+
+Default severity: `ignore`
+
+A constructor-like method overrides a parent class method but does not call `super()`.
+
+```python
+class Base:
+    def __init__(self) -> None:
+        self.value: int = 1
+
+class Child(Base):
+    def __init__(self) -> None:  # missing-super-call
+        pass
+```
+
+To enable this check, set the severity to `error` in your configuration:
+
+```toml
+[tool.pyrefly]
+errors = { missing-super-call = "error" }
+```
+
 ## name-mismatch
 
 Default severity: `warn`


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3681

Detects direct `super(...).__init__()`, `super(...).__new__()`, and `super(...).__init_subclass__()` calls during binding.

Emits missing-super-call when those methods override a non-object parent method without calling the parent method.

Keeps the rule ignored by default, with config/docs support.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test