### PR TITLE
docs: fix unsupported-operation example (reports not-iterable instead)

### DIFF
--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -1778,8 +1778,7 @@ For example, read-only and required `TypedDict` fields cannot be deleted.
 This error arises when attempting to perform an operation between values of two incompatible types.
 
 ```python
-if "hello" in 1:  # int doesn't support `in`!
-  ...
+x = 1 + "oops"  # `+` is not supported between `int` and `str` [unsupported-operation]
 ```
 
 ## untyped-import


### PR DESCRIPTION
# Summary
Fixes #3796

The `unsupported-operation` docs example used `if "hello" in 1:` which 
actually reports `not-iterable` instead of `unsupported-operation`.

Replaced the example with `x = 1 + "oops"` which correctly triggers 
`unsupported-operation`.

# Test Plan
Verified locally using pyrefly CLI:

Old example:
`if "hello" in 1:` → reports `not-iterable` 

New example:
`x = 1 + "oops"` → reports `unsupported-operation`