### PR TITLE
fix Pyrefly does not correctly check iscoroutinefunction #2593

### DIFF
--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -849,6 +849,7 @@ impl FuncId {
 pub enum FunctionKind {
     IsInstance,
     IsSubclass,
+    IsCoroutineFunction,
     Dataclass,
     DataclassField,
     DataclassReplace,
@@ -1240,6 +1241,8 @@ impl FunctionKind {
         match (module.name().as_str(), cls.as_ref(), func.as_str()) {
             ("builtins", None, "isinstance") => Self::IsInstance,
             ("builtins", None, "issubclass") => Self::IsSubclass,
+            ("inspect", None, "iscoroutinefunction") => Self::IsCoroutineFunction,
+            ("asyncio.coroutines", None, "iscoroutinefunction") => Self::IsCoroutineFunction,
             ("builtins", None, "classmethod") => Self::ClassMethod,
             ("dataclasses", None, "dataclass") => Self::Dataclass,
             ("dataclasses", None, "field") => Self::DataclassField,
@@ -1274,6 +1277,7 @@ impl FunctionKind {
         match self {
             Self::IsInstance => ModuleName::builtins(),
             Self::IsSubclass => ModuleName::builtins(),
+            Self::IsCoroutineFunction => ModuleName::from_str("inspect"),
             Self::ClassMethod => ModuleName::builtins(),
             Self::Dataclass => ModuleName::dataclasses(),
             Self::DataclassField => ModuleName::dataclasses(),
@@ -1302,6 +1306,7 @@ impl FunctionKind {
         match self {
             Self::IsInstance => Cow::Owned(Name::new_static("isinstance")),
             Self::IsSubclass => Cow::Owned(Name::new_static("issubclass")),
+            Self::IsCoroutineFunction => Cow::Owned(Name::new_static("iscoroutinefunction")),
             Self::ClassMethod => Cow::Owned(Name::new_static("classmethod")),
             Self::Dataclass => Cow::Owned(Name::new_static("dataclass")),
             Self::DataclassField => Cow::Owned(Name::new_static("field")),
@@ -1330,6 +1335,7 @@ impl FunctionKind {
         match self {
             Self::IsInstance => None,
             Self::IsSubclass => None,
+            Self::IsCoroutineFunction => None,
             Self::ClassMethod => None,
             Self::Dataclass => None,
             Self::DataclassField => None,

--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -1331,7 +1331,28 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
                 ty.clone()
             }
-            AtomicNarrowOp::NotTypeGuard(_, _) => ty.clone(),
+            AtomicNarrowOp::NotTypeGuard(t, _) => {
+                // `iscoroutinefunction` distinguishes async callables from sync callables in
+                // resolver-style unions, but typeshed models it as a `TypeGuard`, not `TypeIs`.
+                if !matches!(
+                    t.callee_kind(),
+                    Some(CalleeKind::Function(FunctionKind::IsCoroutineFunction))
+                ) {
+                    return ty.clone();
+                }
+                let awaitable = self
+                    .heap
+                    .mk_class_type(self.stdlib.awaitable(self.heap.mk_any_implicit()).clone());
+                self.distribute_over_union(ty, |t| {
+                    if t.callable_return_type(self.heap)
+                        .is_some_and(|ret| self.is_subset_eq(&ret, &awaitable))
+                    {
+                        self.heap.mk_never()
+                    } else {
+                        t.clone()
+                    }
+                })
+            }
             AtomicNarrowOp::TypeIs(t, arguments) => {
                 if let CallTargetLookup::Ok(call_target) = self.as_call_target(t.clone()) {
                     let args = arguments.args.map(CallArg::expr_maybe_starred);

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -1345,6 +1345,24 @@ def f(x: Cat | Dog):
 );
 
 testcase!(
+    test_iscoroutinefunction_narrows_callable,
+    r#"
+from inspect import iscoroutinefunction
+from types import CoroutineType
+from typing import Any, Awaitable, Callable, assert_type
+
+type MaybeAwaitable = Callable[[], Awaitable[str]] | Callable[[], str]
+
+async def get_value(fn: MaybeAwaitable) -> str:
+    if iscoroutinefunction(fn):
+        assert_type(fn, Callable[[], CoroutineType[Any, Any, Any]])
+        return await fn()
+    assert_type(fn, Callable[[], str])
+    return fn()
+    "#,
+);
+
+testcase!(
     test_typeis,
     r#"
 from typing import TypeIs, assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2593

Added IsCoroutineFunction function identity for inspect.iscoroutinefunction and asyncio.coroutines.iscoroutinefunction

Scoped NotTypeGuard negative narrowing to only iscoroutinefunction, dropping awaitable-returning callables in the false branch

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test