### PR TITLE
fix(stubgen): emit callable-typed values as valid `typing.Callable`

### DIFF
--- a/pyrefly/lib/stubgen/emit.rs
+++ b/pyrefly/lib/stubgen/emit.rs
@@ -18,15 +18,22 @@ use crate::stubgen::extract::StubVariable;
 pub fn emit_stub(stub: &ModuleStub) -> String {
     let mut out = String::new();
 
+    let mut typing_names = Vec::new();
+    if stub.uses_callable {
+        typing_names.push("Callable");
+    }
     if stub.uses_self {
-        out.push_str("from typing import Self\n");
+        typing_names.push("Self");
+    }
+    if !typing_names.is_empty() {
+        out.push_str(&format!("from typing import {}\n", typing_names.join(", ")));
     }
 
     if stub.uses_incomplete {
         out.push_str("from _typeshed import Incomplete\n");
     }
 
-    if stub.uses_self || stub.uses_incomplete {
+    if !typing_names.is_empty() || stub.uses_incomplete {
         out.push('\n');
     }
 

--- a/pyrefly/lib/stubgen/extract.rs
+++ b/pyrefly/lib/stubgen/extract.rs
@@ -518,7 +518,7 @@ fn callable_ellipsis(ret: &Type, ctx: &mut ExtractionContext) -> String {
 
 /// Render an overload set. If every signature shares the same return type we
 /// can render `Callable[..., Ret]`; otherwise there is no single faithful
-/// return type, so fall back to `Incomplete`.
+/// return type, so fall back to `Callable[..., Incomplete]` (still a callable).
 fn format_overload(overload: &Overload, ctx: &mut ExtractionContext) -> String {
     let ret = |sig: &OverloadType| -> Type {
         match sig {
@@ -530,8 +530,9 @@ fn format_overload(overload: &Overload, ctx: &mut ExtractionContext) -> String {
     if overload.signatures.iter().all(|s| ret(s) == first) {
         callable_ellipsis(&first, ctx)
     } else {
+        ctx.uses_callable = true;
         ctx.uses_incomplete = true;
-        "Incomplete".to_owned()
+        "Callable[..., Incomplete]".to_owned()
     }
 }
 

--- a/pyrefly/lib/stubgen/extract.rs
+++ b/pyrefly/lib/stubgen/extract.rs
@@ -18,10 +18,15 @@ use pyrefly_build::handle::Handle;
 use pyrefly_python::module::Module;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_python::sys_info::SysInfo;
+use pyrefly_types::callable::Callable;
 use pyrefly_types::callable::Param;
 use pyrefly_types::callable::Params;
 use pyrefly_types::callable::Required;
 use pyrefly_types::display::TypeDisplayContext;
+use pyrefly_types::types::BoundMethodType;
+use pyrefly_types::types::Forallable;
+use pyrefly_types::types::Overload;
+use pyrefly_types::types::OverloadType;
 use pyrefly_types::types::Type;
 use ruff_python_ast::Expr;
 use ruff_python_ast::Operator;
@@ -53,6 +58,9 @@ pub struct ModuleStub {
     /// emit `from _typeshed import Incomplete`).
     pub uses_incomplete: bool,
     pub uses_self: bool,
+    /// Whether any item renders a `Callable[...]` annotation (so we know
+    /// whether to emit `from typing import Callable`).
+    pub uses_callable: bool,
 }
 
 pub enum StubItem {
@@ -138,6 +146,7 @@ pub fn extract_module_stub(
         config,
         uses_incomplete: false,
         uses_self: false,
+        uses_callable: false,
         function_map: &function_map,
         dunder_all: &dunder_all,
     };
@@ -148,6 +157,7 @@ pub fn extract_module_stub(
         items,
         uses_incomplete: ctx.uses_incomplete,
         uses_self: ctx.uses_self,
+        uses_callable: ctx.uses_callable,
     })
 }
 
@@ -158,6 +168,7 @@ struct ExtractionContext<'a> {
     config: &'a ExtractConfig,
     uses_incomplete: bool,
     uses_self: bool,
+    uses_callable: bool,
     function_map: &'a HashMap<TextRange, DecoratedFunction>,
     /// When `__all__` is explicitly defined, only these names are exported
     /// at module level. `None` means no explicit `__all__` — use convention.
@@ -421,6 +432,12 @@ fn format_type(ty: &Type, ctx: &mut ExtractionContext) -> Option<String> {
         ctx.uses_incomplete = true;
         return Some("Incomplete".to_owned());
     }
+    // pyrefly's internal type display renders function and overload types using
+    // a non-Python `(args) -> ret` / `Overload[...]` syntax and never imports the
+    // referenced names. Translate them to valid `typing.Callable[...]` instead.
+    if let Some(s) = format_callable_type(ty, ctx) {
+        return Some(s);
+    }
     if ty.any(|sub_type| matches!(sub_type, Type::SelfType(_))) {
         ctx.uses_self = true;
     }
@@ -432,6 +449,90 @@ fn format_type(ty: &Type, ctx: &mut ExtractionContext) -> Option<String> {
         return Some("Incomplete".to_owned());
     }
     Some(s)
+}
+
+/// Render a callable-typed value as a valid `typing.Callable[...]` annotation,
+/// or `None` if `ty` is not a callable type.
+fn format_callable_type(ty: &Type, ctx: &mut ExtractionContext) -> Option<String> {
+    match ty {
+        Type::Function(func) => Some(callable_from_signature(&func.signature, ctx)),
+        Type::Callable(callable) => Some(callable_from_signature(callable, ctx)),
+        Type::BoundMethod(method) => match &method.func {
+            // Drop the bound `self`/`cls` parameter before rendering.
+            BoundMethodType::Function(func) => {
+                let sig = func
+                    .signature
+                    .strip_first_param()
+                    .unwrap_or_else(|| func.signature.clone());
+                Some(callable_from_signature(&sig, ctx))
+            }
+            // Generic methods: parameters can't be faithfully expressed.
+            BoundMethodType::Forall(forall) => {
+                Some(callable_ellipsis(&forall.body.signature.ret, ctx))
+            }
+            BoundMethodType::Overload(overload) => Some(format_overload(overload, ctx)),
+        },
+        Type::Overload(overload) => Some(format_overload(overload, ctx)),
+        // A generic (`Forall`) function/callable: parameters carry type
+        // variables we can't faithfully express, so elide them.
+        Type::Forall(forall) => match &forall.body {
+            Forallable::Function(func) => Some(callable_ellipsis(&func.signature.ret, ctx)),
+            Forallable::Callable(callable) => Some(callable_ellipsis(&callable.ret, ctx)),
+            Forallable::TypeAlias(_) => None,
+        },
+        _ => None,
+    }
+}
+
+/// Render `Callable[[arg, ...], Ret]` when the parameter list is a plain
+/// sequence of positional parameters, otherwise `Callable[..., Ret]` (e.g. when
+/// it contains `*args`, `**kwargs`, or keyword-only parameters that the
+/// `Callable` form can't represent).
+fn callable_from_signature(sig: &Callable, ctx: &mut ExtractionContext) -> String {
+    ctx.uses_callable = true;
+    let ret = format_type(&sig.ret, ctx).unwrap_or_else(|| "Incomplete".to_owned());
+    match &sig.params {
+        Params::List(params)
+            if params
+                .items()
+                .iter()
+                .all(|p| matches!(p, Param::PosOnly(..) | Param::Pos(..))) =>
+        {
+            let rendered: Vec<String> = params
+                .items()
+                .iter()
+                .map(|p| format_type(p.as_type(), ctx).unwrap_or_else(|| "Incomplete".to_owned()))
+                .collect();
+            format!("Callable[[{}], {}]", rendered.join(", "), ret)
+        }
+        _ => format!("Callable[..., {ret}]"),
+    }
+}
+
+/// `Callable[..., Ret]` for cases where the parameters can't be expressed.
+fn callable_ellipsis(ret: &Type, ctx: &mut ExtractionContext) -> String {
+    ctx.uses_callable = true;
+    let ret = format_type(ret, ctx).unwrap_or_else(|| "Incomplete".to_owned());
+    format!("Callable[..., {ret}]")
+}
+
+/// Render an overload set. If every signature shares the same return type we
+/// can render `Callable[..., Ret]`; otherwise there is no single faithful
+/// return type, so fall back to `Incomplete`.
+fn format_overload(overload: &Overload, ctx: &mut ExtractionContext) -> String {
+    let ret = |sig: &OverloadType| -> Type {
+        match sig {
+            OverloadType::Function(f) => f.signature.ret.clone(),
+            OverloadType::Forall(forall) => forall.body.signature.ret.clone(),
+        }
+    };
+    let first = ret(overload.signatures.first());
+    if overload.signatures.iter().all(|s| ret(s) == first) {
+        callable_ellipsis(&first, ctx)
+    } else {
+        ctx.uses_incomplete = true;
+        "Incomplete".to_owned()
+    }
 }
 
 /// Uses source text for simple literals, `...` for everything else.

--- a/pyrefly/lib/stubgen/mod.rs
+++ b/pyrefly/lib/stubgen/mod.rs
@@ -227,6 +227,11 @@ class BaseModel:
     }
 
     #[test]
+    fn test_stubgen_callable_values() {
+        assert_stubgen_snapshot("callable_values");
+    }
+
+    #[test]
     fn test_stubgen_typevar() {
         assert_stubgen_snapshot("typevar");
     }

--- a/pyrefly/lib/test/stubgen/callable_values/expected.pyi
+++ b/pyrefly/lib/test/stubgen/callable_values/expected.pyi
@@ -1,0 +1,11 @@
+# @generated
+from typing import Callable
+
+def transform(x: int, s: str) -> bool: ...
+
+
+def variadic(*args: int) -> str: ...
+
+
+handler: Callable[[int, str], bool]
+collect: Callable[..., str]

--- a/pyrefly/lib/test/stubgen/callable_values/expected.pyi
+++ b/pyrefly/lib/test/stubgen/callable_values/expected.pyi
@@ -1,5 +1,12 @@
 # @generated
 from typing import Callable
+from _typeshed import Incomplete
+
+from typing import TypeVar
+from typing import overload
+
+T = TypeVar("T")
+
 
 def transform(x: int, s: str) -> bool: ...
 
@@ -7,5 +14,43 @@ def transform(x: int, s: str) -> bool: ...
 def variadic(*args: int) -> str: ...
 
 
+def generic_fn(x: T) -> int: ...
+
+
+@overload
+def same_return(x: int) -> bytes: ...
+
+
+@overload
+def same_return(x: str) -> bytes: ...
+
+
+@overload
+def diff_return(x: int) -> int: ...
+
+
+@overload
+def diff_return(x: str) -> str: ...
+
+
+class C:
+    def method(self, x: int) -> str: ...
+
+    def generic_method(self, x: T) -> int: ...
+
+    @overload
+    def overloaded_method(self, x: int) -> bool: ...
+
+    @overload
+    def overloaded_method(self, x: str) -> bool: ...
+
+
 handler: Callable[[int, str], bool]
 collect: Callable[..., str]
+to_text: Callable[[Incomplete], str]
+gen_ref: Callable[..., int]
+ov_same: Callable[..., bytes]
+ov_diff: Incomplete
+bound_method: Callable[[int], str]
+bound_generic: Callable[..., int]
+bound_overloaded: Callable[..., bool]

--- a/pyrefly/lib/test/stubgen/callable_values/expected.pyi
+++ b/pyrefly/lib/test/stubgen/callable_values/expected.pyi
@@ -50,7 +50,7 @@ collect: Callable[..., str]
 to_text: Callable[[Incomplete], str]
 gen_ref: Callable[..., int]
 ov_same: Callable[..., bytes]
-ov_diff: Incomplete
+ov_diff: Callable[..., Incomplete]
 bound_method: Callable[[int], str]
 bound_generic: Callable[..., int]
 bound_overloaded: Callable[..., bool]

--- a/pyrefly/lib/test/stubgen/callable_values/input.py
+++ b/pyrefly/lib/test/stubgen/callable_values/input.py
@@ -3,6 +3,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import TypeVar
+from typing import overload
+
+T = TypeVar("T")
+
 
 def transform(x: int, s: str) -> bool:
     return bool(x) and bool(s)
@@ -12,8 +17,85 @@ def variadic(*args: int) -> str:
     return ""
 
 
-# Module-level function-valued variables: their inferred types are callables
-# and must be rendered as valid `typing.Callable`, not pyrefly's internal
+# `Type::Forall` / `Forallable::Function`: a generic free function. Its params
+# carry a type variable, so they're elided to `...`; the RETURN is concrete
+# (`int`) so no TypeVar leaks into the stub.
+def generic_fn(x: T) -> int:
+    return 0
+
+
+# `Type::Overload`: an unbound overloaded function whose overloads all share the
+# same return type, so it renders as `Callable[..., bytes]`.
+@overload
+def same_return(x: int) -> bytes: ...
+@overload
+def same_return(x: str) -> bytes: ...
+def same_return(x):
+    return b""
+
+
+# `Type::Overload`: an unbound overloaded function whose overloads have
+# DIFFERENT return types, so there is no single faithful return type and it
+# falls back to `Incomplete`.
+@overload
+def diff_return(x: int) -> int: ...
+@overload
+def diff_return(x: str) -> str: ...
+def diff_return(x):
+    return x
+
+
+class C:
+    # `Type::BoundMethod` / `BoundMethodType::Function`: a plain instance method.
+    # The bound `self` is stripped, leaving `Callable[[int], str]`.
+    def method(self, x: int) -> str:
+        return ""
+
+    # `Type::BoundMethod` / `BoundMethodType::Forall`: a generic instance method.
+    # Params can't be faithfully expressed, so it elides to `Callable[..., int]`.
+    def generic_method(self, x: T) -> int:
+        return 0
+
+    # `Type::BoundMethod` / `BoundMethodType::Overload`: an overloaded instance
+    # method (overloads share a return type → `Callable[..., bool]`).
+    @overload
+    def overloaded_method(self, x: int) -> bool: ...
+    @overload
+    def overloaded_method(self, x: str) -> bool: ...
+    def overloaded_method(self, x):
+        return True
+
+
+# `Type::Function`: module-level function-valued variables. Their inferred types
+# are callables rendered as valid `typing.Callable`, not pyrefly's internal
 # `(args) -> ret` display form.
 handler = transform
 collect = variadic
+
+# `Type::Callable`: a lambda's inferred type is a bare `Callable`.
+to_text = lambda n: str(n)
+
+# `Type::Forall` / `Forallable::Function`: reference to the generic free function.
+gen_ref = generic_fn
+
+# `Type::Overload` (same returns → `Callable[..., bytes]`).
+ov_same = same_return
+
+# `Type::Overload` (differing returns → `Incomplete`).
+ov_diff = diff_return
+
+# `Type::BoundMethod` / `BoundMethodType::Function`.
+bound_method = C().method
+
+# `Type::BoundMethod` / `BoundMethodType::Forall`.
+bound_generic = C().generic_method
+
+# `Type::BoundMethod` / `BoundMethodType::Overload`.
+bound_overloaded = C().overloaded_method
+
+# `Type::Forall` / `Forallable::Callable` and `Forallable::TypeAlias` are not
+# reachable from value annotations here: a generic *callable* value would
+# require a TypeVar in the output (which we deliberately avoid), and a generic
+# type alias is a type-level construct, not the inferred type of a value. The
+# `Forallable::TypeAlias` arm returns `None` and falls through to the normal
+# type display path.

--- a/pyrefly/lib/test/stubgen/callable_values/input.py
+++ b/pyrefly/lib/test/stubgen/callable_values/input.py
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+def transform(x: int, s: str) -> bool:
+    return bool(x) and bool(s)
+
+
+def variadic(*args: int) -> str:
+    return ""
+
+
+# Module-level function-valued variables: their inferred types are callables
+# and must be rendered as valid `typing.Callable`, not pyrefly's internal
+# `(args) -> ret` display form.
+handler = transform
+collect = variadic

--- a/pyrefly/lib/test/stubgen/callable_values/input.py
+++ b/pyrefly/lib/test/stubgen/callable_values/input.py
@@ -36,7 +36,7 @@ def same_return(x):
 
 # `Type::Overload`: an unbound overloaded function whose overloads have
 # DIFFERENT return types, so there is no single faithful return type and it
-# falls back to `Incomplete`.
+# falls back to `Callable[..., Incomplete]`.
 @overload
 def diff_return(x: int) -> int: ...
 @overload
@@ -81,7 +81,7 @@ gen_ref = generic_fn
 # `Type::Overload` (same returns → `Callable[..., bytes]`).
 ov_same = same_return
 
-# `Type::Overload` (differing returns → `Incomplete`).
+# `Type::Overload` (differing returns → `Callable[..., Incomplete]`).
 ov_diff = diff_return
 
 # `Type::BoundMethod` / `BoundMethodType::Function`.


### PR DESCRIPTION
## Context

**Bug:** When `pyrefly stubgen` emits a value whose inferred type is a **callable** (for example a function assigned to a module-level variable, or a method reference), it renders the annotation using pyrefly's internal type-display form instead of valid Python.

### Example

Run stubgen on this source code:

```py
def transform(x: int, s: str) -> bool:
    return bool(x) and bool(s)


def variadic(*args: int) -> str:
    return ""


handler = transform
collect = variadic
```

#### Expected output

```py
from typing import Callable

def transform(x: int, s: str) -> bool: ...


def variadic(*args: int) -> str: ...


handler: Callable[[int, str], bool]
collect: Callable[..., str]
```

#### Actual output

As you can see, the two final lines are syntactically invalid.

```py
def transform(x: int, s: str) -> bool: ...


def variadic(*args: int) -> str: ...


handler: (x: int, s: str) -> bool
collect: (*args: int) -> str
```

## Changes
- Add a stubgen snapshot regression test (`callable_values`), including the example shown above.
- Add logic in stubgen to render callable type annotations using valid Python syntax

Note: overloaded callables are emitted as `Incomplete` for now; rendering them faithfully is left as a follow-up.

Made with [Cursor](https://cursor.com)