### PR TITLE
Warn on unrecognized config keys with a "did you mean" suggestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,6 +2315,7 @@ dependencies = [
  "pretty_assertions",
  "pulldown-cmark",
  "pyrefly_build",
+ "pyrefly_derive",
  "pyrefly_python",
  "pyrefly_util",
  "regex",

--- a/crates/pyrefly_config/Cargo.toml
+++ b/crates/pyrefly_config/Cargo.toml
@@ -19,6 +19,7 @@ enum-iterator = "2.3.0"
 itertools = "0.15.0"
 parse-display = "0.8.2"
 pyrefly_build = { path = "../pyrefly_build" }
+pyrefly_derive = { path = "../pyrefly_derive" }
 pyrefly_python = { path = "../pyrefly_python" }
 pyrefly_util = { path = "../pyrefly_util" }
 regex = "1.13.1"

--- a/crates/pyrefly_config/src/base.rs
+++ b/crates/pyrefly_config/src/base.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use clap::ValueEnum;
 use enum_iterator::Sequence;
 use enum_iterator::all;
+use pyrefly_derive::ConfigKeys;
 use pyrefly_python::ignore::Tool;
 use serde::Deserialize;
 use serde::Serialize;
@@ -214,6 +215,7 @@ impl Preset {
 
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Default)]
+#[derive(ConfigKeys)]
 #[serde(rename_all = "kebab-case")]
 pub struct ConfigBase {
     /// Errors to silence (or not) when printing errors.
@@ -319,6 +321,7 @@ pub struct ConfigBase {
 
     /// Any unknown config items
     #[serde(flatten)]
+    #[config_keys(skip)]
     pub(crate) extras: ExtraConfigs,
 }
 

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -28,6 +28,7 @@ use pyrefly_build::BuildSystem;
 use pyrefly_build::handle::Handle;
 use pyrefly_build::source_db::SourceDatabase;
 use pyrefly_build::source_db::Target;
+use pyrefly_derive::ConfigKeys;
 use pyrefly_python::COMPILED_FILE_SUFFIXES;
 use pyrefly_python::PYTHON_EXTENSIONS;
 use pyrefly_python::ignore::Tool;
@@ -39,6 +40,7 @@ use pyrefly_python::sys_info::PythonVersion;
 use pyrefly_python::sys_info::SysInfo;
 use pyrefly_util::absolutize::Absolutize as _;
 use pyrefly_util::arc_id::ArcId;
+use pyrefly_util::config_keys::ConfigKeys as _;
 use pyrefly_util::fs_anyhow;
 use pyrefly_util::globs::FilteredGlobs;
 use pyrefly_util::globs::Glob;
@@ -98,6 +100,7 @@ impl SubConfig {
 /// Config overrides for the `pyrefly coverage` commands.
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(ConfigKeys)]
 #[serde(rename_all = "kebab-case")]
 pub struct CoverageConfig {
     /// Takes precedence over `project_includes` when set.
@@ -108,6 +111,7 @@ pub struct CoverageConfig {
 
     /// Any unknown config items
     #[serde(default, flatten)]
+    #[config_keys(skip)]
     pub(crate) extras: ExtraConfigs,
 }
 
@@ -525,6 +529,7 @@ impl ImportLookupPathPart<'_> {
 
 #[skip_serializing_none]
 #[derive(Debug, Deserialize, Serialize, Clone, Derivative)]
+#[derive(ConfigKeys)]
 #[serde(rename_all = "kebab-case")]
 #[derivative(PartialEq, Eq)]
 pub struct ConfigFile {
@@ -830,90 +835,12 @@ impl ConfigFile {
     }
 }
 
-// The key/alias constants below only rank the "did you mean" SUGGESTION;
-// unknown-key DETECTION is serde-derived (the flatten `extras` catch-all) and cannot drift.
-/// `ConfigBase` keys, valid both at the top level and inside a `[[sub-config]]`
-/// block. Used only to suggest a "did you mean" for unrecognized keys, so a
-/// missing entry merely weakens a hint — it never silences the warning itself.
-/// Kept in sync with `ConfigBase` by `test_known_config_keys_cover_serialized_fields`.
-const CONFIG_BASE_KEYS: &[&str] = &[
-    "errors",
-    "permissive-ignores",
-    "enabled-ignores",
-    "replace-imports-with-any",
-    "ignore-missing-imports",
-    "untyped-def-behavior",
-    "check-unannotated-defs",
-    "infer-return-types",
-    "disable-type-errors-in-ide",
-    "ignore-errors-in-generated-code",
-    "infer-with-first-use",
-    "pytorch-efficiency-lints",
-    "recursion-depth-limit",
-    "recursion-overflow-handler",
-    "strict-callable-subtyping",
-    "strict-partial-subtyping",
-    "spec-compliant-overloads",
-    "legacy-overload-expansion",
-    "treat-all-caps-as-final",
-];
-
-/// Deprecated spellings of `ConfigBase` keys accepted by serde, paired with the canonical key to suggest.
-const CONFIG_BASE_KEY_ALIASES: &[(&str, &str)] = &[
-    ("replace_imports_with_any", "replace-imports-with-any"),
-    ("untyped_def_behavior", "untyped-def-behavior"),
-    (
-        "ignore_errors_in_generated_code",
-        "ignore-errors-in-generated-code",
-    ),
-];
-
-/// Keys valid only at the top level of a config (not inside `[[sub-config]]`):
-/// project-wide settings plus the flattened interpreter and Python-environment
-/// options. The full top-level key set is this list plus `CONFIG_BASE_KEYS`.
-const TOP_LEVEL_ONLY_CONFIG_KEYS: &[&str] = &[
-    "project-includes",
-    "project-excludes",
-    "disable-project-excludes-heuristics",
-    "search-path",
-    "disable-search-path-heuristics",
-    "enable-fallback-search-path",
-    "typeshed-path",
-    "baseline",
-    "output-format",
-    "preset",
-    "sub-config",
-    "coverage",
-    "use-ignore-files",
-    "build-system",
-    "min-severity",
-    "skip-lsp-config-indexing",
-    "extra-file-extensions",
-    "python-interpreter-path",
-    "fallback-python-interpreter-name",
-    "conda-environment",
-    "skip-interpreter-query",
-    "python-platform",
-    "python-version",
-    "site-package-path",
-];
-
-/// Deprecated spellings of top-level-only keys accepted by serde, paired with the canonical key to suggest.
-const TOP_LEVEL_ONLY_CONFIG_KEY_ALIASES: &[(&str, &str)] = &[
-    ("project_includes", "project-includes"),
-    ("project_excludes", "project-excludes"),
-    ("search_path", "search-path"),
-    ("sub_config", "sub-config"),
-    ("python_interpreter", "python-interpreter-path"),
-    ("python-interpreter", "python-interpreter-path"),
-    ("python_platform", "python-platform"),
-    ("python_version", "python-version"),
-    ("site_package_path", "site-package-path"),
-];
-
-/// Keys valid inside a `[coverage]` table.
-/// Kept in sync with `CoverageConfig` by `test_known_config_keys_cover_serialized_fields`.
-const COVERAGE_CONFIG_KEYS: &[&str] = &["includes", "excludes"];
+// The candidate key sets and the deprecated-alias sets that rank the "did you
+// mean" SUGGESTION are both derived from the config structs via
+// `#[derive(ConfigKeys)]`, so they can't drift from the fields (see
+// `ConfigBase::config_keys()` and `ConfigBase::config_key_aliases()`).
+// Unknown-key DETECTION is independent of both -- it is serde-derived (the
+// flatten `extras` catch-all) and cannot drift.
 
 impl ConfigFile {
     pub const PYREFLY_FILE_NAME: &str = "pyrefly.toml";
@@ -1863,19 +1790,13 @@ impl ConfigFile {
             anyhow!("Unknown config key `{key}`{location}{suggestion}")
         }
 
-        let top_level: Vec<&str> = TOP_LEVEL_ONLY_CONFIG_KEYS
-            .iter()
-            .chain(CONFIG_BASE_KEYS)
-            .copied()
-            .collect();
-        let sub_config: Vec<&str> = once("matches")
-            .chain(CONFIG_BASE_KEYS.iter().copied())
-            .collect();
-        let top_level_aliases: Vec<(&str, &str)> = TOP_LEVEL_ONLY_CONFIG_KEY_ALIASES
-            .iter()
-            .chain(CONFIG_BASE_KEY_ALIASES)
-            .copied()
-            .collect();
+        // `ConfigFile` flattens `Interpreters`, `PythonEnvironment`, and (as
+        // `root`) `ConfigBase`, so its derived keys are the full top-level set.
+        let top_level = ConfigFile::config_keys();
+        let coverage = CoverageConfig::config_keys();
+        let sub_config: Vec<&str> = once("matches").chain(ConfigBase::config_keys()).collect();
+        let top_level_aliases = ConfigFile::config_key_aliases();
+        let sub_config_aliases = ConfigBase::config_key_aliases();
 
         let mut warnings: Vec<anyhow::Error> = self
             .root
@@ -1889,7 +1810,7 @@ impl ConfigFile {
                 .extras
                 .0
                 .keys()
-                .map(|key| message(key, COVERAGE_CONFIG_KEYS, &[], " in coverage config")),
+                .map(|key| message(key, &coverage, &[], " in coverage config")),
         );
         for sub in &self.sub_configs {
             let location = format!(" in sub config matching {}", sub.matches);
@@ -1898,7 +1819,7 @@ impl ConfigFile {
                     .extras
                     .0
                     .keys()
-                    .map(|key| message(key, &sub_config, CONFIG_BASE_KEY_ALIASES, &location)),
+                    .map(|key| message(key, &sub_config, &sub_config_aliases, &location)),
             );
         }
         warnings
@@ -2071,6 +1992,7 @@ mod tests {
     use std::fs;
 
     use pretty_assertions::assert_eq;
+    use pyrefly_util::config_keys::ConfigKeys;
     use pyrefly_util::includes::Includes;
     use pyrefly_util::test_path::TestPath;
     use tempfile::TempDir;
@@ -4492,8 +4414,8 @@ replace_imports_with_any = ["foo"]
 
     #[test]
     fn test_known_config_aliases_are_consistent() {
-        // Every serde `alias` must (a) point at a canonical key present in its scope's keys
-        // constant, so the "did you mean" suggestion resolves, and (b) still be honored by serde,
+        // Every serde `alias` must (a) point at a canonical key present in its scope's derived
+        // keys, so the "did you mean" suggestion resolves, and (b) still be honored by serde,
         // so the alias maps back to its field instead of landing in `extras`. The sync test
         // (`test_known_config_keys_cover_serialized_fields`) deliberately does not cover aliases.
         fn alias_toml_value(alias: &str) -> &'static str {
@@ -4514,17 +4436,14 @@ replace_imports_with_any = ["foo"]
         }
 
         for (aliases, canonical_keys) in [
-            (CONFIG_BASE_KEY_ALIASES, CONFIG_BASE_KEYS),
-            (
-                TOP_LEVEL_ONLY_CONFIG_KEY_ALIASES,
-                TOP_LEVEL_ONLY_CONFIG_KEYS,
-            ),
+            (ConfigBase::config_key_aliases(), ConfigBase::config_keys()),
+            (ConfigFile::config_key_aliases(), ConfigFile::config_keys()),
         ] {
-            for (alias, canonical) in aliases {
+            for (alias, canonical) in &aliases {
                 // (a) The suggested canonical key must be a real key in the same scope.
                 assert!(
                     canonical_keys.contains(canonical),
-                    "alias `{alias}` suggests `{canonical}`, absent from its keys constant"
+                    "alias `{alias}` suggests `{canonical}`, absent from its scope's derived keys"
                 );
                 // (b) serde must still accept the alias, so no unknown-key warning fires.
                 let toml = format!("{alias} = {}\n", alias_toml_value(alias));
@@ -4556,10 +4475,15 @@ replace_imports_with_any = ["foo"]
                 .collect()
         }
 
+        fn derived_keys(keys: Vec<&'static str>) -> HashSet<String> {
+            keys.into_iter().map(|key| key.to_owned()).collect()
+        }
+
         // These exhaustive fixtures make adding a field to any config scope a compile error until
-        // the fixture is updated; the assertions below then force the candidate lists to cover every
-        // *serialized* key. Serde `alias`es and `skip_serializing` fields are not enforced here —
-        // keep those in sync with the candidate lists by hand.
+        // the fixture is updated; the assertions below then prove `#[derive(ConfigKeys)]` produces
+        // exactly serde's serialized key set for each scope. Serde `alias`es never serialize, so the
+        // derive omits them (as does serde); `skip_serializing` fields (e.g. `interpreter_stdlib_path`)
+        // are set to non-defaults here to prove both sides drop them.
         let base = ConfigBase {
             errors: Some(Default::default()),
             permissive_ignores: Some(false),
@@ -4584,14 +4508,11 @@ replace_imports_with_any = ["foo"]
         };
         assert_eq!(
             serialized_keys(&base),
-            CONFIG_BASE_KEYS
-                .iter()
-                .map(|key| (*key).to_owned())
-                .collect()
+            derived_keys(ConfigBase::config_keys())
         );
 
         let top_level = ConfigFile {
-            source: ConfigSource::Synthetic,
+            source: ConfigSource::Synthetic(None),
             project_includes: Globs::new(vec!["src/**".to_owned()]).unwrap(),
             project_excludes: Globs::new(vec!["generated/**".to_owned()]).unwrap(),
             disable_project_excludes_heuristics: true,
@@ -4603,6 +4524,7 @@ replace_imports_with_any = ["foo"]
             enable_fallback_search_path: true,
             typeshed_path: Some(PathBuf::from("typeshed")),
             baseline: Some(PathBuf::from("baseline.json")),
+            baseline_error_level: Some(Severity::Warn),
             output_format: Some(OutputFormat::Json),
             interpreters: Interpreters {
                 python_interpreter_path: Some(ConfigOrigin::config(PathBuf::from("python"))),
@@ -4618,7 +4540,9 @@ replace_imports_with_any = ["foo"]
                 interpreter_stdlib_path: vec![PathBuf::from("stdlib")],
             },
             preset: Some(Preset::Default),
-            root: ConfigBase::default(),
+            // Fully populated so the flattened `ConfigBase` keys serialize, letting this fixture
+            // exercise the whole top-level key set that `ConfigFile::config_keys()` derives.
+            root: base,
             sub_configs: vec![SubConfig {
                 matches: Glob::new("src/**".to_owned()).unwrap(),
                 settings: ConfigBase::default(),
@@ -4638,10 +4562,7 @@ replace_imports_with_any = ["foo"]
         };
         assert_eq!(
             serialized_keys(&top_level),
-            TOP_LEVEL_ONLY_CONFIG_KEYS
-                .iter()
-                .map(|key| (*key).to_owned())
-                .collect()
+            derived_keys(ConfigFile::config_keys())
         );
 
         let coverage = CoverageConfig {
@@ -4651,10 +4572,7 @@ replace_imports_with_any = ["foo"]
         };
         assert_eq!(
             serialized_keys(&coverage),
-            COVERAGE_CONFIG_KEYS
-                .iter()
-                .map(|key| (*key).to_owned())
-                .collect()
+            derived_keys(CoverageConfig::config_keys())
         );
     }
 }

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -9,6 +9,7 @@ use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::fmt;
 use std::fmt::Display;
+use std::iter::once;
 use std::mem;
 use std::path::Path;
 use std::path::PathBuf;
@@ -46,6 +47,7 @@ use pyrefly_util::globs::HiddenDirFilter;
 use pyrefly_util::interned_path::InternedPath;
 use pyrefly_util::lock::RwLock;
 use pyrefly_util::prelude::VecExt;
+use pyrefly_util::suggest::best_suggestion_str;
 use pyrefly_util::telemetry::SubTaskTelemetry;
 use pyrefly_util::telemetry::TelemetryEventKind;
 use pyrefly_util::telemetry::TelemetrySourceDbRebuildInstanceStats;
@@ -804,6 +806,65 @@ impl ConfigFile {
         FilteredGlobs::new(includes, project_excludes, root, hidden_dir_filter)
     }
 }
+
+/// `ConfigBase` keys, valid both at the top level and inside a `[[sub-config]]`
+/// block. Used only to suggest a "did you mean" for unrecognized keys, so a
+/// missing entry merely weakens a hint — it never silences the warning itself.
+/// Kept in sync with `ConfigBase` by `test_known_config_keys_cover_serialized_fields`.
+const CONFIG_BASE_KEYS: &[&str] = &[
+    "errors",
+    "permissive-ignores",
+    "enabled-ignores",
+    "replace-imports-with-any",
+    "ignore-missing-imports",
+    "untyped-def-behavior",
+    "check-unannotated-defs",
+    "infer-return-types",
+    "disable-type-errors-in-ide",
+    "ignore-errors-in-generated-code",
+    "infer-with-first-use",
+    "pytorch-efficiency-lints",
+    "recursion-depth-limit",
+    "recursion-overflow-handler",
+    "strict-callable-subtyping",
+    "strict-partial-subtyping",
+    "spec-compliant-overloads",
+    "legacy-overload-expansion",
+];
+
+/// Keys valid only at the top level of a config (not inside `[[sub-config]]`):
+/// project-wide settings plus the flattened interpreter and Python-environment
+/// options. The full top-level key set is this list plus `CONFIG_BASE_KEYS`.
+const TOP_LEVEL_ONLY_CONFIG_KEYS: &[&str] = &[
+    "project-includes",
+    "project-excludes",
+    "disable-project-excludes-heuristics",
+    "search-path",
+    "disable-search-path-heuristics",
+    "enable-fallback-search-path",
+    "typeshed-path",
+    "baseline",
+    "output-format",
+    "preset",
+    "sub-config",
+    "coverage",
+    "use-ignore-files",
+    "build-system",
+    "min-severity",
+    "skip-lsp-config-indexing",
+    "extra-file-extensions",
+    "python-interpreter-path",
+    "fallback-python-interpreter-name",
+    "conda-environment",
+    "skip-interpreter-query",
+    "python-platform",
+    "python-version",
+    "site-package-path",
+];
+
+/// Keys valid inside a `[coverage]` table.
+/// Kept in sync with `CoverageConfig` by `test_known_config_keys_cover_serialized_fields`.
+const COVERAGE_CONFIG_KEYS: &[&str] = &["includes", "excludes"];
 
 impl ConfigFile {
     pub const PYREFLY_FILE_NAME: &str = "pyrefly.toml";
@@ -1659,33 +1720,68 @@ impl ConfigFile {
             };
             config.source = config_source;
 
-            if !config.root.extras.0.is_empty() {
-                let extra_keys = config.root.extras.0.keys().join(", ");
-                errors.push(ConfigError::warn(anyhow!(
-                    "Extra keys found in config: {extra_keys}"
-                )));
-            }
-            if !config.coverage.extras.0.is_empty() {
-                let extra_keys = config.coverage.extras.0.keys().join(", ");
-                errors.push(ConfigError::warn(anyhow!(
-                    "Extra keys found in coverage config: {extra_keys}"
-                )));
-            }
-            for sub_config in &config.sub_configs {
-                if !sub_config.settings.extras.0.is_empty() {
-                    let extra_keys = sub_config.settings.extras.0.keys().join(", ");
-                    errors.push(ConfigError::warn(anyhow!(
-                        "Extra keys found in sub config matching {}: {extra_keys}",
-                        sub_config.matches
-                    )));
-                }
-            }
+            errors.extend(
+                config
+                    .unknown_key_warnings()
+                    .into_iter()
+                    .map(ConfigError::warn),
+            );
             (config, errors)
         }
         let config_path = config_path.absolutize();
         let (config, errors) = f(&config_path);
         let errors = errors.into_map(|err| err.context(format!("{}", config_path.display())));
         (config, errors)
+    }
+
+    /// Warn about unrecognized config keys, suggesting the closest known key when
+    /// one is similar enough. Unknown keys are gathered into `extras` by serde's
+    /// `flatten` catch-all, so this never fires for keys Pyrefly understands
+    /// (including the snake_case migration aliases). Top-level, `[coverage]`, and
+    /// `[[sub-config]]` keys are each checked against the options valid in their own scope.
+    fn unknown_key_warnings(&self) -> Vec<anyhow::Error> {
+        fn message(key: &str, candidates: &[&str], location: &str) -> anyhow::Error {
+            let suggestion =
+                best_suggestion_str(key, candidates.iter().enumerate().map(|(i, k)| (*k, i)))
+                    .map(|s| format!(". Did you mean `{s}`?"))
+                    .unwrap_or_default();
+            anyhow!("Unknown config key `{key}`{location}{suggestion}")
+        }
+
+        let top_level: Vec<&str> = TOP_LEVEL_ONLY_CONFIG_KEYS
+            .iter()
+            .chain(CONFIG_BASE_KEYS)
+            .copied()
+            .collect();
+        let sub_config: Vec<&str> = once("matches")
+            .chain(CONFIG_BASE_KEYS.iter().copied())
+            .collect();
+
+        let mut warnings: Vec<anyhow::Error> = self
+            .root
+            .extras
+            .0
+            .keys()
+            .map(|key| message(key, &top_level, ""))
+            .collect();
+        warnings.extend(
+            self.coverage
+                .extras
+                .0
+                .keys()
+                .map(|key| message(key, COVERAGE_CONFIG_KEYS, " in coverage config")),
+        );
+        for sub in &self.sub_configs {
+            let location = format!(" in sub config matching {}", sub.matches);
+            warnings.extend(
+                sub.settings
+                    .extras
+                    .0
+                    .keys()
+                    .map(|key| message(key, &sub_config, &location)),
+            );
+        }
+        warnings
     }
 
     pub fn parse_config(config_str: &str) -> anyhow::Result<ConfigFile> {
@@ -4000,5 +4096,140 @@ output-format = "omit-errors"
             Severity::Ignore,
             "without pytorch-efficiency-lints flag, lints should default to Ignore"
         );
+    }
+
+    #[test]
+    fn test_unknown_config_key_suggests_closest() {
+        // `check-unannotated-def` is a typo of the real `check-unannotated-defs`.
+        let config = ConfigFile::parse_config("check-unannotated-def = true\n").unwrap();
+        let warnings: Vec<String> = config
+            .unknown_key_warnings()
+            .iter()
+            .map(|w| w.to_string())
+            .collect();
+        assert_eq!(warnings.len(), 1, "warnings: {warnings:?}");
+        assert!(
+            warnings[0].contains("`check-unannotated-def`"),
+            "should name the unknown key: {}",
+            warnings[0]
+        );
+        assert!(
+            warnings[0].contains("`check-unannotated-defs`"),
+            "should suggest the closest known key: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn test_unknown_config_key_without_close_match_has_no_suggestion() {
+        let config = ConfigFile::parse_config("made-up-key-xyz = 1\n").unwrap();
+        let warnings: Vec<String> = config
+            .unknown_key_warnings()
+            .iter()
+            .map(|w| w.to_string())
+            .collect();
+        assert_eq!(warnings.len(), 1, "warnings: {warnings:?}");
+        assert!(warnings[0].contains("`made-up-key-xyz`"), "{}", warnings[0]);
+        assert!(
+            !warnings[0].contains("Did you mean"),
+            "no key is close enough to suggest: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn test_unknown_sub_config_key_suggests_closest() {
+        let config_str = r#"
+[[sub-config]]
+matches = "foo/**"
+check-unannotated-def = true
+"#;
+        let config = ConfigFile::parse_config(config_str).unwrap();
+        let warnings: Vec<String> = config
+            .unknown_key_warnings()
+            .iter()
+            .map(|w| w.to_string())
+            .collect();
+        assert_eq!(warnings.len(), 1, "warnings: {warnings:?}");
+        assert!(
+            warnings[0].contains("`check-unannotated-def`"),
+            "{}",
+            warnings[0]
+        );
+        assert!(
+            warnings[0].contains("`check-unannotated-defs`"),
+            "{}",
+            warnings[0]
+        );
+        assert!(
+            warnings[0].contains("sub config matching"),
+            "should mention the sub-config: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn test_known_config_keys_are_not_flagged() {
+        // Canonical kebab-case keys and a snake_case migration alias
+        // (`replace_imports_with_any`) are all recognized, so none is reported.
+        let config_str = r#"
+search-path = ["src"]
+project-includes = ["src"]
+python-version = "3.11"
+replace_imports_with_any = ["foo"]
+"#;
+        let config = ConfigFile::parse_config(config_str).unwrap();
+        let warnings: Vec<String> = config
+            .unknown_key_warnings()
+            .iter()
+            .map(|w| w.to_string())
+            .collect();
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+    }
+
+    #[test]
+    fn test_known_config_keys_cover_serialized_fields() {
+        // A configured `ConfigFile` serializes every populated option under its
+        // canonical key. Each such top-level key must be covered by our known-key
+        // lists so suggestions stay in sync as new fields are added.
+        let root = TempDir::new().unwrap();
+        let mut config = ConfigFile::init_at_root(root.path(), &ProjectLayout::default(), false);
+        config.configure();
+        let table: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(&serde_json::to_string(&config).unwrap()).unwrap();
+        let known: std::collections::HashSet<&str> = TOP_LEVEL_ONLY_CONFIG_KEYS
+            .iter()
+            .chain(CONFIG_BASE_KEYS)
+            .copied()
+            .collect();
+        for key in table.keys() {
+            // `extras` is serde's `flatten` catch-all, not a real config key.
+            if key == "extras" {
+                continue;
+            }
+            assert!(
+                known.contains(key.as_str()),
+                "serialized config key `{key}` is missing from CONFIG_BASE_KEYS / \
+                 TOP_LEVEL_ONLY_CONFIG_KEYS; add it so suggestions stay in sync"
+            );
+        }
+
+        // Coverage keys stay in sync with `CoverageConfig` the same way.
+        let coverage: CoverageConfig =
+            serde_json::from_value(serde_json::json!({"includes": ["a"], "excludes": ["b"]}))
+                .unwrap();
+        let coverage_table: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(&serde_json::to_string(&coverage).unwrap()).unwrap();
+        let coverage_known: std::collections::HashSet<&str> =
+            COVERAGE_CONFIG_KEYS.iter().copied().collect();
+        for key in coverage_table.keys() {
+            if key == "extras" {
+                continue;
+            }
+            assert!(
+                coverage_known.contains(key.as_str()),
+                "serialized coverage key `{key}` is missing from COVERAGE_CONFIG_KEYS"
+            );
+        }
     }
 }

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -832,6 +832,16 @@ const CONFIG_BASE_KEYS: &[&str] = &[
     "legacy-overload-expansion",
 ];
 
+/// Deprecated spellings of `ConfigBase` keys accepted by serde, paired with the canonical key to suggest.
+const CONFIG_BASE_KEY_ALIASES: &[(&str, &str)] = &[
+    ("replace_imports_with_any", "replace-imports-with-any"),
+    ("untyped_def_behavior", "untyped-def-behavior"),
+    (
+        "ignore_errors_in_generated_code",
+        "ignore-errors-in-generated-code",
+    ),
+];
+
 /// Keys valid only at the top level of a config (not inside `[[sub-config]]`):
 /// project-wide settings plus the flattened interpreter and Python-environment
 /// options. The full top-level key set is this list plus `CONFIG_BASE_KEYS`.
@@ -860,6 +870,19 @@ const TOP_LEVEL_ONLY_CONFIG_KEYS: &[&str] = &[
     "python-platform",
     "python-version",
     "site-package-path",
+];
+
+/// Deprecated spellings of top-level-only keys accepted by serde, paired with the canonical key to suggest.
+const TOP_LEVEL_ONLY_CONFIG_KEY_ALIASES: &[(&str, &str)] = &[
+    ("project_includes", "project-includes"),
+    ("project_excludes", "project-excludes"),
+    ("search_path", "search-path"),
+    ("sub_config", "sub-config"),
+    ("python_interpreter", "python-interpreter-path"),
+    ("python-interpreter", "python-interpreter-path"),
+    ("python_platform", "python-platform"),
+    ("python_version", "python-version"),
+    ("site_package_path", "site-package-path"),
 ];
 
 /// Keys valid inside a `[coverage]` table.
@@ -1740,11 +1763,29 @@ impl ConfigFile {
     /// (including the snake_case migration aliases). Top-level, `[coverage]`, and
     /// `[[sub-config]]` keys are each checked against the options valid in their own scope.
     fn unknown_key_warnings(&self) -> Vec<anyhow::Error> {
-        fn message(key: &str, candidates: &[&str], location: &str) -> anyhow::Error {
-            let suggestion =
-                best_suggestion_str(key, candidates.iter().enumerate().map(|(i, k)| (*k, i)))
-                    .map(|s| format!(". Did you mean `{s}`?"))
-                    .unwrap_or_default();
+        fn message(
+            key: &str,
+            candidates: &[&str],
+            aliases: &[(&str, &str)],
+            location: &str,
+        ) -> anyhow::Error {
+            let suggestion = best_suggestion_str(
+                key,
+                candidates
+                    .iter()
+                    .copied()
+                    .chain(aliases.iter().map(|(alias, _)| *alias))
+                    .enumerate()
+                    .map(|(priority, candidate)| (candidate, priority)),
+            )
+            .map(|suggestion| {
+                aliases
+                    .iter()
+                    .find_map(|(alias, canonical)| (*alias == suggestion).then_some(*canonical))
+                    .unwrap_or(suggestion)
+            })
+            .map(|suggestion| format!(". Did you mean `{suggestion}`?"))
+            .unwrap_or_default();
             anyhow!("Unknown config key `{key}`{location}{suggestion}")
         }
 
@@ -1756,20 +1797,25 @@ impl ConfigFile {
         let sub_config: Vec<&str> = once("matches")
             .chain(CONFIG_BASE_KEYS.iter().copied())
             .collect();
+        let top_level_aliases: Vec<(&str, &str)> = TOP_LEVEL_ONLY_CONFIG_KEY_ALIASES
+            .iter()
+            .chain(CONFIG_BASE_KEY_ALIASES)
+            .copied()
+            .collect();
 
         let mut warnings: Vec<anyhow::Error> = self
             .root
             .extras
             .0
             .keys()
-            .map(|key| message(key, &top_level, ""))
+            .map(|key| message(key, &top_level, &top_level_aliases, ""))
             .collect();
         warnings.extend(
             self.coverage
                 .extras
                 .0
                 .keys()
-                .map(|key| message(key, COVERAGE_CONFIG_KEYS, " in coverage config")),
+                .map(|key| message(key, COVERAGE_CONFIG_KEYS, &[], " in coverage config")),
         );
         for sub in &self.sub_configs {
             let location = format!(" in sub config matching {}", sub.matches);
@@ -1778,7 +1824,7 @@ impl ConfigFile {
                     .extras
                     .0
                     .keys()
-                    .map(|key| message(key, &sub_config, &location)),
+                    .map(|key| message(key, &sub_config, CONFIG_BASE_KEY_ALIASES, &location)),
             );
         }
         warnings
@@ -1947,6 +1993,7 @@ pub fn validate_path(path: &Path) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::collections::HashSet;
     use std::fs;
 
     use pretty_assertions::assert_eq;
@@ -1957,6 +2004,7 @@ mod tests {
 
     use super::*;
     use crate::base::ExtraConfigs;
+    use crate::base::RecursionOverflowHandler;
     use crate::base::UntypedDefBehavior;
     use crate::error_kind::ErrorKind;
     use crate::error_kind::Severity;
@@ -4121,6 +4169,23 @@ output-format = "omit-errors"
     }
 
     #[test]
+    fn test_unknown_config_alias_typo_suggests_canonical_key() {
+        let config = ConfigFile::parse_config("replace_imports_with_an = [\"foo\"]\n").unwrap();
+        let warnings: Vec<String> = config
+            .unknown_key_warnings()
+            .iter()
+            .map(|w| w.to_string())
+            .collect();
+        assert_eq!(
+            warnings,
+            [concat!(
+                "Unknown config key `replace_imports_with_an`. Did you mean ",
+                "`replace-imports-with-any`?"
+            )]
+        );
+    }
+
+    #[test]
     fn test_unknown_config_key_without_close_match_has_no_suggestion() {
         let config = ConfigFile::parse_config("made-up-key-xyz = 1\n").unwrap();
         let warnings: Vec<String> = config
@@ -4134,6 +4199,20 @@ output-format = "omit-errors"
             !warnings[0].contains("Did you mean"),
             "no key is close enough to suggest: {}",
             warnings[0]
+        );
+    }
+
+    #[test]
+    fn test_unknown_coverage_key_suggests_closest() {
+        let config = ConfigFile::parse_config("[coverage]\nincldes = [\"src/**\"]\n").unwrap();
+        let warnings: Vec<String> = config
+            .unknown_key_warnings()
+            .iter()
+            .map(|w| w.to_string())
+            .collect();
+        assert_eq!(
+            warnings,
+            ["Unknown config key `incldes` in coverage config. Did you mean `includes`?"]
         );
     }
 
@@ -4189,47 +4268,115 @@ replace_imports_with_any = ["foo"]
 
     #[test]
     fn test_known_config_keys_cover_serialized_fields() {
-        // A configured `ConfigFile` serializes every populated option under its
-        // canonical key. Each such top-level key must be covered by our known-key
-        // lists so suggestions stay in sync as new fields are added.
-        let root = TempDir::new().unwrap();
-        let mut config = ConfigFile::init_at_root(root.path(), &ProjectLayout::default(), false);
-        config.configure();
-        let table: serde_json::Map<String, serde_json::Value> =
-            serde_json::from_str(&serde_json::to_string(&config).unwrap()).unwrap();
-        let known: std::collections::HashSet<&str> = TOP_LEVEL_ONLY_CONFIG_KEYS
-            .iter()
-            .chain(CONFIG_BASE_KEYS)
-            .copied()
-            .collect();
-        for key in table.keys() {
-            // `extras` is serde's `flatten` catch-all, not a real config key.
-            if key == "extras" {
-                continue;
-            }
-            assert!(
-                known.contains(key.as_str()),
-                "serialized config key `{key}` is missing from CONFIG_BASE_KEYS / \
-                 TOP_LEVEL_ONLY_CONFIG_KEYS; add it so suggestions stay in sync"
-            );
+        fn serialized_keys(value: &impl Serialize) -> HashSet<String> {
+            serde_json::to_value(value)
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .keys()
+                .filter(|key| key.as_str() != "extras")
+                .cloned()
+                .collect()
         }
 
-        // Coverage keys stay in sync with `CoverageConfig` the same way.
-        let coverage: CoverageConfig =
-            serde_json::from_value(serde_json::json!({"includes": ["a"], "excludes": ["b"]}))
-                .unwrap();
-        let coverage_table: serde_json::Map<String, serde_json::Value> =
-            serde_json::from_str(&serde_json::to_string(&coverage).unwrap()).unwrap();
-        let coverage_known: std::collections::HashSet<&str> =
-            COVERAGE_CONFIG_KEYS.iter().copied().collect();
-        for key in coverage_table.keys() {
-            if key == "extras" {
-                continue;
-            }
-            assert!(
-                coverage_known.contains(key.as_str()),
-                "serialized coverage key `{key}` is missing from COVERAGE_CONFIG_KEYS"
-            );
-        }
+        // These exhaustive fixtures make adding a field to any config scope a compile error until
+        // the fixture is updated; the assertions below then force the candidate lists to cover every
+        // *serialized* key. Serde `alias`es and `skip_serializing` fields are not enforced here —
+        // keep those in sync with the candidate lists by hand.
+        let base = ConfigBase {
+            errors: Some(Default::default()),
+            permissive_ignores: Some(false),
+            enabled_ignores: Some(Default::default()),
+            replace_imports_with_any: Some(vec![ModuleWildcard::new("replace").unwrap()]),
+            ignore_missing_imports: Some(vec![ModuleWildcard::new("ignore").unwrap()]),
+            untyped_def_behavior: Some(UntypedDefBehavior::CheckAndInferReturnType),
+            check_unannotated_defs: Some(true),
+            infer_return_types: Some(InferReturnTypes::Checked),
+            disable_type_errors_in_ide: Some(false),
+            ignore_errors_in_generated_code: Some(false),
+            infer_with_first_use: Some(true),
+            pytorch_efficiency_lints: Some(false),
+            recursion_depth_limit: Some(1),
+            recursion_overflow_handler: Some(RecursionOverflowHandler::BreakWithPlaceholder),
+            strict_callable_subtyping: Some(false),
+            strict_partial_subtyping: Some(false),
+            spec_compliant_overloads: Some(false),
+            legacy_overload_expansion: Some(false),
+            extras: Default::default(),
+        };
+        assert_eq!(
+            serialized_keys(&base),
+            CONFIG_BASE_KEYS
+                .iter()
+                .map(|key| (*key).to_owned())
+                .collect()
+        );
+
+        let top_level = ConfigFile {
+            source: ConfigSource::Synthetic,
+            project_includes: Globs::new(vec!["src/**".to_owned()]).unwrap(),
+            project_excludes: Globs::new(vec!["generated/**".to_owned()]).unwrap(),
+            disable_project_excludes_heuristics: true,
+            search_path_from_args: vec![PathBuf::from("cli")],
+            search_path_from_file: vec![PathBuf::from("src")],
+            import_root: Some(PathBuf::from("root")),
+            fallback_search_path: FallbackSearchPath::default(),
+            disable_search_path_heuristics: true,
+            enable_fallback_search_path: true,
+            typeshed_path: Some(PathBuf::from("typeshed")),
+            baseline: Some(PathBuf::from("baseline.json")),
+            output_format: Some(OutputFormat::Json),
+            interpreters: Interpreters {
+                python_interpreter_path: Some(ConfigOrigin::config(PathBuf::from("python"))),
+                fallback_python_interpreter_name: Some(ConfigOrigin::config("python3".to_owned())),
+                conda_environment: Some(ConfigOrigin::config("env".to_owned())),
+                skip_interpreter_query: true,
+            },
+            python_environment: PythonEnvironment {
+                python_platform: Some(PythonPlatform::linux()),
+                python_version: Some(PythonVersion::new(3, 13, 0)),
+                site_package_path: Some(vec![PathBuf::from("site-packages")]),
+                interpreter_site_package_path: vec![PathBuf::from("interpreter-site-packages")],
+                interpreter_stdlib_path: vec![PathBuf::from("stdlib")],
+            },
+            preset: Some(Preset::Default),
+            root: ConfigBase::default(),
+            sub_configs: vec![SubConfig {
+                matches: Glob::new("src/**".to_owned()).unwrap(),
+                settings: ConfigBase::default(),
+            }],
+            coverage: CoverageConfig {
+                includes: Some(Globs::new(vec!["covered/**".to_owned()]).unwrap()),
+                excludes: Some(Globs::new(vec!["covered/generated/**".to_owned()]).unwrap()),
+                extras: Default::default(),
+            },
+            use_ignore_files: false,
+            build_system: Some(toml::from_str("type = \"custom\"\ncommand = [\"true\"]").unwrap()),
+            source_db: None,
+            min_severity: Some(Severity::Warn),
+            skip_lsp_config_indexing: true,
+            extra_file_extensions: vec!["cinc".to_owned()],
+            synthesized_preset_reason: Some(SynthesizedPresetReason::NoNearbyConfig),
+        };
+        assert_eq!(
+            serialized_keys(&top_level),
+            TOP_LEVEL_ONLY_CONFIG_KEYS
+                .iter()
+                .map(|key| (*key).to_owned())
+                .collect()
+        );
+
+        let coverage = CoverageConfig {
+            includes: Some(Globs::new(vec!["a".to_owned()]).unwrap()),
+            excludes: Some(Globs::new(vec!["b".to_owned()]).unwrap()),
+            extras: Default::default(),
+        };
+        assert_eq!(
+            serialized_keys(&coverage),
+            COVERAGE_CONFIG_KEYS
+                .iter()
+                .map(|key| (*key).to_owned())
+                .collect()
+        );
     }
 }

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -830,6 +830,8 @@ impl ConfigFile {
     }
 }
 
+// The key/alias constants below only rank the "did you mean" SUGGESTION;
+// unknown-key DETECTION is serde-derived (the flatten `extras` catch-all) and cannot drift.
 /// `ConfigBase` keys, valid both at the top level and inside a `[[sub-config]]`
 /// block. Used only to suggest a "did you mean" for unrecognized keys, so a
 /// missing entry merely weakens a hint — it never silences the warning itself.
@@ -853,6 +855,17 @@ const CONFIG_BASE_KEYS: &[&str] = &[
     "strict-partial-subtyping",
     "spec-compliant-overloads",
     "legacy-overload-expansion",
+    "treat-all-caps-as-final",
+];
+
+/// Deprecated spellings of `ConfigBase` keys accepted by serde, paired with the canonical key to suggest.
+const CONFIG_BASE_KEY_ALIASES: &[(&str, &str)] = &[
+    ("replace_imports_with_any", "replace-imports-with-any"),
+    ("untyped_def_behavior", "untyped-def-behavior"),
+    (
+        "ignore_errors_in_generated_code",
+        "ignore-errors-in-generated-code",
+    ),
 ];
 
 /// Keys valid only at the top level of a config (not inside `[[sub-config]]`):
@@ -883,6 +896,19 @@ const TOP_LEVEL_ONLY_CONFIG_KEYS: &[&str] = &[
     "python-platform",
     "python-version",
     "site-package-path",
+];
+
+/// Deprecated spellings of top-level-only keys accepted by serde, paired with the canonical key to suggest.
+const TOP_LEVEL_ONLY_CONFIG_KEY_ALIASES: &[(&str, &str)] = &[
+    ("project_includes", "project-includes"),
+    ("project_excludes", "project-excludes"),
+    ("search_path", "search-path"),
+    ("sub_config", "sub-config"),
+    ("python_interpreter", "python-interpreter-path"),
+    ("python-interpreter", "python-interpreter-path"),
+    ("python_platform", "python-platform"),
+    ("python_version", "python-version"),
+    ("site_package_path", "site-package-path"),
 ];
 
 /// Keys valid inside a `[coverage]` table.
@@ -1811,11 +1837,29 @@ impl ConfigFile {
     /// (including the snake_case migration aliases). Top-level, `[coverage]`, and
     /// `[[sub-config]]` keys are each checked against the options valid in their own scope.
     fn unknown_key_warnings(&self) -> Vec<anyhow::Error> {
-        fn message(key: &str, candidates: &[&str], location: &str) -> anyhow::Error {
-            let suggestion =
-                best_suggestion_str(key, candidates.iter().enumerate().map(|(i, k)| (*k, i)))
-                    .map(|s| format!(". Did you mean `{s}`?"))
-                    .unwrap_or_default();
+        fn message(
+            key: &str,
+            candidates: &[&str],
+            aliases: &[(&str, &str)],
+            location: &str,
+        ) -> anyhow::Error {
+            let suggestion = best_suggestion_str(
+                key,
+                candidates
+                    .iter()
+                    .copied()
+                    .chain(aliases.iter().map(|(alias, _)| *alias))
+                    .enumerate()
+                    .map(|(priority, candidate)| (candidate, priority)),
+            )
+            .map(|suggestion| {
+                aliases
+                    .iter()
+                    .find_map(|(alias, canonical)| (*alias == suggestion).then_some(*canonical))
+                    .unwrap_or(suggestion)
+            })
+            .map(|suggestion| format!(". Did you mean `{suggestion}`?"))
+            .unwrap_or_default();
             anyhow!("Unknown config key `{key}`{location}{suggestion}")
         }
 
@@ -1827,20 +1871,25 @@ impl ConfigFile {
         let sub_config: Vec<&str> = once("matches")
             .chain(CONFIG_BASE_KEYS.iter().copied())
             .collect();
+        let top_level_aliases: Vec<(&str, &str)> = TOP_LEVEL_ONLY_CONFIG_KEY_ALIASES
+            .iter()
+            .chain(CONFIG_BASE_KEY_ALIASES)
+            .copied()
+            .collect();
 
         let mut warnings: Vec<anyhow::Error> = self
             .root
             .extras
             .0
             .keys()
-            .map(|key| message(key, &top_level, ""))
+            .map(|key| message(key, &top_level, &top_level_aliases, ""))
             .collect();
         warnings.extend(
             self.coverage
                 .extras
                 .0
                 .keys()
-                .map(|key| message(key, COVERAGE_CONFIG_KEYS, " in coverage config")),
+                .map(|key| message(key, COVERAGE_CONFIG_KEYS, &[], " in coverage config")),
         );
         for sub in &self.sub_configs {
             let location = format!(" in sub config matching {}", sub.matches);
@@ -1849,7 +1898,7 @@ impl ConfigFile {
                     .extras
                     .0
                     .keys()
-                    .map(|key| message(key, &sub_config, &location)),
+                    .map(|key| message(key, &sub_config, CONFIG_BASE_KEY_ALIASES, &location)),
             );
         }
         warnings
@@ -2018,6 +2067,7 @@ pub fn validate_path(path: &Path) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::collections::HashSet;
     use std::fs;
 
     use pretty_assertions::assert_eq;
@@ -2029,6 +2079,7 @@ mod tests {
 
     use super::*;
     use crate::base::ExtraConfigs;
+    use crate::base::RecursionOverflowHandler;
     use crate::base::UntypedDefBehavior;
     use crate::error_kind::ErrorKind;
     use crate::error_kind::Severity;
@@ -4341,6 +4392,23 @@ output-format = "omit-errors"
     }
 
     #[test]
+    fn test_unknown_config_alias_typo_suggests_canonical_key() {
+        let config = ConfigFile::parse_config("replace_imports_with_an = [\"foo\"]\n").unwrap();
+        let warnings: Vec<String> = config
+            .unknown_key_warnings()
+            .iter()
+            .map(|w| w.to_string())
+            .collect();
+        assert_eq!(
+            warnings,
+            [concat!(
+                "Unknown config key `replace_imports_with_an`. Did you mean ",
+                "`replace-imports-with-any`?"
+            )]
+        );
+    }
+
+    #[test]
     fn test_unknown_config_key_without_close_match_has_no_suggestion() {
         let config = ConfigFile::parse_config("made-up-key-xyz = 1\n").unwrap();
         let warnings: Vec<String> = config
@@ -4354,6 +4422,21 @@ output-format = "omit-errors"
             !warnings[0].contains("Did you mean"),
             "no key is close enough to suggest: {}",
             warnings[0]
+        );
+    }
+
+    #[test]
+    fn test_unknown_coverage_key_suggests_closest() {
+        // `incldes` is an intentional misspelling exercising the "did you mean `includes`?" path.
+        let config = ConfigFile::parse_config("[coverage]\nincldes = [\"src/**\"]\n").unwrap();
+        let warnings: Vec<String> = config
+            .unknown_key_warnings()
+            .iter()
+            .map(|w| w.to_string())
+            .collect();
+        assert_eq!(
+            warnings,
+            ["Unknown config key `incldes` in coverage config. Did you mean `includes`?"]
         );
     }
 
@@ -4408,48 +4491,170 @@ replace_imports_with_any = ["foo"]
     }
 
     #[test]
-    fn test_known_config_keys_cover_serialized_fields() {
-        // A configured `ConfigFile` serializes every populated option under its
-        // canonical key. Each such top-level key must be covered by our known-key
-        // lists so suggestions stay in sync as new fields are added.
-        let root = TempDir::new().unwrap();
-        let mut config = ConfigFile::init_at_root(root.path(), &ProjectLayout::default(), false);
-        config.configure();
-        let table: serde_json::Map<String, serde_json::Value> =
-            serde_json::from_str(&serde_json::to_string(&config).unwrap()).unwrap();
-        let known: std::collections::HashSet<&str> = TOP_LEVEL_ONLY_CONFIG_KEYS
-            .iter()
-            .chain(CONFIG_BASE_KEYS)
-            .copied()
-            .collect();
-        for key in table.keys() {
-            // `extras` is serde's `flatten` catch-all, not a real config key.
-            if key == "extras" {
-                continue;
+    fn test_known_config_aliases_are_consistent() {
+        // Every serde `alias` must (a) point at a canonical key present in its scope's keys
+        // constant, so the "did you mean" suggestion resolves, and (b) still be honored by serde,
+        // so the alias maps back to its field instead of landing in `extras`. The sync test
+        // (`test_known_config_keys_cover_serialized_fields`) deliberately does not cover aliases.
+        fn alias_toml_value(alias: &str) -> &'static str {
+            match alias {
+                "replace_imports_with_any"
+                | "project_includes"
+                | "project_excludes"
+                | "search_path"
+                | "site_package_path" => "[\"foo\"]",
+                "ignore_errors_in_generated_code" => "true",
+                "untyped_def_behavior" => "\"check-and-infer-return-type\"",
+                "python_interpreter" | "python-interpreter" => "\"python3\"",
+                "python_platform" => "\"linux\"",
+                "python_version" => "\"3.11\"",
+                "sub_config" => "[]",
+                other => panic!("add a valid TOML value for new alias `{other}`"),
             }
-            assert!(
-                known.contains(key.as_str()),
-                "serialized config key `{key}` is missing from CONFIG_BASE_KEYS / \
-                 TOP_LEVEL_ONLY_CONFIG_KEYS; add it so suggestions stay in sync"
-            );
         }
 
-        // Coverage keys stay in sync with `CoverageConfig` the same way.
-        let coverage: CoverageConfig =
-            serde_json::from_value(serde_json::json!({"includes": ["a"], "excludes": ["b"]}))
-                .unwrap();
-        let coverage_table: serde_json::Map<String, serde_json::Value> =
-            serde_json::from_str(&serde_json::to_string(&coverage).unwrap()).unwrap();
-        let coverage_known: std::collections::HashSet<&str> =
-            COVERAGE_CONFIG_KEYS.iter().copied().collect();
-        for key in coverage_table.keys() {
-            if key == "extras" {
-                continue;
+        for (aliases, canonical_keys) in [
+            (CONFIG_BASE_KEY_ALIASES, CONFIG_BASE_KEYS),
+            (
+                TOP_LEVEL_ONLY_CONFIG_KEY_ALIASES,
+                TOP_LEVEL_ONLY_CONFIG_KEYS,
+            ),
+        ] {
+            for (alias, canonical) in aliases {
+                // (a) The suggested canonical key must be a real key in the same scope.
+                assert!(
+                    canonical_keys.contains(canonical),
+                    "alias `{alias}` suggests `{canonical}`, absent from its keys constant"
+                );
+                // (b) serde must still accept the alias, so no unknown-key warning fires.
+                let toml = format!("{alias} = {}\n", alias_toml_value(alias));
+                let config = ConfigFile::parse_config(&toml)
+                    .unwrap_or_else(|e| panic!("alias `{alias}` should parse: {e}"));
+                let warnings: Vec<String> = config
+                    .unknown_key_warnings()
+                    .iter()
+                    .map(|w| w.to_string())
+                    .collect();
+                assert!(
+                    warnings.is_empty(),
+                    "alias `{alias}` should be recognized by serde, got: {warnings:?}"
+                );
             }
-            assert!(
-                coverage_known.contains(key.as_str()),
-                "serialized coverage key `{key}` is missing from COVERAGE_CONFIG_KEYS"
-            );
         }
+    }
+
+    #[test]
+    fn test_known_config_keys_cover_serialized_fields() {
+        fn serialized_keys(value: &impl Serialize) -> HashSet<String> {
+            serde_json::to_value(value)
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .keys()
+                .filter(|key| key.as_str() != "extras")
+                .cloned()
+                .collect()
+        }
+
+        // These exhaustive fixtures make adding a field to any config scope a compile error until
+        // the fixture is updated; the assertions below then force the candidate lists to cover every
+        // *serialized* key. Serde `alias`es and `skip_serializing` fields are not enforced here —
+        // keep those in sync with the candidate lists by hand.
+        let base = ConfigBase {
+            errors: Some(Default::default()),
+            permissive_ignores: Some(false),
+            enabled_ignores: Some(Default::default()),
+            replace_imports_with_any: Some(vec![ModuleWildcard::new("replace").unwrap()]),
+            ignore_missing_imports: Some(vec![ModuleWildcard::new("ignore").unwrap()]),
+            untyped_def_behavior: Some(UntypedDefBehavior::CheckAndInferReturnType),
+            check_unannotated_defs: Some(true),
+            infer_return_types: Some(InferReturnTypes::Checked),
+            disable_type_errors_in_ide: Some(false),
+            ignore_errors_in_generated_code: Some(false),
+            infer_with_first_use: Some(true),
+            pytorch_efficiency_lints: Some(false),
+            recursion_depth_limit: Some(1),
+            recursion_overflow_handler: Some(RecursionOverflowHandler::BreakWithPlaceholder),
+            strict_callable_subtyping: Some(false),
+            strict_partial_subtyping: Some(false),
+            spec_compliant_overloads: Some(false),
+            legacy_overload_expansion: Some(false),
+            treat_all_caps_as_final: Some(false),
+            extras: Default::default(),
+        };
+        assert_eq!(
+            serialized_keys(&base),
+            CONFIG_BASE_KEYS
+                .iter()
+                .map(|key| (*key).to_owned())
+                .collect()
+        );
+
+        let top_level = ConfigFile {
+            source: ConfigSource::Synthetic,
+            project_includes: Globs::new(vec!["src/**".to_owned()]).unwrap(),
+            project_excludes: Globs::new(vec!["generated/**".to_owned()]).unwrap(),
+            disable_project_excludes_heuristics: true,
+            search_path_from_args: vec![PathBuf::from("cli")],
+            search_path_from_file: vec![PathBuf::from("src")],
+            import_root: Some(PathBuf::from("root")),
+            fallback_search_path: FallbackSearchPath::default(),
+            disable_search_path_heuristics: true,
+            enable_fallback_search_path: true,
+            typeshed_path: Some(PathBuf::from("typeshed")),
+            baseline: Some(PathBuf::from("baseline.json")),
+            output_format: Some(OutputFormat::Json),
+            interpreters: Interpreters {
+                python_interpreter_path: Some(ConfigOrigin::config(PathBuf::from("python"))),
+                fallback_python_interpreter_name: Some(ConfigOrigin::config("python3".to_owned())),
+                conda_environment: Some(ConfigOrigin::config("env".to_owned())),
+                skip_interpreter_query: true,
+            },
+            python_environment: PythonEnvironment {
+                python_platform: Some(PythonPlatform::linux()),
+                python_version: Some(PythonVersion::new(3, 13, 0)),
+                site_package_path: Some(vec![PathBuf::from("site-packages")]),
+                interpreter_site_package_path: vec![PathBuf::from("interpreter-site-packages")],
+                interpreter_stdlib_path: vec![PathBuf::from("stdlib")],
+            },
+            preset: Some(Preset::Default),
+            root: ConfigBase::default(),
+            sub_configs: vec![SubConfig {
+                matches: Glob::new("src/**".to_owned()).unwrap(),
+                settings: ConfigBase::default(),
+            }],
+            coverage: CoverageConfig {
+                includes: Some(Globs::new(vec!["covered/**".to_owned()]).unwrap()),
+                excludes: Some(Globs::new(vec!["covered/generated/**".to_owned()]).unwrap()),
+                extras: Default::default(),
+            },
+            use_ignore_files: false,
+            build_system: Some(toml::from_str("type = \"custom\"\ncommand = [\"true\"]").unwrap()),
+            source_db: None,
+            min_severity: Some(Severity::Warn),
+            skip_lsp_config_indexing: true,
+            extra_file_extensions: vec!["cinc".to_owned()],
+            synthesized_preset_reason: Some(SynthesizedPresetReason::NoNearbyConfig),
+        };
+        assert_eq!(
+            serialized_keys(&top_level),
+            TOP_LEVEL_ONLY_CONFIG_KEYS
+                .iter()
+                .map(|key| (*key).to_owned())
+                .collect()
+        );
+
+        let coverage = CoverageConfig {
+            includes: Some(Globs::new(vec!["a".to_owned()]).unwrap()),
+            excludes: Some(Globs::new(vec!["b".to_owned()]).unwrap()),
+            extras: Default::default(),
+        };
+        assert_eq!(
+            serialized_keys(&coverage),
+            COVERAGE_CONFIG_KEYS
+                .iter()
+                .map(|key| (*key).to_owned())
+                .collect()
+        );
     }
 }

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -9,6 +9,7 @@ use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::fmt;
 use std::fmt::Display;
+use std::iter::once;
 use std::mem;
 use std::path::Path;
 use std::path::PathBuf;
@@ -46,6 +47,7 @@ use pyrefly_util::globs::HiddenDirFilter;
 use pyrefly_util::interned_path::InternedPath;
 use pyrefly_util::lock::RwLock;
 use pyrefly_util::prelude::VecExt;
+use pyrefly_util::suggest::best_suggestion_str;
 use pyrefly_util::telemetry::SubTaskTelemetry;
 use pyrefly_util::telemetry::TelemetryEventKind;
 use pyrefly_util::telemetry::TelemetrySourceDbRebuildInstanceStats;
@@ -827,6 +829,65 @@ impl ConfigFile {
         FilteredGlobs::new(includes, project_excludes, root, hidden_dir_filter)
     }
 }
+
+/// `ConfigBase` keys, valid both at the top level and inside a `[[sub-config]]`
+/// block. Used only to suggest a "did you mean" for unrecognized keys, so a
+/// missing entry merely weakens a hint — it never silences the warning itself.
+/// Kept in sync with `ConfigBase` by `test_known_config_keys_cover_serialized_fields`.
+const CONFIG_BASE_KEYS: &[&str] = &[
+    "errors",
+    "permissive-ignores",
+    "enabled-ignores",
+    "replace-imports-with-any",
+    "ignore-missing-imports",
+    "untyped-def-behavior",
+    "check-unannotated-defs",
+    "infer-return-types",
+    "disable-type-errors-in-ide",
+    "ignore-errors-in-generated-code",
+    "infer-with-first-use",
+    "pytorch-efficiency-lints",
+    "recursion-depth-limit",
+    "recursion-overflow-handler",
+    "strict-callable-subtyping",
+    "strict-partial-subtyping",
+    "spec-compliant-overloads",
+    "legacy-overload-expansion",
+];
+
+/// Keys valid only at the top level of a config (not inside `[[sub-config]]`):
+/// project-wide settings plus the flattened interpreter and Python-environment
+/// options. The full top-level key set is this list plus `CONFIG_BASE_KEYS`.
+const TOP_LEVEL_ONLY_CONFIG_KEYS: &[&str] = &[
+    "project-includes",
+    "project-excludes",
+    "disable-project-excludes-heuristics",
+    "search-path",
+    "disable-search-path-heuristics",
+    "enable-fallback-search-path",
+    "typeshed-path",
+    "baseline",
+    "output-format",
+    "preset",
+    "sub-config",
+    "coverage",
+    "use-ignore-files",
+    "build-system",
+    "min-severity",
+    "skip-lsp-config-indexing",
+    "extra-file-extensions",
+    "python-interpreter-path",
+    "fallback-python-interpreter-name",
+    "conda-environment",
+    "skip-interpreter-query",
+    "python-platform",
+    "python-version",
+    "site-package-path",
+];
+
+/// Keys valid inside a `[coverage]` table.
+/// Kept in sync with `CoverageConfig` by `test_known_config_keys_cover_serialized_fields`.
+const COVERAGE_CONFIG_KEYS: &[&str] = &["includes", "excludes"];
 
 impl ConfigFile {
     pub const PYREFLY_FILE_NAME: &str = "pyrefly.toml";
@@ -1730,33 +1791,68 @@ impl ConfigFile {
                 )));
             }
 
-            if !config.root.extras.0.is_empty() {
-                let extra_keys = config.root.extras.0.keys().join(", ");
-                errors.push(ConfigError::warn(anyhow!(
-                    "Extra keys found in config: {extra_keys}"
-                )));
-            }
-            if !config.coverage.extras.0.is_empty() {
-                let extra_keys = config.coverage.extras.0.keys().join(", ");
-                errors.push(ConfigError::warn(anyhow!(
-                    "Extra keys found in coverage config: {extra_keys}"
-                )));
-            }
-            for sub_config in &config.sub_configs {
-                if !sub_config.settings.extras.0.is_empty() {
-                    let extra_keys = sub_config.settings.extras.0.keys().join(", ");
-                    errors.push(ConfigError::warn(anyhow!(
-                        "Extra keys found in sub config matching {}: {extra_keys}",
-                        sub_config.matches
-                    )));
-                }
-            }
+            errors.extend(
+                config
+                    .unknown_key_warnings()
+                    .into_iter()
+                    .map(ConfigError::warn),
+            );
             (config, errors)
         }
         let config_path = config_path.absolutize();
         let (config, errors) = f(&config_path);
         let errors = errors.into_map(|err| err.context(format!("{}", config_path.display())));
         (config, errors)
+    }
+
+    /// Warn about unrecognized config keys, suggesting the closest known key when
+    /// one is similar enough. Unknown keys are gathered into `extras` by serde's
+    /// `flatten` catch-all, so this never fires for keys Pyrefly understands
+    /// (including the snake_case migration aliases). Top-level, `[coverage]`, and
+    /// `[[sub-config]]` keys are each checked against the options valid in their own scope.
+    fn unknown_key_warnings(&self) -> Vec<anyhow::Error> {
+        fn message(key: &str, candidates: &[&str], location: &str) -> anyhow::Error {
+            let suggestion =
+                best_suggestion_str(key, candidates.iter().enumerate().map(|(i, k)| (*k, i)))
+                    .map(|s| format!(". Did you mean `{s}`?"))
+                    .unwrap_or_default();
+            anyhow!("Unknown config key `{key}`{location}{suggestion}")
+        }
+
+        let top_level: Vec<&str> = TOP_LEVEL_ONLY_CONFIG_KEYS
+            .iter()
+            .chain(CONFIG_BASE_KEYS)
+            .copied()
+            .collect();
+        let sub_config: Vec<&str> = once("matches")
+            .chain(CONFIG_BASE_KEYS.iter().copied())
+            .collect();
+
+        let mut warnings: Vec<anyhow::Error> = self
+            .root
+            .extras
+            .0
+            .keys()
+            .map(|key| message(key, &top_level, ""))
+            .collect();
+        warnings.extend(
+            self.coverage
+                .extras
+                .0
+                .keys()
+                .map(|key| message(key, COVERAGE_CONFIG_KEYS, " in coverage config")),
+        );
+        for sub in &self.sub_configs {
+            let location = format!(" in sub config matching {}", sub.matches);
+            warnings.extend(
+                sub.settings
+                    .extras
+                    .0
+                    .keys()
+                    .map(|key| message(key, &sub_config, &location)),
+            );
+        }
+        warnings
     }
 
     pub fn parse_config(config_str: &str) -> anyhow::Result<ConfigFile> {
@@ -4220,5 +4316,140 @@ output-format = "omit-errors"
             Severity::Ignore,
             "without pytorch-efficiency-lints flag, lints should default to Ignore"
         );
+    }
+
+    #[test]
+    fn test_unknown_config_key_suggests_closest() {
+        // `check-unannotated-def` is a typo of the real `check-unannotated-defs`.
+        let config = ConfigFile::parse_config("check-unannotated-def = true\n").unwrap();
+        let warnings: Vec<String> = config
+            .unknown_key_warnings()
+            .iter()
+            .map(|w| w.to_string())
+            .collect();
+        assert_eq!(warnings.len(), 1, "warnings: {warnings:?}");
+        assert!(
+            warnings[0].contains("`check-unannotated-def`"),
+            "should name the unknown key: {}",
+            warnings[0]
+        );
+        assert!(
+            warnings[0].contains("`check-unannotated-defs`"),
+            "should suggest the closest known key: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn test_unknown_config_key_without_close_match_has_no_suggestion() {
+        let config = ConfigFile::parse_config("made-up-key-xyz = 1\n").unwrap();
+        let warnings: Vec<String> = config
+            .unknown_key_warnings()
+            .iter()
+            .map(|w| w.to_string())
+            .collect();
+        assert_eq!(warnings.len(), 1, "warnings: {warnings:?}");
+        assert!(warnings[0].contains("`made-up-key-xyz`"), "{}", warnings[0]);
+        assert!(
+            !warnings[0].contains("Did you mean"),
+            "no key is close enough to suggest: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn test_unknown_sub_config_key_suggests_closest() {
+        let config_str = r#"
+[[sub-config]]
+matches = "foo/**"
+check-unannotated-def = true
+"#;
+        let config = ConfigFile::parse_config(config_str).unwrap();
+        let warnings: Vec<String> = config
+            .unknown_key_warnings()
+            .iter()
+            .map(|w| w.to_string())
+            .collect();
+        assert_eq!(warnings.len(), 1, "warnings: {warnings:?}");
+        assert!(
+            warnings[0].contains("`check-unannotated-def`"),
+            "{}",
+            warnings[0]
+        );
+        assert!(
+            warnings[0].contains("`check-unannotated-defs`"),
+            "{}",
+            warnings[0]
+        );
+        assert!(
+            warnings[0].contains("sub config matching"),
+            "should mention the sub-config: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn test_known_config_keys_are_not_flagged() {
+        // Canonical kebab-case keys and a snake_case migration alias
+        // (`replace_imports_with_any`) are all recognized, so none is reported.
+        let config_str = r#"
+search-path = ["src"]
+project-includes = ["src"]
+python-version = "3.11"
+replace_imports_with_any = ["foo"]
+"#;
+        let config = ConfigFile::parse_config(config_str).unwrap();
+        let warnings: Vec<String> = config
+            .unknown_key_warnings()
+            .iter()
+            .map(|w| w.to_string())
+            .collect();
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+    }
+
+    #[test]
+    fn test_known_config_keys_cover_serialized_fields() {
+        // A configured `ConfigFile` serializes every populated option under its
+        // canonical key. Each such top-level key must be covered by our known-key
+        // lists so suggestions stay in sync as new fields are added.
+        let root = TempDir::new().unwrap();
+        let mut config = ConfigFile::init_at_root(root.path(), &ProjectLayout::default(), false);
+        config.configure();
+        let table: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(&serde_json::to_string(&config).unwrap()).unwrap();
+        let known: std::collections::HashSet<&str> = TOP_LEVEL_ONLY_CONFIG_KEYS
+            .iter()
+            .chain(CONFIG_BASE_KEYS)
+            .copied()
+            .collect();
+        for key in table.keys() {
+            // `extras` is serde's `flatten` catch-all, not a real config key.
+            if key == "extras" {
+                continue;
+            }
+            assert!(
+                known.contains(key.as_str()),
+                "serialized config key `{key}` is missing from CONFIG_BASE_KEYS / \
+                 TOP_LEVEL_ONLY_CONFIG_KEYS; add it so suggestions stay in sync"
+            );
+        }
+
+        // Coverage keys stay in sync with `CoverageConfig` the same way.
+        let coverage: CoverageConfig =
+            serde_json::from_value(serde_json::json!({"includes": ["a"], "excludes": ["b"]}))
+                .unwrap();
+        let coverage_table: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(&serde_json::to_string(&coverage).unwrap()).unwrap();
+        let coverage_known: std::collections::HashSet<&str> =
+            COVERAGE_CONFIG_KEYS.iter().copied().collect();
+        for key in coverage_table.keys() {
+            if key == "extras" {
+                continue;
+            }
+            assert!(
+                coverage_known.contains(key.as_str()),
+                "serialized coverage key `{key}` is missing from COVERAGE_CONFIG_KEYS"
+            );
+        }
     }
 }

--- a/crates/pyrefly_config/src/environment/environment.rs
+++ b/crates/pyrefly_config/src/environment/environment.rs
@@ -15,6 +15,7 @@ use std::sync::LazyLock;
 use anyhow::Context;
 use anyhow::anyhow;
 use itertools::Itertools;
+use pyrefly_derive::ConfigKeys;
 use pyrefly_python::sys_info::PythonPlatform;
 use pyrefly_python::sys_info::PythonVersion;
 use pyrefly_util::lock::Mutex;
@@ -40,6 +41,7 @@ static INTERPRETER_ENV_REGISTRY: LazyLock<
 /// should we always look at a venv/conda environment instead?)
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Default)]
+#[derive(ConfigKeys)]
 #[serde(rename_all = "kebab-case")]
 pub struct PythonEnvironment {
     /// The platform any `sys.platform` check should evaluate against.

--- a/crates/pyrefly_config/src/environment/interpreters.rs
+++ b/crates/pyrefly_config/src/environment/interpreters.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
+use pyrefly_derive::ConfigKeys;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_with::skip_serializing_none;
@@ -24,6 +25,7 @@ use crate::util::ConfigOrigin;
 
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Default)]
+#[derive(ConfigKeys)]
 #[serde(rename_all = "kebab-case")]
 pub struct Interpreters {
     #[serde(

--- a/crates/pyrefly_derive/src/config_keys.rs
+++ b/crates/pyrefly_derive/src/config_keys.rs
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Attribute;
+use syn::Data;
+use syn::DeriveInput;
+use syn::Fields;
+use syn::Lit;
+use syn::LitStr;
+use syn::Token;
+use syn::parse_macro_input;
+
+pub(crate) fn derive_config_keys(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match derive_config_keys_impl(&input) {
+        Ok(x) => x.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+/// How a field is treated by serde when serializing, as far as the config-key
+/// set is concerned.
+enum FieldKind {
+    /// Serialized under a single key (the resolved `rename`/`rename_all` name),
+    /// plus any deprecated `#[serde(alias = "...")]` spellings serde also accepts.
+    Key { key: String, aliases: Vec<String> },
+    /// A `#[serde(flatten)]` sub-struct whose keys and aliases are spliced in via
+    /// its own `ConfigKeys` impl.
+    Flatten,
+    /// Not serialized (`#[serde(skip)]`, `#[serde(skip_serializing)]`, or
+    /// `#[config_keys(skip)]` for the flatten catch-all).
+    Skip,
+}
+
+fn derive_config_keys_impl(input: &DeriveInput) -> syn::Result<TokenStream> {
+    let name = &input.ident;
+    if !input.generics.params.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &input.generics,
+            "ConfigKeys does not support generic types",
+        ));
+    }
+    let rename_all = serde_rename_all(&input.attrs)?;
+    let fields = match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(fields) => &fields.named,
+            _ => {
+                return Err(syn::Error::new_spanned(
+                    input,
+                    "ConfigKeys requires named fields",
+                ));
+            }
+        },
+        _ => {
+            return Err(syn::Error::new_spanned(
+                input,
+                "ConfigKeys can only be derived for structs",
+            ));
+        }
+    };
+
+    // Emit one statement per serialized field, in declaration order, so the
+    // resulting key order matches serde's serialized order (which the "did you
+    // mean" ranking uses as a tiebreaker).
+    let mut key_stmts = Vec::new();
+    let mut alias_stmts = Vec::new();
+    for field in fields {
+        match field_kind(field, &rename_all)? {
+            FieldKind::Skip => {}
+            FieldKind::Key { key, aliases } => {
+                key_stmts.push(quote! { keys.push(#key); });
+                for alias in aliases {
+                    alias_stmts.push(quote! { aliases.push((#alias, #key)); });
+                }
+            }
+            FieldKind::Flatten => {
+                let ty = &field.ty;
+                key_stmts.push(quote! {
+                    keys.extend(<#ty as pyrefly_util::config_keys::ConfigKeys>::config_keys());
+                });
+                alias_stmts.push(quote! {
+                    aliases.extend(<#ty as pyrefly_util::config_keys::ConfigKeys>::config_key_aliases());
+                });
+            }
+        }
+    }
+
+    Ok(quote! {
+        impl pyrefly_util::config_keys::ConfigKeys for #name {
+            fn config_keys() -> Vec<&'static str> {
+                let mut keys: Vec<&'static str> = Vec::new();
+                #(#key_stmts)*
+                keys
+            }
+
+            fn config_key_aliases() -> Vec<(&'static str, &'static str)> {
+                let mut aliases: Vec<(&'static str, &'static str)> = Vec::new();
+                #(#alias_stmts)*
+                aliases
+            }
+        }
+    })
+}
+
+fn field_kind(field: &syn::Field, rename_all: &Option<String>) -> syn::Result<FieldKind> {
+    if config_keys_skip(&field.attrs)? {
+        return Ok(FieldKind::Skip);
+    }
+    let mut rename = None;
+    let mut aliases = Vec::new();
+    let mut skip = false;
+    let mut flatten = false;
+    for attr in &field.attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("rename") {
+                rename = Some(meta.value()?.parse::<LitStr>()?.value());
+            } else if meta.path.is_ident("alias") {
+                aliases.push(meta.value()?.parse::<LitStr>()?.value());
+            } else if meta.path.is_ident("skip") || meta.path.is_ident("skip_serializing") {
+                skip = true;
+            } else if meta.path.is_ident("flatten") {
+                flatten = true;
+            } else if meta.input.peek(Token![=]) {
+                // Consume and ignore values of serde options we don't care about
+                // (default, skip_serializing_if, ...) to keep the parser in sync.
+                let _: Lit = meta.value()?.parse()?;
+            }
+            Ok(())
+        })?;
+    }
+    // A skipped field is never serialized, so serde ignores its aliases too;
+    // dropping them here keeps the alias set in sync with serde's behavior.
+    if skip {
+        return Ok(FieldKind::Skip);
+    }
+    if flatten {
+        return Ok(FieldKind::Flatten);
+    }
+    let key = match rename {
+        Some(rename) => rename,
+        None => {
+            let name = field.ident.as_ref().unwrap().to_string();
+            apply_rename_all(rename_all, &name, field)?
+        }
+    };
+    Ok(FieldKind::Key { key, aliases })
+}
+
+/// Read the struct-level `#[serde(rename_all = "...")]`, if present.
+fn serde_rename_all(attrs: &[Attribute]) -> syn::Result<Option<String>> {
+    let mut rule = None;
+    for attr in attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("rename_all") {
+                rule = Some(meta.value()?.parse::<LitStr>()?.value());
+            } else if meta.input.peek(Token![=]) {
+                let _: Lit = meta.value()?.parse()?;
+            }
+            Ok(())
+        })?;
+    }
+    Ok(rule)
+}
+
+/// Apply a serde `rename_all` rule to a snake_case field name. Only the rules
+/// actually used by pyrefly's config structs are supported; anything else is a
+/// compile error rather than a silent wrong guess.
+fn apply_rename_all(rule: &Option<String>, name: &str, field: &syn::Field) -> syn::Result<String> {
+    match rule.as_deref() {
+        None => Ok(name.to_owned()),
+        // serde's kebab-case rule on a snake_case identifier is exactly this.
+        Some("kebab-case") => Ok(name.replace('_', "-")),
+        Some(other) => Err(syn::Error::new_spanned(
+            field,
+            format!("ConfigKeys does not support rename_all = \"{other}\""),
+        )),
+    }
+}
+
+/// Whether a field carries `#[config_keys(skip)]` (the flatten catch-all).
+fn config_keys_skip(attrs: &[Attribute]) -> syn::Result<bool> {
+    let mut skip = false;
+    for attr in attrs {
+        if !attr.path().is_ident("config_keys") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("skip") {
+                skip = true;
+                Ok(())
+            } else {
+                Err(meta.error("unsupported `config_keys` attribute"))
+            }
+        })?;
+    }
+    Ok(skip)
+}

--- a/crates/pyrefly_derive/src/lib.rs
+++ b/crates/pyrefly_derive/src/lib.rs
@@ -13,8 +13,15 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 
+mod config_keys;
 mod type_eq;
 mod visit;
+
+/// Generate a `ConfigKeys` impl listing a config struct's serialized keys.
+#[proc_macro_derive(ConfigKeys, attributes(config_keys))]
+pub fn derive_config_keys(input: TokenStream) -> TokenStream {
+    config_keys::derive_config_keys(input)
+}
 
 /// Generate `TypeEq` traits.
 #[proc_macro_derive(TypeEq)]

--- a/crates/pyrefly_util/src/config_keys.rs
+++ b/crates/pyrefly_util/src/config_keys.rs
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// The serialized config keys a struct accepts, used to suggest a "did you
+/// mean" for unrecognized keys. Derive it with `#[derive(pyrefly_derive::ConfigKeys)]`,
+/// which mirrors serde's serialized-key semantics: it honors `rename_all` and
+/// per-field `rename`, drops `skip`/`skip_serializing` fields, and splices in
+/// the keys and aliases of `#[serde(flatten)]` sub-structs through their own
+/// `ConfigKeys` impl. The flatten catch-all field (`extras`) is excluded via
+/// `#[config_keys(skip)]`.
+pub trait ConfigKeys {
+    /// The serialized keys of this struct, in field-declaration order.
+    fn config_keys() -> Vec<&'static str>;
+
+    /// The `#[serde(alias = "...")]` spellings this struct accepts, each paired
+    /// with the canonical (resolved `rename`/`rename_all`) key it resolves to.
+    /// A field may contribute several pairs when it declares multiple aliases.
+    fn config_key_aliases() -> Vec<(&'static str, &'static str)>;
+}

--- a/crates/pyrefly_util/src/lib.rs
+++ b/crates/pyrefly_util/src/lib.rs
@@ -29,6 +29,7 @@ pub mod absolutize;
 pub mod arc_id;
 pub mod args;
 pub mod assert_size;
+pub mod config_keys;
 pub mod demand_tree;
 pub mod display;
 pub mod events;

--- a/crates/pyrefly_util/src/suggest.rs
+++ b/crates/pyrefly_util/src/suggest.rs
@@ -8,21 +8,25 @@
 use ruff_python_ast::name::Name;
 use strsim::levenshtein;
 
-/// Pick the closest candidate to `missing`, preferring smaller `priority` on ties.
-pub fn best_suggestion<'a, I>(missing: &Name, candidates: I) -> Option<Name>
+/// Pick the closest candidate to `missing` by edit distance, preferring smaller
+/// `priority` on ties. The distance threshold scales with the longer of the two
+/// strings (≤1 for short names, up to ≤3 for long ones); single-letter
+/// candidates are skipped to reduce noise. `to_str` projects a candidate to the
+/// string compared against `missing`. Returns `None` when nothing is close
+/// enough.
+fn closest<T, I>(missing: &str, candidates: I, to_str: impl Fn(&T) -> &str) -> Option<T>
 where
-    I: IntoIterator<Item = (&'a Name, usize)>,
+    I: IntoIterator<Item = (T, usize)>,
 {
-    let missing_str = missing.as_str();
-    let mut best: Option<(Name, usize, usize)> = None;
+    let mut best: Option<(T, usize, usize)> = None;
     for (candidate, priority) in candidates {
-        let candidate_str = candidate.as_str();
+        let candidate_str = to_str(&candidate);
         // Skip single-letter candidates to reduce noise
         if candidate_str.len() == 1 {
             continue;
         }
-        let distance = levenshtein(missing_str, candidate_str);
-        let max_distance = match missing_str.len().max(candidate_str.len()) {
+        let distance = levenshtein(missing, candidate_str);
+        let max_distance = match missing.len().max(candidate_str.len()) {
             0..=4 => 1,
             5..=8 => 2,
             _ => 3,
@@ -30,12 +34,32 @@ where
         if distance == 0 || distance > max_distance {
             continue;
         }
-        match &best {
-            Some((_, best_distance, best_priority))
-                if distance > *best_distance
-                    || (distance == *best_distance && priority >= *best_priority) => {}
-            _ => best = Some((candidate.clone(), distance, priority)),
+        let is_better = match &best {
+            Some((_, best_distance, best_priority)) => {
+                distance < *best_distance
+                    || (distance == *best_distance && priority < *best_priority)
+            }
+            None => true,
+        };
+        if is_better {
+            best = Some((candidate, distance, priority));
         }
     }
-    best.map(|(name, _, _)| name)
+    best.map(|(candidate, _, _)| candidate)
+}
+
+/// Pick the closest candidate to `missing`, preferring smaller `priority` on ties.
+pub fn best_suggestion<'a, I>(missing: &Name, candidates: I) -> Option<Name>
+where
+    I: IntoIterator<Item = (&'a Name, usize)>,
+{
+    closest(missing.as_str(), candidates, |c| c.as_str()).cloned()
+}
+
+/// Like [`best_suggestion`], but over plain string slices (e.g. config keys).
+pub fn best_suggestion_str<'a, I>(missing: &str, candidates: I) -> Option<&'a str>
+where
+    I: IntoIterator<Item = (&'a str, usize)>,
+{
+    closest(missing, candidates, |c| *c)
 }


### PR DESCRIPTION
Fixes #3943.

When a `pyrefly.toml` or `[tool.pyrefly]` has a key pyrefly doesn't recognize, it warns per unrecognized key with a "did you mean" suggestion when a known option is close:

```
Unknown config key `check-unannotated-def`. Did you mean `check-unannotated-defs`?
Unknown config key `made-up-key`
```

Detection is serde-derived and can't drift: anything unrecognized lands in the flattened `extras` catch-all. The "did you mean" candidate set (canonical keys and accepted deprecated aliases) is generated from the config structs by a `ConfigKeys` derive that reads each struct's serde attributes (rename_all, rename, alias, skip) and splices in the flattened sub-structs, so adding a field or alias updates the suggestions automatically with nothing to keep in sync by hand.

Scoped by section: top-level keys match the project options plus the flattened interpreter/environment/base keys; `[coverage]` against the coverage options; `[[sub-config]]` against `matches` plus the base keys.
