### PR TITLE
Fix `test.py` nightly-only formatting warnings

### DIFF
--- a/test.py
+++ b/test.py
@@ -133,7 +133,21 @@ class CargoExecutor(Executor):
         os.chdir(str(script_dir))
 
     def rustfmt(self) -> None:
-        run(["cargo", "fmt"])
+        # rustfmt.toml's import options are nightly-only; use nightly when present to
+        # apply them and avoid stable rustfmt's "unstable features" warnings.
+        try:
+            # @lint-ignore FIXIT1 NoUnsafeExecRule
+            has_nightly = (
+                subprocess.run(
+                    ["cargo", "+nightly", "fmt", "--version"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                ).returncode
+                == 0
+            )
+        except OSError:
+            has_nightly = False
+        run(["cargo", "+nightly", "fmt"] if has_nightly else ["cargo", "fmt"])
 
     def clippy(self) -> None:
         run(["cargo", "clippy"])


### PR DESCRIPTION
This changes the format step of `test.py` to use the nightly channel if available, falling back to the stable channel, resolving bunches of warnings reported when running `python test.py`.


Before:

```bash
$ python test.py --no-test --no-conformance
Running formatting...
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Finished in 1.43 seconds.
Running linting...
    Checking pyrefly v1.1.0-dev.2 (/home/joren/Workspace/pyrefly/pyrefly)
    Checking pyrefly_wasm v0.0.0 (/home/joren/Workspace/pyrefly/pyrefly_wasm)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.63s
Finished in 5.68 seconds.
Running jsonschema tests...
........................................................
----------------------------------------------------------------------
Ran 56 tests in 0.011s

OK
Finished in 0.08 seconds.
```

After:

```bash
$ python test.py --no-test --no-conformance
Running formatting...
Finished in 1.43 seconds.
Running linting...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
Finished in 0.15 seconds.
Running jsonschema tests...
........................................................
----------------------------------------------------------------------
Ran 56 tests in 0.013s

OK
Finished in 0.08 seconds.
```