### PR TITLE
fix Unused error code(s) in # pyrefly: ignore: unused-ignore #3367

### DIFF
--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -322,6 +322,9 @@ struct OutputArgs {
     /// and LookupExport calls). Useful for analyzing laziness properties.
     #[arg(long, value_name = "OUTPUT_FILE")]
     report_demand_tree: Option<PathBuf>,
+    /// Generate a JSON report of suppression comments and which codes they used in this run.
+    #[arg(long, value_name = "OUTPUT_FILE")]
+    report_suppressions: Option<PathBuf>,
     /// Generate a CinderX-format type report (experimental, internal-only).
     #[arg(long, value_name = "OUTPUT_DIR", hide = true)]
     report_cinderx: Option<PathBuf>,
@@ -1690,6 +1693,12 @@ impl CheckArgs {
         let output_format = defaults.output_format;
 
         let mut collected = loads.collect_errors();
+        if let Some(path) = &self.output.report_suppressions {
+            let report = loads.collect_suppression_usage(&collected);
+            let mut writer = BufWriter::new(File::create(path)?);
+            serde_json::to_writer_pretty(&mut writer, &report)?;
+            writer.write_all(b"\n")?;
+        }
         // Pass pre-collected errors to avoid redundant error collection.
         let unused_ignore_errors = loads.collect_unused_ignore_errors_for_display(&collected);
         collected.ordinary.extend(unused_ignore_errors.ordinary);

--- a/pyrefly/lib/commands/suppress.rs
+++ b/pyrefly/lib/commands/suppress.rs
@@ -7,6 +7,7 @@
 
 use std::path::PathBuf;
 
+use anyhow::bail;
 use clap::Parser;
 use pyrefly_config::args::ConfigOverrideArgs;
 use pyrefly_util::thread_pool::ThreadCount;
@@ -18,7 +19,9 @@ use crate::commands::util::CommandExitStatus;
 use crate::error::suppress;
 use crate::error::suppress::CommentLocation;
 use crate::error::suppress::SerializedError;
+use crate::error::suppress::SuppressionUsage;
 use crate::error::suppress::UnusedIgnoreKind;
+use crate::error::suppress::unused_errors_from_suppression_usage;
 
 /// Suppress type errors by adding ignore comments to source files.
 #[derive(Clone, Debug, Parser)]
@@ -31,10 +34,13 @@ pub struct SuppressArgs {
     #[command(flatten, next_help_heading = "Config Overrides")]
     config_override: ConfigOverrideArgs,
 
-    /// Path to a JSON file containing errors to suppress.
-    /// The JSON should be an array of objects with "path", "line", "name", and "message" fields.
+    /// Path to JSON input containing errors to suppress.
+    ///
+    /// With `--remove-unused`, this can be passed multiple times with files
+    /// from `check --report-suppressions` to aggregate suppression usage across
+    /// multiple environments.
     #[arg(long)]
-    json: Option<PathBuf>,
+    json: Vec<PathBuf>,
 
     /// Remove unused ignores instead of adding suppressions, optionally selecting `pyrefly`, `type`, or `all`.
     /// Defaults to `pyrefly` when no kind is specified.
@@ -63,17 +69,17 @@ impl SuppressArgs {
     ) -> anyhow::Result<CommandExitStatus> {
         if let Some(kind) = self.remove_unused {
             // Remove unused ignores mode
-            let unused_errors: Vec<SerializedError> = if let Some(json_path) = &self.json {
-                // Parse errors from JSON file, filtering for unused suppression errors only.
-                let json_content = std::fs::read_to_string(json_path)?;
-                let errors: Vec<SerializedError> = serde_json::from_str(&json_content)?;
-                errors
+            let unused_errors: Vec<SerializedError> = if !self.json.is_empty() {
+                let (errors, reports) = read_json_inputs(&self.json)?;
+                let mut unused_errors: Vec<_> = errors
                     .into_iter()
                     .filter(|e| {
-                        kind.includes_pyrefly_or_pyre() && e.is_unused_ignore()
-                            || kind.includes_type() && e.is_unused_type_ignore()
+                        (kind.includes_pyrefly_or_pyre() && e.is_unused_ignore())
+                            || (kind.includes_type() && e.is_unused_type_ignore())
                     })
-                    .collect()
+                    .collect();
+                unused_errors.extend(unused_errors_from_suppression_usage(reports, kind));
+                unused_errors
             } else {
                 // Delegate to `check --remove-unused-ignores`, which
                 // collects unused ignore errors directly (bypassing severity
@@ -109,10 +115,12 @@ impl SuppressArgs {
             suppress::remove_unused_ignores_from_serialized(unused_errors, kind);
         } else {
             // Add suppressions mode (existing behavior)
-            let serialized_errors: Vec<SerializedError> = if let Some(json_path) = &self.json {
+            let serialized_errors: Vec<SerializedError> = if !self.json.is_empty() {
                 // Parse errors from JSON file, filtering out directives and UnusedIgnore errors
-                let json_content = std::fs::read_to_string(json_path)?;
-                let errors: Vec<SerializedError> = serde_json::from_str(&json_content)?;
+                let (errors, reports) = read_json_inputs(&self.json)?;
+                if !reports.is_empty() {
+                    bail!("suppression usage reports can only be used with --remove-unused");
+                }
                 errors
                     .into_iter()
                     .filter(|e| !e.is_directive() && !e.is_unused_ignore())
@@ -150,6 +158,24 @@ impl SuppressArgs {
 
         Ok(CommandExitStatus::Success)
     }
+}
+
+fn read_json_inputs(
+    paths: &[PathBuf],
+) -> anyhow::Result<(Vec<SerializedError>, Vec<SuppressionUsage>)> {
+    let mut errors = Vec::new();
+    let mut reports = Vec::new();
+    for path in paths {
+        let json_content = std::fs::read_to_string(path)?;
+        match serde_json::from_str::<Vec<SuppressionUsage>>(&json_content) {
+            Ok(mut report) => reports.append(&mut report),
+            Err(_) => {
+                let mut parsed_errors: Vec<SerializedError> = serde_json::from_str(&json_content)?;
+                errors.append(&mut parsed_errors);
+            }
+        }
+    }
+    Ok((errors, reports))
 }
 
 #[cfg(test)]

--- a/pyrefly/lib/error/suppress.rs
+++ b/pyrefly/lib/error/suppress.rs
@@ -6,6 +6,7 @@
  */
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
@@ -101,6 +102,52 @@ pub struct SerializedError {
     pub message: String,
 }
 
+/// Per-run usage information for one suppression comment.
+///
+/// Multi-environment checks can merge these reports and remove only the
+/// suppressions that were unused in every environment.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SuppressionUsage {
+    /// The file path where the suppression comment occurs.
+    pub path: PathBuf,
+    /// The 0-indexed line number of the suppression comment.
+    pub line: usize,
+    /// The byte offset of the suppression comment within the line.
+    pub comment_offset: usize,
+    /// The suppression tool, for example `pyrefly`, `pyre`, or `type`.
+    pub tool: String,
+    /// The codes listed in the suppression. An empty list means blanket suppression.
+    pub codes: Vec<String>,
+    /// The error codes suppressed on this suppression's affected line in this run.
+    ///
+    /// For blanket suppressions, this contains the names of all suppressed
+    /// errors on the affected line.
+    pub used_codes: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct SuppressionUsageKey {
+    path: PathBuf,
+    line: usize,
+    comment_offset: usize,
+    tool: String,
+    codes: Vec<String>,
+}
+
+impl SuppressionUsageKey {
+    fn from_usage(usage: &SuppressionUsage) -> Self {
+        let mut codes = usage.codes.clone();
+        codes.sort();
+        Self {
+            path: usage.path.clone(),
+            line: usage.line,
+            comment_offset: usage.comment_offset,
+            tool: usage.tool.clone(),
+            codes,
+        }
+    }
+}
+
 impl SerializedError {
     /// Creates a SerializedError from an internal Error.
     /// Returns None if the error is not from a filesystem path.
@@ -136,6 +183,99 @@ impl SerializedError {
     pub fn is_directive(&self) -> bool {
         self.name == ErrorKind::RevealType.to_name()
     }
+}
+
+/// Convert suppression usage reports into unused-ignore diagnostics.
+///
+/// If the same source tree is checked under multiple environments, callers can
+/// pass all reports together. A code is considered used if it was used in any
+/// report for the same suppression comment.
+pub fn unused_errors_from_suppression_usage(
+    reports: Vec<SuppressionUsage>,
+    kind: UnusedIgnoreKind,
+) -> Vec<SerializedError> {
+    let mut merged: HashMap<SuppressionUsageKey, SmallSet<String>> = HashMap::new();
+    for report in reports {
+        let key = SuppressionUsageKey::from_usage(&report);
+        merged.entry(key).or_default().extend(report.used_codes);
+    }
+
+    let mut errors = Vec::new();
+    for (key, used_codes) in merged {
+        let include = match key.tool.as_str() {
+            "pyrefly" | "pyre" => kind.includes_pyrefly_or_pyre(),
+            "type" => kind.includes_type(),
+            _ => false,
+        };
+        if !include {
+            continue;
+        }
+
+        let (name, message) = match key.tool.as_str() {
+            "pyrefly" => {
+                if key.codes.is_empty() {
+                    if !used_codes.is_empty() {
+                        continue;
+                    }
+                    (
+                        ErrorKind::UnusedIgnore.to_name().to_owned(),
+                        "Unused `# pyrefly: ignore` comment".to_owned(),
+                    )
+                } else {
+                    let unused_codes: Vec<_> = key
+                        .codes
+                        .iter()
+                        .filter(|code| !used_codes.contains(*code))
+                        .cloned()
+                        .collect();
+                    if unused_codes.is_empty() {
+                        continue;
+                    }
+                    let joined = unused_codes.join(", ");
+                    let message = if unused_codes.len() == key.codes.len() {
+                        format!("Unused `# pyrefly: ignore` comment for code(s): {joined}")
+                    } else {
+                        format!("Unused error code(s) in `# pyrefly: ignore`: {joined}")
+                    };
+                    (ErrorKind::UnusedIgnore.to_name().to_owned(), message)
+                }
+            }
+            "pyre" => {
+                if !used_codes.is_empty() {
+                    continue;
+                }
+                (
+                    ErrorKind::UnusedIgnore.to_name().to_owned(),
+                    "Unused pyre-fixme comment".to_owned(),
+                )
+            }
+            "type" => {
+                if !used_codes.is_empty() {
+                    continue;
+                }
+                (
+                    ErrorKind::UnusedTypeIgnore.to_name().to_owned(),
+                    "Unused `# type: ignore` comment".to_owned(),
+                )
+            }
+            _ => continue,
+        };
+        errors.push(SerializedError {
+            path: key.path,
+            line: key.line,
+            name,
+            message,
+        });
+    }
+    errors.sort_by(|left, right| {
+        (&left.path, left.line, &left.name, &left.message).cmp(&(
+            &right.path,
+            right.line,
+            &right.name,
+            &right.message,
+        ))
+    });
+    errors
 }
 
 /// Detects the line ending style used in a string.
@@ -1673,6 +1813,39 @@ a: int = ""
             message: "Unused error code(s) in `# pyrefly: ignore`: bad-override".to_owned(),
         }];
         assert_remove_ignores_from_serialized(before, errors, after, 1);
+    }
+
+    #[test]
+    fn test_unused_errors_from_suppression_usage_merges_environments() {
+        let path = PathBuf::from("test.py");
+        let env_with_error = SuppressionUsage {
+            path: path.clone(),
+            line: 0,
+            comment_offset: 0,
+            tool: "pyrefly".to_owned(),
+            codes: vec!["bad-assignment".to_owned(), "bad-return".to_owned()],
+            used_codes: vec!["bad-assignment".to_owned()],
+        };
+        let env_without_error = SuppressionUsage {
+            path: path.clone(),
+            line: 0,
+            comment_offset: 0,
+            tool: "pyrefly".to_owned(),
+            codes: vec!["bad-return".to_owned(), "bad-assignment".to_owned()],
+            used_codes: Vec::new(),
+        };
+
+        let errors = suppress::unused_errors_from_suppression_usage(
+            vec![env_with_error, env_without_error],
+            UnusedIgnoreKind::Pyrefly,
+        );
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].path, path);
+        assert_eq!(
+            errors[0].message,
+            "Unused error code(s) in `# pyrefly: ignore`: bad-return"
+        );
     }
 
     #[test]

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -622,10 +622,51 @@ impl Errors {
             .iter()
             .map(|(load, _, config)| (load.module_info.path(), config))
             .collect();
+        let unused_ignore_name = ErrorKind::UnusedIgnore.to_name();
+        let unused_ignore_suppression_lines_by_path: SmallMap<&ModulePath, SmallSet<LineNumber>> =
+            self.loads
+                .iter()
+                .filter_map(|(load, _, config)| {
+                    let path = load.module_info.path();
+                    if !config
+                        .enabled_ignores(path.as_path())
+                        .contains(&Tool::Pyrefly)
+                    {
+                        return None;
+                    }
+                    let lines: SmallSet<LineNumber> = load
+                        .module_info
+                        .ignore()
+                        .iter()
+                        .flat_map(|(_, suppressions)| suppressions.iter())
+                        .filter(|supp| {
+                            supp.tool() == Tool::Pyrefly
+                                && supp
+                                    .error_codes()
+                                    .iter()
+                                    .any(|code| code == unused_ignore_name)
+                        })
+                        .map(|supp| supp.comment_line())
+                        .collect();
+                    if lines.is_empty() {
+                        None
+                    } else {
+                        Some((path, lines))
+                    }
+                })
+                .collect();
 
         for error in unused_errors {
-            if let Some(config) = config_by_path.get(&error.path()) {
-                let error_config = config.get_error_config(error.path().as_path());
+            let path = error.path();
+            let line = error.display_range().start.line_within_file();
+            if unused_ignore_suppression_lines_by_path
+                .get(&path)
+                .is_some_and(|lines| lines.contains(&line))
+            {
+                continue;
+            }
+            if let Some(config) = config_by_path.get(&path) {
+                let error_config = config.get_error_config(path.as_path());
                 let severity = error_config.display_config.severity(error.error_kind());
                 match severity {
                     Severity::Error => result.ordinary.push(error.with_severity(Severity::Error)),
@@ -670,6 +711,8 @@ mod tests {
 
     use dupe::Dupe;
     use pyrefly_build::handle::Handle;
+    use pyrefly_config::error_kind::ErrorKind;
+    use pyrefly_config::error_kind::Severity;
     use pyrefly_python::module_name::ModuleName;
     use pyrefly_python::module_path::ModulePath;
     use pyrefly_python::sys_info::SysInfo;
@@ -713,10 +756,28 @@ mod tests {
     }
 
     fn get_errors(contents: &str) -> (Errors, TempDir) {
+        get_errors_with_config(contents, |_| {})
+    }
+
+    fn get_errors_with_unused_ignore_error(contents: &str) -> (Errors, TempDir) {
+        get_errors_with_config(contents, |config| {
+            config
+                .root
+                .errors
+                .get_or_insert_with(Default::default)
+                .set_error_severity(ErrorKind::UnusedIgnore, Severity::Error);
+        })
+    }
+
+    fn get_errors_with_config(
+        contents: &str,
+        configure_config: impl FnOnce(&mut ConfigFile),
+    ) -> (Errors, TempDir) {
         let tdir = tempfile::tempdir().unwrap();
 
         let mut config = ConfigFile::default();
         config.python_environment.set_empty_to_default();
+        configure_config(&mut config);
         let name = "test";
         fs_anyhow::write(&get_path(&tdir), contents).unwrap();
         config.configure();
@@ -766,6 +827,38 @@ def f() -> int:
         let unused = errors.collect_unused_ignore_errors(&collected);
         assert_eq!(unused.len(), 1);
         assert!(unused[0].msg().contains("bad-override"));
+    }
+
+    #[test]
+    fn test_unused_ignore_suppresses_itself_for_display() {
+        let contents = r#"
+def f() -> int:
+    # pyrefly: ignore[unused-ignore]
+    return 1
+"#;
+        let (errors, _tdir) = get_errors_with_unused_ignore_error(contents);
+        let collected = errors.collect_errors();
+        assert_eq!(errors.collect_unused_ignore_errors(&collected).len(), 1);
+        let display = errors.collect_unused_ignore_errors_for_display(&collected);
+        assert!(display.ordinary.is_empty());
+        assert!(display.disabled.is_empty());
+    }
+
+    #[test]
+    fn test_unused_ignore_suppresses_mixed_unused_codes_for_display() {
+        let contents = r#"
+def f() -> int:
+    # pyrefly: ignore[bad-return, unused-ignore]
+    return 1
+"#;
+        let (errors, _tdir) = get_errors_with_unused_ignore_error(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        assert_eq!(unused.len(), 1);
+        assert!(unused[0].msg().contains("bad-return"));
+        let display = errors.collect_unused_ignore_errors_for_display(&collected);
+        assert!(display.ordinary.is_empty());
+        assert!(display.disabled.is_empty());
     }
 
     #[test]

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -47,6 +47,7 @@ use crate::error::error::Error;
 use crate::error::expectation::Expectation;
 use crate::error::legacy::BaselineError;
 use crate::error::style::ErrorStyle;
+use crate::error::suppress::SuppressionUsage;
 use crate::state::load::Load;
 
 /// Extracts `(start_line, end_line)` ranges for all multi-line strings from
@@ -512,15 +513,10 @@ impl Errors {
         ignore_collection
     }
 
-    /// Collects errors for unused ignore comments.
-    /// Returns a vector of errors with ErrorKind::UnusedIgnore for each
-    /// suppression comment that doesn't suppress any actual error.
-    /// Accepts pre-collected errors to avoid redundant error collection.
-    pub fn collect_unused_ignore_errors(&self, collected: &CollectedErrors) -> Vec<Error> {
-        let mut unused_errors = Vec::new();
-
-        // Build a map of which error codes were suppressed on each line, keyed by module path.
-        // Key: module_path, Value: map from line number to set of suppressed error codes
+    fn suppressed_codes_by_module<'a>(
+        &'a self,
+        collected: &'a CollectedErrors,
+    ) -> SmallMap<&'a ModulePath, SmallMap<LineNumber, SmallSet<String>>> {
         let mut suppressed_codes_by_module: SmallMap<
             &ModulePath,
             SmallMap<LineNumber, SmallSet<String>>,
@@ -614,6 +610,59 @@ impl Errors {
                 }
             }
         }
+
+        suppressed_codes_by_module
+    }
+
+    pub fn collect_suppression_usage(&self, collected: &CollectedErrors) -> Vec<SuppressionUsage> {
+        let suppressed_codes_by_module = self.suppressed_codes_by_module(collected);
+        let mut reports = Vec::new();
+        for (load, _, config) in &self.loads {
+            let module = &load.module_info;
+            let module_path = module.path();
+            let enabled_ignores = config.enabled_ignores(module_path.as_path());
+            let module_suppressed_codes = suppressed_codes_by_module.get(&module_path);
+            for (applies_to_line, suppressions) in module.ignore().iter() {
+                for supp in suppressions {
+                    let tool = supp.tool();
+                    if !enabled_ignores.contains(&tool) {
+                        continue;
+                    }
+                    let tool = match tool {
+                        Tool::Pyrefly => "pyrefly",
+                        Tool::Pyre => "pyre",
+                        Tool::Type => "type",
+                        _ => continue,
+                    };
+                    let mut codes = supp.error_codes().to_vec();
+                    codes.sort();
+                    let mut used_codes: Vec<String> = module_suppressed_codes
+                        .and_then(|m| m.get(applies_to_line))
+                        .into_iter()
+                        .flat_map(|codes| codes.iter().cloned())
+                        .collect();
+                    used_codes.sort();
+                    reports.push(SuppressionUsage {
+                        path: module_path.as_path().to_path_buf(),
+                        line: supp.comment_line().to_zero_indexed() as usize,
+                        comment_offset: supp.comment_offset(),
+                        tool: tool.to_owned(),
+                        codes,
+                        used_codes,
+                    });
+                }
+            }
+        }
+        reports
+    }
+
+    /// Collects errors for unused ignore comments.
+    /// Returns a vector of errors with ErrorKind::UnusedIgnore for each
+    /// suppression comment that doesn't suppress any actual error.
+    /// Accepts pre-collected errors to avoid redundant error collection.
+    pub fn collect_unused_ignore_errors(&self, collected: &CollectedErrors) -> Vec<Error> {
+        let mut unused_errors = Vec::new();
+        let suppressed_codes_by_module = self.suppressed_codes_by_module(collected);
 
         // Iterate over each module and check for unused ignores
         for (load, _, config) in &self.loads {
@@ -753,49 +802,9 @@ impl Errors {
             .iter()
             .map(|(load, _, config)| (load.module_info.path(), config))
             .collect();
-        let unused_ignore_name = ErrorKind::UnusedIgnore.to_name();
-        let unused_ignore_suppression_lines_by_path: SmallMap<&ModulePath, SmallSet<LineNumber>> =
-            self.loads
-                .iter()
-                .filter_map(|(load, _, config)| {
-                    let path = load.module_info.path();
-                    if !config
-                        .enabled_ignores(path.as_path())
-                        .contains(&Tool::Pyrefly)
-                    {
-                        return None;
-                    }
-                    let lines: SmallSet<LineNumber> = load
-                        .module_info
-                        .ignore()
-                        .iter()
-                        .flat_map(|(_, suppressions)| suppressions.iter())
-                        .filter(|supp| {
-                            supp.tool() == Tool::Pyrefly
-                                && supp
-                                    .error_codes()
-                                    .iter()
-                                    .any(|code| code == unused_ignore_name)
-                        })
-                        .map(|supp| supp.comment_line())
-                        .collect();
-                    if lines.is_empty() {
-                        None
-                    } else {
-                        Some((path, lines))
-                    }
-                })
-                .collect();
 
         for error in unused_errors {
             let path = error.path();
-            let line = error.display_range().start.line_within_file();
-            if unused_ignore_suppression_lines_by_path
-                .get(&path)
-                .is_some_and(|lines| lines.contains(&line))
-            {
-                continue;
-            }
             if let Some(config) = config_by_path.get(&path) {
                 let error_config = config.get_error_config(path.as_path());
                 let severity = error_config.display_config.severity(error.error_kind());
@@ -845,10 +854,10 @@ mod tests {
 
     use dupe::Dupe;
     use pyrefly_build::handle::Handle;
-    use pyrefly_python::ast::Ast;
-    use pyrefly_python::module::Module;
     use pyrefly_config::error_kind::ErrorKind;
     use pyrefly_config::error_kind::Severity;
+    use pyrefly_python::ast::Ast;
+    use pyrefly_python::module::Module;
     use pyrefly_python::module_name::ModuleName;
     use pyrefly_python::module_path::ModulePath;
     use pyrefly_python::sys_info::SysInfo;
@@ -985,7 +994,7 @@ def f() -> int:
     }
 
     #[test]
-    fn test_unused_ignore_suppresses_itself_for_display() {
+    fn test_unused_ignore_does_not_suppress_itself_for_display() {
         let contents = r#"
 def f() -> int:
     # pyrefly: ignore[unused-ignore]
@@ -995,12 +1004,13 @@ def f() -> int:
         let collected = errors.collect_errors();
         assert_eq!(errors.collect_unused_ignore_errors(&collected).len(), 1);
         let display = errors.collect_unused_ignore_errors_for_display(&collected);
-        assert!(display.ordinary.is_empty());
+        assert_eq!(display.ordinary.len(), 1);
+        assert!(display.ordinary[0].msg().contains("unused-ignore"));
         assert!(display.disabled.is_empty());
     }
 
     #[test]
-    fn test_unused_ignore_suppresses_mixed_unused_codes_for_display() {
+    fn test_unused_ignore_does_not_suppress_mixed_unused_codes_for_display() {
         let contents = r#"
 def f() -> int:
     # pyrefly: ignore[bad-return, unused-ignore]
@@ -1012,8 +1022,27 @@ def f() -> int:
         assert_eq!(unused.len(), 1);
         assert!(unused[0].msg().contains("bad-return"));
         let display = errors.collect_unused_ignore_errors_for_display(&collected);
-        assert!(display.ordinary.is_empty());
+        assert_eq!(display.ordinary.len(), 1);
+        assert!(display.ordinary[0].msg().contains("bad-return"));
         assert!(display.disabled.is_empty());
+    }
+
+    #[test]
+    fn test_suppression_usage_reports_used_codes() {
+        let contents = r#"
+def f() -> int:
+    # pyrefly: ignore[bad-override, bad-return]
+    return ""
+"#;
+        let (errors, _tdir) = get_errors(contents);
+        let collected = errors.collect_errors();
+        let report = errors.collect_suppression_usage(&collected);
+
+        assert_eq!(report.len(), 1);
+        assert_eq!(report[0].tool, "pyrefly");
+        assert_eq!(report[0].codes, ["bad-override", "bad-return"]);
+        assert!(report[0].used_codes.contains(&"bad-return".to_owned()));
+        assert!(!report[0].used_codes.contains(&"bad-override".to_owned()));
     }
 
     #[test]

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -753,10 +753,51 @@ impl Errors {
             .iter()
             .map(|(load, _, config)| (load.module_info.path(), config))
             .collect();
+        let unused_ignore_name = ErrorKind::UnusedIgnore.to_name();
+        let unused_ignore_suppression_lines_by_path: SmallMap<&ModulePath, SmallSet<LineNumber>> =
+            self.loads
+                .iter()
+                .filter_map(|(load, _, config)| {
+                    let path = load.module_info.path();
+                    if !config
+                        .enabled_ignores(path.as_path())
+                        .contains(&Tool::Pyrefly)
+                    {
+                        return None;
+                    }
+                    let lines: SmallSet<LineNumber> = load
+                        .module_info
+                        .ignore()
+                        .iter()
+                        .flat_map(|(_, suppressions)| suppressions.iter())
+                        .filter(|supp| {
+                            supp.tool() == Tool::Pyrefly
+                                && supp
+                                    .error_codes()
+                                    .iter()
+                                    .any(|code| code == unused_ignore_name)
+                        })
+                        .map(|supp| supp.comment_line())
+                        .collect();
+                    if lines.is_empty() {
+                        None
+                    } else {
+                        Some((path, lines))
+                    }
+                })
+                .collect();
 
         for error in unused_errors {
-            if let Some(config) = config_by_path.get(&error.path()) {
-                let error_config = config.get_error_config(error.path().as_path());
+            let path = error.path();
+            let line = error.display_range().start.line_within_file();
+            if unused_ignore_suppression_lines_by_path
+                .get(&path)
+                .is_some_and(|lines| lines.contains(&line))
+            {
+                continue;
+            }
+            if let Some(config) = config_by_path.get(&path) {
+                let error_config = config.get_error_config(path.as_path());
                 let severity = error_config.display_config.severity(error.error_kind());
                 match severity {
                     Severity::Error => result.ordinary.push(error.with_severity(Severity::Error)),
@@ -806,6 +847,8 @@ mod tests {
     use pyrefly_build::handle::Handle;
     use pyrefly_python::ast::Ast;
     use pyrefly_python::module::Module;
+    use pyrefly_config::error_kind::ErrorKind;
+    use pyrefly_config::error_kind::Severity;
     use pyrefly_python::module_name::ModuleName;
     use pyrefly_python::module_path::ModulePath;
     use pyrefly_python::sys_info::SysInfo;
@@ -851,10 +894,28 @@ mod tests {
     }
 
     fn get_errors(contents: &str) -> (Errors, TempDir) {
+        get_errors_with_config(contents, |_| {})
+    }
+
+    fn get_errors_with_unused_ignore_error(contents: &str) -> (Errors, TempDir) {
+        get_errors_with_config(contents, |config| {
+            config
+                .root
+                .errors
+                .get_or_insert_with(Default::default)
+                .set_error_severity(ErrorKind::UnusedIgnore, Severity::Error);
+        })
+    }
+
+    fn get_errors_with_config(
+        contents: &str,
+        configure_config: impl FnOnce(&mut ConfigFile),
+    ) -> (Errors, TempDir) {
         let tdir = tempfile::tempdir().unwrap();
 
         let mut config = ConfigFile::default();
         config.python_environment.set_empty_to_default();
+        configure_config(&mut config);
         let name = "test";
         fs_anyhow::write(&get_path(&tdir), contents).unwrap();
         config.configure();
@@ -921,6 +982,38 @@ def f() -> int:
         let unused = errors.collect_unused_ignore_errors(&collected);
         assert_eq!(unused.len(), 1);
         assert!(unused[0].msg().contains("bad-override"));
+    }
+
+    #[test]
+    fn test_unused_ignore_suppresses_itself_for_display() {
+        let contents = r#"
+def f() -> int:
+    # pyrefly: ignore[unused-ignore]
+    return 1
+"#;
+        let (errors, _tdir) = get_errors_with_unused_ignore_error(contents);
+        let collected = errors.collect_errors();
+        assert_eq!(errors.collect_unused_ignore_errors(&collected).len(), 1);
+        let display = errors.collect_unused_ignore_errors_for_display(&collected);
+        assert!(display.ordinary.is_empty());
+        assert!(display.disabled.is_empty());
+    }
+
+    #[test]
+    fn test_unused_ignore_suppresses_mixed_unused_codes_for_display() {
+        let contents = r#"
+def f() -> int:
+    # pyrefly: ignore[bad-return, unused-ignore]
+    return 1
+"#;
+        let (errors, _tdir) = get_errors_with_unused_ignore_error(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        assert_eq!(unused.len(), 1);
+        assert!(unused[0].msg().contains("bad-return"));
+        let display = errors.collect_unused_ignore_errors_for_display(&collected);
+        assert!(display.ordinary.is_empty());
+        assert!(display.disabled.is_empty());
     }
 
     #[test]

--- a/test/suppress.md
+++ b/test/suppress.md
@@ -48,6 +48,30 @@ b = 2
 [0]
 ```
 
+## `suppress --remove-unused` can aggregate suppression reports from multiple environments
+
+```scrut
+$ mkdir $TMPDIR/suppress_remove_unused_multi_env && \
+> printf '# pyrefly: ignore[bad-assignment, bad-return]\nx: int = ""\n' > $TMPDIR/suppress_remove_unused_multi_env/main.py && \
+> : > $TMPDIR/suppress_remove_unused_multi_env/pyrefly.toml && \
+> $PYREFLY check $TMPDIR/suppress_remove_unused_multi_env/main.py \
+>     --config $TMPDIR/suppress_remove_unused_multi_env/pyrefly.toml \
+>     --report-suppressions $TMPDIR/suppress_remove_unused_multi_env/env_a.json \
+>     --output-format=omit-errors \
+>     --summary=none && \
+> $JQ -n --arg path "$TMPDIR/suppress_remove_unused_multi_env/main.py" \
+>     '[{path: $path, line: 0, comment_offset: 0, tool: "pyrefly", codes: ["bad-assignment", "bad-return"], used_codes: []}]' \
+>     > $TMPDIR/suppress_remove_unused_multi_env/env_b.json && \
+> $PYREFLY suppress --remove-unused \
+>     --json $TMPDIR/suppress_remove_unused_multi_env/env_a.json \
+>     --json $TMPDIR/suppress_remove_unused_multi_env/env_b.json \
+>     >/dev/null 2>/dev/null && \
+> cat $TMPDIR/suppress_remove_unused_multi_env/main.py
+# pyrefly: ignore[bad-assignment]
+x: int = ""
+[0]
+```
+
 ## `--suppress-errors` should not rewrite warnings hidden by `--min-severity`
 
 Use an explicit empty config so the repro does not depend on any ancestor

--- a/website/docs/error-suppressions.mdx
+++ b/website/docs/error-suppressions.mdx
@@ -197,6 +197,26 @@ This will add ` # pyrefly: ignore` comments to your code that will enable you to
 
 By default, `--remove-unused` removes Pyrefly and Pyre ignores and preserves `# type: ignore` comments because they may be shared with other type checkers. `--remove-unused=pyrefly` is equivalent to the bare flag. Use `pyrefly suppress --remove-unused=type` to remove only unused `# type: ignore` comments, or `pyrefly suppress --remove-unused=all` to remove all three kinds.
 
+Projects that check the same source tree under multiple Python environments can
+aggregate unused-ignore removal across those runs. First, write a suppression
+usage report for each environment:
+
+```
+pyrefly check --report-suppressions py310-suppressions.json
+pyrefly check --report-suppressions py313-suppressions.json
+```
+
+Then pass every report to `suppress --remove-unused`:
+
+```
+pyrefly suppress --remove-unused \
+  --json py310-suppressions.json \
+  --json py313-suppressions.json
+```
+
+A suppression code is removed only if it was unused in every report. If a code
+suppresses an error in any checked environment, Pyrefly keeps it.
+
 :::tip
 If your project uses other tools that place suppression comments on the line before the error (e.g. other type checkers or linters), use `pyrefly suppress --comment-location=same-line` in step 1 to avoid conflicts.
 :::


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3367

`# pyrefly: ignore[unused-ignore]` now suppresses the display/reporting of the unused-ignore diagnostic for its own ignore comment, including mixed-code directives like # pyrefly: ignore[bad-return, unused-ignore].

The raw unused-ignore collector still returns those errors, so --remove-unused-ignore behavior remains unchanged.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test