### PR TITLE
Resolve real source locations by reusing the query transaction (#3829)

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -238,6 +238,7 @@ use pyrefly_util::telemetry::TelemetryServerState;
 use pyrefly_util::thread_pool::ThreadCount;
 use pyrefly_util::thread_pool::ThreadPool;
 use pyrefly_util::watch_pattern::WatchPattern;
+use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
@@ -343,6 +344,7 @@ use crate::state::state::Transaction;
 use crate::state::subscriber::CompositeSubscriber;
 use crate::state::subscriber::PublishDiagnosticsSubscriber;
 use crate::state::subscriber::Subscriber;
+use crate::tsp::type_conversion::convert_type_with_resolvers;
 use crate::types::class::ClassDefIndex;
 use crate::types::class::ClassType;
 
@@ -438,76 +440,55 @@ pub trait TspInterface: Send + Sync + 'static {
     /// (e.g. on the wrong platform).
     fn get_python_search_paths(&self, from_url: &Url) -> Result<Vec<String>, String>;
 
-    /// Return the inferred type at the given position in a file.
+    /// Compute the type at the given position and convert it to the TSP wire
+    /// format.
     ///
-    /// `uri` is a file URI string (e.g. `file:///path/to/file.py`).
-    /// `line` and `character` are zero-based positions within the file.
+    /// `uri` is a file URI string (e.g. `file:///path/to/file.py`); `line` and
+    /// `character` are zero-based. Every declaration location in the result is
+    /// resolved against the *same* transaction that computed the type. Because
+    /// computing a type already demands its `Stdlib`, that transaction is warm,
+    /// so the export lookups during conversion cannot hit a cold `get_stdlib`.
     ///
     /// Returns `None` when the URI cannot be resolved, the position is invalid,
     /// or no type information is available at that location.
-    fn get_type_at_position(
-        &self,
-        uri: &str,
-        line: u32,
-        character: u32,
-    ) -> Option<pyrefly_types::types::Type>;
+    fn type_at_position(&self, uri: &str, line: u32, character: u32) -> Option<tsp_types::Type>;
 
-    /// Return the computed (inferred) type for a node spanning the given range.
+    /// Return the computed (inferred) type for a node spanning the given range,
+    /// converted to the TSP wire format.
     ///
-    /// Unlike [`get_type_at_position`], which resolves the identifier at a
-    /// single position, this is range-aware: when the requested range covers a
-    /// whole call expression (e.g. `Foo()`), it returns the call's result type
-    /// rather than the callee's declaration sitting at the range's start. Used
-    /// by the TSP `getComputedType` endpoint, where the client sends the full
-    /// source range of the node it cares about.
+    /// Unlike [`TspInterface::type_at_position`], which resolves the identifier
+    /// at a single position, this is range-aware: when the requested range
+    /// covers a whole call expression (e.g. `Foo()`), it returns the call's
+    /// result type rather than the callee's declaration sitting at the range's
+    /// start. Used by the TSP `getComputedType` endpoint, where the client
+    /// sends the full source range of the node it cares about. Falls back to
+    /// the position-based (declaration-preserving) lookup when the range is not
+    /// a call expression.
     ///
     /// `start_line`/`start_character` and `end_line`/`end_character` are the
-    /// zero-based bounds of the node range. Falls back to the position-based
-    /// (declaration-preserving) lookup when the range is not a call expression.
-    fn get_computed_type_at_range(
+    /// zero-based bounds of the node range. As with [`type_at_position`],
+    /// declaration locations are resolved against the same warm transaction
+    /// that produced the type, so the export lookups cannot hit a cold
+    /// `get_stdlib`.
+    fn computed_type_at_range(
         &self,
         uri: &str,
         start_line: u32,
         start_character: u32,
         end_line: u32,
         end_character: u32,
-    ) -> Option<pyrefly_types::types::Type>;
+    ) -> Option<tsp_types::Type>;
 
-    /// Return the contextually expected type at the given position.
-    ///
-    /// The expected type is what the surrounding context demands of the
-    /// expression at the cursor: a call argument's parameter type, an
-    /// annotated assignment / return / attribute target's declared type, etc.
-    /// When no such context applies, falls back to the computed type at the
-    /// position (so the result is never `None` where a computed type exists).
-    fn get_expected_type_at_position(
+    /// As [`TspInterface::type_at_position`], but returns the contextually
+    /// expected type — a call argument's parameter type, an annotated target's
+    /// declared type, etc. — falling back to the computed type where no
+    /// expected-type context applies.
+    fn expected_type_at_position(
         &self,
         uri: &str,
         line: u32,
         character: u32,
-    ) -> Option<pyrefly_types::types::Type>;
-
-    /// Resolve the source range of a function name from its `FuncDefIndex`.
-    ///
-    /// Uses the binding table to look up `KeyUndecoratedFunctionRange` for
-    /// the function's module, returning the `TextRange` of the function
-    /// name identifier. Returns `None` when the function has no
-    /// `FuncDefIndex` or the module's bindings are unavailable.
-    fn resolve_func_def_range(
-        &self,
-        func_id: &pyrefly_types::callable::FuncId,
-    ) -> Option<TextRange>;
-
-    /// Resolve an importable module to its backing filesystem path using the
-    /// import-resolution context of `source_uri`.
-    ///
-    /// Returns `None` when the source URI is invalid, cannot be mapped to a
-    /// path, or the target module cannot be resolved.
-    fn resolve_module_uri(
-        &self,
-        source_uri: &str,
-        module: &pyrefly_types::module::ModuleType,
-    ) -> Option<PathBuf>;
+    ) -> Option<tsp_types::Type>;
 
     /// Resolve a URI to a filesystem path.
     ///
@@ -6246,6 +6227,106 @@ impl Server {
             |items| items,
         )
     }
+
+    /// Open `uri` at `(line, character)`: resolve the path, build a handle, and
+    /// start a transaction, returning it alongside the handle and the resolved
+    /// in-file position.
+    fn open_at_position<'a>(
+        &'a self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Option<(Transaction<'a>, Handle, TextSize)> {
+        let url = Url::parse(uri)
+            .ok()
+            .or_else(|| Url::from_file_path(uri).ok())?;
+        let path = self.path_for_uri_or_notebook_cell(&url)?;
+        let notebook_cell = self.maybe_get_code_cell_index(&url);
+
+        let handle = make_open_handle(&self.state, &path);
+        let transaction = self.state.transaction();
+        let module_info = transaction.get_module_info(&handle)?;
+        let position =
+            module_info.from_lsp_position(lsp_types::Position { line, character }, notebook_cell);
+        Some((transaction, handle, position))
+    }
+
+    /// Convert `ty` to the TSP wire format, resolving every declaration location
+    /// against `transaction` — the same transaction that produced `ty`, reached
+    /// through `source_handle`'s import context.
+    ///
+    /// Reusing that transaction is what keeps conversion both cheap and correct:
+    /// computing `ty` already populated the transaction's `Stdlib`, so the
+    /// export lookups below cannot hit the cold `get_stdlib` path and need no
+    /// warm-up run; and a single transaction serves the whole query instead of
+    /// one per resolved symbol.
+    fn convert_type_in_transaction(
+        &self,
+        transaction: &Transaction,
+        source_handle: &Handle,
+        ty: &pyrefly_types::types::Type,
+    ) -> tsp_types::Type {
+        // A `Def` function's name range, looked up in its module's binding table.
+        // The handle reuses `source_handle`'s `SysInfo` (as `get_class_fields`
+        // does for cross-module lookups) so the function's module is found under
+        // the same `SysInfo` the transaction computed it with; re-deriving a
+        // config-default `SysInfo` would miss the module in a multi-`SysInfo`
+        // transaction and silently collapse the range to zero.
+        let resolve_func_range = |func_id: &pyrefly_types::callable::FuncId| {
+            let def_index = func_id.def_index?;
+            let handle = Handle::new(
+                func_id.module.name(),
+                func_id.module.path().dupe(),
+                source_handle.sys_info().dupe(),
+            );
+            let bindings = transaction.get_bindings(&handle)?;
+            let key = KeyUndecoratedFunctionRange(def_index);
+            let idx = bindings.key_to_idx_hashed_opt(Hashed::new(&key))?;
+            Some(bindings.get(idx).0.range())
+        };
+        // An importable module's backing filesystem path.
+        let resolve_module_path = |module: &pyrefly_types::module::ModuleType| {
+            let module_name = ModuleName::from_str(&module.to_string());
+            let finding = transaction
+                .import_handle(source_handle, module_name, None)
+                .finding()?;
+            let path = to_real_path(finding.path())?;
+            Some(path.canonicalize().unwrap_or(path))
+        };
+        // An exported symbol's original definition, following re-exports.
+        let resolve_export = |module_name: ModuleName, name: &Name| {
+            resolve_export_location(transaction, source_handle, module_name, name)
+        };
+        convert_type_with_resolvers(
+            ty,
+            Some(&resolve_func_range),
+            Some(&resolve_module_path),
+            Some(&resolve_export),
+        )
+    }
+}
+
+/// Resolve an exported symbol's original definition (following re-exports) to a
+/// `(ModulePath, Range)`, looked up in `transaction` from `source_handle`'s
+/// import context.
+///
+/// The target module is reached via `import_handle`, so it inherits
+/// `source_handle`'s `SysInfo` — the one whose `Stdlib` this transaction already
+/// computed. That keeps the export lookup on the warm `get_stdlib` path:
+/// re-deriving the handle from the module path would pick a config-derived
+/// `SysInfo` that was never computed, panicking in `get_stdlib` whenever the
+/// transaction holds more than one `SysInfo`.
+pub(crate) fn resolve_export_location(
+    transaction: &Transaction,
+    source_handle: &Handle,
+    module_name: ModuleName,
+    name: &Name,
+) -> Option<(ModulePath, lsp_types::Range)> {
+    let target_handle = transaction
+        .import_handle(source_handle, module_name, None)
+        .finding()?;
+    let (module, range) = transaction.lookup_export_location(&target_handle, name)?;
+    Some((module.path().dupe(), module.to_lsp_range(range)))
 }
 
 impl TspInterface for Server {
@@ -6356,38 +6437,24 @@ impl TspInterface for Server {
         Ok(paths)
     }
 
-    fn get_type_at_position(
-        &self,
-        uri: &str,
-        line: u32,
-        character: u32,
-    ) -> Option<pyrefly_types::types::Type> {
-        let url = Url::parse(uri)
-            .ok()
-            .or_else(|| Url::from_file_path(uri).ok())?;
-        let path = self.path_for_uri_or_notebook_cell(&url)?;
-        let notebook_cell = self.maybe_get_code_cell_index(&url);
-
-        let handle = make_open_handle(&self.state, &path);
-        let transaction = self.state.transaction();
-        let module_info = transaction.get_module_info(&handle)?;
-        let position =
-            module_info.from_lsp_position(lsp_types::Position { line, character }, notebook_cell);
+    fn type_at_position(&self, uri: &str, line: u32, character: u32) -> Option<tsp_types::Type> {
+        let (transaction, handle, position) = self.open_at_position(uri, line, character)?;
         // For TSP, return the raw declared type without coercing callees in
         // call position. This keeps the function's `Declaration::Regular`
         // intact on the wire, which TSP clients need to re-resolve the
         // signature (parameters, overloads) from source.
-        transaction.get_type_at_preserving_declaration(&handle, position)
+        let ty = transaction.get_type_at_preserving_declaration(&handle, position)?;
+        Some(self.convert_type_in_transaction(&transaction, &handle, &ty))
     }
 
-    fn get_computed_type_at_range(
+    fn computed_type_at_range(
         &self,
         uri: &str,
         start_line: u32,
         start_character: u32,
         end_line: u32,
         end_character: u32,
-    ) -> Option<pyrefly_types::types::Type> {
+    ) -> Option<tsp_types::Type> {
         let url = Url::parse(uri)
             .ok()
             .or_else(|| Url::from_file_path(uri).ok())?;
@@ -6412,66 +6479,28 @@ impl TspInterface for Server {
             notebook_cell,
         );
         let range = TextRange::new(start, end);
-        transaction.get_computed_type_at_range(&handle, range)
+        // Range-aware lookup: a whole call-expression range resolves to the
+        // call's result type, other ranges to the declaration-preserving type.
+        // Convert against the *same* transaction that produced `ty`, so export
+        // location resolution stays warm and cannot hit a cold `get_stdlib`.
+        let ty = transaction.get_computed_type_at_range(&handle, range)?;
+        Some(self.convert_type_in_transaction(&transaction, &handle, &ty))
     }
 
-    fn get_expected_type_at_position(
+    fn expected_type_at_position(
         &self,
         uri: &str,
         line: u32,
         character: u32,
-    ) -> Option<pyrefly_types::types::Type> {
-        let url = Url::parse(uri)
-            .ok()
-            .or_else(|| Url::from_file_path(uri).ok())?;
-        let path = self.path_for_uri_or_notebook_cell(&url)?;
-        let notebook_cell = self.maybe_get_code_cell_index(&url);
-
-        let handle = make_open_handle(&self.state, &path);
-        let transaction = self.state.transaction();
-        let module_info = transaction.get_module_info(&handle)?;
-        let position =
-            module_info.from_lsp_position(lsp_types::Position { line, character }, notebook_cell);
+    ) -> Option<tsp_types::Type> {
+        let (transaction, handle, position) = self.open_at_position(uri, line, character)?;
         // Prefer the contextually expected type; fall back to the computed type
-        // (preserving declarations, as `get_type_at_position` does) so the
-        // result is meaningful even outside an expected-type context.
-        transaction
+        // (preserving declarations) so the result is meaningful even outside an
+        // expected-type context.
+        let ty = transaction
             .get_expected_type_at(&handle, position)
-            .or_else(|| transaction.get_type_at_preserving_declaration(&handle, position))
-    }
-
-    fn resolve_func_def_range(
-        &self,
-        func_id: &pyrefly_types::callable::FuncId,
-    ) -> Option<TextRange> {
-        let def_index = func_id.def_index?;
-        let handle = handle_from_module_path(&self.state, func_id.module.path().dupe());
-        let transaction = self.state.transaction();
-        let bindings = transaction.get_bindings(&handle)?;
-        let key = KeyUndecoratedFunctionRange(def_index);
-        let idx = bindings.key_to_idx_hashed_opt(Hashed::new(&key))?;
-        Some(bindings.get(idx).0.range())
-    }
-
-    fn resolve_module_uri(
-        &self,
-        source_uri: &str,
-        module: &pyrefly_types::module::ModuleType,
-    ) -> Option<PathBuf> {
-        let url = Url::parse(source_uri)
-            .ok()
-            .or_else(|| Url::from_file_path(source_uri).ok())?;
-        let source_path = self.path_for_uri_or_notebook_cell(&url)?;
-
-        let source_handle = make_open_handle(&self.state, &source_path);
-        let transaction = self.state.transaction();
-        let module_name = ModuleName::from_str(&module.to_string());
-        let finding = transaction
-            .import_handle(&source_handle, module_name, None)
-            .finding()?;
-
-        let path = to_real_path(finding.path())?;
-        Some(path.canonicalize().unwrap_or(path))
+            .or_else(|| transaction.get_type_at_preserving_declaration(&handle, position))?;
+        Some(self.convert_type_in_transaction(&transaction, &handle, &ty))
     }
 
     fn resolve_uri_to_path(&self, uri: &Url) -> Option<PathBuf> {

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -1761,7 +1761,11 @@ impl<'a> Transaction<'a> {
     /// Look up the location of an exported name in a module.
     /// Follows re-exports (ExportLocation::OtherModule) to find the original definition.
     /// Returns the module and text range where the name is defined.
-    fn lookup_export_location(&self, handle: &Handle, name: &Name) -> Option<(Module, TextRange)> {
+    pub(crate) fn lookup_export_location(
+        &self,
+        handle: &Handle,
+        name: &Name,
+    ) -> Option<(Module, TextRange)> {
         let module_data = self.get_module(handle);
         let exports = self.lookup_export(module_data);
         let export_map = exports.exports(&self.lookup(module_data));

--- a/pyrefly/lib/test/state.rs
+++ b/pyrefly/lib/test/state.rs
@@ -33,6 +33,7 @@ use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::telemetry::TelemetrySourceDbRebuildInstanceStats;
 use pyrefly_util::thread_pool::TEST_THREAD_COUNT;
 use pyrefly_util::watch_pattern::WatchPattern;
+use ruff_python_ast::name::Name;
 use starlark_map::small_set::SmallSet;
 use tempfile::TempDir;
 
@@ -41,6 +42,7 @@ use crate::config::config::ConfigFile;
 use crate::config::config::ConfigSource;
 use crate::config::finder::ConfigFinder;
 use crate::error::error::print_errors;
+use crate::lsp::non_wasm::server::resolve_export_location;
 use crate::module::finder::DirEntryCache;
 use crate::module::finder::find_import;
 use crate::state::load::FileContents;
@@ -190,6 +192,132 @@ else:
         .get_errors(&handles)
         .check_against_expectations()
         .unwrap();
+}
+
+/// Regression for the TSP type converter's export-location resolution.
+///
+/// `convert_type_in_transaction` resolves an exported symbol's definition by
+/// demanding the target module's exports, which demands its `Stdlib` via
+/// `get_stdlib`. The target handle must inherit the *source* file's `SysInfo`
+/// (built through `import_handle`), because computing the queried type only
+/// populated `compute_stdlib` for the source's `SysInfo`. When the transaction
+/// holds more than one `SysInfo`, `get_stdlib` no longer short-circuits to its
+/// single entry and looks the `SysInfo` up by key — so a target handle carrying
+/// any other `SysInfo` would hit a missing `Stdlib` and panic.
+///
+/// This test reproduces the multi-`SysInfo` transaction and verifies the warm
+/// path: a target resolved via `import_handle` inherits the source `SysInfo`
+/// and its export location resolves without panicking.
+#[test]
+fn test_lookup_export_location_warm_with_multiple_sysinfos() {
+    let linux = SysInfo::new(PythonVersion::default(), PythonPlatform::linux());
+    let windows = SysInfo::new(PythonVersion::default(), PythonPlatform::windows());
+
+    let mut test_env = TestEnv::new();
+    test_env.add("lib", "CONST = 42\n");
+    // `main` does not import `lib`, so `lib` is never checked during the run and
+    // its exports must be demanded fresh — exercising the `get_stdlib` call.
+    test_env.add("main", "x = 1\n");
+    let config_file = test_env.config();
+    let state = State::new(test_env.config_finder(), TEST_THREAD_COUNT);
+
+    let f = |name: &str, sys_info: &SysInfo| {
+        let name = ModuleName::from_str(name);
+        let path = find_import(
+            &config_file,
+            name,
+            None,
+            None,
+            &DirEntryCache::new(true),
+            None,
+        )
+        .finding()
+        .unwrap();
+        Handle::new(name, path, sys_info.dupe())
+    };
+
+    // Check `main` under BOTH sys_infos so the transaction's stdlib map has two
+    // entries and `get_stdlib`'s single-entry short-circuit no longer applies.
+    let handles = [f("main", &linux), f("main", &windows)];
+    let mut transaction = state.new_transaction(Require::Exports, None);
+    transaction.set_memory(test_env.get_memory());
+    transaction.run(&handles, Require::Everything, None);
+
+    // Resolve `lib.CONST` the way the converter does: build the target handle via
+    // `import_handle` from the source file. It must inherit the source `SysInfo`.
+    let source = f("main", &linux);
+    let target = transaction
+        .import_handle(&source, ModuleName::from_str("lib"), None)
+        .finding()
+        .unwrap();
+    assert_eq!(
+        target.sys_info(),
+        &linux,
+        "import_handle must inherit the source file's SysInfo"
+    );
+    let location = transaction.lookup_export_location(&target, &Name::new_static("CONST"));
+    assert!(
+        location.is_some(),
+        "expected to resolve the location of lib.CONST without panicking"
+    );
+}
+
+// Regression for the TSP `get_stdlib` panic (D107960810), exercising the actual
+// converter seam `resolve_export_location` rather than `lookup_export_location`
+// directly. Before the fix this re-derived the target handle from the module
+// path via the config (which defaults to `linux`); when the source file is
+// checked under other platforms, that `linux` Stdlib is never computed, so the
+// export lookup panicked in `get_stdlib` once the transaction held more than one
+// `SysInfo`. The fix reaches the target via `import_handle`, inheriting the
+// source's (warm) `SysInfo`, so resolution succeeds.
+#[test]
+fn test_resolve_export_location_inherits_source_sysinfo() {
+    // Two run platforms, both different from the config default (`linux`), so the
+    // config-derived handle's Stdlib is never computed and the single-entry
+    // shortcut in `get_stdlib` does not apply.
+    let windows = SysInfo::new(PythonVersion::default(), PythonPlatform::windows());
+    let mac = SysInfo::new(PythonVersion::default(), PythonPlatform::mac());
+
+    let mut test_env = TestEnv::new();
+    test_env.add("lib", "CONST = 42\n");
+    // `main` does not import `lib`, so `lib` is demanded fresh during resolution.
+    test_env.add("main", "x = 1\n");
+    let config_file = test_env.config();
+    let state = State::new(test_env.config_finder(), TEST_THREAD_COUNT);
+
+    let f = |name: &str, sys_info: &SysInfo| {
+        let name = ModuleName::from_str(name);
+        let path = find_import(
+            &config_file,
+            name,
+            None,
+            None,
+            &DirEntryCache::new(true),
+            None,
+        )
+        .finding()
+        .unwrap();
+        Handle::new(name, path, sys_info.dupe())
+    };
+
+    let handles = [f("main", &windows), f("main", &mac)];
+    let mut transaction = state.new_transaction(Require::Exports, None);
+    transaction.set_memory(test_env.get_memory());
+    transaction.run(&handles, Require::Everything, None);
+
+    // Resolve `lib.CONST` from `main` (checked under `windows`). The fix inherits
+    // `windows`; the pre-fix code re-derives `linux` and panics in `get_stdlib`.
+    let source = f("main", &windows);
+    let location = resolve_export_location(
+        &transaction,
+        &source,
+        ModuleName::from_str("lib"),
+        &Name::new_static("CONST"),
+    );
+    assert!(
+        location.is_some(),
+        "expected lib.CONST to resolve against the source file's SysInfo"
+    );
 }
 
 #[test]

--- a/pyrefly/lib/tsp/requests/get_computed_type.rs
+++ b/pyrefly/lib/tsp/requests/get_computed_type.rs
@@ -28,17 +28,16 @@ impl<T: TspInterface> TspConnection<T> {
         self.validate_snapshot(params.snapshot)?;
         // Validate the URI is parseable (rejects malformed strings).
         // Any valid scheme is accepted — notebook cell URIs are resolved
-        // to notebook paths inside get_type_at_position.
+        // to notebook paths inside computed_type_at_range.
         parse_uri(params.uri())?;
         let start = params.position();
         let end = params.end_position();
-        let ty = self.inner().get_computed_type_at_range(
+        Ok(self.inner().computed_type_at_range(
             params.uri(),
             start.line,
             start.character,
             end.line,
             end.character,
-        );
-        Ok(ty.map(|t| self.convert_type(&t, Some(params.uri()))))
+        ))
     }
 }

--- a/pyrefly/lib/tsp/requests/get_declared_type.rs
+++ b/pyrefly/lib/tsp/requests/get_declared_type.rs
@@ -22,9 +22,9 @@ impl<T: TspInterface> TspConnection<T> {
     /// For example, `a: int | str` has declared type `int | str` even if
     /// type narrowing later restricts the computed type to `int`.
     ///
-    /// Currently piggy-backs on `get_type_at_position`, which returns the
-    /// computed type. A future improvement can separate the annotation type
-    /// from the inferred type in the binding infrastructure.
+    /// Currently piggy-backs on `type_at_position`, which returns the computed
+    /// type. A future improvement can separate the annotation type from the
+    /// inferred type in the binding infrastructure.
     pub fn handle_get_declared_type(
         &self,
         params: GetTypeParams,
@@ -32,12 +32,11 @@ impl<T: TspInterface> TspConnection<T> {
         self.validate_snapshot(params.snapshot)?;
         // Validate the URI is parseable (rejects malformed strings).
         // Any valid scheme is accepted — notebook cell URIs are resolved
-        // to notebook paths inside get_type_at_position.
+        // to notebook paths inside type_at_position.
         parse_uri(params.uri())?;
         let position = params.position();
-        let ty = self
+        Ok(self
             .inner()
-            .get_type_at_position(params.uri(), position.line, position.character);
-        Ok(ty.map(|t| self.convert_type(&t, Some(params.uri()))))
+            .type_at_position(params.uri(), position.line, position.character))
     }
 }

--- a/pyrefly/lib/tsp/requests/get_expected_type.rs
+++ b/pyrefly/lib/tsp/requests/get_expected_type.rs
@@ -29,14 +29,11 @@ impl<T: TspInterface> TspConnection<T> {
         self.validate_snapshot(params.snapshot)?;
         // Validate the URI is parseable (rejects malformed strings).
         // Any valid scheme is accepted — notebook cell URIs are resolved
-        // to notebook paths inside get_expected_type_at_position.
+        // to notebook paths inside expected_type_at_position.
         parse_uri(params.uri())?;
         let position = params.position();
-        let ty = self.inner().get_expected_type_at_position(
-            params.uri(),
-            position.line,
-            position.character,
-        );
-        Ok(ty.map(|t| self.convert_type(&t, Some(params.uri()))))
+        Ok(self
+            .inner()
+            .expected_type_at_position(params.uri(), position.line, position.character))
     }
 }

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -44,7 +44,6 @@ use crate::lsp::non_wasm::server::ServerCapabilitiesWithTypeHierarchy;
 use crate::lsp::non_wasm::server::TspInterface;
 use crate::lsp::non_wasm::server::capabilities;
 use crate::lsp::non_wasm::transaction_manager::TransactionManager;
-use crate::tsp::type_conversion::convert_type_with_resolvers;
 use crate::tsp::validation::internal_error;
 use crate::tsp::validation::invalid_params_error;
 use crate::tsp::validation::snapshot_outdated_error;
@@ -166,22 +165,6 @@ impl<T: TspInterface> TspConnection<T> {
     /// Convenience accessor for the inner LSP server.
     pub(crate) fn inner(&self) -> &T {
         &self.server.inner
-    }
-
-    /// Convert a pyrefly `Type` to a TSP protocol `Type`, resolving function
-    /// declaration ranges via the binding table.
-    pub(crate) fn convert_type(
-        &self,
-        ty: &pyrefly_types::types::Type,
-        source_uri: Option<&str>,
-    ) -> tsp_types::Type {
-        let resolver = |func_id: &pyrefly_types::callable::FuncId| {
-            self.inner().resolve_func_def_range(func_id)
-        };
-        let module_path_resolver = |module: &pyrefly_types::module::ModuleType| {
-            source_uri.and_then(|uri| self.inner().resolve_module_uri(uri, module))
-        };
-        convert_type_with_resolvers(ty, Some(&resolver), Some(&module_path_resolver), None)
     }
 
     fn send_response(&self, response: Response) {

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -181,7 +181,7 @@ impl<T: TspInterface> TspConnection<T> {
         let module_path_resolver = |module: &pyrefly_types::module::ModuleType| {
             source_uri.and_then(|uri| self.inner().resolve_module_uri(uri, module))
         };
-        convert_type_with_resolvers(ty, Some(&resolver), Some(&module_path_resolver))
+        convert_type_with_resolvers(ty, Some(&resolver), Some(&module_path_resolver), None)
     }
 
     fn send_response(&self, response: Response) {

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -35,6 +35,8 @@ use std::sync::atomic::AtomicI32;
 use std::sync::atomic::Ordering;
 
 use lsp_types::Url;
+use pyrefly_python::module_name::ModuleName;
+use pyrefly_python::module_path::ModulePath;
 use pyrefly_types::callable::Callable;
 use pyrefly_types::callable::FuncId;
 use pyrefly_types::callable::FunctionKind;
@@ -43,10 +45,13 @@ use pyrefly_types::callable_residual::CallableResidualKind;
 use pyrefly_types::class::Class;
 use pyrefly_types::class::ClassType as PyreflyClassType;
 use pyrefly_types::literal::Lit;
+use pyrefly_types::quantified::Quantified;
+use pyrefly_types::quantified::QuantifiedOrigin;
 use pyrefly_types::type_alias::TypeAliasData;
 use pyrefly_types::types::BoundMethodType;
 use pyrefly_types::types::Forallable;
 use pyrefly_types::types::Type as PyreflyType;
+use ruff_python_ast::name::Name;
 use ruff_text_size::TextRange;
 use tsp_types::BuiltInType;
 use tsp_types::ClassType as TspClassType;
@@ -91,16 +96,26 @@ pub type FuncRangeResolver<'a> = dyn Fn(&FuncId) -> Option<TextRange> + 'a;
 pub type ModulePathResolver<'a> =
     dyn Fn(&pyrefly_types::module::ModuleType) -> Option<PathBuf> + 'a;
 
+/// Callback that resolves an exported symbol (by defining module and name) to
+/// the `ModulePath` and `lsp_types::Range` of its original definition,
+/// following re-exports. Used to give real source locations to special forms,
+/// `typing` classes, and functions whose `FuncId` lacks a `def_index` (e.g.
+/// imported user functions and special functions like `typing.overload`).
+pub type ExportLocationResolver<'a> =
+    dyn Fn(ModuleName, &Name) -> Option<(ModulePath, lsp_types::Range)> + 'a;
+
 /// Convert a pyrefly `Type` to a TSP protocol `Type` using optional
 /// source-range and module-URI resolvers.
 pub fn convert_type_with_resolvers<'a>(
     ty: &PyreflyType,
     func_range_resolver: Option<&'a FuncRangeResolver<'a>>,
     module_path_resolver: Option<&'a ModulePathResolver<'a>>,
+    export_location_resolver: Option<&'a ExportLocationResolver<'a>>,
 ) -> TspType {
     TypeConverter {
         resolve_func_range: func_range_resolver,
         resolve_module_path: module_path_resolver,
+        resolve_export: export_location_resolver,
     }
     .convert(ty)
 }
@@ -112,13 +127,14 @@ pub fn convert_type_with_resolvers<'a>(
 /// locations are needed.
 #[cfg(test)]
 pub fn convert_type(ty: &PyreflyType) -> TspType {
-    convert_type_with_resolvers(ty, None, None)
+    convert_type_with_resolvers(ty, None, None, None)
 }
 
 /// Holds an optional range resolver and drives recursive type conversion.
 struct TypeConverter<'a> {
     resolve_func_range: Option<&'a FuncRangeResolver<'a>>,
     resolve_module_path: Option<&'a ModulePathResolver<'a>>,
+    resolve_export: Option<&'a ExportLocationResolver<'a>>,
 }
 
 impl TypeConverter<'_> {
@@ -291,7 +307,7 @@ impl TypeConverter<'_> {
             // These are TypeVar-like solver-internal placeholders. Emit them as
             // TSP TypeVar so consumers don't see them as malformed BuiltIns.
             PyreflyType::Quantified(q) | PyreflyType::QuantifiedValue(q) => {
-                synthesized_typevar(q.name.as_str())
+                self.convert_quantified(q)
             }
 
             // --- LiteralString → typing.LiteralString class ---
@@ -444,29 +460,7 @@ impl TypeConverter<'_> {
         bound_to_type: Option<Box<TspType>>,
     ) -> TspType {
         let ret = self.convert(&callable.ret);
-        let declaration = if let FunctionKind::Def(func_id) = kind {
-            let module_path = func_id.module.path();
-            let uri = path_to_uri(module_path);
-            let range = self
-                .resolve_func_range
-                .and_then(|resolver| resolver(func_id))
-                .unwrap_or_default();
-            let lsp_range = func_id.module.to_lsp_range(range);
-            Declaration::Regular(RegularDeclaration {
-                category: DeclarationCategory::Function,
-                kind: DeclarationKind::Regular,
-                name: Some(func_id.name.to_string()),
-                node: Node {
-                    range: lsp_range_to_tsp(lsp_range),
-                    uri,
-                },
-            })
-        } else {
-            Declaration::Synthesized(SynthesizedDeclaration {
-                kind: DeclarationKind::Synthesized,
-                uri: String::new(),
-            })
-        };
+        let declaration = self.function_declaration(kind);
         let specialized_types = self.specialized_types(callable, &ret);
 
         TspType::Function(TspFunctionType {
@@ -512,14 +506,119 @@ impl TypeConverter<'_> {
         })
     }
 
-    /// Build a TSP `ClassType` whose declaration points at `typing.<name>`.
+    /// Convert a `Quantified` (solver-internal TypeVar placeholder) to a TSP
+    /// `TypeVar`.
+    ///
+    /// A `Quantified` carries a `QuantifiedIdentity` pinning the source module
+    /// and range where its TypeVar was declared. When the export-location
+    /// resolver can map that `(module, name)` back to a real definition we
+    /// build a `RegularDeclaration` with the true source location, so Pylance
+    /// resolves the declaration and renders the TypeVar's name instead of
+    /// `Unknown`. Otherwise we fall back to a synthesized (locationless)
+    /// declaration.
+    fn convert_quantified(&self, q: &Quantified) -> TspType {
+        if let Some(resolve) = self.resolve_export {
+            let identity = q.identity();
+            if let Some((module_path, lsp_range)) = resolve(identity.module, &q.name) {
+                // A PEP 695 type parameter (`def f[T]()`) is a real type-param
+                // declaration; a legacy `T = TypeVar("T")` resolves to a module-
+                // level *variable* in the consumer. Use the matching category so
+                // Pylance's declaration lookup succeeds.
+                let category = match identity.origin {
+                    QuantifiedOrigin::Pep695 => DeclarationCategory::Typeparam,
+                    _ => DeclarationCategory::Variable,
+                };
+                return TspType::Var(DeclaredType {
+                    declaration: Declaration::Regular(RegularDeclaration {
+                        category,
+                        kind: DeclarationKind::Regular,
+                        name: Some(q.name.to_string()),
+                        node: Node {
+                            range: lsp_range_to_tsp(lsp_range),
+                            uri: path_to_uri(&module_path),
+                        },
+                    }),
+                    flags: TypeFlags::NONE,
+                    id: next_id(),
+                    kind: TypeKind::Typevar,
+                    type_alias_info: None,
+                });
+            }
+        }
+
+        synthesized_typevar(q.name.as_str())
+    }
+
+    /// Build a declaration for a function described by `kind`.
+    ///
+    /// Resolution order:
+    ///  1. A `Def` whose `FuncId` carries a `def_index`: use the binding-table
+    ///     range via `resolve_func_range`.
+    ///  2. Otherwise, resolve the function by `(module, name)` through the
+    ///     export-location resolver. This covers imported user functions whose
+    ///     `FuncId` lacks a `def_index`, and special functions that are not
+    ///     `Def` at all (e.g. `typing.overload`).
+    ///  3. Fall back to a zero range pointing at the defining module (for
+    ///     `Def`), or a synthesized declaration when even the module is unknown.
+    fn function_declaration(&self, kind: &FunctionKind) -> Declaration {
+        if let FunctionKind::Def(func_id) = kind
+            && let Some(range) = self.resolve_func_range.and_then(|resolve| resolve(func_id))
+        {
+            let lsp_range = func_id.module.to_lsp_range(range);
+            return Declaration::Regular(RegularDeclaration {
+                category: DeclarationCategory::Function,
+                kind: DeclarationKind::Regular,
+                name: Some(func_id.name.to_string()),
+                node: Node {
+                    range: lsp_range_to_tsp(lsp_range),
+                    uri: path_to_uri(func_id.module.path()),
+                },
+            });
+        }
+
+        let name = kind.function_name();
+        if let Some((module_path, lsp_range)) = self
+            .resolve_export
+            .and_then(|resolve| resolve(kind.module_name(), name.as_ref()))
+        {
+            return Declaration::Regular(RegularDeclaration {
+                category: DeclarationCategory::Function,
+                kind: DeclarationKind::Regular,
+                name: Some(name.to_string()),
+                node: Node {
+                    range: lsp_range_to_tsp(lsp_range),
+                    uri: path_to_uri(&module_path),
+                },
+            });
+        }
+
+        if let FunctionKind::Def(func_id) = kind {
+            return Declaration::Regular(RegularDeclaration {
+                category: DeclarationCategory::Function,
+                kind: DeclarationKind::Regular,
+                name: Some(func_id.name.to_string()),
+                node: Node {
+                    range: zero_range(),
+                    uri: path_to_uri(func_id.module.path()),
+                },
+            });
+        }
+
+        Declaration::Synthesized(SynthesizedDeclaration {
+            kind: DeclarationKind::Synthesized,
+            uri: String::new(),
+        })
+    }
+
+    /// Build a TSP `ClassType` whose declaration points at `typing.<name>`,
+    /// resolving the real definition range from the typeshed when possible.
     /// Used for `SpecialForm`, anonymous `TypedDict`, `LiteralString`,
     /// `Concatenate`, `ParamSpec`, and `TypeAlias::Ref` where pyrefly does not
     /// have an explicit `Class` backing but the consumer needs a typed handle
     /// it can render and resolve via the typeshed.
     fn typing_class(&self, name: &str, flags: TypeFlags) -> TspType {
         TspType::Class(TspClassType {
-            declaration: Declaration::Regular(make_typing_class_declaration(name)),
+            declaration: Declaration::Regular(self.typing_class_declaration(name)),
             flags,
             id: next_id(),
             kind: TypeKind::Class,
@@ -527,6 +626,28 @@ impl TypeConverter<'_> {
             type_alias_info: None,
             type_args: None,
         })
+    }
+
+    /// Build a class declaration for `typing.<name>`. Resolves the real source
+    /// range via the export-location resolver; falls back to a zero range
+    /// pointing at bundled `typing.pyi` when unavailable.
+    fn typing_class_declaration(&self, name: &str) -> RegularDeclaration {
+        let symbol = Name::new(name);
+        if let Some((module_path, lsp_range)) = self
+            .resolve_export
+            .and_then(|resolve| resolve(ModuleName::typing(), &symbol))
+        {
+            return RegularDeclaration {
+                kind: DeclarationKind::Regular,
+                category: DeclarationCategory::Class,
+                name: Some(name.to_owned()),
+                node: Node {
+                    range: lsp_range_to_tsp(lsp_range),
+                    uri: path_to_uri(&module_path),
+                },
+            };
+        }
+        make_typing_class_declaration(name)
     }
 
     /// Convert a pyrefly `Overload` to a TSP `OverloadedType`.
@@ -805,9 +926,7 @@ mod tests {
     use pyrefly_types::literal::LitStyle;
     use pyrefly_types::module::ModuleType;
     use pyrefly_types::quantified::AnchorIndex;
-    use pyrefly_types::quantified::Quantified;
     use pyrefly_types::quantified::QuantifiedIdentity;
-    use pyrefly_types::quantified::QuantifiedOrigin;
     use pyrefly_types::special_form::SpecialForm;
     use pyrefly_types::type_var::PreInferenceVariance;
     use pyrefly_types::type_var::Restriction;
@@ -815,7 +934,6 @@ mod tests {
     use pyrefly_types::types::NeverStyle;
     use pyrefly_types::types::Type as PyreflyType;
     use pyrefly_types::types::Var;
-    use ruff_python_ast::name::Name;
     use tsp_types::SynthesizedType;
     use tsp_types::SynthesizedTypeMetadata;
 
@@ -1164,7 +1282,7 @@ mod tests {
                 None
             }
         };
-        let tsp = convert_type_with_resolvers(&ty, None, Some(&module_path_resolver));
+        let tsp = convert_type_with_resolvers(&ty, None, Some(&module_path_resolver), None);
         match tsp {
             TspType::Module(m) => {
                 assert_eq!(m.module_name, "pkg");
@@ -1208,6 +1326,45 @@ mod tests {
                 };
                 assert_eq!(decl.name.as_deref(), Some("Literal"));
                 assert_eq!(decl.category, DeclarationCategory::Class);
+                assert!(
+                    decl.node.uri.contains("typing.pyi"),
+                    "expected typing URI, got {}",
+                    decl.node.uri
+                );
+            }
+            other => panic!("expected Class, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_special_form_uses_export_resolver_location() {
+        // When an export resolver is available, the typing class declaration
+        // should carry the resolved source location instead of a zero range.
+        let ty = PyreflyType::SpecialForm(SpecialForm::Final);
+        let range = lsp_types::Range {
+            start: lsp_types::Position {
+                line: 99,
+                character: 0,
+            },
+            end: lsp_types::Position {
+                line: 99,
+                character: 5,
+            },
+        };
+        let resolver = |module: ModuleName, name: &Name| {
+            assert_eq!(module, ModuleName::typing());
+            assert_eq!(name.as_str(), "Final");
+            Some((
+                ModulePath::filesystem(PathBuf::from("/typeshed/typing.pyi")),
+                range,
+            ))
+        };
+        match convert_type_with_resolvers(&ty, None, None, Some(&resolver)) {
+            TspType::Class(c) => {
+                let Declaration::Regular(decl) = c.declaration else {
+                    panic!("expected RegularDeclaration");
+                };
+                assert_eq!(decl.node.range.start.line, 99);
                 assert!(
                     decl.node.uri.contains("typing.pyi"),
                     "expected typing URI, got {}",
@@ -1290,6 +1447,75 @@ mod tests {
     }
 
     #[test]
+    fn test_convert_pep695_quantified_with_resolver_uses_source_location() {
+        // A PEP 695 type parameter resolves to a Typeparam declaration at the
+        // resolved source location.
+        let ty = PyreflyType::Quantified(Box::new(make_quantified(
+            "T",
+            "mymod",
+            QuantifiedOrigin::Pep695,
+        )));
+        let range = lsp_types::Range {
+            start: lsp_types::Position {
+                line: 3,
+                character: 6,
+            },
+            end: lsp_types::Position {
+                line: 3,
+                character: 7,
+            },
+        };
+        let resolver = |module: ModuleName, name: &Name| {
+            assert_eq!(module, ModuleName::from_str("mymod"));
+            assert_eq!(name.as_str(), "T");
+            Some((
+                ModulePath::filesystem(PathBuf::from("/repo/mymod.py")),
+                range,
+            ))
+        };
+        match convert_type_with_resolvers(&ty, None, None, Some(&resolver)) {
+            TspType::Var(v) => {
+                let Declaration::Regular(decl) = v.declaration else {
+                    panic!("expected RegularDeclaration");
+                };
+                assert_eq!(decl.category, DeclarationCategory::Typeparam);
+                assert_eq!(decl.node.range.start.line, 3);
+                assert!(
+                    decl.node.uri.contains("mymod.py"),
+                    "expected resolved URI, got {}",
+                    decl.node.uri
+                );
+            }
+            other => panic!("expected Var, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_convert_legacy_quantified_with_resolver_is_variable_category() {
+        // A legacy `T = TypeVar("T")` resolves to a module-level *variable*.
+        let ty = PyreflyType::Quantified(Box::new(make_quantified(
+            "T",
+            "mymod",
+            QuantifiedOrigin::ScopedLegacy,
+        )));
+        let resolver = |_module: ModuleName, _name: &Name| {
+            Some((
+                ModulePath::filesystem(PathBuf::from("/repo/mymod.py")),
+                lsp_types::Range::default(),
+            ))
+        };
+        match convert_type_with_resolvers(&ty, None, None, Some(&resolver)) {
+            TspType::Var(v) => {
+                let Declaration::Regular(decl) = v.declaration else {
+                    panic!("expected RegularDeclaration");
+                };
+                assert_eq!(decl.category, DeclarationCategory::Variable);
+            }
+            other => panic!("expected Var, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_convert_args_is_synthesized_typevar() {
         // ParamSpec-related internal placeholders become synthesized TypeVars.
         let ty = PyreflyType::Args(Box::new(make_quantified(
@@ -1346,6 +1572,50 @@ mod tests {
                     other => panic!("expected BuiltInType, got {other:?}"),
                 }
                 assert!(specialized.return_type.is_some());
+            }
+            other => panic!("expected Function, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_function_declaration_resolves_special_function_via_export() {
+        // `typing.overload` is FunctionKind::Overload (not a Def). The export
+        // resolver should give it a real declaration location.
+        let callable = Callable::list(ParamList::new(vec![]), PyreflyType::None);
+        let func = Function {
+            signature: callable,
+            metadata: FuncMetadata {
+                kind: FunctionKind::Overload,
+                flags: FuncFlags::default(),
+            },
+        };
+        let ty = PyreflyType::Function(Box::new(func));
+        let range = lsp_types::Range {
+            start: lsp_types::Position {
+                line: 12,
+                character: 4,
+            },
+            end: lsp_types::Position {
+                line: 12,
+                character: 12,
+            },
+        };
+        let resolver = |module: ModuleName, name: &Name| {
+            assert_eq!(module, ModuleName::typing());
+            assert_eq!(name.as_str(), "overload");
+            Some((
+                ModulePath::filesystem(PathBuf::from("/typeshed/typing.pyi")),
+                range,
+            ))
+        };
+        match convert_type_with_resolvers(&ty, None, None, Some(&resolver)) {
+            TspType::Function(f) => {
+                let Declaration::Regular(decl) = f.declaration else {
+                    panic!("expected RegularDeclaration");
+                };
+                assert_eq!(decl.name.as_deref(), Some("overload"));
+                assert_eq!(decl.category, DeclarationCategory::Function);
+                assert_eq!(decl.node.range.start.line, 12);
             }
             other => panic!("expected Function, got {other:?}"),
         }


### PR DESCRIPTION
Summary:

With the converter able to resolve export locations ([1/2]), the server must supply a resolver that actually finds them. Resolving a location demands the target module's exports, which demands its `Stdlib`. Spinning up a fresh transaction per lookup starts cold and would panic in `get_stdlib` unless warmed by an extra `Require::Exports` run.

Instead the server now reuses the single transaction that already produced the type. Computing a type necessarily populated that transaction's `Stdlib`, so the export lookups are warm by construction — no warm-up run, no cold-start guard, and one transaction per query instead of one per resolved symbol. The target handle is reached via `import_handle` so it inherits the source file's `SysInfo`; re-deriving it from the module path would pick a config-default `SysInfo` whose `Stdlib` was never computed and panic once the transaction holds more than one `SysInfo`.

To put the resolver where that transaction lives, type conversion moves server-side: `type_at_position`/`computed_type_at_range`/`expected_type_at_position` now return the TSP wire type directly, collapsing the previous five `TspInterface` methods into two and removing the per-call `convert_type` on the connection. `lookup_export_location` becomes `pub(crate)` so the converter seam can reach it.

Differential Revision: D108667579


