### PR TITLE
Fix completion docstrings for stubbed attributes

### DIFF
--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -427,7 +427,10 @@ impl Transaction<'_> {
             handle,
             &attr_info.name,
             definition,
-            FindPreference::default(),
+            FindPreference {
+                prefer_pyi: false,
+                ..Default::default()
+            },
         );
 
         let (definition, Some(docstring_range)) = attribute_definition? else {

--- a/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/completion.rs
@@ -11,6 +11,7 @@ use itertools::Itertools;
 use lsp_types::CompletionItem;
 use lsp_types::CompletionItemKind;
 use lsp_types::CompletionResponse;
+use lsp_types::Documentation;
 use lsp_types::InsertTextFormat;
 use lsp_types::Url;
 use lsp_types::notification::DidChangeTextDocument;
@@ -59,6 +60,37 @@ fn test_completion_basic() {
         .client
         .completion("foo.py", 11, 1)
         .expect_completion_response_with(|list| list.items.iter().any(|item| item.label == "Bar"))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn completion_attribute_prefers_py_docstring_over_pyi() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings::default())
+        .unwrap();
+
+    let file = "attributes_of_py_docstrings/src.py";
+    interaction.client.did_open(file);
+    interaction
+        .client
+        .completion(file, 9, 10)
+        .expect_completion_response_with(|list| {
+            list.items.iter().any(|item| {
+                item.label == "x"
+                    && matches!(
+                        &item.documentation,
+                        Some(Documentation::MarkupContent(content))
+                            if content
+                                .value
+                                .contains("Docstring coming from the .py implementation.")
+                    )
+            })
+        })
         .unwrap();
 
     interaction.shutdown().unwrap();


### PR DESCRIPTION
## Summary

- use the executable `.py` definition when loading documentation for attribute completions
- keep completion types and signatures sourced from the `.pyi` stub
- add an LSP regression test covering paired `.py` and `.pyi` modules

Fixes #4057.

## Why

Attribute completion documentation used the default stub-first definition preference. When a stub supplied the type but omitted a docstring, completion stopped at the `.pyi` definition instead of using the executable-module fallback that hover already uses.

Selecting the executable definition for this documentation-only lookup reuses that existing fallback without changing the stub-derived completion type.

## Test plan

- `cargo +stable-x86_64-pc-windows-gnu test -p pyrefly --test pyrefly_lsp_interaction_tests completion_attribute_prefers_py_docstring_over_pyi --no-fail-fast`
- `cargo +stable-x86_64-pc-windows-gnu test -p pyrefly --lib docstring --no-fail-fast`
- `cargo +stable-x86_64-pc-windows-gnu test -p pyrefly --test pyrefly_lsp_interaction_tests hover_attribute_prefers_py_docstring_over_pyi --no-fail-fast`
- `py -3.11 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`

## AI disclosure

This pull request was prepared and submitted by an AI agent. The change was validated with the repository's targeted tests, formatting, and linting workflow.
