### PR TITLE
Populate the enclosing Anywhere phi for walrus-in-comprehension targets

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -1758,6 +1758,21 @@ impl<'a> BindingsBuilder<'a> {
         write_info.annotation
     }
 
+    /// PEP 572: a walrus inside a comprehension binds its target in the enclosing
+    /// non-comprehension scope. Mirror `bind_name`'s `Anywhere` bookkeeping so a
+    /// read that resolves to the enclosing `Anywhere` static (e.g. a read before
+    /// the walrus write) finds a populated phi instead of a promised-but-empty key.
+    pub fn bind_walrus_target_in_enclosing_scope(&mut self, name: &Name, idx: Idx<Key>) {
+        if let Some(write_info) = self.scopes.define_in_enclosing_non_comprehension_scope(
+            Hashed::new(name),
+            idx,
+            FlowStyle::Other,
+        ) && let Some(range) = write_info.anywhere_range
+        {
+            self.table.record_bind_in_anywhere(name.clone(), range, idx);
+        }
+    }
+
     fn check_for_type_alias_redefinition(&self, name: &Name, idx: Idx<Key>) {
         let prev_idx = self.scopes.current_flow_idx(name);
         if let Some(prev_idx) = prev_idx {

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -969,11 +969,7 @@ impl<'a> BindingsBuilder<'a> {
                     && let Expr::Name(name) = &*x.target
                     && let Some(idx) = self.scopes.get_current_flow_idx(&name.id)
                 {
-                    self.scopes.define_in_enclosing_non_comprehension_scope(
-                        Hashed::new(&name.id),
-                        idx,
-                        FlowStyle::Other,
-                    );
+                    self.bind_walrus_target_in_enclosing_scope(&name.id, idx);
                 }
             }
             Expr::Lambda(x) => {

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -2064,13 +2064,15 @@ impl Scopes {
 
     /// PEP 572: walrus operators inside comprehensions bind to the enclosing
     /// non-comprehension scope. This method updates the flow of the nearest
-    /// enclosing non-comprehension scope with the given name and binding idx.
+    /// enclosing non-comprehension scope with the given name and binding idx,
+    /// and returns that scope's `NameWriteInfo` so callers can record the
+    /// `Anywhere` bind (mirroring `define_in_current_flow`).
     pub fn define_in_enclosing_non_comprehension_scope(
         &mut self,
         name: Hashed<&Name>,
         idx: Idx<Key>,
         style: FlowStyle,
-    ) {
+    ) -> Option<NameWriteInfo> {
         let len = self.scopes.len();
         for i in (0..len - 1).rev() {
             if !matches!(self.scopes[i].scope.kind, ScopeKind::Comprehension { .. }) {
@@ -2083,9 +2085,15 @@ impl Scopes {
                         *e.get_mut() = e.get().updated_value(idx, style, in_loop);
                     }
                 }
-                break;
+                return self.scopes[i]
+                    .scope
+                    .stat
+                    .0
+                    .get_hashed(name)
+                    .map(StaticInfo::as_name_write_info);
             }
         }
+        None
     }
 
     /// Handle a delete operation by marking a name as uninitialized in this flow.

--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -675,6 +675,87 @@ def h(matrix: list[list[int]]) -> None:
 "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/3670
+// A name assigned by >=2 walrus operators inside comprehensions becomes an
+// `Anywhere` static (phi/SSA) in the enclosing scope. A read that happens
+// before the walrus write must resolve to a populated phi, not panic with
+// "key lacking binding". After the comprehensions, `c` resolves to the
+// last-written value via the enclosing flow (matching pyright's `Literal[2]`).
+testcase!(
+    test_walrus_in_comprehension_anywhere_read_before_write,
+    r#"
+from typing import reveal_type
+print(c)  # E: `c` is uninitialized
+[(c := 1) for _ in []]
+[(c := 2) for _ in []]
+reveal_type(c)  # E: revealed type: Literal[2]
+"#,
+);
+
+// Same read-before-write pattern, but the walrus redirect target is a function
+// scope rather than the module scope. Must not panic.
+testcase!(
+    test_walrus_in_comprehension_anywhere_in_function,
+    r#"
+from typing import reveal_type
+def f() -> None:
+    print(c)  # E: `c` is uninitialized
+    [(c := 1) for _ in []]
+    [(c := 2) for _ in []]
+    reveal_type(c)  # E: revealed type: Literal[2]
+"#,
+);
+
+// Regression guard: two walrus comprehensions with NO early read (the path that
+// already worked before the fix, since the flow write shadowed the phi). The
+// fix must not change this behavior.
+testcase!(
+    test_walrus_in_comprehension_two_walrus_no_early_read,
+    r#"
+from typing import reveal_type
+[(c := 1) for _ in []]
+[(c := 2) for _ in []]
+reveal_type(c)  # E: revealed type: Literal[2]
+"#,
+);
+
+// Raw fuzzer input from #3670. Intentionally malformed; the only hard
+// requirement is that it produces parse errors but does NOT panic.
+testcase!(
+    test_walrus_comprehension_fuzz_no_crash,
+    r#"
+[(c:=)for c+]  # E: Expected an expression  # E: Invalid assignment target  # E: Expected an expression  # E: Expected `in`, found `]`
+[(c:=)for]  # E: Expected an expression  # E: Expected an expression
+"#,
+);
+
+// Nested comprehension: the walrus still binds to the enclosing (module) scope,
+// which the redirect reaches by skipping all comprehension scopes. Read-before-
+// write must populate the enclosing `Anywhere` phi, not panic.
+testcase!(
+    test_walrus_in_comprehension_anywhere_nested,
+    r#"
+from typing import reveal_type
+print(c)  # E: `c` is uninitialized
+[[(c := 1) for _ in inner] for inner in []]
+[[(c := 2) for _ in inner] for inner in []]
+reveal_type(c)  # E: revealed type: Literal[2]
+"#,
+);
+
+// Generator expressions are also comprehension scopes (`is_generator: true`), so
+// the same redirect + read-before-write path applies. Must not panic.
+testcase!(
+    test_walrus_in_comprehension_anywhere_genexp,
+    r#"
+from typing import reveal_type
+print(c)  # E: `c` is uninitialized
+list((c := 1) for _ in [])
+list((c := 2) for _ in [])
+reveal_type(c)  # E: revealed type: Literal[2]
+"#,
+);
+
 testcase!(
     test_forward_reference_ok,
     r#"


### PR DESCRIPTION
Fixes facebook/pyrefly#3670

### What
Pyrefly panicked (`Internal error: key lacking binding, key=Key::Anywhere(c)`) instead of type-checking. Reachable from valid Python, not just the fuzzed input in the issue:

```python
# before: 💥 panic
# after:  print(c) → error "`c` is uninitialized"; reveal_type(c) → Literal[2]
print(c)
[(c := 1) for _ in []]
[(c := 2) for _ in []]
```

### Why
A name assigned by ≥2 walrus operators inside comprehensions becomes an `Anywhere` binding — pyrefly's SSA φ (phi) node whose value is the join of all assignment sites. The φ's *value* is only ever populated by `record_bind_in_anywhere`, reached through `bind_name`. But PEP 572 says a comprehension walrus assigns to the **enclosing** scope, so it routes through `define_in_enclosing_non_comprehension_scope`, which updated only the enclosing flow and **never recorded the φ branch**. When a read resolves to that enclosing `Anywhere` static *before* the walrus write (a read-before-write, or the issue's malformed for-target that reads the name), the φ node is created with no value → panic at solve time. In ordinary code the redirect's flow write shadows the φ, masking the gap. mypy, pyright, and ty all handle this without crashing (the conformance bar): error on the early read, infer `int`/`Literal[2]` after.

### How
Make the walrus redirect fully emulate an enclosing-scope assignment — the same φ bookkeeping `bind_name` does:
- **`pyrefly/lib/binding/scope.rs`** — `define_in_enclosing_non_comprehension_scope` now returns `Option<NameWriteInfo>` (the enclosing scope's static write-info), mirroring `define_in_current_flow`.
- **`pyrefly/lib/binding/bindings.rs`** — new `bind_walrus_target_in_enclosing_scope` helper that, when the enclosing name is `Anywhere`, calls `record_bind_in_anywhere` (must live here — `table`/`record_bind_in_anywhere` are module-private).
- **`pyrefly/lib/binding/expr.rs`** — the `Expr::Named` walrus arm calls the helper instead of the bare redirect.

Deliberately untouched: the single-walrus / no-`Anywhere` case stays a no-op (`anywhere_range` is `None`); `bind_name`'s type-alias/final/annotation checks already run on the comprehension-scope binding.

### Test plan
| Test (`pyrefly/lib/test/scope.rs`) | Protects |
|---|---|
| `test_walrus_in_comprehension_anywhere_read_before_write` | the crash repro: no panic, early-read error, `Literal[2]` after |
| `test_walrus_in_comprehension_anywhere_in_function` | function-scope redirect target |
| `test_walrus_in_comprehension_anywhere_nested` | nested comprehension (redirect skips all comprehension scopes) |
| `test_walrus_in_comprehension_anywhere_genexp` | generator expression (also a comprehension scope) |
| `test_walrus_in_comprehension_two_walrus_no_early_read` | regression guard for the previously-masked path |
| `test_walrus_comprehension_fuzz_no_crash` | raw fuzzer input → parse errors, no panic |

- `cargo test -p pyrefly --lib` → 5360 passed; `test::scope::` → 92 passed (all pre-existing walrus tests unchanged).
- mypy_primer, 57 projects (pydantic, pandas, pandas-stubs, pandera, sympy, scipy, django-stubs, …): **no diff** — no regressions.
- Format + lint clean.
