### PR TITLE
fix Iterating over enumerated tuple loses typing information #1323

### DIFF
--- a/crates/pyrefly_types/src/stdlib.rs
+++ b/crates/pyrefly_types/src/stdlib.rs
@@ -79,6 +79,7 @@ pub struct Stdlib {
     mapping: StdlibResult<(Class, Arc<TParams>)>,
     set: StdlibResult<(Class, Arc<TParams>)>,
     tuple: StdlibResult<(Class, Arc<TParams>)>,
+    enumerate: StdlibResult<(Class, Arc<TParams>)>,
     iterable: StdlibResult<(Class, Arc<TParams>)>,
     async_iterable: StdlibResult<(Class, Arc<TParams>)>,
     async_iterator: StdlibResult<(Class, Arc<TParams>)>,
@@ -240,6 +241,7 @@ impl Stdlib {
             dict_values: lookup_generic(collections_abc, "dict_values", 2),
             set: lookup_generic(builtins, "set", 1),
             tuple: lookup_generic(builtins, "tuple", 1),
+            enumerate: lookup_generic(builtins, "enumerate", 1),
             builtins_type: lookup_concrete(builtins, "type"),
             ellipsis_type: version
                 .at_least(3, 10)
@@ -452,6 +454,10 @@ impl Stdlib {
 
     pub fn tuple(&self, x: Type) -> ClassType {
         Self::apply(&self.tuple, vec![x])
+    }
+
+    pub fn enumerate(&self, x: Type) -> ClassType {
+        Self::apply(&self.enumerate, vec![x])
     }
 
     pub fn list(&self, x: Type) -> ClassType {

--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -49,6 +49,8 @@ use crate::binding::binding::Key;
 use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
 use crate::error::context::ErrorContext;
+use crate::error::context::TypeCheckContext;
+use crate::error::context::TypeCheckKind;
 use crate::solver::solver::QuantifiedHandle;
 use crate::solver::solver::TypeVarSpecializationError;
 use crate::types::callable::Callable;
@@ -2115,6 +2117,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     let arg_ty = self.expr_infer(&x.arguments.args[0], errors);
                     self.type_of(arg_ty)
                 }
+                _ if Self::is_builtin_enumerate(ty) && let Some(ret) = self.call_builtin_enumerate(x, errors) => ret,
                 // Decorators can be applied in two ways:
                 //   - (common, idiomatic) via `@decorator`:
                 //     @staticmethod
@@ -2179,6 +2182,48 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 .args
                 .iter()
                 .all(|e| !matches!(e, Expr::Starred(_)))
+    }
+
+    fn is_builtin_enumerate(ty: &Type) -> bool {
+        if matches!(ty, Type::ClassDef(cls) if cls.is_builtin("enumerate")) {
+            return true;
+        }
+        let Some(CalleeKind::Function(FunctionKind::Def(func))) = ty.callee_kind() else {
+            return false;
+        };
+        func.module.name().as_str() == "builtins"
+            && func.cls.is_none()
+            && func.name.as_str() == "enumerate"
+    }
+
+    fn call_builtin_enumerate(&self, x: &ExprCall, errors: &ErrorCollector) -> Option<Type> {
+        if !x.arguments.keywords.is_empty()
+            || !(1..=2).contains(&x.arguments.args.len())
+            || x.arguments
+                .args
+                .iter()
+                .any(|arg| matches!(arg, Expr::Starred(_)))
+        {
+            return None;
+        }
+        let int_ty = self.heap.mk_class_type(self.stdlib.int().clone());
+        if let Some(start) = x.arguments.args.get(1) {
+            let start_ty = self.expr_infer(start, errors);
+            self.check_type(&start_ty, &int_ty, start.range(), errors, &|| {
+                TypeCheckContext::of_kind(TypeCheckKind::CallArgument(
+                    Some(Name::new_static("start")),
+                    None,
+                ))
+            });
+        }
+        let iterable = self.expr_infer(&x.arguments.args[0], errors);
+        let value = self.get_produced_type(self.iterate(
+            &iterable,
+            x.arguments.args[0].range(),
+            errors,
+            None,
+        ));
+        Some(self.heap.mk_class_type(self.stdlib.enumerate(value)))
     }
 }
 

--- a/pyrefly/lib/test/literal.rs
+++ b/pyrefly/lib/test/literal.rs
@@ -563,7 +563,6 @@ Spam: TypeAlias = Literal[OneOrTwo]
 );
 
 testcase!(
-    bug = "enumerate promotes Literal types to their base type",
     test_enumerate_preserves_literal_type,
     r#"
 from typing import Literal
@@ -577,9 +576,11 @@ c = ("a", "b")
 for i in c:
     test(i)
 
-# enumerate loses Literal types due to TypeVar promotion
 for i, j in enumerate(c):
-    test(j) # E: Argument `str` is not assignable to parameter `x` with type `Literal['a', 'b']` in function `test`
+    test(j)
+
+for i, j in enumerate(c, 1):
+    test(j)
     "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1323

Added builtins.enumerate to stdlib type access.

Added a precise builtin enumerate call fast path, using existing iteration logic so tuple literal element types are preserved.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

update test