### PR TITLE
Fix property override reintroducing inherited dataclass fields into `…

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -3805,11 +3805,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Option<WithDefiningClass<Arc<ClassField>>> {
         self.get_field_from_mro(cls, name, &|cls, name| {
             let field = self.get_non_synthesized_field_from_current_class_only(cls, name)?;
-            if matches!(
+            // Skip members that don't actually declare the dataclass field here, so the
+            // walk continues to the ancestor that does (preserving its type and keywords).
+            let assigned_in_method = matches!(
                 field.initialization(),
                 ClassFieldInitialization::Method | ClassFieldInitialization::ClassMethod
-            ) {
-                // This parent happens to assign to the field in a method but doesn't define it.
+            );
+            let declares_field_here = self
+                .get_class_fields(cls)
+                .is_some_and(|fields| fields.is_field_annotated(name));
+            let shadows_inherited_field = field.is_property() && !declares_field_here;
+            if assigned_in_method || shadows_inherited_field {
                 None
             } else {
                 Some(field)

--- a/pyrefly/lib/test/dataclasses.rs
+++ b/pyrefly/lib/test/dataclasses.rs
@@ -1926,3 +1926,164 @@ class Mutable:
     def __delattr__(self, name: str) -> None: ...
 "#,
 );
+
+// A `@property` override of an inherited `init=False` field must not turn the
+// field into an `__init__` parameter: the field's spec stays inherited.
+testcase!(
+    test_property_override_init_false_field,
+    r#"
+import dataclasses
+@dataclasses.dataclass
+class A:
+    foo: int = dataclasses.field(init=False)
+@dataclasses.dataclass
+class B(A):
+    @property
+    def foo(self) -> int:  # E: Class member `B.foo` overrides parent class `A` in an inconsistent manner
+        return 1
+B()  # foo is init=False, so no argument is expected
+B(foo=2)  # E: Unexpected keyword argument `foo`
+    "#,
+);
+
+// A `@property` override inherits the parent field's type and keywords, so the
+// field is still an `__init__` param typed by the parent (here `int`).
+testcase!(
+    test_property_override_inherits_field_spec,
+    r#"
+import dataclasses
+@dataclasses.dataclass
+class A:
+    foo: int = 0
+@dataclasses.dataclass
+class B(A):
+    @property
+    def foo(self) -> int:  # E: Class member `B.foo` overrides parent class `A` in an inconsistent manner
+        return 1
+B()
+B(5)
+B(foo=5)
+B(foo="x")  # E: Argument `Literal['x']` is not assignable to parameter `foo` with type `int`
+    "#,
+);
+
+// A property override of an inherited field with no default leaves the param
+// required, inheriting the parent's type.
+testcase!(
+    test_property_override_inherits_required_field,
+    r#"
+import dataclasses
+@dataclasses.dataclass
+class A:
+    foo: int
+@dataclasses.dataclass
+class B(A):
+    @property
+    def foo(self) -> int:  # E: Class member `B.foo` overrides parent class `A` in an inconsistent manner
+        return 1
+B()  # E: Missing argument `foo`
+B(5)
+B(foo=5)
+    "#,
+);
+
+// Multi-level: the field declared in A is inherited correctly through B's
+// property override into a grandchild C.
+testcase!(
+    test_property_override_field_multilevel,
+    r#"
+import dataclasses
+@dataclasses.dataclass
+class A:
+    foo: int = dataclasses.field(init=False)
+@dataclasses.dataclass
+class B(A):
+    @property
+    def foo(self) -> int:  # E: Class member `B.foo` overrides parent class `A` in an inconsistent manner
+        return 1
+@dataclasses.dataclass
+class C(B):
+    bar: int = 0
+C()
+C(bar=1)
+C(foo=2)  # E: Unexpected keyword argument `foo`
+    "#,
+);
+
+// A property with a setter still does not reintroduce an inherited init=False
+// field as an `__init__` parameter.
+testcase!(
+    test_property_with_setter_override_init_false_field,
+    r#"
+import dataclasses
+@dataclasses.dataclass
+class A:
+    foo: int = dataclasses.field(init=False)
+@dataclasses.dataclass
+class B(A):
+    @property
+    def foo(self) -> int:  # E: Class member `B.foo` overrides parent class `A` in an inconsistent manner
+        return 1
+    @foo.setter
+    def foo(self, value: int) -> None:
+        pass
+B()
+B(foo=2)  # E: Unexpected keyword argument `foo`
+    "#,
+);
+
+// A property declared alongside a same-class field annotation is left untouched
+// by the inherited-shadow fix: pyrefly keeps treating the property as the member.
+testcase!(
+    test_property_same_class_field_unchanged,
+    r#"
+import dataclasses
+@dataclasses.dataclass
+class A:
+    foo: int = 0
+    @property
+    def foo(self) -> int:
+        return 1
+A()
+A(foo=2)  # E: Unexpected keyword argument `foo`
+    "#,
+);
+
+// A property override of an inherited generic field inherits the substituted type
+// arg, so `x` is typed `int` (from `A[int]`) not the type variable `T`.
+testcase!(
+    test_property_override_generic_dataclass,
+    r#"
+import dataclasses
+@dataclasses.dataclass
+class A[T]:
+    x: T
+@dataclasses.dataclass
+class B(A[int]):
+    @property
+    def x(self) -> int:  # E: Class member `B.x` overrides parent class `A` in an inconsistent manner
+        return 1
+B(1)
+B(x="bad")  # E: Argument `Literal['bad']` is not assignable to parameter `x` with type `int`
+    "#,
+);
+
+// A subclass that both re-annotates the inherited field and shadows it with a
+// property pins the guard branch: the current-class annotation makes
+// `declares_field_here` true, so the resolution is not skipped.
+testcase!(
+    test_property_override_reannotated_field,
+    r#"
+import dataclasses
+@dataclasses.dataclass
+class A:
+    foo: int = 5
+@dataclasses.dataclass
+class B(A):
+    foo: int  # E: Class member `B.foo` overrides parent class `A` in an inconsistent manner
+    @property
+    def foo(self) -> int:
+        return 1
+B(foo="x")  # E: Argument `Literal['x']` is not assignable to parameter `foo` with type `int`
+    "#,
+);


### PR DESCRIPTION
Fixes facebook/pyrefly#3169

### What

When a subclass overrides an inherited dataclass field with a `@property`, the field was wrongly re-added to the subclass constructor.

```python
import dataclasses

@dataclasses.dataclass
class A:
    foo: int = dataclasses.field(init=False)   # foo is NOT an __init__ param

@dataclasses.dataclass
class B(A):
    @property
    def foo(self) -> int:
        return 1
```

| call | before | after |
|------|--------|-------|
| `B()` | ❌ `Missing argument 'foo'` | ✅ no error |
| `B(foo=2)` | ❌ `bad-argument-type` (foo: `(self) -> int`) | ✅ `Unexpected keyword argument 'foo'` |
| `bad-override` on `B.foo` | ✅ reported | ✅ reported (unchanged) |

For an `init=True` parent (`foo: int = 0`), `foo` correctly **stays** a constructor parameter of the inherited type (`B()`, `B(5)`, `B(foo=5)` all OK) — the field is inherited, not dropped.

### Why

A dataclass's field keywords (`init`, `kw_only`, type, …) aren't stored — they're recomputed on every lookup from whichever member the MRO walk resolves. The walk returned the shadowing `@property` (a property has `ClassBody` initialization, so the existing "assigned in a method body" skip didn't catch it), and `dataclass_flags_of` for a property yields fresh defaults (`init=true`). So the ancestor's `init=False` and its type were silently discarded and `foo` re-entered `__init__`. mypy, pyright and ty all agree `foo` is not a constructor parameter here.

The `bad-override` diagnostic is produced by a separate override-consistency pass and is correct — it is untouched.

### How

`pyrefly/lib/alt/class/class_field.rs` — in `get_non_synthesized_dataclass_member_impl`, the dataclass-member MRO walk now also skips a property that does not itself declare an annotated field in the current class, so resolution continues to the ancestor that declares the field and inherits its full spec:

```rust
let shadows_inherited_field = field.is_property() && !declares_field_here;
if assigned_in_method || shadows_inherited_field { None } else { Some(field) }
```

The `!declares_field_here` guard (`get_class_fields(cls).is_some_and(|f| f.is_field_annotated(name))`) scopes the change: a property in a class that *also* annotates the name (the subclass-re-annotation shape) is left as-is, matching the reference checkers.

### Test plan

8 `testcase!`s in `pyrefly/lib/test/dataclasses.rs` (TDD — repro test written and watched fail first):

| test | protects |
|------|----------|
| `test_property_override_init_false_field` | core repro: `B()` clean, `B(foo=2)` → unexpected keyword |
| `test_property_override_inherits_field_spec` | `init=True`+default: inherited `int` type (`B(foo="x")` rejected) |
| `test_property_override_inherits_required_field` | `init=True` no-default: required, inherited type |
| `test_property_override_field_multilevel` | A→B(property)→C: spec inherited across levels |
| `test_property_with_setter_override_init_false_field` | setter doesn't reintroduce the field |
| `test_property_same_class_field_unchanged` | same-class `foo: int = 0` + property left unchanged |
| `test_property_override_generic_dataclass` | `A[int]` type-arg substitution survives the shadow |
| `test_property_override_reannotated_field` | subclass re-annotation + property (pins the guard branch) |

- `cargo test -p pyrefly --lib` → **5421 passed, 0 failed**
- `python3 test.py --no-test --no-conformance --no-jsonschema` → format + lint clean
- `mypy_primer` (45 dataclass/pydantic/attrs-heavy projects incl. pydantic, attrs, pandera, pandas-stubs, strawberry, hydra-zen, xarray-dataclasses, kopf, optuna, prefect) → **no diagnostic changes** (no regressions)