### PR TITLE
Show type parameters in implicit any error messages

### DIFF
--- a/pyrefly/lib/alt/class/targs.rs
+++ b/pyrefly/lib/alt/class/targs.rs
@@ -193,13 +193,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     /// promote(list) == list[Any]
     /// instantiate(list) == list[T]
     pub fn promote(&self, cls: &Class, range: TextRange, errors: &ErrorCollector) -> Type {
+        let tparams = self.get_class_tparams(cls);
         let targs = self.create_default_targs(
-            self.get_class_tparams(cls),
+            tparams.dupe(),
             Some(&|tparam: &Quantified| {
                 Self::add_implicit_any_error(
                     errors,
                     range,
-                    format!("class `{}`", cls.name()),
+                    format!("class `{}{}`", cls.name(), tparams),
                     Some(tparam.name().as_str()),
                 );
             }),
@@ -213,13 +214,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         range: TextRange,
         errors: &ErrorCollector,
     ) -> Type {
+        let tparams = forall.tparams.dupe();
         let targs = self.create_default_targs(
-            forall.tparams.dupe(),
+            tparams.dupe(),
             Some(&|tparam: &Quantified| {
                 Self::add_implicit_any_error(
                     errors,
                     range,
-                    format!("type alias `{}`", forall.body.name()),
+                    format!("type alias `{}{}`", forall.body.name(), tparams),
                     Some(tparam.name().as_str()),
                 );
             }),

--- a/pyrefly/lib/test/generic_basic.rs
+++ b/pyrefly/lib/test/generic_basic.rs
@@ -187,9 +187,9 @@ testcase!(
     r#"
 class C[T]: pass
 
-x: C        # E: Cannot determine the type parameter `T` for generic class `C`
-y: C | int  # E: Cannot determine the type parameter `T` for generic class `C`
-z: list[C]  # E: Cannot determine the type parameter `T` for generic class `C`
+x: C        # E: Cannot determine the type parameter `T` for generic class `C[T]`
+y: C | int  # E: Cannot determine the type parameter `T` for generic class `C[T]`
+z: list[C]  # E: Cannot determine the type parameter `T` for generic class `C[T]`
     "#,
 );
 
@@ -198,7 +198,7 @@ testcase!(
     TestEnv::new().enable_implicit_any_error(),
     r#"
 class C[T]: pass
-class D(C): pass  # E: Cannot determine the type parameter `T` for generic class `C`
+class D(C): pass  # E: Cannot determine the type parameter `T` for generic class `C[T]`
 x: D
     "#,
 );
@@ -635,7 +635,7 @@ testcase!(
 from typing import Callable, Type
 
 def f(
-    x: list,      # E: Cannot determine the type parameter `_T` for generic class `list`
+    x: list,      # E: Cannot determine the type parameter `_T` for generic class `list[_T]`
     y: tuple,     # E: Cannot determine the type parameter for generic class `tuple`
     z: Callable,  # E: Cannot determine the type parameter for generic class `Callable`
     w: Type,      # E: Cannot determine the type parameter for generic class `type`

--- a/pyrefly/lib/test/generic_legacy.rs
+++ b/pyrefly/lib/test/generic_legacy.rs
@@ -220,7 +220,7 @@ from typing import Any, Generic, TypeVar, assert_type
 T = TypeVar('T')
 class A(Generic[T]):
     x: T
-def f(a: A):  # E: Cannot determine the type parameter `T` for generic class `A`
+def f(a: A):  # E: Cannot determine the type parameter `T` for generic class `A[T]`
     assert_type(a.x, Any)
     "#,
 );
@@ -235,7 +235,7 @@ U = TypeVar('U', default=int)
 class A(Generic[T, U]):
     x: T
     y: U
-def f(a: A):  # E: Cannot determine the type parameter `T` for generic class `A`
+def f(a: A):  # E: Cannot determine the type parameter `T` for generic class `A[T, U]`
     assert_type(a.x, Any)
     assert_type(a.y, int)
     "#,

--- a/pyrefly/lib/test/recursive_alias.rs
+++ b/pyrefly/lib/test/recursive_alias.rs
@@ -233,7 +233,7 @@ testcase!(
     test_error_implicit_any,
     TestEnv::new().enable_implicit_any_error(),
     r#"
-type X[T] = int | list[X]  # E: Cannot determine the type parameter `T` for generic type alias `X`
+type X[T] = int | list[X]  # E: Cannot determine the type parameter `T` for generic type alias `X[T]`
 def f(x: X[str]) -> X[int]:
     return [x]
     "#,


### PR DESCRIPTION
## Summary

Fixes #3711 — improves the "implicit any type argument" error message by showing the full generic signature (e.g. `dict[_KT, _VT]`) instead of just the class name.

## Before
```
Cannot determine the type parameter `_KT` for generic class `dict`
```

## After
```
Cannot determine the type parameter `_KT` for generic class `dict[_KT, _VT]`
```

## Changes
- `pyrefly/lib/alt/class/targs.rs`: Include tparams display in the error entity name for `promote()` and `promote_forall()`.
- Updated test expectations in `generic_basic.rs`, `generic_legacy.rs`, and `recursive_alias.rs` to match.

## Verification
Local build unavailable (missing C compiler in this environment). The change is a minimal format string addition using the existing `TParams::Display` trait implementation. CI should confirm correctness.

_Disclosure: This PR was submitted by an AI agent (Paperclip FoundingEngineer)._ 