### PR TITLE
fix Literal not inferred properly when it has more than 8 elements #3779

### DIFF
--- a/pyrefly/lib/alt/unwrap.rs
+++ b/pyrefly/lib/alt/unwrap.rs
@@ -433,21 +433,46 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         decompose: impl Fn(&'b Type) -> Option<D>,
         infer: impl Fn(Option<D>) -> Type,
     ) -> Type {
-        if let Some(hint) = hint
-            && hint.types().len() <= MAX_DECOMPOSE_HINT_WIDTH
-        {
-            for (hint, vs) in self.solver().partial_sort_by_vars(hint.types()) {
-                let mut ret = None;
-                match self.solver().with_snapshot(&vs, || {
-                    let d = decompose(hint);
-                    if d.is_none() {
-                        return Err(SubsetError::Other);
+        if let Some(hint) = hint {
+            if hint.types().len() <= MAX_DECOMPOSE_HINT_WIDTH {
+                for (hint, vs) in self.solver().partial_sort_by_vars(hint.types()) {
+                    let mut ret = None;
+                    match self.solver().with_snapshot(&vs, || {
+                        let d = decompose(hint);
+                        if d.is_none() {
+                            return Err(SubsetError::Other);
+                        }
+                        ret = Some(infer(d));
+                        self.is_subset_eq_with_reason(ret.as_ref().unwrap(), hint)
+                    }) {
+                        SubsetWithSnapshotResult::Ok => return ret.unwrap(),
+                        SubsetWithSnapshotResult::Err(_) => {}
                     }
-                    ret = Some(infer(d));
-                    self.is_subset_eq_with_reason(ret.as_ref().unwrap(), hint)
-                }) {
-                    SubsetWithSnapshotResult::Ok => return ret.unwrap(),
-                    SubsetWithSnapshotResult::Err(_) => {}
+                }
+            } else {
+                let mut decomposed_hint = None;
+                for (hint, vs) in self.solver().partial_sort_by_vars(hint.types()) {
+                    let snapshot = self
+                        .solver()
+                        .snapshot_vars(&hint.collect_maybe_placeholder_vars());
+                    let d = decompose(hint);
+                    self.solver().restore_vars(snapshot);
+                    if let Some(d) = d {
+                        if decomposed_hint.is_some() {
+                            return infer(None);
+                        }
+                        decomposed_hint = Some((hint, vs, d));
+                    }
+                }
+                if let Some((hint, vs, d)) = decomposed_hint {
+                    let mut ret = None;
+                    match self.solver().with_snapshot(&vs, || {
+                        ret = Some(infer(Some(d)));
+                        self.is_subset_eq_with_reason(ret.as_ref().unwrap(), hint)
+                    }) {
+                        SubsetWithSnapshotResult::Ok => return ret.unwrap(),
+                        SubsetWithSnapshotResult::Err(_) => {}
+                    }
                 }
             }
         }

--- a/pyrefly/lib/test/contextual.rs
+++ b/pyrefly/lib/test/contextual.rs
@@ -220,6 +220,29 @@ x9: list[str] = {"a": 1}  # E: `dict[str, int]` is not assignable to `list[str]`
 );
 
 testcase!(
+    test_dict_hint_with_wide_literal_alias,
+    r#"
+from typing import Literal, Mapping, TypeAlias
+
+Thing: TypeAlias = Literal[
+    "bat",
+    "cat",
+    "dat",
+    "eat",
+    "fat",
+    "gat",
+    "hat",
+    "jat",
+]
+
+def func(a: Thing | Mapping[str, Thing]) -> None:
+    pass
+
+func({"a": "bat", "c": "cat"})
+    "#,
+);
+
+testcase!(
     test_call_keyword_arg_is_context_even_for_duplicates,
     r#"
 from typing import assert_type, Callable, Any


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3779

The change is that, wide union hints still keep the existing trial limit, but if exactly one member can be decomposed as the relevant container hint, Pyrefly now uses that member for contextual typing.

That covers `Literal[...] | Mapping[str, Thing]` without broadly raising the union-width limit.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test
