### PR TITLE
Add unused-type-ignore rule

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -374,6 +374,8 @@ pub enum ErrorKind {
     UnusedCoroutine,
     /// A suppression comment is unused (no error to suppress, or specific codes are unused)
     UnusedIgnore,
+    /// A `# type: ignore` comment is unused (no error to suppress on that line)
+    UnusedTypeIgnore,
     /// The inferred variance of a type variable does not match its declared variance.
     /// For example, a type variable used only in covariant positions in a protocol should be declared covariant.
     VarianceMismatch,
@@ -499,6 +501,7 @@ impl ErrorKind {
             ErrorKind::UnresolvableDunderAll => Severity::Warn,
             ErrorKind::UntypedImport => Severity::Warn,
             ErrorKind::UnusedIgnore => Severity::Ignore,
+            ErrorKind::UnusedTypeIgnore => Severity::Ignore,
             ErrorKind::VarianceMismatch => Severity::Warn,
             _ => Severity::Error,
         }

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -447,7 +447,7 @@ impl Errors {
                         continue;
                     }
                     match tool {
-                        Tool::Pyrefly | Tool::Pyre => {}
+                        Tool::Pyrefly | Tool::Pyre | Tool::Type => {}
                         _ => continue,
                     }
 
@@ -474,6 +474,26 @@ impl Errors {
                             "Unused pyre-fixme comment".to_owned(),
                             Vec::new(),
                             ErrorKind::UnusedIgnore,
+                        ));
+                        continue;
+                    }
+
+                    // For Tool::Type (`# type: ignore`), codes are mypy codes (not pyrefly
+                    // codes), so we treat it as a blanket suppression: unused if no errors
+                    // were suppressed on that line.
+                    if tool == Tool::Type {
+                        if !used_codes.is_empty() {
+                            continue; // type: ignore is used
+                        }
+                        let comment_line = supp.comment_line();
+                        let line_start = module.lined_buffer().line_start(comment_line);
+                        let range = TextRange::new(line_start, line_start + TextSize::new(1));
+                        unused_errors.push(Error::new(
+                            module.dupe(),
+                            range,
+                            "Unused `# type: ignore` comment".to_owned(),
+                            Vec::new(),
+                            ErrorKind::UnusedTypeIgnore,
                         ));
                         continue;
                     }
@@ -557,9 +577,7 @@ impl Errors {
         for error in unused_errors {
             if let Some(config) = config_by_path.get(&error.path()) {
                 let error_config = config.get_error_config(error.path().as_path());
-                let severity = error_config
-                    .display_config
-                    .severity(ErrorKind::UnusedIgnore);
+                let severity = error_config.display_config.severity(error.error_kind());
                 match severity {
                     Severity::Error => result.ordinary.push(error.with_severity(Severity::Error)),
                     Severity::Warn => result.ordinary.push(error.with_severity(Severity::Warn)),
@@ -760,6 +778,45 @@ def g() -> str:
         let collected = errors.collect_errors();
         let unused = errors.collect_unused_ignore_errors(&collected);
         assert_eq!(unused.len(), 2);
+    }
+
+    #[test]
+    fn test_unused_type_ignore_no_error() {
+        let contents = r#"
+def f() -> int:
+    return 1  # type: ignore
+"#;
+        let (errors, _tdir) = get_errors(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        assert_eq!(unused.len(), 1);
+        assert!(unused[0].msg().contains("type: ignore"));
+    }
+
+    #[test]
+    fn test_used_type_ignore_suppresses_error() {
+        let contents = r#"
+def f() -> int:
+    return "hello"  # type: ignore
+"#;
+        let (errors, _tdir) = get_errors(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        assert!(unused.is_empty());
+    }
+
+    #[test]
+    fn test_unused_type_ignore_with_codes() {
+        // mypy-style codes are not pyrefly codes; treat as blanket ignore
+        let contents = r#"
+def f() -> int:
+    return 1  # type: ignore[assignment]
+"#;
+        let (errors, _tdir) = get_errors(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        assert_eq!(unused.len(), 1);
+        assert!(unused[0].msg().contains("type: ignore"));
     }
 
     #[test]

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -478,9 +478,7 @@ impl Errors {
                         continue;
                     }
 
-                    // For Tool::Type (`# type: ignore`), codes are mypy codes (not pyrefly
-                    // codes), so we treat it as a blanket suppression: unused if no errors
-                    // were suppressed on that line.
+                    // For `# type: ignore`, unused if no errors were suppressed on this line.
                     if tool == Tool::Type {
                         if !used_codes.is_empty() {
                             continue; // type: ignore is used

--- a/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
@@ -1848,7 +1848,9 @@ fn test_unused_type_ignore_diagnostic_default_severity() {
         })
         .unwrap();
 
-    interaction.client.did_open("unused_type_ignore_no_config.py");
+    interaction
+        .client
+        .did_open("unused_type_ignore_no_config.py");
 
     // Without `unused-type-ignore = "error"` in config, the default severity is "ignore", so no
     // `unused-type-ignore` diagnostic should appear.

--- a/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
@@ -1792,3 +1792,74 @@ fn test_unused_ignore_diagnostic_default_severity() {
 
     interaction.shutdown().unwrap();
 }
+
+#[test]
+fn test_unused_type_ignore_diagnostic() {
+    let root = get_test_files_root();
+    let test_files_root = root.path().join("unused_type_ignore");
+    let scope_uri = Url::from_file_path(test_files_root.as_path()).unwrap();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(test_files_root.clone());
+    interaction
+        .initialize(InitializeSettings {
+            workspace_folders: Some(vec![("test".to_owned(), scope_uri)]),
+            configuration: Some(None),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open("example.py");
+
+    interaction
+        .client
+        .diagnostic("example.py")
+        .expect_response(json!({
+            "items": [
+                {
+                    "code": "unused-type-ignore",
+                    "codeDescription": {
+                        "href": "https://pyrefly.org/en/docs/error-kinds/#unused-type-ignore"
+                    },
+                    "message": "Unused `# type: ignore` comment",
+                    "range": {
+                        "start": {"line": 5, "character": 0},
+                        "end": {"line": 5, "character": 1}
+                    },
+                    "severity": 1,
+                    "source": "Pyrefly"
+                }
+            ],
+            "kind": "full"
+        }))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_unused_type_ignore_diagnostic_default_severity() {
+    let test_files_root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(test_files_root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(None),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open("unused_type_ignore_no_config.py");
+
+    // Without `unused-type-ignore = "error"` in config, the default severity is "ignore", so no
+    // `unused-type-ignore` diagnostic should appear.
+    interaction
+        .client
+        .diagnostic("unused_type_ignore_no_config.py")
+        .expect_response(json!({
+            "items": [],
+            "kind": "full"
+        }))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/unused_type_ignore/example.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/unused_type_ignore/example.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# type: ignore
+x: int = 1

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/unused_type_ignore/pyrefly.toml
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/unused_type_ignore/pyrefly.toml
@@ -1,0 +1,2 @@
+[errors]
+unused-type-ignore = "error"

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/unused_type_ignore_no_config.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/unused_type_ignore_no_config.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# type: ignore
+x: int = 1

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -1810,6 +1810,12 @@ Default severity: `ignore`
 
 This error is raised when a `# pyrefly: ignore` comment is not used to suppress an error, and can be safely removed.
 
+## unused-type-ignore
+
+Default severity: `ignore`
+
+This error is raised when a `# type: ignore` comment is not used to suppress any error, and can be safely removed. This rule is distinct from `unused-ignore` so that projects using multiple type checkers can leave `# type: ignore` comments for other tools (e.g. mypy) without pyrefly flagging them. Enable this rule if your project uses pyrefly exclusively.
+
 ## variance-mismatch
 
 Default severity: `warn`


### PR DESCRIPTION
# Summary

Adds a new `unused-type-ignore` rule that reports `# type: ignore` comments that are not suppressing any error.

Fixes #3766

This rule is off by default to avoid breaking projects using multiple type checkers (e.g. mypy + pyrefly). Enable it in `pyrefly.toml`:

```toml
[errors]
unused-type-ignore = "error"  # or "warn"
```

# Test Plan

- Unit tests for unused/used # type: ignore detection
- LSP integration tests verifying the diagnostic appears when enabled and is silent by default
- Manually verified that the diagnostic shows when the rule is set to "error" and is silent when set to "ignore
