### PR TITLE
Fix types/provide-type resolving the wrong token in notebook cells

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -2853,7 +2853,8 @@ impl Server {
     ) -> Option<ProvideTypeResponse> {
         let uri = &params.text_document.uri;
         let handle = self.make_handle_if_enabled(uri, None).ok()?;
-        provide_type(transaction, &handle, params.positions)
+        let notebook_cell = self.maybe_get_code_cell_index(uri);
+        provide_type(transaction, &handle, params.positions, notebook_cell)
     }
 
     fn type_error_display_status(&self, path: &Path) -> TypeErrorDisplayStatus {

--- a/pyrefly/lib/lsp/wasm/provide_type.rs
+++ b/pyrefly/lib/lsp/wasm/provide_type.rs
@@ -48,6 +48,7 @@ pub fn provide_type(
     transaction: &mut Transaction<'_>,
     handle: &Handle,
     positions: Vec<Position>,
+    notebook_cell: Option<usize>,
 ) -> Option<ProvideTypeResponse> {
     // This LSP method works for unopened files.
     // Check if the file is already loaded in memory. If not, load it.
@@ -59,7 +60,7 @@ pub fn provide_type(
     let mut contents = Vec::new();
 
     for position in positions {
-        let text_size = info.from_lsp_position(position, None);
+        let text_size = info.from_lsp_position(position, notebook_cell);
         if let Some(ty) = transaction.get_result_type_at_for_display(handle, text_size) {
             let mut c = TypeDisplayContext::new(&[&ty]);
             c.set_lsp_display_mode(LspDisplayMode::ProvideType);

--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_provide_type.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_provide_type.rs
@@ -37,3 +37,33 @@ fn test_notebook_provide_type() {
 
     interaction.shutdown().unwrap();
 }
+
+#[test]
+fn test_notebook_provide_type_second_cell() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(None),
+            ..Default::default()
+        })
+        .unwrap();
+    interaction.open_notebook(
+        "notebook.ipynb",
+        vec!["foo = \"bar\"\nfoo", "x = 1\nbar = x"],
+    );
+
+    // `bar` is at cell2 line 1; its type is the value of `x`.
+    interaction
+        .provide_type_cell("notebook.ipynb", "cell2", 1, 0)
+        .expect_response(json!({
+            "contents": [{
+                "kind": "plaintext",
+                "value": "typing.Literal[1]",
+            }]
+        }))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}


### PR DESCRIPTION
# Summary

`provide_type` passed the request position straight to `from_lsp_position(position, None)`, ignoring the notebook cell. For a cell other than the first, an LSP position is cell-relative, so dropping the cell offset resolves the position in the concatenated module at the wrong line - landing in an earlier cell. The IDE drives hover/type resolution (and the completion-trigger type lookup) through this method, so types in every cell after the first came back wrong or empty.

Thread the code-cell index (as the completion handler already does) through `provide_type` and translate the position with it so cell-relative positions map to the correct concatenated-module offset.

# Test Plan

Added a regression test `test_notebook_provide_type_second_cell` in `pyrefly/lib/test/lsp/lsp_interaction/notebook_provide_type.rs`: requests the type of `bar` in the second cell and asserts `typing.Literal[1]`. Fails on main (wrong cell resolved), passes with the fix.

- cargo test -p pyrefly test_notebook_provide_type
- python3 test.py --no-test --no-conformance --no-jsonschema
