### PR TITLE
Preserve omitted slice positions and validate builtin sequence slices

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -935,11 +935,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 self.heap.mk_unpack(ty)
             }
             Expr::Slice(x) => {
-                let elt_exprs = [x.lower.as_ref(), x.upper.as_ref(), x.step.as_ref()];
-                let elts = elt_exprs
-                    .iter()
-                    .filter_map(|e| e.map(|e| self.expr_infer(e, errors)))
-                    .collect::<Vec<_>>();
+                let none = self.heap.mk_none();
+                let elts = vec![
+                    x.lower
+                        .as_ref()
+                        .map_or_else(|| none.clone(), |e| self.expr_infer(e, errors)),
+                    x.upper
+                        .as_ref()
+                        .map_or_else(|| none.clone(), |e| self.expr_infer(e, errors)),
+                    x.step
+                        .as_ref()
+                        .map_or_else(|| none.clone(), |e| self.expr_infer(e, errors)),
+                ];
                 self.specialize(&self.stdlib.slice_class_object(), elts, x.range(), errors)
             }
             Expr::IpyEscapeCommand(x) => {
@@ -2634,6 +2641,67 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         self.subscript_infer_for_type_with_key_present(base, slice, range, errors, false)
     }
 
+    fn slice_type_args(slice_ty: &Type) -> Option<&[Type; 3]> {
+        match slice_ty {
+            Type::ClassType(cls) if cls.is_builtin("slice") => Some(
+                cls.targs()
+                    .as_slice()
+                    .try_into()
+                    .expect("slice class should have exactly three type arguments"),
+            ),
+            _ => None,
+        }
+    }
+
+    fn valid_slice_index_type(&self, ty: &Type, index_dunder: &Name) -> bool {
+        match ty {
+            Type::Any(_) | Type::None => true,
+            Type::Union(u) => u
+                .members
+                .iter()
+                .all(|ty| self.valid_slice_index_type(ty, index_dunder)),
+            Type::Literal(lit) if lit.value.as_index_i64().is_some() => true,
+            _ => self.has_attr(ty, index_dunder),
+        }
+    }
+
+    fn validate_builtin_sequence_slice(
+        &self,
+        slice_expr: &ExprSlice,
+        slice_ty: &Type,
+        errors: &ErrorCollector,
+    ) -> Option<Type> {
+        let [lower_ty, upper_ty, step_ty] =
+            Self::slice_type_args(slice_ty).expect("Expr::Slice should infer to builtins.slice");
+        let index_dunder = Name::new_static("__index__");
+        for (expr, ty, is_step) in [
+            (&slice_expr.lower, lower_ty, false),
+            (&slice_expr.upper, upper_ty, false),
+            (&slice_expr.step, step_ty, true),
+        ]
+        .into_iter()
+        .filter_map(|(expr, ty, is_step)| expr.as_deref().map(|expr| (expr, ty, is_step)))
+        {
+            if is_step && matches!(ty, Type::Literal(lit) if lit.value.as_index_i64() == Some(0)) {
+                return Some(self.error(
+                    errors,
+                    expr.range(),
+                    ErrorKind::BadIndex,
+                    "Slice step cannot be zero".to_owned(),
+                ));
+            }
+            if !self.valid_slice_index_type(ty, &index_dunder) {
+                return Some(self.error(
+                    errors,
+                    expr.range(),
+                    ErrorKind::BadIndex,
+                    "Slice indices must be integers or have an `__index__` method".to_owned(),
+                ));
+            }
+        }
+        None
+    }
+
     fn subscript_infer_for_type_with_key_present(
         &self,
         base: &Type,
@@ -2643,6 +2711,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         key_present: bool, // true if the key is definitely known to be present
     ) -> Type {
         let xs = Ast::unpack_slice(slice);
+        let slice_ty = LazyCell::new(|| self.expr_infer(slice, errors));
         self.distribute_over_union(base, |base| {
             let mut base = base.clone();
             if let Type::Var(v) = base {
@@ -2655,6 +2724,28 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // TODO: Handle subscription of intersections properly.
                 base = x.1;
             }
+            let is_builtin_sequence = match &base {
+                Type::Tuple(_) => true,
+                Type::ClassType(cls) | Type::SelfType(cls) => {
+                    cls.is_builtin("list")
+                        || (self.as_tuple(cls).is_some()
+                            && !self.class_overrides_tuple_getitem(cls))
+                }
+                _ => false,
+            };
+
+            if let Expr::Slice(slice_expr) = slice
+                && is_builtin_sequence
+                && let Some(error_ty) =
+                    self.validate_builtin_sequence_slice(slice_expr, &slice_ty, errors)
+            {
+                return error_ty;
+            }
+            let builtin_sequence_slice_ty = match slice {
+                Expr::Slice(_) if is_builtin_sequence => Some(&*slice_ty),
+                _ => None,
+            };
+
             match base {
                 Type::Forall(forall) => {
                     if matches!(forall.body, Forallable::TypeAlias(_)) {
@@ -2810,6 +2901,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 Type::Tuple(ref tuple) => self.infer_tuple_subscript(
                     tuple.clone(),
                     slice,
+                    builtin_sequence_slice_ty,
                     range,
                     errors,
                     Some(&|| ErrorContext::Index(self.for_display(base.clone()))),
@@ -2817,6 +2909,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 Type::IntTuple(ref int_tuple) => self.infer_int_tuple_subscript(
                     int_tuple,
                     slice,
+                    None,
                     range,
                     errors,
                     Some(&|| ErrorContext::Index(self.for_display(base.clone()))),
@@ -2852,6 +2945,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     self.infer_tuple_subscript(
                         tuple,
                         slice,
+                        None,
                         range,
                         errors,
                         Some(&|| ErrorContext::Index(self.for_display(base.clone()))),
@@ -2889,6 +2983,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     self.infer_tuple_subscript(
                         tuple,
                         slice,
+                        builtin_sequence_slice_ty,
                         range,
                         errors,
                         Some(&|| ErrorContext::Index(self.for_display(base.clone()))),
@@ -2897,6 +2992,21 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // Special handling for nn.ModuleDict with TypedDict type argument
                 Type::ClassType(ref cls) if is_nn_module_dict(cls) => {
                     self.try_nn_module_dict_index(cls, &base, slice, range, errors)
+                }
+                Type::ClassType(ref cls) | Type::SelfType(ref cls) if cls.is_builtin("list") => {
+                    let index_arg = match builtin_sequence_slice_ty {
+                        Some(ty) => CallArg::ty(ty, slice.range()),
+                        None => CallArg::expr(slice),
+                    };
+                    self.call_method_or_error(
+                        &base,
+                        &dunder::GETITEM,
+                        range,
+                        &[index_arg],
+                        &[],
+                        errors,
+                        Some(&|| ErrorContext::Index(self.for_display(base.clone()))),
+                    )
                 }
                 Type::ClassType(_) | Type::SelfType(_) => self.call_method_or_error(
                     &base,

--- a/pyrefly/lib/alt/subscript.rs
+++ b/pyrefly/lib/alt/subscript.rs
@@ -30,16 +30,21 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         &self,
         tuple: Tuple,
         index: &Expr,
+        index_ty: Option<&Type>,
         range: TextRange,
         errors: &ErrorCollector,
         context: Option<&dyn Fn() -> ErrorContext>,
     ) -> Type {
         let fallback = || {
+            let index_arg = match index_ty {
+                Some(ty) => CallArg::ty(ty, index.range()),
+                None => CallArg::expr(index),
+            };
             self.call_method_or_error(
                 &Type::Tuple(tuple.clone()),
                 &dunder::GETITEM,
                 range,
-                &[CallArg::expr(index)],
+                &[index_arg],
                 &[],
                 errors,
                 context,
@@ -47,7 +52,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         };
         match index {
             Expr::Slice(slice) => self
-                .infer_tuple_slice(&tuple, slice)
+                .infer_tuple_slice(&tuple, slice, index_ty)
                 .unwrap_or_else(fallback),
             _ => self
                 .infer_tuple_index(&tuple, index, errors)
@@ -59,12 +64,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         &self,
         int_tuple: &IntTuple,
         index: &Expr,
+        index_ty: Option<&Type>,
         range: TextRange,
         errors: &ErrorCollector,
         context: Option<&dyn Fn() -> ErrorContext>,
     ) -> Type {
         let tuple = int_tuple.to_tuple();
-        let fallback = || self.infer_tuple_subscript(tuple.clone(), index, range, errors, context);
+        let fallback =
+            || self.infer_tuple_subscript(tuple.clone(), index, index_ty, range, errors, context);
         match index {
             Expr::Slice(_) => fallback(),
             _ => self
@@ -73,15 +80,30 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
-    fn infer_tuple_slice(&self, tuple: &Tuple, slice: &ExprSlice) -> Option<Type> {
+    fn infer_tuple_slice(
+        &self,
+        tuple: &Tuple,
+        slice: &ExprSlice,
+        slice_ty: Option<&Type>,
+    ) -> Option<Type> {
         if slice.step.is_some() {
             return None;
         }
+        let slice_targs = Self::slice_targs(slice_ty);
         match tuple {
-            Tuple::Concrete(elts) => self.infer_concrete_slice(elts, &slice.lower, &slice.upper),
+            Tuple::Concrete(elts) => {
+                self.infer_concrete_slice(elts, &slice.lower, &slice.upper, slice_targs)
+            }
             Tuple::Unpacked(f) => {
                 let (prefix, middle, suffix) = &**f;
-                self.infer_unpacked_slice(prefix, middle, suffix, &slice.lower, &slice.upper)
+                self.infer_unpacked_slice(
+                    prefix,
+                    middle,
+                    suffix,
+                    &slice.lower,
+                    &slice.upper,
+                    slice_targs,
+                )
             }
             _ => None,
         }
@@ -137,16 +159,43 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     /// Returns Ok(Some(_)) if the expression is a literal integer
     /// Returns Ok(None) if the expression is absent
     /// Returns Err(()) if the expression is present but is not a literal integer
-    fn parse_slice_literal(&self, expr: &Option<Box<Expr>>) -> Result<Option<i64>, ()> {
+    fn parse_slice_literal(
+        &self,
+        expr: &Option<Box<Expr>>,
+        ty: Option<&Type>,
+    ) -> Result<Option<i64>, ()> {
+        if let Some(ty) = ty {
+            return Self::parse_slice_literal_type(ty);
+        }
         if let Some(expr) = expr {
             let literal_type = self.expr_infer(expr, &self.error_swallower());
-            match &literal_type {
-                Type::Literal(lit) => Ok(lit.value.as_index_i64()),
-                _ => Err(()),
-            }
+            Self::parse_slice_literal_type(&literal_type)
         } else {
             Ok(None)
         }
+    }
+
+    fn parse_slice_literal_type(ty: &Type) -> Result<Option<i64>, ()> {
+        match ty {
+            Type::None => Ok(None),
+            Type::Literal(lit) => lit.value.as_index_i64().map(Some).ok_or(()),
+            _ => Err(()),
+        }
+    }
+
+    fn slice_targs(slice_ty: Option<&Type>) -> Option<&[Type; 3]> {
+        let Some(Type::ClassType(cls)) = slice_ty else {
+            return None;
+        };
+        if !cls.is_builtin("slice") {
+            return None;
+        }
+        Some(
+            cls.targs()
+                .as_slice()
+                .try_into()
+                .expect("slice class should have exactly three type arguments"),
+        )
     }
 
     fn infer_concrete_slice(
@@ -154,10 +203,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         elts: &[Type],
         lower_expr: &Option<Box<Expr>>,
         upper_expr: &Option<Box<Expr>>,
+        slice_targs: Option<&[Type; 3]>,
     ) -> Option<Type> {
         let len = elts.len() as i64;
-        let lower_literal = self.parse_slice_literal(lower_expr).ok()?.unwrap_or(0);
-        let upper_literal = self.parse_slice_literal(upper_expr).ok()?.unwrap_or(len);
+        let lower_literal = self
+            .parse_slice_literal(lower_expr, slice_targs.map(|[lower, _, _]| lower))
+            .ok()?
+            .unwrap_or(0);
+        let upper_literal = self
+            .parse_slice_literal(upper_expr, slice_targs.map(|[_, upper, _]| upper))
+            .ok()?
+            .unwrap_or(len);
 
         // Normalize negative indices (e.g., -1 becomes len-1)
         let lower = if lower_literal < 0 {
@@ -223,9 +279,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         suffix: &[Type],
         lower_expr: &Option<Box<Expr>>,
         upper_expr: &Option<Box<Expr>>,
+        slice_targs: Option<&[Type; 3]>,
     ) -> Option<Type> {
-        let lower_literal = self.parse_slice_literal(lower_expr).ok()?.unwrap_or(0);
-        let upper_literal = self.parse_slice_literal(upper_expr).ok()?;
+        let lower_literal = self
+            .parse_slice_literal(lower_expr, slice_targs.map(|[lower, _, _]| lower))
+            .ok()?
+            .unwrap_or(0);
+        let upper_literal = self
+            .parse_slice_literal(upper_expr, slice_targs.map(|[_, upper, _]| upper))
+            .ok()?;
         match (lower_literal, upper_literal) {
             // Positive lower, positive upper
             (lower, Some(upper)) if lower >= 0 && upper >= 0 => {

--- a/pyrefly/lib/test/assign.rs
+++ b/pyrefly/lib/test/assign.rs
@@ -969,11 +969,10 @@ a, b = "x"
 );
 
 testcase!(
-    bug = "Should detect zero step size in slice",
     test_slice_zero_step,
     r#"
 items = [1, 2, 3, 4]
-bad = items[::0]
+bad = items[::0]  # E: Slice step cannot be zero
 "#,
 );
 

--- a/pyrefly/lib/test/stubgen/type_checking_or_guard/expected.pyi
+++ b/pyrefly/lib/test/stubgen/type_checking_or_guard/expected.pyi
@@ -1,4 +1,6 @@
 # @generated
+from typing import Literal
+
 from typing import TYPE_CHECKING
 
 USE_EXTENSIONS: Literal[True] = True

--- a/pyrefly/lib/test/tuple.rs
+++ b/pyrefly/lib/test/tuple.rs
@@ -454,6 +454,24 @@ def test(x: tuple[int, str, bool], y: tuple[int, ...], start: int, stop: int, st
 );
 
 testcase!(
+    test_slice_decimal_step,
+    r#"
+def test(xs: list[int], ys: tuple[int, ...]) -> None:
+    xs[::1.5]  # E: Slice indices must be integers or have an `__index__` method
+    ys[::1.5]  # E: Slice indices must be integers or have an `__index__` method
+"#,
+);
+
+testcase!(
+    test_slice_zero_step,
+    r#"
+def test(xs: list[int], ys: tuple[int, ...]) -> None:
+    xs[::0]  # E: Slice step cannot be zero
+    ys[::0]  # E: Slice step cannot be zero
+"#,
+);
+
+testcase!(
     test_slice_subset,
     r#"
 def f(x: slice) -> None:


### PR DESCRIPTION
Validate slice values for builtin sequences

Add tests to check for correct slice behaviour

Remove bug status from testcase since behaviour is fixed

# Summary

Validate slice components for builtin list and tuple subscripts. Pyrefly now reports errors for non-index slice values like decimal steps, and for literal zero steps. Also preserve omitted slice positions when inferring `slice[...]` types so start, stop, and step do not shift into the wrong generic slots.

Remove the `bug` marker from the existing zero-step slice test since the behaviour is now fixed, and add list/tuple coverage for decimal and zero step slices.

Fixes #3768, #3896

# Test Plan
- `cargo test test_slice_decimal_step`
- `cargo test test_slice_zero_step`


