### PR TITLE
Support bare factory-boy factory calls returning the model type

### DIFF
--- a/pyrefly/lib/alt/class/factory_boy.rs
+++ b/pyrefly/lib/alt/class/factory_boy.rs
@@ -27,9 +27,10 @@ const CREATE: Name = Name::new_static("create");
 const BUILD: Name = Name::new_static("build");
 const CREATE_BATCH: Name = Name::new_static("create_batch");
 const BUILD_BATCH: Name = Name::new_static("build_batch");
+const NEW: Name = Name::new_static("__new__");
 
 impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
-    /// Synthesize `create`, `build`, `create_batch`, and `build_batch` on
+    /// Synthesize `create`, `build`, `create_batch`, `new` and `build_batch` on
     /// factory-boy `DjangoModelFactory` subclasses, returning the model type
     /// from `class Meta: model = X`.
     pub fn get_factory_boy_synthesized_fields(
@@ -52,7 +53,20 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         );
         fields.insert(
             BUILD,
-            self.factory_classmethod(cls, &BUILD, vec![], model_type),
+            self.factory_classmethod(cls, &BUILD, vec![], model_type.clone()),
+        );
+        fields.insert(
+            NEW,
+            self.factory_classmethod(
+                cls,
+                &NEW,
+                vec![Param::PosOnly(
+                    None,
+                    self.heap.mk_any_implicit(),
+                    Required::Required,
+                )],
+                model_type,
+            ),
         );
         let size_param = Param::Pos(
             Name::new_static("size"),
@@ -72,6 +86,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             BUILD_BATCH,
             self.factory_classmethod(cls, &BUILD_BATCH, vec![size_param], list_model_type),
         );
+
         Some(ClassSynthesizedFields::new(fields))
     }
 

--- a/pyrefly/lib/test/django/factory_boy.rs
+++ b/pyrefly/lib/test/django/factory_boy.rs
@@ -154,3 +154,41 @@ class IncompleteFactory(DjangoModelFactory):
 obj = IncompleteFactory.create()
 "#,
 );
+
+factory_boy_testcase!(
+    test_bare_call_returns_model,
+    r#"
+from typing import assert_type
+
+from django.db import models
+from factory.django import DjangoModelFactory
+
+class User(models.Model):
+    username = models.CharField(max_length=150)
+
+class UserFactory(DjangoModelFactory):
+    class Meta:
+        model = User
+
+user = UserFactory()
+assert_type(user, User)
+"#,
+);
+
+factory_boy_testcase!(
+    test_bare_call_attribute_access,
+    r#"
+from django.db import models
+from factory.django import DjangoModelFactory
+
+class User(models.Model):
+    username = models.CharField(max_length=150)
+
+class UserFactory(DjangoModelFactory):
+    class Meta:
+        model = User
+
+user = UserFactory()
+name = user.username
+"#,
+);


### PR DESCRIPTION
Calling a DjangoModelFactory subclass directly (`UserFactory()`) is equivalent to `UserFactory.create()` at runtime via FactoryMetaClass, but Pyrefly typed it as an instance of the factory rather than the model, producing false missing-attribute errors on every field access.

Add tests to confirim correct behaviour

Fixes #3934

# Test Plan
Add 2 tests:
- test_bare_call_attribute_access
- test_bare_call_returns_model
