### PR TITLE
fix [pyrefly][completions][auto-import] rank based on deprecated aliases #2345

### DIFF
--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -49,6 +49,7 @@ use crate::state::lsp::IdentifierContext;
 use crate::state::lsp::IdentifierWithContext;
 use crate::state::lsp::ImportFormat;
 use crate::state::lsp::MIN_CHARACTERS_TYPED_AUTOIMPORT;
+use crate::state::lsp::is_deprecated_stdlib_alias;
 use crate::state::state::Transaction;
 use crate::types::callable::Param;
 use crate::types::types::Type;
@@ -622,6 +623,12 @@ impl Transaction<'_> {
                     )
                 };
                 let auto_import_label_detail = format!(" (import {imported_module})");
+                let is_deprecated = export.deprecation.is_some()
+                    || is_deprecated_stdlib_alias(
+                        handle.sys_info().version(),
+                        &imported_module,
+                        &name,
+                    );
 
                 completions.push(RankedCompletion {
                     item: CompletionItem {
@@ -639,7 +646,7 @@ impl Transaction<'_> {
                                 description: Some(module_description),
                             },
                         ),
-                        tags: if export.deprecation.is_some() {
+                        tags: if is_deprecated {
                             Some(vec![CompletionItemTag::DEPRECATED])
                         } else {
                             None

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -29,6 +29,7 @@ use pyrefly_python::module_path::ModulePathDetails;
 use pyrefly_python::module_path::ModuleStyle;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_python::symbol_kind::SymbolKind;
+use pyrefly_python::sys_info::PythonVersion;
 use pyrefly_python::sys_info::SysInfo;
 use pyrefly_types::type_alias::TypeAliasData;
 use pyrefly_util::gas::Gas;
@@ -99,6 +100,61 @@ mod quick_fixes;
 
 pub(crate) use self::quick_fixes::move_module::MoveModuleMemberContext;
 pub(crate) use self::quick_fixes::types::LocalRefactorCodeAction;
+
+pub(crate) fn is_deprecated_stdlib_alias(
+    python_version: PythonVersion,
+    module_name: &str,
+    name: &str,
+) -> bool {
+    if module_name != "typing" {
+        return false;
+    }
+    if python_version.at_least(3, 10) && matches!(name, "Optional" | "Union") {
+        return true;
+    }
+    python_version.at_least(3, 9)
+        && matches!(
+            name,
+            "AbstractSet"
+                | "AsyncContextManager"
+                | "AsyncGenerator"
+                | "AsyncIterable"
+                | "AsyncIterator"
+                | "Awaitable"
+                | "ByteString"
+                | "Callable"
+                | "ChainMap"
+                | "Collection"
+                | "Container"
+                | "ContextManager"
+                | "Coroutine"
+                | "Counter"
+                | "DefaultDict"
+                | "Deque"
+                | "Dict"
+                | "FrozenSet"
+                | "Generator"
+                | "ItemsView"
+                | "Iterable"
+                | "Iterator"
+                | "KeysView"
+                | "List"
+                | "Mapping"
+                | "MappingView"
+                | "Match"
+                | "MutableMapping"
+                | "MutableSequence"
+                | "MutableSet"
+                | "OrderedDict"
+                | "Pattern"
+                | "Reversible"
+                | "Sequence"
+                | "Set"
+                | "Tuple"
+                | "Type"
+                | "ValuesView"
+        )
+}
 
 #[derive(Debug)]
 pub(crate) enum CalleeKind {
@@ -3120,7 +3176,12 @@ impl<'a> Transaction<'a> {
             import_format,
         );
         let range = import_edit.range;
-        let is_deprecated = export.deprecation.is_some();
+        let is_deprecated = export.deprecation.is_some()
+            || is_deprecated_stdlib_alias(
+                handle.sys_info().version(),
+                &import_edit.module_name,
+                unknown_name,
+            );
         let title = format!(
             "Insert import: `{}`{}",
             import_edit.display_text,
@@ -4032,7 +4093,7 @@ impl<'a> Transaction<'a> {
     /// - Returns true if both modules should be shown in auto-import suggestions.
     /// - Handles stdlib patterns where a public module (`io`) re-exports from a
     ///   private implementation module (`_io`).
-    fn should_include_reexport(original: &Handle, canonical: &Handle) -> bool {
+    fn should_include_reexport(original: &Handle, canonical: &Handle, name: &Name) -> bool {
         let canonical_module = canonical.module();
         let original_module = original.module();
         let canonical_components = canonical_module.components();
@@ -4068,6 +4129,16 @@ impl<'a> Transaction<'a> {
                 return true;
             }
         }
+        if canonical_module.as_str() == "typing"
+            && original_module.as_str() == "collections.abc"
+            && is_deprecated_stdlib_alias(
+                original.sys_info().version(),
+                canonical_module.as_str(),
+                name.as_str(),
+            )
+        {
+            return true;
+        }
         false
     }
 
@@ -4086,7 +4157,7 @@ impl<'a> Transaction<'a> {
                         {
                             let mut results = vec![(canonical_handle.dupe(), export.clone())];
                             if canonical_handle != *handle
-                                && (Self::should_include_reexport(handle, &canonical_handle)
+                                && (Self::should_include_reexport(handle, &canonical_handle, &name)
                                     || (exports_data.is_explicit_reexport(&name)
                                         && Self::allows_explicit_reexport(handle)))
                             {
@@ -4132,7 +4203,7 @@ impl<'a> Transaction<'a> {
                             export.clone(),
                         ));
                         if canonical_handle != *handle
-                            && (Self::should_include_reexport(handle, &canonical_handle)
+                            && (Self::should_include_reexport(handle, &canonical_handle, name)
                                 || (exports_data.is_explicit_reexport(name)
                                     && Self::allows_explicit_reexport(handle)))
                         {

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -7,14 +7,17 @@
 
 use lsp_types::CompletionItem;
 use lsp_types::CompletionItemKind;
+use lsp_types::CompletionItemTag;
 use pretty_assertions::assert_eq;
 use pyrefly_build::handle::Handle;
+use pyrefly_python::sys_info::PythonVersion;
 use ruff_text_size::TextSize;
 
 use crate::state::lsp::ImportFormat;
 use crate::state::require::Require;
 use crate::state::state::State;
 use crate::state::state::Transaction;
+use crate::test::util::TestEnv;
 use crate::test::util::extract_cursors_for_test;
 use crate::test::util::get_batched_lsp_operations_report;
 use crate::test::util::get_batched_lsp_operations_report_allow_error;
@@ -2257,6 +2260,57 @@ Completion Results:
 "#
         .trim(),
         report.trim(),
+    );
+}
+
+#[test]
+fn autoimport_demotes_deprecated_typing_alias() {
+    let code = r#"
+T = Iterable
+#          ^
+"#;
+    let mut env = TestEnv::new_with_version(PythonVersion::new(3, 9, 0))
+        .with_default_require_level(Require::Exports);
+    env.add("main", code);
+    let (state, handle_for) = env.to_state();
+    let handle = handle_for("main");
+    let position = extract_cursors_for_test(code)[0];
+    let completions =
+        state
+            .transaction()
+            .completion(&handle, position, ImportFormat::Absolute, true, None);
+    let typing_index = completions
+        .iter()
+        .position(|item| {
+            item.label == "Iterable"
+                && item
+                    .detail
+                    .as_ref()
+                    .is_some_and(|detail| detail.contains("from typing import Iterable"))
+        })
+        .expect("expected typing.Iterable auto-import completion");
+    let collections_index = completions
+        .iter()
+        .position(|item| {
+            item.label == "Iterable"
+                && item
+                    .detail
+                    .as_ref()
+                    .is_some_and(|detail| detail.contains("from collections.abc import Iterable"))
+        })
+        .expect("expected collections.abc.Iterable auto-import completion");
+    let typing_tags = completions[typing_index]
+        .tags
+        .as_deref()
+        .unwrap_or_default();
+
+    assert!(
+        typing_tags.contains(&CompletionItemTag::DEPRECATED),
+        "expected typing.Iterable to be tagged deprecated"
+    );
+    assert!(
+        collections_index < typing_index,
+        "expected collections.abc.Iterable to sort before deprecated typing.Iterable"
     );
 }
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2345

Added version-gated deprecated stdlib alias detection for typing aliases, auto-import completions now tag those aliases deprecated, so ranking demotes them.

collections.abc reexports from bundled stubs are now surfaced for deprecated typing aliases.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test