### PR TITLE
Fix sys.path ordering: single-file module from earlier root beats package from later root

### DIFF
--- a/pyrefly/lib/module/finder.rs
+++ b/pyrefly/lib/module/finder.rs
@@ -288,6 +288,13 @@ impl FindResult {
     /// are not compared.
     fn best_result(a: FindResult, b: FindResult) -> Self {
         match (&a, &b) {
+            // A concrete single-file module or compiled module from an earlier root beats any
+            // package from a later root. Python's sys.path semantics are first-match-wins
+            // regardless of whether the match is a file or a package directory.
+            (
+                FindResult::SingleFilePyModule(_) | FindResult::CompiledModule(_),
+                FindResult::RegularPackage(..) | FindResult::LegacyNamespacePackage(..),
+            ) => a,
             // RegularPackage and LegacyNamespacePackage (LNP) share the top tier: both carry a
             // concrete `__init__.py` and resolve to `FileSystem(init_path)`. Tying them lets
             // the prefer-`a` approach keep sys.path order ("first concrete-init wins") when
@@ -5376,6 +5383,51 @@ mod tests {
             )
             .unwrap(),
             FindingOrError::new_finding(ModulePath::filesystem(root.join("rules/if.config.cconf")))
+        );
+    }
+
+    #[test]
+    fn test_single_file_in_earlier_root_beats_package_in_later_root() {
+        // Python's sys.path semantics are first-match-wins regardless of
+        // whether the match is a .py file or a package directory. When root0
+        // has `widget.py` and root1 has `widget/__init__.py`, resolving `widget`
+        // should return root0's `widget.py`.
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        TestPath::setup_test_directory(
+            root,
+            vec![
+                TestPath::dir(
+                    "search_root0",
+                    vec![TestPath::file_with_contents(
+                        "widget.py",
+                        "class WidgetHandler: ...",
+                    )],
+                ),
+                TestPath::dir(
+                    "search_root1",
+                    vec![TestPath::dir("widget", vec![TestPath::file("__init__.py")])],
+                ),
+            ],
+        );
+        let roots = [root.join("search_root0"), root.join("search_root1")];
+
+        assert_eq!(
+            find_module(
+                ModuleName::from_str("widget"),
+                roots.iter(),
+                &mut vec![],
+                None,
+                None,
+                false,
+                &mut None,
+                &DirEntryCache::new(true),
+                None,
+            )
+            .unwrap(),
+            FindingOrError::new_finding(ModulePath::filesystem(
+                root.join("search_root0/widget.py")
+            ))
         );
     }
 }

--- a/pyrefly/lib/test/imports.rs
+++ b/pyrefly/lib/test/imports.rs
@@ -1767,6 +1767,37 @@ fn test_pkgutil_namespace_absorbs_implicit_namespace() {
 }
 
 // ----------------------------------------------------------------------------
+// Search-path ordering regression.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn test_search_path_module_beats_later_package() {
+    // A .py module in search_path[0] must beat a package directory in
+    // search_path[1]. Python's sys.path semantics are first-match-wins
+    // regardless of whether the match is a .py file or a package.
+    let tempdir = tempfile::tempdir().unwrap();
+    let root = tempdir.path();
+    std::fs::write(root.join("widget.py"), "class WidgetHandler: ...\n").unwrap();
+    std::fs::create_dir(root.join("widget_pkg")).unwrap();
+    std::fs::create_dir(root.join("widget_pkg/widget")).unwrap();
+    std::fs::write(root.join("widget_pkg/widget/__init__.py"), "").unwrap();
+
+    let mut env = TestEnv::new().with_site_package_paths(vec![
+        root.to_path_buf(),      // root/widget.py — should win
+        root.join("widget_pkg"), // root/widget_pkg/widget/__init__.py — should lose
+    ]);
+    // No error expected: widget.py from the first search path should be
+    // resolved, making WidgetHandler importable.
+    env.add_with_path("main", "main.py", "from widget import WidgetHandler\n");
+    let (state, handle_fn) = env.to_state();
+    state
+        .transaction()
+        .get_errors(&[handle_fn("main")])
+        .check_against_expectations()
+        .unwrap();
+}
+
+// ----------------------------------------------------------------------------
 // Cross-module class rebind tests: importers should observe whichever class
 // the visible result chose. See `assign.rs` for the same-module regressions.
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

Python's sys.path semantics are first-match-wins regardless of whether the match is a .py file or a package directory. When widget.py exists in root0 and widget/__init__.py exists in root1, root0's module should win.

The bug was in FindResult::best_result, which unconditionally placed RegularPackage and LegacyNamespacePackage at the top priority tier. This meant a package from any fallback root would override a single-file module found earlier in the search path.

The fix adds an explicit match arm before the RegularPackage tier: when a is a SingleFilePyModule or CompiledModule and b is a package type, a wins. This preserves the existing behavior where .pyi stubs from later roots still beat .py implementations (handled by the subsequent SingleFilePyiModule arm).

Fixes #3407

# Test Plan

Two new tests covering the bug directly:
 - module::finder::tests::test_single_file_in_earlier_root_beats_package_in_later_root — unit
   test on find_module
 - test::imports::test_search_path_module_beats_later_package — integration test verifying no
   type error when importing from the correctly resolved module
