### PR TITLE
Route Size/Dim through the stdlib int class (#4095)

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -6330,9 +6330,10 @@ impl Server {
         let resolve_export = |module_name: ModuleName, name: &Name| {
             resolve_export_location(transaction, source_handle, module_name, name)
         };
-        // `None` is encoded as the stdlib's version-aware `NoneType` class.
-        // Computing `ty` already populated this transaction's `Stdlib`, so
-        // `get_stdlib` stays on the warm path (see the doc comment above).
+        // Sentinel-like types (`None`, `TypeGuard`/`TypeIs`) are encoded as the
+        // stdlib's version-aware classes. Computing `ty` already populated this
+        // transaction's `Stdlib`, so `get_stdlib` stays on the warm path (see
+        // the doc comment above).
         let stdlib = transaction.get_stdlib(source_handle);
         convert_type_with_resolvers(
             ty,
@@ -6341,6 +6342,7 @@ impl Server {
             Some(&resolve_export),
             StdlibClasses {
                 none_type: stdlib.none_type(),
+                bool_type: stdlib.bool(),
             },
         )
     }

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -6329,11 +6329,16 @@ impl Server {
         let resolve_export = |module_name: ModuleName, name: &Name| {
             resolve_export_location(transaction, source_handle, module_name, name)
         };
+        // `None` is encoded as the stdlib's version-aware `NoneType` class.
+        // Computing `ty` already populated this transaction's `Stdlib`, so
+        // `get_stdlib` stays on the warm path (see the doc comment above).
+        let stdlib = transaction.get_stdlib(source_handle);
         convert_type_with_resolvers(
             ty,
             Some(&resolve_func_range),
             Some(&resolve_module_path),
             Some(&resolve_export),
+            stdlib.none_type(),
         )
     }
 }

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -351,6 +351,7 @@ use crate::state::state::Transaction;
 use crate::state::subscriber::CompositeSubscriber;
 use crate::state::subscriber::PublishDiagnosticsSubscriber;
 use crate::state::subscriber::Subscriber;
+use crate::tsp::type_conversion::StdlibClasses;
 use crate::tsp::type_conversion::convert_type_with_resolvers;
 use crate::types::class::ClassDefIndex;
 use crate::types::class::ClassType;
@@ -6338,7 +6339,9 @@ impl Server {
             Some(&resolve_func_range),
             Some(&resolve_module_path),
             Some(&resolve_export),
-            stdlib.none_type(),
+            StdlibClasses {
+                none_type: stdlib.none_type(),
+            },
         )
     }
 }

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -6330,10 +6330,10 @@ impl Server {
         let resolve_export = |module_name: ModuleName, name: &Name| {
             resolve_export_location(transaction, source_handle, module_name, name)
         };
-        // Sentinel-like types (`None`, `TypeGuard`/`TypeIs`) are encoded as the
-        // stdlib's version-aware classes. Computing `ty` already populated this
-        // transaction's `Stdlib`, so `get_stdlib` stays on the warm path (see
-        // the doc comment above).
+        // Sentinel-like types (`None`, `TypeGuard`/`TypeIs`, `Size`/`Dim`) are
+        // encoded as the stdlib's version-aware classes. Computing `ty` already
+        // populated this transaction's `Stdlib`, so `get_stdlib` stays on the
+        // warm path (see the doc comment above).
         let stdlib = transaction.get_stdlib(source_handle);
         convert_type_with_resolvers(
             ty,
@@ -6343,6 +6343,7 @@ impl Server {
             StdlibClasses {
                 none_type: stdlib.none_type(),
                 bool_type: stdlib.bool(),
+                int_type: stdlib.int(),
             },
         )
     }

--- a/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
@@ -281,6 +281,14 @@ fn test_get_computed_type_string_is_class() {
 
 #[test]
 fn test_get_computed_type_none_is_class() {
+    // Regression test for https://github.com/facebook/pyrefly/issues/4035:
+    // `None` must be a `NoneType` `ClassType`, not an off-spec `none`
+    // `BuiltInType`, so consumers can reconstruct unions like `str | None`.
+    // The declaration is sourced from the stdlib's `NoneType` class, so it
+    // carries a real location (e.g. `types.pyi`) that matches goto-definition
+    // rather than a synthesized stub. This asserts the wire shape; the
+    // downstream Pylance hover fix (`str | Unknown` → `str | None`) should be
+    // confirmed against a real client, which this test harness cannot drive.
     let (mut tsp, file_uri, snapshot) = setup_project("x = None\n");
 
     let result = get_computed_type_ok(&mut tsp, &file_uri, 0, 0, snapshot);
@@ -289,6 +297,50 @@ fn test_get_computed_type_none_is_class() {
     let declaration = result.get("declaration").expect("Expected declaration");
     let name = declaration.get("name").and_then(|v| v.as_str());
     assert_eq!(name, Some("NoneType"), "Expected class name 'NoneType'");
+
+    // The declaration points at NoneType's real definition, not an empty stub.
+    let uri = declaration
+        .get("node")
+        .and_then(|n| n.get("uri"))
+        .and_then(|v| v.as_str())
+        .expect("Expected declaration node URI");
+    assert!(
+        !uri.is_empty(),
+        "Expected a real NoneType definition URI, got empty"
+    );
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_computed_type_str_or_none_union_reconstructs_none() {
+    // The concrete #4035 symptom: `str | None` must round-trip with its `None`
+    // member encoded as a reconstructable `NoneType` `ClassType` (previously an
+    // off-spec `none` `BuiltInType` that Pylance rendered as `Unknown`).
+    let code = "x: str | None = None\n";
+    let (mut tsp, file_uri, snapshot) = setup_project(code);
+
+    tsp.server.get_declared_type(&file_uri, 0, 0, snapshot);
+    let resp = tsp.client.receive_response_skip_notifications();
+    let result = resp.result.expect("Expected result");
+    assert_kind(&result, TypeKind::Union);
+
+    let sub_types = result
+        .get("subTypes")
+        .and_then(|v| v.as_array())
+        .expect("Expected subTypes array");
+    let has_none_class = sub_types.iter().any(|member| {
+        member.get("kind").and_then(|v| v.as_u64()) == Some(TypeKind::Class as u64)
+            && member
+                .get("declaration")
+                .and_then(|d| d.get("name"))
+                .and_then(|v| v.as_str())
+                == Some("NoneType")
+    });
+    assert!(
+        has_none_class,
+        "Expected a NoneType Class member in the union, got {sub_types:?}"
+    );
 
     tsp.shutdown();
 }

--- a/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
@@ -280,14 +280,15 @@ fn test_get_computed_type_string_is_class() {
 }
 
 #[test]
-fn test_get_computed_type_none_is_builtin() {
+fn test_get_computed_type_none_is_class() {
     let (mut tsp, file_uri, snapshot) = setup_project("x = None\n");
 
     let result = get_computed_type_ok(&mut tsp, &file_uri, 0, 0, snapshot);
-    assert_kind(&result, TypeKind::Builtin);
+    assert_kind(&result, TypeKind::Class);
 
-    let name = result.get("name").and_then(|v| v.as_str());
-    assert_eq!(name, Some("none"), "Expected builtin name 'none'");
+    let declaration = result.get("declaration").expect("Expected declaration");
+    let name = declaration.get("name").and_then(|v| v.as_str());
+    assert_eq!(name, Some("NoneType"), "Expected class name 'NoneType'");
 
     tsp.shutdown();
 }

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -23,9 +23,12 @@
 //!  - `Tensor`/`NNModule` → TSP `ClassType` from their base class.
 //!  - `TypeAlias` → unwraps to the aliased type.
 //!  - `SpecialForm` → TSP `BuiltInType` with the form name.
-//!  - `Any`, `Never`, `None`, `Ellipsis` → TSP `BuiltInType`.
+//!  - `Any`, `Never`, `Ellipsis` → TSP `BuiltInType`.
 //!  - Solver-internal types → TSP `BuiltInType` with a representative name.
 //!
+//! Note: `None` is emitted as a `types.NoneType` `ClassType`, not as a
+//! `BuiltInType`, because `BuiltInType.name` is restricted to protocol
+//! sentinel names.
 //! All `Type` variants are explicitly handled; no types fall through to a
 //! generic `SynthesizedType` stub.
 
@@ -145,7 +148,7 @@ impl TypeConverter<'_> {
             // --- Built-in special types ---
             PyreflyType::Any(_) => builtin("any"),
             PyreflyType::Never(_) => builtin("never"),
-            PyreflyType::None => builtin("none"),
+            PyreflyType::None => self.types_class("NoneType", TypeFlags::INSTANCE),
             PyreflyType::Ellipsis => builtin("ellipsis"),
 
             // --- Class instances (int, str, list[int], user-defined classes, etc.) ---
@@ -659,6 +662,19 @@ impl TypeConverter<'_> {
         })
     }
 
+    /// Build a TSP `ClassType` whose declaration points at `types.<name>`.
+    fn types_class(&self, name: &str, flags: TypeFlags) -> TspType {
+        TspType::Class(TspClassType {
+            declaration: Declaration::Regular(self.types_class_declaration(name)),
+            flags,
+            id: next_id(),
+            kind: TypeKind::Class,
+            literal_value: None,
+            type_alias_info: None,
+            type_args: None,
+        })
+    }
+
     /// Build a class declaration for `typing.<name>`. Resolves the real source
     /// range via the export-location resolver; falls back to a zero range
     /// pointing at bundled `typing.pyi` when unavailable.
@@ -679,6 +695,28 @@ impl TypeConverter<'_> {
             };
         }
         make_typing_class_declaration(name)
+    }
+
+    /// Build a class declaration for `types.<name>`. Resolves the real source
+    /// range via the export-location resolver; falls back to a zero range
+    /// pointing at bundled `types.pyi` when unavailable.
+    fn types_class_declaration(&self, name: &str) -> RegularDeclaration {
+        let symbol = Name::new(name);
+        if let Some((module_path, lsp_range)) = self
+            .resolve_export
+            .and_then(|resolve| resolve(ModuleName::types(), &symbol))
+        {
+            return RegularDeclaration {
+                kind: DeclarationKind::Regular,
+                category: DeclarationCategory::Class,
+                name: Some(name.to_owned()),
+                node: Node {
+                    range: lsp_range_to_tsp(lsp_range),
+                    uri: path_to_uri(&module_path),
+                },
+            };
+        }
+        make_types_class_declaration(name)
     }
 
     /// Convert a pyrefly `Overload` to a TSP `OverloadedType`.
@@ -826,6 +864,21 @@ fn make_builtin_class_declaration(name: &str) -> RegularDeclaration {
 fn make_typing_class_declaration(name: &str) -> RegularDeclaration {
     let module_path =
         pyrefly_python::module_path::ModulePath::bundled_typeshed(PathBuf::from("typing.pyi"));
+    RegularDeclaration {
+        kind: DeclarationKind::Regular,
+        category: DeclarationCategory::Class,
+        name: Some(name.to_owned()),
+        node: Node {
+            range: zero_range(),
+            uri: path_to_uri(&module_path),
+        },
+    }
+}
+
+/// Build a declaration for a class in `types.pyi`.
+fn make_types_class_declaration(name: &str) -> RegularDeclaration {
+    let module_path =
+        pyrefly_python::module_path::ModulePath::bundled_typeshed(PathBuf::from("types.pyi"));
     RegularDeclaration {
         kind: DeclarationKind::Regular,
         category: DeclarationCategory::Class,
@@ -1062,8 +1115,20 @@ mod tests {
     fn test_convert_none() {
         let tsp = convert_type(&PyreflyType::None);
         match tsp {
-            TspType::BuiltInType(b) => assert_eq!(b.name, "none"),
-            other => panic!("expected BuiltInType, got {other:?}"),
+            TspType::Class(c) => {
+                assert!(c.flags.contains(TypeFlags::INSTANCE));
+                let Declaration::Regular(decl) = c.declaration else {
+                    panic!("expected RegularDeclaration");
+                };
+                assert_eq!(decl.name.as_deref(), Some("NoneType"));
+                assert_eq!(decl.category, DeclarationCategory::Class);
+                assert!(
+                    decl.node.uri.contains("types.pyi"),
+                    "expected types URI, got {}",
+                    decl.node.uri
+                );
+            }
+            other => panic!("expected Class, got {other:?}"),
         }
     }
 
@@ -1081,8 +1146,8 @@ mod tests {
         let a = convert_type(&PyreflyType::None);
         let b = convert_type(&PyreflyType::Ellipsis);
         let id_a = match &a {
-            TspType::BuiltInType(b) => b.id,
-            _ => panic!("expected BuiltInType"),
+            TspType::Class(c) => c.id,
+            _ => panic!("expected Class"),
         };
         let id_b = match &b {
             TspType::BuiltInType(b) => b.id,
@@ -1159,10 +1224,15 @@ mod tests {
                 assert_eq!(u.kind, TypeKind::Union);
                 assert_eq!(u.flags, TypeFlags::NONE);
                 assert_eq!(u.sub_types.len(), 2);
-                // First member should be BuiltIn "none"
+                // First member should be `types.NoneType`.
                 match &u.sub_types[0] {
-                    TspType::BuiltInType(b) => assert_eq!(b.name, "none"),
-                    other => panic!("expected BuiltInType for first member, got {other:?}"),
+                    TspType::Class(c) => {
+                        let Declaration::Regular(decl) = &c.declaration else {
+                            panic!("expected RegularDeclaration");
+                        };
+                        assert_eq!(decl.name.as_deref(), Some("NoneType"));
+                    }
+                    other => panic!("expected Class for first member, got {other:?}"),
                 }
                 // Second member should be BuiltIn "any"
                 match &u.sub_types[1] {
@@ -1700,14 +1770,27 @@ mod tests {
                 let specialized = f.specialized_types.expect("expected specialized_types");
                 assert_eq!(specialized.parameter_types.len(), 2);
                 match &specialized.parameter_types[0] {
-                    TspType::BuiltInType(b) => assert_eq!(b.name, "none"),
-                    other => panic!("expected BuiltInType, got {other:?}"),
+                    TspType::Class(c) => {
+                        let Declaration::Regular(decl) = &c.declaration else {
+                            panic!("expected RegularDeclaration");
+                        };
+                        assert_eq!(decl.name.as_deref(), Some("NoneType"));
+                    }
+                    other => panic!("expected Class, got {other:?}"),
                 }
                 match &specialized.parameter_types[1] {
                     TspType::BuiltInType(b) => assert_eq!(b.name, "ellipsis"),
                     other => panic!("expected BuiltInType, got {other:?}"),
                 }
-                assert!(specialized.return_type.is_some());
+                match specialized.return_type.as_deref() {
+                    Some(TspType::Class(c)) => {
+                        let Declaration::Regular(decl) = &c.declaration else {
+                            panic!("expected RegularDeclaration");
+                        };
+                        assert_eq!(decl.name.as_deref(), Some("NoneType"));
+                    }
+                    other => panic!("expected NoneType Class return type, got {other:?}"),
+                }
             }
             other => panic!("expected Function, got {other:?}"),
         }
@@ -1737,8 +1820,13 @@ mod tests {
                     .expect("Callable parameter types must be carried in specialized_types");
                 assert_eq!(specialized.parameter_types.len(), 1);
                 match &specialized.parameter_types[0] {
-                    TspType::BuiltInType(b) => assert_eq!(b.name, "none"),
-                    other => panic!("expected BuiltInType, got {other:?}"),
+                    TspType::Class(c) => {
+                        let Declaration::Regular(decl) = &c.declaration else {
+                            panic!("expected RegularDeclaration");
+                        };
+                        assert_eq!(decl.name.as_deref(), Some("NoneType"));
+                    }
+                    other => panic!("expected Class, got {other:?}"),
                 }
                 assert!(specialized.return_type.is_some());
             }
@@ -1770,12 +1858,19 @@ mod tests {
             },
         };
         let resolver = |module: ModuleName, name: &Name| {
-            assert_eq!(module, ModuleName::typing());
-            assert_eq!(name.as_str(), "overload");
-            Some((
-                ModulePath::filesystem(PathBuf::from("/typeshed/typing.pyi")),
-                range,
-            ))
+            if module == ModuleName::typing() && name.as_str() == "overload" {
+                return Some((
+                    ModulePath::filesystem(PathBuf::from("/typeshed/typing.pyi")),
+                    range,
+                ));
+            }
+            if module == ModuleName::types() && name.as_str() == "NoneType" {
+                return Some((
+                    ModulePath::filesystem(PathBuf::from("/typeshed/types.pyi")),
+                    range,
+                ));
+            }
+            panic!("unexpected export lookup for {module}.{name}");
         };
         match convert_type_with_resolvers(&ty, None, None, Some(&resolver)) {
             TspType::Function(f) => {

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -26,9 +26,9 @@
 //!  - `Any`, `Never`, `Ellipsis` → TSP `BuiltInType`.
 //!  - Solver-internal types → TSP `BuiltInType` with a representative name.
 //!
-//! Note: `None` is emitted as a `types.NoneType` `ClassType`, not as a
-//! `BuiltInType`, because `BuiltInType.name` is restricted to protocol
-//! sentinel names.
+//! Note: `None` is emitted as a `NoneType` `ClassType`, not as a `BuiltInType`,
+//! because `BuiltInType.name` is restricted to protocol sentinel names. See
+//! [`convert_type_with_resolvers`] for how the version-correct class is sourced.
 //! All `Type` variants are explicitly handled; no types fall through to a
 //! generic `SynthesizedType` stub.
 
@@ -110,16 +110,24 @@ pub type ExportLocationResolver<'a> =
 
 /// Convert a pyrefly `Type` to a TSP protocol `Type` using optional
 /// source-range and module-URI resolvers.
+///
+/// `none_type` is the stdlib's authoritative `NoneType` class, used to encode
+/// `None`. Passing the real class (rather than re-deriving `NoneType` by name)
+/// keeps the declaration version-correct — sourced from `types` on Python 3.10+
+/// and `_typeshed` before — and identical to an explicit `types.NoneType`
+/// annotation.
 pub fn convert_type_with_resolvers<'a>(
     ty: &PyreflyType,
     func_range_resolver: Option<&'a FuncRangeResolver<'a>>,
     module_path_resolver: Option<&'a ModulePathResolver<'a>>,
     export_location_resolver: Option<&'a ExportLocationResolver<'a>>,
+    none_type: &'a PyreflyClassType,
 ) -> TspType {
     TypeConverter {
         resolve_func_range: func_range_resolver,
         resolve_module_path: module_path_resolver,
         resolve_export: export_location_resolver,
+        none_type,
     }
     .convert(ty)
 }
@@ -131,7 +139,33 @@ pub fn convert_type_with_resolvers<'a>(
 /// locations are needed.
 #[cfg(test)]
 pub fn convert_type(ty: &PyreflyType) -> TspType {
-    convert_type_with_resolvers(ty, None, None, None)
+    convert_type_with_resolvers(ty, None, None, None, &test_none_type())
+}
+
+/// Build a stand-in for `Stdlib::none_type()` used by the resolver-free tests,
+/// which have no real stdlib. Mirrors the real class closely enough to exercise
+/// the production `None` path: a top-level `NoneType` class in bundled `types`.
+#[cfg(test)]
+fn test_none_type() -> PyreflyClassType {
+    use pyrefly_python::module::Module;
+    use pyrefly_python::nesting_context::NestingContext;
+    use pyrefly_types::class::ClassDefIndex;
+    use pyrefly_types::types::TArgs;
+    use ruff_python_ast::Identifier;
+
+    let module = Module::new(
+        ModuleName::types(),
+        ModulePath::bundled_typeshed(PathBuf::from("types.pyi")),
+        Arc::new(String::new()),
+    );
+    let class = Class::new(
+        ClassDefIndex(0),
+        Identifier::new(Name::new("NoneType"), TextRange::default()),
+        NestingContext::toplevel(),
+        module,
+        None,
+    );
+    PyreflyClassType::new(class, TArgs::default())
 }
 
 /// Holds an optional range resolver and drives recursive type conversion.
@@ -139,6 +173,9 @@ struct TypeConverter<'a> {
     resolve_func_range: Option<&'a FuncRangeResolver<'a>>,
     resolve_module_path: Option<&'a ModulePathResolver<'a>>,
     resolve_export: Option<&'a ExportLocationResolver<'a>>,
+    /// The stdlib's authoritative `NoneType` class, used to encode `None`; see
+    /// [`convert_type_with_resolvers`].
+    none_type: &'a PyreflyClassType,
 }
 
 impl TypeConverter<'_> {
@@ -148,7 +185,8 @@ impl TypeConverter<'_> {
             // --- Built-in special types ---
             PyreflyType::Any(_) => builtin("any"),
             PyreflyType::Never(_) => builtin("never"),
-            PyreflyType::None => self.types_class("NoneType", TypeFlags::INSTANCE),
+            // `None` → the stdlib's real `NoneType` class (see `none_type`).
+            PyreflyType::None => self.convert_class_type(self.none_type, TypeFlags::INSTANCE),
             PyreflyType::Ellipsis => builtin("ellipsis"),
 
             // --- Class instances (int, str, list[int], user-defined classes, etc.) ---
@@ -662,19 +700,6 @@ impl TypeConverter<'_> {
         })
     }
 
-    /// Build a TSP `ClassType` whose declaration points at `types.<name>`.
-    fn types_class(&self, name: &str, flags: TypeFlags) -> TspType {
-        TspType::Class(TspClassType {
-            declaration: Declaration::Regular(self.types_class_declaration(name)),
-            flags,
-            id: next_id(),
-            kind: TypeKind::Class,
-            literal_value: None,
-            type_alias_info: None,
-            type_args: None,
-        })
-    }
-
     /// Build a class declaration for `typing.<name>`. Resolves the real source
     /// range via the export-location resolver; falls back to a zero range
     /// pointing at bundled `typing.pyi` when unavailable.
@@ -695,28 +720,6 @@ impl TypeConverter<'_> {
             };
         }
         make_typing_class_declaration(name)
-    }
-
-    /// Build a class declaration for `types.<name>`. Resolves the real source
-    /// range via the export-location resolver; falls back to a zero range
-    /// pointing at bundled `types.pyi` when unavailable.
-    fn types_class_declaration(&self, name: &str) -> RegularDeclaration {
-        let symbol = Name::new(name);
-        if let Some((module_path, lsp_range)) = self
-            .resolve_export
-            .and_then(|resolve| resolve(ModuleName::types(), &symbol))
-        {
-            return RegularDeclaration {
-                kind: DeclarationKind::Regular,
-                category: DeclarationCategory::Class,
-                name: Some(name.to_owned()),
-                node: Node {
-                    range: lsp_range_to_tsp(lsp_range),
-                    uri: path_to_uri(&module_path),
-                },
-            };
-        }
-        make_types_class_declaration(name)
     }
 
     /// Convert a pyrefly `Overload` to a TSP `OverloadedType`.
@@ -864,21 +867,6 @@ fn make_builtin_class_declaration(name: &str) -> RegularDeclaration {
 fn make_typing_class_declaration(name: &str) -> RegularDeclaration {
     let module_path =
         pyrefly_python::module_path::ModulePath::bundled_typeshed(PathBuf::from("typing.pyi"));
-    RegularDeclaration {
-        kind: DeclarationKind::Regular,
-        category: DeclarationCategory::Class,
-        name: Some(name.to_owned()),
-        node: Node {
-            range: zero_range(),
-            uri: path_to_uri(&module_path),
-        },
-    }
-}
-
-/// Build a declaration for a class in `types.pyi`.
-fn make_types_class_declaration(name: &str) -> RegularDeclaration {
-    let module_path =
-        pyrefly_python::module_path::ModulePath::bundled_typeshed(PathBuf::from("types.pyi"));
     RegularDeclaration {
         kind: DeclarationKind::Regular,
         category: DeclarationCategory::Class,
@@ -1422,7 +1410,13 @@ mod tests {
                 None
             }
         };
-        let tsp = convert_type_with_resolvers(&ty, None, Some(&module_path_resolver), None);
+        let tsp = convert_type_with_resolvers(
+            &ty,
+            None,
+            Some(&module_path_resolver),
+            None,
+            &test_none_type(),
+        );
         match tsp {
             TspType::Module(m) => {
                 assert_eq!(m.module_name, "pkg");
@@ -1499,7 +1493,7 @@ mod tests {
                 range,
             ))
         };
-        match convert_type_with_resolvers(&ty, None, None, Some(&resolver)) {
+        match convert_type_with_resolvers(&ty, None, None, Some(&resolver), &test_none_type()) {
             TspType::Class(c) => {
                 let Declaration::Regular(decl) = c.declaration else {
                     panic!("expected RegularDeclaration");
@@ -1618,7 +1612,7 @@ mod tests {
             ))
         };
         let ty = PyreflyType::TypeAlias(Box::new(TypeAliasData::Ref(make_ref())));
-        match convert_type_with_resolvers(&ty, None, None, Some(&resolver)) {
+        match convert_type_with_resolvers(&ty, None, None, Some(&resolver), &test_none_type()) {
             TspType::Class(c) => {
                 let Declaration::Regular(decl) = c.declaration else {
                     panic!("expected RegularDeclaration");
@@ -1679,7 +1673,7 @@ mod tests {
                 range,
             ))
         };
-        match convert_type_with_resolvers(&ty, None, None, Some(&resolver)) {
+        match convert_type_with_resolvers(&ty, None, None, Some(&resolver), &test_none_type()) {
             TspType::Var(v) => {
                 let Declaration::Regular(decl) = v.declaration else {
                     panic!("expected RegularDeclaration");
@@ -1710,7 +1704,7 @@ mod tests {
                 lsp_types::Range::default(),
             ))
         };
-        match convert_type_with_resolvers(&ty, None, None, Some(&resolver)) {
+        match convert_type_with_resolvers(&ty, None, None, Some(&resolver), &test_none_type()) {
             TspType::Var(v) => {
                 let Declaration::Regular(decl) = v.declaration else {
                     panic!("expected RegularDeclaration");
@@ -1857,6 +1851,9 @@ mod tests {
                 character: 12,
             },
         };
+        // The `None` return converts through the stdlib `NoneType` class, not
+        // the export resolver, so the only lookup here is `typing.overload`;
+        // any other lookup is a regression.
         let resolver = |module: ModuleName, name: &Name| {
             if module == ModuleName::typing() && name.as_str() == "overload" {
                 return Some((
@@ -1864,15 +1861,9 @@ mod tests {
                     range,
                 ));
             }
-            if module == ModuleName::types() && name.as_str() == "NoneType" {
-                return Some((
-                    ModulePath::filesystem(PathBuf::from("/typeshed/types.pyi")),
-                    range,
-                ));
-            }
             panic!("unexpected export lookup for {module}.{name}");
         };
-        match convert_type_with_resolvers(&ty, None, None, Some(&resolver)) {
+        match convert_type_with_resolvers(&ty, None, None, Some(&resolver), &test_none_type()) {
             TspType::Function(f) => {
                 let Declaration::Regular(decl) = f.declaration else {
                     panic!("expected RegularDeclaration");

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -108,26 +108,34 @@ pub type ModulePathResolver<'a> =
 pub type ExportLocationResolver<'a> =
     dyn Fn(ModuleName, &Name) -> Option<(ModulePath, lsp_types::Range)> + 'a;
 
+/// The stdlib classes used to encode pyrefly types that would otherwise be
+/// emitted as off-spec `BuiltInType` sentinels: the protocol restricts
+/// `BuiltInType.name` to a fixed set that excludes names like `none`. Passing
+/// the real classes (rather than re-deriving them by name) keeps each
+/// declaration version-correct — e.g. `NoneType` is sourced from `types` on
+/// Python 3.10+ and `_typeshed` before — and identical to writing the
+/// annotation explicitly.
+#[derive(Clone, Copy)]
+pub struct StdlibClasses<'a> {
+    /// `NoneType`, encoding `None`.
+    pub none_type: &'a PyreflyClassType,
+}
+
 /// Convert a pyrefly `Type` to a TSP protocol `Type` using optional
-/// source-range and module-URI resolvers.
-///
-/// `none_type` is the stdlib's authoritative `NoneType` class, used to encode
-/// `None`. Passing the real class (rather than re-deriving `NoneType` by name)
-/// keeps the declaration version-correct — sourced from `types` on Python 3.10+
-/// and `_typeshed` before — and identical to an explicit `types.NoneType`
-/// annotation.
+/// source-range and module-URI resolvers, plus the stdlib classes used to
+/// encode sentinel-like types (see [`StdlibClasses`]).
 pub fn convert_type_with_resolvers<'a>(
     ty: &PyreflyType,
     func_range_resolver: Option<&'a FuncRangeResolver<'a>>,
     module_path_resolver: Option<&'a ModulePathResolver<'a>>,
     export_location_resolver: Option<&'a ExportLocationResolver<'a>>,
-    none_type: &'a PyreflyClassType,
+    stdlib: StdlibClasses<'a>,
 ) -> TspType {
     TypeConverter {
         resolve_func_range: func_range_resolver,
         resolve_module_path: module_path_resolver,
         resolve_export: export_location_resolver,
-        none_type,
+        stdlib,
     }
     .convert(ty)
 }
@@ -139,14 +147,36 @@ pub fn convert_type_with_resolvers<'a>(
 /// locations are needed.
 #[cfg(test)]
 pub fn convert_type(ty: &PyreflyType) -> TspType {
-    convert_type_with_resolvers(ty, None, None, None, &test_none_type())
+    let stdlib = TestStdlib::new();
+    convert_type_with_resolvers(ty, None, None, None, stdlib.classes())
 }
 
-/// Build a stand-in for `Stdlib::none_type()` used by the resolver-free tests,
-/// which have no real stdlib. Mirrors the real class closely enough to exercise
-/// the production `None` path: a top-level `NoneType` class in bundled `types`.
+/// Stand-in for the real `Stdlib` classes used by the resolver-free tests,
+/// which have no stdlib. Each class mirrors its real counterpart closely enough
+/// to exercise the production path: a top-level class in its bundled module.
 #[cfg(test)]
-fn test_none_type() -> PyreflyClassType {
+struct TestStdlib {
+    none_type: PyreflyClassType,
+}
+
+#[cfg(test)]
+impl TestStdlib {
+    fn new() -> Self {
+        Self {
+            none_type: test_class(ModuleName::types(), "NoneType"),
+        }
+    }
+
+    fn classes(&self) -> StdlibClasses<'_> {
+        StdlibClasses {
+            none_type: &self.none_type,
+        }
+    }
+}
+
+/// Build a top-level `name` class in bundled `module_name` (`<module>.pyi`).
+#[cfg(test)]
+fn test_class(module_name: ModuleName, name: &str) -> PyreflyClassType {
     use pyrefly_python::module::Module;
     use pyrefly_python::nesting_context::NestingContext;
     use pyrefly_types::class::ClassDefIndex;
@@ -154,13 +184,13 @@ fn test_none_type() -> PyreflyClassType {
     use ruff_python_ast::Identifier;
 
     let module = Module::new(
-        ModuleName::types(),
-        ModulePath::bundled_typeshed(PathBuf::from("types.pyi")),
+        module_name,
+        ModulePath::bundled_typeshed(PathBuf::from(format!("{module_name}.pyi"))),
         Arc::new(String::new()),
     );
     let class = Class::new(
         ClassDefIndex(0),
-        Identifier::new(Name::new("NoneType"), TextRange::default()),
+        Identifier::new(Name::new(name), TextRange::default()),
         NestingContext::toplevel(),
         module,
         None,
@@ -173,9 +203,8 @@ struct TypeConverter<'a> {
     resolve_func_range: Option<&'a FuncRangeResolver<'a>>,
     resolve_module_path: Option<&'a ModulePathResolver<'a>>,
     resolve_export: Option<&'a ExportLocationResolver<'a>>,
-    /// The stdlib's authoritative `NoneType` class, used to encode `None`; see
-    /// [`convert_type_with_resolvers`].
-    none_type: &'a PyreflyClassType,
+    /// Stdlib classes used to encode sentinel-like types; see [`StdlibClasses`].
+    stdlib: StdlibClasses<'a>,
 }
 
 impl TypeConverter<'_> {
@@ -185,8 +214,10 @@ impl TypeConverter<'_> {
             // --- Built-in special types ---
             PyreflyType::Any(_) => builtin("any"),
             PyreflyType::Never(_) => builtin("never"),
-            // `None` → the stdlib's real `NoneType` class (see `none_type`).
-            PyreflyType::None => self.convert_class_type(self.none_type, TypeFlags::INSTANCE),
+            // `None` → the stdlib's real `NoneType` class (see `stdlib`).
+            PyreflyType::None => {
+                self.convert_class_type(self.stdlib.none_type, TypeFlags::INSTANCE)
+            }
             PyreflyType::Ellipsis => builtin("ellipsis"),
 
             // --- Class instances (int, str, list[int], user-defined classes, etc.) ---
@@ -1410,12 +1441,13 @@ mod tests {
                 None
             }
         };
+        let stdlib = TestStdlib::new();
         let tsp = convert_type_with_resolvers(
             &ty,
             None,
             Some(&module_path_resolver),
             None,
-            &test_none_type(),
+            stdlib.classes(),
         );
         match tsp {
             TspType::Module(m) => {
@@ -1493,7 +1525,13 @@ mod tests {
                 range,
             ))
         };
-        match convert_type_with_resolvers(&ty, None, None, Some(&resolver), &test_none_type()) {
+        match convert_type_with_resolvers(
+            &ty,
+            None,
+            None,
+            Some(&resolver),
+            TestStdlib::new().classes(),
+        ) {
             TspType::Class(c) => {
                 let Declaration::Regular(decl) = c.declaration else {
                     panic!("expected RegularDeclaration");
@@ -1612,7 +1650,13 @@ mod tests {
             ))
         };
         let ty = PyreflyType::TypeAlias(Box::new(TypeAliasData::Ref(make_ref())));
-        match convert_type_with_resolvers(&ty, None, None, Some(&resolver), &test_none_type()) {
+        match convert_type_with_resolvers(
+            &ty,
+            None,
+            None,
+            Some(&resolver),
+            TestStdlib::new().classes(),
+        ) {
             TspType::Class(c) => {
                 let Declaration::Regular(decl) = c.declaration else {
                     panic!("expected RegularDeclaration");
@@ -1673,7 +1717,13 @@ mod tests {
                 range,
             ))
         };
-        match convert_type_with_resolvers(&ty, None, None, Some(&resolver), &test_none_type()) {
+        match convert_type_with_resolvers(
+            &ty,
+            None,
+            None,
+            Some(&resolver),
+            TestStdlib::new().classes(),
+        ) {
             TspType::Var(v) => {
                 let Declaration::Regular(decl) = v.declaration else {
                     panic!("expected RegularDeclaration");
@@ -1704,7 +1754,13 @@ mod tests {
                 lsp_types::Range::default(),
             ))
         };
-        match convert_type_with_resolvers(&ty, None, None, Some(&resolver), &test_none_type()) {
+        match convert_type_with_resolvers(
+            &ty,
+            None,
+            None,
+            Some(&resolver),
+            TestStdlib::new().classes(),
+        ) {
             TspType::Var(v) => {
                 let Declaration::Regular(decl) = v.declaration else {
                     panic!("expected RegularDeclaration");
@@ -1863,7 +1919,13 @@ mod tests {
             }
             panic!("unexpected export lookup for {module}.{name}");
         };
-        match convert_type_with_resolvers(&ty, None, None, Some(&resolver), &test_none_type()) {
+        match convert_type_with_resolvers(
+            &ty,
+            None,
+            None,
+            Some(&resolver),
+            TestStdlib::new().classes(),
+        ) {
             TspType::Function(f) => {
                 let Declaration::Regular(decl) = f.declaration else {
                     panic!("expected RegularDeclaration");

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -110,17 +110,19 @@ pub type ExportLocationResolver<'a> =
 
 /// The stdlib classes used to encode pyrefly types that would otherwise be
 /// emitted as off-spec `BuiltInType` sentinels: the protocol restricts
-/// `BuiltInType.name` to a fixed set that excludes names like `none` and `bool`.
-/// Passing the real classes (rather than re-deriving them by name) keeps each
-/// declaration version-correct — e.g. `NoneType` is sourced from `types` on
-/// Python 3.10+ and `_typeshed` before — and identical to writing the
-/// annotation explicitly.
+/// `BuiltInType.name` to a fixed set that excludes names like `none`, `bool`,
+/// and `int`. Passing the real classes (rather than re-deriving them by name)
+/// keeps each declaration version-correct — e.g. `NoneType` is sourced from
+/// `types` on Python 3.10+ and `_typeshed` before — and identical to writing
+/// the annotation explicitly.
 #[derive(Clone, Copy)]
 pub struct StdlibClasses<'a> {
     /// `NoneType`, encoding `None`.
     pub none_type: &'a PyreflyClassType,
     /// `bool`, encoding `TypeGuard`/`TypeIs` (their runtime type).
     pub bool_type: &'a PyreflyClassType,
+    /// `int`, encoding `Size`/`Dim` (integer tensor dimensions).
+    pub int_type: &'a PyreflyClassType,
 }
 
 /// Convert a pyrefly `Type` to a TSP protocol `Type` using optional
@@ -160,6 +162,7 @@ pub fn convert_type(ty: &PyreflyType) -> TspType {
 struct TestStdlib {
     none_type: PyreflyClassType,
     bool_type: PyreflyClassType,
+    int_type: PyreflyClassType,
 }
 
 #[cfg(test)]
@@ -168,6 +171,7 @@ impl TestStdlib {
         Self {
             none_type: test_class(ModuleName::types(), "NoneType"),
             bool_type: test_class(ModuleName::builtins(), "bool"),
+            int_type: test_class(ModuleName::builtins(), "int"),
         }
     }
 
@@ -175,6 +179,7 @@ impl TestStdlib {
         StdlibClasses {
             none_type: &self.none_type,
             bool_type: &self.bool_type,
+            int_type: &self.int_type,
         }
     }
 }
@@ -454,8 +459,13 @@ impl TypeConverter<'_> {
             // --- KwCall → convert the return type ---
             PyreflyType::KwCall(kw) => self.convert(&kw.return_ty),
 
-            // --- Size / Dim → int (they represent integer dimensions) ---
-            PyreflyType::Size(_) | PyreflyType::Dim(_) => builtin("int"),
+            // --- Size / Dim → the stdlib `int` class (they represent integer dimensions) ---
+            // Emitted as the real class, not `builtin("int")`: the protocol
+            // restricts `BuiltInType.name` to a fixed sentinel set that excludes
+            // `int`, so a bare builtin surfaces as Unknown on the consumer.
+            PyreflyType::Size(_) | PyreflyType::Dim(_) => {
+                self.convert_class_type(self.stdlib.int_type, TypeFlags::INSTANCE)
+            }
 
             // --- Solver-internal variable → built-in unknown ---
             PyreflyType::Var(_) => builtin("unknown"),
@@ -1188,6 +1198,30 @@ mod tests {
                     assert_eq!(decl.category, DeclarationCategory::Class);
                 }
                 other => panic!("expected bool Class, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_convert_size_and_dim_are_int_class() {
+        use pyrefly_types::dimension::SizeExpr;
+
+        // `Size`/`Dim` are integer tensor dimensions, emitted as the real `int`
+        // class rather than an off-spec `int` `BuiltInType`.
+        for ty in [
+            PyreflyType::Size(SizeExpr::literal(6)),
+            PyreflyType::Dim(Box::new(PyreflyType::Size(SizeExpr::literal(3)))),
+        ] {
+            match convert_type(&ty) {
+                TspType::Class(c) => {
+                    assert!(c.flags.contains(TypeFlags::INSTANCE));
+                    let Declaration::Regular(decl) = c.declaration else {
+                        panic!("expected RegularDeclaration");
+                    };
+                    assert_eq!(decl.name.as_deref(), Some("int"));
+                    assert_eq!(decl.category, DeclarationCategory::Class);
+                }
+                other => panic!("expected int Class, got {other:?}"),
             }
         }
     }

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -110,8 +110,8 @@ pub type ExportLocationResolver<'a> =
 
 /// The stdlib classes used to encode pyrefly types that would otherwise be
 /// emitted as off-spec `BuiltInType` sentinels: the protocol restricts
-/// `BuiltInType.name` to a fixed set that excludes names like `none`. Passing
-/// the real classes (rather than re-deriving them by name) keeps each
+/// `BuiltInType.name` to a fixed set that excludes names like `none` and `bool`.
+/// Passing the real classes (rather than re-deriving them by name) keeps each
 /// declaration version-correct — e.g. `NoneType` is sourced from `types` on
 /// Python 3.10+ and `_typeshed` before — and identical to writing the
 /// annotation explicitly.
@@ -119,6 +119,8 @@ pub type ExportLocationResolver<'a> =
 pub struct StdlibClasses<'a> {
     /// `NoneType`, encoding `None`.
     pub none_type: &'a PyreflyClassType,
+    /// `bool`, encoding `TypeGuard`/`TypeIs` (their runtime type).
+    pub bool_type: &'a PyreflyClassType,
 }
 
 /// Convert a pyrefly `Type` to a TSP protocol `Type` using optional
@@ -157,6 +159,7 @@ pub fn convert_type(ty: &PyreflyType) -> TspType {
 #[cfg(test)]
 struct TestStdlib {
     none_type: PyreflyClassType,
+    bool_type: PyreflyClassType,
 }
 
 #[cfg(test)]
@@ -164,12 +167,14 @@ impl TestStdlib {
     fn new() -> Self {
         Self {
             none_type: test_class(ModuleName::types(), "NoneType"),
+            bool_type: test_class(ModuleName::builtins(), "bool"),
         }
     }
 
     fn classes(&self) -> StdlibClasses<'_> {
         StdlibClasses {
             none_type: &self.none_type,
+            bool_type: &self.bool_type,
         }
     }
 }
@@ -384,8 +389,13 @@ impl TypeConverter<'_> {
             // --- Annotated[X, ...] → unwrap to X ---
             PyreflyType::Annotated(inner, _) => self.convert(inner),
 
-            // --- TypeGuard[X] / TypeIs[X] → convert as bool (the runtime return type) ---
-            PyreflyType::TypeGuard(_) | PyreflyType::TypeIs(_) => builtin("bool"),
+            // --- TypeGuard[X] / TypeIs[X] → the stdlib `bool` class (their runtime type) ---
+            // Emitted as the real class, not `builtin("bool")`: the protocol
+            // restricts `BuiltInType.name` to a fixed sentinel set that excludes
+            // `bool`, so a bare builtin surfaces as Unknown on the consumer.
+            PyreflyType::TypeGuard(_) | PyreflyType::TypeIs(_) => {
+                self.convert_class_type(self.stdlib.bool_type, TypeFlags::INSTANCE)
+            }
 
             // --- SuperInstance → convert as the class type ---
             PyreflyType::SuperInstance(si) => self.convert_class_type(&si.0, TypeFlags::INSTANCE),
@@ -1157,6 +1167,28 @@ mod tests {
         match tsp {
             TspType::BuiltInType(b) => assert_eq!(b.name, "ellipsis"),
             other => panic!("expected BuiltInType, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_convert_type_guard_and_type_is_are_bool_class() {
+        // `TypeGuard`/`TypeIs` erase to their runtime type `bool`, emitted as
+        // the real `bool` class rather than an off-spec `bool` `BuiltInType`.
+        for ty in [
+            PyreflyType::TypeGuard(Box::new(PyreflyType::None)),
+            PyreflyType::TypeIs(Box::new(PyreflyType::None)),
+        ] {
+            match convert_type(&ty) {
+                TspType::Class(c) => {
+                    assert!(c.flags.contains(TypeFlags::INSTANCE));
+                    let Declaration::Regular(decl) = c.declaration else {
+                        panic!("expected RegularDeclaration");
+                    };
+                    assert_eq!(decl.name.as_deref(), Some("bool"));
+                    assert_eq!(decl.category, DeclarationCategory::Class);
+                }
+                other => panic!("expected bool Class, got {other:?}"),
+            }
         }
     }
 


### PR DESCRIPTION
Summary:

`Size`/`Dim` (integer tensor dimensions) were emitted as `int` `BuiltInType`. The protocol restricts `BuiltInType.name` to a fixed sentinel set that does not include `int`, so consumers render the off-spec name as `Unknown` — the same class of bug fixed for `None` and `TypeGuard`/`TypeIs`.

This encodes `Size`/`Dim` as the stdlib's `int` `ClassType` via the existing `convert_class_type(..., INSTANCE)` path, threaded through the `StdlibClasses` bundle. The declaration inherits `int`'s real module and range, so it is navigable and identical to an explicit `int` annotation.

Reviewed By: yangdanny97

Differential Revision: D111366731
