### PR TITLE
Reject @dataclass on NamedTuple classes

### DIFF
--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -446,6 +446,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             protocol_metadata.is_some(),
             enum_metadata.is_some(),
             is_typed_dict,
+            named_tuple_metadata.is_some(),
             errors,
         );
         if let Some(dm) = dataclass_metadata.as_ref()
@@ -1037,6 +1038,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         is_protocol: bool,
         is_enum: bool,
         is_typed_dict: bool,
+        is_named_tuple: bool,
         errors: &ErrorCollector,
     ) -> Option<DataclassMetadata> {
         // If we inherit from a dataclass, inherit its metadata. Note that if this class is
@@ -1106,7 +1108,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 _ => {}
             }
         }
-        // @dataclass cannot be applied to Protocol, Enum, or TypedDict classes.
+        // @dataclass cannot be applied to Protocol, Enum, TypedDict, or NamedTuple classes.
         // Emit the error and return None so the class is not treated as a dataclass.
         if has_dataclass_decorator {
             if is_protocol {
@@ -1136,6 +1138,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     cls.range(),
                     ErrorKind::BadClassDefinition,
                     format!("Cannot apply `@dataclass` to TypedDict `{}`", cls.name()),
+                );
+                return None;
+            }
+            if is_named_tuple {
+                self.error(
+                    errors,
+                    cls.range(),
+                    ErrorKind::BadClassDefinition,
+                    format!("Cannot apply `@dataclass` to NamedTuple `{}`", cls.name()),
                 );
                 return None;
             }

--- a/pyrefly/lib/test/dataclasses.rs
+++ b/pyrefly/lib/test/dataclasses.rs
@@ -2443,6 +2443,19 @@ class DC2(Protocol, DC):  # E: If `Protocol` is included as a base class, all ot
 "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/3751
+testcase!(
+    test_dataclass_decorator_on_named_tuple,
+    r#"
+from dataclasses import dataclass
+from typing import NamedTuple
+
+@dataclass
+class Foo(NamedTuple):  # E: Cannot apply `@dataclass` to NamedTuple
+    x: int
+"#,
+);
+
 // https://github.com/facebook/pyrefly/issues/2920
 testcase!(
     test_frozen_dataclass_override_setattr_delattr,


### PR DESCRIPTION
## Summary
- reject `@dataclass` decorators on classes that are also `NamedTuple` classes
- add a regression test for the decorator form from #3751

Fixes #3751.

## Test plan
- `CARGO_TARGET_DIR=/Users/vivek/Documents/pr-automation-work/pyrefly-target cargo test -j1 test_dataclass_decorator_on_named_tuple`
- `CARGO_TARGET_DIR=/Users/vivek/Documents/pr-automation-work/pyrefly-target python3 test.py --no-test --no-conformance --no-jsonschema`

I am an AI agent submitting this PR on behalf of vivekjm. I reviewed the change and kept it scoped to the issue.