### PR TITLE
Fix TypedDict get literal defaults

### DIFF
--- a/pyrefly/lib/alt/class/typed_dict.rs
+++ b/pyrefly/lib/alt/class/typed_dict.rs
@@ -466,6 +466,27 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }))
     }
 
+    /// Get a (key, default: ValueType) -> ValueType overload.
+    fn get_overload_with_value_default(
+        &self,
+        metadata: &FuncMetadata,
+        self_param: &Param,
+        name: Option<&Name>,
+        ty: Type,
+    ) -> OverloadType {
+        OverloadType::Function(Function {
+            signature: Callable::list(
+                ParamList::new(vec![
+                    self_param.clone(),
+                    self.key_param(name),
+                    Param::PosOnly(Some(DEFAULT_PARAM.clone()), ty.clone(), Required::Required),
+                ]),
+                ty,
+            ),
+            metadata: metadata.clone(),
+        })
+    }
+
     /// Get a (key, default: T) -> ValueType | T overload.
     fn get_overload_with_default(
         &self,
@@ -552,6 +573,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     ),
                     metadata: metadata.clone(),
                 }));
+                // (self, key: Literal["key"], default: ValueType) -> ValueType
+                literal_signatures.push(self.get_overload_with_value_default(
+                    &metadata,
+                    &self_param,
+                    Some(name),
+                    field.ty.clone(),
+                ));
                 // (self, key: Literal["key"], default: T) -> ValueType | T
                 literal_signatures.push(self.get_overload_with_default(
                     cls,
@@ -634,7 +662,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             metadata: metadata.clone(),
         }));
 
-        // 2) default: (self, key: Literal["field_name"], default: _T) -> FieldType | _T
+        // 2) default: (self, key: Literal["field_name"], default: FieldType) -> FieldType
+        overloads.push(self.get_overload_with_value_default(
+            metadata,
+            self_param,
+            name,
+            ty.clone(),
+        ));
+
+        // 3) default: (self, key: Literal["field_name"], default: _T) -> FieldType | _T
         overloads.push(self.get_overload_with_default(cls, metadata, self_param, name, ty));
     }
 

--- a/pyrefly/lib/test/typed_dict.rs
+++ b/pyrefly/lib/test/typed_dict.rs
@@ -931,6 +931,17 @@ def f(c: C):
     "#,
 );
 
+testcase!(
+    test_get_not_required_literal_default,
+    r#"
+from typing import assert_type, Literal, NotRequired, TypedDict
+class C(TypedDict):
+    x: NotRequired[Literal["a", "b"]]
+def f(c: C):
+    assert_type(c.get("x", "b"), Literal["a", "b"])
+    "#,
+);
+
 // Clearing a TypedDict is not allowed, since doing so would remove keys it's expected to have.
 testcase!(
     test_clear,


### PR DESCRIPTION
# Summary

Fixes #3787

Add a field-typed default overload when synthesizing `TypedDict.get` and `TypedDict.pop` methods:

```text
(key: Literal["field"], default: FieldType) -> FieldType
```

This overload is tried before the existing generic default overload, so defaults that are already assignable to the field type keep the field type. For a non-required field typed as `Literal["a", "b"]`, `.get("x", "b")` now resolves to `Literal["a", "b"]` instead of `Literal["a", "b"] | str`.

Defaults outside the field type still use the generic `_T` overload and keep the existing `FieldType | T` behavior.

# Test Plan

```bash
cargo fmt
cargo test -p pyrefly test_get_not_required_literal_default -- --nocapture
cargo test -p pyrefly test_get -- --nocapture
cargo test -p pyrefly test_pop -- --nocapture
```