### PR TITLE
Cache `pkgutil` namespace probes during import resolution

### DIFF
--- a/crates/pyrefly_build/src/module_resolver.rs
+++ b/crates/pyrefly_build/src/module_resolver.rs
@@ -93,7 +93,10 @@ fn is_pkgutil_namespace(init_path: &Path, observer: Option<&dyn ModuleResolution
 /// resolution transaction or replace it when file changes are observed.
 #[derive(Default)]
 pub struct DirEntryCache {
-    cache: LockedMap<PathBuf, Option<Arc<SmallMap<OsString, bool>>>>,
+    /// Cached directory listings: maps a directory to its entries (name -> is_dir).
+    entry_cache: LockedMap<PathBuf, Option<Arc<SmallMap<OsString, bool>>>>,
+    /// Cached `pkgutil.extend_path` namespace-package check, keyed by `__init__` path.
+    pkgutil_cache: LockedMap<PathBuf, bool>,
 }
 
 impl Debug for DirEntryCache {
@@ -105,8 +108,24 @@ impl Debug for DirEntryCache {
 impl DirEntryCache {
     pub fn new() -> Self {
         Self {
-            cache: LockedMap::new(),
+            entry_cache: LockedMap::new(),
+            pkgutil_cache: LockedMap::new(),
         }
+    }
+
+    /// Cached form of [`is_pkgutil_namespace`], keyed by `__init__` path.
+    fn is_pkgutil_namespace(
+        &self,
+        init_path: &Path,
+        observer: Option<&dyn ModuleResolutionObserver>,
+    ) -> bool {
+        let key = init_path.to_path_buf();
+        if let Some(cached) = self.pkgutil_cache.get(&key) {
+            return *cached;
+        }
+        let result = is_pkgutil_namespace(init_path, observer);
+        self.pkgutil_cache.insert(key, result);
+        result
     }
 
     pub fn file_exists(&self, path: &Path) -> bool {
@@ -132,12 +151,12 @@ impl DirEntryCache {
 
     fn get_entries(&self, dir: &Path) -> Option<Arc<SmallMap<OsString, bool>>> {
         let key = dir.to_path_buf();
-        if let Some(cached) = self.cache.get(&key) {
+        if let Some(cached) = self.entry_cache.get(&key) {
             return cached.clone();
         }
         let listing = Self::read_dir_entries(dir);
-        self.cache.insert(key.clone(), listing);
-        self.cache.get(&key).and_then(|v| v.clone())
+        self.entry_cache.insert(key.clone(), listing);
+        self.entry_cache.get(&key).and_then(|v| v.clone())
     }
 
     fn read_dir_entries(dir: &Path) -> Option<Arc<SmallMap<OsString, bool>>> {
@@ -283,7 +302,7 @@ fn find_one_part_in_root(
         for candidate_init_suffix in candidate_init_suffixes {
             let init_path = candidate_dir.join(candidate_init_suffix);
             if timed_stat(observer, || dir_cache.file_exists(&init_path)) {
-                if is_pkgutil_namespace(&init_path, observer) {
+                if dir_cache.is_pkgutil_namespace(&init_path, observer) {
                     return Some(FindResult::LegacyNamespacePackage(
                         init_path,
                         Vec1::new(candidate_dir),


### PR DESCRIPTION
# Summary

* Resolving a module and its submodules walks each path component, and every intermediate package's `__init__.py` is probed with `is_pkgutil_namespace`.

* Crucially, the _same_ `__init__` files are re-opened/re-read _once per resolved submodule_, leading to a lot of redundant calls (each of which is a `File::open` + 4KiB `read` + a regex to check for `pkgutil.extend_path`).

### Solution

Memoise the result in a new `pkgutil_cache` on `DirEntryCache`, keyed by `__init__` path, sharing the same "per-loader, never-invalidated" lifetime as the existing entry cache. The existing `cache` name was updated to `entry_cache` to help differentiate/clarify now there are two caches.

### Impact

Reduces ~14,900 reads to ~1,150 when testing against the `core/homeassistant` package. (One per unique `__init__` reached, for a ~92% reduction).

Didn't see a meaningful performance impact on macOS (cached reads are cheap?). I'd expect a more noticeable positive change on Windows though (especially with corporate security software installed, which may intercept/introspect reads).

This is additive to https://github.com/facebook/pyrefly/pull/3994, with respect to https://github.com/facebook/pyrefly/issues/3993.

# Test Plan

No type-inference logic changes; tests return identical before/after test results.
