### PR TITLE
Fix duplicated-word typos in code comments

### DIFF
--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -3125,7 +3125,7 @@ impl Scopes {
                 } else {
                     flow_info.initialized()
                 };
-                // Because class body scopes are dynamic, if we know that the the name is
+                // Because class body scopes are dynamic, if we know that the name is
                 // definitely not initialized in the flow, we should skip it.
                 if is_class && matches!(initialized, InitializedInFlow::No) {
                     return None;
@@ -3569,7 +3569,7 @@ impl<'a> BindingsBuilder<'a> {
             };
             let branch_idx = flow_info.idx();
 
-            // The BranchInfo always sees the branch_idx, which will will be
+            // The BranchInfo always sees the branch_idx, which will be
             // a narrow if one exists, otherwise the value. Each branch may have a
             // termination key, which potentially causes us to ignore it in the Phi based
             // on Never/NoReturn type information.

--- a/pyrefly/lib/query.rs
+++ b/pyrefly/lib/query.rs
@@ -2113,7 +2113,7 @@ impl Query {
                                 names.pop();
                             }
                         } else {
-                            // If we get here, either the name is undefined or it is is defined in `builtins`;
+                            // If we get here, either the name is undefined or it is defined in `builtins`;
                             // either way we can skip it.
                             break;
                         }

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -1343,7 +1343,7 @@ impl<'a> Transaction<'a> {
         // Clean the module if it hasn't been cleaned in this epoch.
         // If try_start_clean returns None, the module is already checked.
         // Once checked, it stays checked for the duration of the epoch.
-        // We check the the epoch optimistically before calling try_start_clean
+        // We check the epoch optimistically before calling try_start_clean
         // to avoid taking the computing mutex.
         if !module_data.state.is_checked(self.data.now)
             && let Some(guard) = module_data.state.try_start_clean(self.data.now)


### PR DESCRIPTION
## Summary
Four code comments contained accidental duplicated words that hurt readability. This corrects them. Comment-only change — no behavioral impact.

| File | Before | After |
|------|--------|-------|
| `pyrefly/lib/binding/scope.rs` | `...if we know that the the name is` | `...the name is` |
| `pyrefly/lib/binding/scope.rs` | `...the branch_idx, which will will be` | `...which will be` |
| `pyrefly/lib/state/state.rs` | `We check the the epoch optimistically` | `We check the epoch optimistically` |
| `pyrefly/lib/query.rs` | `...or it is is defined in \`builtins\`` | `...or it is defined in \`builtins\`` |