### PR TITLE
Fix: auto-discover typings/ on the CLI path, relative to the config root (#3955)

### DIFF
--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -1208,6 +1208,10 @@ impl ConfigFile {
     pub fn configure(&mut self) -> Vec<ConfigError> {
         let mut configure_errors = Vec::new();
 
+        // Whether the user explicitly configured `site_package_path` (via config
+        // file or CLI flag). If not, we auto-discover a `typings/` directory below.
+        let site_package_path_set = self.python_environment.site_package_path.is_some();
+
         if self.interpreters.skip_interpreter_query {
             self.python_environment.set_empty_to_default();
         } else {
@@ -1231,6 +1235,25 @@ impl ConfigFile {
                     self.python_environment.set_empty_to_default();
                     configure_errors.push(error.context("While finding Python interpreter"));
                 }
+            }
+        }
+
+        // A `typings/` directory under the config root is always a default
+        // `site_package_path` entry (in addition to any interpreter-provided
+        // site-packages, which live in `interpreter_site_package_path`), unless
+        // the user explicitly set `site_package_path`. We resolve it relative to
+        // the config root here, rather than in `set_empty_to_default`, so the CLI
+        // and IDE agree regardless of the process's working directory and so it
+        // applies even when an interpreter query succeeds. A `Synthetic` config
+        // has no on-disk root to anchor `typings/` to, so we skip discovery
+        // rather than fall back to a CWD-relative path.
+        if !site_package_path_set && let Some(root) = self.source.root() {
+            let typings = root.join("typings");
+            if typings.exists() {
+                self.python_environment
+                    .site_package_path
+                    .get_or_insert_with(Vec::new)
+                    .push(typings);
             }
         }
 
@@ -3426,11 +3449,11 @@ output-format = "omit-errors"
 
     #[test]
     fn test_typings_autodiscovered_relative_to_config_root() {
-        // Regression test capturing the bug: on the default CLI path
-        // (`skip_interpreter_query` left at `false`), a `typings/` directory under
-        // the config root is NOT auto-discovered, so the CLI disagrees with the
-        // IDE. The fix in the next commit flips this assertion to the correct
-        // behavior (typings/ should be present).
+        // With no explicit `site_package_path`, a `typings/` directory under the
+        // config root is auto-discovered and resolved relative to that root (not
+        // the process CWD, which is never the temp dir). This must hold on the
+        // default CLI path that queries an interpreter, so we leave
+        // `skip_interpreter_query` at its default of `false`.
         let root = TempDir::new().unwrap();
         let typings = root.path().join("typings");
         fs::create_dir_all(&typings).unwrap();
@@ -3442,8 +3465,8 @@ output-format = "omit-errors"
         config.configure();
 
         assert!(
-            !config.site_package_path().any(|p| p == &typings),
-            "BUG: typings dir {typings:?} should be auto-discovered on the CLI path but is not; got {:?}",
+            config.site_package_path().any(|p| p == &typings),
+            "expected auto-discovered typings dir {typings:?} in site_package_path, got {:?}",
             config.site_package_path().collect::<Vec<_>>(),
         );
     }

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -3425,6 +3425,57 @@ output-format = "omit-errors"
     }
 
     #[test]
+    fn test_typings_autodiscovered_relative_to_config_root() {
+        // Regression test capturing the bug: on the default CLI path
+        // (`skip_interpreter_query` left at `false`), a `typings/` directory under
+        // the config root is NOT auto-discovered, so the CLI disagrees with the
+        // IDE. The fix in the next commit flips this assertion to the correct
+        // behavior (typings/ should be present).
+        let root = TempDir::new().unwrap();
+        let typings = root.path().join("typings");
+        fs::create_dir_all(&typings).unwrap();
+
+        let mut config = ConfigFile {
+            source: ConfigSource::File(root.path().join(ConfigFile::PYREFLY_FILE_NAME)),
+            ..Default::default()
+        };
+        config.configure();
+
+        assert!(
+            !config.site_package_path().any(|p| p == &typings),
+            "BUG: typings dir {typings:?} should be auto-discovered on the CLI path but is not; got {:?}",
+            config.site_package_path().collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn test_typings_not_added_when_site_package_path_explicit() {
+        // An explicit `site_package_path` disables `typings/` auto-discovery,
+        // even when a `typings/` directory exists under the config root.
+        let root = TempDir::new().unwrap();
+        fs::create_dir_all(root.path().join("typings")).unwrap();
+        let explicit = root.path().join("stubs");
+
+        let mut config = ConfigFile {
+            source: ConfigSource::File(root.path().join(ConfigFile::PYREFLY_FILE_NAME)),
+            interpreters: Interpreters {
+                skip_interpreter_query: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        config.python_environment.site_package_path = Some(vec![explicit.clone()]);
+        config.configure();
+
+        let paths = config.site_package_path().collect::<Vec<_>>();
+        assert!(paths.contains(&&explicit));
+        assert!(
+            !paths.iter().any(|p| p.ends_with("typings")),
+            "typings should not be auto-added when site_package_path is explicit, got {paths:?}",
+        );
+    }
+
+    #[test]
     fn test_pytorch_efficiency_lints_flag_enables_lints() {
         let mut config = ConfigFile {
             root: ConfigBase {

--- a/crates/pyrefly_config/src/environment/environment.rs
+++ b/crates/pyrefly_config/src/environment/environment.rs
@@ -95,12 +95,10 @@ impl PythonEnvironment {
             self.python_version = Some(PythonVersion::default());
         }
         if self.site_package_path.is_none() {
-            let typings = PathBuf::from("./typings");
-            if typings.exists() {
-                self.site_package_path = Some(vec![PathBuf::from("./typings")]);
-            } else {
-                self.site_package_path = Some(Vec::new());
-            }
+            // The `typings/` default is applied in `ConfigFile::configure()` so it
+            // can be resolved relative to the config root and applied regardless
+            // of whether an interpreter was queried.
+            self.site_package_path = Some(Vec::new());
         }
     }
 


### PR DESCRIPTION
Summary:

The `typings/` default was only applied inside `set_empty_to_default`, which the CLI bypasses whenever a Python interpreter is queried successfully: `get_env_from_interpreter` moves the real site-packages into `interpreter_site_package_path` and leaves `site_package_path` as `Some(vec![])`, so `set_empty_to_default` never runs and `./typings` is never added. The IDE sets `skip_interpreter_query = true`, so it hit the default and picked up `typings/`, producing different results for the same config. The `./typings` literal was also resolved against the process CWD rather than the config root, since it was injected after `rewrite_with_path_to_config`.

The fix centralizes `typings/` discovery in `ConfigFile::configure()`: after interpreter handling (so it applies on every branch — skipped, found, or failed), if the user did not explicitly set `site_package_path`, a `typings/` directory under the config root (`self.source.root()`) is appended. Interpreter site-packages live in the separate `interpreter_site_package_path` field, so `typings/` coexists with them. `set_empty_to_default` no longer injects the CWD-relative literal.

This flips `test_typings_autodiscovered_relative_to_config_root` to assert the correct behavior, demonstrating the test fails without this change.

fixes #3954

Reviewed By: grievejia

Differential Revision: D109879285


