### PR TITLE
fix new rule - ban raw-string quoted types #3761

### DIFF
--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -1224,6 +1224,13 @@ impl<'a> BindingsBuilder<'a> {
             Expr::StringLiteral(literal)
                 if let Some(literal) = as_forward_ref(literal, in_string_literal) =>
             {
+                if literal.flags.prefix().is_raw() {
+                    self.error(
+                        literal.range(),
+                        ErrorKind::InvalidAnnotation,
+                        "Raw string literals are not allowed in type expressions".to_owned(),
+                    );
+                }
                 match Ast::parse_type_literal(literal) {
                     Ok(expr) => {
                         *x = expr;

--- a/pyrefly/lib/test/annotation.rs
+++ b/pyrefly/lib/test/annotation.rs
@@ -23,6 +23,15 @@ assert_type(D.x, int)  # E: assert_type(Unknown, int) failed
 );
 
 testcase!(
+    test_raw_string_type_annotation,
+    r#"
+def f(x: r"int") -> R"str":  # E: Raw string literals are not allowed in type expressions  # E: Raw string literals are not allowed in type expressions
+    y: r"bool" = True  # E: Raw string literals are not allowed in type expressions
+    return ""
+"#,
+);
+
+testcase!(
     test_union_operator_with_bare_string_literal,
     TestEnv::new_with_version(PythonVersion::new(3, 13, 0)),
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3761

raw quoted type expressions like r"int" now emit InvalidAnnotation, while still parsing the annotation afterward to avoid extra cascade errors.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test