### PR TITLE
Fix stack overflow when a descriptor's `__get__` is itself a descriptor

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -4749,6 +4749,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         {
             let attr =
                 self.as_instance_attribute(&dunder::GET, &getter, &Instance::of_class(&x.cls));
+            // `__get__` is bound and called like a method, never re-fed through the
+            // descriptor protocol. If it is itself a descriptor, recursing here would
+            // loop forever, so report no usable getter.
+            if matches!(attr, ClassAttribute::Descriptor(..)) {
+                return None;
+            }
             Some(
                 self.resolve_get_class_attr(attr_name, attr, x.range, errors, None)
                     .unwrap_or_else(|e| {

--- a/pyrefly/lib/test/descriptors.rs
+++ b/pyrefly/lib/test/descriptors.rs
@@ -912,3 +912,40 @@ def f(c: C):
     assert_type(c.x, str | None)
     "#,
 );
+
+testcase!(
+    // A `__get__` whose type is itself a descriptor must not recurse forever; the
+    // read falls back to the descriptor's instance type, so the call below is reported
+    // as not callable rather than overflowing the stack.
+    test_self_referential_descriptor_get_no_crash,
+    r#"
+class C:
+    def d() -> C:  # E: Function declared to return `C` but is missing an explicit `return`
+        pass
+    @d  # E: Expected 0 positional arguments, got 1 in function `C.d`
+    def __get__():
+        pass
+C.__get__()  # E: Expected a callable, got `C`
+    "#,
+);
+
+testcase!(
+    // Assignment resolves a descriptor through its getter too, so the same guard keeps
+    // the write path from overflowing the stack.
+    test_self_referential_descriptor_set_no_crash,
+    r#"
+class C:
+    def d() -> C:  # E: Function declared to return `C` but is missing an explicit `return`
+        pass
+    @d  # E: Expected 0 positional arguments, got 1 in function `C.d`
+    def __get__():
+        pass
+    @d  # E: Expected 0 positional arguments, got 1 in function `C.d`
+    def __set__():
+        pass
+class Host:
+    x: C = C()
+def f(h: Host) -> None:
+    h.x = 5  # E: Expected a callable, got `C`
+    "#,
+);


### PR DESCRIPTION
Fixes facebook/pyrefly#3671

### What
pyrefly aborted with a stack overflow on this (fuzzed) program:
```python
class C:
  def d() -> C:
    pass
  @d
  def __get__():
    pass
C.__get__()
```
Before: `thread '<unknown>' has overflowed its stack` → abort.
After: terminates with `Expected a callable, got C` at the call — matching pyright/ty, which never crash.

### Why
The decorator `@d` (which returns `C`) gives the `__get__` member type `C`. Because `C` defines `__get__`, that member is *itself* classified as a descriptor of `C`. Resolving the descriptor's getter re-entered attribute resolution, which re-applied the descriptor protocol to `__get__`, which resolved to another descriptor of `C`… with no base case, recursing ~10k frames until the stack overflowed. The descriptor protocol is specified to apply at most once per access — the `__get__` you invoke is a bound method, never re-fed through the protocol — and that "once" rule is the missing termination condition. A type checker must terminate regardless of how pathological the input is.

### How
`pyrefly/lib/alt/class/class_field.rs` — one guard in `resolve_descriptor_getter`: if the `__get__` member resolves to a `ClassAttribute::Descriptor`, return `None` ("no usable getter") instead of recursing. The read then falls back to the descriptor's instance type. A real `__get__` is always a method (resolves to `ReadWrite`/bound method), so this only fires on the pathological self-referential case. The `Descriptor` attribute branch always routes through the getter, so the single guard also terminates the assignment/`__set__` path — no separate setter guard needed. Nothing else is touched.

### Test plan
`pyrefly/lib/test/descriptors.rs`:

| Test | Protects |
|------|----------|
| `test_self_referential_descriptor_get_no_crash` | Read path (the issue repro) terminates; call reported `not-callable` |
| `test_self_referential_descriptor_set_no_crash` | Assignment to a self-referential descriptor also terminates |

