### PR TITLE
Detect duplicate dataclass KW_ONLY markers

### DIFF
--- a/pyrefly/lib/alt/class/dataclass.rs
+++ b/pyrefly/lib/alt/class/dataclass.rs
@@ -94,6 +94,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // Compute kw_only fields once for all methods that need it
         let kw_only_by_class = self.compute_kw_only_fields_by_class(cls);
 
+        self.check_duplicate_kw_only_markers(cls, errors);
         self.check_dataclass_non_data_descriptors(cls, dataclass, errors);
         self.check_dataclass_data_descriptor_defaults(cls, dataclass, errors);
         if dataclass.kws.init {
@@ -281,6 +282,35 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         "Hint: add a `__set__` method to make `{cls}` a data descriptor"
                     ))
                     .emit();
+            }
+        }
+    }
+
+    fn check_duplicate_kw_only_markers(&self, cls: &Class, errors: &ErrorCollector) {
+        let Some(class_fields) = self.get_class_fields(cls) else {
+            return;
+        };
+        let mut seen_kw_only_marker = false;
+        for name in class_fields.class_body_fields() {
+            if !class_fields.is_field_annotated(name) {
+                continue;
+            }
+            if matches!(
+                self.get_dataclass_member(cls, name),
+                DataclassMember::KwOnlyMarker
+            ) {
+                if seen_kw_only_marker {
+                    self.error(
+                        errors,
+                        class_fields
+                            .field_decl_range(name)
+                            .unwrap_or_else(|| cls.range()),
+                        ErrorKind::BadClassDefinition,
+                        "`dataclasses.KW_ONLY` may only appear once in a dataclass".to_owned(),
+                    );
+                } else {
+                    seen_kw_only_marker = true;
+                }
             }
         }
     }

--- a/pyrefly/lib/test/dataclasses.rs
+++ b/pyrefly/lib/test/dataclasses.rs
@@ -78,6 +78,30 @@ D(4, 5, 6) # E: Expected 2 positional arguments, got 3 in function `D.__init__`
 );
 
 testcase!(
+    test_duplicate_kw_only_sentinel,
+    r#"
+from dataclasses import dataclass, KW_ONLY
+from dataclasses import KW_ONLY as KW_ONLY_ALIAS
+
+@dataclass
+class A:
+    b: int
+    _1: KW_ONLY
+    c: str
+    _2: KW_ONLY  # E: `dataclasses.KW_ONLY` may only appear once in a dataclass
+    d: bytes
+
+@dataclass
+class B:
+    b: int
+    _1: KW_ONLY
+    c: str
+    _2: KW_ONLY_ALIAS  # E: `dataclasses.KW_ONLY` may only appear once in a dataclass
+    d: bytes
+    "#,
+);
+
+testcase!(
     test_fields,
     r#"
 from typing import assert_type


### PR DESCRIPTION
## Summary

- Emit a dataclass definition error when a single class body contains more than one `dataclasses.KW_ONLY` marker.
- Keep `KW_ONLY` handling scoped to each class body, so base and subclass dataclasses may each define their own marker.
- Add regression coverage for direct and aliased `KW_ONLY` annotations.

## Why

Python dataclasses reject duplicate `KW_ONLY` markers in the same class body. Pyrefly already recognized the marker when synthesizing dataclass fields, but it did not report the duplicate-marker runtime error.

Fixes #3737.

## Checks

- `cargo test -p pyrefly test_duplicate_kw_only_sentinel`
- `cargo test -p pyrefly kw_only_sentinel`
- `cargo test -p pyrefly dataclasses`
- `cargo fmt -- --check`
- `git diff --check`

Disclosure: This PR was prepared by an AI coding agent, GPT-5.5 with xhigh reasoning effort, operating under the Photon101 account. I reviewed the change and ran the checks above.
