### PR TITLE
fix hover on case _ show the remaining cases #3334

### DIFF
--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -751,38 +751,6 @@ fn in_keyword_in_iteration_at(ast: Option<&ModModule>, position: TextSize) -> Op
     None
 }
 
-fn match_wildcard_type_at(
-    transaction: &Transaction<'_>,
-    handle: &Handle,
-    position: TextSize,
-) -> Option<Type> {
-    let module = transaction.get_ast(handle)?;
-    let covering_nodes = Ast::locate_node(&module, position);
-    let is_wildcard = covering_nodes
-        .iter()
-        .any(|node| matches!(node, AnyNodeRef::PatternMatchAs(pattern) if pattern.name.is_none() && pattern.pattern.is_none()));
-    if !is_wildcard {
-        return None;
-    }
-    let case_range = covering_nodes.iter().find_map(|node| match node {
-        AnyNodeRef::MatchCase(case) => Some(case.range),
-        _ => None,
-    })?;
-    let subject_start = covering_nodes.iter().find_map(|node| match node {
-        AnyNodeRef::StmtMatch(stmt_match) => Some(stmt_match.subject.range().start()),
-        _ => None,
-    })?;
-    let key = Key::PatternNarrow(case_range);
-    if transaction
-        .get_bindings(handle)
-        .is_some_and(|bindings| bindings.is_valid_key(&key))
-    {
-        transaction.get_type_for_display(handle, &key)
-    } else {
-        transaction.get_type_at_for_display(handle, subject_start)
-    }
-}
-
 /// Hover contents when the cursor is on an ignore comment covering suppressed errors.
 fn ignore_comment_hover(
     transaction: &Transaction<'_>,
@@ -847,8 +815,8 @@ fn resolve_hovered_type(
     ast: Option<&ModModule>,
     position: TextSize,
 ) -> Option<Type> {
-    let mut type_ = match_wildcard_type_at(transaction, handle, position)
-        .or_else(|| transaction.subscript_operator_type_at(handle, position))
+    let mut type_ = transaction
+        .subscript_operator_type_at(handle, position)
         .or_else(|| transaction.get_type_at_for_display(handle, position))
         .or_else(|| transaction.operator_type_at(handle, position))?;
 

--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -751,6 +751,38 @@ fn in_keyword_in_iteration_at(ast: Option<&ModModule>, position: TextSize) -> Op
     None
 }
 
+fn match_wildcard_type_at(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    position: TextSize,
+) -> Option<Type> {
+    let module = transaction.get_ast(handle)?;
+    let covering_nodes = Ast::locate_node(&module, position);
+    let is_wildcard = covering_nodes
+        .iter()
+        .any(|node| matches!(node, AnyNodeRef::PatternMatchAs(pattern) if pattern.name.is_none() && pattern.pattern.is_none()));
+    if !is_wildcard {
+        return None;
+    }
+    let case_range = covering_nodes.iter().find_map(|node| match node {
+        AnyNodeRef::MatchCase(case) => Some(case.range),
+        _ => None,
+    })?;
+    let subject_start = covering_nodes.iter().find_map(|node| match node {
+        AnyNodeRef::StmtMatch(stmt_match) => Some(stmt_match.subject.range().start()),
+        _ => None,
+    })?;
+    let key = Key::PatternNarrow(case_range);
+    if transaction
+        .get_bindings(handle)
+        .is_some_and(|bindings| bindings.is_valid_key(&key))
+    {
+        transaction.get_type_for_display(handle, &key)
+    } else {
+        transaction.get_type_at_for_display(handle, subject_start)
+    }
+}
+
 /// Hover contents when the cursor is on an ignore comment covering suppressed errors.
 fn ignore_comment_hover(
     transaction: &Transaction<'_>,
@@ -815,8 +847,8 @@ fn resolve_hovered_type(
     ast: Option<&ModModule>,
     position: TextSize,
 ) -> Option<Type> {
-    let mut type_ = transaction
-        .subscript_operator_type_at(handle, position)
+    let mut type_ = match_wildcard_type_at(transaction, handle, position)
+        .or_else(|| transaction.subscript_operator_type_at(handle, position))
         .or_else(|| transaction.get_type_at_for_display(handle, position))
         .or_else(|| transaction.operator_type_at(handle, position))?;
 

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -910,6 +910,39 @@ impl<'a> Transaction<'a> {
         None
     }
 
+    fn type_from_match_wildcard_at_impl(
+        &self,
+        handle: &Handle,
+        position: TextSize,
+        for_display: bool,
+    ) -> Option<Type> {
+        let module = self.get_ast(handle)?;
+        let covering_nodes = Ast::locate_node(&module, position);
+        let is_wildcard = covering_nodes
+            .iter()
+            .any(|node| matches!(node, AnyNodeRef::PatternMatchAs(pattern) if pattern.name.is_none() && pattern.pattern.is_none()));
+        if !is_wildcard {
+            return None;
+        }
+        let case_range = covering_nodes.iter().find_map(|node| match node {
+            AnyNodeRef::MatchCase(case) => Some(case.range),
+            _ => None,
+        })?;
+        let subject_range = covering_nodes.iter().find_map(|node| match node {
+            AnyNodeRef::StmtMatch(stmt_match) => Some(stmt_match.subject.range()),
+            _ => None,
+        })?;
+        let key = Key::PatternNarrow(case_range);
+        if self
+            .get_bindings(handle)
+            .is_some_and(|bindings| bindings.is_valid_key(&key))
+        {
+            self.get_type_for_surface(handle, &key, for_display)
+        } else {
+            self.get_type_trace_for_surface(handle, subject_range, for_display)
+        }
+    }
+
     pub(crate) fn identifier_at(
         &self,
         handle: &Handle,
@@ -1238,7 +1271,11 @@ impl<'a> Transaction<'a> {
             context,
         }) = self.identifier_at(handle, position)
         else {
-            return self.type_from_expression_at_impl(handle, position, false, for_display);
+            return self
+                .type_from_match_wildcard_at_impl(handle, position, for_display)
+                .or_else(|| {
+                    self.type_from_expression_at_impl(handle, position, false, for_display)
+                });
         };
         let kind = self.classify_surface(handle, &identifier, &context);
         self.type_from_resolution(

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -826,6 +826,33 @@ def f(x: E) -> None:
 }
 
 #[test]
+fn hover_on_match_wildcard_uses_compound_subject_type() {
+    let code = r#"
+class Box:
+    attr: str
+
+def f(obj: Box, xs: list[int], i: int) -> None:
+    match obj.attr:
+        case _:
+#            ^
+            pass
+    match xs[i]:
+        case _:
+#            ^
+            pass
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert!(
+        report.contains("```python\nstr\n```"),
+        "Expected attribute subject type in hover, got: {report}"
+    );
+    assert!(
+        report.contains("```python\nint\n```"),
+        "Expected subscript subject type in hover, got: {report}"
+    );
+}
+
+#[test]
 fn hover_over_string_with_hash_character() {
     let code = r#"
 x = "hello # world"  # pyrefly: ignore

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -794,6 +794,38 @@ def f() -> None:
 }
 
 #[test]
+fn hover_on_match_wildcard_shows_remaining_type() {
+    let code = r#"
+from enum import StrEnum
+
+class E(StrEnum):
+    x = "1"
+    y = "2"
+
+def f(x: E) -> None:
+    match x:
+        case E.x:
+            pass
+        case _:
+#            ^
+            pass
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], |state, handle, position| {
+        match get_hover(&state.transaction(), handle, position, false) {
+            Some(Hover {
+                contents: HoverContents::Markup(markup),
+                ..
+            }) => markup.value,
+            _ => "None".to_owned(),
+        }
+    });
+    assert!(
+        report.contains("Literal[E.y]"),
+        "Expected hover to show remaining match type, got: {report}"
+    );
+}
+
+#[test]
 fn hover_over_string_with_hash_character() {
     let code = r#"
 x = "hello # world"  # pyrefly: ignore


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3334

hovering case _ resolves the enclosing match case’s Key::PatternNarrow type, falling back to the subject type when there is no prior narrowing.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test