### PR TITLE
fix support show range when hover on and or #4065

### DIFF
--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -14,6 +14,7 @@ use lsp_types::Hover;
 use lsp_types::HoverContents;
 use lsp_types::MarkupContent;
 use lsp_types::MarkupKind;
+use lsp_types::Range;
 use lsp_types::Url;
 use pyrefly_build::handle::Handle;
 use pyrefly_python::ast::Ast;
@@ -75,6 +76,7 @@ pub struct HoverValue {
     pub kind: Option<SymbolKind>,
     pub name: Option<String>,
     pub type_: Type,
+    pub range: Option<Range>,
     pub docstring: Option<Docstring>,
     pub parameter_doc: Option<(String, String)>,
     pub type_sources: Vec<String>,
@@ -291,7 +293,7 @@ impl HoverValue {
                     symbol_def_formatted
                 ),
             }),
-            range: None,
+            range: self.range,
         }
     }
 }
@@ -398,6 +400,22 @@ fn position_is_in_docstring(
         false
     }
     body_contains_docstring(ast.body.as_slice(), position)
+}
+
+fn bool_op_hover_range_at(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    position: TextSize,
+) -> Option<Range> {
+    let ast = transaction.get_ast(handle)?;
+    let module = transaction.get_module_info(handle)?;
+    let node = Ast::locate_node(&ast, position)
+        .into_iter()
+        .find(|node| node.as_expr_ref().is_some())?;
+    match node {
+        AnyNodeRef::ExprBoolOp(bool_op) => Some(module.to_lsp_range(bool_op.range())),
+        _ => None,
+    }
 }
 
 /// If we can't determine a symbol name via go-to-definition, fall back to what the
@@ -746,6 +764,7 @@ pub fn get_hover(
         .subscript_operator_type_at(handle, position)
         .or_else(|| transaction.get_type_at_for_display(handle, position))
         .or_else(|| transaction.operator_type_at(handle, position))?;
+    let range = bool_op_hover_range_at(transaction, handle, position);
 
     // Helper function to check if we're hovering over a callee and get its range
     let find_callee_range_at_position = || -> Option<TextRange> {
@@ -886,6 +905,7 @@ pub fn get_hover(
             kind,
             name,
             type_,
+            range,
             docstring,
             parameter_doc,
             type_sources: type_sources_for_hover(transaction, handle, position),

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -7,6 +7,8 @@
 
 use lsp_types::Hover;
 use lsp_types::HoverContents;
+use lsp_types::Position;
+use lsp_types::Range;
 use pretty_assertions::assert_eq;
 use pyrefly_build::handle::Handle;
 use ruff_text_size::TextSize;
@@ -1524,6 +1526,44 @@ def supported_language(lang):
             && report.contains("self: list[str]")
             && report.contains(") -> bool"),
         "Expected hover to show list.__contains__ method signature, got: {report}"
+    );
+}
+
+#[test]
+fn hover_over_bool_operator_highlights_bool_expression() {
+    let code = r#"
+x = 1 and 2
+#     ^
+y = 1 or 2
+#     ^
+"#;
+    let mut test_env = TestEnv::new();
+    test_env.add("main", code);
+    let (state, handle) = test_env
+        .with_default_require_level(Require::Exports)
+        .to_state();
+    let handle = handle("main");
+    let ranges = extract_cursors_for_test(code)
+        .into_iter()
+        .map(
+            |position| match get_hover(&state.transaction(), &handle, position, false) {
+                Some(hover) => hover.range,
+                None => panic!("Expected hover result for boolean operator"),
+            },
+        )
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ranges,
+        vec![
+            Some(Range {
+                start: Position::new(1, 4),
+                end: Position::new(1, 11),
+            }),
+            Some(Range {
+                start: Position::new(3, 4),
+                end: Position::new(3, 10),
+            }),
+        ]
     );
 }
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4065

hover results can carry an explicit range, and and/or operator hovers now return the enclosing boolean expression range.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test