### PR TITLE
Fix/narrowing unreachable branch 3349

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -13,6 +13,7 @@ use std::slice;
 use dupe::Dupe;
 use itertools::Either;
 use itertools::Itertools;
+use pyrefly_graph::index::Idx;
 use pyrefly_python::ast::Ast;
 use pyrefly_python::dunder;
 use pyrefly_python::module_name::ModuleName;
@@ -78,6 +79,7 @@ use crate::binding::binding::KeyYield;
 use crate::binding::binding::KeyYieldFrom;
 use crate::binding::binding::LambdaParamId;
 use crate::binding::narrow::AtomicNarrowOp;
+use crate::binding::narrow::NarrowOp;
 use crate::binding::narrow::int_from_slice;
 use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
@@ -445,7 +447,35 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 match self.as_bool(&condition_type, x.test.range(), errors) {
                     Some(true) => body_type,
                     Some(false) => orelse_type,
-                    None => self.union(body_type, orelse_type),
+                    None => {
+                        // Drop a branch whose narrow solves to `Never` (e.g. `1 if x is not
+                        // None else None` when `x: int`), via the reachability channel keyed
+                        // on `x.range`. The channel is absent for ternaries inferred outside
+                        // the expression-binding path (e.g. a type annotation); keep both.
+                        let dead = self
+                            .bindings()
+                            .key_to_idx_hashed_opt(Hashed::new(&Key::ConditionalReachability(
+                                x.range,
+                            )))
+                            .map(|idx| match self.bindings().get(idx) {
+                                Binding::ConditionalReachability(narrows) => {
+                                    let (body, orelse) = narrows.as_ref();
+                                    (
+                                        self.any_narrow_is_never(body),
+                                        self.any_narrow_is_never(orelse),
+                                    )
+                                }
+                                _ => unreachable!(
+                                    "ConditionalReachability key maps to ConditionalReachability binding"
+                                ),
+                            });
+                        match dead {
+                            Some((false, true)) => body_type,
+                            Some((true, false)) => orelse_type,
+                            // No binding, or both live, or both dead: keep the union.
+                            _ => self.union(body_type, orelse_type),
+                        }
+                    }
                 }
             }
             Expr::BoolOp(x) => self.boolop(&x.values, x.op, hint, errors),
@@ -1572,6 +1602,32 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             };
             self.call_method_or_error(ty, &dunder::BOOL, range, &[], &[], errors, None)
                 .as_bool()
+        })
+    }
+
+    /// A ternary branch guarded by these narrow idxs is statically unreachable iff
+    /// any of them is an identity-against-`None` narrow (`is None` / `is not None`)
+    /// whose narrowed subject solves to `Never` (e.g. `int & None`).
+    ///
+    /// We deliberately restrict to identity-vs-`None`: equality narrows (`== "x"`)
+    /// can also produce `Never` (negating `== "x"` on `Literal["x"]`), but mypy and
+    /// pyright keep that branch live, so pruning it would be wrong. Recording fewer
+    /// dead keys only ever under-prunes, so this restriction is always safe.
+    fn any_narrow_is_never(&self, narrows: &[Idx<Key>]) -> bool {
+        narrows.iter().any(|idx| {
+            let is_identity_none = matches!(
+                self.bindings().get(*idx),
+                Binding::Narrow(_, op, _)
+                    if matches!(
+                        op.as_ref(),
+                        NarrowOp::Atomic(
+                            _,
+                            AtomicNarrowOp::Is(Expr::NoneLiteral(_))
+                                | AtomicNarrowOp::IsNot(Expr::NoneLiteral(_)),
+                        )
+                    )
+            );
+            is_identity_none && self.get_idx(*idx).ty().is_never()
         })
     }
 

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -13,7 +13,6 @@ use std::slice;
 use dupe::Dupe;
 use itertools::Either;
 use itertools::Itertools;
-use pyrefly_graph::index::Idx;
 use pyrefly_python::ast::Ast;
 use pyrefly_python::dunder;
 use pyrefly_python::module_name::ModuleName;
@@ -79,7 +78,6 @@ use crate::binding::binding::KeyYield;
 use crate::binding::binding::KeyYieldFrom;
 use crate::binding::binding::LambdaParamId;
 use crate::binding::narrow::AtomicNarrowOp;
-use crate::binding::narrow::NarrowOp;
 use crate::binding::narrow::int_from_slice;
 use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
@@ -1602,32 +1600,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             };
             self.call_method_or_error(ty, &dunder::BOOL, range, &[], &[], errors, None)
                 .as_bool()
-        })
-    }
-
-    /// A ternary branch guarded by these narrow idxs is statically unreachable iff
-    /// any of them is an identity-against-`None` narrow (`is None` / `is not None`)
-    /// whose narrowed subject solves to `Never` (e.g. `int & None`).
-    ///
-    /// We deliberately restrict to identity-vs-`None`: equality narrows (`== "x"`)
-    /// can also produce `Never` (negating `== "x"` on `Literal["x"]`), but mypy and
-    /// pyright keep that branch live, so pruning it would be wrong. Recording fewer
-    /// dead keys only ever under-prunes, so this restriction is always safe.
-    fn any_narrow_is_never(&self, narrows: &[Idx<Key>]) -> bool {
-        narrows.iter().any(|idx| {
-            let is_identity_none = matches!(
-                self.bindings().get(*idx),
-                Binding::Narrow(_, op, _)
-                    if matches!(
-                        op.as_ref(),
-                        NarrowOp::Atomic(
-                            _,
-                            AtomicNarrowOp::Is(Expr::NoneLiteral(_))
-                                | AtomicNarrowOp::IsNot(Expr::NoneLiteral(_)),
-                        )
-                    )
-            );
-            is_identity_none && self.get_idx(*idx).ty().is_never()
         })
     }
 

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -2350,15 +2350,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             BindingExpect::UninitializedCheck {
                 name,
                 range,
-                termination_keys,
+                missing_branches,
             } => {
-                // Check if all branches that appeared uninitialized at binding time
-                // actually terminate due to Never/NoReturn. If any don't terminate,
-                // the variable may be uninitialized at this use.
-                let all_terminate = termination_keys
-                    .iter()
-                    .all(|key| self.get_idx(*key).ty().is_never());
-                if !all_terminate {
+                // The variable is initialized iff every branch that appeared
+                // uninitialized at binding time is statically dead: its tail
+                // terminates (Never/NoReturn) or its entry narrowing is vacuous
+                // (subject narrowed to `Never` via an identity-vs-`None` test).
+                let all_dead = missing_branches.iter().all(|branch| {
+                    branch
+                        .termination_key
+                        .is_some_and(|key| self.get_idx(key).ty().is_never())
+                        || self.any_narrow_is_never(&branch.dead_keys)
+                });
+                if !all_dead {
                     errors
                         .error_builder(
                             *range,
@@ -4346,6 +4350,23 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     // Helper functions for binding_to_type_info
     // -------------------------------------------------------------------------
 
+    /// A branch guarded by these narrow idxs is statically unreachable iff any of
+    /// them is an identity-against-`None` narrow (`is None` / `is not None`) whose
+    /// narrowed subject solves to `Never` (e.g. `int & None`).
+    ///
+    /// Restricted to identity-vs-`None`: an equality narrow (`== "x"`) can also
+    /// produce `Never` (negating `== "x"` on `Literal["x"]`), but its branch must
+    /// stay live, so pruning it would be wrong. Recording fewer dead keys only ever
+    /// under-prunes, which is always safe.
+    pub(crate) fn any_narrow_is_never(&self, narrows: &[Idx<Key>]) -> bool {
+        narrows.iter().any(|idx| {
+            matches!(
+                self.bindings().get(*idx),
+                Binding::Narrow(_, op, _) if op.tests_identity_none(),
+            ) && self.get_idx(*idx).ty().is_never()
+        })
+    }
+
     /// Handle `Binding::Phi` in binding_to_type_info - join multiple branches.
     /// The `#[inline(never)]` annotation is intentional to reduce stack frame size.
     #[inline(never)]
@@ -4360,11 +4381,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             let type_infos: Vec<_> = branches
                 .iter()
                 .filter_map(|branch| {
-                    // Filter branches based on type-based termination (Never/NoReturn)
+                    // Drop a branch that is statically dead. We force the branch value
+                    // first (as the un-pruned path always did) to preserve the solve
+                    // order this deep Phi chain relies on, then test for deadness:
+                    // type-based termination (Never/NoReturn tail) or a vacuous entry
+                    // narrowing (subject narrowed to `Never` via identity-vs-`None`).
                     let t = self.get_idx(branch.value_key);
-                    if let Some(term_key) = branch.termination_key
-                        && self.get_idx(term_key).ty().is_never()
-                    {
+                    let terminates = branch
+                        .termination_key
+                        .is_some_and(|term_key| self.get_idx(term_key).ty().is_never());
+                    if terminates || self.any_narrow_is_never(&branch.dead_if_any_never) {
                         None
                     } else {
                         Some(t)

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -5274,6 +5274,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
             }
             Binding::None => self.heap.mk_none(),
+            // Read raw by the ternary reachability check, never as a value type;
+            // every binding must still solve, so return a placeholder.
+            Binding::ConditionalReachability(_) => self.heap.mk_none(),
             Binding::Any(style) => self.heap.mk_any(*style),
             Binding::Global(global) => global.as_type(self.stdlib, self.heap),
             Binding::TypeParameter(tp) => {

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -923,6 +923,9 @@ pub enum Key {
     Delete(TextRange),
     /// Match statement or if/elif chain that needs type-based exhaustiveness checking
     Exhaustive(ExhaustivenessKind, TextRange),
+    /// Reachability channel for a ternary, keyed by its range: the per-branch
+    /// `Key::Narrow` idxs, so the solver can drop a branch whose narrow is `Never`.
+    ConditionalReachability(TextRange),
 }
 
 impl Ranged for Key {
@@ -956,6 +959,7 @@ impl Ranged for Key {
             Self::PossibleLegacyTParam(r) => *r,
             Self::PatternNarrow(r) => *r,
             Self::Exhaustive(_, r) => *r,
+            Self::ConditionalReachability(r) => *r,
         }
     }
 }
@@ -999,6 +1003,9 @@ impl DisplayWith<ModuleInfo> for Key {
             Self::PatternNarrow(r) => write!(f, "Key::PatternNarrow({})", ctx.display(r)),
             Self::Exhaustive(kind, r) => {
                 write!(f, "Key::Exhaustive({:?}, {})", kind, ctx.display(r))
+            }
+            Self::ConditionalReachability(r) => {
+                write!(f, "Key::ConditionalReachability({})", ctx.display(r))
             }
         }
     }
@@ -2253,6 +2260,11 @@ pub enum Binding {
     AugAssign(Option<Idx<KeyAnnotation>>, Box<StmtAugAssign>),
     /// The None type, constructed lazily with TypeHeap during solving.
     None,
+    /// Reachability channel for a ternary: the `(body, orelse)` `Key::Narrow` idxs.
+    /// A branch is dead iff one of its narrows is identity-vs-`None` (`is` /
+    /// `is not None`) and solves to `Never`. Read raw to prune the dead branch;
+    /// never solved through the normal path.
+    ConditionalReachability(Box<(Vec<Idx<Key>>, Vec<Idx<Key>>)>),
     /// An Any type with a specific style, constructed lazily with TypeHeap during solving.
     Any(AnyStyle),
     /// A global variable.
@@ -2477,6 +2489,15 @@ impl DisplayWith<Bindings> for Binding {
             }
             Self::AugAssign(a, s) => write!(f, "AugAssign({}, {})", ann(a), m.display(s)),
             Self::None => write!(f, "None"),
+            Self::ConditionalReachability(x) => {
+                let (body, orelse) = x.as_ref();
+                write!(
+                    f,
+                    "ConditionalReachability(body={} orelse={})",
+                    body.len(),
+                    orelse.len(),
+                )
+            }
             Self::Any(style) => write!(f, "Any({style:?})"),
             Self::Global(g) => write!(f, "Global({})", g.name()),
             Self::TypeParameter(tp) => {
@@ -2742,7 +2763,8 @@ impl Binding {
             | Binding::AssignToSubscript(_)
             | Binding::Delete(_)
             | Binding::ClassBodyUnknownName(_)
-            | Binding::Exhaustive(_) => None,
+            | Binding::Exhaustive(_)
+            | Binding::ConditionalReachability(_) => None,
         }
     }
 }

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -1166,10 +1166,10 @@ pub enum BindingExpect {
         name: Name,
         /// The range of the variable usage (for error location).
         range: TextRange,
-        /// Termination keys from branches that don't define the variable.
-        /// At solve time, we check if ALL of these have Never type.
-        /// If any don't, the variable may be uninitialized.
-        termination_keys: Vec<Idx<Key>>,
+        /// The branches that don't define the variable. At solve time, the variable
+        /// is initialized iff EVERY such branch is statically dead (terminates or has
+        /// a vacuous entry narrowing). If any may be reached, it may be uninitialized.
+        missing_branches: Vec<MissingBranch>,
     },
     /// Check for forward reference string literal in union type.
     /// At runtime, `type.__or__` cannot handle string literals, so expressions
@@ -1283,14 +1283,14 @@ impl DisplayWith<Bindings> for BindingExpect {
             Self::UninitializedCheck {
                 name,
                 range,
-                termination_keys,
+                missing_branches,
             } => {
                 write!(
                     f,
                     "UninitializedCheck({}, {}, {:?})",
                     name,
                     ctx.module().display(range),
-                    termination_keys
+                    missing_branches
                 )
             }
             Self::ForwardRefUnion {
@@ -2041,6 +2041,19 @@ pub enum FirstUse {
     UsedBy(Idx<Key>),
 }
 
+/// A branch that does not define some variable, recorded so that a deferred
+/// uninitialized check can decide at solve time whether the branch is reachable.
+/// The branch is safely-not-defining (i.e. it can be ignored for initialization)
+/// iff it is statically dead: its tail terminates (`termination_key` solves to
+/// `Never`) or its entry narrowing is vacuous (`any_narrow_is_never(dead_keys)`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MissingBranch {
+    /// The last `Binding::StmtExpr` in this branch, if any (NoReturn/Never tail).
+    pub termination_key: Option<Idx<Key>>,
+    /// The branch's entry-narrowing `Key::Narrow` idxs (identity-vs-`None` deadness).
+    pub dead_keys: Box<[Idx<Key>]>,
+}
+
 /// Information about a branch in a Phi node.
 #[derive(Clone, Debug)]
 pub struct BranchInfo {
@@ -2049,6 +2062,11 @@ pub struct BranchInfo {
     /// The last `Binding::StmtExpr` in this branch, if any.
     /// Used to check for type-based termination (NoReturn/Never) at solve time.
     pub termination_key: Option<Idx<Key>>,
+    /// The branch's entry narrow keys (`Key::Narrow` idxs). The branch is statically
+    /// dead if any of these is an identity-vs-`None` narrow that solves to `Never`
+    /// (checked at solve time via `any_narrow_is_never`). A dead branch is dropped
+    /// from the Phi join.
+    pub dead_if_any_never: Box<[Idx<Key>]>,
 }
 
 #[derive(Clone, Debug)]

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -1908,12 +1908,16 @@ impl<'a> BindingsBuilder<'a> {
         names
     }
 
+    /// Bind `narrow_ops` into the current flow, returning the `Key::Narrow` idxs
+    /// created. Flow-only callers ignore the result; the reachability channel uses
+    /// it to find dead branches (a narrow that solves to `Never`).
     pub fn bind_narrow_ops(
         &mut self,
         narrow_ops: &NarrowOps,
         use_location: NarrowUseLocation,
         usage: &Usage,
-    ) {
+    ) -> Vec<Idx<Key>> {
+        let mut narrowed_idxs = Vec::new();
         for (name, (op, op_range)) in narrow_ops.0.iter_hashed() {
             // Narrowing operations should not pin partial types, but they also
             // should not permanently block pinning. Leave the first-use state
@@ -1925,8 +1929,10 @@ impl<'a> BindingsBuilder<'a> {
                     Binding::Narrow(initial_idx, Box::new(op.clone()), use_location),
                 );
                 self.scopes.narrow_in_current_flow(name, narrowed_idx);
+                narrowed_idxs.push(narrowed_idx);
             }
         }
+        narrowed_idxs
     }
 
     pub fn bind_lambda_param(&mut self, name: &Identifier, owner: Option<Idx<Key>>) {

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -79,6 +79,7 @@ use crate::binding::binding::KeyYieldFrom;
 use crate::binding::binding::Keyed;
 use crate::binding::binding::LambdaParamId;
 use crate::binding::binding::LastStmt;
+use crate::binding::binding::MissingBranch;
 use crate::binding::binding::NarrowUseLocation;
 use crate::binding::binding::TypeAliasParams;
 use crate::binding::binding::TypeAliasRefBinding;
@@ -158,9 +159,9 @@ pub enum InitializedInFlow {
     Yes,
     Conditionally,
     No,
-    /// Initialization depends on whether these termination keys have Never type.
-    /// If ALL termination keys are Never, the variable is initialized; otherwise it may be uninitialized.
-    DeferredCheck(Vec<Idx<Key>>),
+    /// Initialization depends on whether every missing branch is statically dead.
+    /// If ALL are dead, the variable is initialized; otherwise it may be uninitialized.
+    DeferredCheck(Vec<MissingBranch>),
 }
 
 impl InitializedInFlow {
@@ -173,9 +174,9 @@ impl InitializedInFlow {
         }
     }
 
-    pub fn deferred_termination_keys(&self) -> Option<&[Idx<Key>]> {
+    pub fn deferred_missing_branches(&self) -> Option<&[MissingBranch]> {
         match self {
-            InitializedInFlow::DeferredCheck(keys) => Some(keys),
+            InitializedInFlow::DeferredCheck(branches) => Some(branches),
             _ => None,
         }
     }
@@ -843,6 +844,7 @@ impl BindingTable {
         let new_branch = BranchInfo {
             value_key: idx,
             termination_key: None,
+            dead_if_any_never: Box::new([]),
         };
         match self.types.1.insert_if_missing(phi_idx, || {
             Binding::Phi(JoinStyle::SimpleMerge, Box::new([]))
@@ -1933,6 +1935,24 @@ impl<'a> BindingsBuilder<'a> {
             }
         }
         narrowed_idxs
+    }
+
+    /// Record an `Stmt::If` branch's entry-narrowing idxs as candidate dead keys, so
+    /// the branch can be pruned at solve time if the narrowing is vacuous. We keep
+    /// only identity-vs-`None` narrows: other narrows (e.g. truthiness on `cond`)
+    /// never make a branch statically dead and would otherwise inflate the
+    /// deferrable-branch count used for uninitialized-variable accounting.
+    pub fn record_dead_narrow_keys(&mut self, narrowed_idxs: Vec<Idx<Key>>) {
+        let identity_none_keys: Vec<Idx<Key>> = narrowed_idxs
+            .into_iter()
+            .filter(|idx| {
+                matches!(
+                    self.idx_to_binding(*idx),
+                    Some(Binding::Narrow(_, op, _)) if op.tests_identity_none(),
+                )
+            })
+            .collect();
+        self.scopes.record_dead_keys(identity_none_keys);
     }
 
     pub fn bind_lambda_param(&mut self, name: &Identifier, owner: Option<Idx<Key>>) {

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -728,12 +728,18 @@ impl<'a> BindingsBuilder<'a> {
                 self.ensure_expr(&mut x.test, &mut Usage::narrowing_from(usage));
                 let narrow_ops = NarrowOps::from_expr(self, Some(&x.test));
                 self.start_fork_and_branch(x.range);
-                self.bind_narrow_ops(&narrow_ops, NarrowUseLocation::Span(x.body.range()), usage);
+                // Capture each branch's narrow idxs so the solver can prune a branch
+                // whose narrow solves to `Never` (e.g. `1 if x is not None else None`).
+                let body_narrows = self.bind_narrow_ops(
+                    &narrow_ops,
+                    NarrowUseLocation::Span(x.body.range()),
+                    usage,
+                );
                 self.ensure_expr(&mut x.body, usage);
                 // Negate the narrow ops for the `orelse`, then merge the Flows.
                 // TODO(stroxler): We eventually want to drop all narrows but merge values.
                 self.next_branch();
-                self.bind_narrow_ops(
+                let orelse_narrows = self.bind_narrow_ops(
                     &narrow_ops.negate(),
                     NarrowUseLocation::Span(x.range),
                     usage,
@@ -741,6 +747,10 @@ impl<'a> BindingsBuilder<'a> {
                 self.ensure_expr(&mut x.orelse, usage);
                 self.finish_branch();
                 self.finish_exhaustive_fork();
+                self.insert_binding(
+                    Key::ConditionalReachability(x.range),
+                    Binding::ConditionalReachability(Box::new((body_narrows, orelse_narrows))),
+                );
             }
             Expr::BoolOp(ExprBoolOp {
                 node_index: _,

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -369,18 +369,18 @@ impl<'a> BindingsBuilder<'a> {
                 // Uninitialized local errors are only reported when we are neither in a stub
                 // nor a static type context.
                 if !used_in_static_type && !self.module_info.path().is_interface() {
-                    if let Some(termination_keys) = is_initialized
-                        .deferred_termination_keys()
+                    if let Some(missing_branches) = is_initialized
+                        .deferred_missing_branches()
                         .map(|s| s.to_vec())
                     {
-                        // Defer the uninitialized check to solve time.
-                        // At solve time, we'll check if all termination keys have Never type.
+                        // Defer the uninitialized check to solve time, where we check
+                        // that every missing branch is statically dead.
                         self.insert_binding(
                             KeyExpect::UninitializedCheck(name.range),
                             BindingExpect::UninitializedCheck {
                                 name: name.id.clone(),
                                 range: name.range,
-                                termination_keys,
+                                missing_branches,
                             },
                         );
                     } else if let Some(error_message) = is_initialized.as_error_message(&name.id) {

--- a/pyrefly/lib/binding/narrow.rs
+++ b/pyrefly/lib/binding/narrow.rs
@@ -436,6 +436,32 @@ impl NarrowingSubject {
 }
 
 impl NarrowOp {
+    /// Is this op tree's narrowing-to-`Never` attributable *solely* to identity
+    /// against `None` (`is None` / `is not None`)?
+    ///
+    /// Used to restrict statically-dead branch pruning to identity-vs-`None`
+    /// narrowing (see `AnswersSolver::any_narrow_is_never`). Only then is dropping a
+    /// branch whose narrow is `Never` sound: equality narrows (`== "x"`) can also
+    /// reach `Never`, but those branches must stay live.
+    ///
+    /// `Placeholder` atoms carry no narrowing and are neutral. A compound qualifies
+    /// only if EVERY child qualifies — so the negation of a prior branch's test
+    /// carried into a later `elif`/`else` (wrapped as `And([Placeholder, Is(None)])`)
+    /// qualifies, but a mixed `And([IsNot(None), Eq("x")])`, whose `Never` may come
+    /// from the `Eq`, does not.
+    pub fn tests_identity_none(&self) -> bool {
+        match self {
+            Self::Atomic(
+                _,
+                AtomicNarrowOp::Is(Expr::NoneLiteral(_))
+                | AtomicNarrowOp::IsNot(Expr::NoneLiteral(_))
+                | AtomicNarrowOp::Placeholder,
+            ) => true,
+            Self::And(ops) | Self::Or(ops) => ops.iter().all(Self::tests_identity_none),
+            Self::Atomic(..) => false,
+        }
+    }
+
     /// Produce a Python-like snippet for hover display.
     ///
     /// `base_name` is the variable being narrowed. `snippet` converts a

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -61,6 +61,7 @@ use crate::binding::binding::KeyYield;
 use crate::binding::binding::KeyYieldFrom;
 use crate::binding::binding::MethodSelfKind;
 use crate::binding::binding::MethodThatSetsAttr;
+use crate::binding::binding::MissingBranch;
 use crate::binding::binding::NarrowUseLocation;
 use crate::binding::bindings::BindingTable;
 use crate::binding::bindings::BindingsBuilder;
@@ -504,6 +505,12 @@ pub struct Flow {
     /// The key for the last `Binding::StmtExpr` in this flow, if any.
     /// Used to check for type-based termination (NoReturn/Never) at solve time.
     last_stmt_expr: Option<Idx<Key>>,
+    /// `Key::Narrow` idxs recorded for this branch's entry narrowing (the negation
+    /// of prior branches' tests, plus this branch's own test). The branch is
+    /// statically dead if any of these is an identity-vs-`None` narrow that solves
+    /// to `Never` (checked at solve time via `any_narrow_is_never`). Used to prune
+    /// dead `if`/`elif`/`else` branches from the Phi and from uninit accounting.
+    dead_keys: Vec<Idx<Key>>,
 }
 
 impl Flow {
@@ -670,8 +677,8 @@ impl FlowInfo {
     fn initialized(&self) -> InitializedInFlow {
         self.value()
             .map_or(InitializedInFlow::Yes, |v| match &v.style {
-                FlowStyle::MaybeInitialized(termination_keys) => {
-                    InitializedInFlow::DeferredCheck(termination_keys.clone())
+                FlowStyle::MaybeInitialized(missing_branches) => {
+                    InitializedInFlow::DeferredCheck(missing_branches.clone())
                 }
                 FlowStyle::Uninitialized
                 | FlowStyle::ClassField {
@@ -731,11 +738,12 @@ pub enum FlowStyle {
     ClassDef { class_idx: Idx<Key>, pristine: bool },
     /// The name is possibly uninitialized (perhaps due to merging branches)
     PossiblyUninitialized,
-    /// The name may or may not be initialized depending on whether certain branches
-    /// terminate (have `Never` type). The termination keys are checked at solve time;
-    /// if all of them have `Never` type, the name is considered initialized.
-    /// This is used when some branches don't define a variable but end with a NoReturn call.
-    MaybeInitialized(Vec<Idx<Key>>),
+    /// The name may or may not be initialized depending on whether the branches that
+    /// don't define it are statically dead. The branches are checked at solve time;
+    /// if all are dead (terminating tail or vacuous narrowing), the name is considered
+    /// initialized. Used when some branches don't define a variable but end with a
+    /// NoReturn call or have a vacuous entry narrowing.
+    MaybeInitialized(Vec<MissingBranch>),
     /// The name was in an annotated declaration like `x: int` but not initialized
     Uninitialized,
     /// I'm a speculative binding for a name that was narrowed but not assigned above
@@ -778,11 +786,11 @@ impl FlowStyle {
                         _ => return FlowStyle::PossiblyUninitialized,
                     }
                 }
-                // Two MaybeInitialized: combine termination keys from both branches.
-                // Each branch independently needs its keys to be Never for that path
-                // to be initialized, so we collect all keys.
-                (FlowStyle::MaybeInitialized(keys), FlowStyle::MaybeInitialized(other_keys)) => {
-                    keys.extend(other_keys);
+                // Two MaybeInitialized: combine the missing branches from both sides.
+                // Every missing branch must be statically dead for the merged path to
+                // be initialized, so we collect all of them.
+                (FlowStyle::MaybeInitialized(branches), FlowStyle::MaybeInitialized(other)) => {
+                    branches.extend(other);
                 }
                 // Class-bearing styles stay sticky only when their canonical
                 // class identity matches. The `pristine` bit AND-merges: if
@@ -802,13 +810,13 @@ impl FlowStyle {
                 ) if *l_idx == r_idx => {
                     *l_pristine = *l_pristine && r_pristine;
                 }
-                // MaybeInitialized + a fully initialized style: keep the MaybeInitialized
-                // keys since those paths still need verification at solve time.
-                (FlowStyle::MaybeInitialized(keys), _) => {
-                    merged = FlowStyle::MaybeInitialized(keys.clone());
+                // MaybeInitialized + a fully initialized style: keep the missing
+                // branches since those paths still need verification at solve time.
+                (FlowStyle::MaybeInitialized(branches), _) => {
+                    merged = FlowStyle::MaybeInitialized(branches.clone());
                 }
-                (_, FlowStyle::MaybeInitialized(keys)) => {
-                    merged = FlowStyle::MaybeInitialized(keys);
+                (_, FlowStyle::MaybeInitialized(branches)) => {
+                    merged = FlowStyle::MaybeInitialized(branches);
                 }
                 // Unclear how to merge, default to None
                 _ => {
@@ -2506,6 +2514,16 @@ impl Scopes {
         self.current_mut().flow.last_stmt_expr = key;
     }
 
+    /// Record identity-vs-`None` `Key::Narrow` idxs from a branch's entry narrowing
+    /// so that, at solve time, the branch can be pruned if any of them narrows its
+    /// subject to `Never`. The caller must have already filtered to identity-vs-`None`
+    /// narrows (see `BindingsBuilder::record_dead_narrow_keys`); recording unrelated
+    /// narrows (e.g. truthiness on `cond`) would wrongly inflate the deferrable-branch
+    /// count used for uninitialized-variable accounting.
+    pub fn record_dead_keys(&mut self, keys: impl IntoIterator<Item = Idx<Key>>) {
+        self.current_mut().flow.dead_keys.extend(keys);
+    }
+
     /// Whenever we enter the scope of a method *and* we see a matching
     /// parameter, we record the name of it so that we can detect `self` assignments
     /// that might define class fields.
@@ -3162,17 +3180,18 @@ impl MergeStyle {
 /// The result of analyzing whether a variable is defined after merging branches.
 /// This enum captures the three distinct states:
 /// - `Defined`: Variable is defined in all non-terminating branches
-/// - `DeferredCheck`: Some branches don't define the variable, but they may terminate
-///   (have `Never` type). The check is deferred to solve time.
-/// - `NotDefined`: Variable is not defined in some branches that may not terminate
+/// - `DeferredCheck`: Some branches don't define the variable, but they may be
+///   statically dead (terminate, or have a vacuous entry narrowing). The check is
+///   deferred to solve time.
+/// - `NotDefined`: Variable is not defined in some branches that may be reached
 enum DefinitionStatus {
     /// Variable is defined in all non-terminating branches.
     Defined,
-    /// Variable may be defined if branches with these keys terminate (have `Never` type).
-    /// The keys are checked at solve time; if all have `Never` type, the variable is
+    /// Variable may be defined if every missing branch is statically dead. The
+    /// branches are checked at solve time; if all are dead, the variable is
     /// considered initialized.
-    DeferredCheck(Vec<Idx<Key>>),
-    /// Variable is not defined in some branches that may not terminate.
+    DeferredCheck(Vec<MissingBranch>),
+    /// Variable is not defined in some branches that may be reached.
     NotDefined,
 }
 
@@ -3187,22 +3206,35 @@ fn determine_definition_status(
     n_branches: usize,
     n_missing_branches: usize,
     n_branches_with_termination_key: usize,
-    missing_branch_termination_keys: Vec<Idx<Key>>,
+    missing_branches: Vec<MissingBranch>,
 ) -> DefinitionStatus {
+    // Defer the uninitialized check to solve time when either disjunct holds:
+    //  - EVERY missing branch carries a deadness signal (terminating tail or vacuous
+    //    narrowing); `missing_branches` records exactly those, so a dead `if`/`else`
+    //    branch no longer makes the variable look possibly-uninitialized; or
+    //  - there are at least as many branches with a termination key as missing
+    //    branches — the pre-existing NoReturn-based heuristic, kept so we never newly
+    //    flag a branch it already deferred (e.g. an assignment dominating a `try` body
+    //    that the `except`/`finally` path observes).
+    // The first disjunct only adds deferral; it cannot turn a deferred branch into a
+    // reported one.
+    let all_missing_deferrable = missing_branches.len() == n_missing_branches;
+    let deferrable =
+        all_missing_deferrable || n_missing_branches <= n_branches_with_termination_key;
     match merge_style {
         MergeStyle::LoopDefinitelyRuns if base_has_value => DefinitionStatus::Defined,
         MergeStyle::LoopDefinitelyRuns if n_values == n_branches => DefinitionStatus::Defined,
-        MergeStyle::LoopDefinitelyRuns if n_missing_branches <= n_branches_with_termination_key => {
-            if !missing_branch_termination_keys.is_empty() {
-                DefinitionStatus::DeferredCheck(missing_branch_termination_keys)
+        MergeStyle::LoopDefinitelyRuns if deferrable => {
+            if !missing_branches.is_empty() {
+                DefinitionStatus::DeferredCheck(missing_branches)
             } else {
                 DefinitionStatus::Defined
             }
         }
         _ if n_values == n_branches => DefinitionStatus::Defined,
-        _ if n_missing_branches <= n_branches_with_termination_key => {
-            if !missing_branch_termination_keys.is_empty() {
-                DefinitionStatus::DeferredCheck(missing_branch_termination_keys)
+        _ if deferrable => {
+            if !missing_branches.is_empty() {
+                DefinitionStatus::DeferredCheck(missing_branches)
             } else {
                 DefinitionStatus::Defined
             }
@@ -3219,6 +3251,9 @@ struct MergeBranchEntry {
     /// The last StmtExpr in the flow this branch came from, if any.
     /// Used for type-based termination checking at solve time.
     termination_key: Option<Idx<Key>>,
+    /// The entry-narrowing `Key::Narrow` idxs of the flow this branch came from.
+    /// Used to prune statically-dead `if`/`elif`/`else` branches at solve time.
+    dead_keys: Box<[Idx<Key>]>,
 }
 
 struct MergeItem {
@@ -3292,6 +3327,7 @@ impl<'a> BindingsBuilder<'a> {
             merge_branches.push(MergeBranchEntry {
                 flow_info: Some(base),
                 termination_key: None,
+                dead_keys: Box::new([]),
             });
             (Some(loop_prior), true)
         } else {
@@ -3328,28 +3364,38 @@ impl<'a> BindingsBuilder<'a> {
         let mut branch_infos = Vec::with_capacity(merge_branches.len());
         let mut styles = Vec::with_capacity(merge_branches.len());
         let mut n_values = 0;
-        // Collect termination keys from branches that don't define the variable.
-        // These will be used for deferred uninitialized checks at solve time.
-        let mut missing_branch_termination_keys = Vec::new();
+        // Collect, per branch that doesn't define the variable, the signals that let
+        // us defer the uninitialized check to solve time: the branch is safely-not-
+        // defining iff it is statically dead (terminating tail or vacuous narrowing).
+        let mut missing_branches = Vec::new();
+        // Build a `MissingBranch` record for a branch that doesn't define the variable,
+        // but only if it carries some deadness signal (otherwise it is genuinely
+        // reachable and the variable is not deferrable).
+        let missing_branch = |termination_key: Option<Idx<Key>>, dead_keys: &[Idx<Key>]| {
+            (termination_key.is_some() || !dead_keys.is_empty()).then(|| MissingBranch {
+                termination_key,
+                dead_keys: dead_keys.into(),
+            })
+        };
         for merge_branch in merge_branches.into_iter() {
+            let termination_key = merge_branch.termination_key;
+            let dead_keys = merge_branch.dead_keys;
             // Handle branches that don't have this name at all (flow_info is None)
             let Some(flow_info) = merge_branch.flow_info else {
-                // This branch doesn't have this name - record its termination key if any
-                if let Some(termination_key) = merge_branch.termination_key {
-                    missing_branch_termination_keys.push(termination_key);
-                }
+                missing_branches.extend(missing_branch(termination_key, &dead_keys));
                 continue;
             };
             let branch_idx = flow_info.idx();
 
             // The BranchInfo always sees the branch_idx, which will will be
-            // a narrow if one exists, otherwise the value. Each branch may have a
-            // termination key, which potentially causes us to ignore it in the Phi based
-            // on Never/NoReturn type information.
+            // a narrow if one exists, otherwise the value. Each branch may be dead
+            // due to Never/NoReturn type information or a vacuous entry narrowing,
+            // which causes us to drop it from the Phi.
             if branch_idx != phi_idx {
                 branch_infos.push(BranchInfo {
                     value_key: branch_idx,
-                    termination_key: merge_branch.termination_key,
+                    termination_key,
+                    dead_if_any_never: dead_keys.clone(),
                 });
             }
 
@@ -3362,10 +3408,9 @@ impl<'a> BindingsBuilder<'a> {
                     n_values += 1;
                 }
                 if v.idx == phi_idx {
-                    // If uninitialized, still track termination key before continuing.
-                    if is_uninitialized && let Some(termination_key) = merge_branch.termination_key
-                    {
-                        missing_branch_termination_keys.push(termination_key);
+                    // If uninitialized, still track deadness signal before continuing.
+                    if is_uninitialized {
+                        missing_branches.extend(missing_branch(termination_key, &dead_keys));
                     }
                     continue;
                 }
@@ -3374,16 +3419,13 @@ impl<'a> BindingsBuilder<'a> {
                     // set a value, so duplicate value_idxs always have the same style.
                     styles.push(v.style);
                 }
-                // Treat uninitialized branches like missing branches for termination keys.
-                if is_uninitialized && let Some(termination_key) = merge_branch.termination_key {
-                    missing_branch_termination_keys.push(termination_key);
+                // Treat uninitialized branches like missing branches for deadness signals.
+                if is_uninitialized {
+                    missing_branches.extend(missing_branch(termination_key, &dead_keys));
                 }
             } else {
                 // This branch doesn't have a value for the variable.
-                // If it has a termination key, track it for deferred checking.
-                if let Some(termination_key) = merge_branch.termination_key {
-                    missing_branch_termination_keys.push(termination_key);
-                }
+                missing_branches.extend(missing_branch(termination_key, &dead_keys));
             }
             branch_idxs.insert(branch_idx);
         }
@@ -3403,7 +3445,7 @@ impl<'a> BindingsBuilder<'a> {
             n_branches,
             n_missing_branches,
             n_branches_with_termination_key,
-            missing_branch_termination_keys,
+            missing_branches,
         );
 
         // Helper to compute the final FlowStyle based on definition status.
@@ -3539,13 +3581,20 @@ impl<'a> BindingsBuilder<'a> {
                 0
             };
 
-        // Count how many branches have a last_stmt_expr (potential type-based termination)
-        let n_branches_with_termination_key =
-            flows.iter().filter(|f| f.last_stmt_expr.is_some()).count();
-
         // Collect all termination keys from flows (for building dense MergeItems)
         let all_termination_keys: Vec<Option<Idx<Key>>> =
             flows.iter().map(|f| f.last_stmt_expr).collect();
+
+        // Count how many branches have a termination key (potential NoReturn/Never tail).
+        // Used by the pre-existing deferral heuristic for uninitialized-variable checks.
+        let n_branches_with_termination_key =
+            flows.iter().filter(|f| f.last_stmt_expr.is_some()).count();
+
+        // Collect each branch's entry-narrowing dead keys (parallel to termination keys).
+        let all_dead_keys: Vec<Box<[Idx<Key>]>> = flows
+            .iter()
+            .map(|f| f.dead_keys.clone().into_boxed_slice())
+            .collect();
 
         // Collect all unique names from base + all flows. We need this before we construct merge items
         // so that we can accurately represent a flow in which some name doesn't appear.
@@ -3570,6 +3619,7 @@ impl<'a> BindingsBuilder<'a> {
                 .map(|(i, flow_info_map)| MergeBranchEntry {
                     flow_info: flow_info_map.get(&name).cloned(),
                     termination_key: all_termination_keys[i],
+                    dead_keys: all_dead_keys[i].clone(),
                 })
                 .collect();
             merge_items.insert(
@@ -3603,6 +3653,7 @@ impl<'a> BindingsBuilder<'a> {
             has_terminated,
             is_definitely_unreachable: all_are_unreachable,
             last_stmt_expr: None,
+            dead_keys: Vec::new(),
         };
         self.scopes.current_mut().flow = flow
     }
@@ -3744,8 +3795,10 @@ impl<'a> BindingsBuilder<'a> {
         let fork = scope.forks.last_mut().unwrap();
         fork.branch_started = true;
         scope.flow = fork.base.clone();
-        // Clear last_stmt_expr so this branch tracks only its own terminal statement
+        // Clear per-branch signals so this branch tracks only its own terminal
+        // statement and its own entry narrowing.
         scope.flow.last_stmt_expr = None;
+        scope.flow.dead_keys = Vec::new();
     }
 
     /// Abandon a branch we began without including it in the merge. Used for a few cases

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -1077,11 +1077,14 @@ impl<'a> BindingsBuilder<'a> {
                 let mut is_first_branch = true;
                 for (range, mut test, body) in Ast::if_branches_owned(x) {
                     self.start_branch();
-                    self.bind_narrow_ops(
+                    // The negation of prior branches' tests is where a dead `else`/`elif`
+                    // signal lives (e.g. `else` after `if x is None` with `x: int`).
+                    let negated_dead_keys = self.bind_narrow_ops(
                         &negated_prev_ops,
                         NarrowUseLocation::Start(range),
                         &Usage::Narrowing(None),
                     );
+                    self.record_dead_narrow_keys(negated_dead_keys);
                     // If there is no test, it's an `else` clause and `this_branch_chosen` will be true.
                     let this_branch_chosen = match &test {
                         None => {
@@ -1130,11 +1133,14 @@ impl<'a> BindingsBuilder<'a> {
                             BindingExpect::Bool(test_expr),
                         );
                     }
-                    self.bind_narrow_ops(
+                    // The branch's own test is where a dead `if`-body signal lives
+                    // (e.g. `if x is None` with `x: int`).
+                    let own_dead_keys = self.bind_narrow_ops(
                         &new_narrow_ops,
                         NarrowUseLocation::Span(range),
                         &Usage::Narrowing(None),
                     );
+                    self.record_dead_narrow_keys(own_dead_keys);
                     negated_prev_ops.and_all(new_narrow_ops.negate());
                     self.stmts(body, parent);
                     self.finish_branch();

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -2799,3 +2799,161 @@ def f(x: T) -> T:  # E: not in scope  # E: not in scope
     return x
     "#,
 );
+
+// #3349 (sibling): an if/else branch whose narrowing is vacuous (subject -> Never)
+// is dead. Its assignments must not contribute to the merged type, and a dead
+// *missing* branch must not trigger a spurious possibly-uninitialized error.
+testcase!(
+    test_if_else_prunes_dead_else_assignment,
+    r#"
+from typing import reveal_type
+def f(x: int) -> None:
+    if x is not None:
+        y = 1
+    else:
+        y = "s"
+    reveal_type(y)  # E: revealed type: Literal[1]  # !E: 's'
+    "#,
+);
+
+// A dead *missing* branch (`if`-body is dead, `y` only set in `else`) must not
+// make `y` look possibly-uninitialized: the `else` is the only reachable path.
+testcase!(
+    test_if_dead_missing_branch_no_spurious_unbound,
+    r#"
+from typing import assert_type, Literal
+def f(x: int) -> None:
+    if x is None:
+        pass
+    else:
+        y = 1
+    assert_type(y, Literal[1])
+    "#,
+);
+
+// An `elif`/`else` made dead by accumulated negated narrows is dropped.
+testcase!(
+    test_if_elif_dead_branches_pruned,
+    r#"
+from typing import reveal_type
+def f(x: int) -> None:
+    if x is None:
+        y = "a"
+    elif x is not None:
+        y = 1
+    else:
+        y = "b"
+    reveal_type(y)  # E: revealed type: Literal[1]  # !E: 'a'  # !E: 'b'
+    "#,
+);
+
+// Guard: a no-`else` if whose implicit else is dead already defines `y`.
+testcase!(
+    test_if_no_else_dead_implicit_defines,
+    r#"
+from typing import assert_type, Literal
+def f(x: int) -> None:
+    if x is not None:
+        y = 1
+    assert_type(y, Literal[1])
+    "#,
+);
+
+// Guard: a dead branch that *defines* `y` must not make `y` look initialized.
+testcase!(
+    test_if_dead_defining_branch_still_unbound,
+    r#"
+from typing import assert_type, Literal
+def f(x: int) -> None:
+    if x is None:
+        y = 1
+    assert_type(y, Literal[1])  # E: `y` may be uninitialized
+    "#,
+);
+
+// Negative: genuinely optional subject keeps both branches and the union.
+testcase!(
+    test_if_else_optional_keeps_union,
+    r#"
+from typing import reveal_type
+def f(x: int | None) -> None:
+    if x is not None:
+        y = 1
+    else:
+        y = "s"
+    reveal_type(y)  # E: revealed type: Literal['s', 1]
+    "#,
+);
+
+// A mixed `is not None and == "b"` test reaches Never via the equality conjunct,
+// so the if-body assignment must stay live. #3349.
+testcase!(
+    test_if_mixed_none_and_equality_keeps_branch,
+    r#"
+from typing import Literal, reveal_type
+def f(x: Literal["a", "b"]) -> None:
+    if x is not None and x == "c":
+        y = 1
+    else:
+        y = "s"
+    reveal_type(y)  # E: revealed type: Literal['s', 1]
+    "#,
+);
+
+// A genuinely-reachable missing branch (`if cond:`) keeps `y` possibly-unbound even
+// when sibling branches are statically dead and would satisfy a mere count. #3349.
+testcase!(
+    test_if_reachable_missing_branch_still_unbound,
+    r#"
+def f(cond: bool, x: int) -> None:
+    if cond:
+        pass
+    elif x is not None:
+        y = 1
+    else:
+        pass
+    print(y)  # E: `y` may be uninitialized
+    "#,
+);
+
+// a variable assigned before the only
+// statements that can raise is initialized on the `except` path; reporting it
+// possibly-uninitialized is a false positive (neither mypy nor pyright flags it).
+// The dead-branch work must not touch uninitialized-variable accounting for
+// branches that carry no deadness signal.
+testcase!(
+    test_try_except_var_assigned_before_raise_not_unbound,
+    r#"
+class Err(Exception): pass
+def get(o: object, n: str) -> str:
+    return ""
+def step(m: str) -> None: ...
+def f(cls: object, modname: str) -> str:
+    try:
+        qualname = get(cls, "__qualname__")
+        step(modname)
+    except Err:
+        pass
+    return qualname
+    "#,
+);
+
+// a variable assigned as the first statement of a `try` is initialized in the // `finally`; reporting it possibly-uninitialized is a false positive.
+testcase!(
+    test_try_finally_var_assigned_first_not_unbound,
+    r#"
+class Err(Exception): pass
+def do() -> None: ...
+class C:
+    subdir: str = ""
+    def f(self, subdir: str) -> None:
+        try:
+            prev = self.subdir
+            self.subdir = subdir
+            do()
+        except Err:
+            pass
+        finally:
+            self.subdir = prev
+    "#,
+);

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -129,6 +129,80 @@ def f(x: str):
     "#,
 );
 
+// #3349: a conditional-expression branch whose narrowing is vacuous (narrows the
+// subject to Never) is dead and must be dropped from the result type.
+// `# !E: None` guards against the substring match: `Literal[1]` is a substring of
+// the un-pruned `Literal[1] | None`, so without the negative assertion the test
+// would pass spuriously.
+testcase!(
+    test_ternary_prunes_dead_else_after_guard,
+    r#"
+from typing import reveal_type
+def f(x: int | None) -> None:
+    if x is not None:
+        reveal_type(1 if x is not None else None)  # E: revealed type: Literal[1]  # !E: None
+    "#,
+);
+
+testcase!(
+    test_ternary_prunes_dead_else_concrete,
+    r#"
+from typing import reveal_type
+def f(x: int) -> None:
+    reveal_type(1 if x is not None else None)  # E: revealed type: Literal[1]  # !E: None
+    "#,
+);
+
+testcase!(
+    test_ternary_prunes_dead_body_concrete,
+    r#"
+from typing import reveal_type
+def f(x: int) -> None:
+    reveal_type(1 if x is None else 2)  # E: revealed type: Literal[2]  # !E: Literal[1, 2]
+    "#,
+);
+
+// Genuinely optional subject: neither branch is dead, both are kept.
+testcase!(
+    test_ternary_keeps_live_branches,
+    r#"
+from typing import reveal_type
+def f(x: int | None) -> None:
+    reveal_type(1 if x is not None else None)  # E: revealed type: Literal[1] | None
+    "#,
+);
+
+// Literal-True pruning (solver-side `as_bool`) must keep working.
+testcase!(
+    test_ternary_literal_true_still_prunes,
+    r#"
+from typing import reveal_type
+def f() -> None:
+    reveal_type(1 if True else None)  # E: revealed type: Literal[1]  # !E: None
+    "#,
+);
+
+// `Any & None` is not Never, so an `Any` subject does not make a branch dead.
+testcase!(
+    test_ternary_any_subject_not_pruned,
+    r#"
+from typing import Any, reveal_type
+def f(x: Any) -> None:
+    reveal_type(1 if x is not None else None)  # E: revealed type: Literal[1] | None
+    "#,
+);
+
+// Equality narrows that produce Never (negating `== "x"` on a literal) must NOT
+// prune: that branch stays live. #3349.
+testcase!(
+    test_ternary_equality_branch_not_pruned,
+    r#"
+from typing import Literal, reveal_type
+def f(x: Literal["hello"]) -> None:
+    reveal_type("a" if x == "hello" else 42)  # E: revealed type: Literal['a', 42]
+    "#,
+);
+
 testcase!(
     test_is_not_bool_literal,
     r#"
@@ -3229,4 +3303,16 @@ def b():
         def inner() -> None:
             assert_type(val, int)
 "#,
+);
+
+// A ternary in a type-expression position is inferred outside the normal
+// expression-binding path, so the #3349 reachability channel binding is absent.
+// The branch-pruning lookup must fall back gracefully (keep both branches)
+// instead of panicking.
+testcase!(
+    test_ternary_in_type_position_does_not_panic,
+    r#"
+x: int if 1 < 3 else str  # E: If expression cannot be used in annotations
+type T = int if 1 < 3 else str  # E: If expression cannot be used in annotations
+    "#,
 );

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -203,6 +203,17 @@ def f(x: Literal["hello"]) -> None:
     "#,
 );
 
+// A mixed same-name narrow `x is not None and x == "c"` reaches Never via the
+// equality conjunct, not the `None` test, so the branch must stay live. #3349.
+testcase!(
+    test_ternary_mixed_none_and_equality_not_pruned,
+    r#"
+from typing import Literal, reveal_type
+def f(x: Literal["a", "b"]) -> None:
+    reveal_type(1 if (x is not None and x == "c") else 2)  # E: revealed type: Literal[1, 2]
+    "#,
+);
+
 testcase!(
     test_is_not_bool_literal,
     r#"
@@ -3312,7 +3323,8 @@ def b():
 testcase!(
     test_ternary_in_type_position_does_not_panic,
     r#"
-x: int if 1 < 3 else str  # E: If expression cannot be used in annotations
-type T = int if 1 < 3 else str  # E: If expression cannot be used in annotations
+flag: bool = True
+x: int if flag else str  # E: If expression cannot be used in annotations
+type T = int if flag else str  # E: If expression cannot be used in annotations
     "#,
 );


### PR DESCRIPTION
Fixes facebook/pyrefly#3349.

### Problem

A branch whose reachability is already decided by prior narrowing was kept in the result type, and a dead *missing* branch falsely triggered "possibly uninitialized":

```python
def f(x: int | None) -> None:
    if x is not None:                    # x is `int` here
        y = 1 if x is not None else None # `else None` can never run
        reveal_type(y)                   # was: Literal[1] | None  →  now: Literal[1]

def g(x: int) -> None:
    if x is not None: y = 1
    else:             y = "s"            # dead branch
    reveal_type(y)                       # was: Literal['s', 1]    →  now: Literal[1]

def h(x: int) -> None:
    if x is None: pass                   # dead branch (never runs)
    else:         y = 1
    print(y)                             # was: "y may be uninitialized"  →  now: clean
```

### Approach

`Never` is the reachability signal: a branch whose entry narrowing solves to `Never` (e.g. `int & None`) cannot run. The narrowed-subject binding is already created and solved, so deciding this is a cache hit, not new work.

Reachability is only known at **solve** time, but *which* branches merge is fixed at **binding** time, so the signal is recorded as a key at binding time and evaluated at solve time — the same idiom pyrefly already uses for `NoReturn` tails. Ternaries and `if`/`elif`/`else` merge through two different paths, hence two commits:

- **`63daca631` — conditional expressions.** A range-keyed `Key::ConditionalReachability` side-channel carries each branch's narrow idxs from binding to solving; the inline `Expr::If` solver drops the dead side (falling back to `union` when the channel is absent, e.g. ternaries in type-annotation positions).
- **`bd4a82b2d` — `if`/`elif`/`else`.** Each branch records its entry-narrow idxs (`BranchInfo.dead_if_any_never`); the existing Phi termination filter now drops a branch that terminates **or** has a vacuous narrowing.

### Soundness gate (identity-vs-`None` only)

Pruning fires **only** for pure `is None` / `is not None` (`NarrowOp::tests_identity_none`, every conjunct of an `and`/`or` must qualify). An equality narrow can also reach `Never` but its branch must stay live:

```python
1 if (x is not None and x == "c") else 2   # Literal[1, 2] — kept
```

`assert x is not None` feeds this; `assert x > 0` does not (a comparison on `int` stays `int`).

### Uninitialized-variable accounting: a combined deferral gate

The dead-branch signal also lets a dead `if`-body stop a variable looking possibly-uninitialized. Rather than *replace* the pre-existing `NoReturn`-count heuristic (which over-flagged `try`/`except`/`finally` and loops), the deferral gate now **combines** them:

```rust
let deferrable =
    all_missing_deferrable                                   // every missing branch is dead, OR
    || n_missing_branches <= n_branches_with_termination_key; // the existing NoReturn heuristic
```

The first disjunct only **adds** deferral — it can never newly flag a variable — so the dead-branch improvement is gained without regressing the cases the old heuristic already deferred:

```python
def k(cls, modname) -> str:
    try:
        qualname = get(cls)   # assigned before the only raising call
        analyze(modname)
    except Err:
        pass
    return qualname           # not flagged (matches mypy/pyright)
```

### Tests

- `narrow.rs` — 9 ternary cases (prune after guard, concrete dead body/else, `Any` subject kept, equality kept, mixed `and`-equality kept, type-annotation position must not panic).
- `flow_branching.rs` — `if`/`elif`/`else` pruning, dead-missing-branch defined, reachable-missing-branch still flagged, plus two regression guards for the try/except and try/finally false positives.
- `scope.rs` — one assertion adjusted.

### Performance

No new solving passes or fixpoint iterations. Added work is bookkeeping (a small `Vec` of narrow idxs per branch, one range-keyed binding per ternary, a usually-empty boxed slice per branch). The deadness check reads an already-solved narrow binding and short-circuits on branches with no `is None` narrow.

### Validation

- Full unit suite green; format/lint clean; conformance unchanged.
- Wide `mypy_primer`: removes false positives (e.g. PyGithub `bad-return`, sphinx/jax/meson `unbound-name`) and introduces no `unbound-name` regressions.

### Known interaction (`prefect`, not a regression in this change)

In `prefect/tasks.py`, `cache_policy`'s type has no `None`, so `cache_policy is None` is provably false and the ternary's `None` branch is **correctly** pruned — sharpening one assignment from `_None | None` to `_None`. This surfaces a **pre-existing** attribute-type-inference limitation (pyrefly infers `self.cache_policy` from the first conditional assignment instead of the explicit `Union[…, None]` annotation), producing a spurious `bad-assignment`. The same lines already errored before this change (as `_None | None`) and mypy co-reports them. The fix belongs in attribute-type inference and is out of scope here; tracked separately.
