### PR TITLE
Remove dangling pyrefly_wasm/rust-toolchain symlink

### DIFF
--- a/pyrefly_wasm/rust-toolchain
+++ b/pyrefly_wasm/rust-toolchain
@@ -1,1 +1,0 @@
-../pyrefly/rust-toolchain


### PR DESCRIPTION
Summary: The symlink pyrefly_wasm/rust-toolchain pointed at ../pyrefly/rust-toolchain, whose target was deleted as redundant in D105227815, leaving the symlink dangling. Swatinem/rust-cache globs for rust-toolchain files and crashes with ENOENT when it follows the broken link, breaking the CodSpeed (and eventually all rust-cache) CI jobs on the GitHub mirror. rustup already resolves the toolchain by walking up to the repo-root rust-toolchain.toml, so the symlink is redundant; removing it fixes the cache step with no loss of toolchain pinning for the wasm build.

Differential Revision: D110230704
