### PR TITLE
Fix Callable[..., ...] false negative (#3912)

### DIFF
--- a/pyrefly/lib/alt/class/targs.rs
+++ b/pyrefly/lib/alt/class/targs.rs
@@ -611,6 +611,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         ErrorKind::InvalidTypeVarTuple,
                         "`TypeVarTuple` must be unpacked".to_owned(),
                     )
+                } else if matches!(arg, Type::Ellipsis) {
+                    self.error(
+                        errors,
+                        range,
+                        ErrorKind::InvalidAnnotation,
+                        "`...` cannot be used for type parameter".to_owned(),
+                    )
                 } else if arg.is_kind_param_spec() {
                     self.error(
                         errors,

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -6012,7 +6012,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 | TypeFormContext::ParamSpecDefault
         ) && matches!(
             ty,
-            Type::Concatenate(_, _) | Type::ParamSpecValue(_) | Type::ParamSpec(_)
+            Type::Concatenate(_, _) | Type::ParamSpecValue(_) | Type::ParamSpec(_) | Type::Ellipsis
         ) {
             return self.error(
                 errors,

--- a/pyrefly/lib/alt/specials.rs
+++ b/pyrefly/lib/alt/specials.rs
@@ -428,7 +428,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     self.error(
                         errors,
                         arguments[1].range(),
-                        ErrorKind::BadSpecialization,
+                        ErrorKind::InvalidAnnotation,
                         "`...` is not a valid return type".to_owned(),
                     );
                     self.heap.mk_any_error()

--- a/pyrefly/lib/alt/specials.rs
+++ b/pyrefly/lib/alt/specials.rs
@@ -424,11 +424,21 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     self.heap
                         .mk_type_of(self.heap.mk_callable_ellipsis(self.heap.mk_any_error()))
                 };
-                let ret = self.expr_untype(
-                    &arguments[1],
-                    TypeFormContext::TypeArgumentCallableReturn,
-                    errors,
-                );
+                let ret = if let Expr::EllipsisLiteral(_) = &arguments[1] {
+                    self.error(
+                        errors,
+                        arguments[1].range(),
+                        ErrorKind::BadSpecialization,
+                        "`...` is not a valid return type for `Callable`".to_owned(),
+                    );
+                    self.heap.mk_any_error()
+                } else {
+                    self.expr_untype(
+                        &arguments[1],
+                        TypeFormContext::TypeArgumentCallableReturn,
+                        errors,
+                    )
+                };
                 match &arguments[0] {
                     Expr::List(ExprList { elts, .. }) => {
                         match self.check_args_and_construct_tuple(elts, errors) {

--- a/pyrefly/lib/alt/specials.rs
+++ b/pyrefly/lib/alt/specials.rs
@@ -429,7 +429,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         errors,
                         arguments[1].range(),
                         ErrorKind::BadSpecialization,
-                        "`...` is not a valid return type for `Callable`".to_owned(),
+                        "`...` is not a valid return type".to_owned(),
                     );
                     self.heap.mk_any_error()
                 } else {

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -1510,3 +1510,13 @@ def after_func() -> None: ...
 schedule(1000, after_func)
 "#,
 );
+
+// Regression test for https://github.com/facebook/pyrefly/issues/3912
+testcase!(
+    test_callable_ellipsis_return,
+    r#"
+from typing import Callable, reveal_type
+def f(x: Callable[..., ...]):  # E: `...` is not a valid return type for `Callable`
+    reveal_type(x)  # E: revealed type: (...) -> Unknown
+"#,
+);

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -1516,7 +1516,7 @@ testcase!(
     test_callable_ellipsis_return,
     r#"
 from typing import Callable, reveal_type
-def f(x: Callable[..., ...]):  # E: `...` is not a valid return type for `Callable`
+def f(x: Callable[..., ...]):  # E: `...` is not a valid return type
     reveal_type(x)  # E: revealed type: (...) -> Unknown
 "#,
 );

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -972,6 +972,34 @@ def test(
 );
 
 testcase!(
+    test_ellipsis_invalid_type_form,
+    r#"
+from typing import Callable, ParamSpec, TypeVar, Generic
+
+# `...` leaking into non-ParamSpec positions is rejected.
+class C1[T: ...]: ...                # E: `Ellipsis` is not allowed in this context
+x1: list[...]                        # E: `...` cannot be used for type parameter
+x2: dict[int, ...]                   # E: `...` cannot be used for type parameter
+x3: type[...]                        # E: `Ellipsis` is not allowed in this context
+TBad = TypeVar("TBad", bound=...)    # E: `Ellipsis` is not allowed in this context
+
+# Still rejected via existing paths.
+def g() -> ...: ...                  # E: Expression cannot be used in annotations
+y_ret: Callable[..., ...]            # E: `...` is not a valid return type
+y_tup: tuple[...]                    # E: Invalid position for `...`
+
+# `...` remains valid where a ParamSpec or homogeneous tuple is expected.
+T = TypeVar("T")
+P = ParamSpec("P")
+ok1: Callable[..., int]
+ok2: tuple[int, ...]
+PD = ParamSpec("PD", default=...)
+class X(Generic[T, P]): ...
+def f(a: X[int, ...]) -> None: ...
+"#,
+);
+
+testcase!(
     test_invalid_type_arguments,
     r#"
 from typing import assert_type


### PR DESCRIPTION
## Summary

When Callable[..., ...] is annotated, the second ellipsis sits in the return slot where ... is not a valid type, but pyrefly accepted it silently and revealed (...) -> Ellipsis. The return type was flowing through expr_untype as Type::Ellipsis, which nothing rejected.

This resolves that by checking for a literal ... in the Callable return argument inside specials.rs, emitting an error, and recovering as Unknown. The change is intentionally small and scoped to that slot only, with a regression test in callable.rs.

Fixes #3912 

## Test Plan

Added test_callable_ellipsis_return for the Callable[..., ...] case. Ran the callable and paramspec test suites plus test.py locally all green, no conformance changes.