### PR TITLE
Suppress unannotated-return for @no_type_check functions

### DIFF
--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -687,6 +687,8 @@ pub struct FuncFlags {
     pub has_final_decoration: bool,
     /// A function decorated with `@abc.abstractmethod`
     pub is_abstract_method: bool,
+    /// A function decorated with `@typing.no_type_check` or `@typing_extensions.no_type_check`
+    pub has_no_type_check: bool,
     /// Function body is treated as a stub (e.g. body is `...` or absent in a stub file)
     pub lacks_implementation: bool,
     /// Is the function definition in a `.pyi` file
@@ -875,6 +877,8 @@ pub enum FunctionKind {
     RuntimeCheckable,
     Def(Arc<FuncId>),
     AbstractMethod,
+    /// A function decorated with `typing.no_type_check` or `typing_extensions.no_type_check`.
+    NoTypeCheck,
     /// Instance of a protocol with a `__call__` method. The function has the `__call__` signature.
     CallbackProtocol(Box<ClassType>),
     TotalOrdering,
@@ -1235,6 +1239,7 @@ impl FunctionKind {
                 Self::DataclassTransform
             }
             ("abc", None, "abstractmethod") => Self::AbstractMethod,
+            ("typing" | "typing_extensions", None, "no_type_check") => Self::NoTypeCheck,
             ("functools", None, "total_ordering") => Self::TotalOrdering,
             ("typing" | "typing_extensions", None, "disjoint_base") => Self::DisjointBase,
             ("numba.core.decorators", None, "jit") => Self::NumbaJit,
@@ -1269,6 +1274,7 @@ impl FunctionKind {
             Self::RuntimeCheckable => ModuleName::typing(),
             Self::CallbackProtocol(cls) => cls.qname().module_name(),
             Self::AbstractMethod => ModuleName::abc(),
+            Self::NoTypeCheck => ModuleName::typing(),
             Self::TotalOrdering => ModuleName::functools(),
             Self::DisjointBase => ModuleName::typing(),
             Self::NumbaJit => ModuleName::from_str("numba"),
@@ -1298,6 +1304,7 @@ impl FunctionKind {
             Self::RuntimeCheckable => Cow::Owned(Name::new_static("runtime_checkable")),
             Self::CallbackProtocol(_) => Cow::Owned(dunder::CALL),
             Self::AbstractMethod => Cow::Owned(Name::new_static("abstractmethod")),
+            Self::NoTypeCheck => Cow::Owned(Name::new_static("no_type_check")),
             Self::TotalOrdering => Cow::Owned(Name::new_static("total_ordering")),
             Self::DisjointBase => Cow::Owned(Name::new_static("disjoint_base")),
             Self::NumbaJit => Cow::Owned(Name::new_static("jit")),
@@ -1329,6 +1336,7 @@ impl FunctionKind {
             Self::NumbaNjit => None,
             Self::CallbackProtocol(cls) => Some(cls.class_object().dupe()),
             Self::AbstractMethod => None,
+            Self::NoTypeCheck => None,
             Self::TotalOrdering => None,
             Self::DisjointBase => None,
             Self::Def(func_id) => func_id.cls.clone(),

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -678,7 +678,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .arc_clone_ty();
         // `stmt.returns` is always set to None because the binding step calls `mem::take` on it
         let has_return_annotation = self.bindings().function_has_return_annotation(&stmt.name);
-        if !has_return_annotation {
+        if !has_return_annotation && !def.metadata.flags.has_no_type_check {
             self.error(
                 errors,
                 stmt.name.range(),
@@ -905,6 +905,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Some(CalleeKind::Function(FunctionKind::AbstractMethod)) => {
                 Some(SpecialDecorator::AbstractMethod)
             }
+            Some(CalleeKind::Function(FunctionKind::NoTypeCheck)) => {
+                Some(SpecialDecorator::NoTypeCheck)
+            }
             Some(CalleeKind::Function(FunctionKind::DisjointBase)) => {
                 Some(SpecialDecorator::DisjointBase)
             }
@@ -988,6 +991,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             SpecialDecorator::AbstractMethod => {
                 flags.is_abstract_method = true;
+                true
+            }
+            SpecialDecorator::NoTypeCheck => {
+                flags.has_no_type_check = true;
                 true
             }
             SpecialDecorator::UsesShapeDsl => {

--- a/pyrefly/lib/alt/types/decorated_function.rs
+++ b/pyrefly/lib/alt/types/decorated_function.rs
@@ -98,6 +98,7 @@ pub enum SpecialDecorator<'a> {
     DataclassTransformCall(&'a TypeMap),
     EnumNonmember,
     AbstractMethod,
+    NoTypeCheck,
     UsesShapeDsl,
     DisjointBase,
 }

--- a/pyrefly/lib/test/untyped_def_behaviors.rs
+++ b/pyrefly/lib/test/untyped_def_behaviors.rs
@@ -509,6 +509,42 @@ assert_type(C.__new__(D), D)
 "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/3561
+testcase!(
+    test_no_type_check_suppresses_unannotated_return,
+    TestEnv::new().enable_unannotated_return_error(),
+    r#"
+from typing import no_type_check
+
+@no_type_check
+def f():  # no error: @no_type_check suppresses unannotated-return
+    pass
+
+@no_type_check
+def g() -> None:  # no error: annotated, and @no_type_check suppresses the check anyway
+    pass
+
+def h():  # E: `h` is missing a return annotation
+    pass
+"#,
+);
+
+// https://github.com/facebook/pyrefly/issues/3561 — typing_extensions alias
+testcase!(
+    test_no_type_check_typing_extensions_suppresses_unannotated_return,
+    TestEnv::new().enable_unannotated_return_error(),
+    r#"
+from typing_extensions import no_type_check
+
+@no_type_check
+def f():  # no error: @no_type_check from typing_extensions suppresses unannotated-return
+    pass
+
+def g():  # E: `g` is missing a return annotation
+    pass
+"#,
+);
+
 /// Verifies that `analyze_unannotated_for_ide` is gated on `Require` level:
 /// - `Require::Errors` (batch/CLI): unannotated bodies are skipped, no body errors.
 /// - `Require::Everything` (IDE): unannotated bodies are analyzed, body errors reported.


### PR DESCRIPTION
A function decorated with `typing.no_type_check` (or the `typing_extensions`
alias) should not produce an `[unannotated-return]` diagnostic, since the
decorator explicitly opts the entire function out of type checking.

The fix threads recognition of `@no_type_check` through the same decorator-flag
pipeline already used by `@abc.abstractmethod`: a new `FunctionKind::NoTypeCheck`
variant is recognised in `FunctionKind::from_name`, surfaces as
`SpecialDecorator::NoTypeCheck`, and sets `FuncFlags::has_no_type_check = true`.
The `[unannotated-return]` emission site is then guarded by
`!def.metadata.flags.has_no_type_check`, so the error is suppressed for these
functions while all other functions are unaffected.

Fixes https://github.com/facebook/pyrefly/issues/3561

Test Plan:
- cargo test -p pyrefly --lib untyped_def_behaviors
- cargo test -p pyrefly --lib
- python3 test.py --no-test --no-conformance --no-jsonschema

