### PR TITLE
fix type source not show on field #3898

### DIFF
--- a/pyrefly/lib/lsp/wasm/type_source.rs
+++ b/pyrefly/lib/lsp/wasm/type_source.rs
@@ -44,8 +44,11 @@ mod impl_ {
     use lsp_types::Url;
     use pyrefly_build::handle::Handle;
     use pyrefly_graph::index::Idx;
+    use pyrefly_python::ast::Ast;
     use pyrefly_python::module::Module;
     use pyrefly_python::short_identifier::ShortIdentifier;
+    use ruff_python_ast::AnyNodeRef;
+    use ruff_python_ast::Expr;
     use ruff_python_ast::ExprContext;
     use ruff_text_size::Ranged;
     use ruff_text_size::TextRange;
@@ -57,6 +60,7 @@ mod impl_ {
     use crate::binding::binding::FirstUse;
     use crate::binding::binding::Key;
     use crate::binding::bindings::Bindings;
+    use crate::binding::narrow::identifier_and_chain_for_expr;
     use crate::state::lsp::IdentifierContext;
     use crate::state::state::Transaction;
 
@@ -207,7 +211,11 @@ mod impl_ {
         let Some(identifier_with_context) = transaction.identifier_at(handle, position) else {
             return Vec::new();
         };
-        let key = match identifier_with_context.context {
+        let is_attribute_hover = matches!(
+            &identifier_with_context.context,
+            IdentifierContext::Attribute { .. }
+        );
+        let key = match &identifier_with_context.context {
             IdentifierContext::Expr(expr_context) => match expr_context {
                 ExprContext::Store => {
                     Key::Definition(ShortIdentifier::new(&identifier_with_context.identifier))
@@ -216,9 +224,29 @@ mod impl_ {
                     Key::BoundName(ShortIdentifier::new(&identifier_with_context.identifier))
                 }
             },
-            // Type sources are only meaningful for expression-context identifiers (variables,
-            // parameters). Other contexts like imports, type annotations, and decorators don't
-            // have narrowing or first-use inference semantics.
+            // Attribute hover should surface narrowing attached to the containing facet expression
+            // (`obj.field`) using the base variable's current flow binding.
+            IdentifierContext::Attribute {
+                range,
+                expr_context: ExprContext::Load | ExprContext::Invalid,
+                ..
+            } => {
+                let Some(ast) = transaction.get_ast(handle) else {
+                    return Vec::new();
+                };
+                let Some(base) = Ast::locate_node(&ast, position)
+                    .into_iter()
+                    .find_map(|node| match node {
+                        AnyNodeRef::ExprAttribute(attr) if attr.range() == *range => {
+                            identifier_and_chain_for_expr(&Expr::Attribute(attr.clone()))
+                        }
+                        _ => None,
+                    })
+                else {
+                    return Vec::new();
+                };
+                Key::BoundName(ShortIdentifier::new(&base.0))
+            }
             _ => return Vec::new(),
         };
         if !bindings.is_valid_key(&key) {
@@ -228,6 +256,9 @@ mod impl_ {
         let mut sources = Vec::new();
         if let Some(narrow_source) = narrow_source_for_key(&bindings, &module, idx) {
             sources.push(narrow_source);
+        }
+        if is_attribute_hover {
+            return sources;
         }
         if let Some(first_use_source) = first_use_source_for_key(&bindings, &module, &key, position)
         {

--- a/pyrefly/lib/lsp/wasm/type_source.rs
+++ b/pyrefly/lib/lsp/wasm/type_source.rs
@@ -44,11 +44,8 @@ mod impl_ {
     use lsp_types::Url;
     use pyrefly_build::handle::Handle;
     use pyrefly_graph::index::Idx;
-    use pyrefly_python::ast::Ast;
     use pyrefly_python::module::Module;
     use pyrefly_python::short_identifier::ShortIdentifier;
-    use ruff_python_ast::AnyNodeRef;
-    use ruff_python_ast::Expr;
     use ruff_python_ast::ExprContext;
     use ruff_text_size::Ranged;
     use ruff_text_size::TextRange;
@@ -60,7 +57,6 @@ mod impl_ {
     use crate::binding::binding::FirstUse;
     use crate::binding::binding::Key;
     use crate::binding::bindings::Bindings;
-    use crate::binding::narrow::identifier_and_chain_for_expr;
     use crate::state::lsp::IdentifierContext;
     use crate::state::state::Transaction;
 
@@ -227,26 +223,10 @@ mod impl_ {
             // Attribute hover should surface narrowing attached to the containing facet expression
             // (`obj.field`) using the base variable's current flow binding.
             IdentifierContext::Attribute {
-                range,
+                base_identifier: Some(base_identifier),
                 expr_context: ExprContext::Load | ExprContext::Invalid,
                 ..
-            } => {
-                let Some(ast) = transaction.get_ast(handle) else {
-                    return Vec::new();
-                };
-                let Some(base) = Ast::locate_node(&ast, position)
-                    .into_iter()
-                    .find_map(|node| match node {
-                        AnyNodeRef::ExprAttribute(attr) if attr.range() == *range => {
-                            identifier_and_chain_for_expr(&Expr::Attribute(attr.clone()))
-                        }
-                        _ => None,
-                    })
-                else {
-                    return Vec::new();
-                };
-                Key::BoundName(ShortIdentifier::new(&base.0))
-            }
+            } => Key::BoundName(ShortIdentifier::new(base_identifier)),
             _ => return Vec::new(),
         };
         if !bindings.is_valid_key(&key) {

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -363,6 +363,8 @@ pub(crate) enum IdentifierContext {
     Attribute {
         /// The range of just the base expression.
         base_range: TextRange,
+        /// The root name of the base expression, when the base is an attribute chain rooted at a name.
+        base_identifier: Option<Identifier>,
         /// The range of the entire expression.
         range: TextRange,
         /// Whether the attribute is being loaded, assigned to, or deleted.
@@ -592,11 +594,20 @@ impl IdentifierWithContext {
     }
 
     fn from_expr_attr(id: &Identifier, attr: &ExprAttribute) -> Self {
+        fn base_identifier(expr: &Expr) -> Option<Identifier> {
+            match expr {
+                Expr::Name(name) => Some(Ast::expr_name_identifier(name.clone())),
+                Expr::Attribute(attr) => base_identifier(attr.value.as_ref()),
+                _ => None,
+            }
+        }
+
         let identifier = id.clone();
         Self {
             identifier,
             context: IdentifierContext::Attribute {
                 base_range: attr.value.range(),
+                base_identifier: base_identifier(attr.value.as_ref()),
                 range: attr.range(),
                 expr_context: attr.ctx,
             },

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -354,6 +354,36 @@ def f(x: int | str | None) -> None:
 }
 
 #[test]
+fn hover_type_source_attribute_narrow() {
+    let code = r#"
+class C:
+    x: int | None
+
+def f(c: C) -> None:
+    if c.x is not None:
+        c.x
+#         ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], |state, handle, position| {
+        match get_hover(&state.transaction(), handle, position, false) {
+            Some(Hover {
+                contents: HoverContents::Markup(markup),
+                ..
+            }) => markup.value,
+            _ => "None".to_owned(),
+        }
+    });
+    assert!(
+        report.contains("**Type source**"),
+        "Expected type source section in field hover, got: {report}"
+    );
+    assert!(
+        report.contains("c.x is not None"),
+        "Expected attribute narrow in field hover, got: {report}"
+    );
+}
+
+#[test]
 fn hover_type_source_no_source_at_first_use_site() {
     // When hovering at the first-use site itself, we should not show
     // "Inferred from first use" pointing back to the same location.


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3898

Attribute hovers like c.x collect narrowing source information from the containing facet expression’s base binding. 

Attribute hovers return only narrowing sources, avoiding unrelated first-use info from the base variable.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test