### PR TITLE
Filter signatures by relevant parameters in no-matching-overload errors

### DIFF
--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -31,6 +31,7 @@ use pyrefly_util::visit::Visit;
 use pyrefly_util::visit::VisitMut;
 use ruff_python_ast::Keyword;
 use ruff_python_ast::name::Name;
+use starlark_map::small_set::SmallSet;
 
 use crate::class::Class;
 use crate::class::ClassType;
@@ -216,6 +217,15 @@ pub struct ArgCounts {
     pub overall: ArgCount,
 }
 
+/// Controls which parameters are displayed by `ParamList::fmt_with_type`
+#[derive(Debug, Clone)]
+pub enum ParamOverlay {
+    /// Display all parameters
+    All,
+    /// Display only this set of named parameters, plus all anonymous parameters
+    Subset(SmallSet<Name>),
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[derive(Visit, VisitMut, TypeEq)]
 pub struct ParamList(Vec<Param>);
@@ -250,9 +260,11 @@ impl ParamList {
         &self,
         output: &mut O,
         write_type: &impl Fn(&Type, &mut O) -> fmt::Result,
+        overlay: &ParamOverlay,
     ) -> fmt::Result {
         let mut named_posonly = false;
         let mut kwonly = false;
+        let mut skipped_prev = false;
         for (i, param) in self.0.iter().enumerate() {
             // `/` or `*` markers that should be printed before the param
             let mut marker_prefixes = Vec::new();
@@ -266,14 +278,23 @@ impl ParamList {
                 kwonly = true;
                 marker_prefixes.push("*");
             }
-            if i > 0 {
+            // Should we elide the param?
+            let skip = matches!(overlay, ParamOverlay::Subset(names) if param.name().is_some_and(|name| !names.contains(name)));
+            if i > 0 && (!skipped_prev || !marker_prefixes.is_empty() || !skip) {
                 output.write_str(", ")?;
             }
-            for marker_prefix in marker_prefixes {
+            for marker_prefix in marker_prefixes.iter() {
                 output.write_str(marker_prefix)?;
                 output.write_str(", ")?;
             }
-            param.fmt_with_type(output, write_type)?;
+            if skip {
+                if !skipped_prev || !marker_prefixes.is_empty() {
+                    output.write_str("...")?;
+                }
+            } else {
+                param.fmt_with_type(output, write_type)?;
+            }
+            skipped_prev = skip;
         }
         if named_posonly {
             output.write_str(", /")?;
@@ -883,7 +904,7 @@ impl Callable {
         match &self.params {
             Params::List(params) => {
                 output.write_str("(")?;
-                params.fmt_with_type(output, write_type)?;
+                params.fmt_with_type(output, write_type, &ParamOverlay::All)?;
                 output.write_str(") -> ")?;
                 write_type(&self.ret, output)
             }
@@ -908,7 +929,7 @@ impl Callable {
                         if !args.is_empty() && !params.is_empty() {
                             output.write_str(", ")?;
                         }
-                        params.fmt_with_type(output, write_type)?;
+                        params.fmt_with_type(output, write_type, &ParamOverlay::All)?;
                     }
                     Type::Ellipsis => {
                         if !args.is_empty() {

--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -254,18 +254,24 @@ impl ParamList {
         let mut named_posonly = false;
         let mut kwonly = false;
         for (i, param) in self.0.iter().enumerate() {
-            if i > 0 {
-                output.write_str(", ")?;
-            }
+            // `/` or `*` markers that should be printed before the param
+            let mut marker_prefixes = Vec::new();
             if matches!(param, Param::PosOnly(Some(_), _, _)) {
                 named_posonly = true;
             } else if named_posonly {
                 named_posonly = false;
-                output.write_str("/, ")?;
+                marker_prefixes.push("/");
             }
             if !kwonly && matches!(param, Param::KwOnly(..)) {
                 kwonly = true;
-                output.write_str("*, ")?;
+                marker_prefixes.push("*");
+            }
+            if i > 0 {
+                output.write_str(", ")?;
+            }
+            for marker_prefix in marker_prefixes {
+                output.write_str(marker_prefix)?;
+                output.write_str(", ")?;
             }
             param.fmt_with_type(output, write_type)?;
         }

--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -25,6 +25,7 @@ use starlark_map::small_set::SmallSet;
 use starlark_map::smallmap;
 
 use crate::callable::Function;
+use crate::callable::ParamOverlay;
 use crate::callable_residual::CallableResidualKind;
 use crate::class::Class;
 use crate::heap::TypeHeap;
@@ -727,7 +728,11 @@ impl<'a> TypeDisplayContext<'a> {
             }
             Type::ParamSpecValue(x) => {
                 output.write_str("[")?;
-                x.fmt_with_type(output, &|t, o| self.fmt_helper_generic(t, false, o))?;
+                x.fmt_with_type(
+                    output,
+                    &|t, o| self.fmt_helper_generic(t, false, o),
+                    &ParamOverlay::All,
+                )?;
                 output.write_str("]")
             }
             Type::BoundMethod(bm) => {
@@ -1386,6 +1391,7 @@ pub mod tests {
     use pyrefly_python::nesting_context::NestingContext;
     use ruff_python_ast::Identifier;
     use ruff_text_size::TextSize;
+    use starlark_map::smallset;
     use vec1::vec1;
 
     use super::*;
@@ -2651,5 +2657,77 @@ def overloaded_func[T](
         let parts = get_parts(&t);
 
         assert_part_has_location(&parts, "MyTypedDict", "mymodule", 90);
+    }
+
+    fn display_filtered_param_list(params: &ParamList, overlay: SmallSet<&str>) -> String {
+        let overlay = ParamOverlay::Subset(overlay.iter().map(Name::new).collect());
+        format!(
+            "{}",
+            Fmt(|f| {
+                let ctx = TypeDisplayContext::new(&[]);
+                let mut output = DisplayOutput::new(&ctx, f);
+                output.write_str("(")?;
+                params.fmt_with_type(
+                    &mut output,
+                    &|t: &Type, o: &mut DisplayOutput| o.write_str(&format!("{t}")),
+                    &overlay,
+                )?;
+                output.write_str(")")
+            })
+        )
+    }
+
+    #[test]
+    fn test_filter_pos_param_list() {
+        // (x: None, y: None)
+        let params = ParamList::new(vec![
+            Param::Pos(Name::new_static("x"), Type::None, Required::Required),
+            Param::Pos(Name::new_static("y"), Type::None, Required::Required),
+        ]);
+        let show_x = display_filtered_param_list(&params, smallset! {"x"});
+        assert_eq!(show_x, "(x: None, ...)");
+        let show_y = display_filtered_param_list(&params, smallset! {"y"});
+        assert_eq!(show_y, "(..., y: None)");
+    }
+
+    #[test]
+    fn test_filter_posonly_param_list() {
+        // (x: None, y: None, /)
+        let params = ParamList::new(vec![
+            Param::PosOnly(Some(Name::new_static("x")), Type::None, Required::Required),
+            Param::PosOnly(Some(Name::new_static("y")), Type::None, Required::Required),
+        ]);
+        let show_x = display_filtered_param_list(&params, smallset! {"x"});
+        assert_eq!(show_x, "(x: None, ..., /)");
+        let show_y = display_filtered_param_list(&params, smallset! {"y"});
+        assert_eq!(show_y, "(..., y: None, /)");
+    }
+
+    #[test]
+    fn test_filter_kwonly_param_list() {
+        // (*, x: None, y: None)
+        let params = ParamList::new(vec![
+            Param::KwOnly(Name::new_static("x"), Type::None, Required::Required),
+            Param::KwOnly(Name::new_static("y"), Type::None, Required::Required),
+        ]);
+        let show_x = display_filtered_param_list(&params, smallset! {"x"});
+        assert_eq!(show_x, "(*, x: None, ...)");
+        let show_y = display_filtered_param_list(&params, smallset! {"y"});
+        assert_eq!(show_y, "(*, ..., y: None)");
+    }
+
+    #[test]
+    fn test_filter_complex_param_list() {
+        // (w: None, /, x: None, y: None, *, z: None)
+        let params = ParamList::new(vec![
+            Param::PosOnly(Some(Name::new_static("w")), Type::None, Required::Required),
+            Param::Pos(Name::new_static("x"), Type::None, Required::Required),
+            Param::Pos(Name::new_static("y"), Type::None, Required::Required),
+            Param::KwOnly(Name::new_static("z"), Type::None, Required::Required),
+        ]);
+        let show_head_and_tail = display_filtered_param_list(&params, smallset! {"w", "z"});
+        assert_eq!(show_head_and_tail, "(w: None, /, ..., *, z: None)");
+        let show_middle = display_filtered_param_list(&params, smallset! {"x", "y"});
+        assert_eq!(show_middle, "(..., /, x: None, y: None, *, ...)");
     }
 }

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -485,9 +485,22 @@ impl CallArgPreEval<'_> {
     }
 }
 
+/// The parameter an argument was matched against.
+#[derive(Debug, Clone)]
+pub struct MatchedParam {
+    pub ty: Type,
+    pub name: Option<Name>,
+}
+
+impl MatchedParam {
+    fn new(ty: Type, name: Option<Name>) -> Self {
+        Self { ty, name }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ArgMap {
-    pub range_to_param: HashMap<TextRange, Type>,
+    pub range_to_param: HashMap<TextRange, MatchedParam>,
 }
 
 impl ArgMap {
@@ -497,8 +510,9 @@ impl ArgMap {
         }
     }
 
-    fn insert(&mut self, range: TextRange, param: Type) -> Option<Type> {
-        self.range_to_param.insert(range, param)
+    fn insert(&mut self, range: TextRange, ty: Type, name: Option<Name>) -> Option<MatchedParam> {
+        self.range_to_param
+            .insert(range, MatchedParam::new(ty, name))
     }
 }
 
@@ -554,7 +568,6 @@ enum NameOrigin<'a> {
     /// An unpacked kwargs parameter, e.g., `**kwargs: Unpack[TD]` where `TD` is a TypedDict`.
     /// In this example, the encountered name would be the name of a `TD` field, and the origin
     /// would be the param name "kwargs".
-    #[expect(dead_code)]
     UnpackedKwargs(Option<&'a Name>),
 }
 
@@ -795,7 +808,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             // We ignore positional-only parameters because they can't be passed in by name.
                             seen_names.insert(name, (ty, NameOrigin::Param, true));
                         }
-                        argmap.insert(arg.range(), ty.clone());
+                        argmap.insert(arg.range(), ty.clone(), name.cloned());
                         let unhinted_arg_ty = bound_args
                             .as_ref()
                             .map(|_| arg_pre.inferred_type(self, arg_errors));
@@ -824,7 +837,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }) => {
                         // Store args that get matched to an unpacked *args param
                         // Matched args are typechecked separately later
-                        argmap.insert(arg.range(), ty.clone());
+                        argmap.insert(arg.range(), ty.clone(), name.cloned());
                         unpacked_vararg = Some((name, ty));
                         unpacked_vararg_matched_args.push(arg_pre.clone());
                         arg_pre.post_skip();
@@ -834,7 +847,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         name,
                         kind: PosParamKind::Variadic,
                     }) => {
-                        argmap.insert(arg.range(), ty.clone());
+                        argmap.insert(arg.range(), ty.clone(), name.cloned());
                         let unhinted_arg_ty = bound_args
                             .as_ref()
                             .map(|_| arg_pre.inferred_type(self, arg_errors));
@@ -1193,9 +1206,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                 }
                 Some(id) => {
-                    let mut hint = kwargs.as_ref().and_then(|(_, ty)| *ty);
+                    let mut hint = kwargs.as_ref().and_then(|(name, ty)| {
+                        ty.map(|ty| (NameOrigin::UnpackedKwargs(*name), ty))
+                    });
                     let mut has_matching_param = false;
-                    if let Some((ty, _, definitely_seen)) = seen_names.get(&id.id) {
+                    if let Some((ty, origin, definitely_seen)) = seen_names.get(&id.id) {
                         // Use PotentialBadKeywordArgument when the prior entry came from a
                         // NotRequired TypedDict field — the conflict is only potential.
                         let error_kind = if !*definitely_seen {
@@ -1209,18 +1224,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             error_kind,
                             format!("Multiple values for argument `{}`", id.id),
                         );
-                        hint = Some(*ty);
+                        hint = Some((origin.clone(), *ty));
                         has_matching_param = true;
                     } else if let Some((ty, origin, req)) = kwparams.get(&id.id) {
                         seen_names
                             .insert(&id.id, (*ty, origin.clone(), **req == Required::Required));
-                        hint = Some(*ty);
+                        hint = Some((origin.clone(), *ty));
                         has_matching_param = true;
                     } else if kwargs.is_none_or(|(_, ty)| ty.is_none()) {
                         unexpected_keyword_error(&id.id, id.range);
                     }
-                    if let Some(expected) = hint {
-                        argmap.insert(kw.range, expected.clone());
+                    if let Some((origin, expected)) = &hint {
+                        let name = match origin {
+                            NameOrigin::Param => Some(id.id.clone()),
+                            NameOrigin::UnpackedKwargs(kwargs_name) => kwargs_name.cloned(),
+                        };
+                        argmap.insert(kw.range, (*expected).clone(), name);
                     }
                     let unhinted_arg_ty = bound_args
                         .as_ref()
@@ -1242,7 +1261,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             .expr_with_options(
                                 x,
                                 match hint {
-                                    Some(ty) => ExprOptions::check(
+                                    Some((_, ty)) => ExprOptions::check(
                                         ty,
                                         arg_errors,
                                         call_errors,
@@ -1254,7 +1273,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             )
                             .into_ty(),
                         TypeOrExpr::Type(x, range) => {
-                            if let Some(hint) = &hint
+                            if let Some((_, hint)) = &hint
                                 && !hint.is_any()
                             {
                                 self.check_type_with_options(

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -501,12 +501,15 @@ impl MatchedParam {
 #[derive(Debug, Clone)]
 pub struct ArgMap {
     pub range_to_param: HashMap<TextRange, MatchedParam>,
+    /// Required parameters that were left unmatched
+    pub unmatched_params: SmallSet<Option<Name>>,
 }
 
 impl ArgMap {
     pub fn new() -> Self {
         Self {
             range_to_param: HashMap::new(),
+            unmatched_params: SmallSet::new(),
         }
     }
 
@@ -1321,7 +1324,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             extra_posargs_iter.next();
         }
         let mut extra_posargs_matched = 0;
-        for (name, (want, _, required)) in kwparams.iter() {
+        for (name, (want, origin, required)) in kwparams.iter() {
             if !seen_names.contains_key(name) {
                 match required {
                     Required::Required => {
@@ -1335,6 +1338,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 );
                                 extra_posargs_matched += 1;
                             } else {
+                                argmap.unmatched_params.insert(match origin {
+                                    NameOrigin::Param => Some((*name).clone()),
+                                    NameOrigin::UnpackedKwargs(name) => name.cloned(),
+                                });
                                 error(
                                     call_errors,
                                     arguments_range,

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -485,6 +485,23 @@ impl CallArgPreEval<'_> {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct ArgMap {
+    pub range_to_param: HashMap<TextRange, Type>,
+}
+
+impl ArgMap {
+    pub fn new() -> Self {
+        Self {
+            range_to_param: HashMap::new(),
+        }
+    }
+
+    fn insert(&mut self, range: TextRange, param: Type) -> Option<Type> {
+        self.range_to_param.insert(range, param)
+    }
+}
+
 /// Helps track matching of arguments against positional parameters in AnswersSolver::callable_infer_params.
 #[derive(PartialEq, Eq)]
 enum PosParamKind {
@@ -632,13 +649,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         call_context: &CallContext,
         // If Some, records parameter-name → argument-type bindings (for meta-shape inference).
         bound_args: &mut Option<HashMap<String, Type>>,
-    ) -> HashMap<TextRange, Type> {
+    ) -> ArgMap {
         let record = |bound: &mut Option<HashMap<String, Type>>, name: &Name, ty: Type| {
             if let Some(map) = bound.as_mut() {
                 map.insert(name.to_string(), self.canonicalize_shape_dsl_type(ty));
             }
         };
-        let mut expected_types: HashMap<TextRange, Type> = HashMap::new();
+        let mut argmap = ArgMap::new();
         // We want to work mostly with references, but some things are taken from elsewhere,
         // so have some owners to capture them.
         let param_list_owner = Owner::new();
@@ -733,7 +750,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 call_errors,
                                 context,
                             );
-                            return expected_types;
+                            return argmap;
                         }
                     }
                     paramspec = None;
@@ -766,7 +783,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             // We ignore positional-only parameters because they can't be passed in by name.
                             seen_names.insert(name, (ty, true));
                         }
-                        expected_types.insert(arg.range(), ty.clone());
+                        argmap.insert(arg.range(), ty.clone());
                         let unhinted_arg_ty = bound_args
                             .as_ref()
                             .map(|_| arg_pre.inferred_type(self, arg_errors));
@@ -795,7 +812,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }) => {
                         // Store args that get matched to an unpacked *args param
                         // Matched args are typechecked separately later
-                        expected_types.insert(arg.range(), ty.clone());
+                        argmap.insert(arg.range(), ty.clone());
                         unpacked_vararg = Some((name, ty));
                         unpacked_vararg_matched_args.push(arg_pre.clone());
                         arg_pre.post_skip();
@@ -805,7 +822,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         name,
                         kind: PosParamKind::Variadic,
                     }) => {
-                        expected_types.insert(arg.range(), ty.clone());
+                        argmap.insert(arg.range(), ty.clone());
                         let unhinted_arg_ty = bound_args
                             .as_ref()
                             .map(|_| arg_pre.inferred_type(self, arg_errors));
@@ -984,7 +1001,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 call_errors,
                                 context,
                             );
-                            return expected_types;
+                            return argmap;
                         }
                     }
                     paramspec = None;
@@ -1189,7 +1206,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         unexpected_keyword_error(&id.id, id.range);
                     }
                     if let Some(expected) = hint {
-                        expected_types.insert(kw.range, expected.clone());
+                        argmap.insert(kw.range, expected.clone());
                     }
                     let unhinted_arg_ty = bound_args
                         .as_ref()
@@ -1358,7 +1375,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 format!("Expected {expected}, got {actual}"),
             );
         }
-        expected_types
+        argmap
     }
 
     /// Helper used by `callable_infer` and Expr::Lambda inference to distribute over hints.
@@ -1421,8 +1438,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     // Callers can pass the same error collector for both, and most callers do. We use two collectors
     // for overload matching.
     //
-    // Returns: (return_type, specialization_errors, expected_types) where expected_types maps each
-    // argument's source range to the parameter type it was matched against.
+    // Returns: (return_type, specialization_errors, argmap) where argmap maps each
+    // argument's source range to the parameter it was matched against.
     pub fn callable_infer(
         &self,
         callable: Callable,
@@ -1438,11 +1455,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         context: Option<&dyn Fn() -> ErrorContext>,
         hint: Option<HintRef>,
         mut ctor_targs: Option<&mut TArgs>,
-    ) -> (
-        Type,
-        Vec<TypeVarSpecializationError>,
-        HashMap<TextRange, Type>,
-    ) {
+    ) -> (Type, Vec<TypeVarSpecializationError>, ArgMap) {
         self.callable_infer_with_hint(
             hint,
             call_errors,
@@ -1482,11 +1495,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         context: Option<&dyn Fn() -> ErrorContext>,
         hint: Option<&Type>,
         ctor_targs: &mut Option<&mut TArgs>,
-    ) -> (
-        Type,
-        Vec<TypeVarSpecializationError>,
-        HashMap<TextRange, Type>,
-    ) {
+    ) -> (Type, Vec<TypeVarSpecializationError>, ArgMap) {
         let call_context = CallContext::outside()
             .with_argument_side(ArgumentSide::Got)
             .require_boundary_consumption();
@@ -1552,7 +1561,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             QuantifiedHandle::empty()
         };
         let self_arg = self_obj.as_ref().map(|ty| CallArg::ty(ty, arguments_range));
-        let expected_types = match callable.params {
+        let argmap = match callable.params {
             Params::List(params) => self.callable_infer_params(
                 callable_name,
                 &params,
@@ -1573,7 +1582,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 for arg in self_arg.iter().chain(args.iter()) {
                     arg.pre_eval(self, arg_errors).post_infer(self, arg_errors)
                 }
-                HashMap::new()
+                ArgMap::new()
             }
             Params::ParamSpec(concatenate, p) => {
                 let p = self.solver().expand(p);
@@ -1644,10 +1653,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 &mut bound_args,
                             )
                         } else {
-                            HashMap::new()
+                            ArgMap::new()
                         }
                     }
-                    Type::Any(_) | Type::Ellipsis => HashMap::new(),
+                    Type::Any(_) | Type::Ellipsis => ArgMap::new(),
                     _ => {
                         // This could well be our error, but not really sure
                         self.error_with_context(
@@ -1657,7 +1666,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             format!("Unexpected ParamSpec type: `{}`", self.for_display(p)),
                             context,
                         );
-                        HashMap::new()
+                        ArgMap::new()
                     }
                 }
             }
@@ -1707,11 +1716,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             callable.ret.clone()
         };
 
-        (
-            self.solver().for_return_boundary(ret),
-            errors,
-            expected_types,
-        )
+        (self.solver().for_return_boundary(ret), errors, argmap)
     }
 
     /// Auto-inject module field values into `bound_args` for DSL parameters

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -546,6 +546,18 @@ impl<'a> PosParam<'a> {
     }
 }
 
+/// The origin of a name that has been encountered in a function call
+#[derive(Clone, Debug)]
+enum NameOrigin<'a> {
+    /// Named parameter
+    Param,
+    /// An unpacked kwargs parameter, e.g., `**kwargs: Unpack[TD]` where `TD` is a TypedDict`.
+    /// In this example, the encountered name would be the name of a `TD` field, and the origin
+    /// would be the param name "kwargs".
+    #[expect(dead_code)]
+    UnpackedKwargs(Option<&'a Name>),
+}
+
 impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     fn is_param_spec_args(&self, x: &CallArg, q: &Quantified, errors: &ErrorCollector) -> bool {
         match x {
@@ -686,7 +698,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let mut rparams = params.items().iter().rev().collect::<Vec<_>>();
         let mut num_positional_params = 0;
         let mut extra_positional_args = Vec::new();
-        // Map from seen parameter name to (Type, definitely_seen).
+        // Map from seen parameter name to (Type, NameOrigin, definitely_seen).
         // NotRequired fields of unpacked typed dicts are not definitely seen.
         let mut seen_names = SmallMap::new();
         let mut extra_arg_pos = None;
@@ -781,7 +793,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         {
                             // Remember names of positional parameters to detect duplicates.
                             // We ignore positional-only parameters because they can't be passed in by name.
-                            seen_names.insert(name, (ty, true));
+                            seen_names.insert(name, (ty, NameOrigin::Param, true));
                         }
                         argmap.insert(arg.range(), ty.clone());
                         let unhinted_arg_ty = bound_args
@@ -1031,16 +1043,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
                 Param::Varargs(..) => {}
                 Param::Pos(name, ty, required) | Param::KwOnly(name, ty, required) => {
-                    kwparams.insert(name, (ty, required));
+                    kwparams.insert(name, (ty, NameOrigin::Param, required));
                 }
                 Param::Kwargs(name, Type::Unpack(f)) if let Type::TypedDict(typed_dict) = &**f => {
-                    self.typed_dict_fields(typed_dict)
-                        .into_iter()
-                        .for_each(|(name, field)| {
+                    self.typed_dict_fields(typed_dict).into_iter().for_each(
+                        |(field_name, field)| {
                             kwparams.insert(
-                                name_owner.push(name),
+                                name_owner.push(field_name),
                                 (
                                     type_owner.push(field.ty),
+                                    NameOrigin::UnpackedKwargs(name.as_ref()),
                                     if field.required {
                                         &Required::Required
                                     } else {
@@ -1048,7 +1060,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                     },
                                 ),
                             );
-                        });
+                        },
+                    );
                     if let ExtraItems::Extra(extra) = self.typed_dict_extra_items(typed_dict) {
                         kwargs = Some((name.as_ref(), Some(type_owner.push(extra.ty))))
                     } else {
@@ -1086,7 +1099,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         for (name, field) in self.typed_dict_fields(&typed_dict).into_iter() {
                             let name = name_owner.push(name);
                             let mut hint = kwargs.as_ref().and_then(|(_, ty)| *ty);
-                            if let Some((ty, definitely_seen)) = seen_names.get(name) {
+                            if let Some((ty, _, definitely_seen)) = seen_names.get(name) {
                                 // For Required fields, the conflict is guaranteed, so report
                                 // BadKeywordArgument. For NotRequired fields, the conflict is
                                 // only potential (field may be absent at runtime), so report
@@ -1105,8 +1118,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                     format!("Multiple values for argument `{name}`"),
                                 );
                                 hint = Some(*ty);
-                            } else if let Some((ty, _)) = kwparams.get(name) {
-                                seen_names.insert(name, (*ty, field.required));
+                            } else if let Some((ty, origin, _)) = kwparams.get(name) {
+                                seen_names.insert(name, (*ty, origin.clone(), field.required));
                                 hint = Some(*ty)
                             } else if kwargs.is_none() {
                                 unexpected_keyword_error(name, kw.range);
@@ -1182,7 +1195,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 Some(id) => {
                     let mut hint = kwargs.as_ref().and_then(|(_, ty)| *ty);
                     let mut has_matching_param = false;
-                    if let Some((ty, definitely_seen)) = seen_names.get(&id.id) {
+                    if let Some((ty, _, definitely_seen)) = seen_names.get(&id.id) {
                         // Use PotentialBadKeywordArgument when the prior entry came from a
                         // NotRequired TypedDict field — the conflict is only potential.
                         let error_kind = if !*definitely_seen {
@@ -1198,8 +1211,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         );
                         hint = Some(*ty);
                         has_matching_param = true;
-                    } else if let Some((ty, req)) = kwparams.get(&id.id) {
-                        seen_names.insert(&id.id, (*ty, **req == Required::Required));
+                    } else if let Some((ty, origin, req)) = kwparams.get(&id.id) {
+                        seen_names
+                            .insert(&id.id, (*ty, origin.clone(), **req == Required::Required));
                         hint = Some(*ty);
                         has_matching_param = true;
                     } else if kwargs.is_none_or(|(_, ty)| ty.is_none()) {
@@ -1288,7 +1302,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             extra_posargs_iter.next();
         }
         let mut extra_posargs_matched = 0;
-        for (name, (want, required)) in kwparams.iter() {
+        for (name, (want, _, required)) in kwparams.iter() {
             if !seen_names.contains_key(name) {
                 match required {
                     Required::Required => {

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -12,9 +12,14 @@ use itertools::Itertools;
 use pyrefly_types::callable::ArgCount;
 use pyrefly_types::callable::ArgCounts;
 use pyrefly_types::callable::Param;
+use pyrefly_types::callable::ParamOverlay;
+use pyrefly_types::display::TypeDisplayContext;
 use pyrefly_types::meta_shape_dsl::ShapeTransform;
 use pyrefly_types::tuple::Tuple;
+use pyrefly_types::type_output::DisplayOutput;
+use pyrefly_types::type_output::TypeOutput;
 use pyrefly_types::types::TArgs;
+use pyrefly_util::display::Fmt;
 use pyrefly_util::display::count;
 use pyrefly_util::gas::Gas;
 use pyrefly_util::owner::Owner;
@@ -22,6 +27,7 @@ use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::prelude::VecExt;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
+use starlark_map::small_set::SmallSet;
 use vec1::Vec1;
 
 use crate::alt::answers::LookupAnswer;
@@ -441,6 +447,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 context,
                 &closest_overload.func.1.signature,
                 closest_overload.call_errors,
+                closest_overload.argmap,
             );
             (
                 self.heap.mk_any_error(),
@@ -502,6 +509,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         context: Option<&dyn Fn() -> ErrorContext>,
         closest_overload_signature: &Callable,
         closest_overload_call_errors: ErrorCollector,
+        mut closest_overload_argmap: ArgMap,
     ) {
         // Build a string showing the argument types for error messages
         let mut arg_type_strs = Vec::new();
@@ -530,6 +538,43 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             args_display
         );
         let mut details = vec!["Possible overloads:".to_owned()];
+        // Build an overlay of relevant parameters. We'll show only these parameters when printing overloads.
+        if self_obj.is_some() {
+            // We strip `self` from the displayed signatures, so drop it from the overlay as well.
+            // `callable_infer_inner` uses the entire arguments_range as the range for `self` when
+            // constructing a CallArg for it.
+            closest_overload_argmap
+                .range_to_param
+                .remove(&arguments_range);
+        }
+        let signature_overlay = {
+            // If call errors is empty, the call failed due to an arity mismatch. Show all
+            // parameters so the user can see the number of parameters in each signature.
+            if closest_overload_call_errors.is_empty()
+                // If any args are unpacked, we don't know for sure which parameters are matched,
+                // so show all of them.
+                || args.iter().any(|arg| matches!(arg, CallArg::Star(..)))
+                || keywords.iter().any(|kw| kw.arg.is_none())
+                // If an unexpected argument was passed in, show all the parameters to help the user
+                // figure out which one they actually meant to match.
+                || args.iter().map(|arg| arg.range()).chain(keywords.iter().map(|kw| kw.range)).any(|r| !closest_overload_argmap.range_to_param.contains_key(&r))
+            {
+                ParamOverlay::All
+            } else {
+                // Show only parameters that were matched by passed arguments and required
+                // parameters that were not matched.
+                let names = closest_overload_argmap
+                    .range_to_param
+                    .into_values()
+                    .map(|p| p.name)
+                    .chain(closest_overload_argmap.unmatched_params)
+                    .collect::<Option<SmallSet<_>>>();
+                match names {
+                    Some(names) => ParamOverlay::Subset(names),
+                    None => ParamOverlay::All,
+                }
+            }
+        };
         for overload in overloads {
             let suffix = if overload.1.signature == *closest_overload_signature {
                 " [closest match]"
@@ -544,10 +589,50 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     .unwrap_or_else(|| overload.1.signature.clone()),
                 None => overload.1.signature.clone(),
             };
-            let signature = self
+            let type_for_display = self
                 .solver()
                 .for_display(self.heap.mk_callable_from(signature));
-            details.push(format!("  {signature}{suffix}"));
+            let display_context = TypeDisplayContext::new(&[&type_for_display]);
+            let signature_for_display = match &type_for_display {
+                Type::Callable(callable) => callable,
+                _ => unreachable!("Expected a callable"),
+            };
+            let signature_for_display = match &signature_for_display.params {
+                Params::List(params) => {
+                    if let ParamOverlay::Subset(names) = &signature_overlay
+                        && let cur_names = params
+                            .items()
+                            .iter()
+                            .filter_map(|p| p.name())
+                            .collect::<SmallSet<_>>()
+                        && names.iter().any(|name| !cur_names.contains(name))
+                    {
+                        // If any of the parameters we want to show don't exist in the current
+                        // signature, be conservative and show everything.
+                        format!("{type_for_display}")
+                    } else {
+                        format!(
+                            "{}",
+                            Fmt(|f| {
+                                let mut output = DisplayOutput::new(&display_context, f);
+                                let write_type = |t: &Type, o: &mut DisplayOutput| {
+                                    display_context.fmt_helper_generic(t, false, o)
+                                };
+                                output.write_str("(")?;
+                                params.fmt_with_type(
+                                    &mut output,
+                                    &write_type,
+                                    &signature_overlay,
+                                )?;
+                                output.write_str(") -> ")?;
+                                write_type(&signature_for_display.ret, &mut output)
+                            })
+                        )
+                    }
+                }
+                _ => format!("{type_for_display}"),
+            };
+            details.push(format!("  {signature_for_display}{suffix}"));
         }
         let mut builder = errors
             .error_builder(arguments_range, ErrorKind::NoMatchingOverload, header)

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -6,7 +6,6 @@
  */
 
 use std::cmp::max;
-use std::collections::HashMap;
 
 use itertools::Either;
 use itertools::Itertools;
@@ -29,6 +28,7 @@ use crate::alt::answers::LookupAnswer;
 use crate::alt::answers::OverloadTrace;
 use crate::alt::answers_solver::AnswersSolver;
 use crate::alt::call::TargetWithTParams;
+use crate::alt::callable::ArgMap;
 use crate::alt::callable::CallArg;
 use crate::alt::callable::CallKeyword;
 use crate::alt::callable::CallWithTypes;
@@ -52,8 +52,8 @@ struct CalledOverload<'f> {
     ctor_targs: Option<TArgs>,
     call_errors: ErrorCollector,
     specialization_errors: Vec<TypeVarSpecializationError>,
-    /// Maps each argument's source range to the parameter type it was matched against.
-    expected_types: HashMap<TextRange, Type>,
+    /// Maps each argument's source range to the parameter it was matched against.
+    argmap: ArgMap,
 }
 
 impl CalledOverload<'_> {
@@ -287,7 +287,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     ctor_targs: None,
                     call_errors: self.error_collector(),
                     specialization_errors: Vec::new(),
-                    expected_types: HashMap::new(),
+                    argmap: ArgMap::new(),
                 },
                 false,
             ),
@@ -339,12 +339,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     if let Some(first_overload) = matched_overloads.first() {
                         let func = first_overload.func;
                         let ctor_targs = first_overload.ctor_targs.clone();
-                        let expected_types = first_overload.expected_types.clone();
+                        let argmap = first_overload.argmap.clone();
                         let specialization_errors = first_overload.specialization_errors.clone();
                         closest_overload = CalledOverload {
                             func,
                             ctor_targs,
-                            expected_types,
+                            argmap,
                             res: self.unions(matched_overloads.into_map(|o| o.res)),
                             call_errors: self.error_collector(),
                             specialization_errors,
@@ -706,7 +706,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                     let mut param_types = matched_overloads
                         .iter()
-                        .filter_map(|o| o.expected_types.get(&arg_range));
+                        .filter_map(|o| o.argmap.range_to_param.get(&arg_range));
                     let Some(first) = param_types.next() else {
                         // If we can't find the expected type, be conservative and assume there may be multiple.
                         return true;
@@ -922,7 +922,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let tparams = callable.0.as_deref();
 
         let call_errors = self.error_collector();
-        let (res, specialization_errors, expected_types) = self.callable_infer(
+        let (res, specialization_errors, argmap) = self.callable_infer(
             callable.1.signature.clone(),
             Some(&metadata.kind),
             shape_transform,
@@ -947,7 +947,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             ctor_targs: overload_ctor_targs,
             call_errors,
             specialization_errors,
-            expected_types,
+            argmap,
         }
     }
 }

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -706,7 +706,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                     let mut param_types = matched_overloads
                         .iter()
-                        .filter_map(|o| o.argmap.range_to_param.get(&arg_range));
+                        .filter_map(|o| o.argmap.range_to_param.get(&arg_range).map(|p| &p.ty));
                     let Some(first) = param_types.next() else {
                         // If we can't find the expected type, be conservative and assume there may be multiple.
                         return true;

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -2096,3 +2096,91 @@ def func(
     raise NotImplementedError
     "#,
 );
+
+testcase!(
+    test_overload_error_shows_relevant_signature_part,
+    r#"
+from typing import overload
+
+@overload
+def f(*args: int, **kwargs: str) -> int: ...
+@overload
+def f(*args: str, **kwargs: int) -> str: ...
+def f(*args, **kwargs):
+    return args[0]
+
+f(4.2)  # E: (*args: int, ...) -> int [closest match]\n    (*args: str, ...) -> str
+f(x=4.2)  # E: (..., **kwargs: str) -> int [closest match]\n    (..., **kwargs: int) -> str
+
+# When any arguments are unpacked, we conservatively fall back to showing full signatures
+f(*[4.2])  # E: (*args: int, **kwargs: str) -> int [closest match]\n    (*args: str, **kwargs: int) -> str
+f(**{"x": 4.2})  # E: (*args: int, **kwargs: str) -> int [closest match]\n    (*args: str, **kwargs: int) -> str
+    "#,
+);
+
+testcase!(
+    test_overload_error_shows_unpacked_kwargs,
+    r#"
+from typing import overload, TypedDict, Unpack
+
+class TD(TypedDict):
+    y: int
+
+@overload
+def f(x: int = ..., **kwargs: Unpack[TD]) -> int: ...
+@overload
+def f(x: str = ..., **kwargs: Unpack[TD]) -> str: ...
+def f(x=0, **kwargs):
+    return x
+
+f(y=4.2)  # E: (..., **kwargs: Unpack[TD]) -> int [closest match]\n    (..., **kwargs: Unpack[TD]) -> str
+    "#,
+);
+
+testcase!(
+    test_overload_error_does_not_truncate_on_different_param_names,
+    r#"
+from typing import overload
+
+@overload
+def f(x: int, /) -> int: ...
+@overload
+def f(y: str, /) -> str: ...
+def f(x, /): return x
+
+# Make sure we show 'y' in the second overload even though 'x' was matched in the first overload
+f(4.2)  # E: (x: int, /) -> int [closest match]\n    (y: str, /) -> str
+    "#,
+);
+
+testcase!(
+    test_overload_error_truncates_method_signatures,
+    r#"
+from typing import overload
+
+class A:
+    @overload
+    def f(self, x: str, y: int = ...) -> str: ...
+    @overload
+    def f(self, x: int, y: str = ...) -> int: ...
+    def f(self, x, y=0): return x
+
+A().f(4.2)  # E: (x: str, ...) -> str [closest match]\n    (x: int, ...) -> int
+    "#,
+);
+
+testcase!(
+    test_overload_error_shows_missing_parameter,
+    r#"
+from typing import Any, overload
+
+@overload
+def f(x: int, y: str = ..., z: float = ...) -> int: ...
+@overload
+def f(x: str, y: int = ..., z: float = ...) -> str: ...
+def f(x, y="", z=0.0): return x
+
+y: Any = ...
+f(y=y)  # E: (x: int, y: str = ..., ...) -> int [closest match]\n    (x: str, y: int = ..., ...) -> str
+    "#,
+);


### PR DESCRIPTION
Summary:
When a call to an overloaded function fails but has the right number of arguments, show only the parameters corresponding to passed arguments and required missing arguments when printing possible overloads. This makes the signatures easier to read by hiding irrelevant information.

Before:
```
ERROR No matching overload found for function `subprocess.run` called with arguments: (Literal[42], capture_output=Any) [no-matching-overload]
 --> empty.py:6:15
  |
6 | subprocess.run(42, capture_output=x)
  |               ^^^^^^^^^^^^^^^^^^^^^^
  |
  Possible overloads:
    (args: _CMD, bufsize: int = -1, executable: PathLike[bytes] | PathLike[str] | bytes | str | None = None, stdin: _FILE = None, stdout: _FILE = None, stderr: _FILE = None, preexec_fn: (() -> object) | None = None, close_fds: bool = True, shell: bool = False, cwd: PathLike[bytes] | PathLike[str] | bytes | str | None = None, env: Mapping[bytes, StrOrBytesPath] | Mapping[str, StrOrBytesPath] | None = None, universal_newlines: Literal[True] | None = None, startupinfo: Any = None, creationflags: int = 0, restore_signals: bool = True, start_new_session: bool = False, pass_fds: Collection[int] = ..., *, capture_output: bool = False, check: bool = False, encoding: str | None = None, errors: str | None = None, input: str | None = None, text: Literal[True], timeout: float | None = None, user: int | str | None = None, group: int | str | None = None, extra_groups: Iterable[int | str] | None = None, umask: int = -1, pipesize: int = -1, process_group: int | None = None) -> CompletedProcess[str]
    (args: _CMD, bufsize: int = -1, executable: PathLike[bytes] | PathLike[str] | bytes | str | None = None, stdin: _FILE = None, stdout: _FILE = None, stderr: _FILE = None, preexec_fn: (() -> object) | None = None, close_fds: bool = True, shell: bool = False, cwd: PathLike[bytes] | PathLike[str] | bytes | str | None = None, env: Mapping[bytes, StrOrBytesPath] | Mapping[str, StrOrBytesPath] | None = None, universal_newlines: bool | None = None, startupinfo: Any = None, creationflags: int = 0, restore_signals: bool = True, start_new_session: bool = False, pass_fds: Collection[int] = ..., *, capture_output: bool = False, check: bool = False, encoding: str, errors: str | None = None, input: str | None = None, text: bool | None = None, timeout: float | None = None, user: int | str | None = None, group: int | str | None = None, extra_groups: Iterable[int | str] | None = None, umask: int = -1, pipesize: int = -1, process_group: int | None = None) -> CompletedProcess[str]
    (args: _CMD, bufsize: int = -1, executable: PathLike[bytes] | PathLike[str] | bytes | str | None = None, stdin: _FILE = None, stdout: _FILE = None, stderr: _FILE = None, preexec_fn: (() -> object) | None = None, close_fds: bool = True, shell: bool = False, cwd: PathLike[bytes] | PathLike[str] | bytes | str | None = None, env: Mapping[bytes, StrOrBytesPath] | Mapping[str, StrOrBytesPath] | None = None, universal_newlines: bool | None = None, startupinfo: Any = None, creationflags: int = 0, restore_signals: bool = True, start_new_session: bool = False, pass_fds: Collection[int] = ..., *, capture_output: bool = False, check: bool = False, encoding: str | None = None, errors: str, input: str | None = None, text: bool | None = None, timeout: float | None = None, user: int | str | None = None, group: int | str | None = None, extra_groups: Iterable[int | str] | None = None, umask: int = -1, pipesize: int = -1, process_group: int | None = None) -> CompletedProcess[str]
    (args: _CMD, bufsize: int = -1, executable: PathLike[bytes] | PathLike[str] | bytes | str | None = None, stdin: _FILE = None, stdout: _FILE = None, stderr: _FILE = None, preexec_fn: (() -> object) | None = None, close_fds: bool = True, shell: bool = False, cwd: PathLike[bytes] | PathLike[str] | bytes | str | None = None, env: Mapping[bytes, StrOrBytesPath] | Mapping[str, StrOrBytesPath] | None = None, *, universal_newlines: Literal[True], startupinfo: Any = None, creationflags: int = 0, restore_signals: bool = True, start_new_session: bool = False, pass_fds: Collection[int] = ..., capture_output: bool = False, check: bool = False, encoding: str | None = None, errors: str | None = None, input: str | None = None, text: Literal[True] | None = None, timeout: float | None = None, user: int | str | None = None, group: int | str | None = None, extra_groups: Iterable[int | str] | None = None, umask: int = -1, pipesize: int = -1, process_group: int | None = None) -> CompletedProcess[str]
    (args: _CMD, bufsize: int = -1, executable: PathLike[bytes] | PathLike[str] | bytes | str | None = None, stdin: _FILE = None, stdout: _FILE = None, stderr: _FILE = None, preexec_fn: (() -> object) | None = None, close_fds: bool = True, shell: bool = False, cwd: PathLike[bytes] | PathLike[str] | bytes | str | None = None, env: Mapping[bytes, StrOrBytesPath] | Mapping[str, StrOrBytesPath] | None = None, universal_newlines: Literal[False] | None = None, startupinfo: Any = None, creationflags: int = 0, restore_signals: bool = True, start_new_session: bool = False, pass_fds: Collection[int] = ..., *, capture_output: bool = False, check: bool = False, encoding: None = None, errors: None = None, input: Buffer | None = None, text: Literal[False] | None = None, timeout: float | None = None, user: int | str | None = None, group: int | str | None = None, extra_groups: Iterable[int | str] | None = None, umask: int = -1, pipesize: int = -1, process_group: int | None = None) -> CompletedProcess[bytes] [closest match]
    (args: _CMD, bufsize: int = -1, executable: PathLike[bytes] | PathLike[str] | bytes | str | None = None, stdin: _FILE = None, stdout: _FILE = None, stderr: _FILE = None, preexec_fn: (() -> object) | None = None, close_fds: bool = True, shell: bool = False, cwd: PathLike[bytes] | PathLike[str] | bytes | str | None = None, env: Mapping[bytes, StrOrBytesPath] | Mapping[str, StrOrBytesPath] | None = None, universal_newlines: bool | None = None, startupinfo: Any = None, creationflags: int = 0, restore_signals: bool = True, start_new_session: bool = False, pass_fds: Collection[int] = ..., *, capture_output: bool = False, check: bool = False, encoding: str | None = None, errors: str | None = None, input: Buffer | str | None = None, text: bool | None = None, timeout: float | None = None, user: int | str | None = None, group: int | str | None = None, extra_groups: Iterable[int | str] | None = None, umask: int = -1, pipesize: int = -1, process_group: int | None = None) -> CompletedProcess[Any]
  Argument `Literal[42]` is not assignable to parameter `args` with type `PathLike[bytes] | PathLike[str] | Sequence[StrOrBytesPath] | bytes | str` in function `subprocess.run`
```

After:
```
ERROR No matching overload found for function `subprocess.run` called with arguments: (Literal[42], capture_output=Any) [no-matching-overload]
 --> empty.py:6:15
  |
6 | subprocess.run(42, capture_output=x)
  |               ^^^^^^^^^^^^^^^^^^^^^^
  |
  Possible overloads:
    (args: _CMD, ..., *, capture_output: bool = False, ...) -> CompletedProcess[str]
    (args: _CMD, ..., *, capture_output: bool = False, ...) -> CompletedProcess[str]
    (args: _CMD, ..., *, capture_output: bool = False, ...) -> CompletedProcess[str]
    (args: _CMD, ..., *, ..., capture_output: bool = False, ...) -> CompletedProcess[str]
    (args: _CMD, ..., *, capture_output: bool = False, ...) -> CompletedProcess[bytes] [closest match]
    (args: _CMD, ..., *, capture_output: bool = False, ...) -> CompletedProcess[Any]
  Argument `Literal[42]` is not assignable to parameter `args` with type `PathLike[bytes] | PathLike[str] | Sequence[StrOrBytesPath] | bytes | str` in function `subprocess.run`
```

Context:

This stack is a ground-up re-implementation of https://github.com/facebook/pyrefly/pull/1447. It has a narrower focus (just omits irrelevant parameter types, doesn't try to do any handling of other kinds of call errors), reuses the existing signature display code, tracks parameters by name instead of index, and filters all overload signatures rather than just the closest one.

Differential Revision: D108230384


