### PR TITLE
Fix LSP Var leak panic from lambda params in module cycles (#3789) (#3803)

### DIFF
--- a/pyrefly/lib/alt/answers_solver.rs
+++ b/pyrefly/lib/alt/answers_solver.rs
@@ -1588,7 +1588,10 @@ pub struct ThreadState {
     partial_answers: RefCell<FxHashMap<(Idx<Key>, usize), Arc<TypeInfo>>>,
     /// Solve-time mapping from per-module lambda parameter IDs to the
     /// thread-local Var that represents that parameter in the current solve.
-    lambda_param_vars: RefCell<FxHashMap<(ModuleName, LambdaParamId), Var>>,
+    ///
+    /// The `ModulePath` is needed to distinguish the in-memory and on-disk
+    /// versions of the same module, which can coexist in the IDE (issue #3789).
+    lambda_param_vars: RefCell<FxHashMap<(ModuleName, ModulePath, LambdaParamId), Var>>,
     /// Active trace side-effect sink for the current calculation.
     /// Set before `K::solve`, taken after. `None` when tracing is disabled
     /// or between calculations. Saved sinks form a stack to handle recursive
@@ -1870,14 +1873,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         self.thread_state
             .lambda_param_vars
             .borrow_mut()
-            .insert((self.module().name(), id), var);
+            .insert((self.module().name(), self.module().path().dupe(), id), var);
     }
 
     fn get_lambda_param_var(&self, id: LambdaParamId) -> Option<Var> {
         self.thread_state
             .lambda_param_vars
             .borrow()
-            .get(&(self.module().name(), id))
+            .get(&(self.module().name(), self.module().path().dupe(), id))
             .copied()
     }
 

--- a/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
@@ -438,6 +438,41 @@ fn test_cycle_class() {
     interaction.shutdown().unwrap();
 }
 
+/// Regression test for <https://github.com/facebook/pyrefly/issues/3789>.
+///
+/// Opening `expr.py` — part of a 3-module import cycle
+/// (`expr` -> `add` -> `operations` -> `expr`) whose `expr` module contains a
+/// lambda — used to panic with "a variable has leaked from one module to
+/// another". The lambda parameter's Unwrap `Var` is cached in thread-local
+/// state that is shared across `Solver` instances while a cross-module SCC is
+/// driven iteratively, so a stale `Var` allocated in one module's solver was
+/// returned while solving another module. This reproduces only on the
+/// incremental LSP open path, not on a uniform batch `check`. We only assert
+/// that the server stays alive (does not panic) and answers the diagnostic
+/// request.
+#[test]
+fn test_var_leak_cycle_no_panic() {
+    let test_files_root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(test_files_root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(None),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open("var_leak_cycle_3789/expr.py");
+
+    interaction
+        .client
+        .diagnostic("var_leak_cycle_3789/expr.py")
+        .expect_response_with(|_| true)
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
 #[test]
 fn test_unexpected_keyword_range() {
     let test_files_root = get_test_files_root();

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/var_leak_cycle_3789/add.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/var_leak_cycle_3789/add.py
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from expr import Expr
+from operations import AssocOp
+
+
+class Add(Expr, AssocOp): ...

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/var_leak_cycle_3789/expr.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/var_leak_cycle_3789/expr.py
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Regression fixture for https://github.com/facebook/pyrefly/issues/3789.
+# `expr` -> `add` -> `operations` -> `expr` form an import cycle, and `expr`
+# contains a lambda. Opening this file in the IDE used to panic with "a variable
+# has leaked from one module to another".
+
+from typing import Any
+
+
+class Basic: ...
+
+
+class EvalfMixin: ...
+
+
+func: Any = ...
+k: Any = ...
+o: Any = ...
+exp: Any = ...
+logw: Any = ...
+
+
+class Expr(Basic, EvalfMixin):
+    def aseries(self, x=None, n=6, bound=0):
+        s = func.series(k, 0, n)
+        terms = sorted(
+            Add.make_args(s.removeO()), key=lambda i: int(i.as_coeff_exponent(k)[1])
+        )
+        for t in terms:
+            coeff, expo = t.as_coeff_exponent(k)
+            snew = coeff.aseries(x, n, bound=bound - 1)
+            s += snew * k**expo
+        return (s + o).subs(k, exp(logw))
+
+    def as_coeff_exponent(self, x) -> tuple["Expr", "Expr"]:
+        return self, self
+
+
+from add import Add

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/var_leak_cycle_3789/operations.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/var_leak_cycle_3789/operations.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from expr import Expr
+
+
+class Basic: ...
+
+
+class AssocOp(Basic):
+    @classmethod
+    def make_args(cls, expr: "Expr") -> tuple["Expr", ...]: ...

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/var_leak_cycle_3789/pyrefly.toml
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/var_leak_cycle_3789/pyrefly.toml
@@ -1,0 +1,3 @@
+search_path = ["."]
+python-version = "3.11.0"
+skip-interpreter-query = true


### PR DESCRIPTION
Summary:

Opening a file in the IDE could panic with "a variable has leaked from
one module to another" (solver.rs) when the file is part of a module
import cycle and contains a lambda.

Why: the lambda parameter's Unwrap `Var` is memoized in the thread-local
`lambda_param_vars` cache, which is shared across modules while a
cross-module SCC is driven iteratively. In the IDE the in-memory (open)
and on-disk versions of a module coexist as distinct module instances
with distinct `Solver`s, but the cache was keyed by `ModuleName` alone, so
they collided: a `Var` allocated in one version's solver was handed back
while solving the other, then panicked when looked up in the wrong solver.
This is why it only reproduced on the incremental LSP open path, not a
uniform batch `check`.

What: key `lambda_param_vars` by `(ModuleName, ModulePath, LambdaParamId)`,
matching the way cross-module lookups already identify a module instance
(see `get_from_module`). The two versions now get separate cache entries,
so a cached `Var` is always valid in the current solver.

Fixes https://github.com/facebook/pyrefly/issues/3789

Differential Revision: D108494662


