### PR TITLE
fix report baselined errors as a hint in the language server #3441

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -3000,11 +3000,17 @@ impl Server {
                 diags.insert(handle_path_buf, Vec::new());
             }
         }
-        for e in transaction
+        let (normal_errors, baseline_errors) = transaction
             .get_errors(handles)
-            .collect_display_errors_with_unused_ignores()
-        {
+            .collect_lsp_errors_with_baselines();
+        for e in normal_errors {
             if let Some((path, diag)) = self.get_diag_if_shown(&e, &open_files, None) {
+                diags.entry(path.to_owned()).or_default().push(diag);
+            }
+        }
+        for e in baseline_errors {
+            if let Some((path, mut diag)) = self.get_diag_if_shown(&e, &open_files, None) {
+                diag.severity = Some(DiagnosticSeverity::HINT);
                 diags.entry(path.to_owned()).or_default().push(diag);
             }
         }
@@ -5490,11 +5496,17 @@ impl Server {
         let handle = make_open_handle(&self.state, &path);
         let mut items = Vec::new();
         let open_files = &self.open_files.read();
-        for e in transaction
+        let (normal_errors, baseline_errors) = transaction
             .get_errors(once(&handle))
-            .collect_display_errors_with_unused_ignores()
-        {
+            .collect_lsp_errors_with_baselines();
+        for e in normal_errors {
             if let Some((_, diag)) = self.get_diag_if_shown(&e, open_files, cell_uri) {
+                items.push(diag);
+            }
+        }
+        for e in baseline_errors {
+            if let Some((_, mut diag)) = self.get_diag_if_shown(&e, open_files, cell_uri) {
+                diag.severity = Some(DiagnosticSeverity::HINT);
                 items.push(diag);
             }
         }

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -6,6 +6,7 @@
  */
 
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use dupe::Dupe;
@@ -312,6 +313,54 @@ impl Errors {
             processor.process_errors(&mut errors.ordinary, &mut errors.baseline);
         }
         errors
+    }
+
+    pub fn collect_lsp_errors_with_baselines(&self) -> (Vec<Error>, Vec<Error>) {
+        let collected = self.collect_errors();
+        let unused = self.collect_unused_ignore_errors_for_display(&collected);
+        let config_by_path: SmallMap<&ModulePath, &ArcId<ConfigFile>> = self
+            .loads
+            .iter()
+            .map(|(load, _, config)| (load.module_info.path(), config))
+            .collect();
+        let mut baseline_processors: SmallMap<PathBuf, Option<BaselineProcessor>> = SmallMap::new();
+        let mut errors = collected;
+        let mut ordinary = Vec::new();
+
+        for error in errors.ordinary.drain(..) {
+            let Some(config) = config_by_path.get(&error.path()) else {
+                ordinary.push(error);
+                continue;
+            };
+            let Some(baseline_path) = config.baseline.as_deref() else {
+                ordinary.push(error);
+                continue;
+            };
+            let processor = baseline_processors
+                .entry(baseline_path.to_path_buf())
+                .or_insert_with(|| {
+                    let relative_to = config
+                        .source
+                        .root()
+                        .or_else(|| baseline_path.parent())
+                        .unwrap_or_else(|| Path::new(""));
+                    BaselineProcessor::from_file(baseline_path, relative_to).ok()
+                });
+            if processor
+                .as_ref()
+                .is_some_and(|processor| processor.matches_baseline(&error))
+            {
+                errors.baseline.push(error);
+            } else {
+                ordinary.push(error);
+            }
+        }
+
+        ordinary.extend(unused.ordinary);
+        (
+            Self::merge_display_errors(ordinary, errors.directives),
+            Self::merge_display_errors(errors.baseline, Vec::new()),
+        )
     }
 
     pub fn collect_display_errors(&self) -> Vec<Error> {

--- a/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
@@ -163,6 +163,47 @@ fn test_diagnostics_markdown_messages() {
 
     interaction.shutdown().unwrap();
 }
+
+#[test]
+fn test_baseline_diagnostic_is_hint() {
+    let test_files_root = get_test_files_root();
+    let root_path = test_files_root.path().join("baseline_hint");
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root_path);
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(None),
+            ..Default::default()
+        })
+        .expect("Failed to initialize");
+
+    interaction.client.did_open("bad.py");
+
+    interaction
+        .client
+        .diagnostic("bad.py")
+        .expect_response_with(|response| {
+            if let DocumentDiagnosticReportResult::Report(report) = response
+                && let lsp_types::DocumentDiagnosticReport::Full(full) = report
+            {
+                let items = &full.full_document_diagnostic_report.items;
+                if items.len() != 1 {
+                    return false;
+                }
+                let item = &items[0];
+                return item.code
+                    == Some(lsp_types::NumberOrString::String(
+                        "bad-assignment".to_owned(),
+                    ))
+                    && item.severity == Some(lsp_types::DiagnosticSeverity::HINT);
+            }
+            false
+        })
+        .expect("Failed to receive hint diagnostic");
+
+    interaction.shutdown().unwrap();
+}
+
 #[test]
 fn test_stream_diagnostics_after_save() {
     let root = get_test_files_root();

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/baseline_hint/bad.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/baseline_hint/bad.py
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+x: str = 1

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/baseline_hint/baseline.json
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/baseline_hint/baseline.json
@@ -1,0 +1,15 @@
+{
+  "errors": [
+    {
+      "line": 6,
+      "column": 10,
+      "stop_line": 6,
+      "stop_column": 11,
+      "path": "bad.py",
+      "code": -2,
+      "name": "bad-assignment",
+      "description": "test",
+      "concise_description": "test"
+    }
+  ]
+}

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/baseline_hint/pyrefly.toml
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/baseline_hint/pyrefly.toml
@@ -1,0 +1,1 @@
+baseline = "baseline.json"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3441

split LSP diagnostics into normal vs baseline-matched diagnostics using the existing baseline processor, downgrade baseline-matched push diagnostics to HINT, same behavior for pull diagnostics.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test and related test files.
