### PR TITLE
fix Unable to see generic attributes on abstract classes #4058

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -3440,7 +3440,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 ..
             } => {
                 ty = self.normalize_attr_ty(ty);
-                if ambiguous {
+                if ambiguous && !matches!(cls, ClassBase::SelfType(_)) {
                     ClassAttribute::no_access(NoAccessReason::ClassAttributeIsGeneric(
                         cls.class_object().dupe(),
                     ))

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -702,6 +702,21 @@ C.x  # E: Generic attribute `x` of class `C` is not visible on the class
 );
 
 testcase!(
+    test_class_generic_attribute_lookup_on_self_type,
+    r#"
+from typing import assert_type
+
+class C[T]:
+    x: type[T]
+
+    @classmethod
+    def f(cls) -> type[T]:
+        assert_type(cls.x, type[T])
+        return cls.x
+"#,
+);
+
+testcase!(
     test_var_attribute,
     r#"
 from typing import assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4058

generic class attributes remain visible when accessed through `type[Self@...]`, which is the cls receiver in classmethods.

Bare class access like C.x still keeps the existing missing-attribute behavior.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test