### PR TITLE
Fix TOML parse error locations

### DIFF
--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -53,6 +53,7 @@ use pyrefly_util::telemetry::TelemetrySourceDbRebuildStats;
 use pyrefly_util::watch_pattern::WatchPattern;
 use serde::Deserialize;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use serde_with::skip_serializing_none;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
@@ -1679,19 +1680,159 @@ impl ConfigFile {
         (config, errors)
     }
 
-    fn parse_config(config_str: &str) -> anyhow::Result<ConfigFile> {
-        toml::from_str::<ConfigFile>(config_str).map_err(|err| anyhow::Error::msg(err.to_string()))
+    pub fn parse_config(config_str: &str) -> anyhow::Result<ConfigFile> {
+        parse_toml_document::<ConfigFile>(config_str)
     }
 
     /// Parse a pyproject.toml file. Returns a tuple of:
     /// - `Option<ConfigFile>`: the pyrefly config, if `[tool.pyrefly]` was present
     /// - `bool`: whether Python tool sections like `[tool.ruff]` were detected
     fn parse_pyproject_toml(config_str: &str) -> anyhow::Result<(Option<ConfigFile>, bool)> {
-        let pyproject = toml::from_str::<PyProject>(config_str)
-            .map_err(|err| anyhow::Error::msg(err.to_string()))?;
+        let pyproject = parse_toml_document::<PyProject>(config_str)?;
         let has_python_tools = pyproject.has_python_tools();
         Ok((pyproject.pyrefly(), has_python_tools))
     }
+}
+
+fn parse_toml_document<T: DeserializeOwned>(config_str: &str) -> anyhow::Result<T> {
+    toml_edit::de::from_str::<T>(config_str)
+        .map_err(|err| toml_error_with_adjusted_span(config_str, err))
+}
+
+fn toml_error_with_adjusted_span(config_str: &str, err: toml_edit::de::Error) -> anyhow::Error {
+    let original_span = err.span();
+    let adjusted_span = toml_error_key_span(config_str, &err)
+        .or_else(|| toml_error_value_span(config_str, &err))
+        .filter(|span| original_span.as_ref() != Some(span));
+    match adjusted_span {
+        Some(span) => anyhow::Error::new(TomlErrorWithAdjustedSpan {
+            input: config_str.to_owned(),
+            message: err.message().to_owned(),
+            span,
+        }),
+        None => anyhow::Error::new(err),
+    }
+}
+
+#[derive(Debug)]
+struct TomlErrorWithAdjustedSpan {
+    input: String,
+    message: String,
+    span: std::ops::Range<usize>,
+}
+
+impl std::error::Error for TomlErrorWithAdjustedSpan {}
+
+impl Display for TomlErrorWithAdjustedSpan {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let start = self.span.start.min(self.input.len());
+        let line_start = self.input[..start]
+            .rfind('\n')
+            .map(|idx| idx + 1)
+            .unwrap_or(0);
+        let line_end = self.input[line_start..]
+            .find('\n')
+            .map(|idx| line_start + idx)
+            .unwrap_or(self.input.len());
+        let line_num = self.input[..line_start]
+            .bytes()
+            .filter(|byte| *byte == b'\n')
+            .count()
+            + 1;
+        let column = self.input[line_start..start].chars().count();
+        let col_num = column + 1;
+        let content = &self.input[line_start..line_end];
+        let highlight_end = self.span.end.min(line_end);
+        let highlight_len = self.input[start..highlight_end].chars().count().max(1);
+        let gutter = line_num.to_string().len();
+
+        writeln!(f, "TOML parse error at line {line_num}, column {col_num}")?;
+        for _ in 0..=gutter {
+            write!(f, " ")?;
+        }
+        writeln!(f, "|")?;
+        writeln!(f, "{line_num} | {content}")?;
+        for _ in 0..=gutter {
+            write!(f, " ")?;
+        }
+        write!(f, "|")?;
+        for _ in 0..=column {
+            write!(f, " ")?;
+        }
+        for _ in 0..highlight_len {
+            write!(f, "^")?;
+        }
+        writeln!(f)?;
+        writeln!(f, "{}", self.message)
+    }
+}
+
+pub fn toml_error_span(err: &anyhow::Error) -> Option<std::ops::Range<usize>> {
+    err.downcast_ref::<TomlErrorWithAdjustedSpan>()
+        .map(|err| err.span.clone())
+        .or_else(|| {
+            err.downcast_ref::<toml_edit::de::Error>()
+                .and_then(toml_edit::de::Error::span)
+        })
+        .or_else(|| {
+            err.downcast_ref::<toml::de::Error>()
+                .and_then(toml::de::Error::span)
+        })
+}
+
+fn toml_error_key_span(
+    config_str: &str,
+    err: &toml_edit::de::Error,
+) -> Option<std::ops::Range<usize>> {
+    let key_path = toml_error_key_path(err)?;
+    let document = toml_edit::Document::parse(config_str).ok()?;
+    (0..key_path.len())
+        .find_map(|idx| toml_item_span_for_key_path(document.as_table(), &key_path[idx..]))
+}
+
+fn toml_error_key_path(err: &toml_edit::de::Error) -> Option<Vec<String>> {
+    let mut err_without_input = err.clone();
+    err_without_input.set_input(None);
+    err_without_input.to_string().lines().find_map(|line| {
+        line.strip_prefix("in `")
+            .and_then(|line| line.strip_suffix('`'))
+            .map(|line| line.split('.').map(str::to_owned).collect())
+    })
+}
+
+fn toml_item_span_for_key_path(
+    table: &toml_edit::Table,
+    key_path: &[String],
+) -> Option<std::ops::Range<usize>> {
+    let (first_key, rest) = key_path.split_first()?;
+    let mut item = table.get(first_key.as_str())?;
+    for key in rest {
+        item = item.as_table_like()?.get(key.as_str())?;
+    }
+    item.span()
+}
+
+fn toml_error_value_span(
+    config_str: &str,
+    err: &toml_edit::de::Error,
+) -> Option<std::ops::Range<usize>> {
+    let invalid_string = invalid_string_value(err.message())?;
+    let document = toml_edit::Document::parse(config_str).ok()?;
+    document
+        .as_table()
+        .get_values()
+        .into_iter()
+        .find_map(|(_, value)| {
+            (value.as_str() == Some(invalid_string))
+                .then(|| value.span())
+                .flatten()
+        })
+}
+
+fn invalid_string_value(message: &str) -> Option<&str> {
+    let rest = message.strip_prefix("invalid type: string \"")?;
+    let end = rest.find('"')?;
+    Some(&rest[..end])
 }
 
 impl Display for ConfigFile {
@@ -2307,6 +2448,26 @@ mod tests {
                  ";
         let err = ConfigFile::parse_config(config_str).unwrap_err();
         assert!(err.to_string().contains("unknown variant"));
+    }
+
+    #[test]
+    fn test_toml_parse_error_keeps_original_span() {
+        let config_str = "preset = \"strict\"\npytorch-efficiency-lints = \"true\"\n";
+        let err = ConfigFile::parse_config(config_str).unwrap_err();
+        let value_start = config_str.find("\"true\"").unwrap();
+        assert_eq!(
+            toml_error_span(&err),
+            Some(value_start..value_start + "\"true\"".len())
+        );
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("line 2"),
+            "expected TOML parse error to point to line 2, got: {msg}"
+        );
+        assert!(
+            msg.contains("pytorch-efficiency-lints = \"true\""),
+            "expected TOML parse error to include the invalid value line, got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -54,6 +54,7 @@ use pyrefly_util::watch_pattern::WatchPattern;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::de::IntoDeserializer as _;
 use serde_with::skip_serializing_none;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
@@ -1681,6 +1682,7 @@ impl ConfigFile {
     }
 
     pub fn parse_config(config_str: &str) -> anyhow::Result<ConfigFile> {
+        validate_pytorch_efficiency_lints_in_config(config_str)?;
         parse_toml_document::<ConfigFile>(config_str)
     }
 
@@ -1688,6 +1690,7 @@ impl ConfigFile {
     /// - `Option<ConfigFile>`: the pyrefly config, if `[tool.pyrefly]` was present
     /// - `bool`: whether Python tool sections like `[tool.ruff]` were detected
     fn parse_pyproject_toml(config_str: &str) -> anyhow::Result<(Option<ConfigFile>, bool)> {
+        validate_pytorch_efficiency_lints_in_pyproject(config_str)?;
         let pyproject = parse_toml_document::<PyProject>(config_str)?;
         let has_python_tools = pyproject.has_python_tools();
         Ok((pyproject.pyrefly(), has_python_tools))
@@ -1695,144 +1698,80 @@ impl ConfigFile {
 }
 
 fn parse_toml_document<T: DeserializeOwned>(config_str: &str) -> anyhow::Result<T> {
-    toml_edit::de::from_str::<T>(config_str)
-        .map_err(|err| toml_error_with_adjusted_span(config_str, err))
+    toml_edit::de::from_str::<T>(config_str).map_err(anyhow::Error::new)
 }
 
-fn toml_error_with_adjusted_span(config_str: &str, err: toml_edit::de::Error) -> anyhow::Error {
-    let original_span = err.span();
-    let adjusted_span = toml_error_key_span(config_str, &err)
-        .or_else(|| toml_error_value_span(config_str, &err))
-        .filter(|span| original_span.as_ref() != Some(span));
-    match adjusted_span {
-        Some(span) => anyhow::Error::new(TomlErrorWithAdjustedSpan {
-            input: config_str.to_owned(),
-            message: err.message().to_owned(),
-            span,
-        }),
-        None => anyhow::Error::new(err),
+fn validate_pytorch_efficiency_lints_in_config(config_str: &str) -> anyhow::Result<()> {
+    let Ok(document) = toml_edit::Document::parse(config_str.to_owned()) else {
+        return Ok(());
+    };
+    validate_pytorch_efficiency_lints_item(config_str, document.as_item())
+}
+
+fn validate_pytorch_efficiency_lints_in_pyproject(config_str: &str) -> anyhow::Result<()> {
+    let Ok(document) = toml_edit::Document::parse(config_str.to_owned()) else {
+        return Ok(());
+    };
+    let Some(pyrefly) = document
+        .as_table()
+        .get("tool")
+        .and_then(toml_edit::Item::as_table_like)
+        .and_then(|tool| tool.get("pyrefly"))
+    else {
+        return Ok(());
+    };
+    validate_pytorch_efficiency_lints_item(config_str, pyrefly)
+}
+
+fn validate_pytorch_efficiency_lints_item(
+    config_str: &str,
+    item: &toml_edit::Item,
+) -> anyhow::Result<()> {
+    if let Some(table) = item.as_table_like() {
+        validate_pytorch_efficiency_lints_table(config_str, table)?;
     }
-}
-
-#[derive(Debug)]
-struct TomlErrorWithAdjustedSpan {
-    input: String,
-    message: String,
-    span: std::ops::Range<usize>,
-}
-
-impl std::error::Error for TomlErrorWithAdjustedSpan {}
-
-impl Display for TomlErrorWithAdjustedSpan {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let start = self.span.start.min(self.input.len());
-        let line_start = self.input[..start]
-            .rfind('\n')
-            .map(|idx| idx + 1)
-            .unwrap_or(0);
-        let line_end = self.input[line_start..]
-            .find('\n')
-            .map(|idx| line_start + idx)
-            .unwrap_or(self.input.len());
-        let line_num = self.input[..line_start]
-            .bytes()
-            .filter(|byte| *byte == b'\n')
-            .count()
-            + 1;
-        let column = self.input[line_start..start].chars().count();
-        let col_num = column + 1;
-        let content = &self.input[line_start..line_end];
-        let highlight_end = self.span.end.min(line_end);
-        let highlight_len = self.input[start..highlight_end].chars().count().max(1);
-        let gutter = line_num.to_string().len();
-
-        writeln!(f, "TOML parse error at line {line_num}, column {col_num}")?;
-        for _ in 0..=gutter {
-            write!(f, " ")?;
+    if let Some(array) = item.as_array_of_tables() {
+        for table in array.iter() {
+            validate_pytorch_efficiency_lints_table(config_str, table)?;
         }
-        writeln!(f, "|")?;
-        writeln!(f, "{line_num} | {content}")?;
-        for _ in 0..=gutter {
-            write!(f, " ")?;
-        }
-        write!(f, "|")?;
-        for _ in 0..=column {
-            write!(f, " ")?;
-        }
-        for _ in 0..highlight_len {
-            write!(f, "^")?;
-        }
-        writeln!(f)?;
-        writeln!(f, "{}", self.message)
     }
+    Ok(())
+}
+
+fn validate_pytorch_efficiency_lints_table(
+    config_str: &str,
+    table: &dyn toml_edit::TableLike,
+) -> anyhow::Result<()> {
+    if let Some(item) = table.get("pytorch-efficiency-lints") {
+        deserialize_bool_toml_item(config_str, item)?;
+    }
+    for key in ["sub-config", "sub_config"] {
+        if let Some(item) = table.get(key) {
+            validate_pytorch_efficiency_lints_item(config_str, item)?;
+        }
+    }
+    Ok(())
+}
+
+fn deserialize_bool_toml_item(config_str: &str, item: &toml_edit::Item) -> anyhow::Result<()> {
+    let Some(value) = item.as_value() else {
+        return Ok(());
+    };
+    bool::deserialize(value.clone().into_deserializer())
+        .map(|_| ())
+        .map_err(|mut err| {
+            err.set_input(Some(config_str));
+            anyhow::Error::new(err)
+        })
 }
 
 pub fn toml_error_span(err: &anyhow::Error) -> Option<std::ops::Range<usize>> {
-    err.downcast_ref::<TomlErrorWithAdjustedSpan>()
-        .map(|err| err.span.clone())
-        .or_else(|| {
-            err.downcast_ref::<toml_edit::de::Error>()
-                .and_then(toml_edit::de::Error::span)
-        })
+    err.downcast_ref::<toml_edit::de::Error>()
+        .and_then(toml_edit::de::Error::span)
         .or_else(|| {
             err.downcast_ref::<toml::de::Error>()
                 .and_then(toml::de::Error::span)
         })
-}
-
-fn toml_error_key_span(
-    config_str: &str,
-    err: &toml_edit::de::Error,
-) -> Option<std::ops::Range<usize>> {
-    let key_path = toml_error_key_path(err)?;
-    let document = toml_edit::Document::parse(config_str).ok()?;
-    (0..key_path.len())
-        .find_map(|idx| toml_item_span_for_key_path(document.as_table(), &key_path[idx..]))
-}
-
-fn toml_error_key_path(err: &toml_edit::de::Error) -> Option<Vec<String>> {
-    let mut err_without_input = err.clone();
-    err_without_input.set_input(None);
-    err_without_input.to_string().lines().find_map(|line| {
-        line.strip_prefix("in `")
-            .and_then(|line| line.strip_suffix('`'))
-            .map(|line| line.split('.').map(str::to_owned).collect())
-    })
-}
-
-fn toml_item_span_for_key_path(
-    table: &toml_edit::Table,
-    key_path: &[String],
-) -> Option<std::ops::Range<usize>> {
-    let (first_key, rest) = key_path.split_first()?;
-    let mut item = table.get(first_key.as_str())?;
-    for key in rest {
-        item = item.as_table_like()?.get(key.as_str())?;
-    }
-    item.span()
-}
-
-fn toml_error_value_span(
-    config_str: &str,
-    err: &toml_edit::de::Error,
-) -> Option<std::ops::Range<usize>> {
-    let invalid_string = invalid_string_value(err.message())?;
-    let document = toml_edit::Document::parse(config_str).ok()?;
-    document
-        .as_table()
-        .get_values()
-        .into_iter()
-        .find_map(|(_, value)| {
-            (value.as_str() == Some(invalid_string))
-                .then(|| value.span())
-                .flatten()
-        })
-}
-
-fn invalid_string_value(message: &str) -> Option<&str> {
-    let rest = message.strip_prefix("invalid type: string \"")?;
-    let end = rest.find('"')?;
-    Some(&rest[..end])
 }
 
 impl Display for ConfigFile {
@@ -2463,6 +2402,27 @@ mod tests {
         assert!(
             msg.contains("line 2"),
             "expected TOML parse error to point to line 2, got: {msg}"
+        );
+        assert!(
+            msg.contains("pytorch-efficiency-lints = \"true\""),
+            "expected TOML parse error to include the invalid value line, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_pyproject_toml_parse_error_keeps_original_span() {
+        let config_str =
+            "[tool.pyrefly]\npreset = \"strict\"\npytorch-efficiency-lints = \"true\"\n";
+        let err = ConfigFile::parse_pyproject_toml(config_str).unwrap_err();
+        let value_start = config_str.find("\"true\"").unwrap();
+        assert_eq!(
+            toml_error_span(&err),
+            Some(value_start..value_start + "\"true\"".len())
+        );
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("line 3"),
+            "expected TOML parse error to point to line 3, got: {msg}"
         );
         assert!(
             msg.contains("pytorch-efficiency-lints = \"true\""),

--- a/pyrefly/lib/playground.rs
+++ b/pyrefly/lib/playground.rs
@@ -41,6 +41,7 @@ use serde::Serialize;
 use starlark_map::small_map::SmallMap;
 
 use crate::config::config::ConfigFile;
+use crate::config::config::toml_error_span;
 use crate::config::error_kind::Severity;
 use crate::config::finder::ConfigFinder;
 use crate::lsp::wasm::hover::get_hover;
@@ -161,6 +162,37 @@ impl Range {
             },
         })
     }
+}
+
+fn byte_offset_to_line_column(contents: &str, offset: usize) -> (i32, i32) {
+    let offset = offset.min(contents.len());
+    let mut line = 1;
+    let mut line_start = 0;
+    for (idx, ch) in contents.char_indices() {
+        if idx >= offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            line_start = idx + ch.len_utf8();
+        }
+    }
+    let column = contents[line_start..offset].chars().count() as i32 + 1;
+    (line, column)
+}
+
+fn toml_parse_error_range(contents: &str, err: &anyhow::Error) -> (i32, i32, i32, i32) {
+    let Some(span) = toml_error_span(err) else {
+        return (1, 1, 1, 1);
+    };
+    let start = span.start.min(contents.len());
+    let end = span.end.min(contents.len()).max(start);
+    let (start_line, start_col) = byte_offset_to_line_column(contents, start);
+    let (end_line, mut end_col) = byte_offset_to_line_column(contents, end);
+    if start_line == end_line && end_col <= start_col {
+        end_col = start_col + 1;
+    }
+    (start_line, start_col, end_line, end_col)
 }
 
 #[derive(Serialize, Clone)]
@@ -296,15 +328,17 @@ impl Playground {
         // Parse configuration if present in the in-memory files
         let mut parsed_config: Option<ConfigFile> = None;
         if let Some(cfg_str) = files.get("pyrefly.toml") {
-            match toml::from_str::<ConfigFile>(cfg_str) {
+            match ConfigFile::parse_config(cfg_str) {
                 Ok(cfg) => parsed_config = Some(cfg),
                 Err(err) => {
+                    let (start_line, start_col, end_line, end_col) =
+                        toml_parse_error_range(cfg_str, &err);
                     // Attach a diagnostic to pyrefly.toml on parse/validation failure
                     self.config_diagnostics.push(Diagnostic {
-                        start_line: 1,
-                        start_col: 1,
-                        end_line: 1,
-                        end_col: 1,
+                        start_line,
+                        start_col,
+                        end_line,
+                        end_col,
                         message_header: "TOML parse error".to_owned(),
                         message_details: err.to_string(),
                         kind: "parse-error".to_owned(),
@@ -970,6 +1004,28 @@ mod tests {
             !state.handles.contains_key("pyrefly.toml"),
             "Config file should not be a module"
         );
+    }
+
+    #[test]
+    fn test_config_toml_parse_error_range() {
+        let mut state = Playground::new(None).unwrap();
+        let mut files = SmallMap::new();
+        files.insert("main.py".to_owned(), String::new());
+        files.insert(
+            "pyrefly.toml".to_owned(),
+            "preset = \"strict\"\npytorch-efficiency-lints = \"true\"\n".to_owned(),
+        );
+
+        state.update_sandbox_files(files, true);
+
+        let diagnostic = state
+            .get_errors()
+            .into_iter()
+            .find(|error| error.filename == "pyrefly.toml")
+            .expect("expected a pyrefly.toml parse diagnostic");
+        assert_eq!(diagnostic.message_header, "TOML parse error");
+        assert_eq!(diagnostic.start_line, 2);
+        assert_eq!(diagnostic.start_col, 28);
     }
 
     #[test]


### PR DESCRIPTION
# Summary

Fixes #4060

This fixes TOML parse diagnostics so invalid config values point at the offending value instead of the start of the file.

The config parser now keeps usable TOML span information and adjusts broad serde validation spans to the matching TOML value span when possible. The playground now uses the same config parser and reports the derived range instead of hardcoding line 1, column 1.

# Test Plan

- `cargo test -p pyrefly_config`
- `cargo test -p pyrefly test_config_toml_parse_error_range -- --nocapture`
- `cargo fmt --all -- --check`