### PR TITLE
fix Support #region/#endregion folding #3305

### DIFF
--- a/crates/pyrefly_python/src/folding.rs
+++ b/crates/pyrefly_python/src/folding.rs
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use lsp_types::FoldingRangeKind;
+use pyrefly_util::lined_buffer::LineNumber;
 use ruff_python_ast::Expr;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::visitor::Visitor;
@@ -17,11 +17,17 @@ use crate::comment_section::CommentSection;
 use crate::docstring::Docstring;
 use crate::module::Module;
 
+/// Semantic category of a folding range before conversion to LSP kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FoldKind {
+    Code,
+    Comment,
+    CommentSection,
+    Region,
+}
+
 /// Find the folding ranges (where you can collapse the code) in a module, given the AST.
-pub fn folding_ranges(
-    module: &Module,
-    body: &[Stmt],
-) -> Vec<(TextRange, Option<FoldingRangeKind>)> {
+pub fn folding_ranges(module: &Module, body: &[Stmt]) -> Vec<(TextRange, FoldKind)> {
     use ruff_python_ast::ExceptHandler;
     use ruff_text_size::Ranged;
 
@@ -39,14 +45,14 @@ pub fn folding_ranges(
     }
 
     struct FoldingRangeCollector<'a> {
-        ranges: Vec<(TextRange, Option<FoldingRangeKind>)>,
+        ranges: Vec<(TextRange, FoldKind)>,
         module: &'a Module,
     }
 
     impl Visitor<'_> for FoldingRangeCollector<'_> {
         fn visit_body(&mut self, body: &[Stmt]) {
             if let Some(range) = Docstring::range_from_stmts(body) {
-                self.ranges.push((range, Some(FoldingRangeKind::Comment)));
+                self.ranges.push((range, FoldKind::Comment));
             }
             walk_body(self, body);
         }
@@ -55,47 +61,47 @@ pub fn folding_ranges(
             match stmt {
                 Stmt::FunctionDef(func) if !func.body.is_empty() => {
                     let range = range_without_decorators(func.range, &func.decorator_list);
-                    self.ranges.push((range, None));
+                    self.ranges.push((range, FoldKind::Code));
                 }
                 Stmt::ClassDef(class) if !class.body.is_empty() => {
                     let range = range_without_decorators(class.range, &class.decorator_list);
-                    self.ranges.push((range, None));
+                    self.ranges.push((range, FoldKind::Code));
                 }
                 Stmt::If(if_stmt) => {
                     if !if_stmt.body.is_empty() {
-                        self.ranges.push((if_stmt.range, None));
+                        self.ranges.push((if_stmt.range, FoldKind::Code));
                     }
                     for elif_else in &if_stmt.elif_else_clauses {
                         if !elif_else.body.is_empty() {
-                            self.ranges.push((elif_else.range, None));
+                            self.ranges.push((elif_else.range, FoldKind::Code));
                         }
                     }
                 }
                 Stmt::For(for_stmt) if !for_stmt.body.is_empty() => {
-                    self.ranges.push((for_stmt.range, None));
+                    self.ranges.push((for_stmt.range, FoldKind::Code));
                 }
                 Stmt::While(while_stmt) if !while_stmt.body.is_empty() => {
-                    self.ranges.push((while_stmt.range, None));
+                    self.ranges.push((while_stmt.range, FoldKind::Code));
                 }
                 Stmt::With(with_stmt) if !with_stmt.body.is_empty() => {
-                    self.ranges.push((with_stmt.range, None));
+                    self.ranges.push((with_stmt.range, FoldKind::Code));
                 }
                 Stmt::Match(match_stmt) => {
-                    self.ranges.push((match_stmt.range, None));
+                    self.ranges.push((match_stmt.range, FoldKind::Code));
                     for case in &match_stmt.cases {
                         if !case.body.is_empty() {
-                            self.ranges.push((case.range, None));
+                            self.ranges.push((case.range, FoldKind::Code));
                         }
                     }
                 }
                 Stmt::Try(try_stmt) => {
                     if !try_stmt.body.is_empty() {
-                        self.ranges.push((try_stmt.range, None));
+                        self.ranges.push((try_stmt.range, FoldKind::Code));
                     }
                     for handler in &try_stmt.handlers {
                         let ExceptHandler::ExceptHandler(handler_inner) = handler;
                         if !handler_inner.body.is_empty() {
-                            self.ranges.push((handler_inner.range(), None));
+                            self.ranges.push((handler_inner.range(), FoldKind::Code));
                         }
                     }
                 }
@@ -117,7 +123,7 @@ pub fn folding_ranges(
             if let Some(range) = range {
                 let lsp_range = self.module.to_lsp_range(range);
                 if lsp_range.start.line != lsp_range.end.line {
-                    self.ranges.push((range, None));
+                    self.ranges.push((range, FoldKind::Code));
                 }
             }
             ruff_python_ast::visitor::walk_expr(self, expr);
@@ -130,9 +136,7 @@ pub fn folding_ranges(
     };
 
     if let Some(range) = Docstring::range_from_stmts(body) {
-        collector
-            .ranges
-            .push((range, Some(FoldingRangeKind::Comment)));
+        collector.ranges.push((range, FoldKind::Comment));
     }
 
     for stmt in body {
@@ -142,6 +146,43 @@ pub fn folding_ranges(
     // Add comment section folding ranges
     add_comment_section_ranges(&mut collector.ranges, module);
 
+    // Explicit regions follow VS Code's Python folding marker syntax.
+    let lined_buffer = module.lined_buffer();
+    let mut region_starts = Vec::new();
+    for (line_number, line) in lined_buffer.lines().enumerate() {
+        let line_number = u32::try_from(line_number).expect("module line number should fit in u32");
+        let Some(marker) = line.trim_start().strip_prefix('#').map(str::trim_start) else {
+            continue;
+        };
+        let has_marker = |prefix| {
+            marker.strip_prefix(prefix).is_some_and(|rest| {
+                rest.chars()
+                    .next()
+                    .is_none_or(|c| !c.is_ascii_alphanumeric() && c != '_')
+            })
+        };
+        if has_marker("region") {
+            region_starts.push(lined_buffer.line_start(LineNumber::from_zero_indexed(line_number)));
+        } else if has_marker("endregion")
+            && let Some(start) = region_starts.pop()
+        {
+            let next_line = line_number
+                .checked_add(1)
+                .expect("module line count should fit in u32");
+            let end = if usize::try_from(next_line).expect("u32 should fit in usize")
+                < lined_buffer.line_count()
+            {
+                lined_buffer.line_start(LineNumber::from_zero_indexed(next_line))
+            } else {
+                TextSize::try_from(module.contents().len())
+                    .expect("module contents should fit in TextSize")
+            };
+            collector
+                .ranges
+                .push((TextRange::new(start, end), FoldKind::Region));
+        }
+    }
+
     collector.ranges.sort_by_key(|(range, _)| range.start());
     collector.ranges.dedup();
     collector.ranges
@@ -149,10 +190,7 @@ pub fn folding_ranges(
 
 /// Add folding ranges for comment sections.
 /// Each section folds from its line to the line before the next section at the same or higher level.
-fn add_comment_section_ranges(
-    ranges: &mut Vec<(TextRange, Option<FoldingRangeKind>)>,
-    module: &Module,
-) {
+fn add_comment_section_ranges(ranges: &mut Vec<(TextRange, FoldKind)>, module: &Module) {
     let sections = CommentSection::extract_from_module(module);
 
     for (i, section) in sections.iter().enumerate() {
@@ -175,22 +213,20 @@ fn add_comment_section_ranges(
 
         // Only create a folding range if there's at least one line to fold
         if end_line > section.line_number {
-            let line_start = module.lined_buffer().line_start(
-                pyrefly_util::lined_buffer::LineNumber::from_zero_indexed(section.line_number),
-            );
+            let line_start = module
+                .lined_buffer()
+                .line_start(LineNumber::from_zero_indexed(section.line_number));
             let line_end = if (end_line as usize) < module.lined_buffer().line_count() {
-                module.lined_buffer().line_start(
-                    pyrefly_util::lined_buffer::LineNumber::from_zero_indexed(end_line + 1),
-                )
+                module
+                    .lined_buffer()
+                    .line_start(LineNumber::from_zero_indexed(end_line + 1))
             } else {
-                // Last line in file - use the actual end of content
-                // Safely convert length to TextSize
                 TextSize::try_from(module.contents().len())
-                    .unwrap_or_else(|_| TextSize::new(u32::MAX))
+                    .expect("module contents should fit in TextSize")
             };
 
             let range = TextRange::new(line_start, line_end);
-            ranges.push((range, Some(FoldingRangeKind::Region)));
+            ranges.push((range, FoldKind::CommentSection));
         }
     }
 }

--- a/pyrefly/lib/lsp/non_wasm/folding_ranges.rs
+++ b/pyrefly/lib/lsp/non_wasm/folding_ranges.rs
@@ -5,18 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use lsp_types::FoldingRangeKind;
 use pyrefly_build::handle::Handle;
+use pyrefly_python::folding::FoldKind;
 use pyrefly_python::folding::folding_ranges;
 use ruff_text_size::TextRange;
 
 use crate::state::state::Transaction;
 
 impl Transaction<'_> {
-    pub fn folding_ranges(
-        &self,
-        handle: &Handle,
-    ) -> Option<Vec<(TextRange, Option<FoldingRangeKind>)>> {
+    pub fn folding_ranges(&self, handle: &Handle) -> Option<Vec<(TextRange, FoldKind)>> {
         let ast = self.get_ast(handle)?;
         let module_info = self.get_module_info(handle)?;
         Some(folding_ranges(&module_info, &ast.body))
@@ -28,7 +25,7 @@ impl Transaction<'_> {
             ranges
                 .into_iter()
                 .filter_map(|(range, kind)| {
-                    if kind == Some(FoldingRangeKind::Comment) {
+                    if kind == FoldKind::Comment {
                         Some(range)
                     } else {
                         None

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -213,6 +213,7 @@ use pyrefly_config::config::ConfigSource;
 use pyrefly_config::error_kind::Severity;
 use pyrefly_python::PYTHON_EXTENSIONS;
 use pyrefly_python::ast::Ast;
+use pyrefly_python::folding::FoldKind;
 use pyrefly_python::module::TextRangeWithModule;
 use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::module_name::ModuleNameWithKind;
@@ -5459,10 +5460,16 @@ impl Server {
                     {
                         return None;
                     }
-                    // Filter out comment section folding ranges (Region) unless enabled
-                    if !self.comment_folding_ranges && kind == Some(FoldingRangeKind::Region) {
+                    if !self.comment_folding_ranges && kind == FoldKind::CommentSection {
                         return None;
                     }
+                    let kind = match kind {
+                        FoldKind::Code => None,
+                        FoldKind::Comment => Some(FoldingRangeKind::Comment),
+                        FoldKind::CommentSection | FoldKind::Region => {
+                            Some(FoldingRangeKind::Region)
+                        }
+                    };
                     let lsp_range = module.to_lsp_range(range);
                     if lsp_range.start.line >= lsp_range.end.line {
                         return None;

--- a/pyrefly/lib/test/lsp/folding_ranges.rs
+++ b/pyrefly/lib/test/lsp/folding_ranges.rs
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use lsp_types::FoldingRangeKind;
 use pretty_assertions::assert_eq;
 use pyrefly_build::handle::Handle;
+use pyrefly_python::folding::FoldKind;
 use serde::Serialize;
 
 use crate::state::state::State;
@@ -34,11 +34,11 @@ fn get_folding_ranges_report(state: &State, handle: &Handle) -> String {
             FoldingRangeInfo {
                 start_line: range.start.line,
                 end_line: range.end.line,
-                kind: kind.map(|k| match k {
-                    FoldingRangeKind::Comment => "comment".to_owned(),
-                    FoldingRangeKind::Imports => "imports".to_owned(),
-                    FoldingRangeKind::Region => "region".to_owned(),
-                }),
+                kind: match kind {
+                    FoldKind::Code => None,
+                    FoldKind::Comment => Some("comment".to_owned()),
+                    FoldKind::CommentSection | FoldKind::Region => Some("region".to_owned()),
+                },
             }
         })
         .collect();
@@ -863,6 +863,40 @@ z = 3
   {
     "start_line": 19,
     "end_line": 22,
+    "kind": "region"
+  }
+]"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
+fn folding_ranges_for_explicit_regions() {
+    let code = r#"#region Outer
+x = 1
+# region Inner
+y = 2
+# endregion
+z = 3
+#endregion
+"#;
+
+    let report =
+        get_batched_lsp_operations_report_no_cursor(&[("main", code)], get_folding_ranges_report);
+
+    assert_eq!(
+        r#"# main.py
+
+[
+  {
+    "start_line": 0,
+    "end_line": 7,
+    "kind": "region"
+  },
+  {
+    "start_line": 2,
+    "end_line": 5,
     "kind": "region"
   }
 ]"#

--- a/pyrefly/lib/test/lsp/lsp_interaction/folding_range.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/folding_range.rs
@@ -150,3 +150,41 @@ fn test_folding_ranges_comment_sections_explicitly_disabled() {
 
     interaction.shutdown().expect("Failed to shutdown");
 }
+
+#[test]
+fn test_explicit_region_folding_enabled_by_default() {
+    let test_files_root = get_test_files_root();
+    let root_path = test_files_root.path().to_path_buf();
+    std::fs::write(
+        root_path.join("test.py"),
+        "#region Example\nx = 1\n#endregion\n",
+    )
+    .expect("Failed to write test file");
+    let scope_uri = Url::from_file_path(&root_path).unwrap();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root_path.clone());
+
+    interaction
+        .initialize(InitializeSettings {
+            workspace_folders: Some(vec![("test".to_owned(), scope_uri.clone())]),
+            initialization_options: None,
+            configuration: Some(None),
+            ..Default::default()
+        })
+        .expect("Failed to initialize");
+
+    interaction.client.did_open("test.py");
+    interaction
+        .client
+        .folding_range("test.py")
+        .expect_response_with(|ranges: Option<Vec<FoldingRange>>| {
+            ranges.unwrap_or_default().iter().any(|range| {
+                range.start_line == 0
+                    && range.end_line == 2
+                    && range.kind == Some(FoldingRangeKind::Region)
+            })
+        })
+        .expect("Expected an explicit Region folding range by default");
+
+    interaction.shutdown().expect("Failed to shutdown");
+}


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3305

Added nested #region/#endregion and spaced # region support.
Explicit regions remain enabled independently of optional comment-section folding.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
Added collector and end-to-end LSP regression tests.