### PR TITLE
Don't add unnecessary parentheses during inline variable extraction

### DIFF
--- a/pyrefly/lib/state/lsp/quick_fixes/inline_variable.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/inline_variable.rs
@@ -107,9 +107,10 @@ pub(crate) fn inline_variable_code_actions(
         let covering_nodes = Ast::locate_node(ast.as_ref(), range.start());
         let parent = covering_nodes.get(1);
 
-        let needs_parens_for_attribute_access =
-            matches!(parent, Some(AnyNodeRef::ExprAttribute(_)))
-                && matches!(value_expr, Expr::NumberLiteral(_));
+        let needs_parens_for_attribute_access = matches!(
+            parent,
+            Some(AnyNodeRef::ExprAttribute(_))
+        ) && matches!(value_expr, Expr::NumberLiteral(n) if matches!(n.value, ruff_python_ast::Number::Int(_)));
 
         let replacement = if needs_parens_for_attribute_access || always_needs_parens {
             format!("({value_text})")

--- a/pyrefly/lib/state/lsp/quick_fixes/inline_variable.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/inline_variable.rs
@@ -11,6 +11,7 @@ use pyrefly_build::handle::Handle;
 use pyrefly_python::ast::Ast;
 use pyrefly_python::symbol_kind::SymbolKind;
 use pyrefly_util::visit::Visit;
+use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprContext;
 use ruff_python_ast::ModModule;
@@ -82,13 +83,40 @@ pub(crate) fn inline_variable_code_actions(
     if value_text.contains('\n') {
         return None;
     }
-    let replacement = format!("({value_text})");
     let mut edits = Vec::new();
+    let always_needs_parens = matches!(
+        value_expr,
+        Expr::BoolOp(_)
+            | Expr::BinOp(_)
+            | Expr::Compare(_)
+            | Expr::UnaryOp(_)
+            | Expr::If(_)
+            | Expr::Lambda(_)
+            | Expr::Named(_)
+            | Expr::Generator(_)
+            | Expr::Tuple(_)
+            | Expr::Await(_)
+            | Expr::Yield(_)
+            | Expr::YieldFrom(_)
+    );
+
     for range in references {
         if range == def.definition_range {
             continue;
         }
-        edits.push((module_info.dupe(), range, replacement.clone()));
+        let covering_nodes = Ast::locate_node(ast.as_ref(), range.start());
+        let parent = covering_nodes.get(1);
+
+        let needs_parens_for_attribute_access =
+            matches!(parent, Some(AnyNodeRef::ExprAttribute(_)))
+                && matches!(value_expr, Expr::NumberLiteral(_));
+
+        let replacement = if needs_parens_for_attribute_access || always_needs_parens {
+            format!("({value_text})")
+        } else {
+            value_text.to_owned()
+        };
+        edits.push((module_info.dupe(), range, replacement));
     }
     if edits.is_empty() {
         return None;

--- a/pyrefly/lib/state/lsp/quick_fixes/inline_variable.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/inline_variable.rs
@@ -15,6 +15,7 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprContext;
 use ruff_python_ast::ModModule;
+use ruff_python_ast::Number::Int;
 use ruff_python_ast::Stmt;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
@@ -107,10 +108,9 @@ pub(crate) fn inline_variable_code_actions(
         let covering_nodes = Ast::locate_node(ast.as_ref(), range.start());
         let parent = covering_nodes.get(1);
 
-        let needs_parens_for_attribute_access = matches!(
-            parent,
-            Some(AnyNodeRef::ExprAttribute(_))
-        ) && matches!(value_expr, Expr::NumberLiteral(n) if matches!(n.value, ruff_python_ast::Number::Int(_)));
+        let needs_parens_for_attribute_access =
+            matches!(parent, Some(AnyNodeRef::ExprAttribute(_)))
+                && matches!(value_expr, Expr::NumberLiteral(n) if matches!(n.value, Int(_)));
 
         let replacement = if needs_parens_for_attribute_access || always_needs_parens {
             format!("({value_text})")

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -4428,6 +4428,26 @@ def compute():
 }
 
 #[test]
+fn inline_variable_no_parens_for_float_literal_in_attribute() {
+    let code = r#"
+def compute():
+    value = 4.2
+    result = value.hex()
+#            ^
+    return result
+"#;
+    let updated =
+        apply_first_inline_variable_action(code).expect("expected inline variable action");
+    let expected = r#"
+def compute():
+    result = 4.2.hex()
+#            ^
+    return result
+"#;
+    assert_eq!(expected, updated);
+}
+
+#[test]
 fn inline_variable_parens_for_bool_op() {
     let code = r#"
 def compute(a, b, c):

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -4376,6 +4376,98 @@ def compute():
 }
 
 #[test]
+fn inline_variable_parens_for_bin_op_in_attribute() {
+    let code = r#"
+value = 1 + 3
+result = value.real
+#        ^
+"#;
+    let updated =
+        apply_first_inline_variable_action(code).expect("expected inline variable action");
+    let expected = r#"
+result = (1 + 3).real
+#        ^
+"#;
+    assert_eq!(expected, updated);
+}
+
+#[test]
+fn inline_variable_no_parens_for_number_literal() {
+    let code = r#"
+value = 42
+result = value + 1
+#        ^
+"#;
+    let updated =
+        apply_first_inline_variable_action(code).expect("expected inline variable action");
+    let expected = r#"
+result = 42 + 1
+#        ^
+"#;
+    assert_eq!(expected, updated);
+}
+
+#[test]
+fn inline_variable_parens_for_number_literal_in_attribute() {
+    let code = r#"
+def compute():
+    value = 42
+    result = value.bit_length()
+#            ^
+    return result
+"#;
+    let updated =
+        apply_first_inline_variable_action(code).expect("expected inline variable action");
+    let expected = r#"
+def compute():
+    result = (42).bit_length()
+#            ^
+    return result
+"#;
+    assert_eq!(expected, updated);
+}
+
+#[test]
+fn inline_variable_parens_for_bool_op() {
+    let code = r#"
+def compute(a, b, c):
+    value = a and b
+    result = value or c
+#            ^
+    return result
+"#;
+    let updated =
+        apply_first_inline_variable_action(code).expect("expected inline variable action");
+    let expected = r#"
+def compute(a, b, c):
+    result = (a and b) or c
+#            ^
+    return result
+"#;
+    assert_eq!(expected, updated);
+}
+
+#[test]
+fn inline_variable_parens_for_tuple() {
+    let code = r#"
+def compute():
+    value = 1, 2
+    result = len(value)
+#                ^
+    return result
+"#;
+    let updated =
+        apply_first_inline_variable_action(code).expect("expected inline variable action");
+    let expected = r#"
+def compute():
+    result = len((1, 2))
+#                ^
+    return result
+"#;
+    assert_eq!(expected, updated);
+}
+
+#[test]
 fn inline_method_basic_refactor() {
     let code = r#"
 def add(a, b):


### PR DESCRIPTION
# Summary

Fix inline variable refactoring to only add parentheses when they are needed for the expression being inlined and the context where it is inserted.

- Parenthesize expressions that require grouping, such as binary operations, boolean operations, comparisons, tuples, lambdas, and similar expression forms.
- Avoid unnecessary parentheses for simple values like number literals in normal expression contexts.
- Add parentheses for number literals when inlining into attribute access, e.g. `value = 42; value.bit_length()` becomes `(42).bit_length()`.

Fixes #3882


# Test Plan
Added LSP code action tests for:
- Binary expression inlined into attribute access.
- Number literal inlined without unnecessary parentheses.
- Number literal inlined into attribute access.
- Boolean operation requiring parentheses.
- Tuple expression requiring parentheses.

