### PR TITLE
Inline `collect_dunder_all_or_empty` in `pyrefly coverage`

### DIFF
--- a/pyrefly/lib/commands/coverage/collect.rs
+++ b/pyrefly/lib/commands/coverage/collect.rs
@@ -1094,10 +1094,6 @@ fn collect_dunder_all(transaction: &Transaction, handle: &Handle) -> Option<Smal
         .map(|it| it.cloned().collect())
 }
 
-fn collect_dunder_all_or_empty(transaction: &Transaction, handle: &Handle) -> SmallSet<Name> {
-    collect_dunder_all(transaction, handle).unwrap_or_default()
-}
-
 /// The `(module_prefix, __all__ FQNs)` that gate which `.py`-only symbols a stub merge keeps,
 /// or `None` when the stub has no explicit `__all__` (leaving the merge unfiltered).
 fn stub_merge_filter(
@@ -1380,7 +1376,7 @@ impl ModuleSymbols {
         let module = transaction.get_module_info(handle)?;
         let answers = transaction.get_answers(handle)?;
         let exports = transaction.get_exports(handle);
-        let dunder_all = collect_dunder_all_or_empty(transaction, handle);
+        let dunder_all = collect_dunder_all(transaction, handle).unwrap_or_default();
         let tco_classes = collect_type_check_only_classes(&bindings);
         let mut functions = parse_functions(
             &module,


### PR DESCRIPTION
# Summary

The single-line internal `collect_dunder_all_or_empty` helper function was only used once, so this inlines it.

And I hear you thinking: "Wow, awesome, this should definitely be a highlight on the release notes!". But to be honest, I'm not sure if this is as exciting as it sounds like.

# Test Plan

Just winging it