### PR TITLE
Reject dataclass decorators on NamedTuple classes

### DIFF
--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -444,6 +444,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             pydantic_before_validator_fields,
             is_attrs_class,
             protocol_metadata.is_some(),
+            named_tuple_metadata.is_some(),
             enum_metadata.is_some(),
             is_typed_dict,
             errors,
@@ -1035,6 +1036,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         pydantic_before_validator_fields: &[Name],
         is_attrs_class: bool,
         is_protocol: bool,
+        is_named_tuple: bool,
         is_enum: bool,
         is_typed_dict: bool,
         errors: &ErrorCollector,
@@ -1106,7 +1108,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 _ => {}
             }
         }
-        // @dataclass cannot be applied to Protocol, Enum, or TypedDict classes.
+        // @dataclass cannot be applied to Protocol, NamedTuple, Enum, or TypedDict classes.
         // Emit the error and return None so the class is not treated as a dataclass.
         if has_dataclass_decorator {
             if is_protocol {
@@ -1118,6 +1120,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         "`@dataclass` cannot be applied to Protocol `{}`",
                         cls.name()
                     ),
+                );
+                return None;
+            }
+            if is_named_tuple {
+                self.error(
+                    errors,
+                    cls.range(),
+                    ErrorKind::BadClassDefinition,
+                    format!("Cannot apply `@dataclass` to NamedTuple `{}`", cls.name()),
                 );
                 return None;
             }

--- a/pyrefly/lib/test/dataclasses.rs
+++ b/pyrefly/lib/test/dataclasses.rs
@@ -2391,6 +2391,19 @@ C(42)
 "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/3751
+testcase!(
+    test_dataclass_decorator_on_named_tuple,
+    r#"
+from dataclasses import dataclass
+from typing import NamedTuple
+
+@dataclass
+class Foo(NamedTuple):  # E: Cannot apply `@dataclass` to NamedTuple `Foo`
+    x: int
+    "#,
+);
+
 // https://github.com/facebook/pyrefly/issues/2923
 testcase!(
     bug = "Should reject @dataclass applied to NamedTuple subclass",


### PR DESCRIPTION
Summary:
- report a bad-class-definition error when @dataclass decorates a NamedTuple class
- avoid treating invalid NamedTuple dataclasses as dataclass metadata
- add regression coverage for #3751

Closes #3751

Checks:
- cargo fmt -- --check
- cargo test test_dataclass_decorator_on_named_tuple -- --nocapture
- git diff --check