### PR TITLE
Make `binding` module pub

### DIFF
--- a/pyrefly/lib/lib.rs
+++ b/pyrefly/lib/lib.rs
@@ -25,7 +25,7 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 pub mod alt;
-mod binding;
+pub mod binding;
 #[cfg(not(target_arch = "wasm32"))]
 #[doc(hidden)]
 pub mod commands;


### PR DESCRIPTION
# Summary

Made the `binding` module `pub`. 

As discussed in the pyrefly discord: I am working on a Rust tool for static call graph analysis based on pyrefly and its (experimental) `query` module. We built our own custom AST walker on top to catch cases that `Query::get_callees_with_location` misses / that are specific to our use-case. 

It would be a _huge_ help to have access to `pyrefly::binding::binding::KeyClassMro` to get a class’ ancestors. While the class itself is pub, the `binding` module is not. 

(Note that we are well aware of the implications of using the experimental query module & pinning a git tag.)

# Test Plan

<!-- Describe how you tested this PR -->
Ran `python3 test.py`.

<!-- Run test.py and commit any changes to generated files -->
