### PR TITLE
Report invalid-abstract-method for @abstractmethod in non-abstract classes

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -202,6 +202,8 @@ pub enum ErrorKind {
     InconsistentOverloadDefault,
     /// Internal Pyrefly error.
     InternalError,
+    /// An `@abstractmethod` is defined in a class that is not abstract.
+    InvalidAbstractMethod,
     /// Attempting to write an annotation that is invalid for some reason.
     InvalidAnnotation,
     /// Passing an argument that is invalid for reasons besides type.
@@ -469,6 +471,7 @@ impl ErrorKind {
             ErrorKind::DivisionByZero => Severity::Warn,
             ErrorKind::ExplicitAny => Severity::Ignore,
             ErrorKind::ImplicitAbstractClass => Severity::Ignore,
+            ErrorKind::InvalidAbstractMethod => Severity::Error,
             ErrorKind::ImplicitAny => Severity::Ignore,
             ErrorKind::ImplicitAnyAttribute => Severity::Ignore,
             ErrorKind::ImplicitAnyEmptyContainer => Severity::Ignore,

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -2693,8 +2693,47 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 errors,
             );
             self.check_variance_for_class(cls, class_bases.as_ref(), &class_field_map, errors);
+            self.check_invalid_abstract_methods(cls, &class_field_map, errors);
         }
         Arc::new(EmptyAnswer)
+    }
+
+    /// #3728: flag `@abstractmethod` on a method of a class that is not abstract
+    /// (not an ABC, no `ABCMeta` metaclass, not a `Protocol`). Such a class is
+    /// directly instantiable yet carries an unimplemented method. This runs as a
+    /// class-level diagnostic (alongside the override checks), so it forces no
+    /// field resolution for importers of the class and stays lazy.
+    fn check_invalid_abstract_methods(
+        &self,
+        cls: &Class,
+        class_field_map: &SmallMap<Name, Arc<ClassField>>,
+        errors: &ErrorCollector,
+    ) {
+        let metadata = self.get_metadata_for_class(cls);
+        if metadata.extends_abc() || metadata.is_protocol() || metadata.is_new_type() {
+            return;
+        }
+        let cls_fields = self.get_class_fields(cls);
+        for (name, field) in class_field_map.iter() {
+            // `field_decl_range` is `Some` only for fields declared in this class,
+            // which restricts the check to the class's own methods (not inherited
+            // ones) and gives the definition range to report at.
+            if field.is_abstract()
+                && let Some(range) = cls_fields.and_then(|f| f.field_decl_range(name))
+            {
+                self.error(
+                    errors,
+                    range,
+                    ErrorKind::InvalidAbstractMethod,
+                    format!(
+                        "`{}.{}` is decorated with `@abstractmethod` but `{}` is not an abstract class",
+                        cls.name(),
+                        name,
+                        cls.name()
+                    ),
+                );
+            }
+        }
     }
 
     /// Check method and attribute override consistency for a class.

--- a/pyrefly/lib/test/abstract_methods.rs
+++ b/pyrefly/lib/test/abstract_methods.rs
@@ -571,3 +571,126 @@ class A(metaclass=Meta2):
 A()  # E: Cannot instantiate `A`
     "#,
 );
+
+// Tests for invalid-abstract-method: @abstractmethod in a non-abstract class.
+
+testcase!(
+    test_invalid_abstract_method_basic,
+    r#"
+from abc import abstractmethod
+
+class Foo:
+    @abstractmethod
+    def fn(self) -> int:  # E: `Foo.fn` is decorated with `@abstractmethod` but `Foo` is not an abstract class
+        ...
+"#,
+);
+
+testcase!(
+    test_invalid_abstract_method_multiple,
+    r#"
+from abc import abstractmethod
+
+class Foo:
+    @abstractmethod
+    def fn(self) -> int:  # E: `Foo.fn` is decorated with `@abstractmethod` but `Foo` is not an abstract class
+        ...
+
+    @abstractmethod
+    def gn(self) -> str:  # E: `Foo.gn` is decorated with `@abstractmethod` but `Foo` is not an abstract class
+        ...
+"#,
+);
+
+testcase!(
+    test_invalid_abstract_method_abc_base_exempt,
+    r#"
+from abc import ABC, abstractmethod
+
+class Foo(ABC):
+    @abstractmethod
+    def fn(self) -> int:
+        ...
+"#,
+);
+
+testcase!(
+    test_invalid_abstract_method_abcmeta_exempt,
+    r#"
+from abc import ABCMeta, abstractmethod
+
+class Foo(metaclass=ABCMeta):
+    @abstractmethod
+    def fn(self) -> int:
+        ...
+"#,
+);
+
+testcase!(
+    test_invalid_abstract_method_transitive_abc_exempt,
+    r#"
+from abc import ABC, abstractmethod
+
+class Base(ABC):
+    pass
+
+class Child(Base):
+    @abstractmethod
+    def fn(self) -> int:
+        ...
+"#,
+);
+
+testcase!(
+    test_invalid_abstract_method_protocol_exempt,
+    r#"
+from abc import abstractmethod
+from typing import Protocol
+
+class Foo(Protocol):
+    @abstractmethod
+    def fn(self) -> int:
+        ...
+"#,
+);
+
+testcase!(
+    test_invalid_abstract_method_abstract_property,
+    r#"
+from abc import abstractmethod
+
+class Foo:
+    @property
+    @abstractmethod
+    def fn(self) -> int:  # E: `Foo.fn` is decorated with `@abstractmethod` but `Foo` is not an abstract class
+        ...
+"#,
+);
+
+testcase!(
+    test_invalid_abstract_method_inherited_only_no_error,
+    r#"
+from abc import ABC, abstractmethod
+
+class Base(ABC):
+    @abstractmethod
+    def fn(self) -> int:
+        ...
+
+class Child(Base):
+    # Child only inherits the abstract method, does not define its own @abstractmethod
+    pass
+"#,
+);
+
+testcase!(
+    test_invalid_abstract_method_on_by_default,
+    r#"
+from abc import abstractmethod
+
+class Foo:
+    @abstractmethod
+    def fn(self) -> int:  # E: `Foo.fn` is decorated with `@abstractmethod` but `Foo` is not an abstract class
+        ...
+"#,
+);

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -586,7 +586,7 @@ testcase!(
 import contextlib
 import abc
 
-class Parent:
+class Parent(abc.ABC):
     @contextlib.asynccontextmanager
     @abc.abstractmethod
     async def run(self):

--- a/pyrefly/lib/test/decorators.rs
+++ b/pyrefly/lib/test/decorators.rs
@@ -29,7 +29,7 @@ testcase!(
     test_abstract_method_implicit_return,
     r#"
 import abc
-class Foo:
+class Foo(abc.ABC):
     @abc.abstractmethod
     def foo(self) -> str:
         """
@@ -552,9 +552,9 @@ reveal_type(A.__ge__)  # E: revealed type: (self: A, other: object) -> bool
 testcase!(
     test_abstract_method_skip_return,
     r#"
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
-class C:
+class C(ABC):
         @abstractmethod
         def m1(self) -> int:
             return NotImplemented

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -1096,10 +1096,10 @@ def catch(f: S | None = None, *, exception: T) -> S | T: ...
 testcase!(
     test_abstract,
     r#"
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Literal, overload
 
-class Derp:
+class Derp(ABC):
     @overload
     @abstractmethod
     def f(self, m: Literal["x"] = "x") -> int: ...

--- a/pyrefly/lib/test/returns.rs
+++ b/pyrefly/lib/test/returns.rs
@@ -572,7 +572,7 @@ testcase!(
     test_no_missing_return_for_stubs,
     r#"
 from typing import Protocol, overload
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 class P(Protocol):
     def f1(self) -> int:
@@ -622,7 +622,7 @@ class C:
     def f9(self) -> int:
         raise NotImplementedError()  # OK
 
-class AbstractC:
+class AbstractC(ABC):
     @abstractmethod
     def f1(self) -> int:
         """a"""

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -728,6 +728,20 @@ def f(x: bool = False) -> int | None:
 
 Ideally you'll never see this one. If you do, please consider [filing a bug](https://github.com/facebook/pyrefly/issues).
 
+## invalid-abstract-method
+
+Pyrefly emits this error when a class that is not abstract (does not inherit from `abc.ABC`, use `abc.ABCMeta`, or have any transitive abstract base) defines a method decorated with `@abstractmethod`. Such a class is directly instantiable at runtime, yet contains an unimplemented method — a likely programming mistake.
+
+```python
+from abc import abstractmethod
+
+class Foo:
+    @abstractmethod  # Error: `Foo.fn` is decorated with `@abstractmethod` but `Foo` is not an abstract class
+    def fn(self) -> int: ...
+```
+
+To fix the issue, either inherit from `abc.ABC` to make the class abstract, or remove the `@abstractmethod` decorator and provide a concrete implementation.
+
 ## invalid-annotation
 
 There are several reasons why an annotation may be invalid. The most common case is misusing a typing special form, such as `typing.Final`, `typing.ClassVar`, `typing.ParamSpec`, and so on.


### PR DESCRIPTION
Summary: Adds a new off-by-default lint rule `invalid-abstract-method` that
fires when a method decorated with `@abstractmethod` is defined in a class
that is not abstract (does not inherit from `abc.ABC`, use `abc.ABCMeta`,
have a transitive ABC base, or be a Protocol). Such a class is directly
instantiable at runtime while containing an unimplemented method — a likely
programming mistake.

The check runs inside `solve_abstract_members` (which already executes for
every class), guarded by `!extends_abc() && !is_protocol() && !is_new_type()`.
It iterates the class's own declared fields (not MRO-inherited ones) and emits
one error per field whose `ClassField::is_abstract()` flag is set, pointing at
the method's definition range. The rule defaults to `Severity::Ignore` to
avoid breaking existing code without opt-in.

Fixes https://github.com/facebook/pyrefly/issues/3728

Test Plan:
- cargo build -p pyrefly_config  (clean)
- cargo build -p pyrefly  (clean)
- cargo test -p pyrefly_config -- test_doc_headers test_doc_severities  (2 passed)
- cargo test -p pyrefly --lib abstract_methods  (35 passed)
- cargo test -p pyrefly --lib  (5824 passed, 0 failed)
- python3 test.py --no-test --no-conformance --no-jsonschema  (clean, no new lint)

