### PR TITLE
Build torch stubs package in GitHub CI

### DIFF
--- a/.github/workflows/build_shape_stubs.yml
+++ b/.github/workflows/build_shape_stubs.yml
@@ -1,0 +1,105 @@
+name: Build shape stubs
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  build-shape-stubs:
+    name: Build shape stubs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Get package version
+        run: |
+          set -euo pipefail
+          RAW_VERSION=$(sed -n -e 's/^VERSION = "\(.*\)"/\1/p' version.bzl)
+          PACKAGE_VERSION=$(python3 scripts/version_helpers.py to-pypi "$RAW_VERSION")
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
+      - name: Build shape extension
+        run: |
+          set -euo pipefail
+          SHAPE_EXT_BUILD_DIR="$RUNNER_TEMP/pyrefly-shape-extensions-build"
+          rm -rf "$SHAPE_EXT_BUILD_DIR" shape-stubs-dist
+          cp -R tensor-shapes/pyrefly-shape-extensions "$SHAPE_EXT_BUILD_DIR"
+          PACKAGE_VERSION="$PACKAGE_VERSION" SHAPE_EXT_BUILD_DIR="$SHAPE_EXT_BUILD_DIR" python3 - <<'PY'
+          from pathlib import Path
+          import os
+
+          path = Path(os.environ["SHAPE_EXT_BUILD_DIR"]) / "pyproject.toml"
+          text = path.read_text()
+          placeholder = 'version = "0.0.0"'
+          if text.count(placeholder) != 1:
+              raise SystemExit(f"Expected exactly one {placeholder!r} in {path}")
+          path.write_text(
+              text.replace(
+                  placeholder,
+                  f'version = "{os.environ["PACKAGE_VERSION"]}"',
+              )
+          )
+          PY
+
+          python -m pip install --upgrade build
+          python -m build --outdir shape-stubs-dist "$SHAPE_EXT_BUILD_DIR"
+      - name: Smoke test shape extension wheel
+        run: |
+          set -euo pipefail
+          python -m venv "$RUNNER_TEMP/shape-ext-wheel-venv"
+          "$RUNNER_TEMP/shape-ext-wheel-venv/bin/pip" install shape-stubs-dist/pyrefly_shape_extensions-*.whl
+          "$RUNNER_TEMP/shape-ext-wheel-venv/bin/python" -c "import shape_extensions"
+      - name: Smoke test shape extension sdist
+        run: |
+          set -euo pipefail
+          python -m venv "$RUNNER_TEMP/shape-ext-sdist-venv"
+          "$RUNNER_TEMP/shape-ext-sdist-venv/bin/pip" install shape-stubs-dist/pyrefly_shape_extensions-*.tar.gz
+          "$RUNNER_TEMP/shape-ext-sdist-venv/bin/python" -c "import shape_extensions"
+      - name: Verify shape extension artifacts
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          import os
+          import tarfile
+          import zipfile
+
+          dist = Path("shape-stubs-dist")
+          wheels = list(dist.glob("pyrefly_shape_extensions-*.whl"))
+          sdists = list(dist.glob("pyrefly_shape_extensions-*.tar.gz"))
+          assert len(wheels) == 1, wheels
+          assert len(sdists) == 1, sdists
+
+          with zipfile.ZipFile(wheels[0]) as z:
+              names = set(z.namelist())
+              assert "shape_extensions/__init__.py" in names
+              assert "shape_extensions/dsl.py" in names
+              assert "shape_extensions/py.typed" in names
+              metadata_name = next(
+                  name
+                  for name in names
+                  if name.endswith(".dist-info/METADATA")
+              )
+              metadata = z.read(metadata_name).decode()
+              assert f"Version: {os.environ['PACKAGE_VERSION']}" in metadata
+
+          with tarfile.open(sdists[0]) as t:
+              names = set(t.getnames())
+              assert any(name.endswith("/shape_extensions/__init__.py") for name in names)
+              assert any(name.endswith("/shape_extensions/dsl.py") for name in names)
+              assert any(name.endswith("/shape_extensions/py.typed") for name in names)
+          PY
+      - name: Upload shape stubs dist
+        uses: actions/upload-artifact@v6
+        with:
+          name: shape-stubs-dist
+          path: shape-stubs-dist

--- a/.github/workflows/build_shape_stubs.yml
+++ b/.github/workflows/build_shape_stubs.yml
@@ -27,31 +27,55 @@ jobs:
           RAW_VERSION=$(sed -n -e 's/^VERSION = "\(.*\)"/\1/p' version.bzl)
           PACKAGE_VERSION=$(python3 scripts/version_helpers.py to-pypi "$RAW_VERSION")
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
-      - name: Build shape extension
+      - name: Build shape stubs packages
         run: |
           set -euo pipefail
           SHAPE_EXT_BUILD_DIR="$RUNNER_TEMP/pyrefly-shape-extensions-build"
-          rm -rf "$SHAPE_EXT_BUILD_DIR" shape-stubs-dist
+          TORCH_STUBS_BUILD_DIR="$RUNNER_TEMP/pyrefly-torch-stubs-build"
+          rm -rf "$SHAPE_EXT_BUILD_DIR" "$TORCH_STUBS_BUILD_DIR" shape-stubs-dist
           cp -R tensor-shapes/pyrefly-shape-extensions "$SHAPE_EXT_BUILD_DIR"
-          PACKAGE_VERSION="$PACKAGE_VERSION" SHAPE_EXT_BUILD_DIR="$SHAPE_EXT_BUILD_DIR" python3 - <<'PY'
+          cp -R tensor-shapes/pyrefly-torch-stubs "$TORCH_STUBS_BUILD_DIR"
+          PACKAGE_VERSION="$PACKAGE_VERSION" SHAPE_EXT_BUILD_DIR="$SHAPE_EXT_BUILD_DIR" TORCH_STUBS_BUILD_DIR="$TORCH_STUBS_BUILD_DIR" python3 - <<'PY'
           from pathlib import Path
           import os
 
-          path = Path(os.environ["SHAPE_EXT_BUILD_DIR"]) / "pyproject.toml"
-          text = path.read_text()
-          placeholder = 'version = "0.0.0"'
-          if text.count(placeholder) != 1:
-              raise SystemExit(f"Expected exactly one {placeholder!r} in {path}")
-          path.write_text(
-              text.replace(
-                  placeholder,
-                  f'version = "{os.environ["PACKAGE_VERSION"]}"',
-              )
+          package_version = os.environ["PACKAGE_VERSION"]
+
+          def replace_once(text: str, old: str, new: str, path: Path) -> str:
+              if text.count(old) != 1:
+                  raise SystemExit(f"Expected exactly one {old!r} in {path}")
+              return text.replace(old, new)
+
+          shape_ext_pyproject = Path(os.environ["SHAPE_EXT_BUILD_DIR"]) / "pyproject.toml"
+          text = shape_ext_pyproject.read_text()
+          text = replace_once(
+              text,
+              'version = "0.0.0"',
+              f'version = "{package_version}"',
+              shape_ext_pyproject,
           )
+          shape_ext_pyproject.write_text(text)
+
+          torch_stubs_pyproject = Path(os.environ["TORCH_STUBS_BUILD_DIR"]) / "pyproject.toml"
+          text = torch_stubs_pyproject.read_text()
+          text = replace_once(
+              text,
+              'version = "0.0.0"',
+              f'version = "{package_version}"',
+              torch_stubs_pyproject,
+          )
+          text = replace_once(
+              text,
+              '"pyrefly-shape-extensions==0.0.0"',
+              f'"pyrefly-shape-extensions=={package_version}"',
+              torch_stubs_pyproject,
+          )
+          torch_stubs_pyproject.write_text(text)
           PY
 
           python -m pip install --upgrade build
           python -m build --outdir shape-stubs-dist "$SHAPE_EXT_BUILD_DIR"
+          python -m build --outdir shape-stubs-dist "$TORCH_STUBS_BUILD_DIR"
       - name: Smoke test shape extension wheel
         run: |
           set -euo pipefail
@@ -64,7 +88,29 @@ jobs:
           python -m venv "$RUNNER_TEMP/shape-ext-sdist-venv"
           "$RUNNER_TEMP/shape-ext-sdist-venv/bin/pip" install shape-stubs-dist/pyrefly_shape_extensions-*.tar.gz
           "$RUNNER_TEMP/shape-ext-sdist-venv/bin/python" -c "import shape_extensions"
-      - name: Verify shape extension artifacts
+      - name: Smoke test torch stubs wheel
+        run: |
+          set -euo pipefail
+          python -m venv "$RUNNER_TEMP/torch-stubs-wheel-venv"
+          "$RUNNER_TEMP/torch-stubs-wheel-venv/bin/pip" install --find-links shape-stubs-dist shape-stubs-dist/pyrefly_torch_stubs-*.whl
+          "$RUNNER_TEMP/torch-stubs-wheel-venv/bin/python" - <<'PY'
+          from importlib.metadata import distribution
+
+          distribution("pyrefly-torch-stubs")
+          distribution("pyrefly-shape-extensions")
+          PY
+      - name: Smoke test torch stubs sdist
+        run: |
+          set -euo pipefail
+          python -m venv "$RUNNER_TEMP/torch-stubs-sdist-venv"
+          "$RUNNER_TEMP/torch-stubs-sdist-venv/bin/pip" install --find-links shape-stubs-dist shape-stubs-dist/pyrefly_torch_stubs-*.tar.gz
+          "$RUNNER_TEMP/torch-stubs-sdist-venv/bin/python" - <<'PY'
+          from importlib.metadata import distribution
+
+          distribution("pyrefly-torch-stubs")
+          distribution("pyrefly-shape-extensions")
+          PY
+      - name: Verify shape stubs artifacts
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -74,12 +120,16 @@ jobs:
           import zipfile
 
           dist = Path("shape-stubs-dist")
-          wheels = list(dist.glob("pyrefly_shape_extensions-*.whl"))
-          sdists = list(dist.glob("pyrefly_shape_extensions-*.tar.gz"))
-          assert len(wheels) == 1, wheels
-          assert len(sdists) == 1, sdists
+          shape_ext_wheels = list(dist.glob("pyrefly_shape_extensions-*.whl"))
+          shape_ext_sdists = list(dist.glob("pyrefly_shape_extensions-*.tar.gz"))
+          torch_stubs_wheels = list(dist.glob("pyrefly_torch_stubs-*.whl"))
+          torch_stubs_sdists = list(dist.glob("pyrefly_torch_stubs-*.tar.gz"))
+          assert len(shape_ext_wheels) == 1, shape_ext_wheels
+          assert len(shape_ext_sdists) == 1, shape_ext_sdists
+          assert len(torch_stubs_wheels) == 1, torch_stubs_wheels
+          assert len(torch_stubs_sdists) == 1, torch_stubs_sdists
 
-          with zipfile.ZipFile(wheels[0]) as z:
+          with zipfile.ZipFile(shape_ext_wheels[0]) as z:
               names = set(z.namelist())
               assert "shape_extensions/__init__.py" in names
               assert "shape_extensions/dsl.py" in names
@@ -92,11 +142,34 @@ jobs:
               metadata = z.read(metadata_name).decode()
               assert f"Version: {os.environ['PACKAGE_VERSION']}" in metadata
 
-          with tarfile.open(sdists[0]) as t:
+          with tarfile.open(shape_ext_sdists[0]) as t:
               names = set(t.getnames())
               assert any(name.endswith("/shape_extensions/__init__.py") for name in names)
               assert any(name.endswith("/shape_extensions/dsl.py") for name in names)
               assert any(name.endswith("/shape_extensions/py.typed") for name in names)
+
+          with zipfile.ZipFile(torch_stubs_wheels[0]) as z:
+              names = set(z.namelist())
+              assert "torch-stubs/__init__.pyi" in names
+              assert "torch-stubs/nn/__init__.pyi" in names
+              assert "torch-stubs/py.typed" in names
+              metadata_name = next(
+                  name
+                  for name in names
+                  if name.endswith(".dist-info/METADATA")
+              )
+              metadata = z.read(metadata_name).decode()
+              assert f"Version: {os.environ['PACKAGE_VERSION']}" in metadata
+              assert (
+                  f"Requires-Dist: pyrefly-shape-extensions=={os.environ['PACKAGE_VERSION']}"
+                  in metadata
+              )
+
+          with tarfile.open(torch_stubs_sdists[0]) as t:
+              names = set(t.getnames())
+              assert any(name.endswith("/torch-stubs/__init__.pyi") for name in names)
+              assert any(name.endswith("/torch-stubs/nn/__init__.pyi") for name in names)
+              assert any(name.endswith("/torch-stubs/py.typed") for name in names)
           PY
       - name: Upload shape stubs dist
         uses: actions/upload-artifact@v6

--- a/.github/workflows/build_stub_packages.yml
+++ b/.github/workflows/build_stub_packages.yml
@@ -1,0 +1,12 @@
+name: Build stub packages
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-shape-stubs:
+    uses: ./.github/workflows/build_shape_stubs.yml

--- a/tensor-shapes/pyrefly-torch-stubs/LICENSE
+++ b/tensor-shapes/pyrefly-torch-stubs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tensor-shapes/pyrefly-torch-stubs/README.md
+++ b/tensor-shapes/pyrefly-torch-stubs/README.md
@@ -1,0 +1,10 @@
+# pyrefly-torch-stubs
+
+PyTorch type stubs with tensor shape information for Pyrefly.
+
+This package is a PEP 561 stub-only distribution. It installs the
+`torch-stubs` stub package so Pyrefly can discover shape-aware stubs for the
+runtime `torch` package without replacing or shadowing PyTorch itself.
+
+The package is versioned in lockstep with Pyrefly and depends on the matching
+`pyrefly-shape-extensions` package.

--- a/tensor-shapes/pyrefly-torch-stubs/pyproject.toml
+++ b/tensor-shapes/pyrefly-torch-stubs/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pyrefly-torch-stubs"
+description = "PyTorch type stubs with tensor-shape tracking, maintained by Pyrefly"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { file = "LICENSE" }
+version = "0.0.0"
+keywords = ["typechecker", "typechecking", "stubs", "torch", "pytorch"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Typing :: Stubs Only",
+]
+dependencies = [
+  "pyrefly-shape-extensions==0.0.0",
+]
+
+[project.urls]
+homepage = "https://pyrefly.org"
+documentation = "https://pyrefly.org/en/docs/"
+
+[tool.hatch.build.targets.wheel]
+only-include = ["torch-stubs"]
+
+[tool.hatch.build.targets.sdist]
+include = ["torch-stubs/", "README.md", "LICENSE"]

--- a/tensor-shapes/pyrefly-torch-stubs/torch-stubs/py.typed
+++ b/tensor-shapes/pyrefly-torch-stubs/torch-stubs/py.typed
@@ -1,0 +1,1 @@
+partial


### PR DESCRIPTION
Summary: Extend the shape-stubs build workflow so `pyrefly-torch-stubs` is built, smoke-installed, and archived alongside `pyrefly-shape-extensions`. The shared `shape-stubs-dist` artifact remains the publish boundary, so the existing publish workflow can upload every package distribution produced by the build job without adding package-specific release logic.

Differential Revision: D110066967


