### PR TITLE
Fix hover classification for union methods

### DIFF
--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -62,6 +62,7 @@ use crate::state::lsp::FindDefinitionItemWithDocstring;
 use crate::state::lsp::FindPreference;
 use crate::state::lsp::IdentifierContext;
 use crate::state::lsp::IdentifierWithContext;
+use crate::state::lsp::attribute_symbol_kind_from_type;
 use crate::state::state::Transaction;
 use crate::state::state::TransactionHandle;
 
@@ -113,14 +114,7 @@ impl HoverValue {
 
     fn resolve_symbol_kind(&self) -> Option<SymbolKind> {
         match self.kind {
-            Some(SymbolKind::Attribute) if self.type_.is_toplevel_callable() => self
-                .type_
-                .visit_toplevel_func_metadata(&|meta| match &meta.kind {
-                    FunctionKind::Def(func) if func.cls.is_some() => Some(SymbolKind::Method),
-                    _ => Some(SymbolKind::Function),
-                })
-                .unwrap_or(SymbolKind::Method)
-                .into(),
+            Some(SymbolKind::Attribute) => Some(attribute_symbol_kind_from_type(&self.type_)),
             Some(other) => Some(other),
             None => None,
         }

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -30,6 +30,7 @@ use pyrefly_python::module_path::ModuleStyle;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_python::symbol_kind::SymbolKind;
 use pyrefly_python::sys_info::SysInfo;
+use pyrefly_types::callable::FunctionKind;
 use pyrefly_types::type_alias::TypeAliasData;
 use pyrefly_util::gas::Gas;
 use pyrefly_util::lock::Mutex;
@@ -298,6 +299,25 @@ impl DefinitionMetadata {
             DefinitionMetadata::Variable(symbol_kind) => symbol_kind.as_ref().copied(),
             DefinitionMetadata::VariableOrAttribute(symbol_kind) => symbol_kind.as_ref().copied(),
         }
+    }
+}
+
+pub(crate) fn attribute_symbol_kind_from_type(ty: &Type) -> SymbolKind {
+    match ty {
+        ty if ty.is_toplevel_callable() => {
+            let is_method = ty.visit_toplevel_func_metadata(
+                &|meta| matches!(&meta.kind, FunctionKind::Def(func) if func.cls.is_some()),
+            );
+            if is_method {
+                SymbolKind::Method
+            } else {
+                SymbolKind::Function
+            }
+        }
+        Type::ClassDef(_) | Type::Type(_) => SymbolKind::Class,
+        Type::TypeAlias(_) | Type::UntypedAlias(_) => SymbolKind::TypeAlias,
+        Type::Module(_) => SymbolKind::Module,
+        _ => SymbolKind::Attribute,
     }
 }
 

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -304,6 +304,18 @@ impl DefinitionMetadata {
 
 pub(crate) fn attribute_symbol_kind_from_type(ty: &Type) -> SymbolKind {
     match ty {
+        Type::Union(union) => {
+            let mut members = union.members.iter();
+            let Some(first) = members.next() else {
+                return SymbolKind::Attribute;
+            };
+            let kind = attribute_symbol_kind_from_type(first);
+            if members.all(|member| attribute_symbol_kind_from_type(member) == kind) {
+                kind
+            } else {
+                SymbolKind::Attribute
+            }
+        }
         ty if ty.is_toplevel_callable() => {
             let is_method = ty.visit_toplevel_func_metadata(
                 &|meta| matches!(&meta.kind, FunctionKind::Def(func) if func.cls.is_some()),

--- a/pyrefly/lib/state/semantic_tokens.rs
+++ b/pyrefly/lib/state/semantic_tokens.rs
@@ -17,7 +17,6 @@ use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_python::symbol_kind::SymbolKind;
 use pyrefly_python::sys_info::SysInfo;
-use pyrefly_types::callable::FunctionKind;
 use pyrefly_types::literal::Lit;
 use pyrefly_types::types::Type;
 use pyrefly_util::visit::Visit as _;
@@ -38,6 +37,7 @@ use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
 
 use crate::binding::binding::Key;
+use crate::state::lsp::attribute_symbol_kind_from_type;
 
 const SELF_PARAMETER_MODIFIER: SemanticTokenModifier = SemanticTokenModifier::new("selfParameter");
 
@@ -254,9 +254,7 @@ fn range_overlaps(limit_range: Option<TextRange>, range: TextRange) -> bool {
     })
 }
 
-/// Classify an attribute's resolved type into a semantic token kind. For a union,
-/// every member must agree on the same kind; any disagreement (or a member that is
-/// a plain attribute) falls back to `PROPERTY`.
+/// Classify an attribute's resolved type into a semantic token kind.
 fn attribute_semantic_token_type(ty: Type) -> SemanticTokenType {
     match ty {
         Type::Union(union) => {
@@ -275,20 +273,11 @@ fn attribute_semantic_token_type(ty: Type) -> SemanticTokenType {
             }
         }
         Type::Literal(lit) if matches!(lit.value, Lit::Enum(_)) => SemanticTokenType::ENUM_MEMBER,
-        ty if ty.is_toplevel_callable() => {
-            let is_method = ty.visit_toplevel_func_metadata(
-                &|meta| matches!(&meta.kind, FunctionKind::Def(func) if func.cls.is_some()),
-            );
-            if is_method {
-                SemanticTokenType::METHOD
-            } else {
-                SemanticTokenType::FUNCTION
-            }
+        _ => {
+            attribute_symbol_kind_from_type(&ty)
+                .to_lsp_semantic_token_type_with_modifiers()
+                .0
         }
-        Type::ClassDef(_) | Type::Type(_) => SemanticTokenType::CLASS,
-        Type::TypeAlias(_) | Type::UntypedAlias(_) => SemanticTokenType::INTERFACE,
-        Type::Module(_) => SemanticTokenType::NAMESPACE,
-        _ => SemanticTokenType::PROPERTY,
     }
 }
 

--- a/pyrefly/lib/state/semantic_tokens.rs
+++ b/pyrefly/lib/state/semantic_tokens.rs
@@ -254,7 +254,9 @@ fn range_overlaps(limit_range: Option<TextRange>, range: TextRange) -> bool {
     })
 }
 
-/// Classify an attribute's resolved type into a semantic token kind.
+/// Classify an attribute's resolved type into a semantic token kind. For a union,
+/// every member must agree on the same kind; any disagreement (or a member that is
+/// a plain attribute) falls back to `PROPERTY`.
 fn attribute_semantic_token_type(ty: Type) -> SemanticTokenType {
     match ty {
         Type::Union(union) => {

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -88,6 +88,32 @@ xyz = [foo.meth]
 }
 
 #[test]
+fn hover_on_union_method_call_shows_method_signature() {
+    let code = r#"
+class A:
+    def foo(self) -> int:
+        return 0
+
+class B:
+    def foo(self) -> str:
+        return ""
+
+def f(x: A | B) -> None:
+    x.foo()
+#     ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert!(
+        report.contains("(method) foo:"),
+        "Expected union method call hover, got: {report}"
+    );
+    assert!(
+        report.contains("-> int") && report.contains("-> str"),
+        "Expected hover to show both union method return types, got: {report}"
+    );
+}
+
+#[test]
 fn renamed_reexport_shows_original_name() {
     let lib2 = r#"
 def foo() -> None: ...

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -114,6 +114,53 @@ def f(x: A | B) -> None:
 }
 
 #[test]
+fn hover_on_union_class_attribute_shows_class() {
+    let code = r#"
+class C:
+    pass
+
+class A:
+    foo = C
+
+class B:
+    foo = C
+
+def f(x: A | B) -> None:
+    x.foo
+#     ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert!(
+        report.contains("(class) foo:"),
+        "Expected union class attribute hover, got: {report}"
+    );
+}
+
+#[test]
+fn hover_on_mixed_union_attribute_falls_back_to_attribute() {
+    let code = r#"
+class C:
+    pass
+
+class A:
+    def foo(self) -> None:
+        pass
+
+class B:
+    foo = C
+
+def f(x: A | B) -> None:
+    x.foo
+#     ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert!(
+        report.contains("(attribute) foo:"),
+        "Expected mixed union attribute hover, got: {report}"
+    );
+}
+
+#[test]
 fn renamed_reexport_shows_original_name() {
     let lib2 = r#"
 def foo() -> None: ...


### PR DESCRIPTION
# Summary

- We share attribute classification between semantic tokens and hover.
- Changes hover to check each member of a union when choosing the symbol kind for an attribute.
- This fixes cases like `x: A | B; x.foo()`, where hover should show `foo` as a method when both `A.foo` and `B.foo` are methods.

Related PR: https://github.com/facebook/pyrefly/pull/3940 (follow-up PR for related discussion)
Follow-up on https://github.com/facebook/pyrefly/issues/3873

# Test Plan

- ./test.py
- Added failing test + two more to make check intended behavior