### PR TITLE
Treat inherited-annotated attributes as typed in `pyrefly coverage`

### DIFF
--- a/pyrefly/lib/commands/coverage/collect.rs
+++ b/pyrefly/lib/commands/coverage/collect.rs
@@ -23,7 +23,7 @@ use pyrefly_python::module_path::ModuleStyle;
 use pyrefly_python::nesting_context::NestingContext;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_types::callable::PropertyRole;
-use pyrefly_types::class::ClassDefIndex;
+use pyrefly_types::class::Class;
 use pyrefly_types::class::ClassType;
 use pyrefly_types::types::Type;
 use pyrefly_util::forgetter::Forgetter;
@@ -578,6 +578,50 @@ fn parse_variables(
     variables
 }
 
+/// The MRO of `class`, or `Cyclic` if unresolved.
+fn class_mro(bindings: &Bindings, answers: &Answers, class: &Class) -> Arc<ClassMro> {
+    answers
+        .get_idx(bindings.key_to_idx(&KeyClassMro(class.index())))
+        .unwrap_or_else(|| Arc::new(ClassMro::Cyclic))
+}
+
+/// Slots for `field_name` from the nearest base class annotating it in `class_idx`'s MRO (gh-3997).
+fn inherited_annotation_slots(
+    bindings: &Bindings,
+    answers: &Answers,
+    transaction: &Transaction,
+    handle: &Handle,
+    class_idx: Idx<KeyClass>,
+    field_name: &Name,
+) -> Option<SlotCounts> {
+    let class = answers.get_idx(class_idx).and_then(|r| r.0.clone())?;
+    class_mro(bindings, answers, &class)
+        .ancestors_no_object()
+        .iter()
+        .find_map(|ancestor| {
+            let cls = ancestor.class_object();
+            let h = Handle::new(
+                cls.module_name(),
+                cls.module_path().dupe(),
+                handle.sys_info().dupe(),
+            );
+            let b = transaction.get_bindings(&h)?;
+            let idx = b.key_to_idx_hashed_opt(Hashed::new(&KeyClassField(
+                cls.index(),
+                field_name.clone(),
+            )))?;
+            let annot = match &b.get(idx).definition {
+                ClassFieldDefinition::DeclaredByAnnotation { annotation, .. } => Some(*annotation),
+                ClassFieldDefinition::DefinedInMethod { annotation, .. }
+                | ClassFieldDefinition::AssignedInBody { annotation, .. } => *annotation,
+                _ => None,
+            }?;
+            let m = transaction.get_module_info(&h)?;
+            let a = transaction.get_answers(&h)?;
+            Some(classify_annotation(&m, &b, &a, Some(annot)).1)
+        })
+}
+
 /// Extract instance attributes assigned in `__init__`/`__new__`/`__post_init__`,
 /// plus schema class body fields (dataclass, enum, TypedDict, NamedTuple).
 ///
@@ -594,6 +638,8 @@ fn parse_instance_attrs(
     module: &Module,
     bindings: &Bindings,
     answers: &Answers,
+    transaction: &Transaction,
+    handle: &Handle,
     tco_classes: &SmallSet<Idx<KeyClass>>,
 ) -> Vec<Variable> {
     let mut attrs = Vec::new();
@@ -634,7 +680,20 @@ fn parse_instance_attrs(
                 if !method.recognized_attribute_defining_method {
                     continue;
                 }
-                classify_annotation(module, bindings, answers, *annotation)
+                if annotation.is_none()
+                    && let Some(slots) = inherited_annotation_slots(
+                        bindings,
+                        answers,
+                        transaction,
+                        handle,
+                        field.class_idx,
+                        &field.name,
+                    )
+                {
+                    (None, slots)
+                } else {
+                    classify_annotation(module, bindings, answers, *annotation)
+                }
             }
             // Schema class fields are always IMPLICIT regardless of whether they're
             // also initialized in a recognized method — the class definition governs
@@ -1191,9 +1250,7 @@ fn parse_classes(
             None => continue,
         };
         let class_name = class_fqn(module, parent, name);
-        let mro = answers
-            .get_idx(bindings.key_to_idx(&KeyClassMro(ClassDefIndex(class_type.index().0))))
-            .unwrap_or_else(|| Arc::new(ClassMro::Cyclic));
+        let mro = class_mro(bindings, answers, &class_type);
         // Check methods defined directly on this class
         let mut incomplete_attributes = Vec::new();
         for &undecorated_idx in methods_by_class.get(&class_idx).into_iter().flatten() {
@@ -1286,9 +1343,7 @@ fn collect_class_members(
 
         let fqname = class_fqn(module, &binding.parent, &binding.def.name);
 
-        let mro = answers
-            .get_idx(bindings.key_to_idx(&KeyClassMro(cls.index())))
-            .unwrap_or_else(|| Arc::new(ClassMro::Cyclic));
+        let mro = class_mro(bindings, answers, &cls);
         let ancestors = mro.ancestors_no_object();
         for obj in std::iter::once(&cls).chain(ancestors.iter().map(ClassType::class_object)) {
             if obj.module_name().as_str() == "builtins" {
@@ -1377,6 +1432,8 @@ impl ModuleSymbols {
             &module,
             &bindings,
             &answers,
+            transaction,
+            handle,
             &tco_classes,
         ));
         let suppressions = parse_suppressions(&module);

--- a/pyrefly/lib/commands/coverage/collect.rs
+++ b/pyrefly/lib/commands/coverage/collect.rs
@@ -586,6 +586,7 @@ fn class_mro(bindings: &Bindings, answers: &Answers, class: &Class) -> Arc<Class
 }
 
 /// Slots for `field_name` from the nearest base class annotating it in `class_idx`'s MRO (gh-3997).
+/// Nearest annotating base wins; unannotated bases don't count.
 fn inherited_annotation_slots(
     bindings: &Bindings,
     answers: &Answers,

--- a/pyrefly/lib/test/coverage/test_files/inherited_attrs.expected.json
+++ b/pyrefly/lib/test/coverage/test_files/inherited_attrs.expected.json
@@ -4,17 +4,24 @@
   "names": [
     "test.Base.x",
     "test.Base.y",
+    "test.Base.a",
     "test.Child.z",
     "test.OverridingChild.x",
+    "test.OverridingChild.a",
     "test.OverridingChild.w",
+    "test.AttrChild.attrs",
+    "test.AttrChild.extra",
     "test.Base.__init__",
     "test.Child.__init__",
     "test.OverridingChild.__init__",
+    "test.AttrChild.__init__",
+    "test.AttrBase",
+    "test.AttrChild",
     "test.Base",
     "test.Child",
     "test.OverridingChild"
   ],
-  "line_count": 28,
+  "line_count": 47,
   "symbol_reports": [
     {
       "kind": "attr",
@@ -24,7 +31,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 13,
+        "line": 17,
         "column": 14
       }
     },
@@ -36,7 +43,19 @@
       "n_any": 0,
       "n_untyped": 1,
       "location": {
-        "line": 14,
+        "line": 18,
+        "column": 14
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.Base.a",
+      "n_typable": 1,
+      "n_typed": 0,
+      "n_any": 1,
+      "n_untyped": 0,
+      "location": {
+        "line": 19,
         "column": 14
       }
     },
@@ -48,7 +67,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 20,
+        "line": 25,
         "column": 14
       }
     },
@@ -56,11 +75,23 @@
       "kind": "attr",
       "name": "test.OverridingChild.x",
       "n_typable": 1,
-      "n_typed": 0,
+      "n_typed": 1,
       "n_any": 0,
-      "n_untyped": 1,
+      "n_untyped": 0,
       "location": {
-        "line": 26,
+        "line": 31,
+        "column": 14
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.OverridingChild.a",
+      "n_typable": 1,
+      "n_typed": 0,
+      "n_any": 1,
+      "n_untyped": 0,
+      "location": {
+        "line": 32,
         "column": 14
       }
     },
@@ -72,7 +103,31 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 27,
+        "line": 33,
+        "column": 14
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.AttrChild.attrs",
+      "n_typable": 1,
+      "n_typed": 1,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 45,
+        "column": 14
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.AttrChild.extra",
+      "n_typable": 1,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 1,
+      "location": {
+        "line": 46,
         "column": 14
       }
     },
@@ -84,7 +139,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 12,
+        "line": 16,
         "column": 5
       }
     },
@@ -96,7 +151,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 18,
+        "line": 23,
         "column": 5
       }
     },
@@ -108,8 +163,44 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 25,
+        "line": 30,
         "column": 5
+      }
+    },
+    {
+      "kind": "function",
+      "name": "test.AttrChild.__init__",
+      "n_typable": 1,
+      "n_typed": 1,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 44,
+        "column": 5
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.AttrBase",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 39,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test.AttrChild",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 43,
+        "column": 1
       }
     },
     {
@@ -120,7 +211,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 11,
+        "line": 15,
         "column": 1
       }
     },
@@ -132,7 +223,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 17,
+        "line": 22,
         "column": 1
       }
     },
@@ -144,24 +235,24 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 24,
+        "line": 29,
         "column": 1
       }
     }
   ],
   "type_ignores": [],
-  "n_typable": 5,
-  "n_typed": 3,
-  "n_any": 0,
+  "n_typable": 10,
+  "n_typed": 6,
+  "n_any": 2,
   "n_untyped": 2,
-  "coverage": 60.0,
+  "coverage": 80.0,
   "strict_coverage": 60.0,
   "n_functions": 0,
-  "n_methods": 3,
+  "n_methods": 4,
   "n_function_params": 0,
-  "n_method_params": 0,
-  "n_classes": 3,
-  "n_attrs": 5,
+  "n_method_params": 1,
+  "n_classes": 5,
+  "n_attrs": 9,
   "n_properties": 0,
   "n_type_ignores": 0
 }

--- a/pyrefly/lib/test/coverage/test_files/inherited_attrs.py
+++ b/pyrefly/lib/test/coverage/test_files/inherited_attrs.py
@@ -6,12 +6,17 @@
 # Tests that inherited attrs are NOT double-counted.
 # If class B(A) inherits field `x` from A, `x` should only appear
 # under A's report, not under B as well.
+#
+# gh-3997: a reassigned attr inherits its base annotation's type quality.
+
+from typing import Any
 
 
 class Base:
     def __init__(self):
         self.x: int = 1
         self.y = "hello"
+        self.a: Any = None
 
 
 class Child(Base):
@@ -20,8 +25,22 @@ class Child(Base):
         self.z: str = "child-only"
 
 
-# Child re-assigns parent field without super().__init__()
+# Reassigns inherited fields unannotated: `x` typed (Base.x: int), `a` any (Base.a: Any).
 class OverridingChild(Base):
     def __init__(self):
         self.x = 42
+        self.a = object()
         self.w: float = 3.14
+
+
+# gh-3997's exact shape: `attrs` is annotated only in the base class body (so it is
+# not reported on the base) yet the subclass reassignment inherits its type, while
+# `extra` is annotated nowhere and stays untyped.
+class AttrBase:
+    attrs: dict[str, Any]
+
+
+class AttrChild(AttrBase):
+    def __init__(self, attrs: dict[str, Any]) -> None:
+        self.attrs = attrs
+        self.extra = attrs


### PR DESCRIPTION
# Summary

A method-assigned attribute without its own annotation is no longer reported as untyped by `pyrefly coverage {check, report}` when a base class declares it:

```py
class P_AttrList:
    attrs: dict[str, Any]

class DefaultStatement(P_AttrList):
    def __init__(self, attrs: dict[str, Any]) -> None:
        self.attrs = attrs  # was: untyped
```

It takes the type quality of the nearest base annotation, so `dict[str, Any]` is typed and a bare `Any` is `any`.

Fixes #3997

# Test Plan

Regression tests added, and verified that `check` / `report` are still in sync