### PR TITLE
Dedupe module prefix formatting in `pyrefly coverage`

### DIFF
--- a/pyrefly/lib/commands/coverage/collect.rs
+++ b/pyrefly/lib/commands/coverage/collect.rs
@@ -166,6 +166,15 @@ fn class_qualified_name(
     }
 }
 
+/// The module name with a trailing `.`, or empty for the unknown module; prefixed to symbol FQNs.
+fn module_prefix(module: &Module) -> String {
+    if module.name() != ModuleName::unknown() {
+        format!("{}.", module.name())
+    } else {
+        String::new()
+    }
+}
+
 /// Merge overloads with the same qualified name into one entry,
 /// keeping the best annotation quality per deduplicated slot.
 fn merge_overloads(functions: &mut Vec<Function>) {
@@ -494,11 +503,7 @@ fn parse_variables(
         }
     }
 
-    let module_prefix = if module.name() != ModuleName::unknown() {
-        format!("{}.", module.name())
-    } else {
-        String::new()
-    };
+    let module_prefix = module_prefix(module);
     let deleted = bindings.module_deletes();
     // Collect names already reported as functions or classes so we can skip them.
     let reported_names: SmallSet<&str> = functions
@@ -605,11 +610,7 @@ fn parse_instance_attrs(
     tco_classes: &SmallSet<Idx<KeyClass>>,
 ) -> Vec<Variable> {
     let mut attrs = Vec::new();
-    let module_prefix = if module.name() != ModuleName::unknown() {
-        format!("{}.", module.name())
-    } else {
-        String::new()
-    };
+    let module_prefix = module_prefix(module);
 
     for field_idx in bindings.keys::<KeyClassField>() {
         let field = bindings.get(field_idx);
@@ -695,11 +696,7 @@ fn parse_functions(
     tco_classes: &SmallSet<Idx<KeyClass>>,
 ) -> Vec<Function> {
     let mut functions = Vec::new();
-    let module_prefix = if module.name() != ModuleName::unknown() {
-        format!("{}.", module.name())
-    } else {
-        String::new()
-    };
+    let module_prefix = module_prefix(module);
     let deleted = bindings.module_deletes();
 
     for idx in bindings.keys::<Key>() {
@@ -1158,11 +1155,7 @@ fn parse_classes(
     tco_classes: &SmallSet<Idx<KeyClass>>,
 ) -> Vec<ReportClass> {
     let mut classes = Vec::new();
-    let module_prefix = if module.name() != ModuleName::unknown() {
-        format!("{}.", module.name())
-    } else {
-        String::new()
-    };
+    let module_prefix = module_prefix(module);
     let deleted = bindings.module_deletes();
 
     // group method definitions by class
@@ -1307,11 +1300,7 @@ fn collect_class_members(
     handle: &Handle,
     tco_classes: &SmallSet<Idx<KeyClass>>,
 ) -> SmallSet<String> {
-    let fqname_prefix = if module.name() != ModuleName::unknown() {
-        format!("{}.", module.name())
-    } else {
-        String::new()
-    };
+    let fqname_prefix = module_prefix(module);
 
     let mut members = SmallSet::new();
     for idx in bindings.keys::<KeyClass>() {
@@ -1360,11 +1349,7 @@ fn collect_reexport_fqns(
     exports_data: &Exports,
     dunder_all: &SmallSet<Name>,
 ) -> SmallSet<String> {
-    let module_prefix = if module.name() != ModuleName::unknown() {
-        format!("{}.", module.name())
-    } else {
-        String::new()
-    };
+    let module_prefix = module_prefix(module);
     exports
         .iter()
         .filter(|&(name, loc)| {


### PR DESCRIPTION
# Summary

This extracts a ~5x~ 6x duplicated bit of helper code related to module FQN formatting into a function to reduce code duplication.

I ensured that this wouldn't lead to merge conflicts with my three other currently open PRs.

# Test Plan

Refactor only; tests still pass
