### PR TITLE
fix Unpacking dict in class header (i.e. in class kwargs) #1762

### DIFF
--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 
 use dupe::Dupe;
 use dupe::IterDupedExt;
-use itertools::Either;
 use itertools::Itertools;
 use pyrefly_graph::index::Idx;
 use pyrefly_python::dunder;
@@ -29,7 +28,7 @@ use pyrefly_util::display::DisplayWithCtx;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::prelude::VecExt;
 use ruff_python_ast::Expr;
-use ruff_python_ast::Identifier;
+use ruff_python_ast::Keyword;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
@@ -44,7 +43,6 @@ use crate::alt::call::CallStyle;
 use crate::alt::callable::CallKeyword;
 use crate::alt::class::attrs::is_attrs_setters_frozen;
 use crate::alt::class::django::is_django_choices_subclass;
-use crate::alt::expr::TypeOrExpr;
 use crate::alt::solve::TypeFormContext;
 use crate::alt::types::abstract_class::AbstractClassMembers;
 use crate::alt::types::class_metadata::ClassDisjointBase;
@@ -144,11 +142,47 @@ pub(crate) struct TransformDataclass {
 }
 
 impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
+    fn extend_unpacked_class_keywords(
+        &self,
+        keyword: &Keyword,
+        keywords: &mut Vec<(Name, Annotation)>,
+        errors: &ErrorCollector,
+    ) {
+        let ty = self.expr_infer(&keyword.value, errors);
+        if let Type::TypedDict(typed_dict) = ty {
+            for (name, field) in self.typed_dict_fields(&typed_dict) {
+                keywords.push((name, Annotation::new_type(field.ty)));
+            }
+        } else if let Some((key, _)) = self.unwrap_mapping(&ty) {
+            if !self.is_subset_eq(&key, &self.heap.mk_class_type(self.stdlib.str().clone())) {
+                self.error(
+                    errors,
+                    keyword.value.range(),
+                    ErrorKind::BadUnpacking,
+                    format!(
+                        "Expected argument after ** to have `str` keys, got: {}",
+                        self.for_display(key)
+                    ),
+                );
+            }
+        } else {
+            self.error(
+                errors,
+                keyword.value.range(),
+                ErrorKind::BadUnpacking,
+                format!(
+                    "Expected argument after ** to be a mapping, got: {}",
+                    self.for_display(ty)
+                ),
+            );
+        }
+    }
+
     pub fn class_metadata_of(
         &self,
         cls: &Class,
         bases: &[BaseClass],
-        keywords: &[(Identifier, Expr)],
+        raw_keywords: &[Keyword],
         decorators: &[Idx<KeyDecorator>],
         is_new_type: bool,
         pydantic_config_dict: &PydanticConfigDict,
@@ -212,12 +246,20 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .collect::<Vec<_>>();
 
         // Compute class keywords, including the metaclass.
-        let (metaclasses, keyword_annotations): (Vec<_>, Vec<(_, _)>) =
-            keywords.iter().partition_map(|(n, x)| match n.id.as_str() {
-                "metaclass" => Either::Left(x),
-                _ => Either::Right((n.clone(), self.expr_class_keyword(x, errors))),
-            });
-        let keyword_annotations = keyword_annotations.into_map(|(name, annot)| (name.id, annot));
+        let mut metaclasses = Vec::new();
+        let mut keyword_annotations = Vec::new();
+        for keyword in raw_keywords {
+            match &keyword.arg {
+                Some(name) if name.id == "metaclass" => metaclasses.push(&keyword.value),
+                Some(name) => keyword_annotations.push((
+                    name.id.clone(),
+                    self.expr_class_keyword(&keyword.value, errors),
+                )),
+                None => {
+                    self.extend_unpacked_class_keywords(keyword, &mut keyword_annotations, errors)
+                }
+            }
+        }
 
         let direct_metaclass = metaclasses
             .into_iter()
@@ -271,7 +313,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let metaclass = calculated_metaclass.get();
         // Compute base classes with metadata.
         let bases_with_metadata = self.bases_with_metadata(parsed_results, is_new_type, errors);
-        self.check_init_subclass_keywords(cls, &bases_with_metadata, metaclass, keywords, errors);
+        self.check_init_subclass_keywords(
+            cls,
+            &bases_with_metadata,
+            metaclass,
+            raw_keywords,
+            errors,
+        );
 
         let mut directly_inherits_model = false;
         let mut inherited_django_metadata: Option<&DjangoModelMetadata> = None;
@@ -616,7 +664,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         cls: &Class,
         bases_with_metadata: &[(Class, Arc<ClassMetadata>)],
         metaclass: Option<&ClassType>,
-        keywords: &[(Identifier, Expr)],
+        keywords: &[Keyword],
         errors: &ErrorCollector,
     ) {
         let is_pydantic_model = bases_with_metadata.iter().any(|(base, metadata)| {
@@ -625,7 +673,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         });
         let keywords = keywords
             .iter()
-            .filter(|(name, _)| name.id != "metaclass" && !(is_pydantic_model && name.id == EXTRA))
+            .filter(|keyword| {
+                keyword.arg.as_ref().is_none_or(|name| {
+                    name.id != "metaclass" && !(is_pydantic_model && name.id == EXTRA)
+                })
+            })
             .collect::<Vec<_>>();
         if !keywords.is_empty() && metaclass.is_some() {
             return;
@@ -645,11 +697,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         };
         let keywords = keywords
             .into_iter()
-            .map(|(name, value)| CallKeyword {
-                range: name.range(),
-                arg: Some(name),
-                value: TypeOrExpr::Expr(value),
-            })
+            .map(CallKeyword::new)
             .collect::<Vec<_>>();
         self.call_infer(
             self.as_call_target_or_error(

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -43,6 +43,7 @@ use ruff_python_ast::ExprSubscript;
 use ruff_python_ast::ExprYield;
 use ruff_python_ast::ExprYieldFrom;
 use ruff_python_ast::Identifier;
+use ruff_python_ast::Keyword;
 use ruff_python_ast::Parameters;
 use ruff_python_ast::StmtAugAssign;
 use ruff_python_ast::StmtClassDef;
@@ -3389,7 +3390,7 @@ pub struct BindingClassMetadata {
     /// The class keywords (these are keyword args that appear in the base class list, the
     /// Python runtime will dispatch most of them to the metaclass, but the metaclass
     /// itself can also potentially be one of these).
-    pub keywords: Box<[(Identifier, Expr)]>,
+    pub keywords: Box<[Keyword]>,
     /// The class decorators.
     pub decorators: Box<[Idx<KeyDecorator>]>,
     /// Is this a new type? True only for synthesized classes created from a `NewType` call.

--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -386,16 +386,8 @@ impl<'a> BindingsBuilder<'a> {
         let mut keywords = Vec::new();
         if let Some(args) = &mut x.arguments {
             args.keywords.iter_mut().for_each(|keyword| {
-                if let Some(name) = &keyword.arg {
-                    self.ensure_expr(&mut keyword.value, class_object.usage());
-                    keywords.push((name.clone(), keyword.value.clone()));
-                } else {
-                    self.error(
-                        keyword.range(),
-                        ErrorKind::InvalidInheritance,
-                        "Unpacking is not supported in class header".to_owned(),
-                    )
-                }
+                self.ensure_expr(&mut keyword.value, class_object.usage());
+                keywords.push(keyword.clone());
             });
         }
         let bases: Arc<[BaseClass]> = Arc::from(bases.into_boxed_slice());
@@ -1157,7 +1149,7 @@ impl<'a> BindingsBuilder<'a> {
         class_indices: ClassIndices,
         parent: &NestingContext,
         base: Option<Expr>,
-        keywords: Box<[(Identifier, Expr)]>,
+        keywords: Box<[Keyword]>,
         // name, position, annotation, value
         member_definitions: Vec<(String, TextRange, Option<Expr>, Option<ExprOrBinding>)>,
         illegal_identifier_handling: IllegalIdentifierHandling,
@@ -1606,11 +1598,7 @@ impl<'a> BindingsBuilder<'a> {
                 _ => None,
             };
             if recognized_kw.is_some() {
-                let kw_name = kw
-                    .arg
-                    .clone()
-                    .expect("recognized TypedDict keyword must have a name");
-                base_class_keywords.push((kw_name, kw.value.clone()));
+                base_class_keywords.push(kw.clone());
             } else {
                 let msg = if let Some(name) = &kw.arg {
                     format!("Unrecognized keyword argument `{name}`")

--- a/pyrefly/lib/test/class_keywords.rs
+++ b/pyrefly/lib/test/class_keywords.rs
@@ -52,6 +52,7 @@ fn test_look_up_class_keywords() {
     let (handle, state) = mk_state(
         r#"
 class A(foo=True): pass
+class B(**{"foo": True, "bar": 1}): pass
 "#,
     );
     assert_eq!(
@@ -59,6 +60,8 @@ class A(foo=True): pass
         vec![Lit::Bool(true).to_implicit_type()],
     );
     assert_eq!(get_class_keywords("A", "bar", &handle, &state), vec![]);
+    assert_eq!(get_class_keywords("B", "foo", &handle, &state).len(), 1);
+    assert_eq!(get_class_keywords("B", "bar", &handle, &state).len(), 1);
 }
 
 #[test]
@@ -169,10 +172,19 @@ class E(metaclass=D):
 );
 
 testcase!(
-    test_illegal_unpacking,
+    test_class_keyword_unpacking,
     r#"
-def f() -> dict: ...
-class A(**f):  # E: Unpacking is not supported in class header
+from typing import Any
+
+meta: dict[str, Any] = {}
+class A(**meta, tag="A"):
+    pass
+
+class B(**1):  # E: Expected argument after ** to be a mapping, got: Literal[1]
+    pass
+
+bad_keys: dict[int, str] = {}
+class C(**bad_keys):  # E: Expected argument after ** to have `str` keys, got: int
     pass
     "#,
 );


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1762

Changed class header keyword handling so `**kwargs` is no longer rejected in binding.

Unpacked class keywords are now validated at solve time: precise TypedDict/anonymous dict fields are expanded into class metadata, broad `Mapping[str, T]` values are accepted as opaque, and invalid `**` operands/key types report BadUnpacking.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test