### PR TITLE
Fix/issue 3897 constrained typevar overload

### DIFF
--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -50,6 +50,7 @@ use crate::types::callable::FuncMetadata;
 use crate::types::callable::Function;
 use crate::types::callable::Params;
 use crate::types::literal::Lit;
+use crate::types::type_var::Restriction;
 use crate::types::types::Type;
 use crate::types::types::Var;
 
@@ -239,6 +240,13 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
                     Vec::new()
                 }
             }
+
+            // a constraind typevar argument is one of its constraints, so expand like a union ie try each constraint against overloads + union the matched returns
+            Type::Quantified(q) => match q.restriction() {
+                Restriction::Constraints(constraints) => constraints.clone(),
+                _ => Vec::new(),
+            },
+
             _ => Vec::new(),
         }
     }

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -2410,16 +2410,49 @@ testcase!(
     test_arg_error_isolation,
     r#"
 from typing import Callable, Literal, assert_type, overload
-
 @overload
 def f(tag: Literal[1], xs: list[Callable[[int], str]]) -> int: ...
-
 @overload
 def f(tag: Literal[2], xs: list[Callable[[str], str]]) -> str: ...
-
 def f(tag: Literal[1, 2], xs: list[Callable[..., str]]) -> int | str:
     return 0 if tag == 1 else ""
-
 assert_type(f(2, [lambda value: value + "x"]), str)
     "#,
+);
+
+testcase!(
+    test_overload_constrained_typevar_arg,
+    r#"
+from typing import overload, assert_type
+class A: ...
+class B: ...
+@overload
+def g(x: A) -> A: ...
+@overload
+def g(x: B) -> B: ...
+def g(x: A | B) -> A | B: ...
+def f[T: (A, B)](x: T) -> None:
+    g(x)  # constrained typevar expands to its constraints; each matches an overload
+def h[T: (A, B)](x: T) -> A | B:
+    return g(x)
+assert_type(g(A()), A)
+assert_type(g(B()), B)
+"#,
+);
+
+testcase!(
+    test_overload_constrained_typevar_arg_no_match,
+    r#"
+from typing import overload
+class A: ...
+class B: ...
+class C: ...
+@overload
+def g(x: A) -> A: ...
+@overload
+def g(x: C) -> C: ...
+def g(x: A | C) -> A | C: ...
+def f[T: (A, B)](x: T) -> None:
+    g(x)  # E: No matching overload found for function `g`
+"#,
 );


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3897

Expand constrained TypeVar arguments during overload resolution

Constrained TypeVar arg (eg x:T where T:(A,B)) was matched as a whole against each overload, which fails because T is assignable to a param only if every constraint is. Overload resolution already performs union-style argument expansion via expand_type, but it didn't have a case for a constrained TypeVar.

Expand a constrained TypeVar into its constraints, like a union ie each constraint is tried against the overloads and the matched returns are unioned. Existing all-expansions-must-match rule keeps this sound, if a constraint matches no overload, call is still rejected

# Test Plan

<!-- Describe how you tested this PR -->

Added two regression tests to pyrefly/lib/test/overload.rs, both passing:

- test_overload_constrained_typevar_arg -- #3897 repro now resolves
- test_overload_constrained_typevar_arg_no_match -- uncovered constraint still errors

8 failing tests fail in main as well

<!-- Run test.py and commit any changes to generated files -->
