### PR TITLE
fix Incorrect union narrowing with is EnumMember #3820

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -182,7 +182,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     }
 
     fn intersect_impl(&self, left: &Type, right: &Type, fallback: IntersectFallback) -> Type {
-        if self.is_subset_eq(right, left) {
+        if Self::enum_instance(left, right).is_some() {
+            right.clone()
+        } else if Self::enum_instance(right, left).is_some() {
+            left.clone()
+        } else if self.is_subset_eq(right, left) {
             if left.is_toplevel_callable()
                 && right.is_toplevel_callable()
                 && self.is_subset_eq(left, right)
@@ -279,9 +283,20 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         right: &Type,
         fallback: IntersectFallback,
     ) -> Type {
-        self.distribute_over_union(left, |l| {
-            self.distribute_over_union(right, |r| self.intersect_impl(l, r, fallback))
-        })
+        let mut narrowed = Vec::new();
+        self.map_over_union(left, |l| {
+            self.map_over_union(right, |r| {
+                let t = self.intersect_impl(l, r, fallback);
+                if !t.is_never() {
+                    narrowed.push(t);
+                }
+            });
+        });
+        match narrowed.len() {
+            0 => self.heap.mk_never(),
+            1 => narrowed.pop().expect("narrowed has one element"),
+            _ => self.unions(narrowed),
+        }
     }
 
     fn intersect(&self, left: &Type, right: &Type) -> Type {
@@ -335,26 +350,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Some((left, &right.member))
         } else {
             None
-        }
-    }
-
-    /// Narrow a type to values identity-equal to `right` (`is` semantics).
-    fn narrow_is(&self, ty: &Type, right: &Type) -> Type {
-        let mut narrowed = Vec::new();
-        self.map_over_union(ty, |t| {
-            let t = if Self::enum_instance(t, right).is_some() {
-                right.clone()
-            } else {
-                self.intersect(t, right)
-            };
-            if !t.is_never() {
-                narrowed.push(t);
-            }
-        });
-        match narrowed.len() {
-            0 => self.heap.mk_never(),
-            1 => narrowed.pop().expect("narrowed has one element"),
-            _ => self.unions(narrowed),
         }
     }
 
@@ -1037,9 +1032,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                 }
                 Type::Literal(f) if matches!(f.value, Lit::Bool(_) | Lit::Enum(_)) => {
-                    if self.is_subset_eq(right, &facet_ty)
-                        || Self::enum_instance(&facet_ty, right).is_some()
-                    {
+                    if !self.intersect(&facet_ty, right).is_never() {
                         t.clone()
                     } else {
                         self.heap.mk_never()
@@ -1532,7 +1525,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             AtomicNarrowOp::Is(v) => {
                 let right = self.expr_infer(v, errors);
                 // Get our best approximation of ty & right.
-                self.narrow_is(ty, &right)
+                self.intersect(ty, &right)
             }
             AtomicNarrowOp::IsNot(v) => {
                 let right = self.expr_infer(v, errors);

--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -338,6 +338,26 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
+    /// Narrow a type to values identity-equal to `right` (`is` semantics).
+    fn narrow_is(&self, ty: &Type, right: &Type) -> Type {
+        let mut narrowed = Vec::new();
+        self.map_over_union(ty, |t| {
+            let t = if Self::enum_instance(t, right).is_some() {
+                right.clone()
+            } else {
+                self.intersect(t, right)
+            };
+            if !t.is_never() {
+                narrowed.push(t);
+            }
+        });
+        match narrowed.len() {
+            0 => self.heap.mk_never(),
+            1 => narrowed.pop().expect("narrowed has one element"),
+            _ => self.unions(narrowed),
+        }
+    }
+
     /// Narrow a type by removing values identity-equal to `right` (`is not` semantics).
     fn narrow_is_not(&self, ty: &Type, right: &Type) -> Type {
         self.distribute_over_union(ty, |t| match (t, right) {
@@ -1017,7 +1037,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                 }
                 Type::Literal(f) if matches!(f.value, Lit::Bool(_) | Lit::Enum(_)) => {
-                    if self.is_subset_eq(right, &facet_ty) {
+                    if self.is_subset_eq(right, &facet_ty)
+                        || Self::enum_instance(&facet_ty, right).is_some()
+                    {
                         t.clone()
                     } else {
                         self.heap.mk_never()
@@ -1510,7 +1532,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             AtomicNarrowOp::Is(v) => {
                 let right = self.expr_infer(v, errors);
                 // Get our best approximation of ty & right.
-                self.intersect(ty, &right)
+                self.narrow_is(ty, &right)
             }
             AtomicNarrowOp::IsNot(v) => {
                 let right = self.expr_infer(v, errors);

--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -443,6 +443,26 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
+    /// Narrow a type to values identity-equal to `right` (`is` semantics).
+    fn narrow_is(&self, ty: &Type, right: &Type) -> Type {
+        let mut narrowed = Vec::new();
+        self.map_over_union(ty, |t| {
+            let t = if Self::enum_instance(t, right).is_some() {
+                right.clone()
+            } else {
+                self.intersect(t, right)
+            };
+            if !t.is_never() {
+                narrowed.push(t);
+            }
+        });
+        match narrowed.len() {
+            0 => self.heap.mk_never(),
+            1 => narrowed.pop().expect("narrowed has one element"),
+            _ => self.unions(narrowed),
+        }
+    }
+
     /// Narrow a type by removing values identity-equal to `right` (`is not` semantics).
     fn narrow_is_not(&self, ty: &Type, right: &Type) -> Type {
         self.distribute_over_union(ty, |t| match (t, right) {
@@ -1110,7 +1130,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 &FacetChain::new(Vec1::new(facet.clone())),
                 range,
             );
-            if Self::is_identity_literal(right) && !self.is_subset_eq(right, &facet_ty) {
+            if Self::is_identity_literal(right)
+                && !self.is_subset_eq(right, &facet_ty)
+                && Self::enum_instance(&facet_ty, right).is_none()
+            {
                 self.heap.mk_never()
             } else {
                 t.clone()
@@ -1625,7 +1648,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             AtomicNarrowOp::Is(v) => {
                 let right = self.expr_infer(v, errors);
                 // Get our best approximation of ty & right.
-                self.intersect(ty, &right)
+                self.narrow_is(ty, &right)
             }
             AtomicNarrowOp::IsNot(v) => {
                 let right = self.expr_infer(v, errors);

--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -179,7 +179,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     }
 
     fn intersect_impl(&self, left: &Type, right: &Type, fallback: IntersectFallback) -> Type {
-        if self.is_subset_eq(right, left) {
+        if Self::enum_instance(left, right).is_some() {
+            right.clone()
+        } else if Self::enum_instance(right, left).is_some() {
+            left.clone()
+        } else if self.is_subset_eq(right, left) {
             if left.is_toplevel_callable()
                 && right.is_toplevel_callable()
                 && self.is_subset_eq(left, right)
@@ -282,9 +286,20 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         right: &Type,
         fallback: IntersectFallback,
     ) -> Type {
-        self.distribute_over_union(left, |l| {
-            self.distribute_over_union(right, |r| self.intersect_impl(l, r, fallback))
-        })
+        let mut narrowed = Vec::new();
+        self.map_over_union(left, |l| {
+            self.map_over_union(right, |r| {
+                let t = self.intersect_impl(l, r, fallback);
+                if !t.is_never() {
+                    narrowed.push(t);
+                }
+            });
+        });
+        match narrowed.len() {
+            0 => self.heap.mk_never(),
+            1 => narrowed.pop().expect("narrowed has one element"),
+            _ => self.unions(narrowed),
+        }
     }
 
     fn intersect(&self, left: &Type, right: &Type) -> Type {
@@ -440,26 +455,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Some((left, &right.member))
         } else {
             None
-        }
-    }
-
-    /// Narrow a type to values identity-equal to `right` (`is` semantics).
-    fn narrow_is(&self, ty: &Type, right: &Type) -> Type {
-        let mut narrowed = Vec::new();
-        self.map_over_union(ty, |t| {
-            let t = if Self::enum_instance(t, right).is_some() {
-                right.clone()
-            } else {
-                self.intersect(t, right)
-            };
-            if !t.is_never() {
-                narrowed.push(t);
-            }
-        });
-        match narrowed.len() {
-            0 => self.heap.mk_never(),
-            1 => narrowed.pop().expect("narrowed has one element"),
-            _ => self.unions(narrowed),
         }
     }
 
@@ -1130,10 +1125,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 &FacetChain::new(Vec1::new(facet.clone())),
                 range,
             );
-            if Self::is_identity_literal(right)
-                && !self.is_subset_eq(right, &facet_ty)
-                && Self::enum_instance(&facet_ty, right).is_none()
-            {
+            if Self::is_identity_literal(right) && self.intersect(&facet_ty, right).is_never() {
                 self.heap.mk_never()
             } else {
                 t.clone()
@@ -1648,7 +1640,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             AtomicNarrowOp::Is(v) => {
                 let right = self.expr_infer(v, errors);
                 // Get our best approximation of ty & right.
-                self.narrow_is(ty, &right)
+                self.intersect(ty, &right)
             }
             AtomicNarrowOp::IsNot(v) => {
                 let right = self.expr_infer(v, errors);

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -160,6 +160,27 @@ def f2(x: E | int):
 );
 
 testcase!(
+    test_is_final_enum_literal,
+    r#"
+from typing import Final, Literal, assert_type, final
+import enum
+
+@final
+class UnsetType(enum.Enum):
+    UNSET = "UNSET"
+    def __bool__(self) -> Literal[False]: ...
+
+UNSET: Final = UnsetType.UNSET
+
+assert_type(UNSET, Literal[UnsetType.UNSET])
+
+def f(x: int | UnsetType) -> None:
+    if x is UNSET:
+        assert_type(x, Literal[UnsetType.UNSET])
+    "#,
+);
+
+testcase!(
     test_is_not_final_enum,
     r#"
 from enum import Enum


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3820

positive `is` narrowing preserves a single surviving enum literal instead of letting union simplification widen it back to the enum class.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test