### PR TITLE
fix bad-argument-type on Annotated pydantic fields with custom schema #2586

### DIFF
--- a/pyrefly/lib/alt/class/pydantic.rs
+++ b/pyrefly/lib/alt/class/pydantic.rs
@@ -43,6 +43,7 @@ use crate::binding::binding::KeyAnnotation;
 use crate::binding::pydantic::EXTRA;
 use crate::binding::pydantic::FROZEN;
 use crate::binding::pydantic::FROZEN_DEFAULT;
+use crate::binding::pydantic::GET_PYDANTIC_CORE_SCHEMA;
 use crate::binding::pydantic::POPULATE_BY_NAME;
 use crate::binding::pydantic::PydanticConfigDict;
 use crate::binding::pydantic::ROOT;
@@ -628,20 +629,32 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             return None;
         }
         if let BindingAnnotation::AnnotateExpr(_, annotation_expr, _) = self.bindings().get(annot) {
+            let ignore_errors = self.error_swallower();
             let metadata_items = self.get_annotated_metadata(
                 annotation_expr,
                 TypeFormContext::ClassVarAnnotation,
-                &self.error_swallower(),
+                &ignore_errors,
             );
-            // Look through metadata items and find a Field(...) call, then extract its keywords
+            let mut field_flags = None;
+            let mut has_custom_schema = false;
             for metadata_item in &metadata_items {
                 if let Expr::Call(call) = metadata_item
                     && let Some(keywords) =
                         self.compute_dataclass_field_initialization(call, field_name, None, dm)
                 {
-                    return Some(keywords);
+                    field_flags = Some(keywords);
+                }
+                let metadata_ty = self.expr_infer(metadata_item, &ignore_errors);
+                if self.has_static_attr(&metadata_ty, &GET_PYDANTIC_CORE_SCHEMA) {
+                    has_custom_schema = true;
                 }
             }
+            if has_custom_schema {
+                let mut flags = field_flags.unwrap_or_else(DataclassFieldKeywords::new);
+                flags.converter_param = Some(self.heap.mk_any_explicit());
+                return Some(flags);
+            }
+            return field_flags;
         }
         None
     }

--- a/pyrefly/lib/binding/pydantic.rs
+++ b/pyrefly/lib/binding/pydantic.rs
@@ -148,6 +148,7 @@ impl PydanticAliasGenerator {
         snake
     }
 }
+pub const GET_PYDANTIC_CORE_SCHEMA: Name = Name::new_static("__get_pydantic_core_schema__");
 
 // An abstraction to iterate over configuration values, whether `ConfigDict()` or a dict display
 // is used.

--- a/pyrefly/lib/test/pydantic/field.rs
+++ b/pyrefly/lib/test/pydantic/field.rs
@@ -368,6 +368,27 @@ house = House(
 );
 
 pydantic_testcase!(
+    test_annotated_field_with_custom_schema_accepts_any_init_param,
+    r#"
+from typing import Annotated, Any, reveal_type
+from pydantic import BaseModel
+
+class DType: ...
+
+class DTypeAdapter:
+    def __get_pydantic_core_schema__(self, source_type: Any, handler: Any) -> Any: ...
+
+class Model(BaseModel, strict=True):
+    dtype: Annotated[DType, DTypeAdapter()]
+    other: DType
+
+reveal_type(Model.__init__)  # E: revealed type: (self: Model, *, dtype: Any, other: DType, **Unknown) -> None
+Model(dtype=">i4", other=DType())
+Model(dtype=DType(), other=">i4")  # E: Argument `Literal['>i4']` is not assignable to parameter `other` with type `DType`
+    "#,
+);
+
+pydantic_testcase!(
     test_model_fields_with_bounded_typevar,
     r#"
 from pydantic import BaseModel


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2586

Annotated Pydantic fields detect metadata objects with a static `__get_pydantic_core_schema__` hook and widen that field’s synthesized `__init__` parameter to explicit Any.

Added the hook name constant.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test