### PR TITLE
Dedupe symbol count fields in `pyrefly coverage`

### DIFF
--- a/pyrefly/lib/commands/coverage/collect.rs
+++ b/pyrefly/lib/commands/coverage/collect.rs
@@ -369,33 +369,28 @@ fn filter_module_report_to_public(report: &mut ModuleReport, public_fqns: &HashS
         .names
         .retain(|n| is_public_fqn(n, &module_prefix, public_fqns));
 
-    // recompute all aggregates in a single pass
+    // recompute all aggregates in a single pass; type ignores attach to the
+    // module itself, not symbols, so their count is unaffected by filtering
     report.slots = SlotCounts::default();
-    report.n_methods = 0;
-    report.n_functions = 0;
-    report.n_method_params = 0;
-    report.n_function_params = 0;
-    report.n_classes = 0;
-    report.n_attrs = 0;
-    report.n_properties = 0;
-    // `n_type_ignores` is not affected by public filtering since type ignores are always
-    // attached to the module itself, not individual symbols, so we don't need to recalculate
-    // it here.
+    report.symbols = SymbolCounts {
+        n_type_ignores: report.symbols.n_type_ignores,
+        ..SymbolCounts::default()
+    };
 
     for sym in &report.symbol_reports {
         report.slots = report.slots.merge(*sym.slots());
         match sym {
             SymbolReport::Function { name, n_params, .. } if is_method(name, &module_prefix) => {
-                report.n_methods += 1;
-                report.n_method_params += *n_params;
+                report.symbols.n_methods += 1;
+                report.symbols.n_method_params += *n_params;
             }
             SymbolReport::Function { n_params, .. } => {
-                report.n_functions += 1;
-                report.n_function_params += *n_params;
+                report.symbols.n_functions += 1;
+                report.symbols.n_function_params += *n_params;
             }
-            SymbolReport::Class { .. } => report.n_classes += 1,
-            SymbolReport::Attr { .. } => report.n_attrs += 1,
-            SymbolReport::Property { .. } => report.n_properties += 1,
+            SymbolReport::Class { .. } => report.symbols.n_classes += 1,
+            SymbolReport::Attr { .. } => report.symbols.n_attrs += 1,
+            SymbolReport::Property { .. } => report.symbols.n_properties += 1,
         }
     }
 
@@ -1201,44 +1196,20 @@ fn is_method(name: &str, module_prefix: &str) -> bool {
     without_prefix.contains('.')
 }
 
-/// Calculate the aggregate summary by summing per-module entity counts.
+/// Calculate the aggregate summary by summing per-module symbol counts.
 pub fn calculate_summary(module_reports: &[ModuleReport]) -> ReportSummary {
-    let n_modules = module_reports.len();
-    let mut total_slots = SlotCounts::default();
-    let mut n_functions = 0usize;
-    let mut n_methods = 0usize;
-    let mut n_function_params = 0usize;
-    let mut n_method_params = 0usize;
-    let mut n_classes = 0usize;
-    let mut n_attrs = 0usize;
-    let mut n_properties = 0usize;
-    let mut n_type_ignores = 0usize;
-
+    let mut slots = SlotCounts::default();
+    let mut symbols = SymbolCounts::default();
     for module in module_reports {
-        total_slots = total_slots.merge(module.slots);
-        n_functions += module.n_functions;
-        n_methods += module.n_methods;
-        n_function_params += module.n_function_params;
-        n_method_params += module.n_method_params;
-        n_classes += module.n_classes;
-        n_attrs += module.n_attrs;
-        n_properties += module.n_properties;
-        n_type_ignores += module.n_type_ignores;
+        slots = slots.merge(module.slots);
+        symbols = symbols.merge(module.symbols);
     }
-
     ReportSummary {
-        n_modules,
-        slots: total_slots,
-        coverage: total_slots.coverage(),
-        strict_coverage: total_slots.strict_coverage(),
-        n_functions,
-        n_methods,
-        n_function_params,
-        n_method_params,
-        n_classes,
-        n_attrs,
-        n_properties,
-        n_type_ignores,
+        n_modules: module_reports.len(),
+        slots,
+        coverage: slots.coverage(),
+        strict_coverage: slots.strict_coverage(),
+        symbols,
     }
 }
 
@@ -1591,37 +1562,33 @@ fn build_module_report(
     let mut seen = SmallSet::new();
     names.retain(|n| seen.insert(n.clone()));
 
-    // Compute per-module entity counts. Use the derived (file-based)
+    // Compute per-module symbol counts. Use the derived (file-based)
     // module name for prefix matching, since symbol names are built from
     // the derived name and only rewritten to the override name later.
     let module_prefix = format!("{}.", derived_name);
-    let mut n_functions = 0usize;
-    let mut n_methods = 0usize;
-    let mut n_function_params = 0usize;
-    let mut n_method_params = 0usize;
-    let mut n_classes = 0usize;
-    let mut n_attrs = 0usize;
-    let mut n_properties = 0usize;
+    let mut symbols = SymbolCounts {
+        n_type_ignores: suppressions.len(),
+        ..SymbolCounts::default()
+    };
     // Count functions/methods using the `Function` list directly so we
     // can use `n_params` (accurate even for implicit-return dunders).
     for func in functions.iter().filter(|f| f.property_role.is_none()) {
         if is_method(&func.name, &module_prefix) {
-            n_methods += 1;
-            n_method_params += func.n_params;
+            symbols.n_methods += 1;
+            symbols.n_method_params += func.n_params;
         } else {
-            n_functions += 1;
-            n_function_params += func.n_params;
+            symbols.n_functions += 1;
+            symbols.n_function_params += func.n_params;
         }
     }
     for sym in &symbol_reports {
         match sym {
-            SymbolReport::Property { .. } => n_properties += 1,
-            SymbolReport::Attr { .. } => n_attrs += 1,
-            SymbolReport::Class { .. } => n_classes += 1,
+            SymbolReport::Property { .. } => symbols.n_properties += 1,
+            SymbolReport::Attr { .. } => symbols.n_attrs += 1,
+            SymbolReport::Class { .. } => symbols.n_classes += 1,
             SymbolReport::Function { .. } => {}
         }
     }
-    let n_type_ignores = suppressions.len();
 
     ModuleReport {
         name,
@@ -1633,14 +1600,7 @@ fn build_module_report(
         coverage: total_slots.coverage(),
         strict_coverage: total_slots.strict_coverage(),
         slots: total_slots,
-        n_functions,
-        n_methods,
-        n_function_params,
-        n_method_params,
-        n_classes,
-        n_attrs,
-        n_properties,
-        n_type_ignores,
+        symbols,
     }
 }
 
@@ -2894,7 +2854,7 @@ mod tests {
         compare_snapshot("del_module_level.expected.json", &report);
     }
 
-    /// --module name override: entity counts (n_functions vs n_methods) must
+    /// --module name override: symbol counts (n_functions vs n_methods) must
     /// be correct even when the output module name differs from the derived name.
     #[test]
     fn test_report_module_name_override() {
@@ -3083,14 +3043,16 @@ def g(x: int) -> int:
             slots: SlotCounts::default(),
             coverage: 100.0,
             strict_coverage: 100.0,
-            n_functions: 2,
-            n_methods: 0,
-            n_function_params: 123,
-            n_method_params: 456,
-            n_classes: 1,
-            n_attrs: 1,
-            n_properties: 0,
-            n_type_ignores: 0,
+            symbols: SymbolCounts {
+                n_functions: 2,
+                n_methods: 0,
+                n_function_params: 123,
+                n_method_params: 456,
+                n_classes: 1,
+                n_attrs: 1,
+                n_properties: 0,
+                n_type_ignores: 0,
+            },
         };
 
         let public_fqns: HashSet<String> = ["pkg.Foo", "pkg.bar"]
@@ -3101,12 +3063,12 @@ def g(x: int) -> int:
 
         assert_eq!(report.names, vec!["pkg.Foo", "pkg.bar"]);
         assert_eq!(report.symbol_reports.len(), 3); // Foo, Foo.method, bar
-        assert_eq!(report.n_functions, 1);
-        assert_eq!(report.n_methods, 1);
-        assert_eq!(report.n_function_params, 1);
-        assert_eq!(report.n_method_params, 2);
-        assert_eq!(report.n_classes, 1);
-        assert_eq!(report.n_attrs, 0);
+        assert_eq!(report.symbols.n_functions, 1);
+        assert_eq!(report.symbols.n_methods, 1);
+        assert_eq!(report.symbols.n_function_params, 1);
+        assert_eq!(report.symbols.n_method_params, 2);
+        assert_eq!(report.symbols.n_classes, 1);
+        assert_eq!(report.symbols.n_attrs, 0);
     }
 
     #[test]

--- a/pyrefly/lib/commands/coverage/types.rs
+++ b/pyrefly/lib/commands/coverage/types.rs
@@ -171,7 +171,7 @@ pub struct Function {
     /// Property role if this function is a property accessor, `None` otherwise.
     #[serde(skip)]
     pub property_role: Option<PropertyRole>,
-    /// Number of non-self/cls, non-implicit params (for entity counting).
+    /// Number of non-self/cls, non-implicit params (for symbol counting).
     pub n_params: usize,
     pub slots: SlotCounts,
     pub location: Location,
@@ -269,6 +269,34 @@ impl SymbolReport {
     }
 }
 
+/// Per-kind counts of the symbols in a report.
+#[derive(Debug, Serialize, Default, Clone, Copy)]
+pub struct SymbolCounts {
+    pub n_functions: usize,
+    pub n_methods: usize,
+    pub n_function_params: usize,
+    pub n_method_params: usize,
+    pub n_classes: usize,
+    pub n_attrs: usize,
+    pub n_properties: usize,
+    pub n_type_ignores: usize,
+}
+
+impl SymbolCounts {
+    pub fn merge(self, other: SymbolCounts) -> SymbolCounts {
+        SymbolCounts {
+            n_functions: self.n_functions + other.n_functions,
+            n_methods: self.n_methods + other.n_methods,
+            n_function_params: self.n_function_params + other.n_function_params,
+            n_method_params: self.n_method_params + other.n_method_params,
+            n_classes: self.n_classes + other.n_classes,
+            n_attrs: self.n_attrs + other.n_attrs,
+            n_properties: self.n_properties + other.n_properties,
+            n_type_ignores: self.n_type_ignores + other.n_type_ignores,
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct ModuleReport {
     /// Fully-qualified module name (e.g. "mypackage.submodule").
@@ -284,14 +312,8 @@ pub struct ModuleReport {
     pub slots: SlotCounts,
     pub coverage: f64,
     pub strict_coverage: f64,
-    pub n_functions: usize,
-    pub n_methods: usize,
-    pub n_function_params: usize,
-    pub n_method_params: usize,
-    pub n_classes: usize,
-    pub n_attrs: usize,
-    pub n_properties: usize,
-    pub n_type_ignores: usize,
+    #[serde(flatten)]
+    pub symbols: SymbolCounts,
 }
 
 #[derive(Debug, Serialize)]
@@ -301,14 +323,8 @@ pub struct ReportSummary {
     pub slots: SlotCounts,
     pub coverage: f64,
     pub strict_coverage: f64,
-    pub n_functions: usize,
-    pub n_methods: usize,
-    pub n_function_params: usize,
-    pub n_method_params: usize,
-    pub n_classes: usize,
-    pub n_attrs: usize,
-    pub n_properties: usize,
-    pub n_type_ignores: usize,
+    #[serde(flatten)]
+    pub symbols: SymbolCounts,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
# Summary

The `ModuleReport` and `ReportSummary` structs both had the same 8 `n_{symbol}` count fields, which were modified in `collect.rs` one by one in three functions. So if you wanted to add a new symbol counter, you'd have to do so  in 5 places.

This dedupes these fields using he same `#[serde(flatten)]` trick used for the "slot" (typable) counts. 

This is purely a refactor; so there are no behavior changes.

This shouldn't cause any merge conflicts with #3747.

# Test Plan

Tests still pass.