### PR TITLE
fix invalid-inheritance on a call-expression base class even when the callable returns type[...] (mixin factory) #3931

### DIFF
--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -1570,6 +1570,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     Some(ty) => parse_base_class_type(ty),
                 }
             }
+            BaseClass::Call(x) => {
+                // Ignore all type errors here since they'll be reported in `class_bases_of` anyway.
+                let errors = ErrorCollector::new(self.module().dupe(), ErrorStyle::Never);
+                let ty = self.expr_infer(x, &errors);
+                match self.untype_opt(ty.clone(), x.range(), &errors) {
+                    None => BaseClassParseResult::InvalidType(ty, x.range()),
+                    Some(ty) => parse_base_class_type(ty),
+                }
+            }
             BaseClass::NamedTuple(..) => parse_base_class_type(
                 self.heap
                     .mk_class_type(self.stdlib.named_tuple_fallback().clone()),

--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -1745,6 +1745,15 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     Some(ty) => parse_base_class_type(ty),
                 }
             }
+            BaseClass::Call(x) => {
+                // Ignore all type errors here since they'll be reported in `class_bases_of` anyway.
+                let errors = ErrorCollector::new(self.module().dupe(), ErrorStyle::Never);
+                let ty = self.expr_infer(x, &errors);
+                match self.untype_opt(ty.clone(), x.range(), &errors) {
+                    None => BaseClassParseResult::InvalidType(ty, x.range()),
+                    Some(ty) => parse_base_class_type(ty),
+                }
+            }
             BaseClass::NamedTuple(..) => parse_base_class_type(
                 self.heap
                     .mk_class_type(self.stdlib.named_tuple_fallback().clone()),

--- a/pyrefly/lib/alt/types/class_bases.rs
+++ b/pyrefly/lib/alt/types/class_bases.rs
@@ -263,6 +263,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                     Some((ty, x.range()))
                 }
+                BaseClass::Call(x) => Some((
+                    self.expr_untype(x, TypeFormContext::BaseClassList, &fake_error_collector),
+                    x.range(),
+                )),
                 BaseClass::NamedTuple(..) => Some((
                     self.heap
                         .mk_class_type(self.stdlib.named_tuple_fallback().clone()),

--- a/pyrefly/lib/alt/types/class_bases.rs
+++ b/pyrefly/lib/alt/types/class_bases.rs
@@ -287,6 +287,10 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     }
                     Some((ty, x.range()))
                 }
+                BaseClass::Call(x) => Some((
+                    self.expr_untype(x, TypeFormContext::BaseClassList, &fake_error_collector),
+                    x.range(),
+                )),
                 BaseClass::NamedTuple(..) => Some((
                     self.heap
                         .mk_class_type(self.stdlib.named_tuple_fallback().clone()),

--- a/pyrefly/lib/binding/base_class.rs
+++ b/pyrefly/lib/binding/base_class.rs
@@ -95,6 +95,8 @@ pub enum BaseClass {
     TypedDict(TextRange),
     Generic(BaseClassGeneric),
     BaseClassExpr(BaseClassExpr),
+    /// A call expression that should be evaluated as a type form.
+    Call(Expr),
     InvalidExpr(Expr),
     /// A namedtuple base class.
     /// The bool indicates whether fields were dynamically generated
@@ -131,6 +133,7 @@ impl Ranged for BaseClass {
             BaseClass::TypedDict(range) => *range,
             BaseClass::Generic(x) => x.range(),
             BaseClass::BaseClassExpr(base_expr) => base_expr.range(),
+            BaseClass::Call(expr) => expr.range(),
             BaseClass::InvalidExpr(expr) => expr.range(),
             BaseClass::NamedTuple(range, _) => *range,
             BaseClass::SynthesizedBase(_, range) => *range,
@@ -183,6 +186,14 @@ impl<'a> BindingsBuilder<'a> {
                     && let Some(inner) = BaseClassExpr::from_expr(&call.arguments.args[0])
                 {
                     return BaseClass::TypeOf(inner, base_expr.range());
+                }
+                if let Expr::Call(call) = &base_expr {
+                    match self.as_special_export(&call.func) {
+                        Some(
+                            SpecialExport::CollectionsNamedTuple | SpecialExport::TypingNamedTuple,
+                        ) => {}
+                        _ => return BaseClass::Call(base_expr),
+                    }
                 }
                 if let Some(valid_expr) = BaseClassExpr::from_expr(&base_expr) {
                     BaseClass::BaseClassExpr(valid_expr)

--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -357,7 +357,7 @@ impl<'a> BindingsBuilder<'a> {
             // usage tracking.
             if matches!(
                 base_class,
-                BaseClass::BaseClassExpr(..) | BaseClass::TypeOf(..)
+                BaseClass::BaseClassExpr(..) | BaseClass::Call(..) | BaseClass::TypeOf(..)
             ) {
                 self.insert_binding(
                     KeyExpect::TypeCheckBaseClassExpr(base.range()),

--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -356,7 +356,7 @@ impl<'a> BindingsBuilder<'a> {
             // usage tracking.
             if matches!(
                 base_class,
-                BaseClass::BaseClassExpr(..) | BaseClass::TypeOf(..)
+                BaseClass::BaseClassExpr(..) | BaseClass::Call(..) | BaseClass::TypeOf(..)
             ) {
                 self.insert_binding(
                     KeyExpect::TypeCheckBaseClassExpr(base.range()),

--- a/pyrefly/lib/test/class_subtyping.rs
+++ b/pyrefly/lib/test/class_subtyping.rs
@@ -304,6 +304,28 @@ assert_type(B.x, int)
 );
 
 testcase!(
+    test_call_returning_type_in_base_class_list,
+    r#"
+from typing import Any, assert_type
+
+class Mixin:
+    def greet(self) -> str:
+        return "hi"
+
+def factory(name: str) -> type[Mixin]: ...
+def untyped_factory(name: str) -> Any: ...
+
+class C(factory("x")):
+    pass
+
+class D(untyped_factory("x")):
+    pass
+
+assert_type(C().greet(), str)
+    "#,
+);
+
+testcase!(
     test_type_function_in_base_class_list_self_cycle,
     r#"
 from typing import assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3931

Call-expression bases like class `C(factory("x"))` are now represented as evaluable base-class expressions instead of being rejected syntactically.

The solver now untypes the call result in base-class context, so `type[Mixin]` becomes a valid Mixin base, and Any-returning factories are tolerated.

Invalid functional namedtuple/NamedTuple bases keep their existing diagnostics.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test