### PR TITLE
Skip optional imports in `pyrefly coverage`

### DIFF
--- a/pyrefly/lib/commands/coverage/collect.rs
+++ b/pyrefly/lib/commands/coverage/collect.rs
@@ -466,6 +466,28 @@ fn parse_variables(
         }
     }
 
+    /// True if the binding resolves to an import in at least one flow branch.
+    fn involves_import(bindings: &Bindings, idx: Idx<Key>, seen: &mut SmallSet<Idx<Key>>) -> bool {
+        if !seen.insert(idx) {
+            return false; // LoopPhi can be cyclic
+        }
+        match bindings.get(idx) {
+            Binding::Module(..) | Binding::Import(..) => true,
+            Binding::Forward(i)
+            | Binding::PromoteForward(i)
+            | Binding::ForwardToFirstUse(i)
+            | Binding::Narrow(i, _, _) => involves_import(bindings, *i, seen),
+            Binding::Phi(_, branches) => branches
+                .iter()
+                .any(|b| involves_import(bindings, b.value_key, seen)),
+            Binding::LoopPhi(prior, members) => {
+                involves_import(bindings, *prior, seen)
+                    || members.iter().any(|i| involves_import(bindings, *i, seen))
+            }
+            _ => false,
+        }
+    }
+
     let module_prefix = if module.name() != ModuleName::unknown() {
         format!("{}.", module.name())
     } else {
@@ -583,6 +605,9 @@ fn parse_variables(
                             );
                         }
                     },
+                    // Skip optional imports (`try: import x; except _: x = None`) like plain imports.
+                    Binding::Phi(..) | Binding::LoopPhi(..)
+                        if involves_import(bindings, *idx, &mut SmallSet::new()) => {}
                     _ => {
                         variables.push(Variable {
                             name: qualified_name,
@@ -2304,6 +2329,13 @@ mod tests {
         compare_snapshot("variables.expected.json", &report);
     }
 
+    /// gh-3773: optional imports must not be reported as untyped variables.
+    #[test]
+    fn test_report_optional_imports() {
+        let report = build_module_report_for_test("optional_imports.py");
+        compare_snapshot("optional_imports.expected.json", &report);
+    }
+
     #[test]
     fn test_report_multi_target_aliases() {
         let report = build_module_report_for_test("multi_target_aliases.py");
@@ -2519,6 +2551,7 @@ mod tests {
             "inherited_attrs.py",
             "instance_attrs.py",
             "method_aliases.py",
+            "optional_imports.py",
             "overloads.py",
             "overloads_partial.py",
             "partial_any.py",

--- a/pyrefly/lib/test/coverage/test_files/optional_imports.expected.json
+++ b/pyrefly/lib/test/coverage/test_files/optional_imports.expected.json
@@ -1,0 +1,37 @@
+{
+  "name": "test",
+  "path": "test.py",
+  "names": [
+    "test.w"
+  ],
+  "line_count": 23,
+  "symbol_reports": [
+    {
+      "kind": "attr",
+      "name": "test.w",
+      "n_typable": 1,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 1,
+      "location": {
+        "line": 20,
+        "column": 5
+      }
+    }
+  ],
+  "type_ignores": [],
+  "n_typable": 1,
+  "n_typed": 0,
+  "n_any": 0,
+  "n_untyped": 1,
+  "coverage": 0.0,
+  "strict_coverage": 0.0,
+  "n_functions": 0,
+  "n_methods": 0,
+  "n_function_params": 0,
+  "n_method_params": 0,
+  "n_classes": 0,
+  "n_attrs": 1,
+  "n_properties": 0,
+  "n_type_ignores": 0
+}

--- a/pyrefly/lib/test/coverage/test_files/optional_imports.py
+++ b/pyrefly/lib/test/coverage/test_files/optional_imports.py
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# gh-3773: optional imports are imports, not variables, and must not be reported.
+
+try:
+    import json
+except ImportError:
+    json = None
+
+try:
+    from os import path
+except ImportError:
+    path = None
+
+# Non-import flow merge: still untyped.
+if bool():
+    w = list()
+else:
+    w = dict()


### PR DESCRIPTION
# Summary

Optional imports like 

```py
try:
    import a
except ImportError:
    a = None
```

are now no longer reported as untyped by `pyrefly coverage {check, report}`.

Fixes #3773

# Test Plan

Regression tests and verified consistent behavior between `check` / `report`