### PR TITLE
fix Support for Django Manager/QuerySet #3648

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -2489,6 +2489,17 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         range: TextRange,
         errors: &ErrorCollector,
     ) -> Option<Type> {
+        let initial_value_expr = match field_definition {
+            ClassFieldDefinition::AssignedInBody { value, .. } => {
+                if let ExprOrBinding::Expr(expr) = value.as_ref() {
+                    Some(expr)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+
         self.get_enum_class_field_type(
             class,
             name,
@@ -2502,18 +2513,12 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         .or_else(|| self.get_property_class_field_type(class, name, field_definition))
         .or_else(|| self.get_pydantic_root_model_class_field_type(class, name))
         .or_else(|| {
-            let initial_value_expr = match field_definition {
-                ClassFieldDefinition::AssignedInBody { value, .. } => {
-                    if let ExprOrBinding::Expr(expr) = value.as_ref() {
-                        Some(expr)
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            };
-            self.get_django_field_type(ty, class, Some(name), initial_value_expr)
+            direct_annotation
+                .is_none()
+                .then(|| self.get_django_manager_from_queryset_type(class, initial_value_expr))
+                .flatten()
         })
+        .or_else(|| self.get_django_field_type(ty, class, Some(name), initial_value_expr))
     }
 
     /// Recognize `x = property(fget, fset, fdel)` and return the corresponding
@@ -2998,6 +3003,14 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         let inferred_ty = match value {
             ExprOrBinding::Expr(e) => {
                 match inherited_ty {
+                    Some(_)
+                        if direct_annotation.is_none()
+                            && self
+                                .get_django_manager_from_queryset_type(class, Some(e))
+                                .is_some() =>
+                    {
+                        self.attribute_expr_infer(e, None, name, errors)
+                    }
                     Some(inherited_ty) if inferred_from_method => {
                         // Inherit the previous type of the attribute if the only declaration-like
                         // thing the current class does is assign to the attribute in a method.
@@ -3902,6 +3915,12 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             || class_metadata.is_django_rest_framework_model_serializer())
             && field_name.as_str() == "Meta"
         {
+            return false;
+        }
+
+        // Django models commonly replace `Model.objects` with a model-specific
+        // manager, which should not be checked as a normal class override.
+        if class_metadata.is_django_model() && field_name.as_str() == "objects" {
             return false;
         }
 

--- a/pyrefly/lib/alt/class/django.rs
+++ b/pyrefly/lib/alt/class/django.rs
@@ -79,6 +79,7 @@ const MANY_TO_MANY_FIELD: Name = Name::new_static("ManyToManyField");
 const MODEL: Name = Name::new_static("Model");
 const MANYRELATEDMANAGER: Name = Name::new_static("ManyRelatedManager");
 const SYMMETRICAL: Name = Name::new_static("symmetrical");
+const AS_MANAGER: Name = Name::new_static("as_manager");
 
 /// Find a keyword argument by name and return its value expression.
 fn find_keyword<'a>(call_expr: &'a ExprCall, name: &Name) -> Option<&'a Expr> {
@@ -234,6 +235,39 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             })
     }
 
+    fn inherits_from_django_queryset(&self, cls: &Class) -> bool {
+        cls.has_toplevel_qname("django.db.models.query", "QuerySet")
+            || self
+                .get_mro_for_class(cls)
+                .ancestors(self.stdlib)
+                .any(|ancestor| ancestor.has_qname("django.db.models.query", "QuerySet"))
+    }
+
+    pub fn get_django_manager_from_queryset_type(
+        &self,
+        model: &Class,
+        initial_value_expr: Option<&Expr>,
+    ) -> Option<Type> {
+        if !self.get_metadata_for_class(model).is_django_model() {
+            return None;
+        }
+        let call_expr = initial_value_expr?.as_call_expr()?;
+        let Expr::Attribute(attr) = call_expr.func.as_ref() else {
+            return None;
+        };
+        if attr.attr.id != AS_MANAGER {
+            return None;
+        }
+
+        match self.expr_infer(&attr.value, &self.error_swallower()) {
+            Type::ClassDef(queryset_cls) if self.inherits_from_django_queryset(&queryset_cls) => {
+                Some(self.instantiate(&queryset_cls))
+            }
+            _ => None,
+        }
+    }
+
+    // Get ManyRelatedManager class from django stubs
     fn get_manager_type(&self, target_model_type: Type) -> Option<Type> {
         let model_class = self.try_get_from_export(ModuleName::django_models(), MODEL)?;
         let model_instance_type = self.class_def_to_instance_type(model_class);

--- a/pyrefly/lib/test/django/fields.rs
+++ b/pyrefly/lib/test/django/fields.rs
@@ -106,3 +106,21 @@ def probe(m: M) -> None:
     reveal_type(m.x)  # E: revealed type: str
 "#,
 );
+
+django_testcase!(
+    test_queryset_as_manager_preserves_custom_methods,
+    r#"
+from django.db import models
+
+class NotificationQuerySet(models.QuerySet["Notification"]):
+    def resolved(self):
+        return self.filter(resolved_at__isnull=False)
+
+class Notification(models.Model):
+    resolved_at = models.DateTimeField(null=True, blank=True)
+    objects = NotificationQuerySet.as_manager()
+
+Notification.objects.resolved()
+Notification.objects.all().resolved()
+"#,
+);


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3648

recognizes QuerySetSubclass.as_manager() on Django models and preserves the custom queryset type, and routes that Django manager assignment through the new helper and avoids inherited Model.objects assignment/override noise.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test