### PR TITLE
Fix notebook inlay hints lost in code cells after a markdown cell

### DIFF
--- a/crates/pyrefly_util/src/lined_buffer.rs
+++ b/crates/pyrefly_util/src/lined_buffer.rs
@@ -261,7 +261,15 @@ impl LinedBuffer {
                 LineNumber::from_one_indexed(loc.line),
             )
         {
-            Some(cell.to_zero_indexed())
+            // ruff's `cell()` is the raw all-cells index (markdown included), but callers
+            // compare against the code-cell index from `get_code_cell_index`. Translate.
+            let abs = cell.to_zero_indexed();
+            Some(
+                notebook.cells()[..abs]
+                    .iter()
+                    .filter(|c| c.is_code_cell())
+                    .count(),
+            )
         } else {
             None
         }
@@ -592,7 +600,46 @@ impl DisplayPos {
 mod tests {
     use std::sync::Arc;
 
+    use ruff_notebook::Cell;
+    use ruff_notebook::CellMetadata;
+    use ruff_notebook::CodeCell;
+    use ruff_notebook::MarkdownCell;
+    use ruff_notebook::RawNotebook;
+    use ruff_notebook::RawNotebookMetadata;
+    use ruff_notebook::SourceValue;
+
     use super::*;
+
+    /// A `[code "x = 1", markdown, code "y = 2"]` notebook. Its concatenated
+    /// source (code cells only) is `"x = 1\ny = 2\n"`, so `y = 2` sits at
+    /// code-cell index 1 but all-cells index 2 — the mismatch these tests probe.
+    fn code_markdown_code_notebook() -> Notebook {
+        let code = |src: &str| {
+            Cell::Code(CodeCell {
+                execution_count: None,
+                id: None,
+                metadata: CellMetadata::default(),
+                outputs: vec![],
+                source: SourceValue::String(src.to_owned()),
+            })
+        };
+        let raw = RawNotebook {
+            cells: vec![
+                code("x = 1"),
+                Cell::Markdown(MarkdownCell {
+                    attachments: None,
+                    id: None,
+                    metadata: CellMetadata::default(),
+                    source: SourceValue::String("# heading".to_owned()),
+                }),
+                code("y = 2"),
+            ],
+            metadata: RawNotebookMetadata::default(),
+            nbformat: 4,
+            nbformat_minor: 5,
+        };
+        Notebook::from_raw_notebook(raw, false).unwrap()
+    }
 
     #[test]
     fn test_line_buffer_unicode() {
@@ -721,43 +768,7 @@ mod tests {
     ///     start of code_1 — giving the wrong concatenated line
     #[test]
     fn test_from_lsp_position_notebook_cell_index_mismatch() {
-        use ruff_notebook::Cell;
-        use ruff_notebook::CellMetadata;
-        use ruff_notebook::CodeCell;
-        use ruff_notebook::MarkdownCell;
-        use ruff_notebook::Notebook;
-        use ruff_notebook::RawNotebook;
-        use ruff_notebook::RawNotebookMetadata;
-        use ruff_notebook::SourceValue;
-
-        let raw = RawNotebook {
-            cells: vec![
-                Cell::Code(CodeCell {
-                    execution_count: None,
-                    id: None,
-                    metadata: CellMetadata::default(),
-                    outputs: vec![],
-                    source: SourceValue::String("x = 1".to_owned()),
-                }),
-                Cell::Markdown(MarkdownCell {
-                    attachments: None,
-                    id: None,
-                    metadata: CellMetadata::default(),
-                    source: SourceValue::String("# heading".to_owned()),
-                }),
-                Cell::Code(CodeCell {
-                    execution_count: None,
-                    id: None,
-                    metadata: CellMetadata::default(),
-                    outputs: vec![],
-                    source: SourceValue::String("y = 2".to_owned()),
-                }),
-            ],
-            metadata: RawNotebookMetadata::default(),
-            nbformat: 4,
-            nbformat_minor: 5,
-        };
-        let notebook = Notebook::from_raw_notebook(raw, false).unwrap();
+        let notebook = code_markdown_code_notebook();
         // source_code() concatenates only code cells: "x = 1\ny = 2\n"
         let source = notebook.source_code().to_owned();
         assert_eq!(source, "x = 1\ny = 2\n");
@@ -787,6 +798,30 @@ mod tests {
             correct_offset, wrong_offset,
             "all-cells index 2 must differ from code-cell index 1 — \
              callers must translate via get_code_cell_index"
+        );
+    }
+
+    /// Regression test: `to_cell_for_lsp` must return the code-cell index
+    /// (matching `get_code_cell_index`), not ruff's raw all-cells index. For
+    /// [code_0, markdown, code_1], a position in "y = 2" is code-cell 1, not
+    /// all-cells index 2.
+    #[test]
+    fn test_to_cell_for_lsp_returns_code_cell_index() {
+        let notebook = code_markdown_code_notebook();
+        let source = notebook.source_code().to_owned();
+        assert_eq!(source, "x = 1\ny = 2\n");
+        let lined_buffer = LinedBuffer::new(Arc::new(source));
+
+        // Offset 0 ("x") is in the first code cell → code-cell index 0.
+        assert_eq!(
+            lined_buffer.to_cell_for_lsp(TextSize::new(0), Some(&notebook)),
+            Some(0)
+        );
+        // Offset 6 ("y") is in the second code cell, which is all-cells index 2
+        // but code-cell index 1.
+        assert_eq!(
+            lined_buffer.to_cell_for_lsp(TextSize::new(6), Some(&notebook)),
+            Some(1)
         );
     }
 }

--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_inlay_hint.rs
@@ -7,6 +7,7 @@
 
 use serde_json::json;
 
+use crate::object_model::CellKind;
 use crate::object_model::InitializeSettings;
 use crate::object_model::LspInteraction;
 use crate::util::check_inlay_hint_label_values;
@@ -128,6 +129,49 @@ fn test_inlay_hints() {
                     ("]", false),
                 ],
             )
+        })
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+/// Regression test: a markdown cell preceding a code cell must not suppress the
+/// code cell's inlay hints. The cell filter compares the code-cell index (which
+/// skips markdown cells) against `to_cell_for_lsp`, so the latter must also
+/// return a code-cell index rather than the absolute all-cells index.
+#[test]
+fn test_inlay_hints_with_preceding_markdown_cell() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+    // cell1: code, cell2: markdown, cell3: code (the cell under test).
+    interaction.open_notebook_with_kinds(
+        "notebook.ipynb",
+        vec![
+            (CellKind::Code, "def make():\n    return (1, 2)"),
+            (CellKind::Markdown, "# Title"),
+            (CellKind::Code, "result = make()"),
+        ],
+    );
+
+    interaction
+        .inlay_hint_cell("notebook.ipynb", "cell3", 0, 0, 100, 0)
+        .expect_response_with(|result| {
+            let hints = match result {
+                Some(hints) => hints,
+                None => return false,
+            };
+            // The `result = make()` assignment must get a variable-type hint
+            // right after `result` (column 6), despite the preceding markdown cell.
+            hints.len() == 1 && hints[0].position.line == 0 && hints[0].position.character == 6
         })
         .unwrap();
 

--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_sync.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_sync.rs
@@ -9,6 +9,7 @@ use lsp_types::Url;
 use lsp_types::notification::DidOpenNotebookDocument;
 use serde_json::json;
 
+use crate::object_model::CellKind;
 use crate::object_model::InitializeSettings;
 use crate::object_model::LspInteraction;
 use crate::util::get_test_files_root;
@@ -501,8 +502,10 @@ fn test_notebook_did_change_add_cell() {
     );
 
     // Open cells 4 and 5
-    let (cell4, cell4_doc) = interaction.create_notebook_cell("notebook.ipynb", 3, "x += 1");
-    let (cell5, cell5_doc) = interaction.create_notebook_cell("notebook.ipynb", 4, "x += 2");
+    let (cell4, cell4_doc) =
+        interaction.create_notebook_cell("notebook.ipynb", 3, CellKind::Code, "x += 1");
+    let (cell5, cell5_doc) =
+        interaction.create_notebook_cell("notebook.ipynb", 4, CellKind::Code, "x += 2");
 
     interaction.change_notebook(
         "notebook.ipynb",

--- a/pyrefly/lib/test/lsp/lsp_interaction/object_model.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/object_model.rs
@@ -121,6 +121,13 @@ impl std::fmt::Display for LspMessageError {
 
 impl std::error::Error for LspMessageError {}
 
+/// Kind of a notebook cell, sidestepping boolean-blindness at call sites.
+#[derive(Clone, Copy)]
+pub enum CellKind {
+    Code,
+    Markdown,
+}
+
 #[derive(Default)]
 pub struct InitializeSettings {
     pub workspace_folders: Option<Vec<(String, Url)>>,
@@ -1460,34 +1467,50 @@ impl LspInteraction {
         &self,
         file_name: &str,
         cell_number: usize,
+        kind: CellKind,
         cell_contents: &str,
     ) -> (Value, Value) {
         let cell_uri = self.cell_uri(file_name, &format!("cell{}", cell_number + 1));
+        // LSP notebook cell kinds: Code = 2, Markup = 1.
+        let (kind_id, language_id) = match kind {
+            CellKind::Code => (2, "python"),
+            CellKind::Markdown => (1, "markdown"),
+        };
         let cell = json!({
-            "kind": 2,
+            "kind": kind_id,
             "document": cell_uri,
         });
         let doc = json!({
             "uri": cell_uri,
-            "languageId": "python",
+            "languageId": language_id,
             "version": 1,
             "text": *cell_contents
         });
         (cell, doc)
     }
 
-    /// Opens a notebook document with the given cell contents.
-    /// Each string in `cell_contents` becomes a separate code cell in the notebook.
+    /// Opens a notebook document whose cells are all code cells.
     pub fn open_notebook(&self, file_name: &str, cell_contents: Vec<&str>) {
+        self.open_notebook_with_kinds(
+            file_name,
+            cell_contents
+                .into_iter()
+                .map(|text| (CellKind::Code, text))
+                .collect(),
+        );
+    }
+
+    /// Opens a notebook document with mixed cell kinds. Each entry is
+    /// `(kind, text)`. Cells are addressed by fragment `cell{i+1}`.
+    pub fn open_notebook_with_kinds(&self, file_name: &str, cells_spec: Vec<(CellKind, &str)>) {
         let root = self.client.get_root_or_panic();
         let notebook_path = root.join(file_name);
         let notebook_uri = Url::from_file_path(&notebook_path).unwrap().to_string();
 
         let mut cells = Vec::new();
         let mut cell_text_documents = Vec::new();
-
-        for (i, text) in cell_contents.iter().enumerate() {
-            let (cell, doc) = self.create_notebook_cell(file_name, i, text);
+        for (i, (kind, text)) in cells_spec.iter().enumerate() {
+            let (cell, doc) = self.create_notebook_cell(file_name, i, *kind, text);
             cells.push(cell);
             cell_text_documents.push(doc);
         }


### PR DESCRIPTION
# Summary

Adding a markdown cell above a code cell made that code cell lose its inlay hints - and every code cell after it. The same bug silently hit semantic tokens, document symbols, references, and diagnostic grouping, since they all share one per-cell filter.

The filter compares two cell indices that are supposed to mean the same thing. `LinedBuffer::to_cell_for_lsp` returned ruff's all-cells index (position among every cell, markdown included), but callers compare it against the code-cell index from `LspNotebook::get_code_cell_index` (position among code cells only, matching `cell_offsets()`). The two agree only when a notebook has no markdown cells, so a leading markdown cell shifts them apart and the filter matches nothing.

Translate the all-cells index to the code-cell index inside `to_cell_for_lsp` by counting the preceding code cells, mirroring `get_code_cell_index`, so the indices agree and every feature sharing this filter is fixed at once.

# Test Plan

Added a unit test `test_to_cell_for_lsp_returns_code_cell_index` in `crates/pyrefly_util/src/lined_buffer.rs`: for a `[code, markdown, code]` notebook, asserts a position in the second code cell resolves to code-cell index 1 (not all-cells index 2). Added a regression test `test_inlay_hints_with_preceding_markdown_cell` in `pyrefly/lib/test/lsp/lsp_interaction/notebook_inlay_hint.rs`: a code cell after a markdown cell still gets its variable-type hint. Both fail on main, pass with the fix.

- cargo test -p pyrefly_util lined_buffer
- cargo test -p pyrefly --test pyrefly_lsp_interaction_tests -- inlay sync
- python3 test.py --no-test --no-conformance --no-jsonschema