### PR TITLE
Treat merged stub symbols as untyped in `pyrefly coverage`

### DIFF
--- a/pyrefly/lib/commands/coverage/collect.rs
+++ b/pyrefly/lib/commands/coverage/collect.rs
@@ -1537,7 +1537,8 @@ impl ModuleSymbols {
 
     /// When this `.pyi` stub only covers a subset of its `.py` counterpart's public
     /// symbols, add the uncovered `py` symbols so that completeness metrics reflect
-    /// the full module interface. `transaction`/`handle` must be the stub's.
+    /// the full module interface. Merged symbols count as fully untyped, since type
+    /// checkers ignore the `.py` when a stub exists. `transaction`/`handle` must be the stub's.
     fn merge_uncovered_py_symbols(
         &mut self,
         transaction: &Transaction,
@@ -1586,19 +1587,21 @@ impl ModuleSymbols {
                         .is_some_and(|rest| rest.starts_with('.'))
             })
         };
-        for py_func in py.functions {
+        for mut py_func in py.functions {
             if keep(&py_func.name)
                 && !stub_class_members.contains(&py_func.name)
                 && !is_reexported(&py_func.name)
             {
+                py_func.slots = py_func.slots.as_untyped();
                 self.functions.push(py_func);
             }
         }
-        for py_var in py.variables {
+        for mut py_var in py.variables {
             if keep(&py_var.name)
                 && !stub_class_members.contains(&py_var.name)
                 && !is_reexported(&py_var.name)
             {
+                py_var.slots = py_var.slots.as_untyped();
                 self.variables.push(py_var);
             }
         }
@@ -2073,10 +2076,10 @@ mod tests {
         report
     }
 
-    /// Build a `ModuleReport` that merges a `.pyi` stub with its `.py` source,
-    /// mirroring the production pipeline in `collect_module_reports` when `prefer_stubs` is
-    /// true and both files exist for the same module.
-    fn build_stub_module_report(pyi_file: &str, py_file: &str) -> ModuleReport {
+    /// Merge a `.pyi` stub's symbols with its `.py` source, mirroring the production
+    /// pipeline in `collect_module_reports` when `prefer_stubs` is true and both
+    /// files exist for the same module.
+    fn merged_stub_symbols(pyi_file: &str, py_file: &str) -> ModuleSymbols {
         // Keep the state alive: the merge needs the stub's transaction.
         let pyi_code = load_test_file(pyi_file);
         let (pyi_state, pyi_handle_fn) = TestEnv::one_with_path("test", "test.pyi", &pyi_code)
@@ -2088,7 +2091,11 @@ mod tests {
 
         let (py, _) = parse_test_module(py_file, TestEnv::new());
         stub.merge_uncovered_py_symbols(&pyi_txn, &pyi_handle, py);
+        stub
+    }
 
+    fn build_stub_module_report(pyi_file: &str, py_file: &str) -> ModuleReport {
+        let stub = merged_stub_symbols(pyi_file, py_file);
         build_module_report(
             "test".to_owned(),
             "test.pyi".to_owned(),
@@ -2193,6 +2200,16 @@ mod tests {
     fn test_report_stub_reexport_class() {
         let report = build_stub_module_report("stub_reexport_class.pyi", "stub_reexport_class.py");
         compare_snapshot("stub_reexport_class.expected.json", &report);
+    }
+
+    /// gh-3778: `.py`-only symbols count as fully untyped, even when annotated in the `.py`.
+    #[test]
+    fn test_report_stub_ignores_py_annotations() {
+        let report = build_stub_module_report(
+            "stub_ignores_py_annotations.pyi",
+            "stub_ignores_py_annotations.py",
+        );
+        compare_snapshot("stub_ignores_py_annotations.expected.json", &report);
     }
 
     /// gh-3519: don't double-count methods whose stub coverage is inherited.
@@ -2333,9 +2350,19 @@ mod tests {
             "partial_any.py",
             "property_basic.py",
             "schema_classes_methods.py",
+            "stub_ignores_py_annotations.pyi",
             "variables.py",
         ] {
-            let (p, module_path) = parse_test_module(file, TestEnv::new());
+            // `.pyi` entries are stub-merged with their `.py` source.
+            let (p, module_path) = if let Some(stem) = file.strip_suffix(".pyi") {
+                (
+                    merged_stub_symbols(file, &format!("{stem}.py")),
+                    "test.pyi".to_owned(),
+                )
+            } else {
+                parse_test_module(file, TestEnv::new())
+            };
+
             let report = build_module_report(
                 "test".to_owned(),
                 module_path,

--- a/pyrefly/lib/commands/coverage/types.rs
+++ b/pyrefly/lib/commands/coverage/types.rs
@@ -66,6 +66,15 @@ impl SlotCounts {
         }
     }
 
+    pub fn as_untyped(self) -> SlotCounts {
+        SlotCounts {
+            n_typable: self.n_typable,
+            n_typed: 0,
+            n_any: 0,
+            n_untyped: self.n_typable,
+        }
+    }
+
     /// Coverage: (n_typed + n_any) / n_typable. Treats Any-annotated slots as covered.
     pub fn coverage(&self) -> f64 {
         if self.n_typable == 0 {

--- a/pyrefly/lib/test/coverage/test_files/stub_ignores_py_annotations.expected.json
+++ b/pyrefly/lib/test/coverage/test_files/stub_ignores_py_annotations.expected.json
@@ -1,0 +1,89 @@
+{
+  "name": "test",
+  "path": "test.pyi",
+  "names": [
+    "test.z",
+    "test.C.covered",
+    "test.C.__setstate__",
+    "test.typed_in_py",
+    "test.C"
+  ],
+  "line_count": 8,
+  "symbol_reports": [
+    {
+      "kind": "attr",
+      "name": "test.z",
+      "n_typable": 1,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 1,
+      "location": {
+        "line": 19,
+        "column": 1
+      }
+    },
+    {
+      "kind": "function",
+      "name": "test.C.covered",
+      "n_typable": 2,
+      "n_typed": 2,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 7,
+        "column": 5
+      }
+    },
+    {
+      "kind": "function",
+      "name": "test.C.__setstate__",
+      "n_typable": 2,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 2,
+      "location": {
+        "line": 11,
+        "column": 5
+      }
+    },
+    {
+      "kind": "function",
+      "name": "test.typed_in_py",
+      "n_typable": 2,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 2,
+      "location": {
+        "line": 15,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.C",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 6,
+        "column": 1
+      }
+    }
+  ],
+  "type_ignores": [],
+  "n_typable": 7,
+  "n_typed": 2,
+  "n_any": 0,
+  "n_untyped": 5,
+  "coverage": 28.57142857142857,
+  "strict_coverage": 28.57142857142857,
+  "n_functions": 1,
+  "n_methods": 2,
+  "n_function_params": 1,
+  "n_method_params": 2,
+  "n_classes": 1,
+  "n_attrs": 1,
+  "n_properties": 0,
+  "n_type_ignores": 0
+}

--- a/pyrefly/lib/test/coverage/test_files/stub_ignores_py_annotations.py
+++ b/pyrefly/lib/test/coverage/test_files/stub_ignores_py_annotations.py
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+class C:
+    def covered(self, x: int) -> str:
+        return str(x)
+
+    def __setstate__(self, state: tuple[int, bool]):
+        pass
+
+
+def typed_in_py(x: int) -> str:
+    return str(x)
+
+
+z: int = 5

--- a/pyrefly/lib/test/coverage/test_files/stub_ignores_py_annotations.pyi
+++ b/pyrefly/lib/test/coverage/test_files/stub_ignores_py_annotations.pyi
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+class C:
+    def covered(self, x: int) -> str: ...


### PR DESCRIPTION
# Summary

From the typing spec ([src](https://typing.python.org/en/latest/spec/distributing.html#partial-stub-packages)):

> Type checkers should merge the stub package and runtime package directories. This can be thought of as the functional equivalent of copying the stub package into the same directory as the corresponding runtime package and type checking the combined directory structure. **Thus type checkers MUST maintain the normal resolution order of checking `*.pyi` before `*.py` files.**

So this ensures that annotated symbols in a `.py` are treated as untyped if those symbols are not annotated in the `.pyi` by `pyrefly coverage {check, report}`.

Fixes #3778

# Test Plan

There are tests :)