### PR TITLE
Make TSP getComputedType range-aware for call expressions

### DIFF
--- a/crates/tsp_types/src/common.rs
+++ b/crates/tsp_types/src/common.rs
@@ -155,6 +155,16 @@ impl GetTypeArg {
             GetTypeArg::Node(n) => n.range.start.clone(),
         }
     }
+
+    /// Extract the end position of the range. Together with `position()` this
+    /// recovers the full requested node range, which `getComputedType` uses to
+    /// distinguish a whole call expression from its callee identifier.
+    pub fn end_position(&self) -> tsp::Position {
+        match self {
+            GetTypeArg::Declaration { node, .. } => node.range.end.clone(),
+            GetTypeArg::Node(n) => n.range.end.clone(),
+        }
+    }
 }
 
 /// Parameters for getComputedType, getDeclaredType, and getExpectedType
@@ -180,6 +190,11 @@ impl GetTypeParams {
     /// Convenience: extract the start position from the arg's range.
     pub fn position(&self) -> tsp::Position {
         self.arg.position()
+    }
+
+    /// Convenience: extract the end position from the arg's range.
+    pub fn end_position(&self) -> tsp::Position {
+        self.arg.end_position()
     }
 }
 

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -452,6 +452,27 @@ pub trait TspInterface: Send + Sync + 'static {
         character: u32,
     ) -> Option<pyrefly_types::types::Type>;
 
+    /// Return the computed (inferred) type for a node spanning the given range.
+    ///
+    /// Unlike [`get_type_at_position`], which resolves the identifier at a
+    /// single position, this is range-aware: when the requested range covers a
+    /// whole call expression (e.g. `Foo()`), it returns the call's result type
+    /// rather than the callee's declaration sitting at the range's start. Used
+    /// by the TSP `getComputedType` endpoint, where the client sends the full
+    /// source range of the node it cares about.
+    ///
+    /// `start_line`/`start_character` and `end_line`/`end_character` are the
+    /// zero-based bounds of the node range. Falls back to the position-based
+    /// (declaration-preserving) lookup when the range is not a call expression.
+    fn get_computed_type_at_range(
+        &self,
+        uri: &str,
+        start_line: u32,
+        start_character: u32,
+        end_line: u32,
+        end_character: u32,
+    ) -> Option<pyrefly_types::types::Type>;
+
     /// Return the contextually expected type at the given position.
     ///
     /// The expected type is what the surrounding context demands of the
@@ -6357,6 +6378,41 @@ impl TspInterface for Server {
         // intact on the wire, which TSP clients need to re-resolve the
         // signature (parameters, overloads) from source.
         transaction.get_type_at_preserving_declaration(&handle, position)
+    }
+
+    fn get_computed_type_at_range(
+        &self,
+        uri: &str,
+        start_line: u32,
+        start_character: u32,
+        end_line: u32,
+        end_character: u32,
+    ) -> Option<pyrefly_types::types::Type> {
+        let url = Url::parse(uri)
+            .ok()
+            .or_else(|| Url::from_file_path(uri).ok())?;
+        let path = self.path_for_uri_or_notebook_cell(&url)?;
+        let notebook_cell = self.maybe_get_code_cell_index(&url);
+
+        let handle = make_open_handle(&self.state, &path);
+        let transaction = self.state.transaction();
+        let module_info = transaction.get_module_info(&handle)?;
+        let start = module_info.from_lsp_position(
+            lsp_types::Position {
+                line: start_line,
+                character: start_character,
+            },
+            notebook_cell,
+        );
+        let end = module_info.from_lsp_position(
+            lsp_types::Position {
+                line: end_line,
+                character: end_character,
+            },
+            notebook_cell,
+        );
+        let range = TextRange::new(start, end);
+        transaction.get_computed_type_at_range(&handle, range)
     }
 
     fn get_expected_type_at_position(

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -1252,6 +1252,42 @@ impl<'a> Transaction<'a> {
         self.get_type_at_impl_with_options(handle, position, false, false)
     }
 
+    /// Computed type for the TSP `getComputedType` endpoint, resolved from the
+    /// full requested node range rather than a single position.
+    ///
+    /// TSP clients send the source range of the node they care about, but the
+    /// position-based lookup ([`get_type_at_preserving_declaration`]) resolves
+    /// the identifier sitting at the range's start. For a call expression
+    /// (`Foo()`), that start offset lands on the callee, so the
+    /// declaration-preserving lookup returns the callee (e.g. the constructor)
+    /// instead of the call's result. When the requested range exactly covers a
+    /// call expression, return the recorded result type of that expression so
+    /// the client sees the call's value type (e.g. the constructed instance).
+    ///
+    /// All other ranges keep the declaration-preserving behavior, which clients
+    /// rely on to re-resolve signatures/overloads from a callee's declaration.
+    pub fn get_computed_type_at_range(&self, handle: &Handle, range: TextRange) -> Option<Type> {
+        if self.range_is_call_expr(handle, range)
+            && let Some(ty) = self.get_type_trace(handle, range)
+        {
+            return Some(ty);
+        }
+        self.get_type_at_preserving_declaration(handle, range.start())
+    }
+
+    /// Whether `range` exactly covers a call expression node (`Foo()`).
+    fn range_is_call_expr(&self, handle: &Handle, range: TextRange) -> bool {
+        if range.is_empty() {
+            return false;
+        }
+        let Some(module) = self.get_ast(handle) else {
+            return false;
+        };
+        Ast::locate_node(&module, range.start())
+            .into_iter()
+            .any(|node| node.range() == range && matches!(node, AnyNodeRef::ExprCall(_)))
+    }
+
     fn get_result_type_at_impl(
         &self,
         handle: &Handle,

--- a/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
@@ -71,6 +71,35 @@ fn get_computed_type_ok(
     result
 }
 
+/// Helper to send a range-based getComputedType request and return a successful result.
+fn get_computed_type_range_ok(
+    tsp: &mut TspInteraction,
+    file_uri: &str,
+    start_line: u32,
+    start_character: u32,
+    end_line: u32,
+    end_character: u32,
+    snapshot: i32,
+) -> serde_json::Value {
+    tsp.server.get_computed_type_range(
+        file_uri,
+        start_line,
+        start_character,
+        end_line,
+        end_character,
+        snapshot,
+    );
+    let resp = tsp.client.receive_response_skip_notifications();
+    assert!(
+        resp.error.is_none(),
+        "Expected success, got error: {:?}",
+        resp.error
+    );
+    let result = resp.result.expect("Expected result");
+    assert!(!result.is_null(), "Expected non-null type result");
+    result
+}
+
 /// Helper to send a getExpectedType request and return a successful (non-null) result.
 fn get_expected_type_ok(
     tsp: &mut TspInteraction,
@@ -1092,6 +1121,103 @@ greet(\"world\")
         Some(file_uri.as_str()),
         "Expected declaration URI to match the source file"
     );
+
+    tsp.shutdown();
+}
+
+// =======================================================================
+// Regression: a whole call-expression range returns the call's result
+//
+// `typeServer/getComputedType` is range-aware. When the requested range
+// exactly covers a call expression (`Foo()`), it returns the call's
+// *result* type (the constructed instance / return value) rather than the
+// callee declaration sitting at the range start. This complements the
+// call-position behavior above: an empty range (or a range that only spans
+// the callee identifier) still preserves the callee declaration, but the
+// full call range resolves to the value the call produces.
+//
+// Pylance bug: https://github.com/microsoft/pylance-release/issues/8016
+// ("[TSP] Goto def doesn't work on special methods"). Operator go-to-def
+// needs the left operand of `ClassWithMagicMethod() < 1` to resolve to a
+// class *instance* so the `__lt__` magic method can be found.
+// =======================================================================
+
+/// Assert the result is a class type carrying the INSTANCE flag (2).
+fn assert_class_instance(result: &serde_json::Value) {
+    assert_kind(result, TypeKind::Class);
+    let flags = result.get("flags").and_then(|v| v.as_i64());
+    assert!(
+        flags.is_some_and(|f| f & 2 != 0),
+        "Expected INSTANCE flag (2), got flags={flags:?} in: {result}"
+    );
+}
+
+#[test]
+fn test_get_computed_type_call_expr_range_returns_instance() {
+    // Repro for pylance-release#8016. `ClassWithMagicMethod()` is a call
+    // expression on line 4. Querying the *whole* call range must return the
+    // constructed instance (Class + INSTANCE flag), not the constructor.
+    let code = "\
+class ClassWithMagicMethod:
+    def __lt__(self, v: int) -> bool:
+        return True
+
+a = ClassWithMagicMethod()
+";
+    let (mut tsp, file_uri, snapshot) = setup_project(code);
+
+    // Line 4: `a = ClassWithMagicMethod()` — the call spans chars 4..26.
+    let result = get_computed_type_range_ok(&mut tsp, &file_uri, 4, 4, 4, 26, snapshot);
+    assert_class_instance(&result);
+
+    let decl = result.get("declaration").expect("Expected declaration");
+    let name = decl.get("name").and_then(|v| v.as_str());
+    assert_eq!(name, Some("ClassWithMagicMethod"), "Expected class name");
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_computed_type_call_expr_range_vs_callee_position() {
+    // The range-aware behavior must distinguish the whole call expression
+    // from the callee identifier:
+    //   - whole call range  -> the constructed instance (INSTANCE flag set)
+    //   - callee position    -> the class itself (instantiable, no INSTANCE)
+    let code = "\
+class Foo:
+    pass
+
+a = Foo()
+";
+    let (mut tsp, file_uri, snapshot) = setup_project(code);
+
+    // Line 3: `a = Foo()` — the call `Foo()` spans chars 4..9.
+    let whole_call = get_computed_type_range_ok(&mut tsp, &file_uri, 3, 4, 3, 9, snapshot);
+    assert_class_instance(&whole_call);
+
+    // Callee identifier position (empty range at the start of `Foo`) keeps
+    // the declaration-preserving behavior: the class object, not an instance.
+    let callee = get_computed_type_ok(&mut tsp, &file_uri, 3, 4, snapshot);
+    assert_kind(&callee, TypeKind::Class);
+    let callee_flags = callee.get("flags").and_then(|v| v.as_i64()).unwrap_or(0);
+    assert!(
+        callee_flags & 2 == 0,
+        "Expected callee `Foo` to be the class itself (no INSTANCE flag), got flags={callee_flags}"
+    );
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_computed_type_builtin_call_expr_range_returns_instance() {
+    // A builtin call expression range (`str()`) likewise resolves to the
+    // produced instance rather than the `str` class/constructor.
+    let code = "x = str()\n";
+    let (mut tsp, file_uri, snapshot) = setup_project(code);
+
+    // Line 0: `x = str()` — the call `str()` spans chars 4..9.
+    let result = get_computed_type_range_ok(&mut tsp, &file_uri, 0, 4, 0, 9, snapshot);
+    assert_class_instance(&result);
 
     tsp.shutdown();
 }

--- a/pyrefly/lib/test/tsp/tsp_interaction/object_model.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/object_model.rs
@@ -184,6 +184,36 @@ impl TestTspServer {
         self.send_get_type_request("typeServer/getComputedType", uri, line, character, snapshot);
     }
 
+    /// Send a `typeServer/getComputedType` request whose node arg spans an
+    /// explicit `[start, end)` range rather than a single (empty) position.
+    /// Used to exercise the range-aware call-expression handling.
+    pub fn get_computed_type_range(
+        &mut self,
+        uri: &str,
+        start_line: u32,
+        start_character: u32,
+        end_line: u32,
+        end_character: u32,
+        snapshot: i32,
+    ) {
+        let id = self.next_request_id();
+        self.send_message(Message::Request(Request {
+            id,
+            method: "typeServer/getComputedType".to_owned(),
+            params: serde_json::json!({
+                "arg": {
+                    "uri": uri,
+                    "range": {
+                        "start": { "line": start_line, "character": start_character },
+                        "end": { "line": end_line, "character": end_character },
+                    },
+                },
+                "snapshot": snapshot,
+            }),
+            activity_key: None,
+        }));
+    }
+
     /// Send a `typeServer/getExpectedType` request with a Node arg.
     pub fn get_expected_type(&mut self, uri: &str, line: u32, character: u32, snapshot: i32) {
         self.send_get_type_request("typeServer/getExpectedType", uri, line, character, snapshot);

--- a/pyrefly/lib/tsp/requests/get_computed_type.rs
+++ b/pyrefly/lib/tsp/requests/get_computed_type.rs
@@ -30,10 +30,15 @@ impl<T: TspInterface> TspConnection<T> {
         // Any valid scheme is accepted — notebook cell URIs are resolved
         // to notebook paths inside get_type_at_position.
         parse_uri(params.uri())?;
-        let position = params.position();
-        let ty = self
-            .inner()
-            .get_type_at_position(params.uri(), position.line, position.character);
+        let start = params.position();
+        let end = params.end_position();
+        let ty = self.inner().get_computed_type_at_range(
+            params.uri(),
+            start.line,
+            start.character,
+            end.line,
+            end.character,
+        );
         Ok(ty.map(|t| self.convert_type(&t, Some(params.uri()))))
     }
 }


### PR DESCRIPTION
## Summary

Makes the `typeServer/getComputedType` TSP endpoint range-aware so that querying the full range of a **call expression** (`Foo()`) returns the call's *result* type rather than the callee declaration.

## Problem

`getComputedType` resolved the type at the requested range's **start** position. For a call expression, the start offset lands on the callee, so the declaration-preserving lookup returned the callee (e.g. the constructor function) instead of the call's result. TSP clients (e.g. Pylance) that send the whole call-expression range therefore saw the constructor instead of the constructed instance. This broke downstream features such as go-to-definition on an operator whose operand is a call expression (`ClassWithMagicMethod() < 1`), where the client needs the operand to resolve to a class **instance** to find the `__lt__` magic method.

## Change

- Add `Transaction::get_computed_type_at_range`: when the requested range exactly covers a call expression, return its recorded result type; otherwise fall back to the existing declaration-preserving position lookup.
- Add the `range_is_call_expr` helper.
- Thread the full node range (start + end) through the `getComputedType` request handler and the `TspInterface`.

The callee/identifier behavior is unchanged: an empty range, or a range that only spans the callee identifier, still preserves the callee declaration (so the existing pylance-release#8020 behavior is intact). Only a whole-call-expression range resolves to the call result.

## Tests

New tests in `get_type_queries.rs`:
- `test_get_computed_type_call_expr_range_returns_instance` — whole call range returns the constructed instance.
- `test_get_computed_type_call_expr_range_vs_callee_position` — whole call range → instance; callee position → the class itself (declaration preserved).
- `test_get_computed_type_builtin_call_expr_range_returns_instance` — `str()` range → instance.

Related: https://github.com/microsoft/pylance-release/issues/8016
