### PR TITLE
fix feature: Track relationships between narrows of different variables #997

### DIFF
--- a/pyrefly/benches/micro.rs
+++ b/pyrefly/benches/micro.rs
@@ -309,7 +309,7 @@ fn overload_resolution(overloads: usize, calls: usize) -> String {
     }
     src.push_str("def choose(x): return x\n");
     for i in 0..calls {
-        let _ = write!(src, "r{i} = choose({})\n", ARGS[i % ARGS.len()]);
+        let _ = writeln!(src, "r{i} = choose({})", ARGS[i % ARGS.len()]);
     }
     src
 }

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -2101,6 +2101,7 @@ impl<'a> BindingsBuilder<'a> {
                 self.scopes.narrow_in_current_flow(name, narrowed_idx);
             }
         }
+        self.scopes.apply_conditional_flow_facts(narrow_ops);
     }
 
     pub fn bind_lambda_param(&mut self, name: &Identifier, owner: Option<Idx<Key>>) {

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -2221,6 +2221,7 @@ impl<'a> BindingsBuilder<'a> {
                 self.scopes.narrow_in_current_flow(name, narrowed_idx);
             }
         }
+        self.scopes.apply_conditional_flow_facts(narrow_ops);
     }
 
     pub fn bind_lambda_param(&mut self, name: &Identifier, kind: LambdaKind, usage: &Usage) {

--- a/pyrefly/lib/binding/narrow.rs
+++ b/pyrefly/lib/binding/narrow.rs
@@ -54,7 +54,7 @@ assert_words!(NarrowOp, 12);
 
 /// Indicates where an isinstance-style narrow operation originated from.
 /// This determines whether validation needs to happen during narrowing.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NarrowSource {
     /// From an isinstance() call - validation already happened in special_calls.rs.
     Call,
@@ -62,7 +62,7 @@ pub enum NarrowSource {
     Pattern,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum AtomicNarrowOp {
     Is(Expr),
     IsNot(Expr),
@@ -127,7 +127,7 @@ pub enum AtomicNarrowOp {
     ClassCoverageGateNeg(Box<[Idx<Key>]>),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum NarrowOp {
     Atomic(Option<FacetSubject>, AtomicNarrowOp),
     And(Vec<NarrowOp>),
@@ -411,6 +411,12 @@ pub struct FacetSubject {
     pub origin: FacetOrigin,
 }
 
+impl PartialEq for FacetSubject {
+    fn eq(&self, other: &Self) -> bool {
+        self.origin == other.origin && self.chain.facets() == other.chain.facets()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum NarrowingSubject {
     Name(Name),
@@ -676,7 +682,7 @@ impl NarrowOp {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct NarrowOps(pub SmallMap<Name, (NarrowOp, TextRange)>);
 
 impl NarrowOps {

--- a/pyrefly/lib/binding/narrow.rs
+++ b/pyrefly/lib/binding/narrow.rs
@@ -29,6 +29,8 @@ use ruff_python_ast::ExprUnaryOp;
 use ruff_python_ast::Identifier;
 use ruff_python_ast::Number;
 use ruff_python_ast::UnaryOp;
+use ruff_python_ast::comparable::ComparableArguments;
+use ruff_python_ast::comparable::ComparableExpr;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
@@ -55,7 +57,7 @@ assert_words!(NarrowOp, 12);
 
 /// Indicates where an isinstance-style narrow operation originated from.
 /// This determines whether validation needs to happen during narrowing.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NarrowSource {
     /// From an isinstance() call - validation already happened in special_calls.rs.
     Call,
@@ -263,6 +265,84 @@ impl DisplayWith<ModuleInfo> for NarrowOp {
 }
 
 impl AtomicNarrowOp {
+    /// Compares narrowing semantics while ignoring AST source locations and trivia.
+    fn semantically_eq(&self, other: &Self) -> bool {
+        use AtomicNarrowOp::*;
+
+        let expr_eq =
+            |left: &Expr, right: &Expr| ComparableExpr::from(left) == ComparableExpr::from(right);
+        let optional_expr_eq = |left: &Option<Box<Expr>>, right: &Option<Box<Expr>>| {
+            left.as_deref().map(ComparableExpr::from) == right.as_deref().map(ComparableExpr::from)
+        };
+        let arguments_eq = |left: &Arguments, right: &Arguments| {
+            ComparableArguments::from(left) == ComparableArguments::from(right)
+        };
+
+        match (self, other) {
+            (Is(left), Is(right))
+            | (IsNot(left), IsNot(right))
+            | (Eq(left), Eq(right))
+            | (NotEq(left), NotEq(right))
+            | (IsSubclass(left), IsSubclass(right))
+            | (IsNotSubclass(left), IsNotSubclass(right))
+            | (TypeEq(left), TypeEq(right))
+            | (TypeNotEq(left), TypeNotEq(right))
+            | (In(left), In(right))
+            | (NotIn(left), NotIn(right))
+            | (LenEq(left), LenEq(right))
+            | (LenNotEq(left), LenNotEq(right))
+            | (LenGt(left), LenGt(right))
+            | (LenGte(left), LenGte(right))
+            | (LenLt(left), LenLt(right))
+            | (LenLte(left), LenLte(right)) => expr_eq(left, right),
+            (IsInstance(left, left_source), IsInstance(right, right_source))
+            | (IsNotInstance(left, left_source), IsNotInstance(right, right_source)) => {
+                left_source == right_source && expr_eq(left, right)
+            }
+            (HasAttr(left), HasAttr(right))
+            | (NotHasAttr(left), NotHasAttr(right))
+            | (HasKey(left), HasKey(right))
+            | (NotHasKey(left), NotHasKey(right)) => left == right,
+            (GetAttr(left_name, left_default), GetAttr(right_name, right_default))
+            | (NotGetAttr(left_name, left_default), NotGetAttr(right_name, right_default)) => {
+                left_name == right_name && optional_expr_eq(left_default, right_default)
+            }
+            (TypeGuard(left_type, left_args), TypeGuard(right_type, right_args))
+            | (NotTypeGuard(left_type, left_args), NotTypeGuard(right_type, right_args))
+            | (TypeIs(left_type, left_args), TypeIs(right_type, right_args))
+            | (NotTypeIs(left_type, left_args), NotTypeIs(right_type, right_args)) => {
+                left_type == right_type && arguments_eq(left_args, right_args)
+            }
+            (Call(left_expr, left_args), Call(right_expr, right_args))
+            | (NotCall(left_expr, left_args), NotCall(right_expr, right_args)) => {
+                expr_eq(left_expr, right_expr) && arguments_eq(left_args, right_args)
+            }
+            (PolarsColumnMutation(left), PolarsColumnMutation(right)) => match (left, right) {
+                (PolarsMutationKind::Add, PolarsMutationKind::Add)
+                | (PolarsMutationKind::Replace, PolarsMutationKind::Replace) => true,
+                (
+                    PolarsMutationKind::Insert(left_name, left_index, left_expr),
+                    PolarsMutationKind::Insert(right_name, right_index, right_expr),
+                ) => {
+                    left_name == right_name
+                        && left_index == right_index
+                        && expr_eq(left_expr, right_expr)
+                }
+                _ => false,
+            },
+            (ClassCoverageGate(left), ClassCoverageGate(right))
+            | (ClassCoverageGateNeg(left), ClassCoverageGateNeg(right)) => left == right,
+            (IsSequence, IsSequence)
+            | (IsNotSequence, IsNotSequence)
+            | (IsMapping, IsMapping)
+            | (IsNotMapping, IsNotMapping)
+            | (IsTruthy, IsTruthy)
+            | (IsFalsy, IsFalsy)
+            | (Placeholder, Placeholder) => true,
+            _ => false,
+        }
+    }
+
     /// Produce a Python-like snippet for hover display.
     ///
     /// `subject` is the name (possibly with facet chain) being narrowed.
@@ -425,6 +505,49 @@ pub struct FacetSubject {
     pub allow_never_collapse: bool,
 }
 
+impl FacetSubject {
+    /// Compares facet semantics while ignoring locations in embedded AST nodes.
+    fn semantically_eq(&self, other: &Self) -> bool {
+        self.origin == other.origin
+            && self.chain.facets().len() == other.chain.facets().len()
+            && self
+                .chain
+                .facets()
+                .iter()
+                .zip(other.chain.facets())
+                .all(|(left, right)| match (left, right) {
+                    (
+                        UnresolvedFacetKind::Attribute(left),
+                        UnresolvedFacetKind::Attribute(right),
+                    ) => left == right,
+                    (UnresolvedFacetKind::Index(left), UnresolvedFacetKind::Index(right)) => {
+                        left == right
+                    }
+                    (UnresolvedFacetKind::Key(left), UnresolvedFacetKind::Key(right)) => {
+                        left == right
+                    }
+                    (
+                        UnresolvedFacetKind::VariableSubscript(left),
+                        UnresolvedFacetKind::VariableSubscript(right),
+                    ) => left.id == right.id,
+                    (
+                        UnresolvedFacetKind::MatchArg {
+                            class: left_class,
+                            index: left_index,
+                        },
+                        UnresolvedFacetKind::MatchArg {
+                            class: right_class,
+                            index: right_index,
+                        },
+                    ) => {
+                        left_index == right_index
+                            && ComparableExpr::from(left_class) == ComparableExpr::from(right_class)
+                    }
+                    _ => false,
+                })
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum NarrowingSubject {
     Name(Name),
@@ -464,6 +587,28 @@ impl NarrowingSubject {
 }
 
 impl NarrowOp {
+    /// Compares narrowing semantics while ignoring AST source locations and trivia.
+    pub(crate) fn semantically_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Atomic(left_facet, left_op), Self::Atomic(right_facet, right_op)) => {
+                match (left_facet, right_facet) {
+                    (Some(left), Some(right)) if left.semantically_eq(right) => {}
+                    (None, None) => {}
+                    _ => return false,
+                }
+                left_op.semantically_eq(right_op)
+            }
+            (Self::And(left), Self::And(right)) | (Self::Or(left), Self::Or(right)) => {
+                left.len() == right.len()
+                    && left
+                        .iter()
+                        .zip(right)
+                        .all(|(left, right)| left.semantically_eq(right))
+            }
+            _ => false,
+        }
+    }
+
     /// Produce a Python-like snippet for hover display.
     ///
     /// `base_name` is the variable being narrowed. `snippet` converts a
@@ -734,6 +879,17 @@ pub struct NarrowOps(pub SmallMap<Name, (NarrowOp, TextRange)>);
 impl NarrowOps {
     pub fn new() -> Self {
         Self(SmallMap::new())
+    }
+
+    /// Compares narrowing semantics without considering the source range of each operation.
+    pub(crate) fn semantically_eq(&self, other: &Self) -> bool {
+        self.0.len() == other.0.len()
+            && self.0.iter().all(|(name, (op, _))| {
+                other
+                    .0
+                    .get(name)
+                    .is_some_and(|(other_op, _)| op.semantically_eq(other_op))
+            })
     }
 
     /// Adds or merges a narrowing operation for the given subject.

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -570,6 +570,7 @@ impl Static {
 #[derive(Default, Clone, Debug)]
 pub struct Flow {
     info: SmallMap<Name, FlowInfo>,
+    conditional_facts: Vec<ConditionalFlowFact>,
     // Have we seen control flow terminate?
     //
     // We continue to analyze the rest of the code after a flow terminates, but
@@ -604,6 +605,12 @@ impl Flow {
 
     fn get_value_mut(&mut self, name: &Name) -> Option<&mut FlowValue> {
         self.info.get_mut(name)?.value_mut()
+    }
+
+    fn invalidate_conditional_facts_for_assignment(&mut self, name: Hashed<&Name>) {
+        self.conditional_facts.retain(|fact| {
+            fact.name != **name.key() && fact.conditions.0.get_hashed(name).is_none()
+        });
     }
 }
 
@@ -652,6 +659,36 @@ struct FlowInfo {
     /// - Always set to our current inferred type when a flow info is created
     /// - Updated whenever we update the inferred type outside of all loops, but not inside
     loop_prior: Idx<Key>,
+}
+
+/// A value known to hold when a previously-analyzed predicate is active again.
+///
+/// For `if b == "bar": x = 3`, the branch records that under `b == "bar"`,
+/// `x` has the branch-end flow info. The fact is discarded if `x` or `b` is
+/// rebound before the predicate is used again.
+#[derive(Debug, Clone)]
+pub(crate) struct ConditionalFlowFact {
+    conditions: NarrowOps,
+    name: Name,
+    info: FlowInfo,
+}
+
+impl ConditionalFlowFact {
+    fn matches_active_conditions(&self, active: &NarrowOps) -> bool {
+        !self.conditions.0.is_empty()
+            && self.conditions.0.iter().all(|(name, (op, _))| {
+                active
+                    .0
+                    .get(name)
+                    .is_some_and(|(active_op, _)| active_op == op)
+            })
+    }
+
+    fn same_fact(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.conditions == other.conditions
+            && self.info.idx() == other.info.idx()
+    }
 }
 
 /// The most recent value for a name. Used in several cases:
@@ -2172,6 +2209,9 @@ impl Scopes {
         style: FlowStyle,
     ) -> Option<NameWriteInfo> {
         let in_loop = self.loop_depth() != 0;
+        self.current_mut()
+            .flow
+            .invalidate_conditional_facts_for_assignment(name);
         match self.current_mut().flow.info.entry_hashed(name.cloned()) {
             Entry::Vacant(e) => {
                 e.insert(FlowInfo::new_value(idx, style));
@@ -2234,6 +2274,10 @@ impl Scopes {
         for i in (0..len - 1).rev() {
             if !matches!(self.scopes[i].scope.kind, ScopeKind::Comprehension { .. }) {
                 let in_loop = !self.scopes[i].scope.loops.is_empty();
+                self.scopes[i]
+                    .scope
+                    .flow
+                    .invalidate_conditional_facts_for_assignment(name);
                 match self.scopes[i].scope.flow.info.entry_hashed(name.cloned()) {
                     Entry::Vacant(e) => {
                         e.insert(FlowInfo::new_value(idx, style));
@@ -2253,6 +2297,9 @@ impl Scopes {
     /// uninitialized local errors but keep using our best guess for the type.
     pub fn mark_as_deleted(&mut self, name: &Name) {
         let scope = self.current_mut();
+        scope
+            .flow
+            .invalidate_conditional_facts_for_assignment(Hashed::new(name));
         if let Some(value) = scope.flow.get_value_mut(name) {
             value.style = FlowStyle::Uninitialized;
         }
@@ -2295,6 +2342,73 @@ impl Scopes {
     /// Returns `None` if there is no active fork or the name is not in the base flow.
     pub fn current_fork_base_idx(&self, name: &Name) -> Option<Idx<Key>> {
         Some(self.current().forks.last()?.base.get_info(name)?.idx())
+    }
+
+    pub(crate) fn conditional_flow_facts_for_current_branch(
+        &self,
+        conditions: &NarrowOps,
+    ) -> Vec<ConditionalFlowFact> {
+        if conditions.0.is_empty() {
+            return Vec::new();
+        }
+        let scope = self.current();
+        let fork = scope
+            .forks
+            .last()
+            .expect("conditional flow facts requested outside of a fork");
+
+        for name in conditions.0.keys() {
+            let base_value = fork.base.get_info(name).and_then(|info| info.value());
+            let current_value = scope.flow.get_info(name).and_then(|info| info.value());
+            if base_value.map(|value| value.idx) != current_value.map(|value| value.idx) {
+                return Vec::new();
+            }
+        }
+
+        scope
+            .flow
+            .info
+            .iter()
+            .filter_map(|(name, info)| {
+                let value = info.value()?;
+                let base_value = fork.base.get_info(name).and_then(|info| info.value());
+                if base_value.is_some_and(|base_value| base_value.idx == value.idx) {
+                    None
+                } else {
+                    Some(ConditionalFlowFact {
+                        conditions: conditions.clone(),
+                        name: name.clone(),
+                        info: info.clone(),
+                    })
+                }
+            })
+            .collect()
+    }
+
+    pub(crate) fn add_conditional_flow_facts(&mut self, facts: Vec<ConditionalFlowFact>) {
+        let flow = &mut self.current_mut().flow;
+        for fact in facts {
+            if !flow
+                .conditional_facts
+                .iter()
+                .any(|existing| existing.same_fact(&fact))
+            {
+                flow.conditional_facts.push(fact);
+            }
+        }
+    }
+
+    pub(crate) fn apply_conditional_flow_facts(&mut self, active: &NarrowOps) {
+        let flow = &mut self.current_mut().flow;
+        let matching_facts = flow
+            .conditional_facts
+            .iter()
+            .filter(|fact| fact.matches_active_conditions(active))
+            .cloned()
+            .collect::<Vec<_>>();
+        for fact in matching_facts {
+            flow.info.insert(fact.name, fact.info);
+        }
     }
 
     /// Copy walrus-defined names from the current branch flow into the fork's
@@ -3447,6 +3561,24 @@ fn determine_definition_status(
     }
 }
 
+fn common_conditional_facts(flows: &[Flow]) -> Vec<ConditionalFlowFact> {
+    let Some((first, rest)) = flows.split_first() else {
+        return Vec::new();
+    };
+    first
+        .conditional_facts
+        .iter()
+        .filter(|fact| {
+            rest.iter().all(|flow| {
+                flow.conditional_facts
+                    .iter()
+                    .any(|other| fact.same_fact(other))
+            })
+        })
+        .cloned()
+        .collect()
+}
+
 /// Information about a single branch being merged, including both the flow info
 /// for a specific name (if present) and the termination key from the flow this branch came from.
 struct MergeBranchEntry {
@@ -3751,6 +3883,7 @@ impl<'a> BindingsBuilder<'a> {
         } else {
             live_branches
         };
+        let conditional_facts = common_conditional_facts(&flows);
         // Determine reachability of the merged flow.
         // For Loop style with empty flows (all branches terminated), the loop body might
         // never execute (empty iterable), so we use the base flow's reachability.
@@ -3834,6 +3967,7 @@ impl<'a> BindingsBuilder<'a> {
         // The resulting flow has terminated only if all branches had terminated.
         let flow = Flow {
             info: merged_flow_infos,
+            conditional_facts,
             has_terminated,
             is_definitely_unreachable: all_are_unreachable,
             last_stmt_expr: None,

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -7,6 +7,7 @@
 
 use std::cmp::max;
 use std::fmt::Debug;
+use std::iter;
 use std::mem;
 
 use itertools::Either;
@@ -616,6 +617,7 @@ impl TerminationKind {
 #[derive(Default, Clone, Debug)]
 pub struct Flow {
     info: SmallMap<Name, FlowInfo>,
+    conditional_facts: Vec<ConditionalFlowFact>,
     // Have we seen control flow terminate?
     //
     // We continue to analyze the rest of the code after a flow terminates, but
@@ -653,6 +655,12 @@ impl Flow {
 
     fn get_value_mut(&mut self, name: &Name) -> Option<&mut FlowValue> {
         self.info.get_mut(name)?.value_mut()
+    }
+
+    fn invalidate_conditional_facts_for_assignment(&mut self, name: Hashed<&Name>) {
+        self.conditional_facts.retain(|fact| {
+            fact.name != **name.key() && fact.conditions.0.get_hashed(name).is_none()
+        });
     }
 }
 
@@ -701,6 +709,36 @@ struct FlowInfo {
     /// - Always set to our current inferred type when a flow info is created
     /// - Updated whenever we update the inferred type outside of all loops, but not inside
     loop_prior: Idx<Key>,
+}
+
+/// A value known to hold when a previously-analyzed predicate is active again.
+///
+/// For `if b == "bar": x = 3`, the branch records that under `b == "bar"`,
+/// `x` has the branch-end flow info. The fact is discarded if `x` or `b` is
+/// rebound before the predicate is used again.
+#[derive(Debug, Clone)]
+pub(crate) struct ConditionalFlowFact {
+    conditions: NarrowOps,
+    name: Name,
+    info: FlowInfo,
+}
+
+impl ConditionalFlowFact {
+    fn matches_active_conditions(&self, active: &NarrowOps) -> bool {
+        !self.conditions.0.is_empty()
+            && self.conditions.0.iter().all(|(name, (op, _))| {
+                active
+                    .0
+                    .get(name)
+                    .is_some_and(|(active_op, _)| active_op.semantically_eq(op))
+            })
+    }
+
+    fn same_fact(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.conditions.semantically_eq(&other.conditions)
+            && self.info.idx() == other.info.idx()
+    }
 }
 
 /// The most recent value for a name. Used in several cases:
@@ -2361,6 +2399,9 @@ impl Scopes {
         style: FlowStyle,
     ) -> Option<NameWriteInfo> {
         let in_loop = self.loop_depth() != 0;
+        self.current_mut()
+            .flow
+            .invalidate_conditional_facts_for_assignment(name);
         match self.current_mut().flow.info.entry_hashed(name.cloned()) {
             Entry::Vacant(e) => {
                 e.insert(FlowInfo::new_value(idx, style));
@@ -2423,6 +2464,10 @@ impl Scopes {
         for i in (0..len - 1).rev() {
             if !matches!(self.scopes[i].scope.kind, ScopeKind::Comprehension { .. }) {
                 let in_loop = !self.scopes[i].scope.loops.is_empty();
+                self.scopes[i]
+                    .scope
+                    .flow
+                    .invalidate_conditional_facts_for_assignment(name);
                 match self.scopes[i].scope.flow.info.entry_hashed(name.cloned()) {
                     Entry::Vacant(e) => {
                         e.insert(FlowInfo::new_value(idx, style));
@@ -2442,6 +2487,9 @@ impl Scopes {
     /// uninitialized local errors but keep using our best guess for the type.
     pub fn mark_as_deleted(&mut self, name: &Name) {
         let scope = self.current_mut();
+        scope
+            .flow
+            .invalidate_conditional_facts_for_assignment(Hashed::new(name));
         if let Some(value) = scope.flow.get_value_mut(name) {
             value.style = FlowStyle::Uninitialized;
         }
@@ -2484,6 +2532,73 @@ impl Scopes {
     /// Returns `None` if there is no active fork or the name is not in the base flow.
     pub fn current_fork_base_idx(&self, name: &Name) -> Option<Idx<Key>> {
         Some(self.current().forks.last()?.base.get_info(name)?.idx())
+    }
+
+    pub(crate) fn conditional_flow_facts_for_current_branch(
+        &self,
+        conditions: &NarrowOps,
+    ) -> Vec<ConditionalFlowFact> {
+        if conditions.0.is_empty() {
+            return Vec::new();
+        }
+        let scope = self.current();
+        let fork = scope
+            .forks
+            .last()
+            .expect("conditional flow facts requested outside of a fork");
+
+        for name in conditions.0.keys() {
+            let base_value = fork.base.get_info(name).and_then(|info| info.value());
+            let current_value = scope.flow.get_info(name).and_then(|info| info.value());
+            if base_value.map(|value| value.idx) != current_value.map(|value| value.idx) {
+                return Vec::new();
+            }
+        }
+
+        scope
+            .flow
+            .info
+            .iter()
+            .filter_map(|(name, info)| {
+                let value = info.value()?;
+                let base_value = fork.base.get_info(name).and_then(|info| info.value());
+                if base_value.is_some_and(|base_value| base_value.idx == value.idx) {
+                    None
+                } else {
+                    Some(ConditionalFlowFact {
+                        conditions: conditions.clone(),
+                        name: name.clone(),
+                        info: info.clone(),
+                    })
+                }
+            })
+            .collect()
+    }
+
+    pub(crate) fn add_conditional_flow_facts(&mut self, facts: Vec<ConditionalFlowFact>) {
+        let flow = &mut self.current_mut().flow;
+        for fact in facts {
+            if !flow
+                .conditional_facts
+                .iter()
+                .any(|existing| existing.same_fact(&fact))
+            {
+                flow.conditional_facts.push(fact);
+            }
+        }
+    }
+
+    pub(crate) fn apply_conditional_flow_facts(&mut self, active: &NarrowOps) {
+        let flow = &mut self.current_mut().flow;
+        let matching_facts = flow
+            .conditional_facts
+            .iter()
+            .filter(|fact| fact.matches_active_conditions(active))
+            .cloned()
+            .collect::<Vec<_>>();
+        for fact in matching_facts {
+            flow.info.insert(fact.name, fact.info);
+        }
     }
 
     /// Copy walrus-defined names from the current branch flow into the fork's
@@ -3735,6 +3850,24 @@ fn determine_definition_status(
     }
 }
 
+fn common_conditional_facts(flows: &[&Flow]) -> Vec<ConditionalFlowFact> {
+    let Some((first, rest)) = flows.split_first() else {
+        return Vec::new();
+    };
+    first
+        .conditional_facts
+        .iter()
+        .filter(|fact| {
+            rest.iter().all(|flow| {
+                flow.conditional_facts
+                    .iter()
+                    .any(|other| fact.same_fact(other))
+            })
+        })
+        .cloned()
+        .collect()
+}
+
 /// Information about a single branch being merged, including both the flow info
 /// for a specific name (if present) and the termination key from the flow this branch came from.
 struct MergeBranchEntry {
@@ -4045,6 +4178,12 @@ impl<'a> BindingsBuilder<'a> {
         } else {
             live_branches
         };
+        let fact_flows: Vec<&Flow> = if merge_style.is_loop() {
+            iter::once(&base).chain(flows.iter()).collect()
+        } else {
+            flows.iter().collect()
+        };
+        let conditional_facts = common_conditional_facts(&fact_flows);
         // Determine reachability of the merged flow.
         // For Loop style with empty flows (all branches terminated), the loop body might
         // never execute (empty iterable), so we use the base flow's reachability.
@@ -4128,6 +4267,7 @@ impl<'a> BindingsBuilder<'a> {
         // The resulting flow has terminated only if all branches had terminated.
         let flow = Flow {
             info: merged_flow_infos,
+            conditional_facts,
             has_terminated,
             terminated_by_raise: has_terminated && any_terminated_by_raise,
             is_definitely_unreachable: all_are_unreachable,

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -1246,6 +1246,7 @@ impl<'a> BindingsBuilder<'a> {
                 // x is bound to Narrow(x, Is(None)) in the if branch, and the negation, Narrow(x, IsNot(None)),
                 // is carried over to the else branch.
                 let mut negated_prev_ops = NarrowOps::new();
+                let mut conditional_flow_facts = Vec::new();
                 let mut contains_static_test_with_no_else = false;
                 let mut is_first_branch = true;
                 let mut following_runtime_only_branch = false;
@@ -1318,6 +1319,10 @@ impl<'a> BindingsBuilder<'a> {
                         NarrowUseLocation::Span(range),
                         &Usage::NonPinningValue(None),
                     );
+                    let mut active_narrow_ops = negated_prev_ops.clone();
+                    if !new_narrow_ops.0.is_empty() {
+                        active_narrow_ops.and_all(new_narrow_ops.clone());
+                    }
                     negated_prev_ops.and_all(new_narrow_ops.negate());
                     if is_type_checking_branch {
                         self.type_checking_depth += 1;
@@ -1326,6 +1331,10 @@ impl<'a> BindingsBuilder<'a> {
                     } else {
                         self.stmts(body, parent);
                     }
+                    conditional_flow_facts.extend(
+                        self.scopes
+                            .conditional_flow_facts_for_current_branch(&active_narrow_ops),
+                    );
                     self.finish_branch();
                     if this_branch_chosen == Some(true) {
                         exhaustive = true;
@@ -1352,6 +1361,8 @@ impl<'a> BindingsBuilder<'a> {
                 } else {
                     self.finish_non_exhaustive_fork(&negated_prev_ops, exhaustive_key);
                 }
+                self.scopes
+                    .add_conditional_flow_facts(conditional_flow_facts);
                 // If we have a statically evaluated test like `sys.version_info`, we should set `is_definitely_unreachable` to false
                 // to reduce false positive unreachable errors, since some code paths can still be hit at runtime
                 if contains_static_test_with_no_else && !is_definitely_unreachable {

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -1256,6 +1256,7 @@ impl<'a> BindingsBuilder<'a> {
                 // x is bound to Narrow(x, Is(None)) in the if branch, and the negation, Narrow(x, IsNot(None)),
                 // is carried over to the else branch.
                 let mut negated_prev_ops = NarrowOps::new();
+                let mut conditional_flow_facts = Vec::new();
                 let mut contains_static_test_with_no_else = false;
                 let mut is_first_branch = true;
                 let mut following_runtime_only_branch = false;
@@ -1328,7 +1329,18 @@ impl<'a> BindingsBuilder<'a> {
                         NarrowUseLocation::Span(range),
                         &Usage::NonPinningValue(None),
                     );
-                    negated_prev_ops.and_all(new_narrow_ops.negate());
+                    let mut active_narrow_ops = negated_prev_ops.clone();
+                    if active_narrow_ops.0.is_empty() {
+                        active_narrow_ops = new_narrow_ops.clone();
+                    } else if !new_narrow_ops.0.is_empty() {
+                        active_narrow_ops.and_all(new_narrow_ops.clone());
+                    }
+                    let negated_new_narrow_ops = new_narrow_ops.negate();
+                    if negated_prev_ops.0.is_empty() {
+                        negated_prev_ops = negated_new_narrow_ops;
+                    } else {
+                        negated_prev_ops.and_all(negated_new_narrow_ops);
+                    }
                     if is_type_checking_branch {
                         self.type_checking_depth += 1;
                         self.stmts(body, parent);
@@ -1336,6 +1348,10 @@ impl<'a> BindingsBuilder<'a> {
                     } else {
                         self.stmts(body, parent);
                     }
+                    conditional_flow_facts.extend(
+                        self.scopes
+                            .conditional_flow_facts_for_current_branch(&active_narrow_ops),
+                    );
                     self.finish_branch();
                     if this_branch_chosen == Some(true) {
                         exhaustive = true;
@@ -1362,6 +1378,8 @@ impl<'a> BindingsBuilder<'a> {
                 } else {
                     self.finish_non_exhaustive_fork(&negated_prev_ops, exhaustive_key);
                 }
+                self.scopes
+                    .add_conditional_flow_facts(conditional_flow_facts);
                 // If we have a statically evaluated test like `sys.version_info`, we should set `is_definitely_unreachable` to false
                 // to reduce false positive unreachable errors, since some code paths can still be hit at runtime
                 if contains_static_test_with_no_else && !is_definitely_unreachable {

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -60,6 +60,28 @@ assert_type(y, Literal[7, 100])
 );
 
 testcase!(
+    test_repeated_predicate_tracks_branch_assignment,
+    r#"
+from typing import reveal_type
+
+def f(b: str):
+    x: int | None = None
+    if b == "bar":
+        x = 3
+    if b == "bar":
+        reveal_type(x)  # E: revealed type: int
+
+def invalidated_predicate(b: str):
+    x: int | None = None
+    if b == "bar":
+        x = 3
+    b = "baz"
+    if b == "bar":
+        reveal_type(x)  # E: revealed type: int | None
+"#,
+);
+
+testcase!(
     test_listcomp_simple,
     r#"
 from typing import assert_type

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -64,6 +64,28 @@ assert_type(y, Literal[7, 100])
 );
 
 testcase!(
+    test_repeated_predicate_tracks_branch_assignment,
+    r#"
+from typing import Literal, assert_type
+
+def f(b: str):
+    x: int | None = None
+    if b == "bar":
+        x = 3
+    if b == "bar":
+        assert_type(x, Literal[3])
+
+def invalidated_predicate(b: str):
+    x: int | None = None
+    if b == "bar":
+        x = 3
+    b = "baz"
+    if b == "bar":
+        assert_type(x, int | None)
+"#,
+);
+
+testcase!(
     test_listcomp_simple,
     r#"
 from typing import assert_type
@@ -2768,7 +2790,6 @@ for x in range(10):
 // `if a:`, the variable is guaranteed to be initialized because the same
 // condition guards both the definition and the use.
 testcase!(
-    bug = "false positive: b is always initialized when a is truthy",
     test_guarded_initialization_basic,
     r#"
 def f(a: bool) -> int:
@@ -2776,7 +2797,7 @@ def f(a: bool) -> int:
         b = 3
     c = 5
     if a:
-        return b  # E: `b` may be uninitialized
+        return b
     return 9
     "#,
 );
@@ -2806,7 +2827,6 @@ def f(a: bool, c: bool) -> int:
 );
 
 testcase!(
-    bug = "false positive: b and c are always initialized when a is truthy",
     test_guarded_initialization_multiple_variables,
     r#"
 def f(a: bool) -> int:
@@ -2814,13 +2834,12 @@ def f(a: bool) -> int:
         b = 3
         c = 4
     if a:
-        return b + c  # E: `b` may be uninitialized  # E: `c` may be uninitialized
+        return b + c
     return 0
     "#,
 );
 
 testcase!(
-    bug = "false positive: b is always initialized when a is truthy",
     test_guarded_initialization_with_intermediate_statements,
     r#"
 def f(a: bool) -> int:
@@ -2829,13 +2848,12 @@ def f(a: bool) -> int:
     x = 5
     y = x + 1
     if a:
-        return b  # E: `b` may be uninitialized
+        return b
     return 9
     "#,
 );
 
 testcase!(
-    bug = "false positive: b is always initialized when a is truthy",
     test_guarded_initialization_annotation_then_guarded_assign,
     r#"
 def f(a: bool) -> int:
@@ -2843,20 +2861,19 @@ def f(a: bool) -> int:
     if a:
         b = 3
     if a:
-        return b  # E: `b` may be uninitialized
+        return b
     return 9
     "#,
 );
 
 testcase!(
-    bug = "false positive: b is always initialized when a is truthy",
     test_guarded_initialization_repeated_use,
     r#"
 def f(a: bool) -> None:
     if a:
         b = 3
     if a:
-        print(b)  # E: `b` may be uninitialized
+        print(b)
     if a:
         print(b)
     "#,


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #997

This is an experiment.

Added guarded flow facts so `if b == "bar": x = 3` records that x has the branch value when the same predicate is active again.

Applied matching guarded facts whenever narrowing ops are bound, recorded those facts from if branches and invalidated them on predicate/target reassignment.

With help from gpt 5.6 sol high.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added regression test coverage for repeated predicates and predicate reassignment invalidation.