### PR TITLE
Fix special export attribute lookup on imported modules

### DIFF
--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -2350,7 +2350,9 @@ impl Scopes {
                         .or_else(|| lookup.is_special_export(base_module, name))
                 }
                 FlowStyle::ImportAs(m) => lookup.is_special_export(*m, name),
-                FlowStyle::Import(m, upstream_name) => lookup.is_special_export(*m, upstream_name),
+                FlowStyle::Import(m, upstream_name) => {
+                    lookup.is_special_export(m.append(upstream_name), name)
+                }
                 _ => None,
             }
         } else if let Some(flow_info) = self.get_flow_info(name) {

--- a/pyrefly/lib/test/imports.rs
+++ b/pyrefly/lib/test/imports.rs
@@ -2148,3 +2148,23 @@ def get_files():
     return data_schema_files
 "#,
 );
+
+fn env_special_export_package_reexport() -> TestEnv {
+    let mut t = TestEnv::new();
+    t.add_with_path("pkg", "pkg/__init__.py", "");
+    t.add_with_path(
+        "pkg.my_typing",
+        "pkg/my_typing.py",
+        "from typing import Annotated",
+    );
+    t
+}
+
+testcase!(
+    test_special_export_package_reexport_import,
+    env_special_export_package_reexport(),
+    r#"
+from pkg import my_typing as mt
+x: mt.Annotated[int, "metadata"] = 5
+"#,
+);


### PR DESCRIPTION
# Summary

Fixes a module attribute lookup bug in Pyrefly's binder when resolving special exports (like `Annotated`, `TypeVar`, etc.) from modules imported using `from ... import ... as ...`.

### Bug Context
When a user re-exports typing constructs through a wrapper/helper module and imports it using an alias:
```python
# pkg/my_typing.py
from typing import Annotated

# main.py
from pkg import my_typing as mt
x: mt.Annotated[int, "metadata"] = 5
```
Pyrefly's binder needs to determine if `mt.Annotated` is a special export.
The imported module `mt` is bound with style `FlowStyle::Import(pkg, my_typing)`.

Previously, the binder checked special exports for `FlowStyle::Import` by checking if the imported module name `"my_typing"` itself was a special export in the parent package `"pkg"`, while completely ignoring the attribute name `"Annotated"`. Because of this, it failed to recognize `mt.Annotated` as `typing.Annotated` at binding time, causing it to fall back to standard generic class subscript parsing and raising an `unknown-name` error for the metadata string `"metadata"`.

### Change
This PR updates the module attribute lookup resolver for `FlowStyle::Import` to construct the full module name (`pkg.my_typing`) and query the attribute name (`Annotated`) on it:
```rust
FlowStyle::Import(m, upstream_name) => {
    lookup.is_special_export(m.append(upstream_name), name)
}
```

Since the transitive exporter already knows how to follow imports, this correctly resolves `mt.Annotated` back to `typing.Annotated`.

---

# Test Plan

### Reproduction Test Case
Added a unit test case in `pyrefly/lib/test/imports.rs` replicating the issue:
```python
# Environment:
# pkg/__init__.py: ""
# pkg/my_typing.py: "from typing import Annotated"

from pkg import my_typing as mt
x: mt.Annotated[int, "metadata"] = 5
```

*   **Before this PR**: Fails with `ERROR Could not find name metadata [unknown-name]`.
*   **After this PR**: Passes cleanly.

Also run
```bash
python3 test.py
```
