### PR TITLE
collapse non-convergent class field types to Any (#3921)

### DIFF
--- a/pyrefly/lib/alt/answers_solver.rs
+++ b/pyrefly/lib/alt/answers_solver.rs
@@ -55,9 +55,11 @@ use crate::alt::answers::OverloadedCallee;
 use crate::alt::answers::SolutionsEntry;
 use crate::alt::answers::SolutionsTable;
 use crate::alt::answers::TraceSideEffects;
+use crate::alt::class::class_field::ClassField;
 use crate::alt::traits::Solve;
 use crate::binding::binding::AnyIdx;
 use crate::binding::binding::Binding;
+use crate::binding::binding::ClassFieldDefinition;
 use crate::binding::binding::Exported;
 use crate::binding::binding::Key;
 use crate::binding::binding::KeyExport;
@@ -2779,6 +2781,29 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         } else {
             Vec::new()
         };
+
+        if exceeded_max_iterations {
+            // An *inferred* instance attribute whose type never converges is
+            // degenerately recursive (each iteration nests another container layer,
+            // e.g. `list[list[...]]`). Commit `Any` for those fields instead of the
+            // unrolled blowup, so it does not produce spurious downstream errors.
+            // Restricted to `DefinedInMethod` fields: annotated members and class-body
+            // type aliases (e.g. `type X = int | list[C.X]`) are intentional recursion
+            // whose errors must be preserved, not collapsed to `Any`.
+            let any_field: Arc<dyn Any + Send + Sync> =
+                Arc::new(Arc::new(ClassField::recursive(self.heap)));
+            for (calc_id, state) in scc.node_state.iter_mut() {
+                if let AnyIdx::KeyClassField(idx) = &calc_id.1
+                    && matches!(
+                        calc_id.0.get(*idx).definition,
+                        ClassFieldDefinition::DefinedInMethod { .. }
+                    )
+                    && let SccNodeState::Done { answer, .. } = state
+                {
+                    *answer = any_field.dupe();
+                }
+            }
+        }
 
         let did_commit = self.commit_final_answers(scc);
         if did_commit {

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -2911,3 +2911,19 @@ def f(a: A):
     assert_type(a.val, int | str)
     "#,
 );
+
+testcase!(
+    test_self_referential_attribute_collapses_to_any,
+    r#"
+from typing import Any, assert_type
+class C:
+    def m(self) -> None:
+        # `self.x = [self.x]` is self-referential and never converges (each fixpoint
+        # iteration nests another `list[...]`). Rather than commit the degenerate
+        # unrolled type, a non-convergent inferred attribute collapses to `Any`
+        # (the non-convergence is still reported).
+        self.x = [self.x]  # E: Fixpoint iteration did not converge
+def f(c: C):
+    assert_type(c.x, Any)
+    "#,
+);


### PR DESCRIPTION
Summary:

Unannotated attribute type inference can produce degenerate, deeply-nested
types for self-referential attributes -- e.g. `self.x = local` where `local`
was built from `self.x[i]`, yielding `list[list[list[...]]]`.

The SCC fixpoint
never converges for these: each iteration nests another container layer until
it hits MAX_ITERATIONS.

When a class-field SCC exceeds MAX_ITERATIONS without converging, commit `Any`
for its class-field members instead of the unrolled blowup.

Differential Revision: D109344076


