### PR TITLE
Let `unused-ignore` in a suppression opt out of unused-ignore reporting

### DIFF
--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -551,6 +551,11 @@ impl Errors {
                     let declared_codes: SmallSet<String> =
                         supp.error_codes().iter().cloned().collect();
 
+                    // listing `unused-ignore` opts this comment out of unused-ignore and doesn't flag itself as unused
+                    if declared_codes.contains(ErrorKind::UnusedIgnore.to_name()) {
+                        continue;
+                    }
+
                     // Determine if the suppression is unused
                     let unused_codes: SmallSet<String> = if declared_codes.is_empty() {
                         // Blanket ignore - unused if no errors were suppressed
@@ -796,6 +801,62 @@ def f() -> int:
         assert_eq!(unused.len(), 1);
         assert!(unused[0].msg().contains("bad-override"));
         assert!(!unused[0].msg().contains("bad-return"));
+    }
+
+    #[test]
+    fn test_unused_ignore_listed_with_used_code() {
+        // `unused-ignore` in the list is never itself reported as unused, even when another listed code is used ("error present" version). Issue 3951
+        let contents = r#"
+def f() -> int:
+    # pyrefly: ignore [bad-return, unused-ignore]
+    return "hello"
+"#;
+        let (errors, _tdir) = get_errors(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        assert!(unused.is_empty());
+    }
+
+    #[test]
+    fn test_unused_ignore_listed_suppresses_comment() {
+        // Listing `unused-ignore` opts the comment out of unused-ignore reporting even when the other listed code didn't fire ("error absent" version).
+        let contents = r#"
+def f() -> int:
+    # pyrefly: ignore [bad-return, unused-ignore]
+    return 1
+"#;
+        let (errors, _tdir) = get_errors(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        assert!(unused.is_empty());
+    }
+
+    #[test]
+    fn test_unused_ignore_alone_not_flagged() {
+        // `# pyrefly: ignore[unused-ignore]` on a clean line doesn't self-flag
+        let contents = r#"
+def f() -> int:
+    # pyrefly: ignore [unused-ignore]
+    return 1
+"#;
+        let (errors, _tdir) = get_errors(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        assert!(unused.is_empty());
+    }
+
+    #[test]
+    fn test_unused_ignore_without_listing_still_flagged() {
+        // Without `unused-ignore` in the list, an unused comment is still reported, so the change only affects comments that opt in.
+        let contents = r#"
+def f() -> int:
+    # pyrefly: ignore [bad-return]
+    return 1
+"#;
+        let (errors, _tdir) = get_errors(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        assert_eq!(unused.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

A `# pyrefly: ignore[...]` comment that lists `unused-ignore` is now not itself reported as unused, and listing it suppresses the unused-ignore diagnostic for that comment. This lets a single comment cover code that errors on one Python version but not another (used on one, unused on other) without dead-ending, matching mypy/ty.

Normal unused comment that doesn't explicitly list `unused-ignore` is still reported.

Fixes #3951

# Test Plan

<!-- Describe how you tested this PR -->
4 unit tests in pyrefly/lib/state/errors.rs
`cargo test -p pyrefly --lib unused_ignore`

- test_unused_ignore_listed_with_used_code -- not flagged when error present
- test_unused_ignore_listed_suppresses_comment -- not flagged when error absent
- test_unused_ignore_alone_not_flagged -- bare `[unused-ignore]` doesn't self-flag
- test_unused_ignore_without_listing_still_flagged -- regression guard, normal comment still reported

cargo fmt and cargo clippy run fine

<!-- Run test.py and commit any changes to generated files -->
