### PR TITLE
Fix dataclass/BaseModel field named "self" incorrectly flagged as duplicate (issue #3900)

### DIFF
--- a/pyrefly/lib/alt/class/dataclass.rs
+++ b/pyrefly/lib/alt/class/dataclass.rs
@@ -986,7 +986,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         kw_only_by_class: &SmallMap<Class, SmallSet<Name>>,
         errors: &ErrorCollector,
     ) -> ClassSynthesizedField {
-        let mut params = vec![self.class_self_param(cls, false)];
+        /// detects when a field named "self" exists and names receiver param "__dataclass_self__" which is what CPython dataclasses does at runtime
+        let self_param = if dataclass.fields.contains(&Name::new_static("self")) {
+            Param::Pos(
+                Name::new_static("__dataclass_self__"),
+                self.instantiate(cls),
+                Required::Required,
+            )
+        } else {
+            self.class_self_param(cls, false)
+        };
+        let mut params = vec![self_param];
         let mut has_seen_default = false;
         for (name, field, field_flags) in self.iter_fields(cls, dataclass, true, kw_only_by_class) {
             let strict = field_flags.strict.unwrap_or(strict_default);

--- a/pyrefly/lib/test/dataclasses.rs
+++ b/pyrefly/lib/test/dataclasses.rs
@@ -2586,3 +2586,19 @@ class C:
 reveal_type(C.__init__)  # E: revealed type: (self: C, _x: int) -> None
 "#,
 );
+
+// A dataclass field named 'self" must not collide with the implicit "self" parameter of the synthesized "__init__". cpython renames the instance param to "__dataclass_self__".
+testcase!(
+    test_dataclass_field_named_self,
+    r#"
+from dataclasses import dataclass
+from typing import assert_type
+
+@dataclass
+class C:
+    self: str
+
+c = C(self="test")
+assert_type(c.self, str)
+"#,
+);

--- a/pyrefly/lib/test/pydantic/field.rs
+++ b/pyrefly/lib/test/pydantic/field.rs
@@ -457,3 +457,19 @@ class Right:
 class Conflict(Left, Right): ...  # E: inherits from incompatible disjoint bases `BaseModel`, `Right`
 "#,
 );
+
+// pydantic field named 'self' must not collide with the synthesized '__init__''s implicit 'self' param.
+// same as the stdlib dataclass fix.
+pydantic_testcase!(
+    test_pydantic_field_named_self,
+    r#"
+from pydantic import BaseModel
+from typing import assert_type
+
+class Model(BaseModel):
+    self: str
+
+m = Model(self="test")
+assert_type(m.self, str)
+"#,
+);


### PR DESCRIPTION
# Summary

A "@dataclass" (or Pydantic "BaseModel") field named "self" was incorrectly flagged with "bad-keyword-argument" and "bad-argument-type" errors on construction, e.g. "MyDataClass(self="test")", even though this is valid Python that runs fine.

Instance receiver is bound by prepending it as a positional argument rather than dropping the param so two params named `self` caused the keyword "self=" to bind to the instance param instead of the field.

Fix is to mirror CPython dataclasses as follows: when there exists a field named "self", name the instance param "__dataclass_self__" instead. Pydantic BaseModel also covered by this change since its init goes through get_dataclass_init.

Fixes issue #3900 + dillydill123's comment about Pydantic BaseModel

# Test Plan

<!-- Describe how you tested this PR -->

Added two regression tests, one for dataclass and one for BaseModel, both passing.

- test_dataclass_field_named_self in ./pyrefly/lib/test/dataclasses.rs
- test_pydantic_field_named_self in ./pyrefly/lib/test/pydantic/field.rs
Both construct instances via "self=" keyword and assert field type with "assert_type". Both reproduce #3900 errors on main and pass with the fix. 

<!-- Run test.py and commit any changes to generated files -->
no diffs!