### PR TITLE
Ban subclassing dataclasses with order=True

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -310,6 +310,8 @@ pub enum ErrorKind {
     NotRequiredKeyAccess,
     /// Unpacking an open TypedDict that may contain a bad key via inheritance.
     OpenUnpacking,
+    /// A class inherits from a stdlib dataclass with `order=True`.
+    OrderedDataclassInheritance,
     /// An error related to parsing or syntax.
     ParseError,
     /// A potential conflict between an explicit keyword argument and a NotRequired
@@ -468,6 +470,7 @@ impl ErrorKind {
             ErrorKind::NoAnyReturnExplicit | ErrorKind::NoAnyReturnImplicit => {
                 Some(ErrorKind::NoAnyReturn)
             }
+            ErrorKind::OrderedDataclassInheritance => Some(ErrorKind::InvalidInheritance),
             _ => None,
         }
     }
@@ -520,6 +523,7 @@ impl ErrorKind {
             ErrorKind::NonConvergentRecursion => Severity::Warn,
             ErrorKind::NotRequiredKeyAccess => Severity::Ignore,
             ErrorKind::OpenUnpacking => Severity::Ignore,
+            ErrorKind::OrderedDataclassInheritance => Severity::Warn,
             ErrorKind::PytorchEfficiencyLintCudaCall => Severity::Ignore,
             ErrorKind::PytorchEfficiencyLintItemCall => Severity::Ignore,
             ErrorKind::PytorchEfficiencyLintPrintTensor => Severity::Ignore,

--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -1226,6 +1226,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         fields,
                         pseudo_field_names,
                         kws,
+                        is_stdlib_dataclass: true,
                         alias_keyword: alias_keyword.clone(),
                         init_defaults: init_defaults.clone(),
                         default_can_be_positional,
@@ -1260,6 +1261,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         fields,
                         pseudo_field_names,
                         kws,
+                        is_stdlib_dataclass: true,
                         alias_keyword: alias_keyword.clone(),
                         init_defaults: init_defaults.clone(),
                         default_can_be_positional,
@@ -1348,6 +1350,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 fields,
                 pseudo_field_names,
                 kws,
+                is_stdlib_dataclass: false,
                 alias_keyword,
                 init_defaults,
                 default_can_be_positional,
@@ -1652,6 +1655,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             range,
                             ErrorKind::InvalidInheritance,
                             format!("Cannot extend final class `{}`", class_object.name()),
+                        );
+                    }
+
+                    if !is_new_type
+                        && let Some(dm) = metadata.dataclass_metadata()
+                        && dm.kws.order
+                        && dm.is_stdlib_dataclass
+                    {
+                        self.error(
+                            errors,
+                            range,
+                            ErrorKind::OrderedDataclassInheritance,
+                            format!(
+                                "Cannot extend dataclass `{}` with `order=True`",
+                                class_object.name()
+                            ),
                         );
                     }
                     if is_new_type {

--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -640,6 +640,8 @@ pub struct DataclassMetadata {
     /// duplicating every instance-field name.
     pub pseudo_field_names: SmallSet<Name>,
     pub kws: DataclassKeywords,
+    /// Whether this metadata originates from stdlib `@dataclass`, rather than a dataclass-like transform.
+    pub is_stdlib_dataclass: bool,
     pub alias_keyword: Name,
     pub init_defaults: InitDefaults,
     /// Whether a default can be passed positionally to field specifier calls

--- a/pyrefly/lib/test/attrs/attributes.rs
+++ b/pyrefly/lib/test/attrs/attributes.rs
@@ -394,6 +394,20 @@ A()  # E: Missing argument `x`
 "#,
 );
 
+attrs_testcase!(
+    test_ordered_attrs_inheritance,
+    r#"
+import attr
+
+@attr.s()
+class Parent:
+    x: int
+
+class Child(Parent):
+    pass
+"#,
+);
+
 // Under `auto_attribs=True`, attrs collects fields from annotations, so an unannotated
 // `attr.ib()` is not a valid field and attrs raises `UnannotatedAttributeError` at runtime.
 attrs_testcase!(

--- a/pyrefly/lib/test/dataclass_transform.rs
+++ b/pyrefly/lib/test/dataclass_transform.rs
@@ -102,6 +102,23 @@ E(x=0, y="")
 );
 
 testcase!(
+    test_ordered_dataclass_transform_inheritance,
+    r#"
+from typing import dataclass_transform
+
+@dataclass_transform(order_default=True)
+def create[T](cls: type[T]) -> type[T]: ...
+
+@create
+class Parent:
+    x: int
+
+class Child(Parent):
+    pass
+    "#,
+);
+
+testcase!(
     test_metaclass_basic,
     r#"
 from typing import dataclass_transform

--- a/pyrefly/lib/test/dataclasses.rs
+++ b/pyrefly/lib/test/dataclasses.rs
@@ -1278,6 +1278,22 @@ def f(d: D2, e: D2, f: D3):
 );
 
 testcase!(
+    test_parent_dataclass_with_order,
+    r#"
+from dataclasses import dataclass
+@dataclass(order=True)
+class D:
+    x: int
+
+class C(D):  # E: Cannot extend dataclass `D` with `order=True`
+    pass
+
+class E(C):  # E: Cannot extend dataclass `C` with `order=True`
+    pass
+    "#,
+);
+
+testcase!(
     test_call_comparison_unbound_with_named_args,
     r#"
 from dataclasses import dataclass

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -1455,6 +1455,28 @@ class OpenTypedDict(TypedDict, closed=True): ...
 Note: In Python versions before 3.15, import `TypedDict` from `typing_extensions` rather than
 `typing` to use the `closed` feature.
 
+## ordered-dataclass-inheritance
+
+Default severity: `warn`
+
+This warning is reported when a class inherits from a stdlib dataclass with `order=True`. The class
+definition is valid Python, but mixed comparisons between parent and subclass instances can raise
+`TypeError` at runtime because stdlib dataclass ordering methods only compare instances of the exact
+same class.
+
+```python
+from dataclasses import dataclass
+
+@dataclass(order=True)
+class Parent:
+    value: int
+
+class Child(Parent):  # ordered-dataclass-inheritance
+    pass
+
+Child(1) < Parent(2)  # TypeError
+```
+
 ## parse-error
 
 An error related to parsing or syntax. This covers a variety of cases, such as function calls with duplicate keyword args, some poorly defined functions, and so on.


### PR DESCRIPTION
# Summary

Adds an `invalid-inheritance` error when a class subclasses a dataclass that has `order=True`. 


Fixes #3762

# Test Plan

Added test `test_parent_dataclass_with_order` to confirm behaviour
