### PR TITLE
Don't truncate inferred return types that are callables (#3958)

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -381,12 +381,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     x.attr.range,
                 );
                 let attr_type = self.attr_infer(&base, &x.attr.id, x.range, errors, None);
+                
                 if base.ty().is_literal_string() {
                     match attr_type.ty() {
                         Type::BoundMethod(method) => attr_type
                             .clone()
                             .with_ty(method.with_bound_object(base.ty().clone()).as_type()),
                         _ => attr_type,
+                    }
+                } else if let (Type::ClassDef(_), Type::Function(func)) = (base.ty(), attr_type.ty()) {
+                    if func.metadata.flags.property_metadata.is_some() {
+                        attr_type.with_ty(self.heap.mk_class_type(self.stdlib.property().clone()))
+                    } else {
+                        attr_type
                     }
                 } else {
                     attr_type

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -381,19 +381,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     x.attr.range,
                 );
                 let attr_type = self.attr_infer(&base, &x.attr.id, x.range, errors, None);
-                
                 if base.ty().is_literal_string() {
                     match attr_type.ty() {
                         Type::BoundMethod(method) => attr_type
                             .clone()
                             .with_ty(method.with_bound_object(base.ty().clone()).as_type()),
                         _ => attr_type,
-                    }
-                } else if let (Type::ClassDef(_), Type::Function(func)) = (base.ty(), attr_type.ty()) {
-                    if func.metadata.flags.property_metadata.is_some() {
-                        attr_type.with_ty(self.heap.mk_class_type(self.stdlib.property().clone()))
-                    } else {
-                        attr_type
                     }
                 } else {
                     attr_type

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -3594,6 +3594,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             .collect(),
                     )
                 };
+                let return_ty = match return_ty {
+                    Type::BoundMethod(method) => self
+                        .bind_boundmethod(&method, &mut |a, b| self.is_subset_eq(a, b))
+                        .unwrap_or_else(|| self.heap.mk_bound_method(*method)),
+                    return_ty => return_ty,
+                };
                 // Cap inferred return unions aggressively. A small shared width
                 // budget keeps both top-level and nested inferred unions from
                 // accumulating many alternatives across recursive inference.
@@ -3606,7 +3612,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // per iteration. A limit of 3 lets truncation kick in by iteration 4
                 // while keeping the global fixpoint iteration budget at 5.
                 const MAX_INFERRED_RETURN_NESTING_DEPTH: usize = 3;
-                let return_ty = if return_ty.union_width() > MAX_INFERRED_RETURN_UNION_WIDTH {
+                let return_ty = if return_ty.is_toplevel_callable() {
+                    return_ty
+                } else if return_ty.union_width() > MAX_INFERRED_RETURN_UNION_WIDTH {
                     self.heap.mk_any_implicit()
                 } else {
                     let any = self.heap.mk_any_implicit();

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -3975,7 +3975,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // per iteration. A limit of 3 lets truncation kick in by iteration 4
                 // while keeping the global fixpoint iteration budget at 5.
                 const MAX_INFERRED_RETURN_NESTING_DEPTH: usize = 3;
-                let return_ty = if return_ty.union_width() > MAX_INFERRED_RETURN_UNION_WIDTH {
+                // Callables do not accumulate a nesting level per iteration, so capping one
+                // cannot help convergence and would only replace the types in its signature
+                // with `Any`. Inferred types there are capped when their own function is solved.
+                let return_ty = if return_ty.is_toplevel_callable() {
+                    return_ty
+                } else if return_ty.union_width() > MAX_INFERRED_RETURN_UNION_WIDTH {
                     self.heap.mk_any_implicit()
                 } else {
                     let any = self.heap.mk_any_implicit();

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -1180,6 +1180,31 @@ def test(stack: ThemeStack) -> None:
 "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/3958
+testcase!(
+    test_property_returning_bound_method_preserves_signature,
+    r#"
+from typing import reveal_type
+
+class Foo:
+    def bar(
+        self,
+        simple_union: int | str,
+        complex_union: int | str | tuple[int, str] | None = None,
+    ) -> None: ...
+
+class FooManager:
+    def __init__(self) -> None:
+        self.foo = Foo()
+
+    @property
+    def bar(self):
+        return self.foo.bar
+
+reveal_type(FooManager().bar)  # E: revealed type: (simple_union: int | str, complex_union: int | str | tuple[int, str] | None = None) -> None
+"#,
+);
+
 testcase!(
     test_generic_function_as_closure_default_arg,
     r#"

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -1198,6 +1198,31 @@ def test(stack: ThemeStack) -> None:
 "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/3958
+testcase!(
+    test_property_returning_bound_method_preserves_signature,
+    r#"
+from typing import reveal_type
+
+class Foo:
+    def bar(
+        self,
+        simple_union: int | str,
+        complex_union: int | str | tuple[int, str] | None = None,
+    ) -> None: ...
+
+class FooManager:
+    def __init__(self) -> None:
+        self.foo = Foo()
+
+    @property
+    def bar(self):
+        return self.foo.bar
+
+reveal_type(FooManager().bar)  # E: revealed type: (simple_union: int | str, complex_union: int | str | tuple[int, str] | None = None) -> None
+"#,
+);
+
 testcase!(
     test_generic_function_as_closure_default_arg,
     r#"


### PR DESCRIPTION
# Summary

Inferred return types are capped for union width and nesting depth so that
mutually-recursive functions converge during fixpoint solving. The cap is applied
by walking the entire type, so it also rewrote the signature of a returned
callable: any parameter union of four or more members became `Any`. This matches
the observation in #3958 that the problem only appears at four or more members.

The effect is visible through a property whose getter returns a bound method:

```python
class Foo:
    def bar(self, simple_union: int | str, complex_union: int | str | tuple[int, str] | None = None): ...


class FooManager:
    def __init__(self):
        self.foo = Foo()

    @property
    def bar(self):
        return self.foo.bar


reveal_type(FooManager().bar)
```

Before:

```
(simple_union: int | str, complex_union: Unknown = None) -> None
```

After:

```
(simple_union: int | str, complex_union: int | str | tuple[int, str] | None = None) -> None
```

# Approach

Inferred return types that are themselves callables are exempted from both caps.
Only `ClassType` and `Tuple` consume depth in the truncation walk, so a callable
signature cannot produce the unbounded growth the caps guard against, and
truncating it only discards annotations written in the source. Types inferred
inside the signature are still capped where they are solved, so recursive cases
converge as before.

# Scope

The exemption applies when the inferred return type is itself a callable. Wide
unions reached through an enclosing type, such as `Callable | None` or
`list[Callable]`, are still truncated. That is the case reported in #3958, and
this change is limited to it.

# Test Plan

- Added a regression test in `pyrefly/lib/test/attributes.rs` built from the
  snippet in #3958.
- `cargo test -p pyrefly --lib`: 7798 passed, 0 failed.
- Confirmed `__self__`, `__func__`, and `types.MethodType` assignability on a
  returned bound method are unchanged from `main`.

Fixes #3958