### PR TITLE
Fix false-positive unused-variable on unpacked loop variables

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -1803,7 +1803,7 @@ impl<'a> BindingsBuilder<'a> {
     ) -> Option<Idx<KeyAnnotation>> {
         // Ignore imports and other items from unused variable detection
         if matches!(style, FlowStyle::Other) {
-            self.scopes.register_variable(name);
+            self.scopes.register_variable(name, false);
         }
         let idx = self.insert_binding(Key::Definition(ShortIdentifier::new(name)), binding);
         self.bind_name(&name.id, idx, style)

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -1135,6 +1135,12 @@ struct ImportUsage {
 struct VariableUsage {
     range: TextRange,
     used: bool,
+    /// When set, the variable is tracked for usage but never reported as unused.
+    /// Set for unpacking, multi-target, `for`, and `with` targets. These are
+    /// registered (rather than skipped) so their reads still get recorded, which
+    /// keeps the read-before-reassignment check correct across loop iterations.
+    /// Only plain `x = ...` single-name assignments are ever reported as unused.
+    allow_unused: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -1909,7 +1915,7 @@ impl Scopes {
         variables
             .into_iter()
             .filter_map(|(name, usage)| {
-                if usage.used {
+                if usage.used || usage.allow_unused {
                     None
                 } else {
                     Some(UnusedVariable {
@@ -2520,7 +2526,7 @@ impl Scopes {
         }
     }
 
-    pub fn register_variable(&mut self, name: &Identifier) {
+    pub fn register_variable(&mut self, name: &Identifier, allow_unused: bool) {
         // Track variables in Module, Function, and Method scopes.
         // Module-level variables won't be reported as unused since they can be imported
         // by other modules, but function/method-level variables will be reported.
@@ -2531,6 +2537,14 @@ impl Scopes {
             // Don't track variables declared as `global` or `nonlocal` — they are
             // visible to other scopes and can't be considered locally unused.
             if self.is_mutable_capture(&name.id) {
+                return;
+            }
+            // A tracking-only registration must not overwrite an existing entry. A prior
+            // single-name `x = ...` may have already registered this name as reportable,
+            // and overwriting it here would wrongly suppress that report; the recorded
+            // `used` flag must also survive. Only tracking-only registrations bail here; a
+            // later single-name assignment is reportable and still overwrites this entry.
+            if allow_unused && self.current().variables.contains_key(&name.id) {
                 return;
             }
             // Preserve the `used` flag if the variable was already marked as used.
@@ -2547,6 +2561,7 @@ impl Scopes {
                 VariableUsage {
                     range: name.range,
                     used: was_used,
+                    allow_unused,
                 },
             );
         }

--- a/pyrefly/lib/binding/target.rs
+++ b/pyrefly/lib/binding/target.rs
@@ -495,6 +495,13 @@ impl<'a> BindingsBuilder<'a> {
             },
             None => FlowStyle::Other,
         };
+        // Register unpacking / multi-target / `for` / `with` names for
+        // unused-variable tracking, but exempt from reporting (only single-name
+        // assignments are reported)
+        if matches!(style, FlowStyle::Other) {
+            self.scopes
+                .register_variable(&Identifier::new(name.id.clone(), name.range), true);
+        }
         let ann = self.bind_current(&name.id, &user, style);
         if was_uninitialized && let Some(ann_idx) = ann {
             self.insert_subsequently_initialized(ann_idx);
@@ -613,7 +620,7 @@ impl<'a> BindingsBuilder<'a> {
                 pristine: false,
             }
         } else {
-            self.scopes.register_variable(name);
+            self.scopes.register_variable(name, false);
             FlowStyle::Other
         };
         // Must check before bind_name updates the flow.

--- a/pyrefly/lib/test/lsp/diagnostic.rs
+++ b/pyrefly/lib/test/lsp/diagnostic.rs
@@ -398,3 +398,158 @@ from math import tau as my_tau
     let report = get_unused_import_diagnostics(&state, handle);
     assert_eq!(report, "Import `my_tau` is unused");
 }
+
+#[test]
+fn test_unused_variable_unpacked_reassigned_in_loop() {
+    let code = r#"
+from typing import Generator
+
+def foo() -> Generator[int]:
+    li, ri = 0, 100
+    while li <= ri:
+        mid = (li + ri) // 2
+        if mid % 2 == 0:
+            li = mid + 1
+        else:
+            ri = mid - 1
+        yield li
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, true);
+    let handle = handles.get("main").unwrap();
+    let report = get_unused_variable_diagnostics(&state, handle);
+    assert_eq!(report, "No unused variables");
+}
+
+// With no trailing read of either var, both were flagged before the fix.
+#[test]
+fn test_unused_variable_unpacked_reassigned_in_loop_no_trailing_read() {
+    let code = r#"
+def foo() -> None:
+    li, ri = 0, 100
+    while li <= ri:
+        mid = (li + ri) // 2
+        if mid % 2 == 0:
+            li = mid + 1
+        else:
+            ri = mid - 1
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, true);
+    let handle = handles.get("main").unwrap();
+    let report = get_unused_variable_diagnostics(&state, handle);
+    assert_eq!(report, "No unused variables");
+}
+
+// Policy preserved: a genuinely-unused tuple-unpacking target is not reported.
+#[test]
+fn test_unused_variable_unpacking_target_not_reported() {
+    let code = r#"
+def f():
+    a, b = 1, 2
+    print(a)
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, true);
+    let handle = handles.get("main").unwrap();
+    let report = get_unused_variable_diagnostics(&state, handle);
+    assert_eq!(report, "No unused variables");
+}
+
+// An exempt unpacking registration must not erase the report from a prior
+// single-name dead store: `x` here is still unused.
+#[test]
+fn test_unused_variable_single_then_unpack_still_reported() {
+    let code = r#"
+def f():
+    x = 1
+    x, y = (2, 3)
+    print(y)
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, true);
+    let handle = handles.get("main").unwrap();
+    let report = get_unused_variable_diagnostics(&state, handle);
+    assert_eq!(report, "Variable `x` is unused");
+}
+
+// Policy preserved: an unused `for` target is not reported.
+#[test]
+fn test_unused_variable_for_loop_target_not_reported() {
+    let code = r#"
+def f():
+    for i in range(3):
+        pass
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, true);
+    let handle = handles.get("main").unwrap();
+    let report = get_unused_variable_diagnostics(&state, handle);
+    assert_eq!(report, "No unused variables");
+}
+
+// Policy preserved: a multi-target assignment name is not reported.
+#[test]
+fn test_unused_variable_multi_target_not_reported() {
+    let code = r#"
+def f():
+    a = b = 5
+    print(a)
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, true);
+    let handle = handles.get("main").unwrap();
+    let report = get_unused_variable_diagnostics(&state, handle);
+    assert_eq!(report, "No unused variables");
+}
+
+// Policy preserved: a `with ... as` target is not reported.
+#[test]
+fn test_unused_variable_with_target_not_reported() {
+    let code = r#"
+def f(cm):
+    with cm as x:
+        pass
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, true);
+    let handle = handles.get("main").unwrap();
+    let report = get_unused_variable_diagnostics(&state, handle);
+    assert_eq!(report, "No unused variables");
+}
+
+// A walrus target routes through `bind_target_name`, so it is tracked but never
+// reported (same policy as unpacking/`for`/`with`).
+#[test]
+fn test_unused_variable_walrus_target_not_reported() {
+    let code = r#"
+def f():
+    (x := 5)
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, true);
+    let handle = handles.get("main").unwrap();
+    let report = get_unused_variable_diagnostics(&state, handle);
+    assert_eq!(report, "No unused variables");
+}
+
+// A comprehension target lives in its own scope, which the tracker does not
+// cover, so it is never reported.
+#[test]
+fn test_unused_variable_comprehension_target_not_reported() {
+    let code = r#"
+def f(items):
+    return [1 for x in items]
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, true);
+    let handle = handles.get("main").unwrap();
+    let report = get_unused_variable_diagnostics(&state, handle);
+    assert_eq!(report, "No unused variables");
+}
+
+// PEP 572: a walrus inside a comprehension binds to the enclosing scope. Even
+// when unused there, it is not reported.
+#[test]
+fn test_unused_variable_comprehension_walrus_not_reported() {
+    let code = r#"
+def f(items, h):
+    result = [x for x in items if (y := h(x))]
+    return result
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, true);
+    let handle = handles.get("main").unwrap();
+    let report = get_unused_variable_diagnostics(&state, handle);
+    assert_eq!(report, "No unused variables");
+}


### PR DESCRIPTION
Fixes facebook/pyrefly#3911

## What

A loop variable first bound by tuple unpacking and then reassigned inside the loop was reported as unused, even though it is read on every iteration:

```python
def foo() -> Generator[int]:
    li, ri = 0, 100
    while li <= ri:
        mid = (li + ri) // 2
        if mid % 2 == 0:
            li = mid + 1
        else:
            ri = mid - 1   # before: "Variable `ri` is unused"; after: no warning
        yield li
```

The reporter saw it only with a `Generator` return type, but that was a coincidence. It reproduces with any return type, and with no read after the reassignment both `li` and `ri` get flagged.

## Why

`unused-variable` is a binding-phase check: each assignment registers the name in a per-scope usage map, each read marks it used, and names still unused at scope exit are reported. `mark_variable_used` is a no-op if the name is not already in the map, so a name has to be registered before its reads to be tracked.

Only single-name assignments (`x = ...`) registered. Tuple/list unpacking, multi-target (`a = b = ...`), `for`, and `with` targets all flow through `bind_target_name`, which never called `register_variable`. So `li, ri = 0, 100` left both names out of the map. The loop-header reads (`while li <= ri`, `mid = (li + ri)`) found nothing to mark, and the later single-name write `ri = mid - 1` registered `ri` fresh as unused. With no read after that point in source order, it was reported. `li` survived only because `yield li` reads it after its own reassignment.

## How

- `bind_target_name` now registers its target, but as tracking-only (`allow_unused = true`). The name is tracked so its reads land and the read-before-reassignment carry works across loop iterations, but it is never itself reported. This keeps the existing policy that only single-name assignments are flagged.
- The tracking-only registration is insert-if-absent, so it cannot overwrite a stricter existing entry. A prior dead store like `x = 1; x, y = f()` still reports `x`. A later single-name assignment is not tracking-only and still overwrites, staying reportable.
- `VariableUsage` gains an `allow_unused` field, matching `ParameterUsage.allow_unused` and `ImportUsage.skip_unused_check`, which already had equivalent flags.
- No change to `for`, `with`, `_`, or comprehension reporting. Comprehension targets reach `bind_target_name` but are inert, because the tracker only covers `Module`, `Function`, and `Method` scopes.

Files: `binding/scope.rs`, `binding/target.rs`, `binding/bindings.rs`, plus tests.

## Test plan

All tests use the `get_unused_variable_diagnostics` harness in `test/lsp/diagnostic.rs`.

| Test | What it checks |
|------|----------------|
| `test_unused_variable_unpacked_reassigned_in_loop` | the issue repro (with `Generator`) reports nothing |
| `test_unused_variable_unpacked_reassigned_in_loop_no_trailing_read` | the both-flagged variant (`li` and `ri`) reports nothing |
| `test_unused_variable_single_then_unpack_still_reported` | `x = 1; x, y = (2,3)` still reports `x` (no-clobber guard) |
| `test_unused_variable_unpacking_target_not_reported` | `a, b = 1, 2; print(a)` stays unflagged |
| `test_unused_variable_for_loop_target_not_reported` | `for i in range(3)` stays unflagged |
| `test_unused_variable_with_target_not_reported` | `with cm as x` stays unflagged |
| `test_unused_variable_walrus_target_not_reported` | `(x := 5)` stays unflagged |
| `test_unused_variable_multi_target_not_reported` | `a = b = 5` stays unflagged |
| `test_unused_variable_comprehension_target_not_reported` | `[1 for x in items]` stays unflagged |
| `test_unused_variable_comprehension_walrus_not_reported` | a walrus hoisted out of a comprehension stays unflagged |

Full lib suite: 5869 passed, 0 failed. Format and lint clean. A wide `mypy_primer` run over 73 projects showed zero diff, which is expected: `unused-variable` is an IDE-only hint and is never emitted by `pyrefly check`, so it does not appear in primer output.

## Future improvements

This PR fixes the false positive without widening what gets reported. The check still only flags plain single-name local assignments. The cases below are deliberately left uncovered and could be follow-up PRs. Most of them need a dummy-name (`_`) exemption first, since pyrefly has none today and reporting these without one would flag `_` everywhere.

- Unused tuple/list-unpacking targets: `a, b = f(); print(a)` does not flag `b`.
- Unused `for` targets: `for i in range(3): pass` does not flag `i`.
- Unused `with ... as` targets: `with cm as x: pass` does not flag `x`.
- Unused walrus targets: `(x := 5)` does not flag `x`.
- Unused multi-target names: `a = b = 5; print(a)` does not flag `b`.
- Comprehension targets: `[1 for x in items]` does not flag `x`. These live in a separate scope the tracker does not cover, so adding them is a larger change than the others.
- Module-level unused variables are never reported, by design, because another module can import them.
- Dead stores: `x = 5; print(x); x = 7` does not flag the final `x = 7`, whose value is never read. This is tracked by the existing `test_reassignment_false_negative`, which carries a TODO.

A reasonable sequencing for the follow-up work: add the `_` / dummy-name exemption, then decide per construct whether to report it (assignment unpacking is the least noisy candidate, `for` indices the most noisy), and run `mypy_primer` for each since these would change reported diagnostics. The `allow_unused` flag added here is the seam where that policy would be flipped per call site.
