### PR TITLE
Fix auto-import completions in the sandbox #2967

### DIFF
--- a/pyrefly/lib/playground.rs
+++ b/pyrefly/lib/playground.rs
@@ -18,6 +18,7 @@ use lsp_types::HoverContents;
 use lsp_types::SemanticTokens;
 use lsp_types::SemanticTokensLegend;
 use lsp_types::SemanticTokensResult;
+use lsp_types::TextEdit;
 use pyrefly_build::handle::Handle;
 use pyrefly_build::source_db::SourceDatabase;
 use pyrefly_build::source_db::Target;
@@ -199,13 +200,57 @@ pub struct Diagnostic {
     pub filename: String,
 }
 
+/// A Monaco `ISingleEditOperation`.
+#[derive(Serialize)]
+pub struct CompletionTextEdit {
+    range: Range,
+    text: String,
+}
+
 #[derive(Serialize)]
 pub struct AutoCompletionItem {
     label: String,
     detail: Option<String>,
-    kind: Option<CompletionItemKind>,
+    /// A Monaco `CompletionItemKind`, whose numbering differs from LSP's.
+    kind: Option<i32>,
     #[serde(rename(serialize = "sortText"))]
     sort_text: Option<String>,
+    /// Without these, accepting an import completion does nothing visible.
+    #[serde(rename(serialize = "additionalTextEdits"))]
+    import_edits: Option<Vec<CompletionTextEdit>>,
+}
+
+/// LSP and Monaco both number `CompletionItemKind`, but differently. Monaco's values:
+/// https://github.com/microsoft/vscode/blob/main/src/vs/editor/common/standalone/standaloneEnums.ts
+fn to_monaco_completion_kind(kind: CompletionItemKind) -> i32 {
+    match kind {
+        CompletionItemKind::METHOD => 0,
+        CompletionItemKind::FUNCTION => 1,
+        CompletionItemKind::CONSTRUCTOR => 2,
+        CompletionItemKind::FIELD => 3,
+        CompletionItemKind::VARIABLE => 4,
+        CompletionItemKind::CLASS => 5,
+        CompletionItemKind::STRUCT => 6,
+        CompletionItemKind::INTERFACE => 7,
+        CompletionItemKind::MODULE => 8,
+        CompletionItemKind::PROPERTY => 9,
+        CompletionItemKind::EVENT => 10,
+        CompletionItemKind::OPERATOR => 11,
+        CompletionItemKind::UNIT => 12,
+        CompletionItemKind::VALUE => 13,
+        CompletionItemKind::CONSTANT => 14,
+        CompletionItemKind::ENUM => 15,
+        CompletionItemKind::ENUM_MEMBER => 16,
+        CompletionItemKind::KEYWORD => 17,
+        CompletionItemKind::TEXT => 18,
+        CompletionItemKind::COLOR => 19,
+        CompletionItemKind::FILE => 20,
+        CompletionItemKind::REFERENCE => 21,
+        CompletionItemKind::FOLDER => 23,
+        CompletionItemKind::TYPE_PARAMETER => 24,
+        CompletionItemKind::SNIPPET => 27,
+        _ => unreachable!("unknown LSP CompletionItemKind"),
+    }
 }
 
 #[derive(Serialize)]
@@ -434,7 +479,7 @@ impl Playground {
                     message_header: e.msg_header().to_owned(),
                     message_details: e.msg_details().unwrap_or("").to_owned(),
                     kind: e.error_kind().to_name().to_owned(),
-                    // Severity values defined here: https://microsoft.github.io/monaco-editor/typedoc/enums/MarkerSeverity.html
+                    // Severity values defined here: https://github.com/microsoft/vscode/blob/main/src/vs/editor/common/standalone/standaloneEnums.ts
                     severity: match e.severity() {
                         Severity::Error => 8,
                         Severity::Warn => 4,
@@ -621,12 +666,25 @@ impl Playground {
                      detail,
                      sort_text,
                      kind,
+                     additional_text_edits,
                      ..
                  }| AutoCompletionItem {
                     label,
                     detail,
-                    kind,
+                    kind: kind.map(to_monaco_completion_kind),
                     sort_text,
+                    // Convert LSP ranges (0-based) to the 1-based coordinates Monaco wants.
+                    import_edits: additional_text_edits.map(|edits| {
+                        edits.into_map(|TextEdit { range, new_text }| CompletionTextEdit {
+                            range: Range {
+                                start_line: range.start.line as i32 + 1,
+                                start_col: range.start.character as i32 + 1,
+                                end_line: range.end.line as i32 + 1,
+                                end_col: range.end.character as i32 + 1,
+                            },
+                            text: new_text,
+                        })
+                    }),
                 },
             )
     }
@@ -660,6 +718,33 @@ impl Playground {
 mod tests {
     use super::*;
     use crate::config::error_kind::ErrorKind;
+
+    #[test]
+    fn test_autocomplete_includes_auto_import_edit() {
+        // gh-2967: accepting an auto-import completion must also insert its import line.
+        let mut state = Playground::new(None).unwrap();
+        let mut files = SmallMap::new();
+        files.insert("sandbox.py".to_owned(), "reveal_type".to_owned());
+        state.update_sandbox_files(files, true);
+        state.set_active_file("sandbox.py");
+
+        let items = state.autocomplete(Position::new(1, 12));
+        let reveal = items
+            .iter()
+            .find(|i| i.label == "reveal_type")
+            .expect("reveal_type completion should be offered");
+
+        // Monaco's Function kind is 1 (LSP's is 3), verifying the kind remap.
+        assert_eq!(reveal.kind, Some(1));
+        let edits = reveal
+            .import_edits
+            .as_ref()
+            .expect("reveal_type completion should carry an auto-import edit");
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].text, "from typing import reveal_type\n");
+        assert_eq!(edits[0].range.start_line, 1);
+        assert_eq!(edits[0].range.start_col, 1);
+    }
 
     #[test]
     fn test_regular_import() {


### PR DESCRIPTION
# Summary

Accepting an import completion in the sandbox didn't work. The playground dropped each completion's `additional_text_edits` (i.e. the `from x import y` line) when handing items to Monaco. So this fixes it by forwarding them.

This also remaps the `kind` to Monaco's `CompletionItemKind` numbering so icons are correct. I also took the liberty of fixing two 404'd monaco-editor doc links. 

Fixes #2967

# Test Plan

Regression test added, and manually verified that auto-import-completions now indeed work by locally running the website (i.e. that whole yarn adventure).
