### PR TITLE
fix unknown even when has definition #4064

### DIFF
--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -740,9 +740,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         self.distribute_over_union(left, |left| {
             self.distribute_over_union(right, |right| {
                 match (left, right) {
-                    // If either operand is Any, the comparison result is Any.
-                    // This mirrors the same check in binop_infer.
-                    (Type::Any(style), _) => style.propagate(),
+                    // Membership against a known container still calls its `__contains__`
+                    // method and produces `bool`, even when the item is Any.
+                    (Type::Any(style), _) if !matches!(op, CmpOp::In | CmpOp::NotIn) => {
+                        style.propagate()
+                    }
                     (_, Type::Any(style)) => style.propagate(),
                     // If the RHS of a containment check isn't a quantified, it may contain a
                     // nested quantified that on_quantifieds would fail to detect.

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -1426,6 +1426,25 @@ c = Container()
 }
 
 #[test]
+fn hover_over_in_operator_with_unknown_left_operand_shows_contains_dunder() {
+    let code = r#"
+languages: list[str] = []
+
+def supported_language(lang):
+    if lang in languages:
+#           ^
+        return lang
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert!(
+        report.contains("(method) __contains__:")
+            && report.contains("self: list[str]")
+            && report.contains(") -> bool"),
+        "Expected hover to show list.__contains__ method signature, got: {report}"
+    );
+}
+
+#[test]
 fn hover_on_constructor_with_arguments() {
     let code = r#"
 class Person:

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -584,7 +584,8 @@ def test1(x: Any) -> None:
     assert_type(x != 1, Any)
     assert_type(x is None, Any)
     assert_type(x is not None, Any)
-    assert_type(x in [1, 2], Any)
+    assert_type(x in [1, 2], bool)
+    assert_type(x not in [1, 2], bool)
     assert_type(1 in x, Any)
 
 def test2(x: float, y: Any) -> None:


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4064

 Membership with an Any/unknown item now invokes the known container's `__contains__` and returns bool.

Hover now displays the resolved `list[str].__contains__` signature instead of Unknown.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test