### PR TITLE
Add combined full text and GitHub output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,4 +51,4 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       env:
         EXTRA_ARGS: ${{ inputs.args }}
-      run: pyrefly check --output-format=github $EXTRA_ARGS
+      run: pyrefly check --output-format=full-text-with-github $EXTRA_ARGS

--- a/action.yml
+++ b/action.yml
@@ -51,4 +51,9 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       env:
         EXTRA_ARGS: ${{ inputs.args }}
-      run: pyrefly check --output-format=full-text-with-github $EXTRA_ARGS
+      run: |
+        OUTPUT_FORMAT=github
+        if pyrefly check --help | grep -q "full-text-with-github"; then
+          OUTPUT_FORMAT=full-text-with-github
+        fi
+        pyrefly check --output-format="$OUTPUT_FORMAT" $EXTRA_ARGS

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -156,6 +156,8 @@ pub enum OutputFormat {
     #[default]
     /// Full, verbose text output
     FullText,
+    /// Full, verbose text output followed by GitHub Actions workflow commands
+    FullTextWithGithub,
     /// JSON output
     Json,
     /// Emit GitHub Actions workflow commands
@@ -2180,6 +2182,13 @@ output-format = "omit-errors"
         let config_str = r#"output-format = "junit-xml""#;
         let config = ConfigFile::parse_config(config_str).unwrap();
         assert_eq!(config.output_format, Some(OutputFormat::JunitXml));
+    }
+
+    #[test]
+    fn test_output_format_full_text_with_github_config_parsing() {
+        let config_str = r#"output-format = "full-text-with-github""#;
+        let config = ConfigFile::parse_config(config_str).unwrap();
+        assert_eq!(config.output_format, Some(OutputFormat::FullTextWithGithub));
     }
 
     #[test]

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
+use anstream::ColorChoice;
 use anstream::eprintln;
 use anstream::stderr;
 use anstream::stdout;
@@ -431,6 +432,9 @@ fn write_errors_to_file(
     match format {
         OutputFormat::MinText => write_error_text_to_file(path, relative_to, errors, false),
         OutputFormat::FullText => write_error_text_to_file(path, relative_to, errors, true),
+        OutputFormat::FullTextWithGithub => {
+            write_error_full_text_with_github_to_file(path, relative_to, errors)
+        }
         OutputFormat::Json => write_error_json_to_file(path, relative_to, errors),
         OutputFormat::Github => write_error_github_to_file(path, errors),
         OutputFormat::JunitXml => write_error_junit_xml_to_file(path, relative_to, errors),
@@ -446,6 +450,9 @@ pub(crate) fn write_errors_to_console(
     match format {
         OutputFormat::MinText => write_error_text_to_console(relative_to, errors, false),
         OutputFormat::FullText => write_error_text_to_console(relative_to, errors, true),
+        OutputFormat::FullTextWithGithub => {
+            write_error_full_text_with_github_to_console(relative_to, errors)
+        }
         OutputFormat::Json => write_error_json_to_console(relative_to, errors),
         OutputFormat::Github => write_error_github_to_console(errors),
         OutputFormat::JunitXml => write_error_junit_xml_to_console(relative_to, errors),
@@ -560,6 +567,42 @@ fn write_error_github_to_file(path: &Path, errors: &[Error]) -> anyhow::Result<(
 
 fn write_error_github_to_console(errors: &[Error]) -> anyhow::Result<()> {
     buffered_write_error_github(stdout(), errors)
+}
+
+fn write_error_full_text_with_github(
+    writer: impl Write,
+    color_choice: ColorChoice,
+    relative_to: &Path,
+    errors: &[Error],
+) -> anyhow::Result<()> {
+    let mut writer = BufWriter::new(writer);
+    {
+        let mut renderer = ErrorRenderer::new(&mut writer, color_choice);
+        for error in errors {
+            renderer.write(error, relative_to, true)?;
+        }
+        renderer.flush()?;
+    }
+    write_error_github(&mut writer, errors)?;
+    writer.flush()?;
+    Ok(())
+}
+
+fn write_error_full_text_with_github_to_file(
+    path: &Path,
+    relative_to: &Path,
+    errors: &[Error],
+) -> anyhow::Result<()> {
+    write_error_full_text_with_github(File::create(path)?, ColorChoice::Never, relative_to, errors)
+}
+
+fn write_error_full_text_with_github_to_console(
+    relative_to: &Path,
+    errors: &[Error],
+) -> anyhow::Result<()> {
+    let stdout = stdout();
+    let color_choice = stdout.current_choice();
+    write_error_full_text_with_github(stdout.lock(), color_choice, relative_to, errors)
 }
 
 /// True for characters allowed by the XML 1.0 `Char` production. Everything else
@@ -1597,6 +1640,18 @@ mod tests {
         let mut buf = Vec::new();
         write_error_github(&mut buf, &errors).unwrap();
         let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("::error file=/repo/foo.py"));
+        assert!(output.ends_with("::bad\n"));
+    }
+
+    #[test]
+    fn full_text_with_github_output_format_writes_both() {
+        let errors = vec![sample_error("bad".into())];
+        let mut buf = Vec::new();
+        write_error_full_text_with_github(&mut buf, ColorChoice::Never, Path::new("/"), &errors)
+            .unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("ERROR bad [bad-assignment]"));
         assert!(output.contains("::error file=/repo/foo.py"));
         assert!(output.ends_with("::bad\n"));
     }

--- a/test/errors.md
+++ b/test/errors.md
@@ -69,6 +69,23 @@ ERROR */bad.py:1:1-8: `+` is not supported * (glob)
 [1]
 ```
 
+## `full-text-with-github` preserves diagnostics in GitHub Actions logs
+
+```scrut
+$ echo "x: str = 0" > $TMPDIR/bad_combined.py && \
+> $PYREFLY check $TMPDIR/bad_combined.py --preset strict --output-format=full-text-with-github --summary=none
+ERROR `Literal[0]` is not assignable to `str` [bad-assignment]
+ --> */bad_combined.py:1:10 (glob)
+  |
+1 | x: str = 0
+  |    ---   ^
+  |    |
+  |    declared type
+  |
+::error file=*/bad_combined.py,line=1,col=10,endLine=1,endColumn=11,title=Pyrefly bad-assignment::`Literal[0]` is not assignable to `str` (glob)
+[1]
+```
+
 ## Source code snippet
 
 ```scrut


### PR DESCRIPTION
# Summary

- add a `full-text-with-github` output format that emits readable diagnostics followed by GitHub workflow commands
- use the combined format in the Pyrefly composite action so source locations remain visible in raw workflow logs
- cover config parsing, combined rendering, and CLI output behavior

Fixes #4087.

# Test Plan

- `cargo +stable-x86_64-pc-windows-gnu test -p pyrefly_config output_format` (3 passed)
- `cargo +stable-x86_64-pc-windows-gnu test -p pyrefly commands::check::tests` (16 passed)
- `py -3.11 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema` (formatting and linting passed)
- ran the compiled CLI with `--output-format=full-text-with-github` and confirmed it prints both the full diagnostic and the corresponding `::error` workflow command

# AI disclosure

I am an AI agent working under the `paranoa233` account. I inspected the implementation path, added focused tests, and validated the change with the checks above.
