### PR TITLE
fix Typed functools.Cache #4010

### DIFF
--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -1771,6 +1771,8 @@ impl Type {
                     }
                 }
             }
+            Type::Intersect(intersect) => intersect.1.visit_toplevel_callable(f),
+            Type::KwCall(call) => call.return_ty.visit_toplevel_callable(f),
             _ => {}
         }
     }
@@ -1806,6 +1808,8 @@ impl Type {
                     }
                 }
             }
+            Type::Intersect(intersect) => intersect.1.transform_toplevel_callable(f),
+            Type::KwCall(call) => call.return_ty.transform_toplevel_callable(f),
             _ => {}
         }
     }

--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -1871,8 +1871,16 @@ impl Type {
     pub fn toplevel_callable_signatures(
         &self,
     ) -> impl Iterator<Item = (&Callable, Option<&Arc<TParams>>)> {
+        let mut ty = self;
+        loop {
+            match ty {
+                Type::Intersect(intersect) => ty = &intersect.1,
+                Type::KwCall(call) => ty = &call.return_ty,
+                _ => break,
+            }
+        }
         let (one, overloads): (Option<(&Callable, Option<&Arc<TParams>>)>, &[OverloadType]) =
-            match self {
+            match ty {
                 Type::Callable(callable) => (Some((callable, None)), &[]),
                 Type::Forall(forall) => match &forall.body {
                     Forallable::Callable(callable) => {
@@ -1922,6 +1930,14 @@ impl Type {
                     .signatures
                     .mapped(|signature| signature.transform(&mut f));
                 Type::Overload(overload)
+            }
+            Type::Intersect(mut intersect) => {
+                intersect.1.transform_toplevel_callable_signatures(f);
+                Type::Intersect(intersect)
+            }
+            Type::KwCall(mut call) => {
+                call.return_ty.transform_toplevel_callable_signatures(f);
+                Type::KwCall(call)
             }
             ty => ty,
         };

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1306,6 +1306,15 @@ fn make_bound_method_helper(
             }
             return Ok(unions(bound_methods, heap));
         }
+        Type::Intersect(intersect) => {
+            let (members, fallback) = *intersect;
+            let bound_fallback = make_bound_method_helper(heap, obj, fallback, should_bind)?;
+            return Ok(heap.mk_intersect(members, bound_fallback));
+        }
+        Type::KwCall(mut call) => {
+            call.return_ty = make_bound_method_helper(heap, obj, call.return_ty, should_bind)?;
+            return Ok(heap.mk_kw_call(*call));
+        }
         _ => return Err(attr),
     };
     Ok(heap.mk_bound_method(BoundMethod { obj, func }))
@@ -1365,6 +1374,8 @@ pub enum DataclassMember {
 fn has_any_method_type(ty: &Type) -> bool {
     match ty {
         Type::Union(union) => union.members.iter().any(|t| t.has_toplevel_func_metadata()),
+        Type::Intersect(intersect) => intersect.1.has_toplevel_func_metadata(),
+        Type::KwCall(call) => has_any_method_type(&call.return_ty),
         _ => ty.has_toplevel_func_metadata(),
     }
 }

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1312,6 +1312,15 @@ fn make_bound_method_helper(
             }
             return Ok(unions(bound_methods, heap));
         }
+        Type::Intersect(intersect) => {
+            let (members, fallback) = *intersect;
+            let bound_fallback = make_bound_method_helper(heap, obj, fallback, should_bind)?;
+            return Ok(heap.mk_intersect(members, bound_fallback));
+        }
+        Type::KwCall(mut call) => {
+            call.return_ty = make_bound_method_helper(heap, obj, call.return_ty, should_bind)?;
+            return Ok(heap.mk_kw_call(*call));
+        }
         _ => return Err(attr),
     };
     Ok(heap.mk_bound_method(BoundMethod { obj, func }))
@@ -1377,6 +1386,8 @@ pub enum DataclassMember<'a> {
 fn has_any_method_type(ty: &Type) -> bool {
     match ty {
         Type::Union(union) => union.members.iter().any(|t| t.has_toplevel_func_metadata()),
+        Type::Intersect(intersect) => intersect.1.has_toplevel_func_metadata(),
+        Type::KwCall(call) => has_any_method_type(&call.return_ty),
         _ => ty.has_toplevel_func_metadata(),
     }
 }

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -1830,6 +1830,25 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             {
                 original_decoratee.clone()
             }
+            Type::ClassType(cls) if cls.has_qname("functools", "_lru_cache_wrapper") => {
+                // Keep the original callable as a real intersection member so simplification
+                // cannot collapse the type to just the wrapper.
+                self.heap.mk_intersect(
+                    vec![self.heap.mk_class_type(cls), original_decoratee.clone()],
+                    original_decoratee.clone(),
+                )
+            }
+            Type::KwCall(mut call) if matches!(&call.return_ty, Type::ClassType(cls) if cls.has_qname("functools", "_lru_cache_wrapper")) => {
+                if original_decoratee.property_metadata().is_some() {
+                    original_decoratee.clone()
+                } else {
+                    call.return_ty = self.heap.mk_intersect(
+                        vec![call.return_ty.clone(), original_decoratee.clone()],
+                        original_decoratee.clone(),
+                    );
+                    self.heap.mk_kw_call(*call)
+                }
+            }
             // Heuristic for union-typed decorators (e.g. dual-use decorators that
             // can be applied with or without parentheses like @d or @d(flag)):
             //

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -2114,6 +2114,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         errors: &ErrorCollector,
     ) -> Vec1<(TextRange, OverloadType)> {
         ts.mapped(|(range, t, metadata)| {
+            let display_t = t.clone();
+            let mut t = t;
+            let t = loop {
+                match t {
+                    Type::Intersect(intersect) => t = intersect.1,
+                    Type::KwCall(call) => t = call.return_ty,
+                    t => break t,
+                }
+            };
             (
                 range,
                 match t {
@@ -2165,7 +2174,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     format!(
                         "`{}` has type `{}` after decorator application, which is not callable",
                         func,
-                        self.for_display(t)
+                        self.for_display(display_t)
                     ),
                 );
                         OverloadType::Function(Function {

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -2129,6 +2129,15 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         errors: &ErrorCollector,
     ) -> Vec1<(TextRange, OverloadType)> {
         ts.mapped(|(range, t, metadata)| {
+            let display_t = t.clone();
+            let mut t = t;
+            let t = loop {
+                match t {
+                    Type::Intersect(intersect) => t = intersect.1,
+                    Type::KwCall(call) => t = call.return_ty,
+                    t => break t,
+                }
+            };
             (
                 range,
                 match t {
@@ -2180,7 +2189,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     format!(
                         "`{}` has type `{}` after decorator application, which is not callable",
                         func,
-                        self.for_display(t)
+                        self.for_display(display_t)
                     ),
                 );
                         OverloadType::Function(Function {

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -1846,6 +1846,25 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             {
                 original_decoratee.clone()
             }
+            Type::ClassType(cls) if cls.has_qname("functools", "_lru_cache_wrapper") => {
+                // Keep the original callable as a real intersection member so simplification
+                // cannot collapse the type to just the wrapper.
+                self.heap.mk_intersect(
+                    vec![self.heap.mk_class_type(cls), original_decoratee.clone()],
+                    original_decoratee.clone(),
+                )
+            }
+            Type::KwCall(mut call) if matches!(&call.return_ty, Type::ClassType(cls) if cls.has_qname("functools", "_lru_cache_wrapper")) => {
+                if original_decoratee.property_metadata().is_some() {
+                    original_decoratee.clone()
+                } else {
+                    call.return_ty = self.heap.mk_intersect(
+                        vec![call.return_ty.clone(), original_decoratee.clone()],
+                        original_decoratee.clone(),
+                    );
+                    self.heap.mk_kw_call(*call)
+                }
+            }
             // Heuristic for union-typed decorators (e.g. dual-use decorators that
             // can be applied with or without parentheses like @d or @d(flag)):
             //

--- a/pyrefly/lib/test/functools.rs
+++ b/pyrefly/lib/test/functools.rs
@@ -6,6 +6,7 @@
  */
 
 #![cfg(test)]
+mod cache;
 mod partial;
 mod partial_edge;
 mod partial_generics;

--- a/pyrefly/lib/test/functools/cache.rs
+++ b/pyrefly/lib/test/functools/cache.rs
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! `functools.cache` and `functools.lru_cache` preserve the wrapped function's call signature.
+
+use crate::functools_testcase;
+
+functools_testcase!(
+    test_cache_preserves_function_signature,
+    r#"
+from functools import cache
+from typing import assert_type
+
+@cache
+def f() -> int:
+    return 0
+
+assert_type(f(), int)
+f(1, 2, 3)  # E: Expected 0 positional arguments, got 3
+f.cache_clear()
+assert_type(f.cache_info().hits, int)
+"#,
+);
+
+functools_testcase!(
+    test_lru_cache_preserves_function_signature,
+    r#"
+from functools import lru_cache
+from typing import assert_type
+
+@lru_cache
+def f(x: int, y: str = "") -> bool:
+    return True
+
+assert_type(f(1), bool)
+assert_type(f(1, "x"), bool)
+f("x")  # E: Argument `Literal['x']` is not assignable to parameter `x` with type `int`
+f(1, y=2)  # E: Argument `Literal[2]` is not assignable to parameter `y` with type `str`
+f.cache_info()
+"#,
+);
+
+functools_testcase!(
+    test_lru_cache_call_preserves_function_signature,
+    r#"
+from functools import lru_cache
+from typing import assert_type
+
+@lru_cache(maxsize=None)
+def f(x: int) -> str:
+    return ""
+
+assert_type(f(1), str)
+f("x")  # E: Argument `Literal['x']` is not assignable to parameter `x` with type `int`
+f.cache_clear()
+"#,
+);
+
+functools_testcase!(
+    test_lru_cache_method_binds_self,
+    r#"
+from functools import cache, lru_cache
+from typing import assert_type
+
+class C:
+    @cache
+    def cache_method(self, x: int) -> str:
+        return ""
+
+    @lru_cache(maxsize=4)
+    def lru_method(self, x: int) -> str:
+        return ""
+
+c = C()
+assert_type(C.cache_method(c, 1), str)
+assert_type(c.cache_method(1), str)
+c.cache_method("x")  # E: Argument `Literal['x']` is not assignable to parameter `x` with type `int`
+c.cache_method.cache_info()
+assert_type(C.lru_method(c, 1), str)
+assert_type(c.lru_method(1), str)
+c.lru_method("x")  # E: Argument `Literal['x']` is not assignable to parameter `x` with type `int`
+c.lru_method.cache_clear()
+"#,
+);

--- a/pyrefly/lib/test/functools/cache.rs
+++ b/pyrefly/lib/test/functools/cache.rs
@@ -8,6 +8,31 @@
 //! `functools.cache` and `functools.lru_cache` preserve the wrapped function's call signature.
 
 use crate::functools_testcase;
+use crate::test::util::TestEnv;
+use crate::testcase;
+
+fn cached_overload_env() -> TestEnv {
+    let mut env = TestEnv::new();
+    env.add_with_path(
+        "pkg",
+        "pkg/__init__.pyi",
+        r#"
+from functools import lru_cache
+from typing import Literal, Self, overload
+
+class HasProps:
+    @overload
+    @classmethod
+    @lru_cache
+    def properties(cls: type[Self], *, _with_props: Literal[False] = False) -> set[str]: ...
+    @overload
+    @classmethod
+    @lru_cache
+    def properties(cls: type[Self], *, _with_props: Literal[True] = True) -> dict[str, object]: ...
+"#,
+    );
+    env
+}
 
 functools_testcase!(
     test_cache_preserves_function_signature,
@@ -84,5 +109,17 @@ assert_type(C.lru_method(c, 1), str)
 assert_type(c.lru_method(1), str)
 c.lru_method("x")  # E: Argument `Literal['x']` is not assignable to parameter `x` with type `int`
 c.lru_method.cache_clear()
+"#,
+);
+
+testcase!(
+    test_lru_cache_preserves_overload_signatures_in_stubs,
+    cached_overload_env(),
+    r#"
+from pkg import HasProps
+from typing import assert_type
+
+assert_type(HasProps.properties(), set[str])
+assert_type(HasProps.properties(_with_props=True), dict[str, object])
 "#,
 );

--- a/pyrefly/lib/test/pysa/call_graph.rs
+++ b/pyrefly/lib/test/pysa/call_graph.rs
@@ -6282,7 +6282,10 @@ def foo():
             vec![
                 (
                     "4:3-6:13",
-                    define_callees(vec![create_call_target("test.inner", TargetType::Function)]),
+                    define_callees(vec![
+                        create_call_target("test.inner", TargetType::Function)
+                            .with_return_type(ScalarTypeProperties::int()),
+                    ]),
                 ),
                 (
                     "7:3-7:10",

--- a/pyrefly/lib/test/pysa/call_graph.rs
+++ b/pyrefly/lib/test/pysa/call_graph.rs
@@ -6308,7 +6308,10 @@ def foo():
             vec![
                 (
                     "4:3-6:13",
-                    define_callees(vec![create_call_target("test.inner", TargetType::Function)]),
+                    define_callees(vec![
+                        create_call_target("test.inner", TargetType::Function)
+                            .with_return_type(ScalarTypeProperties::int()),
+                    ]),
                 ),
                 (
                     "7:3-7:10",


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes part of #4010

now models `functools._lru_cache_wrapper` as an intersection of the runtime wrapper and the original callable, preserving call signatures while keeping cache_info / cache_clear.

preserves binding behavior through intersections/KwCall wrappers for cached methods.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

added coverage for cache, lru_cache, called decorators, and methods.
