### PR TITLE
fix Transforming a tuple loses track of its length #4083

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1075,8 +1075,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             && ct.targs().as_slice().len() == 1
         {
             let targ = ct.targs().as_slice()[0].clone();
+            let ty = self
+                .tuple_constructor_arg_type(args, keywords)
+                .unwrap_or_else(|| self.heap.mk_unbounded_tuple(targ));
             ConstructedInstance {
-                ty: self.heap.mk_unbounded_tuple(targ),
+                ty,
                 matched_hint,
                 errors,
                 specialization_errors,
@@ -1242,6 +1245,36 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         } else {
             None
+        }
+    }
+
+    fn tuple_constructor_arg_type(
+        &self,
+        args: &[CallArg],
+        keywords: &[CallKeyword],
+    ) -> Option<Type> {
+        if !keywords.is_empty() {
+            return None;
+        }
+        let [CallArg::Arg(arg)] = args else {
+            return None;
+        };
+        let errors = self.error_collector();
+        self.tuple_constructor_arg_type_from_type(arg.infer(self, &errors))
+    }
+
+    fn tuple_constructor_arg_type_from_type(&self, ty: Type) -> Option<Type> {
+        match ty {
+            Type::Tuple(tuple) => Some(self.heap.mk_tuple(tuple)),
+            Type::ClassType(cls) => self.as_tuple(&cls).map(|tuple| self.heap.mk_tuple(tuple)),
+            Type::Union(union) => {
+                let mut members = Vec::with_capacity(union.members.len());
+                for member in union.members {
+                    members.push(self.tuple_constructor_arg_type_from_type(member)?);
+                }
+                Some(self.unions(members))
+            }
+            _ => None,
         }
     }
 

--- a/pyrefly/lib/test/tuple.rs
+++ b/pyrefly/lib/test/tuple.rs
@@ -483,6 +483,17 @@ def test(x: Iterable[int]) -> None:
 );
 
 testcase!(
+    test_tuple_constructor_preserves_fixed_length,
+    r#"
+from typing import assert_type
+def test(xs: tuple[int, int]) -> None:
+    ys: tuple[int, int] = tuple(xs)
+    assert_type(tuple(xs), tuple[int, int])
+    zs: tuple[int, int] = tuple(x for x in xs)  # E: `tuple[int, ...]` is not assignable to `tuple[int, int]`
+"#,
+);
+
+testcase!(
     test_tuple_constructor_concat,
     r#"
 from typing import assert_type, Iterable, Literal


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4083

tuple(xs) preserves a known tuple shape when xs is already tuple-typed, while other iterables still use the existing homogeneous tuple[T, ...] behavior.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test