### PR TITLE
Improve implicit any error message to show full type parameter list

### DIFF
--- a/crates/pyrefly_types/src/quantified.rs
+++ b/crates/pyrefly_types/src/quantified.rs
@@ -350,6 +350,19 @@ impl Quantified {
         &self.restriction
     }
 
+    /// Display this type parameter name with the `*`/`**` kind prefix
+    /// (e.g. `*Ts` for TypeVarTuple, `**P` for ParamSpec).
+    pub fn display_name_with_prefix(&self) -> impl Display + '_ {
+        Fmt(move |f| {
+            if self.is_param_spec() {
+                write!(f, "**")?;
+            } else if self.is_type_var_tuple() {
+                write!(f, "*")?;
+            }
+            write!(f, "{}", self.name)
+        })
+    }
+
     /// Display this type parameter with its bounds/constraints and default,
     /// in the format used for type parameter lists (e.g. `T: int = str`).
     pub fn display_with_bounds(&self) -> impl Display + '_ {

--- a/pyrefly/lib/alt/class/targs.rs
+++ b/pyrefly/lib/alt/class/targs.rs
@@ -193,13 +193,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     /// promote(list) == list[Any]
     /// instantiate(list) == list[T]
     pub fn promote(&self, cls: &Class, range: TextRange, errors: &ErrorCollector) -> Type {
+        let tparams = self.get_class_tparams(cls);
+        let generic_entity = if tparams.is_empty() {
+            format!("class `{}`", cls.name())
+        } else {
+            let names = tparams
+                .iter()
+                .map(|t| t.name().as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("class `{}[{}]`", cls.name(), names)
+        };
         let targs = self.create_default_targs(
-            self.get_class_tparams(cls),
+            tparams,
             Some(&|tparam: &Quantified| {
                 Self::add_implicit_any_error(
                     errors,
                     range,
-                    format!("class `{}`", cls.name()),
+                    generic_entity.clone(),
                     Some(tparam.name().as_str()),
                 );
             }),
@@ -213,13 +224,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         range: TextRange,
         errors: &ErrorCollector,
     ) -> Type {
+        let tparams = forall.tparams.dupe();
+        let generic_entity = if tparams.is_empty() {
+            format!("type alias `{}`", forall.body.name())
+        } else {
+            let names = tparams
+                .iter()
+                .map(|t| t.name().as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("type alias `{}[{}]`", forall.body.name(), names)
+        };
         let targs = self.create_default_targs(
-            forall.tparams.dupe(),
+            tparams,
             Some(&|tparam: &Quantified| {
                 Self::add_implicit_any_error(
                     errors,
                     range,
-                    format!("type alias `{}`", forall.body.name()),
+                    generic_entity.clone(),
                     Some(tparam.name().as_str()),
                 );
             }),

--- a/pyrefly/lib/alt/class/targs.rs
+++ b/pyrefly/lib/alt/class/targs.rs
@@ -199,7 +199,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         } else {
             let names = tparams
                 .iter()
-                .map(|t| t.name().as_str())
+                .map(|t| format!("{}", t.display_name_with_prefix()))
                 .collect::<Vec<_>>()
                 .join(", ");
             format!("class `{}[{}]`", cls.name(), names)
@@ -230,7 +230,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         } else {
             let names = tparams
                 .iter()
-                .map(|t| t.name().as_str())
+                .map(|t| format!("{}", t.display_name_with_prefix()))
                 .collect::<Vec<_>>()
                 .join(", ");
             format!("type alias `{}[{}]`", forall.body.name(), names)

--- a/pyrefly/lib/test/generic_basic.rs
+++ b/pyrefly/lib/test/generic_basic.rs
@@ -187,9 +187,9 @@ testcase!(
     r#"
 class C[T]: pass
 
-x: C        # E: Cannot determine the type parameter `T` for generic class `C`
-y: C | int  # E: Cannot determine the type parameter `T` for generic class `C`
-z: list[C]  # E: Cannot determine the type parameter `T` for generic class `C`
+x: C        # E: Cannot determine the type parameter `T` for generic class `C[T]`
+y: C | int  # E: Cannot determine the type parameter `T` for generic class `C[T]`
+z: list[C]  # E: Cannot determine the type parameter `T` for generic class `C[T]`
     "#,
 );
 
@@ -198,7 +198,7 @@ testcase!(
     TestEnv::new().enable_implicit_any_error(),
     r#"
 class C[T]: pass
-class D(C): pass  # E: Cannot determine the type parameter `T` for generic class `C`
+class D(C): pass  # E: Cannot determine the type parameter `T` for generic class `C[T]`
 x: D
     "#,
 );
@@ -635,7 +635,7 @@ testcase!(
 from typing import Callable, Type
 
 def f(
-    x: list,      # E: Cannot determine the type parameter `_T` for generic class `list`
+    x: list,      # E: Cannot determine the type parameter `_T` for generic class `list[_T]`
     y: tuple,     # E: Cannot determine the type parameter for generic class `tuple`
     z: Callable,  # E: Cannot determine the type parameter for generic class `Callable`
     w: Type,      # E: Cannot determine the type parameter for generic class `type`

--- a/pyrefly/lib/test/generic_legacy.rs
+++ b/pyrefly/lib/test/generic_legacy.rs
@@ -220,7 +220,7 @@ from typing import Any, Generic, TypeVar, assert_type
 T = TypeVar('T')
 class A(Generic[T]):
     x: T
-def f(a: A):  # E: Cannot determine the type parameter `T` for generic class `A`
+def f(a: A):  # E: Cannot determine the type parameter `T` for generic class `A[T]`
     assert_type(a.x, Any)
     "#,
 );
@@ -235,7 +235,7 @@ U = TypeVar('U', default=int)
 class A(Generic[T, U]):
     x: T
     y: U
-def f(a: A):  # E: Cannot determine the type parameter `T` for generic class `A`
+def f(a: A):  # E: Cannot determine the type parameter `T` for generic class `A[T, U]`
     assert_type(a.x, Any)
     assert_type(a.y, int)
     "#,

--- a/pyrefly/lib/test/recursive_alias.rs
+++ b/pyrefly/lib/test/recursive_alias.rs
@@ -233,7 +233,7 @@ testcase!(
     test_error_implicit_any,
     TestEnv::new().enable_implicit_any_error(),
     r#"
-type X[T] = int | list[X]  # E: Cannot determine the type parameter `T` for generic type alias `X`
+type X[T] = int | list[X]  # E: Cannot determine the type parameter `T` for generic type alias `X[T]`
 def f(x: X[str]) -> X[int]:
     return [x]
     "#,


### PR DESCRIPTION
## Summary

Closes #3711

When a generic class or type alias is used without explicit type arguments, the error message currently only shows the bare name (e.g. `dict`) but doesn't tell the user what type parameters are expected. This change includes the full type parameter list in the error message.

### Before
```
Cannot determine the type parameter `_KT` for generic class `dict`
```

### After
```
Cannot determine the type parameter `_KT` for generic class `dict[_KT, _VT]`
```

## Changes

- `pyrefly/lib/alt/class/targs.rs`: Modified `promote` and `promote_forall` to format the generic entity name with type parameters (e.g. `class \`dict[_KT, _VT]\``)
- `pyrefly/lib/test/generic_basic.rs`: Updated test expectations
- `pyrefly/lib/test/generic_legacy.rs`: Updated test expectations
- `pyrefly/lib/test/recursive_alias.rs`: Updated test expectations

## Verification

The implementation follows the suggestion from @yangdanny97 in the issue discussion. Test expectations in the affected test modules have been updated to match the new error format. Local build verification was not possible due to missing C toolchain in the environment; CI should validate.
