### PR TITLE
Discard return hint if it produces more function argument errors

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1539,6 +1539,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Type {
         // First try the call without the hint to see if it succeeds.
         let mut ctor_targs_no_hint = ctor_targs.as_ref().map(|x| (**x).clone());
+        let arg_errors_no_hint = self.error_collector();
         let call_errors_no_hint = self.error_collector();
         let res_no_hint = self.callable_infer(
             callable.clone(),
@@ -1549,16 +1550,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             args,
             keywords,
             arguments_range,
-            arg_errors,
+            &arg_errors_no_hint,
             &call_errors_no_hint,
             context,
             None,
             ctor_targs_no_hint.as_mut(),
         );
         // If the call succeeds, attempt contextual typing with the hint.
-        let (chosen_ctor_targs, chosen_call_errors, chosen_res) =
+        let (chosen_ctor_targs, chosen_call_errors, chosen_arg_errors, chosen_res) =
             if call_errors_no_hint.is_empty() && hint.is_some() {
                 let mut ctor_targs_with_hint = ctor_targs.as_ref().map(|x| (**x).clone());
+                let arg_errors_with_hint = self.error_collector();
                 let call_errors_with_hint = self.error_collector();
                 let res_with_hint = self.callable_infer(
                     callable,
@@ -1569,21 +1571,39 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     args,
                     keywords,
                     arguments_range,
-                    arg_errors,
+                    &arg_errors_with_hint,
                     &call_errors_with_hint,
                     context,
                     hint,
                     ctor_targs_with_hint.as_mut(),
                 );
-                if call_errors_with_hint.is_empty() {
-                    (ctor_targs_with_hint, call_errors_with_hint, res_with_hint)
+                if call_errors_with_hint.is_empty()
+                    && arg_errors_with_hint.len() <= arg_errors_no_hint.len()
+                {
+                    (
+                        ctor_targs_with_hint,
+                        call_errors_with_hint,
+                        arg_errors_with_hint,
+                        res_with_hint,
+                    )
                 } else {
-                    (ctor_targs_no_hint, call_errors_no_hint, res_no_hint)
+                    (
+                        ctor_targs_no_hint,
+                        call_errors_no_hint,
+                        arg_errors_no_hint,
+                        res_no_hint,
+                    )
                 }
             } else {
-                (ctor_targs_no_hint, call_errors_no_hint, res_no_hint)
+                (
+                    ctor_targs_no_hint,
+                    call_errors_no_hint,
+                    arg_errors_no_hint,
+                    res_no_hint,
+                )
             };
         call_errors.extend(chosen_call_errors);
+        arg_errors.extend(chosen_arg_errors);
         if let Some(targs) = ctor_targs
             && let Some(chosen_targs) = chosen_ctor_targs
         {

--- a/pyrefly/lib/test/calls.rs
+++ b/pyrefly/lib/test/calls.rs
@@ -637,3 +637,29 @@ def g(a: A):
     a.x = None  # E:  # !E: `is not None` check  # !E: changing the declared type
     "#,
 );
+
+testcase!(
+    bug = "Always using the return hint was producing false positive arg errors, see #3688",
+    test_return_hint_not_used_if_detrimental,
+    r#"
+from collections.abc import Callable
+from typing import reveal_type
+
+def first[T](items: list[T], matcher: Callable[[T], bool]) -> T | None: ...
+def foo(items: list[int]) -> int | None:
+    return first(items, lambda i: reveal_type(i) == 3)  # E: revealed type: int
+    "#,
+);
+
+testcase!(
+    test_uses_return_hint_even_if_some_arg_error,
+    r#"
+from collections.abc import Iterable
+from typing import Any
+
+def collect[T](xs: Iterable[T], unrelated: Any) -> list[T]: ...
+
+def f() -> list[object]:
+    return collect(["x"], 1 + "oops")  # E: `+` is not supported between `Literal[1]` and `Literal['oops']`
+    "#,
+);


### PR DESCRIPTION
# Summary

This PR avoids using the return hint if it produces more argument errors, to avoid false positives where the return hint is detrimental.

Fixes #3688

# Test Plan

* Ran automated tests
* Ran pyrefly check on the closed source code base where I discovered this false positive to make sure it was fixed
* Ran pyrefly LSP through Zed on the same code base to make sure it was also working properly through the LSP
