### PR TITLE
fix enum hover should show fields, not call #3889

### DIFF
--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -792,6 +792,33 @@ pub fn get_hover(
                 return display;
             }
             if show_constructor {
+                let enum_class = match &cloned {
+                    Type::ClassDef(cls) => Some(cls),
+                    Type::ClassType(cls) => Some(cls.class_object()),
+                    Type::Type(t) => match &**t {
+                        Type::ClassType(cls) => Some(cls.class_object()),
+                        _ => None,
+                    },
+                    _ => None,
+                };
+                if let Some(cls) = enum_class
+                    && solver.get_metadata_for_class(cls).is_enum()
+                {
+                    let members: Vec<Type> = solver
+                        .get_enum_members(cls)
+                        .into_iter()
+                        .map(|lit| lit.to_implicit_type())
+                        .collect();
+                    let enum_display_type = if members.is_empty() {
+                        cloned
+                    } else {
+                        solver.heap.mk_union(members)
+                    };
+                    return enum_display_type.as_lsp_string_with_fallback_name(
+                        name_for_display.as_deref(),
+                        LspDisplayMode::Hover,
+                    );
+                }
                 let constructor = match cloned {
                     Type::ClassDef(ref cls)
                         if !solver.get_metadata_for_class(cls).is_typed_dict() =>

--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -538,6 +538,55 @@ fn type_parameter_hover_display(
     ))
 }
 
+fn class_hover_display(
+    solver: &AnswersSolver<TransactionHandle<'_>>,
+    type_: &Type,
+    name_for_display: Option<&str>,
+) -> Option<String> {
+    let enum_class = match type_ {
+        Type::ClassDef(cls) => Some(cls),
+        Type::ClassType(cls) => Some(cls.class_object()),
+        Type::Type(t) => match &**t {
+            Type::ClassType(cls) => Some(cls.class_object()),
+            _ => None,
+        },
+        _ => None,
+    };
+    if let Some(cls) = enum_class
+        && solver.get_metadata_for_class(cls).is_enum()
+    {
+        let members: Vec<Type> = solver
+            .get_enum_members(cls)
+            .into_iter()
+            .map(|lit| lit.to_implicit_type())
+            .collect();
+        let enum_display_type = if members.is_empty() {
+            type_.clone()
+        } else {
+            solver.heap.mk_union(members)
+        };
+        return Some(
+            enum_display_type
+                .as_lsp_string_with_fallback_name(name_for_display, LspDisplayMode::Hover),
+        );
+    }
+
+    let mut constructor = match type_ {
+        Type::ClassDef(cls) if !solver.get_metadata_for_class(cls).is_typed_dict() => Some(
+            solver
+                .type_order()
+                .constructor_to_callable(&solver.promote_nontypeddict_silently_to_classtype(cls)),
+        ),
+        Type::Type(t) => match &**t {
+            Type::ClassType(cls) => Some(solver.type_order().constructor_to_callable(cls)),
+            _ => None,
+        },
+        _ => None,
+    }?;
+    constructor.transform_toplevel_callable(|c| expand_callable_kwargs_for_hover(solver, c));
+    Some(constructor.as_lsp_string_with_fallback_name(name_for_display, LspDisplayMode::Hover))
+}
+
 fn parameter_documentation_for_callee(
     transaction: &Transaction<'_>,
     handle: &Handle,
@@ -791,56 +840,11 @@ pub fn get_hover(
             {
                 return display;
             }
-            if show_constructor {
-                let enum_class = match &cloned {
-                    Type::ClassDef(cls) => Some(cls),
-                    Type::ClassType(cls) => Some(cls.class_object()),
-                    Type::Type(t) => match &**t {
-                        Type::ClassType(cls) => Some(cls.class_object()),
-                        _ => None,
-                    },
-                    _ => None,
-                };
-                if let Some(cls) = enum_class
-                    && solver.get_metadata_for_class(cls).is_enum()
-                {
-                    let members: Vec<Type> = solver
-                        .get_enum_members(cls)
-                        .into_iter()
-                        .map(|lit| lit.to_implicit_type())
-                        .collect();
-                    let enum_display_type = if members.is_empty() {
-                        cloned
-                    } else {
-                        solver.heap.mk_union(members)
-                    };
-                    return enum_display_type.as_lsp_string_with_fallback_name(
-                        name_for_display.as_deref(),
-                        LspDisplayMode::Hover,
-                    );
-                }
-                let constructor = match cloned {
-                    Type::ClassDef(ref cls)
-                        if !solver.get_metadata_for_class(cls).is_typed_dict() =>
-                    {
-                        Some(solver.type_order().constructor_to_callable(
-                            &solver.promote_nontypeddict_silently_to_classtype(cls),
-                        ))
-                    }
-                    Type::Type(ref t) if let Type::ClassType(cls) = &**t => {
-                        Some(solver.type_order().constructor_to_callable(cls))
-                    }
-                    _ => None,
-                };
-                if let Some(mut constructor) = constructor {
-                    constructor.transform_toplevel_callable(|c| {
-                        expand_callable_kwargs_for_hover(&solver, c)
-                    });
-                    return constructor.as_lsp_string_with_fallback_name(
-                        name_for_display.as_deref(),
-                        LspDisplayMode::Hover,
-                    );
-                }
+            if show_constructor
+                && let Some(display) =
+                    class_hover_display(&solver, &cloned, name_for_display.as_deref())
+            {
+                return display;
             }
             cloned.transform_toplevel_callable(|c| expand_callable_kwargs_for_hover(&solver, c));
             cloned.as_lsp_string_with_fallback_name(

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -989,6 +989,46 @@ Test docstring
 }
 
 #[test]
+fn hover_on_imported_enum_shows_members() {
+    let code = r#"
+from http import HTTPStatus
+#                ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert!(
+        report.contains("(class) HTTPStatus: Literal[HTTPStatus.CONTINUE"),
+        "Expected enum hover to show members, got: {report}"
+    );
+    assert!(
+        report.contains("HTTPStatus.OK"),
+        "Expected enum hover to include later members, got: {report}"
+    );
+    assert!(
+        !report.contains("def __new__") && !report.contains("def __init__"),
+        "Enum hover should not show a constructor, got: {report}"
+    );
+}
+
+#[test]
+fn hover_on_imported_enum_call_shows_call() {
+    let code = r#"
+from http import HTTPStatus
+
+HTTPStatus(200)
+#^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert!(
+        report.contains("(method) __new__") && report.contains("value: Any"),
+        "Expected enum call hover to show the call signature, got: {report}"
+    );
+    assert!(
+        !report.contains("Literal[HTTPStatus.CONTINUE"),
+        "Enum call hover should not show the member list, got: {report}"
+    );
+}
+
+#[test]
 fn hover_on_class_in_type_annotation_shows_constructor() {
     let code = r#"
 class Foo:

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -994,18 +994,26 @@ fn hover_on_imported_enum_shows_members() {
 from http import HTTPStatus
 #                ^
 "#;
-    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
-    assert!(
-        report.contains("(class) HTTPStatus: Literal[HTTPStatus.CONTINUE"),
-        "Expected enum hover to show members, got: {report}"
-    );
-    assert!(
-        report.contains("HTTPStatus.OK"),
-        "Expected enum hover to include later members, got: {report}"
-    );
-    assert!(
-        !report.contains("def __new__") && !report.contains("def __init__"),
-        "Enum hover should not show a constructor, got: {report}"
+    let report = get_batched_lsp_operations_report(&[("main", code)], |state, handle, position| {
+        match get_hover(&state.transaction(), handle, position, false) {
+            Some(Hover {
+                contents: HoverContents::Markup(markup),
+                ..
+            }) => markup.value,
+            _ => "None".to_owned(),
+        }
+    });
+    assert_eq!(
+        r#"
+# main.py
+2 | from http import HTTPStatus
+                     ^
+```python
+(class) HTTPStatus: Literal[HTTPStatus.CONTINUE, HTTPStatus.SWITCHING_PROTOCOLS, HTTPStatus.PROCESSING, HTTPStatus.EARLY_HINTS, HTTPStatus.OK, HTTPStatus.CREATED, HTTPStatus.ACCEPTED, HTTPStatus.NON_AUTHORITATIVE_INFORMATION, HTTPStatus.NO_CONTENT, HTTPStatus.RESET_CONTENT, HTTPStatus.PARTIAL_CONTENT, HTTPStatus.MULTI_STATUS, HTTPStatus.ALREADY_REPORTED, HTTPStatus.IM_USED, HTTPStatus.MULTIPLE_CHOICES, HTTPStatus.MOVED_PERMANENTLY, HTTPStatus.FOUND, HTTPStatus.SEE_OTHER, HTTPStatus.NOT_MODIFIED, HTTPStatus.USE_PROXY, HTTPStatus.TEMPORARY_REDIRECT, HTTPStatus.PERMANENT_REDIRECT, HTTPStatus.BAD_REQUEST, HTTPStatus.UNAUTHORIZED, HTTPStatus.PAYMENT_REQUIRED, HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND, HTTPStatus.METHOD_NOT_ALLOWED, HTTPStatus.NOT_ACCEPTABLE, HTTPStatus.PROXY_AUTHENTICATION_REQUIRED, HTTPStatus.REQUEST_TIMEOUT, HTTPStatus.CONFLICT, HTTPStatus.GONE, HTTPStatus.LENGTH_REQUIRED, HTTPStatus.PRECONDITION_FAILED, HTTPStatus.CONTENT_TOO_LARGE, HTTPStatus.REQUEST_ENTITY_TOO_LARGE, HTTPStatus.URI_TOO_LONG, HTTPStatus.REQUEST_URI_TOO_LONG, HTTPStatus.UNSUPPORTED_MEDIA_TYPE, HTTPStatus.RANGE_NOT_SATISFIABLE, HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE, HTTPStatus.EXPECTATION_FAILED, HTTPStatus.IM_A_TEAPOT, HTTPStatus.MISDIRECTED_REQUEST, HTTPStatus.UNPROCESSABLE_CONTENT, HTTPStatus.UNPROCESSABLE_ENTITY, HTTPStatus.LOCKED, HTTPStatus.FAILED_DEPENDENCY, HTTPStatus.TOO_EARLY, HTTPStatus.UPGRADE_REQUIRED, HTTPStatus.PRECONDITION_REQUIRED, HTTPStatus.TOO_MANY_REQUESTS, HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE, HTTPStatus.UNAVAILABLE_FOR_LEGAL_REASONS, HTTPStatus.INTERNAL_SERVER_ERROR, HTTPStatus.NOT_IMPLEMENTED, HTTPStatus.BAD_GATEWAY, HTTPStatus.SERVICE_UNAVAILABLE, HTTPStatus.GATEWAY_TIMEOUT, HTTPStatus.HTTP_VERSION_NOT_SUPPORTED, HTTPStatus.VARIANT_ALSO_NEGOTIATES, HTTPStatus.INSUFFICIENT_STORAGE, HTTPStatus.LOOP_DETECTED, HTTPStatus.NOT_EXTENDED, HTTPStatus.NETWORK_AUTHENTICATION_REQUIRED]
+```
+"#
+        .trim(),
+        report.trim(),
     );
 }
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3889

enum classes display their enum member literal union instead of constructor signatures.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test for hover and `__new__` test