### PR TITLE
Add off-by-default rule for unused call results

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -370,6 +370,8 @@ pub enum ErrorKind {
     UnsupportedOperation,
     /// Import is missing an expected stubs package
     UntypedImport,
+    /// Result of a call expression is not used.
+    UnusedCallResult,
     /// Result of async function call is never used or awaited
     UnusedCoroutine,
     /// A suppression comment is unused (no error to suppress, or specific codes are unused)
@@ -502,6 +504,7 @@ impl ErrorKind {
             ErrorKind::UnreachableMatchCase => Severity::Warn,
             ErrorKind::UnresolvableDunderAll => Severity::Warn,
             ErrorKind::UntypedImport => Severity::Warn,
+            ErrorKind::UnusedCallResult => Severity::Ignore,
             ErrorKind::UnusedIgnore => Severity::Ignore,
             ErrorKind::UnusedTypeIgnore => Severity::Ignore,
             ErrorKind::VarianceMismatch => Severity::Warn,

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -4310,6 +4310,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 "Result of async function call is unused. Did you forget to `await`?".to_owned()
             };
             self.error(errors, e.range(), ErrorKind::UnusedCoroutine, msg);
+        } else if matches!(e, Expr::Call(_))
+            && !result.is_none()
+            && !result.is_any()
+            && !result.is_never()
+            && !matches!(&result, Type::ClassType(cls) if self.extends_any(cls.class_object()))
+        {
+            self.error(
+                errors,
+                e.range(),
+                ErrorKind::UnusedCallResult,
+                format!(
+                    "Result of call expression is of type `{}` and is not used; \
+                     assign to `_` if this is intentional",
+                    result
+                ),
+            );
         }
         result
     }

--- a/pyrefly/lib/test/mod.rs
+++ b/pyrefly/lib/test/mod.rs
@@ -86,6 +86,7 @@ mod typing_self;
 mod unnecessary_comparison;
 mod unnecessary_type_conversion;
 mod untyped_def_behaviors;
+mod unused_call_result;
 pub mod util;
 mod var_resolution;
 mod variance_inference;

--- a/pyrefly/lib/test/unused_call_result.rs
+++ b/pyrefly/lib/test/unused_call_result.rs
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::test::util::TestEnv;
+use crate::testcase;
+
+fn env() -> TestEnv {
+    TestEnv::new().enable_unused_call_result_error()
+}
+
+// R1/R4: discarded call with informative return type fires the rule.
+testcase!(
+    discarded_call_result,
+    env(),
+    r#"
+def combine(a: list[int], b: list[int]) -> list[int]:
+    return a + b
+
+items = [1, 2, 3]
+combine(items, [4, 5])  # E: is not used
+"#,
+);
+
+// R1: assignment does not fire.
+testcase!(
+    assigned_call_result_no_error,
+    env(),
+    r#"
+def combine(a: list[int], b: list[int]) -> list[int]:
+    return a + b
+
+items = [1, 2, 3]
+x = combine(items, [4, 5])
+"#,
+);
+
+// I2: call returning None does not fire.
+testcase!(
+    call_returning_none_no_error,
+    env(),
+    r#"
+def side_effect() -> None:
+    pass
+
+side_effect()
+"#,
+);
+
+// I2: builtin print returns None — no error.
+testcase!(
+    print_no_error,
+    env(),
+    r#"
+items = [1, 2, 3]
+print(items)
+"#,
+);
+
+// I2: call returning Any does not fire.
+testcase!(
+    call_returning_any_no_error,
+    env(),
+    r#"
+from typing import Any
+
+def get_any() -> Any:
+    ...
+
+get_any()
+"#,
+);
+
+// I2: call through Any-typed callable does not fire.
+testcase!(
+    any_typed_callable_no_error,
+    env(),
+    r#"
+from typing import Any
+
+def make_any() -> Any:
+    ...
+
+f: Any = make_any()
+f()
+"#,
+);
+
+// I2: call returning Never/NoReturn does not fire.
+testcase!(
+    call_returning_never_no_error,
+    env(),
+    r#"
+from typing import NoReturn
+
+def bail() -> NoReturn:
+    raise RuntimeError("bail")
+
+bail()
+"#,
+);
+
+// R1: discarded method call fires.
+testcase!(
+    discarded_method_call,
+    env(),
+    r#"
+class Foo:
+    def bar(self) -> int:
+        return 1
+
+Foo().bar()  # E: is not used
+"#,
+);
+
+// R1: discarded constructor call fires.
+testcase!(
+    discarded_constructor_call,
+    env(),
+    r#"
+class Foo:
+    pass
+
+Foo()  # E: is not used
+"#,
+);
+
+// R4: bare name statement does not fire (not a call).
+testcase!(
+    bare_name_no_error,
+    env(),
+    r#"
+x = 1
+x
+"#,
+);
+
+// R4: comparison statement does not fire (not a call).
+testcase!(
+    comparison_no_error,
+    env(),
+    r#"
+x = 1
+x == 1
+"#,
+);
+
+// R4: attribute access statement does not fire (not a call).
+testcase!(
+    attribute_no_error,
+    env(),
+    r#"
+class Foo:
+    x: int = 1
+
+Foo.x
+"#,
+);
+
+// R5: discarded coroutine call fires exactly unused-coroutine, NOT unused-call-result,
+// even when unused-call-result is enabled.
+testcase!(
+    discarded_coroutine_fires_unused_coroutine_not_unused_call_result,
+    env(),
+    r#"
+async def foo() -> int:
+    return 1
+
+async def bar() -> None:
+    foo()  # E: Did you forget to `await`?
+"#,
+);
+
+// R2: rule is off by default; no errors without enable_unused_call_result_error.
+testcase!(
+    off_by_default,
+    TestEnv::new(),
+    r#"
+def combine(a: list[int], b: list[int]) -> list[int]:
+    return a + b
+
+items = [1, 2, 3]
+combine(items, [4, 5])
+"#,
+);

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -118,6 +118,7 @@ pub struct TestEnv {
     not_required_key_access_error: bool,
     pytorch_efficiency_lint_error: bool,
     incompatible_comparison_error: bool,
+    unused_call_result_error: bool,
     string_as_iterable_warning: bool,
     strict_callable_subtyping: bool,
     spec_compliant_overloads: bool,
@@ -152,6 +153,7 @@ impl TestEnv {
             not_required_key_access_error: false,
             pytorch_efficiency_lint_error: false,
             incompatible_comparison_error: false,
+            unused_call_result_error: false,
             string_as_iterable_warning: false,
             strict_callable_subtyping: false,
             spec_compliant_overloads: false,
@@ -307,6 +309,11 @@ impl TestEnv {
         self
     }
 
+    pub fn enable_unused_call_result_error(mut self) -> Self {
+        self.unused_call_result_error = true;
+        self
+    }
+
     pub fn enable_string_as_iterable_warning(mut self) -> Self {
         self.string_as_iterable_warning = true;
         self
@@ -452,6 +459,9 @@ impl TestEnv {
         }
         if self.incompatible_comparison_error {
             errors.set_error_severity(ErrorKind::IncompatibleComparison, Severity::Error);
+        }
+        if self.unused_call_result_error {
+            errors.set_error_severity(ErrorKind::UnusedCallResult, Severity::Error);
         }
         if self.string_as_iterable_warning {
             errors.set_error_severity(ErrorKind::StringAsIterable, Severity::Warn);

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -1785,6 +1785,24 @@ Type information for some third-party libraries is shipped in a stubs package se
 library's source code. This error is emitted when we detect that a library is being used without
 the recommended stubs package being installed.
 
+## unused-call-result
+
+Default severity: `ignore`
+
+This warning is raised when the result of a call expression is discarded and the result type is
+informative (not `None`, `Any`, or `Never`). This is often a sign of a mistake, such as forgetting
+to use the return value.
+
+```python
+def combine(a: list[int], b: list[int]) -> list[int]:
+    return a + b
+
+items = [1, 2, 3]
+combine(items, [4, 5])  # warning: result is discarded
+print(items)  # ok: print returns None
+x = combine(items, [4, 5])  # ok: result is used
+```
+
 ## unused-coroutine
 
 If the result of an async function call is not awaited or used, we will raise an error.


### PR DESCRIPTION
Introduce an `unused-call-result` diagnostic that fires when a bare
expression statement is a function/method call whose result is discarded
and the result type is informative (not `None`, `Any`, or `Never`).

The check sits in `binding_to_type_stmt_expr` as an `else if` branch
after the existing `unused-coroutine` check, so the two diagnostics
are mutually exclusive: a discarded coroutine call still emits only
`unused-coroutine`. The guard `matches!(e, Expr::Call(_))` ensures
assignments, bare names, comparisons, and similar non-call statements
are not flagged. Results of type `Any` or that extend `Any` are also
exempted, consistent with the coroutine rule. The rule defaults to
`Severity::Ignore` and must be explicitly enabled.

A new test file covers every spec boundary: the golden-path discard,
assigned/None/Any/Never/extends-Any exemptions, method and constructor
calls, non-call bare statements, the R5 coroutine mutual-exclusion case
(rule ON + coroutine discard → exactly one `unused-coroutine` error),
and the default-off regression.

Fixes https://github.com/facebook/pyrefly/issues/3719

Test Plan:
- cargo test -p pyrefly_config test_doc_headers test_doc_severities
- cargo test -p pyrefly --lib unused_call_result
- cargo test -p pyrefly --lib simple::test_unused_coroutine
- python3 test.py --no-test --no-conformance --no-jsonschema

