### PR TITLE
fix Literal str type is unexpectedly broaden via pattern matching #3658

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -5769,6 +5769,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // TODO: check against duplicate keys (optional)
                 let key_ty = self.expr_infer(mapping_key, errors);
                 let binding = self.get_idx(*binding_key);
+                if let Type::TypedDict(typed_dict) = binding.ty()
+                    && let Type::Literal(lit) = &key_ty
+                    && let Lit::Str(key) = &lit.value
+                    && let Some(field) = self.typed_dict_field(typed_dict, &Name::new(key))
+                {
+                    return field.ty;
+                }
                 let arg = CallArg::ty(&key_ty, mapping_key.range());
                 self.call_method_or_error(
                     binding.ty(),

--- a/pyrefly/lib/test/pattern_match.rs
+++ b/pyrefly/lib/test/pattern_match.rs
@@ -182,6 +182,52 @@ def my_func(x: dict[MyEnumType, int]) -> int:
 );
 
 testcase!(
+    test_mapping_pattern_typed_dict_preserves_literal_value_type,
+    r#"
+from dataclasses import dataclass
+from typing import Literal, TypeAlias, TypedDict, TypeVar, assert_never
+
+T = TypeVar("T")
+Pair: TypeAlias = tuple[T, T]
+PairSpec: TypeAlias = T | Pair[T]
+BoundaryStr: TypeAlias = Literal["closed", "periodic"]
+
+class BoundaryDictSpec(TypedDict):
+    x: PairSpec[BoundaryStr]
+    y: PairSpec[BoundaryStr]
+
+BoundarySpec: TypeAlias = BoundaryStr | BoundaryDictSpec
+
+def as_pair(b: PairSpec[BoundaryStr], /) -> Pair[BoundaryStr]:
+    match b:
+        case str():
+            return (b, b)
+        case (str(b1), str(b2)):
+            return (b1, b2)
+        case _ as unreachable:
+            assert_never(unreachable)
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class BoundarySet:
+    x: Pair[BoundaryStr]
+    y: Pair[BoundaryStr]
+
+    @staticmethod
+    def from_spec(spec: BoundarySpec, /) -> "BoundarySet | None":
+        match spec:
+            case str() as b:
+                return BoundarySet(x=as_pair(b), y=as_pair(b))
+            case {
+                "x": (str() | (str(), str())) as bx,
+                "y": (str() | (str(), str())) as by,
+            } if len(spec) == 2:
+                return BoundarySet(x=as_pair(bx), y=as_pair(by))
+            case _:
+                raise TypeError
+"#,
+);
+
+testcase!(
     test_non_exhaustive_flow_merging,
     r#"
 from typing import assert_type, Literal


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3658

facet narrowing now treats impossible isinstance / not isinstance checks as eliminating the parent value, so the tuple branch reaches Never.

mapping pattern lookup on a TypedDict with a literal string key now returns the declared field type instead of falling back to broad `__getitem__`.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test