### PR TITLE
Add opt-in --remove-unused-type-ignores flag

### DIFF
--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -232,6 +232,7 @@ impl SnippetCheckArgs {
                 suppress_errors: false,
                 expectations: false,
                 remove_unused_ignores: false,
+                remove_unused_type_ignores: false,
             },
         };
         let (status, check_result) =
@@ -419,6 +420,10 @@ struct BehaviorArgs {
     /// Remove unused ignores from the input files.
     #[arg(long)]
     remove_unused_ignores: bool,
+    /// Also remove unused `# type: ignore` comments (off by default; shared with
+    /// other type checkers).
+    #[arg(long)]
+    remove_unused_type_ignores: bool,
 }
 
 fn write_errors_to_file(
@@ -1302,7 +1307,10 @@ impl CheckArgs {
             // TODO: Deprecate this in favor of `pyrefly suppress`
             let collected = loads.collect_errors();
             let unused_errors = loads.collect_unused_ignore_errors(&collected);
-            suppress::remove_unused_ignores(unused_errors);
+            suppress::remove_unused_ignores(
+                unused_errors,
+                self.behavior.remove_unused_type_ignores,
+            );
         }
 
         // We update the baseline file if requested, after reporting any new

--- a/pyrefly/lib/commands/suppress.rs
+++ b/pyrefly/lib/commands/suppress.rs
@@ -39,6 +39,10 @@ pub struct SuppressArgs {
     #[arg(long)]
     remove_unused: bool,
 
+    /// Also remove unused `# type: ignore` comments when removing unused ignores.
+    #[arg(long)]
+    remove_unused_type_ignores: bool,
+
     /// Where to place suppression comments: on the line before the error
     /// (`line-before`, the default) or on the same line (`same-line`).
     #[arg(long, default_value = "line-before")]
@@ -57,9 +61,12 @@ impl SuppressArgs {
                 // Parse errors from JSON file, filtering for UnusedIgnore errors only
                 let json_content = std::fs::read_to_string(json_path)?;
                 let errors: Vec<SerializedError> = serde_json::from_str(&json_content)?;
+                let remove_type_ignores = self.remove_unused_type_ignores;
                 errors
                     .into_iter()
-                    .filter(|e| e.is_unused_ignore())
+                    .filter(|e| {
+                        e.is_unused_ignore() || (remove_type_ignores && e.is_unused_type_ignore())
+                    })
                     .collect()
             } else {
                 // Delegate to `check --remove-unused-ignores`, which calls
@@ -71,18 +78,25 @@ impl SuppressArgs {
                     .clone()
                     .resolve(self.config_override.clone(), wrapper.clone())?;
 
-                let check_args = CheckArgs::parse_from([
+                let mut check_argv = vec![
                     "check",
                     "--output-format",
                     "omit-errors",
                     "--remove-unused-ignores",
-                ]);
+                ];
+                if self.remove_unused_type_ignores {
+                    check_argv.push("--remove-unused-type-ignores");
+                }
+                let check_args = CheckArgs::parse_from(check_argv);
                 check_args.run_once(files_to_check, config_finder, upsell, thread_count)?;
                 return Ok(CommandExitStatus::Success);
             };
 
             // Remove unused ignores (JSON path only)
-            suppress::remove_unused_ignores_from_serialized(unused_errors);
+            suppress::remove_unused_ignores_from_serialized(
+                unused_errors,
+                self.remove_unused_type_ignores,
+            );
         } else {
             // Add suppressions mode (existing behavior)
             let serialized_errors: Vec<SerializedError> = if let Some(json_path) = &self.json {

--- a/pyrefly/lib/error/suppress.rs
+++ b/pyrefly/lib/error/suppress.rs
@@ -98,6 +98,11 @@ impl SerializedError {
         self.name == ErrorKind::UnusedIgnore.to_name()
     }
 
+    /// Returns true if this error is an UnusedTypeIgnore error.
+    pub fn is_unused_type_ignore(&self) -> bool {
+        self.name == ErrorKind::UnusedTypeIgnore.to_name()
+    }
+
     /// Returns true if this error is a directive (e.g. reveal_type) that
     /// should never be suppressed.
     pub fn is_directive(&self) -> bool {
@@ -555,18 +560,21 @@ fn update_ignore_comment_with_used_codes(
 /// - "Unused `# pyrefly: ignore` comment" -> remove entire comment
 /// - "Unused `# pyrefly: ignore` comment for code(s): X, Y" -> remove entire comment
 /// - "Unused error code(s) in `# pyrefly: ignore`: X, Y" -> remove only those codes
-pub fn remove_unused_ignores(unused_ignore_errors: Vec<Error>) -> usize {
+pub fn remove_unused_ignores(unused_ignore_errors: Vec<Error>, remove_type_ignores: bool) -> usize {
     let serialized: Vec<SerializedError> = unused_ignore_errors
         .iter()
         .filter_map(SerializedError::from_error)
         .collect();
-    remove_unused_ignores_from_serialized(serialized)
+    remove_unused_ignores_from_serialized(serialized, remove_type_ignores)
 }
 
 /// Removes unused ignore comments from source files using SerializedError.
 /// This is similar to remove_unused_ignores but works with SerializedError instead of Error,
 /// allowing it to be used with errors parsed from JSON.
-pub fn remove_unused_ignores_from_serialized(unused_ignore_errors: Vec<SerializedError>) -> usize {
+pub fn remove_unused_ignores_from_serialized(
+    unused_ignore_errors: Vec<SerializedError>,
+    remove_type_ignores: bool,
+) -> usize {
     if unused_ignore_errors.is_empty() {
         return 0;
     }
@@ -608,6 +616,8 @@ pub fn remove_unused_ignores_from_serialized(unused_ignore_errors: Vec<Serialize
                             // Pyre messages are "Unused pyre-fixme comment".
                             if msg.starts_with("Unused `# pyrefly: ignore` comment")
                                 || msg.starts_with("Unused pyre-fixme comment")
+                                || (remove_type_ignores
+                                    && msg.starts_with("Unused `# type: ignore` comment"))
                             {
                                 // Remove entire comment (blanket unused or all codes unused)
                                 let code_part = &line[..comment_start];
@@ -734,7 +744,7 @@ mod tests {
         let (errors, tdir) = get_errors(before);
         let collected = errors.collect_errors();
         let unused_errors = errors.collect_unused_ignore_errors(&collected);
-        let removals = suppress::remove_unused_ignores(unused_errors);
+        let removals = suppress::remove_unused_ignores(unused_errors, false);
         let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
         assert_eq!(after, got_file);
         assert_eq!(removals, expected_removals);
@@ -751,7 +761,7 @@ mod tests {
         let (errors, tdir) = get_errors(before);
         let collected = errors.collect_errors();
         let unused_errors = errors.collect_unused_ignore_errors(&collected);
-        let removals = suppress::remove_unused_ignores(unused_errors);
+        let removals = suppress::remove_unused_ignores(unused_errors, false);
         let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
         assert_eq!(after, got_file);
         assert_eq!(removals, expected_removals);
@@ -1437,9 +1447,25 @@ def f() -> int:
     // Helper function to test remove_unused_ignores_from_serialized
     fn assert_remove_ignores_from_serialized(
         file_content: &str,
+        serialized_errors: Vec<SerializedError>,
+        expected_content: &str,
+        expected_removals: usize,
+    ) {
+        assert_remove_ignores_from_serialized_with_flag(
+            file_content,
+            serialized_errors,
+            expected_content,
+            expected_removals,
+            false,
+        );
+    }
+
+    fn assert_remove_ignores_from_serialized_with_flag(
+        file_content: &str,
         mut serialized_errors: Vec<SerializedError>,
         expected_content: &str,
         expected_removals: usize,
+        remove_type_ignores: bool,
     ) {
         let tdir = tempfile::tempdir().unwrap();
         let path = get_path(&tdir);
@@ -1450,7 +1476,8 @@ def f() -> int:
             error.path = path.clone();
         }
 
-        let removals = suppress::remove_unused_ignores_from_serialized(serialized_errors);
+        let removals =
+            suppress::remove_unused_ignores_from_serialized(serialized_errors, remove_type_ignores);
 
         let got_file = fs_anyhow::read_to_string(&path).unwrap();
         assert_eq!(expected_content, got_file);
@@ -1560,7 +1587,7 @@ def g() -> str:
             },
         ];
 
-        let removals = suppress::remove_unused_ignores_from_serialized(errors);
+        let removals = suppress::remove_unused_ignores_from_serialized(errors, false);
 
         assert_eq!(fs_anyhow::read_to_string(&path1).unwrap(), "x = 1\n");
         assert_eq!(fs_anyhow::read_to_string(&path2).unwrap(), "y = 2\n");
@@ -1570,7 +1597,7 @@ def g() -> str:
     #[test]
     fn test_remove_unused_ignores_from_serialized_empty_list() {
         let errors: Vec<SerializedError> = vec![];
-        let removals = suppress::remove_unused_ignores_from_serialized(errors);
+        let removals = suppress::remove_unused_ignores_from_serialized(errors, false);
         assert_eq!(removals, 0);
     }
 
@@ -2074,10 +2101,89 @@ build_query(
             name: "unused-ignore".to_owned(),
             message: "Unused pyre-fixme comment".to_owned(),
         }];
-        let removals = suppress::remove_unused_ignores_from_serialized(errors);
+        let removals = suppress::remove_unused_ignores_from_serialized(errors, false);
         let got = fs_anyhow::read_to_string(&path).unwrap();
         assert_eq!(want, got);
         assert_eq!(removals, 1);
+    }
+
+    #[test]
+    fn test_remove_unused_type_ignore_inline() {
+        let input = "x = 1  # type: ignore\n";
+        let want = "x = 1\n";
+        let errors = vec![SerializedError {
+            path: PathBuf::from("test.py"),
+            line: 0,
+            name: "unused-type-ignore".to_owned(),
+            message: "Unused `# type: ignore` comment".to_owned(),
+        }];
+        assert_remove_ignores_from_serialized_with_flag(input, errors, want, 1, true);
+    }
+
+    #[test]
+    fn test_remove_unused_type_ignore_preserved_without_flag() {
+        // R1: without the flag, # type: ignore must never be removed
+        let input = "x = 1  # type: ignore\n";
+        let errors = vec![SerializedError {
+            path: PathBuf::from("test.py"),
+            line: 0,
+            name: "unused-type-ignore".to_owned(),
+            message: "Unused `# type: ignore` comment".to_owned(),
+        }];
+        assert_remove_ignores_from_serialized_with_flag(input, errors, input, 0, false);
+    }
+
+    #[test]
+    fn test_remove_unused_type_ignore_with_code() {
+        // R7: unused # type: ignore[code] is removed whole
+        let input = "x = 1  # type: ignore[attr-defined]\n";
+        let want = "x = 1\n";
+        let errors = vec![SerializedError {
+            path: PathBuf::from("test.py"),
+            line: 0,
+            name: "unused-type-ignore".to_owned(),
+            message: "Unused `# type: ignore` comment".to_owned(),
+        }];
+        assert_remove_ignores_from_serialized_with_flag(input, errors, want, 1, true);
+    }
+
+    #[test]
+    fn test_remove_both_unused_type_and_pyrefly_ignores() {
+        // Both pyrefly:ignore and type:ignore on the same line, both unused.
+        // With flag=true, replace_all removes all matching patterns on the line.
+        // Note: line_errors holds one error per line (last-insert wins), so
+        // the type:ignore error drives removal; replace_all clears both patterns.
+        let input = "x = 1  # pyrefly: ignore  # type: ignore\n";
+        let want = "x = 1\n";
+        let errors = vec![
+            SerializedError {
+                path: PathBuf::from("test.py"),
+                line: 0,
+                name: "unused-ignore".to_owned(),
+                message: "Unused `# pyrefly: ignore` comment".to_owned(),
+            },
+            SerializedError {
+                path: PathBuf::from("test.py"),
+                line: 0,
+                name: "unused-type-ignore".to_owned(),
+                message: "Unused `# type: ignore` comment".to_owned(),
+            },
+        ];
+        assert_remove_ignores_from_serialized_with_flag(input, errors, want, 1, true);
+    }
+
+    #[test]
+    fn test_pyrefly_ignore_removed_with_type_ignore_flag_set() {
+        // R5: existing pyrefly:ignore removal is unaffected regardless of the type-ignore flag.
+        let input = "x = 1  # pyrefly: ignore\n";
+        let want = "x = 1\n";
+        let errors = vec![SerializedError {
+            path: PathBuf::from("test.py"),
+            line: 0,
+            name: "unused-ignore".to_owned(),
+            message: "Unused `# pyrefly: ignore` comment".to_owned(),
+        }];
+        assert_remove_ignores_from_serialized_with_flag(input, errors, want, 1, true);
     }
 
     #[test]

--- a/website/docs/error-suppressions.mdx
+++ b/website/docs/error-suppressions.mdx
@@ -150,3 +150,22 @@ If your project uses other tools that place suppression comments on the line bef
 :::note
 `pyrefly suppress` is equivalent to `pyrefly check --suppress-errors`, and `pyrefly suppress --remove-unused` is equivalent to `pyrefly check --remove-unused-ignores`.
 :::
+
+:::note
+By default, `pyrefly suppress --remove-unused` (and `pyrefly check --remove-unused-ignores`) only
+removes unused `# pyrefly: ignore` and `# pyre-...` comments. It never touches `# type: ignore`
+comments, because those are shared with other type checkers and removing them by default could break
+other tools in your project.
+
+To also remove unused `# type: ignore` comments, pass `--remove-unused-type-ignores` alongside
+the removal flag:
+
+```
+pyrefly suppress --remove-unused --remove-unused-type-ignores
+# or
+pyrefly check --remove-unused-ignores --remove-unused-type-ignores
+```
+
+Only **unused** `# type: ignore` comments are removed — if the comment is actively suppressing a
+real error, it is left in place.
+:::


### PR DESCRIPTION
## Summary
`pyrefly suppress --remove-unused` and `pyrefly check --remove-unused-ignores` remove unused `# pyrefly: ignore` comments, but they leave unused `# type: ignore` comments behind — even though Pyrefly honors `# type: ignore` and already detects when one is unused. After cleaning up suppressions, any stale `# type: ignore` comments have to be found and deleted by hand, which is painful in codebases that adopted `# type: ignore` (e.g. coming from another type checker).

This adds an opt-in `--remove-unused-type-ignores` flag (on both `check` and `suppress`) that additionally removes unused `# type: ignore` comments, working just like the existing `--remove-unused` / `--remove-unused-ignores` flags. It is **off by default**, so `# type: ignore` comments — which are shared with other type checkers — are never touched unless the flag is explicitly passed.

The change threads a `remove_type_ignores` boolean into the existing removal path and adds a single gated arm that handles the `UnusedTypeIgnore` errors Pyrefly already produces; unused detection is unchanged.

```
$ pyrefly check --remove-unused-ignores --remove-unused-type-ignores repro.py
# removes both "# pyrefly: ignore" and unused "# type: ignore"
$ pyrefly check --remove-unused-ignores repro.py
# removes only "# pyrefly: ignore" (default, unchanged)
```

Fixes #3984.

## Test plan
- `cargo build -p pyrefly`
- `cargo test -p pyrefly remove_unused` — 23 passed, including new `test_remove_unused_type_ignore_inline` / `test_remove_unused_type_ignore_with_code` and a regression test asserting the comment is kept when the flag is absent.
- `cargo clippy -p pyrefly --tests`
- Manual repro from the issue: with the flag both comments are removed; without it only the pyrefly one is removed.
