### PR TITLE
Subtract a union member matched by a literal sequence-pattern element

### DIFF
--- a/pyrefly/lib/binding/pattern.rs
+++ b/pyrefly/lib/binding/pattern.rs
@@ -238,6 +238,20 @@ impl<'a> BindingsBuilder<'a> {
                     .patterns
                     .iter()
                     .all(|p| p.is_irrefutable() || p.is_wildcard());
+                // Strip the spurious Placeholders that `and_all` adds for sub-patterns with
+                // no narrow ops, so negative narrowing can subtract a matched member. Safe
+                // for a star-free pattern whose elements are all irrefutable (wildcards,
+                // captures) or value / singleton patterns: those emit `Eq`/`Is` facet
+                // narrows whose negation removes a union member only when the element type
+                // guarantees the match, so refutable members are preserved.
+                // https://github.com/facebook/pyrefly/issues/3883
+                let strip_placeholders = all_subpatterns_irrefutable
+                    || (num_patterns == num_non_star_patterns
+                        && x.patterns.iter().all(|p| {
+                            p.is_irrefutable()
+                                || p.is_wildcard()
+                                || matches!(p, Pattern::MatchValue(_) | Pattern::MatchSingleton(_))
+                        }));
                 let mut subject_idx = subject_idx;
                 let synthesized_len = Expr::NumberLiteral(ExprNumberLiteral {
                     node_index: AtomicNodeIndex::default(),
@@ -381,7 +395,7 @@ impl<'a> BindingsBuilder<'a> {
                     KeyExpect::UnpackedLength(x.range),
                     BindingExpect::UnpackedLength(subject_idx, x.range, expect),
                 );
-                if all_subpatterns_irrefutable
+                if strip_placeholders
                     && let Some(subject) = match_subject.as_single()
                     && let Some((op, _)) = narrow_ops.scope.0.get_mut(subject.name())
                 {

--- a/pyrefly/lib/test/pattern_match.rs
+++ b/pyrefly/lib/test/pattern_match.rs
@@ -396,6 +396,71 @@ def f(value: float | tuple[float, float]) -> float | tuple[float, float]:
 );
 
 testcase!(
+    // https://github.com/facebook/pyrefly/issues/3883: a sequence pattern whose
+    // element is a literal matching the member's element type exactly (e.g.
+    // `("b", _)` against `tuple[Literal["b"], int]`) is irrefutable for that
+    // member, so the member is subtracted from the subject union.
+    test_match_sequence_literal_element_narrows_out_of_union,
+    r#"
+from typing import Literal, assert_never
+
+def f(
+    value: Literal["a"] | tuple[Literal["b"], int] | tuple[Literal["c"], int],
+) -> None:
+    match value:
+        case "a":
+            pass
+        case ("b", _):
+            pass
+        case ("c", _):
+            pass
+        case _ as unreachable:
+            assert_never(unreachable)
+"#,
+);
+
+testcase!(
+    // A capture after the literal element is irrefutable for that element, so the
+    // member is still subtracted (the maintainer's "treat bindings like wildcards"
+    // case). https://github.com/facebook/pyrefly/issues/3883
+    test_match_sequence_literal_element_with_capture_narrows,
+    r#"
+from typing import Literal, assert_never
+
+def f(
+    value: Literal["a"] | tuple[Literal["b"], int] | tuple[Literal["c"], int],
+) -> int:
+    match value:
+        case "a":
+            return 0
+        case ("b", v):
+            return v
+        case ("c", v):
+            return v
+        case _ as unreachable:
+            assert_never(unreachable)
+"#,
+);
+
+testcase!(
+    // The literal element only subtracts a member when the element type guarantees
+    // the match. Against a wider element type (`str`), `("b", _)` is refutable, so
+    // the type must be preserved.
+    test_match_sequence_literal_element_wider_type_no_strip,
+    r#"
+from typing import assert_type
+
+def f(value: tuple[str, int]) -> tuple[str, int]:
+    match value:
+        case ("b", _):
+            return value
+        case other:
+            assert_type(other, tuple[str, int])
+            return other
+"#,
+);
+
+testcase!(
     test_match_exhaustive_call_subject_assert_never,
     r#"
 from dataclasses import dataclass
@@ -1395,12 +1460,11 @@ def bar(b: bool) -> int:  # E: one or more paths are missing an explicit
 
 // https://github.com/facebook/pyrefly/issues/3883
 testcase!(
-    bug = "sequence pattern with a literal element does not subtract the tuple from the union, so the match is not seen as exhaustive",
     test_match_sequence_literal_element,
     r#"
 from typing import Literal, reveal_type
 type MyUnion = Literal["a"] | tuple[Literal["b"], int] | tuple[Literal["c"], int]
-def broken(value: MyUnion) -> str:  # E: one or more paths are missing an explicit
+def f(value: MyUnion) -> str:
     match value:
         case "a":
             return "a"
@@ -1408,7 +1472,7 @@ def broken(value: MyUnion) -> str:  # E: one or more paths are missing an explic
             return "b"
         case "c", v:
             return "c"
-    reveal_type(value)  # E: revealed type: tuple[Literal['b'], int] | tuple[Literal['c'], int]
+    reveal_type(value)  # E: revealed type: Never
 "#,
 );
 


### PR DESCRIPTION
## Summary

Closes #3883.

A `match` arm whose sequence pattern has a **literal** element — e.g. `case ("b", _)` against the union member `tuple[Literal["b"], int]` — is irrefutable for that member, but the member was not subtracted from the subject in the fall-through / exhaustiveness branch. A full-capture pattern (`case (k, v)`) did subtract correctly. So this match left a non-`Never` remainder when it should have been exhaustive:

```python
from typing import Literal, assert_never

def f(value: Literal["a"] | tuple[Literal["b"], int] | tuple[Literal["c"], int]) -> None:
    match value:
        case "a":
            pass
        case ("b", _):
            pass
        case ("c", _):
            pass
        case _ as unreachable:
            assert_never(unreachable)  # was: error, `tuple[...] | tuple[...]` not `Never`
```

## Root cause

The `MatchSequence` arm already emits the right scope narrow — `And(IsSequence, LenEq(n), <element narrows>)`, where a value element contributes an `Eq(v)` narrow on the element facet `Index(i)`. But `NarrowOps::and_all` appends an `AtomicNarrowOp::Placeholder` for the subject whenever a sub-pattern contributes no narrow, which is exactly what an irrefutable element like `_` does. Negating `And(..., Placeholder)` gives `Or(..., Placeholder)`, and `Placeholder` narrows to the full type — so the union re-includes the member and nothing is subtracted. Placeholders were only stripped when **every** element was irrefutable, which a literal element defeats.

## Fix

Strip the placeholders for any **star-free** sequence pattern whose elements are all irrefutable, value, or singleton patterns (this is the maintainer's suggestion on the issue: treat variable bindings like wildcards, and let the literal element contribute its condition).

This is sound because the subtraction is gated by the type-directed facet narrowing (`atomic_narrow_for_facet`'s `NotEq`/`IsNot` arms), which removes a union member only when the element type *guarantees* the match (exact literal/singleton) and preserves it otherwise:
- `("b", _)` vs `tuple[Literal["b"], int]` → subtracted ✓
- `("b", _)` vs `tuple[str, int]` (wider) → preserved ✓
- `(1.0, 2.0)` vs `tuple[float, float]` → preserved ✓ (unchanged)

Star patterns are excluded (post-star elements get no facet subject), and nested/`OR`/class sub-patterns fall to the existing conservative path — no behavior change there. Guarded arms (`case ("b", _) if cond:`) still don't subtract, because the guard re-introduces a placeholder.

## Test plan

- New tests in `pyrefly/lib/test/pattern_match.rs`:
  - `test_match_sequence_literal_element_narrows_out_of_union` — the issue repro (`assert_never` reached)
  - `test_match_sequence_literal_element_with_capture_narrows` — the `case ("b", v)` capture form
  - `test_match_sequence_literal_element_wider_type_no_strip` — over-narrow guard: `("b", _)` vs `tuple[str, int]` is preserved
- Existing `test_match_sequence_refutable_subpattern_no_strip` and `test_match_sequence_star_pattern_narrows` still pass.
- Full lib suite: `cargo test -p pyrefly --lib` — **5978 passed, 0 failed**.
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema` — clean.