### PR TITLE
Don't count `Literal` alias members against the hint width cap

### DIFF
--- a/pyrefly/lib/alt/unwrap.rs
+++ b/pyrefly/lib/alt/unwrap.rs
@@ -437,8 +437,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             let raw_hints = hint.types();
             let flattened_hints = self.flatten_alias_union_hints(raw_hints);
             let hints = flattened_hints.as_ref().map_or(raw_hints, |x| x);
-            if hints.len() <= MAX_DECOMPOSE_HINT_WIDTH {
+            let is_scalar = // Scalar literals can't decompose into a container
+                |t: &Type| matches!(t, Type::Literal(_) | Type::LiteralString(_) | Type::None);
+            let decomposable_width = hints.iter().filter(|h| !is_scalar(h)).count();
+            if decomposable_width <= MAX_DECOMPOSE_HINT_WIDTH {
                 for (hint, vs) in self.solver().partial_sort_by_vars(hints) {
+                    if is_scalar(hint) {
+                        continue;
+                    }
                     let mut ret = None;
                     match self.solver().with_snapshot(&vs, || {
                         let d = decompose(hint);

--- a/pyrefly/lib/test/contextual.rs
+++ b/pyrefly/lib/test/contextual.rs
@@ -839,6 +839,23 @@ f(list())
 );
 
 testcase!(
+    // Regression: a list/set literal against `Alias | Collection[Alias]`, where the
+    // `Literal[...]` alias is wide, must still pick up the `Collection` element hint.
+    // Flattening the alias used to count its members against `MAX_DECOMPOSE_HINT_WIDTH`,
+    // incorrectly triggering the cap so the literal fell back to `list[str]`.
+    test_list_hint_with_wide_literal_alias_union,
+    r#"
+from typing import Literal, TypeAlias
+from collections.abc import Collection
+L: TypeAlias = Literal["a", "b", "c", "d", "e", "f", "g", "h"]
+def f(*, x: L | Collection[L] = "a") -> None: ...
+f(x=["a", "b"])
+f(x={"a", "b"})
+f(x=["a", "bad"])  # E: `list[str]` is not assignable to parameter `x`
+    "#,
+);
+
+testcase!(
     // Regression: when a TypeVar's only constraints are upper bounds, multiple
     // such bounds where one is a subtype of the other must collapse to the
     // *narrowest* one. Previously `get_new_bound`'s absorb logic kept the wider


### PR DESCRIPTION
# Summary

* A container literal (list/set/etc) checked against a hint of the form `SomeLiteralAlias | Collection[SomeLiteralAlias]` fails to pick up the `Collection` element-type hint _if_ the literal alias has 8 or more members, producing a spurious `bad-argument-type`.

* Scalar literals can never decompose into a container, so they shouldn't count toward (or be visited by) the width-capped decomposition loop. 

* This change skips `Type::Literal`, `Type::LiteralString`, and `Type::None`, both when measuring the hint width and inside the loop (matching the existing "scalar" predicate used in `alt/narrow.rs`).

Fixes #3945.

(Note: this is not the same as https://github.com/facebook/pyrefly/issues/3779. No changes have been made to the cap, and even if the cap became much larger scalar literals shouldn't count against it).

# Test Plan

* Validated against the original failure (discovered in [polars#28084](https://github.com/pola-rs/polars/pull/28084/)). 
* Added new test coverage (in `test/contextual.rs`).
* Existing unit tests all pass.