### PR TITLE
Fix semantic token highlighting for union methods

### DIFF
--- a/pyrefly/lib/state/semantic_tokens.rs
+++ b/pyrefly/lib/state/semantic_tokens.rs
@@ -323,28 +323,46 @@ impl SemanticTokenBuilder {
         get_type_of_attribute: &dyn Fn(TextRange) -> Option<Type>,
         get_symbol_kind: &dyn Fn(&Key) -> Option<(ModuleName, SymbolKind)>,
     ) {
-        let kind = match get_type_of_attribute(attr.range()) {
-            Some(Type::Literal(lit)) if matches!(lit.value, Lit::Enum(_)) => {
+        let kind = get_type_of_attribute(attr.range())
+            .map(Self::attribute_semantic_token_type)
+            .unwrap_or(SemanticTokenType::PROPERTY);
+        self.push_if_in_range(attr.attr.range(), kind, Vec::new());
+        attr.value
+            .visit(&mut |x| self.process_expr(x, get_type_of_attribute, get_symbol_kind));
+    }
+
+    fn attribute_semantic_token_type(ty: Type) -> SemanticTokenType {
+        match ty {
+            Type::Union(union) => {
+                let mut members = union.members.into_iter();
+                let Some(first) = members.next() else {
+                    return SemanticTokenType::PROPERTY;
+                };
+                let kind = Self::attribute_semantic_token_type(first);
+                if members.all(|member| Self::attribute_semantic_token_type(member) == kind) {
+                    kind
+                } else {
+                    SemanticTokenType::PROPERTY
+                }
+            }
+            Type::Literal(lit) if matches!(lit.value, Lit::Enum(_)) => {
                 SemanticTokenType::ENUM_MEMBER
             }
-            Some(ty) if ty.is_toplevel_callable() => {
-                let is_method = ty.visit_toplevel_func_metadata(&|meta| {
-                    matches!(&meta.kind, FunctionKind::Def(func) if func.cls.is_some())
-                });
+            ty if ty.is_toplevel_callable() => {
+                let is_method = ty.visit_toplevel_func_metadata(
+                    &|meta| matches!(&meta.kind, FunctionKind::Def(func) if func.cls.is_some()),
+                );
                 if is_method {
                     SemanticTokenType::METHOD
                 } else {
                     SemanticTokenType::FUNCTION
                 }
             }
-            Some(Type::ClassDef(_) | Type::Type(_)) => SemanticTokenType::CLASS,
-            Some(Type::TypeAlias(_) | Type::UntypedAlias(_)) => SemanticTokenType::INTERFACE,
-            Some(Type::Module(_)) => SemanticTokenType::NAMESPACE,
+            Type::ClassDef(_) | Type::Type(_) => SemanticTokenType::CLASS,
+            Type::TypeAlias(_) | Type::UntypedAlias(_) => SemanticTokenType::INTERFACE,
+            Type::Module(_) => SemanticTokenType::NAMESPACE,
             _ => SemanticTokenType::PROPERTY,
-        };
-        self.push_if_in_range(attr.attr.range(), kind, Vec::new());
-        attr.value
-            .visit(&mut |x| self.process_expr(x, get_type_of_attribute, get_symbol_kind));
+        }
     }
 
     fn process_expr(

--- a/pyrefly/lib/state/semantic_tokens.rs
+++ b/pyrefly/lib/state/semantic_tokens.rs
@@ -24,6 +24,7 @@ use pyrefly_util::visit::Visit as _;
 use ruff_python_ast::Arguments;
 use ruff_python_ast::ExceptHandler;
 use ruff_python_ast::Expr;
+use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprContext;
 use ruff_python_ast::ModModule;
 use ruff_python_ast::Stmt;
@@ -316,6 +317,36 @@ impl SemanticTokenBuilder {
         }
     }
 
+    fn process_attribute_expr(
+        &mut self,
+        attr: &ExprAttribute,
+        get_type_of_attribute: &dyn Fn(TextRange) -> Option<Type>,
+        get_symbol_kind: &dyn Fn(&Key) -> Option<(ModuleName, SymbolKind)>,
+    ) {
+        let kind = match get_type_of_attribute(attr.range()) {
+            Some(Type::Literal(lit)) if matches!(lit.value, Lit::Enum(_)) => {
+                SemanticTokenType::ENUM_MEMBER
+            }
+            Some(ty) if ty.is_toplevel_callable() => {
+                let is_method = ty.visit_toplevel_func_metadata(&|meta| {
+                    matches!(&meta.kind, FunctionKind::Def(func) if func.cls.is_some())
+                });
+                if is_method {
+                    SemanticTokenType::METHOD
+                } else {
+                    SemanticTokenType::FUNCTION
+                }
+            }
+            Some(Type::ClassDef(_) | Type::Type(_)) => SemanticTokenType::CLASS,
+            Some(Type::TypeAlias(_) | Type::UntypedAlias(_)) => SemanticTokenType::INTERFACE,
+            Some(Type::Module(_)) => SemanticTokenType::NAMESPACE,
+            _ => SemanticTokenType::PROPERTY,
+        };
+        self.push_if_in_range(attr.attr.range(), kind, Vec::new());
+        attr.value
+            .visit(&mut |x| self.process_expr(x, get_type_of_attribute, get_symbol_kind));
+    }
+
     fn process_expr(
         &mut self,
         x: &Expr,
@@ -350,30 +381,7 @@ impl SemanticTokenBuilder {
                 x.recurse(&mut |x| self.process_expr(x, get_type_of_attribute, get_symbol_kind));
             }
             Expr::Attribute(attr) => {
-                let kind = match get_type_of_attribute(attr.range()) {
-                    Some(Type::Literal(lit)) if matches!(lit.value, Lit::Enum(_)) => {
-                        SemanticTokenType::ENUM_MEMBER
-                    }
-                    Some(ty) if ty.is_toplevel_callable() => {
-                        let is_method = ty.visit_toplevel_func_metadata(&|meta| {
-                            matches!(&meta.kind, FunctionKind::Def(func) if func.cls.is_some())
-                        });
-                        if is_method {
-                            SemanticTokenType::METHOD
-                        } else {
-                            SemanticTokenType::FUNCTION
-                        }
-                    }
-                    Some(Type::ClassDef(_) | Type::Type(_)) => SemanticTokenType::CLASS,
-                    Some(Type::TypeAlias(_) | Type::UntypedAlias(_)) => {
-                        SemanticTokenType::INTERFACE
-                    }
-                    Some(Type::Module(_)) => SemanticTokenType::NAMESPACE,
-                    _ => SemanticTokenType::PROPERTY,
-                };
-                self.push_if_in_range(attr.attr.range(), kind, Vec::new());
-                attr.value
-                    .visit(&mut |x| self.process_expr(x, get_type_of_attribute, get_symbol_kind));
+                self.process_attribute_expr(attr, get_type_of_attribute, get_symbol_kind);
             }
             // Comprehensions need special handling because the Visit trait doesn't visit targets
             Expr::ListComp(list_comp) => {

--- a/pyrefly/lib/test/lsp/semantic_tokens.rs
+++ b/pyrefly/lib/test/lsp/semantic_tokens.rs
@@ -352,6 +352,63 @@ token-type: method
 }
 
 #[test]
+fn type_aware_union_method_test() {
+    let code = r#"
+class A:
+    def foo(self) -> None:
+        pass
+
+class B:
+    def foo(self) -> None:
+        pass
+
+def f(x: A | B) -> None:
+    x.foo()
+"#;
+    assert_full_semantic_tokens(
+        &[("main", code)],
+        r#"
+# main.py
+line: 1, column: 6, length: 1, text: A
+token-type: class
+
+line: 2, column: 8, length: 3, text: foo
+token-type: method
+
+line: 2, column: 12, length: 4, text: self
+token-type: parameter, token-modifiers: [selfParameter]
+
+line: 5, column: 6, length: 1, text: B
+token-type: class
+
+line: 6, column: 8, length: 3, text: foo
+token-type: method
+
+line: 6, column: 12, length: 4, text: self
+token-type: parameter, token-modifiers: [selfParameter]
+
+line: 9, column: 4, length: 1, text: f
+token-type: function
+
+line: 9, column: 6, length: 1, text: x
+token-type: parameter
+
+line: 9, column: 9, length: 1, text: A
+token-type: class
+
+line: 9, column: 13, length: 1, text: B
+token-type: class
+
+line: 10, column: 4, length: 1, text: x
+token-type: parameter
+
+line: 10, column: 6, length: 3, text: foo
+token-type: method
+"#,
+    );
+}
+
+#[test]
 fn deprecated_token_for_disabled_branch() {
     let code = r#"
 import sys


### PR DESCRIPTION
# Summary

- We check each member of a union when choosing the semantic token for an attribute.
- This fixes cases like `x: A | B; x.foo()`, where foo should get method highlighting when both `A.foo` and `B.foo` are methods.
- Hover still has a similar issue: `x.foo` will show as an attribute even when every union member resolves foo to a method. That could be a follow-up?

Fixes https://github.com/facebook/pyrefly/issues/3873

# Test Plan

./test.py