### PR TITLE
Report duplicate TypeVar definitions

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -1893,6 +1893,19 @@ impl<'a> BindingsBuilder<'a> {
         }
     }
 
+    pub fn check_for_type_var_redefinition(&self, name: &Name, range: TextRange) {
+        let prev_idx = self.scopes.current_flow_idx(name);
+        if let Some(prev_idx) = prev_idx
+            && matches!(self.idx_to_binding(prev_idx), Some(Binding::TypeVar(..)))
+        {
+            self.error(
+                range,
+                ErrorKind::Redefinition,
+                format!("Cannot redefine existing TypeVar `{name}`"),
+            );
+        }
+    }
+
     fn check_for_imported_final_reassignment(&self, name: &Name, idx: Idx<Key>) {
         let prev_idx = self.scopes.current_flow_idx(name);
         if let Some(prev_idx) = prev_idx

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -311,6 +311,7 @@ impl<'a> BindingsBuilder<'a> {
     }
 
     fn assign_type_var(&mut self, name: &ExprName, call: &mut ExprCall) {
+        self.check_for_type_var_redefinition(&name.id, name.range);
         // Type var declarations are static types only; skip them for first-usage type inference.
         let static_type_usage = &mut Usage::StaticTypeInformation {
             is_annotation: false,

--- a/pyrefly/lib/test/generic_legacy.rs
+++ b/pyrefly/lib/test/generic_legacy.rs
@@ -262,6 +262,15 @@ Ts = TypeVarTuple("Z")  # E: TypeVarTuple must be assigned to a variable named `
 );
 
 testcase!(
+    test_tvar_duplicate_definition,
+    r#"
+from typing import TypeVar
+T = TypeVar("T")
+T = TypeVar("T")  # E: Cannot redefine existing TypeVar `T`
+    "#,
+);
+
+testcase!(
     test_tvar_wrong_name_expr,
     r#"
 from typing import TypeVar, ParamSpec, TypeVarTuple


### PR DESCRIPTION
now this PR adds a focused binder-time check for duplicate legacy `TypeVar` definitions. Previously, Pyrefly accepted duplicate definitions like this without reporting an error:

```python
from typing import TypeVar

T = TypeVar("T")
T = TypeVar("T")
```

After this change, the second definition reports a redefinition error.

The change is intentionally kept small and limited to the existing legacy `TypeVar` binding path. I also added a regression test in `generic_legacy.rs` to cover this case.

Fixes #3754

# Test Plan

* `cargo test test_tvar_duplicate_definition`
* `cargo test generic_legacy`
