### PR TITLE
Add no-any-return error code

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -267,6 +267,14 @@ pub enum ErrorKind {
     NameMismatch,
     /// The attribute exists but does not support this access pattern.
     NoAccess,
+    /// Umbrella error kind for cases where `Any` is returned from a function with a concrete return type.
+    NoAnyReturn,
+    /// An explicit `Any` returned from a function with a concrete return type.
+    /// This is a sub-kind of [NoAnyReturn]: suppressing `no-any-return` also suppresses this error.
+    NoAnyReturnExplicit,
+    /// An implicit `Any` returned from a function with a concrete return type.
+    /// This is a sub-kind of [NoAnyReturn]: suppressing `no-any-return` also suppresses this error.
+    NoAnyReturnImplicit,
     /// Attempting to call an overloaded function, but none of the signatures match.
     NoMatchingOverload,
     /// The SCC fixpoint iteration did not converge within the maximum number of
@@ -437,6 +445,9 @@ impl ErrorKind {
             | ErrorKind::ImplicitAnyEmptyContainer
             | ErrorKind::ImplicitAnyParameter
             | ErrorKind::ImplicitAnyTypeArgument => Some(ErrorKind::ImplicitAny),
+            ErrorKind::NoAnyReturnExplicit | ErrorKind::NoAnyReturnImplicit => {
+                Some(ErrorKind::NoAnyReturn)
+            }
             _ => None,
         }
     }
@@ -481,6 +492,9 @@ impl ErrorKind {
             ErrorKind::MissingOverrideDecorator => Severity::Ignore,
             ErrorKind::MissingSource => Severity::Ignore,
             ErrorKind::NameMismatch => Severity::Warn,
+            ErrorKind::NoAnyReturn => Severity::Ignore,
+            ErrorKind::NoAnyReturnExplicit => Severity::Ignore,
+            ErrorKind::NoAnyReturnImplicit => Severity::Ignore,
             ErrorKind::NonExhaustiveMatch => Severity::Warn,
             ErrorKind::NonConvergentRecursion => Severity::Warn,
             ErrorKind::NotRequiredKeyAccess => Severity::Ignore,

--- a/crates/pyrefly_config/src/migration/error_codes.rs
+++ b/crates/pyrefly_config/src/migration/error_codes.rs
@@ -23,6 +23,7 @@ impl ConfigOptionMigrater for ErrorCodes {
         mypy_cfg: &Ini,
         pyrefly_cfg: &mut ConfigFile,
     ) -> anyhow::Result<()> {
+        let warn_return_any = util::get_bool_or_default(mypy_cfg, "mypy", "warn_return_any");
         let warn_redundant_casts =
             util::get_bool_or_default(mypy_cfg, "mypy", "warn_redundant_casts");
         let disallow_untyped_defs =
@@ -39,6 +40,7 @@ impl ConfigOptionMigrater for ErrorCodes {
             util::get_bool_or_default(mypy_cfg, "mypy", "allow_redefinitions");
         let strict = util::get_bool_or_default(mypy_cfg, "mypy", "strict");
         let mypy_flags = MypyErrorConfigFlags {
+            warn_return_any,
             warn_redundant_casts,
             disallow_untyped_defs,
             disallow_incomplete_defs,

--- a/crates/pyrefly_config/src/migration/mypy/util.rs
+++ b/crates/pyrefly_config/src/migration/mypy/util.rs
@@ -118,6 +118,7 @@ pub fn expand_config_file_dir(path: &str) -> String {
 
 #[derive(Default)]
 pub struct MypyErrorConfigFlags {
+    pub warn_return_any: bool,
     pub warn_redundant_casts: bool,
     pub disallow_untyped_defs: bool,
     pub disallow_incomplete_defs: bool,
@@ -143,6 +144,7 @@ pub fn make_error_config(
         errors.insert(error_code, Severity::Error);
     }
     if let Some(MypyErrorConfigFlags {
+        warn_return_any,
         warn_redundant_casts,
         disallow_untyped_defs,
         disallow_incomplete_defs,
@@ -154,6 +156,9 @@ pub fn make_error_config(
     }) = mypy_error_config_flags
     {
         // These severities take precedence over enable/disable
+        if warn_return_any {
+            errors.insert(ErrorKind::NoAnyReturn.to_name().to_owned(), Severity::Error);
+        }
         if warn_redundant_casts || strict {
             errors.insert(
                 ErrorKind::RedundantCast.to_name().to_owned(),
@@ -243,6 +248,7 @@ fn code_to_kind(errors: HashMap<String, Severity>) -> Option<ErrorDisplayConfig>
             }
             "deprecated" => add(severity, ErrorKind::Deprecated),
             "name-match" => add(severity, ErrorKind::NameMismatch),
+            "no-any-return" => add(severity, ErrorKind::NoAnyReturn),
             _ => {}
         }
     }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -3674,7 +3674,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     .with_annotation(annot_range, "declared return type".to_owned())
             };
             if let Some(expr) = &x.expr {
-                self.expr_check(expr, hint.as_ref().map(|t| (t, tcc)), errors)
+                let return_ty = self.expr_check(expr, hint.as_ref().map(|t| (t, tcc)), errors);
+                self.check_any_return(&hint, &return_ty, expr.as_ref(), errors);
+                return_ty
             } else if let Some(hint) = hint {
                 let none = self.heap.mk_none();
                 self.check_type(&none, &hint, x.range, errors, tcc);
@@ -3683,11 +3685,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 self.heap.mk_none()
             }
         } else if matches!(hint, Some(Type::TypeGuard(_) | Type::TypeIs(_))) {
+            let declared_hint = hint; // outer hint (shadowed below)
             let hint = Some(self.heap.mk_class_type(self.stdlib.bool().clone()));
             let tcc: &dyn Fn() -> TypeCheckContext =
                 &|| TypeCheckContext::of_kind(TypeCheckKind::TypeGuardReturn);
             if let Some(expr) = &x.expr {
-                self.expr_check(expr, hint.as_ref().map(|t| (t, tcc)), errors)
+                let return_ty = self.expr_check(expr, hint.as_ref().map(|t| (t, tcc)), errors);
+                self.check_any_return(&declared_hint, &return_ty, expr.as_ref(), errors);
+                return_ty
             } else if let Some(hint) = hint {
                 let none = self.heap.mk_none();
                 self.check_type(&none, &hint, x.range, errors, tcc);
@@ -3702,7 +3707,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     .with_annotation(annot_range, "declared return type".to_owned())
             };
             if let Some(expr) = &x.expr {
-                self.expr_check(expr, hint.as_ref().map(|t| (t, tcc)), errors)
+                let return_ty = self.expr_check(expr, hint.as_ref().map(|t| (t, tcc)), errors);
+                self.check_any_return(&hint, &return_ty, expr.as_ref(), errors);
+                return_ty
             } else if let Some(hint) = hint {
                 let none = self.heap.mk_none();
                 self.check_type(&none, &hint, x.range, errors, tcc);
@@ -3710,6 +3717,49 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             } else {
                 self.heap.mk_none()
             }
+        }
+    }
+
+    /// Check if returning an Any-typed expression from a function with a concrete return type,
+    /// and emit the appropriate error (NoAnyReturnExplicit or NoAnyReturnImplicit).
+    fn check_any_return(
+        &self,
+        hint: &Option<Type>,
+        return_ty: &Type,
+        expr_range: impl Ranged,
+        errors: &crate::error::collector::ErrorCollector,
+    ) {
+        let Some(declared_ty) = &hint else { return };
+        if declared_ty.is_any() {
+            return;
+        }
+        match return_ty {
+            Type::Any(AnyStyle::Explicit) => {
+                self.error(
+                    errors,
+                    expr_range.range(),
+                    ErrorKind::NoAnyReturnExplicit,
+                    format!(
+                        "Returning Any from function declared to return \"{}\"",
+                        self.for_display(declared_ty.clone())
+                    ),
+                );
+            }
+            // Grouping Error with Implicit is intentional. When analysis fails to recover an
+            // explicit type (e.g., undefined name), we fall back to AnyStyle::Error. Treating
+            // it as implicit allows surfacing of the no-any-return-implicit diagnostic.
+            Type::Any(AnyStyle::Implicit | AnyStyle::Error) => {
+                self.error(
+                    errors,
+                    expr_range.range(),
+                    ErrorKind::NoAnyReturnImplicit,
+                    format!(
+                        "Returning implicit Any from function declared to return \"{}\"",
+                        self.for_display(declared_ty.clone())
+                    ),
+                );
+            }
+            _ => {}
         }
     }
 

--- a/pyrefly/lib/test/returns.rs
+++ b/pyrefly/lib/test/returns.rs
@@ -872,3 +872,251 @@ def _process_null_values(
     return ['a', 'b']
 "#,
 );
+
+// Tests for no-any-return
+
+testcase!(
+    test_no_any_return_explicit,
+    crate::test::util::TestEnv::new().enable_no_any_return_explicit_error(),
+    r#"
+from typing import Any
+
+def get_explicit_any(x) -> Any:
+    return x
+
+def f() -> int:
+    x = get_explicit_any(3)
+    return x  # E: Returning Any from function declared to return "int"
+"#,
+);
+
+testcase!(
+    test_no_any_return_implicit,
+    crate::test::util::TestEnv::new().enable_no_any_return_implicit_error(),
+    r#"
+def get_implicit_any(x):
+    return x
+
+def f() -> int:
+    return get_implicit_any(3)  # E: Returning implicit Any from function declared to return "int"
+"#,
+);
+
+testcase!(
+    test_no_any_return_explicit_with_union,
+    crate::test::util::TestEnv::new().enable_no_any_return_explicit_error(),
+    r#"
+from typing import Any
+
+def f() -> int | str:
+    x: Any = None
+    return x  # E: Returning Any from function declared to return "int | str"
+"#,
+);
+
+testcase!(
+    test_no_any_return_explicit_with_none,
+    crate::test::util::TestEnv::new().enable_no_any_return_explicit_error(),
+    r#"
+from typing import Any
+
+def f() -> None:
+    x: Any = 3
+    return x  # E: Returning Any from function declared to return "None"
+"#,
+);
+
+testcase!(
+    test_no_any_return_implicit_with_none,
+    crate::test::util::TestEnv::new().enable_no_any_return_implicit_error(),
+    r#"
+from typing import Any
+
+def get_implicit_any(x):
+    return x
+
+def f() -> None:
+    x = get_implicit_any(3)
+    return x  # E: Returning implicit Any from function declared to return "None"
+"#,
+);
+
+testcase!(
+    test_no_any_return_explicit_in_generator,
+    crate::test::util::TestEnv::new().enable_no_any_return_explicit_error(),
+    r#"
+from typing import Any, Generator
+
+def f() -> Generator[int, None, str]:
+    yield 1
+    x: Any = 3
+    return x  # E: Returning Any from function declared to return "str"
+"#,
+);
+
+testcase!(
+    test_no_any_return_explicit_no_error_for_any_yield_in_generator,
+    crate::test::util::TestEnv::new().enable_no_any_return_explicit_error(),
+    r#"
+from typing import Any, Generator
+
+def f() -> Generator[int, None, int]:  # OK
+    x: Any = 3
+    yield x  # OK, despite `x` being of type `Any`. The error code is for return, not yield.
+    y: int = 4
+    return y
+"#,
+);
+
+testcase!(
+    test_no_any_return_explicit_in_async_function,
+    crate::test::util::TestEnv::new().enable_no_any_return_explicit_error(),
+    r#"
+from typing import Any
+
+async def f() -> int:
+    x: Any = 3
+    return x  # E: Returning Any from function declared to return "int"
+"#,
+);
+
+testcase!(
+    test_no_any_return_explicit_no_error_when_return_type_is_any,
+    crate::test::util::TestEnv::new().enable_no_any_return_explicit_error(),
+    r#"
+from typing import Any
+
+def get_explicit_any(x: int) -> Any:
+    return x
+
+def f() -> Any:
+    x: Any = 3
+    return x
+
+def g() -> Any:
+    return get_explicit_any(3)
+"#,
+);
+
+testcase!(
+    test_no_any_return_implicit_no_error_when_return_type_is_any,
+    crate::test::util::TestEnv::new().enable_no_any_return_implicit_error(),
+    r#"
+from typing import Any
+
+def get_implicit_any(x):
+    return x
+
+def f() -> Any:
+    x = get_implicit_any(3)
+    return x
+"#,
+);
+
+testcase!(
+    test_no_any_return_explicit_no_error_when_no_return_annotation,
+    crate::test::util::TestEnv::new().enable_no_any_return_explicit_error(),
+    r#"
+from typing import Any
+
+def get_explicit_any(x: int) -> Any:
+    return x
+
+def f():
+    x = get_explicit_any(3)
+    return x
+"#,
+);
+
+testcase!(
+    test_no_any_return_explicit_suppression_with_parent,
+    crate::test::util::TestEnv::new().enable_no_any_return_explicit_error(),
+    r#"
+from typing import Any
+
+def get_explicit_any(x: int) -> Any:
+    return x
+
+def f() -> int:
+    x: Any = get_explicit_any(3)
+    return x  # pyrefly: ignore[no-any-return]
+"#,
+);
+
+testcase!(
+    test_no_any_return_implicit_suppression_with_parent,
+    crate::test::util::TestEnv::new().enable_no_any_return_implicit_error(),
+    r#"
+def get_implicit_any(x):
+    return x
+
+def f() -> int:
+    x = get_implicit_any(3)
+    return x  # pyrefly: ignore[no-any-return]
+"#,
+);
+
+testcase!(
+    test_no_any_return_implicit_parent_activates_error,
+    crate::test::util::TestEnv::new().enable_no_any_return_error(),
+    r#"
+def get_implicit_any(x):
+    return x
+
+def f() -> int:
+    x = get_implicit_any(3)
+    return x  # E: Returning implicit Any from function declared to return "int"
+"#,
+);
+
+testcase!(
+    test_no_any_return_explicit_parent_activates_error,
+    crate::test::util::TestEnv::new().enable_no_any_return_error(),
+    r#"
+from typing import Any
+
+def get_explicit_any(x: int) -> Any:
+    return x
+
+def f() -> int:
+    x: Any = get_explicit_any(3)
+    return x  # E: Returning Any from function declared to return "int"
+"#,
+);
+
+testcase!(
+    test_no_any_return_explicit_suppression_with_specific_error,
+    crate::test::util::TestEnv::new().enable_no_any_return_explicit_error(),
+    r#"
+from typing import Any
+
+def get_explicit_any(x: int) -> Any:
+    return x
+
+def f() -> int:
+    x: Any = get_explicit_any(3)
+    return x  # pyrefly: ignore[no-any-return-explicit]
+"#,
+);
+
+testcase!(
+    test_no_any_return_implicit_suppression_with_specific_error,
+    crate::test::util::TestEnv::new().enable_no_any_return_implicit_error(),
+    r#"
+def get_implicit_any(x):
+    return x
+
+def f() -> int:
+    return get_implicit_any(3)  # pyrefly: ignore[no-any-return-implicit]
+"#,
+);
+
+testcase!(
+    test_no_any_return_implicit_fallback_any_error_shows_no_any_return_implicit_error,
+    crate::test::util::TestEnv::new().enable_no_any_return_implicit_error(),
+    r#"
+def f() -> int:
+    x = undefined_causes_analysis_failure  # E: Could not find name `undefined_causes_analysis_failure`
+    return x  # E: Returning implicit Any from function declared to return "int"
+"#,
+);

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -121,6 +121,9 @@ pub struct TestEnv {
     string_as_iterable_warning: bool,
     strict_callable_subtyping: bool,
     spec_compliant_overloads: bool,
+    no_any_return_error: bool,
+    no_any_return_explicit_error: bool,
+    no_any_return_implicit_error: bool,
     default_require_level: Require,
     extra_file_extensions: Vec<String>,
     /// The `Require` level passed to `run()` in `to_state()`. Controls whether
@@ -155,6 +158,9 @@ impl TestEnv {
             string_as_iterable_warning: false,
             strict_callable_subtyping: false,
             spec_compliant_overloads: false,
+            no_any_return_error: false,
+            no_any_return_explicit_error: false,
+            no_any_return_implicit_error: false,
             default_require_level: Require::Exports,
             extra_file_extensions: Vec::new(),
             run_require: Require::Everything,
@@ -322,6 +328,21 @@ impl TestEnv {
         self
     }
 
+    pub fn enable_no_any_return_error(mut self) -> Self {
+        self.no_any_return_error = true;
+        self
+    }
+
+    pub fn enable_no_any_return_explicit_error(mut self) -> Self {
+        self.no_any_return_explicit_error = true;
+        self
+    }
+
+    pub fn enable_no_any_return_implicit_error(mut self) -> Self {
+        self.no_any_return_implicit_error = true;
+        self
+    }
+
     pub fn with_default_require_level(mut self, level: Require) -> Self {
         self.default_require_level = level;
         self
@@ -446,6 +467,15 @@ impl TestEnv {
         }
         if self.not_required_key_access_error {
             errors.set_error_severity(ErrorKind::NotRequiredKeyAccess, Severity::Error);
+        }
+        if self.no_any_return_error {
+            errors.set_error_severity(ErrorKind::NoAnyReturn, Severity::Error);
+        }
+        if self.no_any_return_explicit_error {
+            errors.set_error_severity(ErrorKind::NoAnyReturnExplicit, Severity::Error);
+        }
+        if self.no_any_return_implicit_error {
+            errors.set_error_severity(ErrorKind::NoAnyReturnImplicit, Severity::Error);
         }
         if self.pytorch_efficiency_lint_error {
             config.root.pytorch_efficiency_lints = Some(true);

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -1140,6 +1140,60 @@ class Ex:
 del Ex.meaning  # no-access
 ```
 
+## no-any-return
+
+Default severity: `ignore`
+
+Umbrella error code for cases where a returned expression is `Any` in a function declared to return a concrete type. Enabling this catches places where `Any` silently bypasses the function's declared return type.
+
+Concrete diagnostics are emitted under one of the more specific sub-kinds:
+- [`no-any-return-explicit`](#no-any-return-explicit)
+- [`no-any-return-implicit`](#no-any-return-implicit)
+
+## no-any-return-explicit
+
+Default severity: `ignore`
+
+The returned expression has type `Any`, but the function is declared to return a concrete type. The returned `Any` originates from an explicit annotation or other introduction into the type system.
+
+This is a sub-kind of [no-any-return](#no-any-return): suppressing `no-any-return` also suppresses this error.
+
+```python
+from typing import Any
+
+def f() -> int:
+    x: Any = 3
+    return x  # no-any-return-explicit: Returning Any from function declared to return "int"
+
+# Fix: provide an explicit annotation so the type is known precisely.
+def g() -> int:
+    x: int = 3
+    return x
+```
+
+## no-any-return-implicit
+
+Default severity: `ignore`
+
+The returned expression was inferred as `Any` (e.g., from an untyped function or undefined variable), but the function's return annotation is a concrete type. This usually indicates that adding annotations would restore type precision.
+
+This is a sub-kind of [no-any-return](#no-any-return): suppressing `no-any-return` also suppresses this error.
+
+```python
+def get_value(x):  # no annotations, return type is Any
+    return x
+
+def f() -> int:
+    return get_value(3)  # no-any-return-implicit: Returning implicit Any from function declared to return "int"
+
+# Fix: annotate the source function.
+def get_typed_value(x: int) -> int:
+    return x
+
+def g() -> int:
+    return get_typed_value(3)  # OK
+```
+
 ## no-matching-overload
 
 This error is similar to the other bad function call errors, but specifically for cases where a function decorated with `@overload` is called with arguments that do not match any of the overloaded variations.


### PR DESCRIPTION
# Summary

Add an umbrella `no-any-return` error code that enables
`no-any-return-implicit` and `no-any-return-explicit`. These error codes
catch returning `Any` on a function that has a concrete type. The first,
`no-any-return-explicit`, will present itself in cases where an
explicitly typed `Any` is returned on a function that has a concrete
return type annotation. The latter, `no-any-return-implicit`, appears in
the case of an implicit `Any`, often coming from an another untyped
function.

Returning `Any` through a concrete return annotation weakens the guarantee
provided by the annotation. The caller sees a precise type while the
implementation has not demonstrated that the value satisfies that type.
Enabling these error codes will improve bug finding ability.

The strategy is to hook into where explicit `return` statements and
their expressions are processed and compare the return type to the
declared hint. This will be done for `async` and `Generator` functions
as well. `yield` from generators is explicitly not included in this
error code.

`no-any-return` is completely opt-in. The `strict` preset will not
include it by default. Migration from `mypy`'s `warn_return_any` is
included in this change.

Fixes #3806

# Test Plan

New unit tests added to cover this functionality.

No changes from `test.py` to commit.
