### PR TITLE
fix no-matching-overload when using descriptor #3742

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -8,7 +8,6 @@
 use std::iter;
 use std::sync::Arc;
 
-use dupe::Dupe;
 use pyrefly_python::dunder;
 use pyrefly_types::literal::LitStyle;
 use pyrefly_types::meta_shape_dsl::ShapeTransform;
@@ -1671,7 +1670,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // and the class object as `objtype`.
         let (objtype, obj) = match base {
             DescriptorBase::Instance(classtype) => (
-                self.heap.mk_class_def(classtype.class_object().dupe()),
+                self.heap
+                    .mk_type_of(self.heap.mk_class_type(classtype.clone())),
                 self.heap.mk_class_type(classtype),
             ),
             DescriptorBase::SelfInstance(classtype) => (

--- a/pyrefly/lib/test/descriptors.rs
+++ b/pyrefly/lib/test/descriptors.rs
@@ -810,6 +810,33 @@ class B[T: A]:
 );
 
 testcase!(
+    test_overloaded_descriptor_get_preserves_specialized_owner,
+    r#"
+from typing import Any, Generic, Literal, TypeAlias, TypeVar, overload, reveal_type
+
+Storage: TypeAlias = Literal["python", "pyarrow"]
+StorageT = TypeVar("StorageT", bound=Storage)
+_StorageT = TypeVar("_StorageT", bound=Storage | None, default=None)
+
+class _CatStorageDescriptor:
+    @overload
+    def __get__(self, instance: Cat[None], owner: type[Cat[None]]) -> Storage: ...
+    @overload
+    def __get__(
+        self, instance: Cat[StorageT], owner: type[Cat[StorageT]]
+    ) -> StorageT: ...
+
+    def __get__(self, *args: Any, **kwargs: Any) -> Any: ...
+
+class Cat(Generic[_StorageT]):
+    storage = _CatStorageDescriptor()
+
+def main(cat: Cat[Literal["pyarrow"]]) -> None:
+    reveal_type(cat.storage)  # E: revealed type: Literal['pyarrow']
+    "#,
+);
+
+testcase!(
     test_property_constructor_non_callable_arg,
     r#"
 from typing import Any, assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3742

now descriptor instance access passes type[Cat[...]] as the synthetic owner argument instead of dropping specialization to bare type[Cat].

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test