### PR TITLE
Drop redundant 2nd flatten pass in union construction

### DIFF
--- a/crates/pyrefly_types/src/simplify.rs
+++ b/crates/pyrefly_types/src/simplify.rs
@@ -33,12 +33,11 @@ fn flatten_and_dedup(xs: Vec<Type>, heap: &TypeHeap) -> Vec<Type> {
     let mut flattened = Vec::with_capacity(xs.len());
     flatten(xs, &mut flattened);
     simplify_intersections(&mut flattened, heap);
-    let mut res = Vec::with_capacity(flattened.len());
-    flatten(flattened, &mut res);
-
-    res.sort();
-    res.dedup();
-    res
+    // `simplify_intersections` only ever introduces `Never`s, so dropping them in place suffices.
+    flattened.retain(|x| !x.is_never());
+    flattened.sort();
+    flattened.dedup();
+    flattened
 }
 
 /// Given a list of types to union together,


### PR DESCRIPTION
# Summary

`flatten_and_dedup` flattened the member list twice. The second pass only drops the `Never`s that `simplify_intersections` adds, which can be avoid with a simple (and effectively  equivalent) `retain`.

| corpus | before | after | improvement |
|---|---:|---:|---:|
| `scipy-stubs`, (589 modules) | 1786.8ms | 1762.6ms | ~1.4% |
| `matplotlib` (inline typed) | 1199.2ms | 1190.7ms | ~0.7% |

(single-threaded, mean of 12 interleaved runs)

The speedup is modest, but it seems consistent.

# Test Plan

Tests still pass (no behavior changes).