### PR TITLE
fix(binding): resolve adjacent defaults name lookup panic

### DIFF
--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -1373,7 +1373,7 @@ impl<'a> BindingsBuilder<'a> {
         members: &mut [Expr],
         keywords: &mut [Keyword],
         bind_to_name: bool,
-        adjacent_defaults: Option<Vec<Expr>>,
+        mut adjacent_defaults: Option<Vec<Expr>>,
     ) -> Idx<KeyClass> {
         let (mut class_object, class_indices) = if bind_to_name {
             self.class_object_and_indices(&class_name)
@@ -1427,7 +1427,10 @@ impl<'a> BindingsBuilder<'a> {
                 );
             }
         }
-        if let Some(ref default_elts) = adjacent_defaults {
+        if let Some(ref mut default_elts) = adjacent_defaults {
+            for elt in default_elts.iter_mut() {
+                self.ensure_expr(elt, class_object.usage());
+            }
             apply_adjacent_defaults(default_elts, n_members, &mut defaults);
         }
         let member_definitions_with_defaults: Vec<(
@@ -1472,7 +1475,7 @@ impl<'a> BindingsBuilder<'a> {
         func: &mut Expr,
         members: &[Expr],
         bind_to_name: bool,
-        adjacent_defaults: Option<Vec<Expr>>,
+        mut adjacent_defaults: Option<Vec<Expr>>,
     ) -> Idx<KeyClass> {
         let (mut class_object, class_indices) = if bind_to_name {
             self.class_object_and_indices(&class_name)
@@ -1484,7 +1487,10 @@ impl<'a> BindingsBuilder<'a> {
             self.parse_typing_namedtuple_fields(members, class_name.range);
         let n_members = parsed_fields.len();
         let mut defaults: Vec<Option<Expr>> = vec![None; n_members];
-        if let Some(ref default_elts) = adjacent_defaults {
+        if let Some(ref mut default_elts) = adjacent_defaults {
+            for elt in default_elts.iter_mut() {
+                self.ensure_expr(elt, class_object.usage());
+            }
             apply_adjacent_defaults(default_elts, n_members, &mut defaults);
         }
         let member_definitions: Vec<(String, TextRange, Option<Expr>, Option<ExprOrBinding>)> =

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -758,6 +758,39 @@ p = Point(1, 2)  # should succeed — z defaults to 0
 );
 
 testcase!(
+    test_typing_namedtuple_adjacent_defaults_with_non_trivial_expressions,
+    r#"
+from typing import NamedTuple, assert_type
+
+A = NamedTuple('A', [('x', int)])
+B = NamedTuple('B', [('a', A)])
+B.__new__.__defaults__ = (A(1),)
+b = B()  # should succeed
+assert_type(b.a, A)
+
+D = NamedTuple('D', [('a', A)])
+D.__new__.__defaults__ = (C(),)  # E: Could not find name `C`
+"#,
+);
+
+testcase!(
+    test_collections_namedtuple_adjacent_defaults_with_non_trivial_expressions,
+    r#"
+import collections
+from typing import assert_type, Any
+
+A = collections.namedtuple('A', ['x'])
+B = collections.namedtuple('B', ['a'])
+B.__new__.__defaults__ = (A(1),)
+b = B()  # should succeed
+assert_type(b.a, Any)
+
+D = collections.namedtuple('D', ['a'])
+D.__new__.__defaults__ = (C(),)  # E: Could not find name `C`
+"#,
+);
+
+testcase!(
     test_namedtuple_adjacent_defaults_multiple,
     r#"
 from collections import namedtuple


### PR DESCRIPTION
# Summary

This PR fixes a thread lookup panic in Pyrefly's bindings table when analyzing adjacent `__new__.__defaults__ = ...` assignments.

During name binding, adjacent defaults statements (used to assign default values to functional `NamedTuple` and `namedtuple` definitions) are peek-extracted and skipped from standard statement iteration. Consequently, their inner expressions were never walked by `ensure_expr`. This meant that any identifier references inside the defaults tuple (such as class constructor calls like `A(1)`) were never registered in the bindings table under their specific source spans, triggering a "key not found" panic at solve-time during constructor type-checking.

To fix this, we:
1. Updated `synthesize_typing_named_tuple_def` and `synthesize_collections_named_tuple_def` in `class.rs` to mark `adjacent_defaults` as mutable.
2. Explicitly traversed each element in the defaults list using `ensure_expr` under the class object's usage context before mapping them to fields.

Fixes #3712

# Test Plan

1. Added `test_typing_namedtuple_adjacent_defaults_with_non_trivial_expressions` and `test_collections_namedtuple_adjacent_defaults_with_non_trivial_expressions` in `pyrefly/lib/test/named_tuple.rs` to verify that:
   * Non-trivial default values are resolved, and constructor calls using defaults (`B()`) succeed with correct type inference. Previously, pyrefly crashed for the `typing.NamedTuple` case. 
   * Undefined symbols inside defaults (like `C()`) are correctly identified and report a static analysis error (`E: Could not find name 'C'`). Previously, no errors were emitted for these. 
2. Ran `python3 test.py` locally and confirmed that the entire test suite passes without failure.
