### PR TITLE
fix Django: ForeignKey(mymodule.MyModel) not recognized #4092

### DIFF
--- a/pyrefly/lib/alt/class/django.rs
+++ b/pyrefly/lib/alt/class/django.rs
@@ -253,8 +253,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
     fn resolve_target(&self, to_expr: &Expr, class: &Class) -> Option<Type> {
         match to_expr {
-            // Use expr_infer to resolve the name in the current scope
-            Expr::Name(_) => {
+            // Use expr_infer to resolve the model in the current scope.
+            Expr::Name(_) | Expr::Attribute(_) => {
                 let model_type = self.expr_infer(to_expr, &self.error_swallower());
                 Some(self.class_def_to_instance_type(&model_type))
             }

--- a/pyrefly/lib/test/django/foreign_key.rs
+++ b/pyrefly/lib/test/django/foreign_key.rs
@@ -110,6 +110,24 @@ assert_type(article.reporter_id, int)
 "#,
 );
 
+testcase!(
+    test_foreign_key_module_alias,
+    django_env_with_model_import(),
+    r#"
+from typing import assert_type
+from django.db import models
+import reporter as reporter_models
+
+class Article(models.Model):
+    reporter = models.ForeignKey(reporter_models.Reporter, on_delete=models.CASCADE)
+
+article = Article()
+assert_type(article.reporter, reporter_models.Reporter)
+assert_type(article.reporter.full_name, str)
+assert_type(article.reporter_id, int)
+"#,
+);
+
 django_testcase!(
     test_foreign_key_self_reference,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4092

Django relationship targets now resolve attribute expressions.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test