### PR TITLE
Fix bidirectional type checking not working for lambdas

### DIFF
--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -65,11 +65,24 @@ use crate::types::types::Var;
 /// This is used to avoid re-inferring types for arguments multiple types.
 ///
 /// Implemented by keeping an `Owner` to hand out references to `Type`.
-pub struct CallWithTypes(Owner<Type>);
+pub struct CallWithTypes {
+    owner: Owner<Type>,
+    bidirectional_lambda_inferrence: bool,
+}
 
 impl CallWithTypes {
     pub fn new() -> Self {
-        Self(Owner::new())
+        Self {
+            owner: Owner::new(),
+            bidirectional_lambda_inferrence: false,
+        }
+    }
+
+    pub fn new_with_lambda(bidirectional_lambda_inferrence: bool) -> Self {
+        Self {
+            owner: Owner::new(),
+            bidirectional_lambda_inferrence,
+        }
     }
 
     pub fn type_or_expr<'a, 'b: 'a, Ans: LookupAnswer>(
@@ -85,9 +98,17 @@ impl CallWithTypes {
                 // the function's parameter types.
                 TypeOrExpr::Expr(e)
             }
+            TypeOrExpr::Expr(e @ Expr::Lambda(_)) if self.bidirectional_lambda_inferrence => {
+                // Even more of a hack: When the generic arguments going into the lambda are
+                // already solved, we can use bidirectional typechecking for the lambda, this only
+                // works if the type arguments are already solved in order, as it is not yet
+                // supported to solve type arguments in the order they are simplest in, they are
+                // always solved in order.
+                TypeOrExpr::Expr(e)
+            }
             TypeOrExpr::Expr(e) => {
                 let t = solver.expr_infer(e, errors);
-                TypeOrExpr::Type(self.0.push(t), e.range())
+                TypeOrExpr::Type(self.owner.push(t), e.range())
             }
             TypeOrExpr::Type(t, r) => TypeOrExpr::Type(t, r),
         }

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -56,6 +56,7 @@ struct CalledOverload<'f> {
     func: &'f TargetWithTParams<Function>,
     res: Type,
     ctor_targs: Option<TArgs>,
+    arg_errors: ErrorCollector,
     call_errors: ErrorCollector,
     specialization_errors: Vec<TypeVarSpecializationError>,
     /// Maps each argument's source range to the parameter it was matched against.
@@ -258,11 +259,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // If we're constructing a class, its type arguments. A successful call will fill these in.
         ctor_targs: Option<&mut TArgs>,
     ) -> (Type, Callable) {
+        let allow_bidirectional_lambda_inferrence = match &metadata.kind {
+            pyrefly_types::callable::FunctionKind::Def(def) => def.cls.is_some(),
+            _ => false,
+        };
         // There may be Expr values in args and keywords.
         // If we infer them for each overload, we may end up inferring them multiple times.
         // If those overloads contain nested overloads, then we can easily end up with O(2^n) perf.
         // Therefore, flatten all TypeOrExpr's into Type before we start
-        let call = CallWithTypes::new();
+        let call = CallWithTypes::new_with_lambda(allow_bidirectional_lambda_inferrence);
         let args = call.vec_call_arg(args, self, errors);
         let keywords = call.vec_call_keyword(keywords, self, errors);
 
@@ -291,6 +296,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     func: arity_closest_overload.unwrap().0,
                     res: self.heap.mk_any_error(),
                     ctor_targs: None,
+                    arg_errors: self.error_collector(),
                     call_errors: self.error_collector(),
                     specialization_errors: Vec::new(),
                     argmap: ArgMap::new(),
@@ -316,7 +322,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // Step 3: perform argument type expansion.
                 let mut args_expander = ArgsExpander::new(args.clone(), keywords.clone(), self);
                 let owner = Owner::new();
-                'outer: while !matched && let Some(arg_lists) = args_expander.expand(errors, &owner)
+                let expansion_errors = self.error_collector();
+                'outer: while !matched
+                    && let Some(arg_lists) = args_expander.expand(&expansion_errors, &owner)
                 {
                     // Expand by one argument (for example, try splitting up union types), and try the call with each
                     // resulting arguments list.
@@ -352,6 +360,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             ctor_targs,
                             argmap,
                             res: self.unions(matched_overloads.into_map(|o| o.res)),
+                            arg_errors: self.error_collector(),
                             call_errors: self.error_collector(),
                             specialization_errors,
                         };
@@ -414,6 +423,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
                 error_builder.with_context(context).emit();
             }
+            errors.extend(closest_overload.arg_errors);
             errors.extend(closest_overload.call_errors);
             if let Ok(specialization_errors) =
                 Vec1::try_from_vec(closest_overload.specialization_errors)
@@ -720,7 +730,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 args,
                 keywords,
                 arguments_range,
-                errors,
                 None, // don't use the hint yet, it shouldn't influence overload selection
                 ctor_targs,
             );
@@ -744,6 +753,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             // If there are multiple overloads, use steps 4-6 here to select one:
             // https://typing.python.org/en/latest/spec/overload.html#overload-call-evaluation.
             let spec_compliant = self.solver().spec_compliant_overloads;
+            let selection_errors = self.error_collector();
             if matched_overloads.len() > 1 {
                 // Step 4: if any arguments supply an unknown number of args and at least one
                 // overload has a corresponding variadic parameter, eliminate overloads without
@@ -765,7 +775,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                 }
                 let nkeywords_unknown = keywords.iter().any(|kw| {
-                    kw.arg.is_none() && !matches!(kw.value.infer(self, errors), Type::TypedDict(_))
+                    kw.arg.is_none()
+                        && !matches!(kw.value.infer(self, &selection_errors), Type::TypedDict(_))
                 });
                 if nkeywords_unknown {
                     let has_kwargs = |o: &CalledOverload<'_>| {
@@ -809,7 +820,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 };
                 let materialized_args = args.map(|arg| {
                     let (materialized_arg, arg_changed) = if should_materialize(arg.range()) {
-                        arg.materialize(self, errors, &owner)
+                        arg.materialize(self, &selection_errors, &owner)
                     } else {
                         (arg.clone(), false)
                     };
@@ -818,7 +829,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 });
                 let materialized_keywords = keywords.map(|kw| {
                     let (materialized_kw, kw_changed) = if should_materialize(kw.range()) {
-                        kw.materialize(self, errors, &owner)
+                        kw.materialize(self, &selection_errors, &owner)
                     } else {
                         (kw.clone(), false)
                     };
@@ -842,7 +853,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 &materialized_args,
                                 &materialized_keywords,
                                 arguments_range,
-                                errors,
                                 None, // don't use the hint yet, it shouldn't influence overload selection
                                 &None,
                             );
@@ -874,7 +884,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     args,
                     keywords,
                     arguments_range,
-                    &self.error_collector(),
                     hint,
                     ctor_targs,
                 );
@@ -999,7 +1008,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         args: &[CallArg],
         keywords: &[CallKeyword],
         arguments_range: TextRange,
-        errors: &ErrorCollector,
         hint: Option<HintRef>,
         ctor_targs: &Option<&mut TArgs>,
     ) -> CalledOverload<'c> {
@@ -1010,6 +1018,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let mut overload_ctor_targs = ctor_targs.as_ref().map(|x| (**x).clone());
         let tparams = callable.0.as_deref();
 
+        let arg_errors = self.error_collector();
         let call_errors = self.error_collector();
         let (res, specialization_errors, argmap) = self.callable_infer(
             callable.1.signature.clone(),
@@ -1020,7 +1029,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             args,
             keywords,
             arguments_range,
-            errors,
+            &arg_errors,
             &call_errors,
             // We intentionally drop the context here, as arg errors don't need it,
             // and if there are any call errors, we'll log a "No matching overloads"
@@ -1034,6 +1043,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             func: callable,
             res,
             ctor_targs: overload_ctor_targs,
+            arg_errors,
             call_errors,
             specialization_errors,
             argmap,

--- a/pyrefly/lib/test/calls.rs
+++ b/pyrefly/lib/test/calls.rs
@@ -662,3 +662,77 @@ def f() -> list[object]:
     return collect(["x"], 1 + "oops")  # E: `+` is not supported between `Literal[1]` and `Literal['oops']`
     "#,
 );
+
+testcase!(
+    test_lambda_infers_arg_types_from_outer_call,
+    r#"
+from typing import reveal_type
+
+lst: list[int] = []
+lst.sort(key=lambda e: reveal_type(e))  # E: revealed type: int
+    "#,
+);
+
+testcase!(
+    test_lambda_infers_arg_types_from_outer_call_large_union,
+    r#"
+from dataclasses import dataclass
+from typing import reveal_type
+
+@dataclass
+class Event1:
+    id: int
+
+@dataclass
+class Event2:
+    id: int
+
+@dataclass
+class Event3:
+    id: int
+
+AnyEvent = Event1 | Event2 | Event3
+lst: list[AnyEvent] = []
+lst.sort(key=lambda e: reveal_type(e).id)  # E: revealed type: Event1 | Event2 | Event3
+    "#,
+);
+
+testcase!(
+    test_overload_with_second_arg_still_infers_second_arg,
+    r#"
+from collections.abc import AsyncIterable, Awaitable, Callable, Iterable
+from dataclasses import dataclass
+from typing import overload, reveal_type
+
+
+@overload
+def find[T](predicate: Callable[[T], bool], iterable: AsyncIterable[T], /) -> Awaitable[T | None]: ...
+
+
+@overload
+def find[T](predicate: Callable[[T], bool], iterable: Iterable[T], /) -> T | None: ...
+
+
+def find[T](
+    predicate: Callable[[T], bool], iterable: Iterable[T] | AsyncIterable[T], /
+) -> T | None | Awaitable[T | None]: ...
+
+
+@dataclass
+class WithName:
+    name: str
+
+
+@dataclass
+class PartialReaction:
+    emoticon: WithName | None
+    sticker: WithName
+
+
+emoticon: WithName = WithName("abc")
+partial_reactions: list[PartialReaction] = []
+
+reaction = find(lambda r: (r.emoticon or r.sticker).name == emoticon.name, partial_reactions)
+reveal_type(reaction)  # E: revealed type: PartialReaction | None
+    "#,
+);


### PR DESCRIPTION
# Summary

I addressed the missing bidirectional type-checking for lambdas with a fairly easy one line fix, but it revealed a separate problem with overloads leaking errors between each other in my sort unit test so I ended up fixing that as the first commit with a separate regression test.

There is one other unit test that got modified by this change, as it was relying on the previous behvaiour of eagerly inferring lambdas in function calls,  but it should be fine this way as well. Pyrefly should never have a problem with casting a literal back down to a string right?

Fixes #3950 

# Test Plan

Only tested through unit tests, this only touches on the solving step, so it shouldn't be close to anything else.

No files generated by `test.py`
