### PR TITLE
add regression test for Pydantic: parent fields in subclasses are incorrectly assumed to exist / not exist #3596

### DIFF
--- a/pyrefly/lib/test/pydantic/field.rs
+++ b/pyrefly/lib/test/pydantic/field.rs
@@ -241,6 +241,22 @@ Foo()  # E: Missing argument `a`
 );
 
 pydantic_testcase!(
+    test_inherited_fields_are_init_fields,
+    r#"
+from pydantic import BaseModel
+
+class SuperBase(BaseModel, extra="forbid"):
+    x: int
+
+class Derived(SuperBase, extra="forbid"):
+    z: int
+
+Derived(x=1, z=1)
+Derived(z=1)  # E: Missing argument `x`
+    "#,
+);
+
+pydantic_testcase!(
     test_pydantic_dataclass_underscore_field_is_init_param,
     r#"
 from pydantic.dataclasses import dataclass


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

this seems fixed.

close #3596

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add regression test for #3596

