### PR TITLE
Let `# pyrefly: ignore` exclude symbols from `pyrefly coverage`

### DIFF
--- a/pyrefly/lib/commands/coverage/collect.rs
+++ b/pyrefly/lib/commands/coverage/collect.rs
@@ -8,14 +8,17 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use dupe::Dupe;
 use pyrefly_build::handle::Handle;
 use pyrefly_config::error_kind::ErrorKind;
+use pyrefly_config::error_kind::Severity;
 use pyrefly_config::finder::ConfigFinder;
 use pyrefly_graph::index::Idx;
 use pyrefly_python::dunder;
+use pyrefly_python::ignore::Tool;
 use pyrefly_python::module::Module;
 use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::module_path::ModuleStyle;
@@ -27,6 +30,7 @@ use pyrefly_types::class::ClassType;
 use pyrefly_types::types::Type;
 use pyrefly_util::forgetter::Forgetter;
 use pyrefly_util::includes::Includes;
+use pyrefly_util::lined_buffer::LineNumber;
 use pyrefly_util::lock::Mutex;
 use pyrefly_util::thread_pool::ThreadCount;
 use ruff_python_ast::Expr;
@@ -1589,39 +1593,98 @@ fn untyped_error(
     )
 }
 
+/// Coverage ignore codes that silenced nothing, i.e. whose kind never fired on their line.
+/// `warned` maps each in-scope line to the kinds that fired there.
+fn unused_coverage_ignores(
+    module: &Module,
+    warned: &SmallMap<LineNumber, SmallSet<ErrorKind>>,
+) -> Vec<Error> {
+    let mut errors = Vec::new();
+    for (line, supps) in module.ignore().iter() {
+        let Some(fired) = warned.get(line) else {
+            continue;
+        };
+
+        for supp in supps.iter().filter(|s| s.tool() == Tool::Pyrefly) {
+            let codes = supp.error_codes();
+            let unused: Vec<&str> = codes
+                .iter()
+                .map(String::as_str)
+                .filter(|&c| {
+                    ErrorKind::from_str(c).is_ok_and(|k| k.is_coverage() && !fired.contains(&k))
+                })
+                .collect();
+            if !unused.is_empty() {
+                // `UnusedIgnore` is hidden by default; show it like the coverage findings.
+                errors.push(
+                    Error::unused_pyrefly_ignore(module, supp.comment_line(), codes.len(), &unused)
+                        .with_severity(Severity::Warn),
+                );
+            }
+        }
+    }
+    errors
+}
+
+/// Collect untyped-symbol findings, and exclude `# pyrefly: ignore`d symbols from coverage by
+/// zeroing their slots (so they drop out of the percentage, not just the output).
+///
+/// `untyped_strict` is `None` for `coverage report` (exclude only) and `Some(strict)` for
+/// `coverage check` (also emit findings, counting `Any` as untyped when strict).
 fn collect_untyped_errors(
     errors: &mut Vec<Error>,
     module: &Module,
-    functions: &[Function],
-    variables: &[Variable],
-    strict: bool,
+    functions: &mut [Function],
+    variables: &mut [Variable],
+    untyped_strict: Option<bool>,
     public_fqns: Option<&HashSet<String>>,
+    enabled_ignores: &SmallSet<Tool>,
 ) {
+    let strict = untyped_strict.unwrap_or(false);
+    let emit = untyped_strict.is_some();
+
+    // Only consider `# pyrefly: ignore`; Pyrefly is the only checker that measures type coverage.
+    let pyrefly_enabled = enabled_ignores.contains(&Tool::Pyrefly);
+    let mut coverage_ignores = SmallSet::new();
+    if pyrefly_enabled {
+        coverage_ignores.insert(Tool::Pyrefly);
+    }
     let module_prefix = format!("{}.", module.name());
     let is_public =
         |name: &str| public_fqns.is_none_or(|fqns| is_public_fqn(name, &module_prefix, fqns));
-    // Property accessors share a name; emit one error per property, as `report` merges them.
-    let mut seen_properties = SmallSet::new();
-    for func in functions {
-        if is_untyped(&func.slots, strict)
-            && is_public(&func.name)
-            && (func.property_role.is_none() || seen_properties.insert(&func.name))
-        {
-            errors.push(untyped_error(
-                module,
-                &func.slots,
-                strict,
-                func.range,
-                &func.name,
-            ));
+
+    // Accessors of a property share a name and `report` merges them, so warn once per name.
+    let mut seen_properties: SmallSet<String> = SmallSet::new();
+
+    // Coverage kinds fired per in-scope line, recorded pre-suppression so a silenced warning still
+    // marks its ignore used. An absent line is out of scope: no unused ignores.
+    let mut warned: SmallMap<LineNumber, SmallSet<ErrorKind>> = SmallMap::new();
+    let line_of = |range| module.display_range(range).start.line_within_file();
+    let funcs = functions
+        .iter_mut()
+        .map(|f| (&f.name, f.range, &mut f.slots, f.property_role.is_some()));
+    let vars = variables
+        .iter_mut()
+        .map(|v| (&v.name, v.range, &mut v.slots, false));
+    for (name, range, slots, is_property) in funcs.chain(vars) {
+        if !is_public(name) {
+            continue;
+        }
+
+        let kinds = warned.entry(line_of(range)).or_default();
+        if is_untyped(slots, strict) {
+            let error = untyped_error(module, slots, strict, range, name);
+            kinds.insert(error.error_kind());
+            if error.is_ignored(&coverage_ignores) {
+                *slots = SlotCounts::default();
+            } else if emit && (!is_property || seen_properties.insert(name.clone())) {
+                errors.push(error);
+            }
         }
     }
-    for var in variables {
-        if is_untyped(&var.slots, strict) && is_public(&var.name) {
-            errors.push(untyped_error(
-                module, &var.slots, strict, var.range, &var.name,
-            ));
-        }
+
+    if emit && pyrefly_enabled {
+        errors.extend(unused_coverage_ignores(module, &warned));
     }
 }
 
@@ -1755,17 +1818,17 @@ pub fn collect_module_reports(
         let Some(mut symbols) = collected.remove(handle) else {
             continue;
         };
+        let config = config_finder.python_file(handle.module_kind(), handle.path());
         // Per source module, so stub-merged `.py` symbols render against their own file.
-        if let Some(strict) = untyped_strict {
-            collect_untyped_errors(
-                &mut errors,
-                &symbols.module,
-                &symbols.functions,
-                &symbols.variables,
-                strict,
-                public_fqns.as_ref(),
-            );
-        }
+        collect_untyped_errors(
+            &mut errors,
+            &symbols.module,
+            &mut symbols.functions,
+            &mut symbols.variables,
+            untyped_strict,
+            public_fqns.as_ref(),
+            config.enabled_ignores(handle.path().as_path()),
+        );
 
         // When a .pyi stub shadows a .py file, include uncovered .py symbols.
         if let Some(py_handle) = pyi_to_py.get(&handle.path().as_path().to_path_buf())
@@ -1775,16 +1838,16 @@ pub fn collect_module_reports(
             let own_functions = symbols.functions.len();
             let own_variables = symbols.variables.len();
             symbols.merge_uncovered_py_symbols(py_symbols);
-            if let Some(strict) = untyped_strict {
-                collect_untyped_errors(
-                    &mut errors,
-                    &py_module,
-                    &symbols.functions[own_functions..],
-                    &symbols.variables[own_variables..],
-                    strict,
-                    public_fqns.as_ref(),
-                );
-            }
+            let py_config = config_finder.python_file(py_handle.module_kind(), py_handle.path());
+            collect_untyped_errors(
+                &mut errors,
+                &py_module,
+                &mut symbols.functions[own_functions..],
+                &mut symbols.variables[own_variables..],
+                untyped_strict,
+                public_fqns.as_ref(),
+                py_config.enabled_ignores(py_handle.path().as_path()),
+            );
         }
 
         let derived_name = handle.module().to_string();
@@ -1879,6 +1942,160 @@ mod tests {
         let handle = handle_fn("test");
         let symbols = ModuleSymbols::collect(&state.transaction(), &handle, false).unwrap();
         (symbols, module_path)
+    }
+
+    /// Run the coverage exclusion/findings pass over inline source with default-enabled ignores,
+    /// mirroring the production path. Returns the mutated symbols and any emitted findings.
+    fn collect_inline(
+        code: &str,
+        untyped_strict: Option<bool>,
+        public_fqns: Option<&HashSet<String>>,
+    ) -> (ModuleSymbols, Vec<Error>) {
+        let mut env = TestEnv::new();
+        env.add_with_path("test", "test.py", code);
+        let (state, handle_fn) = env
+            .with_default_require_level(Require::Everything)
+            .to_state();
+        let handle = handle_fn("test");
+        let mut symbols = ModuleSymbols::collect(&state.transaction(), &handle, false).unwrap();
+        let mut errors = Vec::new();
+        collect_untyped_errors(
+            &mut errors,
+            &symbols.module,
+            &mut symbols.functions,
+            &mut symbols.variables,
+            untyped_strict,
+            public_fqns,
+            &Tool::default_enabled(),
+        );
+        (symbols, errors)
+    }
+
+    /// Coverage findings (warnings + unused-coverage-ignore errors) for inline source.
+    fn coverage_findings(code: &str, public_fqns: Option<&HashSet<String>>) -> Vec<Error> {
+        collect_inline(code, Some(false), public_fqns).1
+    }
+
+    #[test]
+    fn test_coverage_inline_ignore_suppresses() {
+        // Inline ignores silence the matching coverage warning (by code or bare);
+        // the unannotated sibling without a comment is still reported.
+        let findings = coverage_findings(
+            r#"
+def ignored(x):  # pyrefly: ignore[coverage-missing]
+    return x
+def bare(x):  # pyrefly: ignore
+    return x
+def partial(x: int, y):  # pyrefly: ignore[coverage-partial]
+    return x
+def reported(x):
+    return x
+"#,
+            None,
+        );
+        let headers: Vec<&str> = findings.iter().map(|e| e.msg_header()).collect();
+        assert_eq!(headers, vec!["`test.reported` is untyped"]);
+    }
+
+    #[test]
+    fn test_coverage_unused_ignore_skips_out_of_scope() {
+        // Under `--public-only`, a coverage ignore on a non-public symbol is out of scope,
+        // not unused: it is still needed when coverage runs over the whole module.
+        let public_fqns = HashSet::from(["test.public_fn".to_owned()]);
+        let findings = coverage_findings(
+            r#"
+def _helper(x):  # pyrefly: ignore[coverage-missing]
+    return x
+def public_fn(x: int) -> int:
+    return x
+"#,
+            Some(&public_fqns),
+        );
+        assert!(findings.is_empty(), "got: {findings:?}");
+    }
+
+    #[test]
+    fn test_coverage_unused_ignore_reported() {
+        // A coverage-code ignore on a fully-typed symbol matches nothing: unused.
+        let findings = coverage_findings(
+            r#"
+def typed(x: int) -> int:  # pyrefly: ignore[coverage-missing]
+    return x
+"#,
+            None,
+        );
+        assert_eq!(findings.len(), 1);
+        assert_eq!(
+            findings[0].msg_header(),
+            "Unused `# pyrefly: ignore` comment for code(s): coverage-missing"
+        );
+        // Raised to `Warn` from its hidden default so it shows like coverage findings.
+        assert_eq!(findings[0].severity(), Severity::Warn);
+    }
+
+    /// Build a `ModuleReport` from inline source through the production pipeline (exclusion pass
+    /// then report build), so coverage ignores affect the totals. `untyped_strict` mirrors the
+    /// command: `None` for `report`, `Some(strict)` for `check`.
+    fn coverage_report(code: &str, untyped_strict: Option<bool>) -> ModuleReport {
+        let (symbols, _) = collect_inline(code, untyped_strict, None);
+        build_module_report(
+            "test".to_owned(),
+            "test.py".to_owned(),
+            "test",
+            symbols.line_count(),
+            &symbols.functions,
+            &symbols.variables,
+            &symbols.classes,
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn test_coverage_ignore_excluded_from_totals() {
+        // The point of a coverage ignore: the silenced symbol must drop out of the percentage,
+        // not just stop printing. `f`'s two slots (param + return) are excluded entirely, so
+        // coverage is 100% over zero remaining typables — for both `report` and `check`.
+        for untyped_strict in [None, Some(false)] {
+            let report = coverage_report(
+                "def f(x):  # pyrefly: ignore[coverage-missing]\n    return x\n",
+                untyped_strict,
+            );
+            assert_eq!(report.slots.n_typable, 0, "{untyped_strict:?}");
+            assert_eq!(report.coverage, 100.0, "{untyped_strict:?}");
+        }
+        // Without the ignore the same symbol still counts: 2 untyped slots, 0% coverage.
+        let report = coverage_report("def f(x):\n    return x\n", Some(false));
+        assert_eq!(report.slots.n_typable, 2);
+        assert_eq!(report.slots.n_untyped, 2);
+        assert_eq!(report.coverage, 0.0);
+    }
+
+    #[test]
+    fn test_coverage_ignore_excludes_every_property_accessor() {
+        // `report` merges a property's accessors into one symbol, so an ignore must zero every
+        // accessor's slots, not just the first. The ignore sits on the decorator line because a
+        // decorated symbol's range (hence its diagnostic) starts there.
+        let report = coverage_report(
+            r#"
+class C:
+    @property  # pyrefly: ignore
+    def x(self):
+        return 1
+    @x.setter  # pyrefly: ignore
+    def x(self, v):
+        pass
+"#,
+            Some(false),
+        );
+        assert_eq!(report.slots.n_typable, 0);
+    }
+
+    #[test]
+    fn test_coverage_type_ignore_does_not_exclude() {
+        // `# type: ignore` suppresses type errors, not coverage, so the symbol still counts.
+        let report = coverage_report("def f(x):  # type: ignore\n    return x\n", Some(false));
+        assert_eq!(report.slots.n_typable, 2);
+        assert_eq!(report.slots.n_untyped, 2);
     }
 
     fn build_module_report_for_test_with_env(file: &str, env: TestEnv) -> ModuleReport {
@@ -2200,7 +2417,7 @@ mod tests {
             "variables.py",
         ] {
             // `.pyi` entries are stub-merged with their `.py` source.
-            let (p, module_path) = if let Some(stem) = file.strip_suffix(".pyi") {
+            let (mut p, module_path) = if let Some(stem) = file.strip_suffix(".pyi") {
                 (
                     merged_stub_symbols(file, &format!("{stem}.py")),
                     "test.pyi".to_owned(),
@@ -2232,10 +2449,11 @@ mod tests {
                 collect_untyped_errors(
                     &mut errors,
                     &p.module,
-                    &p.functions,
-                    &p.variables,
-                    strict,
+                    &mut p.functions,
+                    &mut p.variables,
+                    Some(strict),
                     None,
+                    &Tool::default_enabled(),
                 );
                 let mut got: Vec<&str> = errors
                     .iter()
@@ -2252,16 +2470,17 @@ mod tests {
     /// so it must be reported as coverage-missing, not coverage-partial.
     #[test]
     fn test_untyped_error_kinds() {
-        let (p, _) = parse_test_module("any_annotations.py", TestEnv::new());
-        let kinds = |strict: bool| {
+        let (mut p, _) = parse_test_module("any_annotations.py", TestEnv::new());
+        let mut kinds = |strict: bool| {
             let mut errors = Vec::new();
             collect_untyped_errors(
                 &mut errors,
                 &p.module,
-                &p.functions,
-                &p.variables,
-                strict,
+                &mut p.functions,
+                &mut p.variables,
+                Some(strict),
                 None,
+                &Tool::default_enabled(),
             );
             errors
                 .iter()

--- a/pyrefly/lib/commands/coverage/collect.rs
+++ b/pyrefly/lib/commands/coverage/collect.rs
@@ -9,14 +9,17 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use dupe::Dupe;
 use pyrefly_build::handle::Handle;
 use pyrefly_config::error_kind::ErrorKind;
+use pyrefly_config::error_kind::Severity;
 use pyrefly_config::finder::ConfigFinder;
 use pyrefly_graph::index::Idx;
 use pyrefly_python::dunder;
+use pyrefly_python::ignore::Tool;
 use pyrefly_python::module::Module;
 use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::module_path::ModuleStyle;
@@ -28,6 +31,7 @@ use pyrefly_types::function::PropertyRole;
 use pyrefly_types::types::Type;
 use pyrefly_util::forgetter::Forgetter;
 use pyrefly_util::includes::Includes;
+use pyrefly_util::lined_buffer::LineNumber;
 use pyrefly_util::lock::Mutex;
 use pyrefly_util::thread_pool::ThreadCount;
 use ruff_python_ast::Expr;
@@ -1553,39 +1557,98 @@ fn untyped_error(
     )
 }
 
+/// Coverage ignore codes that silenced nothing, i.e. whose kind never fired on their line.
+/// `warned` maps each in-scope line to the kinds that fired there.
+fn unused_coverage_ignores(
+    module: &Module,
+    warned: &SmallMap<LineNumber, SmallSet<ErrorKind>>,
+) -> Vec<Error> {
+    let mut errors = Vec::new();
+    for (line, supps) in module.ignore().iter() {
+        let Some(fired) = warned.get(line) else {
+            continue;
+        };
+
+        for supp in supps.iter().filter(|s| s.tool() == Tool::Pyrefly) {
+            let codes = supp.error_codes();
+            let unused: Vec<&str> = codes
+                .iter()
+                .map(String::as_str)
+                .filter(|&c| {
+                    ErrorKind::from_str(c).is_ok_and(|k| k.is_coverage() && !fired.contains(&k))
+                })
+                .collect();
+            if !unused.is_empty() {
+                // `UnusedIgnore` is hidden by default; show it like the coverage findings.
+                errors.push(
+                    Error::unused_pyrefly_ignore(module, supp, codes.len(), &unused)
+                        .with_severity(Severity::Warn),
+                );
+            }
+        }
+    }
+    errors
+}
+
+/// Collect untyped-symbol findings, and exclude `# pyrefly: ignore`d symbols from coverage by
+/// zeroing their slots (so they drop out of the percentage, not just the output).
+///
+/// `untyped_strict` is `None` for `coverage report` (exclude only) and `Some(strict)` for
+/// `coverage check` (also emit findings, counting `Any` as untyped when strict).
 fn collect_untyped_errors(
     errors: &mut Vec<Error>,
     module: &Module,
-    functions: &[Function],
-    variables: &[Variable],
-    strict: bool,
+    functions: &mut [Function],
+    variables: &mut [Variable],
+    untyped_strict: Option<bool>,
     public_fqns: Option<&HashSet<String>>,
+    enabled_ignores: &SmallSet<Tool>,
 ) {
+    let strict = untyped_strict.unwrap_or(false);
+    let emit = untyped_strict.is_some();
+
+    // Only consider `# pyrefly: ignore`; Pyrefly is the only checker that measures type coverage.
+    let pyrefly_enabled = enabled_ignores.contains(&Tool::Pyrefly);
+    let mut coverage_ignores = SmallSet::new();
+    if pyrefly_enabled {
+        coverage_ignores.insert(Tool::Pyrefly);
+    }
     let module_prefix = format!("{}.", module.name());
     let is_public =
         |name: &str| public_fqns.is_none_or(|fqns| is_public_fqn(name, &module_prefix, fqns));
-    // Property accessors share a name; emit one error per property, as `report` merges them.
-    let mut seen_properties = SmallSet::new();
-    for func in functions {
-        if is_untyped(&func.slots, strict)
-            && is_public(&func.name)
-            && (func.property_role.is_none() || seen_properties.insert(&func.name))
-        {
-            errors.push(untyped_error(
-                module,
-                &func.slots,
-                strict,
-                func.range,
-                &func.name,
-            ));
+
+    // Accessors of a property share a name and `report` merges them, so warn once per name.
+    let mut seen_properties: SmallSet<String> = SmallSet::new();
+
+    // Coverage kinds fired per in-scope line, recorded pre-suppression so a silenced warning still
+    // marks its ignore used. An absent line is out of scope: no unused ignores.
+    let mut warned: SmallMap<LineNumber, SmallSet<ErrorKind>> = SmallMap::new();
+    let line_of = |range| module.display_range(range).start.line_within_file();
+    let funcs = functions
+        .iter_mut()
+        .map(|f| (&f.name, f.range, &mut f.slots, f.property_role.is_some()));
+    let vars = variables
+        .iter_mut()
+        .map(|v| (&v.name, v.range, &mut v.slots, false));
+    for (name, range, slots, is_property) in funcs.chain(vars) {
+        if !is_public(name) {
+            continue;
+        }
+
+        let kinds = warned.entry(line_of(range)).or_default();
+        if is_untyped(slots, strict) {
+            let error = untyped_error(module, slots, strict, range, name);
+            kinds.insert(error.error_kind());
+            if error.is_ignored(&coverage_ignores) {
+                *slots = SlotCounts::default();
+            } else if emit && (!is_property || seen_properties.insert(name.clone())) {
+                errors.push(error);
+            }
         }
     }
-    for var in variables {
-        if is_untyped(&var.slots, strict) && is_public(&var.name) {
-            errors.push(untyped_error(
-                module, &var.slots, strict, var.range, &var.name,
-            ));
-        }
+
+    if emit && pyrefly_enabled {
+        errors.extend(unused_coverage_ignores(module, &warned));
     }
 }
 
@@ -1750,17 +1813,17 @@ pub fn collect_module_reports(
         let Some(mut symbols) = collected.remove(handle) else {
             continue;
         };
+        let config = config_finder.python_file(handle.module_kind(), handle.path());
         // Per source module, so stub-merged `.py` symbols render against their own file.
-        if let Some(strict) = untyped_strict {
-            collect_untyped_errors(
-                &mut errors,
-                &symbols.module,
-                &symbols.functions,
-                &symbols.variables,
-                strict,
-                public_fqns.as_ref(),
-            );
-        }
+        collect_untyped_errors(
+            &mut errors,
+            &symbols.module,
+            &mut symbols.functions,
+            &mut symbols.variables,
+            untyped_strict,
+            public_fqns.as_ref(),
+            config.enabled_ignores(handle.path().as_path()),
+        );
 
         // When a .pyi stub shadows a .py file, include uncovered .py symbols.
         if let Some(py_handle) = pyi_to_py.get(&handle.path().as_path().to_path_buf())
@@ -1770,16 +1833,16 @@ pub fn collect_module_reports(
             let own_functions = symbols.functions.len();
             let own_variables = symbols.variables.len();
             symbols.merge_uncovered_py_symbols(py_symbols);
-            if let Some(strict) = untyped_strict {
-                collect_untyped_errors(
-                    &mut errors,
-                    &py_module,
-                    &symbols.functions[own_functions..],
-                    &symbols.variables[own_variables..],
-                    strict,
-                    public_fqns.as_ref(),
-                );
-            }
+            let py_config = config_finder.python_file(py_handle.module_kind(), py_handle.path());
+            collect_untyped_errors(
+                &mut errors,
+                &py_module,
+                &mut symbols.functions[own_functions..],
+                &mut symbols.variables[own_variables..],
+                untyped_strict,
+                public_fqns.as_ref(),
+                py_config.enabled_ignores(py_handle.path().as_path()),
+            );
         }
 
         let derived_name = handle.module().to_string();
@@ -1883,6 +1946,160 @@ mod tests {
         let handle = handle_fn("test");
         let symbols = ModuleSymbols::collect(&state.transaction(), &handle, false).unwrap();
         (symbols, module_path)
+    }
+
+    /// Run the coverage exclusion/findings pass over inline source with default-enabled ignores,
+    /// mirroring the production path. Returns the mutated symbols and any emitted findings.
+    fn collect_inline(
+        code: &str,
+        untyped_strict: Option<bool>,
+        public_fqns: Option<&HashSet<String>>,
+    ) -> (ModuleSymbols, Vec<Error>) {
+        let mut env = TestEnv::new();
+        env.add_with_path("test", "test.py", code);
+        let (state, handle_fn) = env
+            .with_default_require_level(Require::Everything)
+            .to_state();
+        let handle = handle_fn("test");
+        let mut symbols = ModuleSymbols::collect(&state.transaction(), &handle, false).unwrap();
+        let mut errors = Vec::new();
+        collect_untyped_errors(
+            &mut errors,
+            &symbols.module,
+            &mut symbols.functions,
+            &mut symbols.variables,
+            untyped_strict,
+            public_fqns,
+            &Tool::default_enabled(),
+        );
+        (symbols, errors)
+    }
+
+    /// Coverage findings (warnings + unused-coverage-ignore errors) for inline source.
+    fn coverage_findings(code: &str, public_fqns: Option<&HashSet<String>>) -> Vec<Error> {
+        collect_inline(code, Some(false), public_fqns).1
+    }
+
+    #[test]
+    fn test_coverage_inline_ignore_suppresses() {
+        // Inline ignores silence the matching coverage warning (by code or bare);
+        // the unannotated sibling without a comment is still reported.
+        let findings = coverage_findings(
+            r#"
+def ignored(x):  # pyrefly: ignore[coverage-missing]
+    return x
+def bare(x):  # pyrefly: ignore
+    return x
+def partial(x: int, y):  # pyrefly: ignore[coverage-partial]
+    return x
+def reported(x):
+    return x
+"#,
+            None,
+        );
+        let headers: Vec<&str> = findings.iter().map(|e| e.msg_header()).collect();
+        assert_eq!(headers, vec!["`test.reported` is untyped"]);
+    }
+
+    #[test]
+    fn test_coverage_unused_ignore_skips_out_of_scope() {
+        // Under `--public-only`, a coverage ignore on a non-public symbol is out of scope,
+        // not unused: it is still needed when coverage runs over the whole module.
+        let public_fqns = HashSet::from(["test.public_fn".to_owned()]);
+        let findings = coverage_findings(
+            r#"
+def _helper(x):  # pyrefly: ignore[coverage-missing]
+    return x
+def public_fn(x: int) -> int:
+    return x
+"#,
+            Some(&public_fqns),
+        );
+        assert!(findings.is_empty(), "got: {findings:?}");
+    }
+
+    #[test]
+    fn test_coverage_unused_ignore_reported() {
+        // A coverage-code ignore on a fully-typed symbol matches nothing: unused.
+        let findings = coverage_findings(
+            r#"
+def typed(x: int) -> int:  # pyrefly: ignore[coverage-missing]
+    return x
+"#,
+            None,
+        );
+        assert_eq!(findings.len(), 1);
+        assert_eq!(
+            findings[0].msg_header(),
+            "Unused `# pyrefly: ignore` comment for code(s): coverage-missing"
+        );
+        // Raised to `Warn` from its hidden default so it shows like coverage findings.
+        assert_eq!(findings[0].severity(), Severity::Warn);
+    }
+
+    /// Build a `ModuleReport` from inline source through the production pipeline (exclusion pass
+    /// then report build), so coverage ignores affect the totals. `untyped_strict` mirrors the
+    /// command: `None` for `report`, `Some(strict)` for `check`.
+    fn coverage_report(code: &str, untyped_strict: Option<bool>) -> ModuleReport {
+        let (symbols, _) = collect_inline(code, untyped_strict, None);
+        build_module_report(
+            "test".to_owned(),
+            "test.py".to_owned(),
+            "test",
+            symbols.line_count(),
+            &symbols.functions,
+            &symbols.variables,
+            &symbols.classes,
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn test_coverage_ignore_excluded_from_totals() {
+        // The point of a coverage ignore: the silenced symbol must drop out of the percentage,
+        // not just stop printing. `f`'s two slots (param + return) are excluded entirely, so
+        // coverage is 100% over zero remaining typables — for both `report` and `check`.
+        for untyped_strict in [None, Some(false)] {
+            let report = coverage_report(
+                "def f(x):  # pyrefly: ignore[coverage-missing]\n    return x\n",
+                untyped_strict,
+            );
+            assert_eq!(report.slots.n_typable, 0, "{untyped_strict:?}");
+            assert_eq!(report.coverage, 100.0, "{untyped_strict:?}");
+        }
+        // Without the ignore the same symbol still counts: 2 untyped slots, 0% coverage.
+        let report = coverage_report("def f(x):\n    return x\n", Some(false));
+        assert_eq!(report.slots.n_typable, 2);
+        assert_eq!(report.slots.n_untyped, 2);
+        assert_eq!(report.coverage, 0.0);
+    }
+
+    #[test]
+    fn test_coverage_ignore_excludes_every_property_accessor() {
+        // `report` merges a property's accessors into one symbol, so an ignore must zero every
+        // accessor's slots, not just the first. The ignore sits on the decorator line because a
+        // decorated symbol's range (hence its diagnostic) starts there.
+        let report = coverage_report(
+            r#"
+class C:
+    @property  # pyrefly: ignore
+    def x(self):
+        return 1
+    @x.setter  # pyrefly: ignore
+    def x(self, v):
+        pass
+"#,
+            Some(false),
+        );
+        assert_eq!(report.slots.n_typable, 0);
+    }
+
+    #[test]
+    fn test_coverage_type_ignore_does_not_exclude() {
+        // `# type: ignore` suppresses type errors, not coverage, so the symbol still counts.
+        let report = coverage_report("def f(x):  # type: ignore\n    return x\n", Some(false));
+        assert_eq!(report.slots.n_typable, 2);
+        assert_eq!(report.slots.n_untyped, 2);
     }
 
     fn build_module_report_for_test_with_env(file: &str, env: TestEnv) -> ModuleReport {
@@ -2213,7 +2430,7 @@ mod tests {
             "variables.py",
         ] {
             // `.pyi` entries are stub-merged with their `.py` source.
-            let (p, module_path) = if let Some(stem) = file.strip_suffix(".pyi") {
+            let (mut p, module_path) = if let Some(stem) = file.strip_suffix(".pyi") {
                 (
                     merged_stub_symbols(file, &format!("{stem}.py")),
                     "test.pyi".to_owned(),
@@ -2245,10 +2462,11 @@ mod tests {
                 collect_untyped_errors(
                     &mut errors,
                     &p.module,
-                    &p.functions,
-                    &p.variables,
-                    strict,
+                    &mut p.functions,
+                    &mut p.variables,
+                    Some(strict),
                     None,
+                    &Tool::default_enabled(),
                 );
                 let mut got: Vec<&str> = errors
                     .iter()
@@ -2265,16 +2483,17 @@ mod tests {
     /// so it must be reported as coverage-missing, not coverage-partial.
     #[test]
     fn test_untyped_error_kinds() {
-        let (p, _) = parse_test_module("any_annotations.py", TestEnv::new());
-        let kinds = |strict: bool| {
+        let (mut p, _) = parse_test_module("any_annotations.py", TestEnv::new());
+        let mut kinds = |strict: bool| {
             let mut errors = Vec::new();
             collect_untyped_errors(
                 &mut errors,
                 &p.module,
-                &p.functions,
-                &p.variables,
-                strict,
+                &mut p.functions,
+                &mut p.variables,
+                Some(strict),
                 None,
+                &Tool::default_enabled(),
             );
             errors
                 .iter()
@@ -2775,17 +2994,18 @@ def g(x: int) -> int:
             .to_state();
         let handle = handle_fn("__unknown__");
         let transaction = state.transaction();
-        let symbols = ModuleSymbols::collect(&transaction, &handle, false).unwrap();
+        let mut symbols = ModuleSymbols::collect(&transaction, &handle, false).unwrap();
 
         let (public_fqns, _) = compute_public_fqns(std::slice::from_ref(&handle), &transaction);
         let mut errors = Vec::new();
         collect_untyped_errors(
             &mut errors,
             &symbols.module,
-            &symbols.functions,
-            &symbols.variables,
-            false,
+            &mut symbols.functions,
+            &mut symbols.variables,
+            Some(false),
             Some(&public_fqns),
+            &Tool::default_enabled(),
         );
 
         assert!(

--- a/pyrefly/lib/error/error.rs
+++ b/pyrefly/lib/error/error.rs
@@ -11,6 +11,7 @@ use std::io;
 use std::io::Write;
 use std::path::Path;
 
+use dupe::Dupe;
 use itertools::Itertools;
 use lsp_types::CodeDescription;
 use lsp_types::Diagnostic;
@@ -29,6 +30,7 @@ use ruff_annotate_snippets::Renderer;
 use ruff_annotate_snippets::Snippet;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
+use ruff_text_size::TextSize;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 use yansi::Paint;
@@ -428,6 +430,37 @@ impl Error {
             secondary_annotations: Vec::new(),
             quick_fixes: Vec::new(),
         }
+    }
+
+    /// Build an unused-suppression error spanning the first character of `line`.
+    pub fn unused_ignore(module: &Module, line: LineNumber, msg: String, kind: ErrorKind) -> Self {
+        let start = module.lined_buffer().line_start(line);
+        Error::new(
+            module.dupe(),
+            TextRange::new(start, start + TextSize::new(1)),
+            msg,
+            Vec::new(),
+            kind,
+        )
+    }
+
+    /// Flag a `# pyrefly: ignore` at `line` as unused. `declared_len` is the declared code count
+    /// (0 = blanket); it picks the wording for the `unused` codes.
+    pub fn unused_pyrefly_ignore(
+        module: &Module,
+        line: LineNumber,
+        declared_len: usize,
+        unused: &[&str],
+    ) -> Self {
+        let codes = unused.iter().join(", ");
+        let msg = if declared_len == 0 {
+            "Unused `# pyrefly: ignore` comment".to_owned()
+        } else if unused.len() == declared_len {
+            format!("Unused `# pyrefly: ignore` comment for code(s): {codes}")
+        } else {
+            format!("Unused error code(s) in `# pyrefly: ignore`: {codes}")
+        };
+        Error::unused_ignore(module, line, msg, ErrorKind::UnusedIgnore)
     }
 
     /// Add a secondary labeled annotation to this error. These appear as additional

--- a/pyrefly/lib/error/error.rs
+++ b/pyrefly/lib/error/error.rs
@@ -11,11 +11,13 @@ use std::io;
 use std::io::Write;
 use std::path::Path;
 
+use dupe::Dupe;
 use itertools::Itertools;
 use lsp_types::CodeDescription;
 use lsp_types::Diagnostic;
 use lsp_types::DiagnosticTag;
 use lsp_types::Url;
+use pyrefly_python::ignore::Suppression;
 use pyrefly_python::ignore::Tool;
 use pyrefly_python::module::Module;
 use pyrefly_python::module_path::ModulePath;
@@ -29,6 +31,7 @@ use ruff_annotate_snippets::Renderer;
 use ruff_annotate_snippets::Snippet;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
+use ruff_text_size::TextSize;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 use yansi::Paint;
@@ -429,6 +432,44 @@ impl Error {
             secondary_annotations: Vec::new(),
             quick_fixes: Vec::new(),
         }
+    }
+
+    /// Build an unused-suppression error spanning the `#` that starts `supp`'s comment.
+    pub fn unused_ignore(
+        module: &Module,
+        supp: &Suppression,
+        msg: String,
+        kind: ErrorKind,
+    ) -> Self {
+        let start = module.lined_buffer().line_start(supp.comment_line())
+            + TextSize::try_from(supp.comment_offset())
+                .expect("Python source offsets fit in TextSize");
+        Error::new(
+            module.dupe(),
+            TextRange::new(start, start + TextSize::new(1)),
+            msg,
+            Vec::new(),
+            kind,
+        )
+    }
+
+    /// Flag `supp`, a `# pyrefly: ignore`, as unused. `declared_len` is the declared code count
+    /// (0 = blanket); it picks the wording for the `unused` codes.
+    pub fn unused_pyrefly_ignore(
+        module: &Module,
+        supp: &Suppression,
+        declared_len: usize,
+        unused: &[&str],
+    ) -> Self {
+        let codes = unused.iter().join(", ");
+        let msg = if declared_len == 0 {
+            "Unused `# pyrefly: ignore` comment".to_owned()
+        } else if unused.len() == declared_len {
+            format!("Unused `# pyrefly: ignore` comment for code(s): {codes}")
+        } else {
+            format!("Unused error code(s) in `# pyrefly: ignore`: {codes}")
+        };
+        Error::unused_ignore(module, supp, msg, ErrorKind::UnusedIgnore)
     }
 
     /// Add a secondary labeled annotation to this error. These appear as additional

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -6,6 +6,7 @@
  */
 
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use dupe::Dupe;
@@ -26,8 +27,6 @@ use ruff_python_ast::ModModule;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::visitor::walk_expr;
 use ruff_text_size::Ranged;
-use ruff_text_size::TextRange;
-use ruff_text_size::TextSize;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 
@@ -517,14 +516,10 @@ impl Errors {
                         if !used_codes.is_empty() {
                             continue; // Pyre suppression is used
                         }
-                        let comment_line = supp.comment_line();
-                        let line_start = module.lined_buffer().line_start(comment_line);
-                        let range = TextRange::new(line_start, line_start + TextSize::new(1));
-                        unused_errors.push(Error::new(
-                            module.dupe(),
-                            range,
+                        unused_errors.push(Error::unused_ignore(
+                            module,
+                            supp.comment_line(),
                             "Unused pyre-fixme comment".to_owned(),
-                            Vec::new(),
                             ErrorKind::UnusedIgnore,
                         ));
                         continue;
@@ -535,37 +530,33 @@ impl Errors {
                         if !used_codes.is_empty() {
                             continue; // type: ignore is used
                         }
-                        let comment_line = supp.comment_line();
-                        let line_start = module.lined_buffer().line_start(comment_line);
-                        let range = TextRange::new(line_start, line_start + TextSize::new(1));
-                        unused_errors.push(Error::new(
-                            module.dupe(),
-                            range,
+                        unused_errors.push(Error::unused_ignore(
+                            module,
+                            supp.comment_line(),
                             "Unused `# type: ignore` comment".to_owned(),
-                            Vec::new(),
                             ErrorKind::UnusedTypeIgnore,
                         ));
                         continue;
                     }
 
                     // Tool::Pyrefly: check individual error codes
-                    let declared_codes: SmallSet<String> =
-                        supp.error_codes().iter().cloned().collect();
-
-                    // Determine if the suppression is unused
-                    let unused_codes: SmallSet<String> = if declared_codes.is_empty() {
-                        // Blanket ignore - unused if no errors were suppressed
-                        if used_codes.is_empty() {
-                            SmallSet::new() // Mark as unused (empty set signals blanket unused)
-                        } else {
+                    let declared = supp.error_codes();
+                    let unused_codes: Vec<&str> = if declared.is_empty() {
+                        // Blanket ignore: unused only when nothing was suppressed on the line.
+                        if !used_codes.is_empty() {
                             continue; // Used, skip
                         }
+                        Vec::new()
                     } else {
-                        // Specific codes - find which are unused
-                        let unused: SmallSet<String> = declared_codes
+                        // Coverage codes are emitted only by `coverage check`, never here, so they
+                        // are never unused during ordinary checking.
+                        let unused: Vec<&str> = declared
                             .iter()
-                            .filter(|code| !used_codes.contains(*code))
-                            .cloned()
+                            .map(String::as_str)
+                            .filter(|&c| {
+                                !used_codes.contains(c)
+                                    && !ErrorKind::from_str(c).is_ok_and(ErrorKind::is_coverage)
+                            })
                             .collect();
                         if unused.is_empty() {
                             continue; // All codes used, skip
@@ -573,31 +564,11 @@ impl Errors {
                         unused
                     };
 
-                    // Create an error for the unused suppression
-                    let comment_line = supp.comment_line();
-                    let line_start = module.lined_buffer().line_start(comment_line);
-                    let range = TextRange::new(line_start, line_start + TextSize::new(1));
-
-                    let msg = if declared_codes.is_empty() {
-                        "Unused `# pyrefly: ignore` comment".to_owned()
-                    } else if unused_codes.len() == declared_codes.len() {
-                        format!(
-                            "Unused `# pyrefly: ignore` comment for code(s): {}",
-                            unused_codes.iter().cloned().collect::<Vec<_>>().join(", ")
-                        )
-                    } else {
-                        format!(
-                            "Unused error code(s) in `# pyrefly: ignore`: {}",
-                            unused_codes.iter().cloned().collect::<Vec<_>>().join(", ")
-                        )
-                    };
-
-                    unused_errors.push(Error::new(
-                        module.dupe(),
-                        range,
-                        msg,
-                        Vec::new(),
-                        ErrorKind::UnusedIgnore,
+                    unused_errors.push(Error::unused_pyrefly_ignore(
+                        module,
+                        supp.comment_line(),
+                        declared.len(),
+                        &unused_codes,
                     ));
                 }
             }
@@ -767,6 +738,35 @@ def f() -> int:
         let unused = errors.collect_unused_ignore_errors(&collected);
         assert_eq!(unused.len(), 1);
         assert!(unused[0].msg().contains("bad-override"));
+    }
+
+    #[test]
+    fn test_coverage_code_ignore_not_unused() {
+        // Coverage codes are emitted only by `pyrefly coverage check`, so an ordinary check
+        // shouldn't flag them as unused.
+        let contents = r#"
+def f(x):  # pyrefly: ignore[coverage-missing]
+    return x
+"#;
+        let (errors, _tdir) = get_errors(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        assert!(unused.is_empty());
+    }
+
+    #[test]
+    fn test_mixed_coverage_and_real_code_ignore() {
+        // A coverage code is skipped while a genuinely-unused real code is reported.
+        let contents = r#"
+def f(x):  # pyrefly: ignore[coverage-missing, bad-override]
+    return x
+"#;
+        let (errors, _tdir) = get_errors(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        assert_eq!(unused.len(), 1);
+        assert!(unused[0].msg().contains("bad-override"));
+        assert!(!unused[0].msg().contains("coverage-missing"));
     }
 
     #[test]

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -6,6 +6,7 @@
  */
 
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use dupe::Dupe;
@@ -27,8 +28,6 @@ use ruff_python_ast::ModModule;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::visitor::walk_expr;
 use ruff_text_size::Ranged;
-use ruff_text_size::TextRange;
-use ruff_text_size::TextSize;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 
@@ -527,11 +526,6 @@ impl Errors {
                         .and_then(|m| m.get(applies_to_line))
                         .cloned()
                         .unwrap_or_default();
-                    let comment_start = module.lined_buffer().line_start(supp.comment_line())
-                        + TextSize::try_from(supp.comment_offset())
-                            .expect("Python source offsets fit in TextSize");
-                    let comment_range =
-                        TextRange::new(comment_start, comment_start + TextSize::new(1));
 
                     // For Tool::Pyre, error code filtering is not enforced
                     // (any Pyre suppression suppresses all errors on the line),
@@ -541,11 +535,10 @@ impl Errors {
                         if !used_codes.is_empty() {
                             continue; // Pyre suppression is used
                         }
-                        unused_errors.push(Error::new(
-                            module.dupe(),
-                            comment_range,
+                        unused_errors.push(Error::unused_ignore(
+                            module,
+                            supp,
                             "Unused pyre-fixme comment".to_owned(),
-                            Vec::new(),
                             ErrorKind::UnusedIgnore,
                         ));
                         continue;
@@ -556,34 +549,33 @@ impl Errors {
                         if !used_codes.is_empty() {
                             continue; // type: ignore is used
                         }
-                        unused_errors.push(Error::new(
-                            module.dupe(),
-                            comment_range,
+                        unused_errors.push(Error::unused_ignore(
+                            module,
+                            supp,
                             "Unused `# type: ignore` comment".to_owned(),
-                            Vec::new(),
                             ErrorKind::UnusedTypeIgnore,
                         ));
                         continue;
                     }
 
                     // Tool::Pyrefly: check individual error codes
-                    let declared_codes: SmallSet<String> =
-                        supp.error_codes().iter().cloned().collect();
-
-                    // Determine if the suppression is unused
-                    let unused_codes: SmallSet<String> = if declared_codes.is_empty() {
-                        // Blanket ignore - unused if no errors were suppressed
-                        if used_codes.is_empty() {
-                            SmallSet::new() // Mark as unused (empty set signals blanket unused)
-                        } else {
+                    let declared = supp.error_codes();
+                    let unused_codes: Vec<&str> = if declared.is_empty() {
+                        // Blanket ignore: unused only when nothing was suppressed on the line.
+                        if !used_codes.is_empty() {
                             continue; // Used, skip
                         }
+                        Vec::new()
                     } else {
-                        // Specific codes - find which are unused
-                        let unused: SmallSet<String> = declared_codes
+                        // Coverage codes are emitted only by `coverage check`, never here, so they
+                        // are never unused during ordinary checking.
+                        let unused: Vec<&str> = declared
                             .iter()
-                            .filter(|code| !used_codes.contains(*code))
-                            .cloned()
+                            .map(String::as_str)
+                            .filter(|&c| {
+                                !used_codes.contains(c)
+                                    && !ErrorKind::from_str(c).is_ok_and(ErrorKind::is_coverage)
+                            })
                             .collect();
                         if unused.is_empty() {
                             continue; // All codes used, skip
@@ -591,27 +583,11 @@ impl Errors {
                         unused
                     };
 
-                    // Create an error for the unused suppression
-                    let msg = if declared_codes.is_empty() {
-                        "Unused `# pyrefly: ignore` comment".to_owned()
-                    } else if unused_codes.len() == declared_codes.len() {
-                        format!(
-                            "Unused `# pyrefly: ignore` comment for code(s): {}",
-                            unused_codes.iter().cloned().collect::<Vec<_>>().join(", ")
-                        )
-                    } else {
-                        format!(
-                            "Unused error code(s) in `# pyrefly: ignore`: {}",
-                            unused_codes.iter().cloned().collect::<Vec<_>>().join(", ")
-                        )
-                    };
-
-                    unused_errors.push(Error::new(
-                        module.dupe(),
-                        comment_range,
-                        msg,
-                        Vec::new(),
-                        ErrorKind::UnusedIgnore,
+                    unused_errors.push(Error::unused_pyrefly_ignore(
+                        module,
+                        supp,
+                        declared.len(),
+                        &unused_codes,
                     ));
                 }
             }
@@ -785,6 +761,35 @@ def f() -> int:
         let unused = errors.collect_unused_ignore_errors(&collected);
         assert_eq!(unused.len(), 1);
         assert!(unused[0].msg().contains("bad-override"));
+    }
+
+    #[test]
+    fn test_coverage_code_ignore_not_unused() {
+        // Coverage codes are emitted only by `pyrefly coverage check`, so an ordinary check
+        // shouldn't flag them as unused.
+        let contents = r#"
+def f(x):  # pyrefly: ignore[coverage-missing]
+    return x
+"#;
+        let (errors, _tdir) = get_errors(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        assert!(unused.is_empty());
+    }
+
+    #[test]
+    fn test_mixed_coverage_and_real_code_ignore() {
+        // A coverage code is skipped while a genuinely-unused real code is reported.
+        let contents = r#"
+def f(x):  # pyrefly: ignore[coverage-missing, bad-override]
+    return x
+"#;
+        let (errors, _tdir) = get_errors(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        assert_eq!(unused.len(), 1);
+        assert!(unused[0].msg().contains("bad-override"));
+        assert!(!unused[0].msg().contains("coverage-missing"));
     }
 
     #[test]


### PR DESCRIPTION
# Summary

The `pyrefly coverage` commands now respects `# pyrefly: ignore`. Because, well, they didn't before... An ignored symbol was still reported and still counted against the percentage. If unused ignores were configured, then `pyrefly check` would also complain about them.

Now, we can do things like

```py
def legacy(x):  # pyrefly: ignore[coverage-missing]
    ...
```

which will cause `legacy` to not be reported as a warning anymore by `coverage check`, and will no longer affect the total coverage percentages of `coverage check` and `coverage report` (counted as 0 typables).

Specifically ignoring `[coverage-partial]` and a bare `# pyrefly: ignore` work too. 
However, I chose to not include `# type: ignore`, even if explicitly configured. That's because those have always been intended for type errors, and also because Pyrefly is the only type-coverage checker out there, so it's probably safe to assume that a `# type: ignore` wasn't intended to ignore coverage.

A coverage ignore that matches nothing is flagged as unused by `coverage check`, and plain `pyrefly check` no longer reports `coverage-*` codes as unused (they're only for `coverage check`).

For decorated symbols like a `@property`, the `# pyrefly: ignore` should be placed on the decorator line (that's where the coverage diagnostic starts).

# Test Plan

Added tests for exclusion (incl. properties), unused/out-of-scope ignores, the `type: ignore` boundary, and `check`  /  `report` consistency.