### PR TITLE
Fix stack overflow on self-referential protocol overload filtering

### DIFF
--- a/pyrefly/lib/alt/answers_solver.rs
+++ b/pyrefly/lib/alt/answers_solver.rs
@@ -21,6 +21,7 @@ use std::sync::OnceLock;
 use dupe::Dupe;
 use dupe::IterDupedExt;
 use fxhash::FxHashMap;
+use fxhash::FxHashSet;
 use pyrefly_graph::calculation::Calculation;
 use pyrefly_graph::calculation::ProposalResult;
 use pyrefly_graph::index::Idx;
@@ -1602,6 +1603,10 @@ pub struct ThreadState {
     /// is pushed here. When the nested call takes its sink, the previous
     /// one is restored.
     trace_sink_stack: RefCell<Vec<Option<TraceSideEffects>>>,
+    /// `(self_type, self_param)` pairs whose overload-self-type compatibility
+    /// check is currently in progress, used as a coinductive guard against
+    /// self-referential protocols. See `filter_overloads_by_self_type`.
+    overload_self_filter_stack: RefCell<FxHashSet<(Type, Type)>>,
 }
 
 impl ThreadState {
@@ -1614,6 +1619,7 @@ impl ThreadState {
             lambda_param_vars: RefCell::new(FxHashMap::default()),
             trace_sink: RefCell::new(None),
             trace_sink_stack: RefCell::new(Vec::new()),
+            overload_self_filter_stack: RefCell::new(FxHashSet::default()),
         }
     }
 
@@ -1964,6 +1970,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .borrow()
             .get(&(def_idx, height))
             .cloned()
+    }
+
+    /// Mark an overload-self-type compatibility check `(self_type, self_param)` as in
+    /// progress. Returns `true` if it was already active, signaling a coinductive cycle
+    /// (a self-referential protocol). See `filter_overloads_by_self_type`.
+    pub(crate) fn enter_overload_self_filter(&self, key: (Type, Type)) -> bool {
+        !self
+            .thread_state
+            .overload_self_filter_stack
+            .borrow_mut()
+            .insert(key)
+    }
+
+    pub(crate) fn exit_overload_self_filter(&self, key: &(Type, Type)) {
+        self.thread_state
+            .overload_self_filter_stack
+            .borrow_mut()
+            .remove(key);
     }
 
     /// Given the target idx of a ForwardToFirstUse binding, find the NameAssign's

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -2782,9 +2782,28 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if func.metadata.flags.is_staticmethod || func.metadata.flags.is_classmethod {
                     return true;
                 }
-                func.signature
-                    .get_first_param()
-                    .is_none_or(|p| self.is_subset_eq(self_type, &p))
+                func.signature.get_first_param().is_none_or(|p| {
+                    // A non-protocol `self:` can't re-enter protocol conformance, so check
+                    // it directly. A protocol-typed `self:`, however, makes
+                    // `is_subset_eq(self_type, p)` re-enter this same filtering on the same
+                    // `(self_type, p)` pair — unbounded recursion for a self-referential
+                    // protocol. Guard only that case coinductively: on re-entry
+                    // of the same pair, assume the overload applies (keep it).
+                    let p_is_protocol = matches!(
+                        &p,
+                        Type::ClassType(cls) if self.type_order().is_protocol(cls.class_object())
+                    );
+                    if !p_is_protocol {
+                        return self.is_subset_eq(self_type, &p);
+                    }
+                    let key = (self_type.clone(), p.clone());
+                    if self.enter_overload_self_filter(key.clone()) {
+                        return true;
+                    }
+                    let applies = self.is_subset_eq(self_type, &p);
+                    self.exit_overload_self_filter(&key);
+                    applies
+                })
             })
             .cloned()
             .collect();

--- a/pyrefly/lib/test/protocol.rs
+++ b/pyrefly/lib/test/protocol.rs
@@ -1047,3 +1047,82 @@ def main2(s: Series[timedelta]) -> None:
     assert_type(s / td, Series[float])
 "#,
 );
+
+testcase!(
+    test_protocol_overloaded_generic_self_referencing_protocol_terminates,
+    r#"
+from typing import Protocol, TypeVar, overload
+
+S = TypeVar("S", covariant=True)
+R = TypeVar("R", covariant=True)
+
+
+class Lens(Protocol[S, R]):
+    @overload
+    def __call__[S2, R2](self: Lens[S2, R2], state: S2, /, value: R2) -> S2: ...
+    @overload
+    def __call__[S2, R2](self: Lens[S2, R2], state: S2, /) -> R2: ...
+
+
+class BaseLens(Lens[S, R], Protocol):
+    def at(self) -> Lens[S, R]:
+        return self
+"#,
+);
+
+testcase!(
+    test_protocol_overloaded_generic_self_mutual_recursion_terminates,
+    r#"
+from typing import Protocol, TypeVar, overload
+
+S = TypeVar("S", covariant=True)
+
+
+class A(Protocol[S]):
+    @overload
+    def __call__[S2, R2](self: B[S2], state: S2, /, value: R2) -> S2: ...
+    @overload
+    def __call__[S2, R2](self: B[S2], state: S2, /) -> R2: ...
+
+
+class B(Protocol[S]):
+    @overload
+    def __call__[S2, R2](self: A[S2], state: S2, /, value: R2) -> S2: ...
+    @overload
+    def __call__[S2, R2](self: A[S2], state: S2, /) -> R2: ...
+
+
+class Impl(A[S], B[S], Protocol):
+    def at(self) -> A[S]:
+        return self
+"#,
+);
+
+testcase!(
+    test_protocol_overloaded_generic_self_non_conforming_still_rejected,
+    r#"
+from typing import Protocol, TypeVar, overload
+
+S = TypeVar("S", covariant=True)
+R = TypeVar("R", covariant=True)
+
+
+class Lens(Protocol[S, R]):
+    @overload
+    def __call__[S2, R2](self: Lens[S2, R2], state: S2, /, value: R2) -> S2: ...
+    @overload
+    def __call__[S2, R2](self: Lens[S2, R2], state: S2, /) -> R2: ...
+    def extra(self) -> int: ...
+
+
+class HasCallNoExtra(Protocol[S, R]):
+    @overload
+    def __call__[S2, R2](self: HasCallNoExtra[S2, R2], state: S2, /, value: R2) -> S2: ...
+    @overload
+    def __call__[S2, R2](self: HasCallNoExtra[S2, R2], state: S2, /) -> R2: ...
+
+
+def f(x: HasCallNoExtra[int, str]) -> Lens[int, str]:
+    return x  # E: not assignable to declared return type
+"#,
+);


### PR DESCRIPTION
Fixes https://github.com/facebook/pyrefly/issues/3893

## What

pyrefly aborts with a native stack overflow when it checks certain self-referential protocols. The smallest reproduction is a protocol whose overloaded method annotates `self` with the protocol itself:

```python
from typing import Protocol, TypeVar, overload

S = TypeVar("S", covariant=True)
R = TypeVar("R", covariant=True)

class Lens(Protocol[S, R]):
    @overload
    def __call__[S2, R2](self: Lens[S2, R2], state: S2, /, value: R2) -> S2: ...
    @overload
    def __call__[S2, R2](self: Lens[S2, R2], state: S2, /) -> R2: ...

class BaseLens(Lens[S, R], Protocol):
    def at(self) -> Lens[S, R]:
        return self
```

Before this change pyrefly prints `thread '<unknown>' has overflowed its stack / fatal runtime error: stack overflow` and aborts. After it, the file type-checks with no crash. mypy, pyright, and ty all terminate on this input, so the crash was a pyrefly bug rather than bad code.

It shows up on real projects. `pyrefly check src/` on the kUPS library (https://github.com/cusp-ai-oss/kUPS) crashed partway through; it now runs to completion. The crash is a regression since 1.1.1.

## Why

When pyrefly checks a value against a protocol, it filters the candidate's overloaded methods by their explicit `self:` annotations, so an overload whose `self:` cannot match the receiver does not get to bind type variables it should not. That filter landed in 1.1.1 (#3819).

The filter tests each overload with `is_subset_eq(self_type, self_param)`. When `self_param` is itself a protocol, that check re-enters protocol conformance, looks up the same overloaded member again, and re-filters the same `(self_type, self_param)` pair. Nothing breaks the loop, so it recurses until the stack is exhausted.

pyrefly already has two cycle guards for protocol subtyping, and neither catches this one. Both live on `Subset`, and `Solver::is_subset_eq` builds a fresh `Subset` on every call. The recursion passes through `is_subset_eq` at each turn, so the `(got, want)` subset cache and the `class_protocol_assumptions` coinductive set are both empty again by the time the same pair comes back around.

## How

The guard goes where the recursion is actually observable. It lives on `ThreadState`, which persists across the `is_subset_eq` boundary that resets `Subset`.

- `pyrefly/lib/alt/answers_solver.rs`: a per-thread `overload_self_filter_stack` of in-progress `(self_type, self_param)` pairs, plus `enter_overload_self_filter` and `exit_overload_self_filter`.
- `pyrefly/lib/alt/class/class_field.rs`, in `filter_overloads_by_self_type`: before testing a protocol-typed `self:`, record the pair; on re-entry of the same pair, assume the overload applies and return. That is the greatest-fixpoint reading of a recursive protocol, which matches mypy and pyright.

A non-protocol `self:` cannot start this recursion, so it skips the guard and runs the plain check. That keeps the common path free of the extra bookkeeping, including hot cases like `str` methods with `self: LiteralString` overloads. The guard only changes the filter's decision on a real cycle, where keeping the overload is the safe direction. The conformance verdict still comes from the attribute-subset check that runs afterward, so a class that does not satisfy the protocol is still rejected.

This leaves the subtyping solver, the existing `Subset` cycle guards, and the unbound class-access caller of the same filter unchanged.

## Test plan

Three tests in `pyrefly/lib/test/protocol.rs`:

| Test | What it pins |
|------|--------------|
| `test_protocol_overloaded_generic_self_referencing_protocol_terminates` | the issue repro: a protocol with a self-typed overloaded `__call__` type-checks instead of crashing |
| `test_protocol_overloaded_generic_self_mutual_recursion_terminates` | two protocols whose `self:` annotations reference each other also terminate |
| `test_protocol_overloaded_generic_self_non_conforming_still_rejected` | a class that matches `__call__` but lacks another required member is still reported as not assignable, so the guard does not hide a real failure |

Each terminate test aborts the test runner without the fix. The existing `test_protocol_overloaded_method_filtered_by_self` (#3819) still passes, so filtering by concrete protocol self-types is unchanged.

- `cargo test -p pyrefly --lib`: 5746 passed, 0 failed.
- Formatting and linting clean.
- `mypy_primer` over 69 protocol-heavy and overload-heavy projects (pydantic, pandas-stubs, pandera, sympy, xarray, scipy, attrs, strawberry, kornia, jax, and more): no diagnostic changes.
