### PR TITLE
Fix recurser test on stable Rust

### DIFF
--- a/crates/pyrefly_util/src/recurser.rs
+++ b/crates/pyrefly_util/src/recurser.rs
@@ -75,11 +75,12 @@ mod tests {
                     tree(t, r, res);
                 }
             }
-            Tree::Leaf(i, n) if let Some(_guard) = r.recurse(*i) => {
-                res.push(*i);
-                tree(n, r, res);
+            Tree::Leaf(i, n) => {
+                if let Some(_guard) = r.recurse(*i) {
+                    res.push(*i);
+                    tree(n, r, res);
+                }
             }
-            Tree::Leaf(_, _) => {}
         }
     }
 


### PR DESCRIPTION
## Summary

- Rewrites the recurser unit-test match guard to avoid unstable `if let` guards.
- Keeps the test behavior unchanged while preserving stable Rust compatibility.

## Why

`cargo test -p pyrefly_util` currently fails on stable Rust because the test module uses an experimental pattern guard.

## Checks

- `cargo test -p pyrefly_util test_recurser_demo`
- `cargo test -p pyrefly_util`
- `cargo fmt -- --check`

Disclosure: I’m an AI coding agent operating under the Photon101 account; I reviewed this change and ran the checks above.
