### PR TITLE
Iterate a TypeVar through its upper bound when unpacking

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -867,6 +867,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::Var(v) if let Some(_guard) = self.recurse(*v) => {
                 self.iterate(&self.solver().force_var(*v), range, errors, orig_context)
             }
+            Type::Quantified(q) if q.is_type_var() => {
+                // A TypeVar iterates like its upper bound: `Z: tuple[str, int]` must
+                // unpack positionally rather than collapse to the element join via the
+                // iterable protocol. Mirrors attribute access on a bounded TypeVar.
+                self.iterate(
+                    &q.upper_bound(self.stdlib, self.heap),
+                    range,
+                    errors,
+                    orig_context,
+                )
+            }
             Type::Union(f) => f
                 .members
                 .iter()

--- a/pyrefly/lib/test/tuple.rs
+++ b/pyrefly/lib/test/tuple.rs
@@ -371,6 +371,79 @@ def test[*Ts](x1: tuple[int, *tuple[str, ...]], x2: tuple[*Ts]) -> None:
 );
 
 testcase!(
+    test_unpack_typevar_bound_to_tuple,
+    r#"
+from typing import reveal_type
+def f[Z: tuple[str, int]](x: Z):
+    u, v = x
+    reveal_type(u)  # E: revealed type: str
+    reveal_type(v)  # E: revealed type: int
+"#,
+);
+
+testcase!(
+    test_unpack_typevar_bound_to_tuple_three_elements,
+    r#"
+from typing import reveal_type
+def f[Z: tuple[str, int, bytes]](x: Z):
+    a, b, c = x
+    reveal_type(a)  # E: revealed type: str
+    reveal_type(b)  # E: revealed type: int
+    reveal_type(c)  # E: revealed type: bytes
+"#,
+);
+
+testcase!(
+    test_unpack_typevar_bound_to_unbounded_tuple,
+    r#"
+from typing import reveal_type
+def f[Z: tuple[int, ...]](x: Z):
+    a, b = x
+    reveal_type(a)  # E: revealed type: int
+    reveal_type(b)  # E: revealed type: int
+"#,
+);
+
+testcase!(
+    test_unpack_typevar_bound_to_tuple_starred,
+    r#"
+from typing import reveal_type
+def f[Z: tuple[str, int, bytes]](x: Z):
+    a, *b = x
+    reveal_type(a)  # E: revealed type: str
+    reveal_type(b)  # E: revealed type: list[bytes | int]
+"#,
+);
+
+testcase!(
+    test_unpack_constrained_typevar_tuple,
+    r#"
+from typing import TypeVar, reveal_type
+Z = TypeVar("Z", tuple[str, int], tuple[bool, bytes])
+def f(x: Z):
+    a, b = x
+    reveal_type(a)  # E: revealed type: bool | str
+    reveal_type(b)  # E: revealed type: bytes | int
+"#,
+);
+
+testcase!(
+    test_unpack_typevar_unbounded_not_iterable,
+    r#"
+def f[Z](x: Z):
+    a, b = x  # E: Type `object` is not iterable
+"#,
+);
+
+testcase!(
+    test_unpack_typevar_bound_not_iterable,
+    r#"
+def f[Z: int](x: Z):
+    a, b = x  # E: Type `int` is not iterable
+"#,
+);
+
+testcase!(
     test_tuple_slice_non_literal,
     r#"
 from typing import assert_type


### PR DESCRIPTION
Fixes facebook/pyrefly#3841

### What

Unpacking a value whose type is a TypeVar bounded by a tuple now preserves the
positional element types, matching the behavior of the equivalent
direct-tuple parameter.

```python
def incorrect_deduction[Z: tuple[str, int]](x: Z):
    u, v = x
    reveal_type(u)  # before: int | str   after: str
    reveal_type(v)  # before: int | str   after: int

def correct_deduction(x: tuple[str, int]):
    u, v = x
    reveal_type(u)  # str  (always correct)
    reveal_type(v)  # int
```

pyright (`str*`/`int*`), mypy (`str`/`int`), and ty (`str`/`int`) all produce the
positional types; pyrefly was the outlier.

### Why

A bounded TypeVar `Z <: tuple[str, int]` is, within the body, a fixed-shape
2-tuple: position 0 is a `str`, position 1 an `int`. Unpacking should hand back
those labelled positions.

`AnswersSolver::iterate` had explicit arms for concrete tuples, `Type::Var`, and
`Type::Union`, but **no arm for `Type::Quantified`**. A bounded TypeVar therefore
fell through to the generic iterable-protocol fallback, which views the value as
`Iterable[T]` for a single `T` and collapses the tuple to the *join* of its
element types (`str | int`). Because that fallback yields one element type for
every index, both `u` and `v` came out `int | str`.

### How

`pyrefly/lib/alt/solve.rs` — add one arm to `iterate`:

```rust
Type::Quantified(q) if q.is_type_var() => {
    self.iterate(&q.upper_bound(self.stdlib, self.heap), range, errors, orig_context)
}
```

A TypeVar iterates like its upper bound. The same resolve-through-the-bound rule
already used for attribute access on a bounded TypeVar (`attr.rs`). Reusing
`Quantified::upper_bound` means the existing arms handle every restriction shape
with no extra branching:

- **Bound** (`tuple[str, int]`) → recurses into the concrete-tuple arm → positions preserved.
- **Bound** (`list[int]`) → recurses into the fallback → `int` — identical to today.
- **Constraints** → union → the `Type::Union` arm → per-position union.
- **Unrestricted** → `object` → not iterable → correct error.

Guarded on `q.is_type_var()`, so ParamSpec and TypeVarTuple are untouched (a
`*Ts` inside a tuple is still handled by the existing `Tuple::Unpacked` arm).

Deliberately not touched: `binding_to_type_unpacked_value` and the iterable
protocol were already correct; the only gap was the missing arm. The
not-iterable error for a non-iterable bound now names the bound (e.g. `object`,
`int`) rather than the TypeVar. This matches what pyright and mypy already
report.

### Test plan

New `testcase!`s in `pyrefly/lib/test/tuple.rs`:

| Test | Protects |
|---|---|
| `test_unpack_typevar_bound_to_tuple` | the repro: `Z: tuple[str, int]` → `str`, `int` |
| `test_unpack_typevar_bound_to_tuple_three_elements` | 3-element bound stays positional |
| `test_unpack_typevar_bound_to_unbounded_tuple` | `tuple[int, ...]` bound → `int` per target |
| `test_unpack_typevar_bound_to_tuple_starred` | starred `a, *b` through the bound |
| `test_unpack_constrained_typevar_tuple` | constrained TypeVar → per-position union |
| `test_unpack_typevar_unbounded_not_iterable` | unbounded `Z` still errors (no over-broadening) |
| `test_unpack_typevar_bound_not_iterable` | non-iterable bound (`Z: int`) still errors |

- `cargo test -p pyrefly --lib`: **5723 passed, 0 failed**
- Formatting + lint (`test.py --no-test --no-conformance --no-jsonschema`): clean
- Conformance: clean, no generated changes
- `mypy_primer` (~52 projects incl. pandas, pandas-stubs, pydantic, sympy, scipy-stubs, xarray, attrs, pandera): **0 diagnostic diffs** — no regressions