### PR TITLE
Fix completions for import aliases

### DIFF
--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -1038,6 +1038,10 @@ impl Transaction<'_> {
             .and_then(Self::identifier_from_covering_nodes)
         {
             Some(IdentifierWithContext {
+                context: IdentifierContext::AliasDefinition,
+                ..
+            }) => return (Vec::new(), false),
+            Some(IdentifierWithContext {
                 identifier,
                 context:
                     IdentifierContext::ImportedName {

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -440,6 +440,9 @@ pub(crate) enum IdentifierContext {
         /// ex: For `from ... import x`, the name is `x`. For `from ... import x as y`, the name is `y`.
         name_after_import: Identifier,
     },
+    /// An identifier introduced as a local import alias.
+    /// ex: `y` in `import x as y` or `from x import z as y`.
+    AliasDefinition,
     /// An identifier appeared as the name of a function.
     /// ex: `x` in `def x(...): ...`
     FunctionDef { docstring_range: Option<TextRange> },
@@ -479,6 +482,7 @@ impl IdentifierContext {
                 }
                 | IdentifierContext::ImportedModule { .. }
                 | IdentifierContext::ImportedName { .. }
+                | IdentifierContext::AliasDefinition
                 | IdentifierContext::FunctionDef { .. }
                 | IdentifierContext::MethodDef { .. }
                 | IdentifierContext::ClassDef { .. }
@@ -569,6 +573,13 @@ impl IdentifierWithContext {
                 dots,
                 name_after_import,
             },
+        }
+    }
+
+    fn from_alias_definition(id: &Identifier) -> Self {
+        Self {
+            identifier: id.clone(),
+            context: IdentifierContext::AliasDefinition,
         }
     }
 
@@ -900,7 +911,17 @@ impl<'a> Transaction<'a> {
                 _,
             ) => {
                 // `import id` or `import ... as id`
-                Some(IdentifierWithContext::from_stmt_import(id, alias))
+                Some(
+                    if alias
+                        .asname
+                        .as_ref()
+                        .is_some_and(|asname| asname.range() == id.range())
+                    {
+                        IdentifierWithContext::from_alias_definition(id)
+                    } else {
+                        IdentifierWithContext::from_stmt_import(id, alias)
+                    },
+                )
             }
             (
                 Some(AnyNodeRef::Identifier(id)),
@@ -921,11 +942,17 @@ impl<'a> Transaction<'a> {
                 _,
             ) => {
                 // `from ... import id`
-                Some(IdentifierWithContext::from_stmt_import_from_name(
-                    id,
-                    alias,
-                    import_from,
-                ))
+                Some(
+                    if alias
+                        .asname
+                        .as_ref()
+                        .is_some_and(|asname| asname.range() == id.range())
+                    {
+                        IdentifierWithContext::from_alias_definition(id)
+                    } else {
+                        IdentifierWithContext::from_stmt_import_from_name(id, alias, import_from)
+                    },
+                )
             }
             (
                 Some(AnyNodeRef::Identifier(id)),
@@ -1104,6 +1131,9 @@ impl<'a> Transaction<'a> {
             IdentifierContext::ImportedName {
                 name_after_import, ..
             } => ResolutionKind::Key(Key::Definition(ShortIdentifier::new(name_after_import))),
+            IdentifierContext::AliasDefinition => {
+                ResolutionKind::Key(Key::Definition(ShortIdentifier::new(identifier)))
+            }
             IdentifierContext::FunctionDef { .. }
             | IdentifierContext::MethodDef { .. }
             | IdentifierContext::ClassDef { .. }
@@ -2544,6 +2574,16 @@ impl<'a> Transaction<'a> {
                     }),
                 }
             }
+            Some(IdentifierWithContext {
+                identifier,
+                context: IdentifierContext::AliasDefinition,
+            }) => match self.find_definition_for_name_def(handle, &identifier, preference)? {
+                Some(item) => Ok(vec1![item]),
+                None => Err(EmptyResponseReason::DefinitionNotFound {
+                    name: identifier.id.to_string(),
+                    context: DefinitionContext::NameDef,
+                }),
+            },
             Some(IdentifierWithContext {
                 identifier,
                 context: IdentifierContext::MethodDef { docstring_range },

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -2191,6 +2191,54 @@ Completion Results:
 }
 
 #[test]
+fn import_alias_has_no_completions() {
+    let code = r#"
+import pandas as pd
+#                  ^
+"#;
+    let files = [("main", code), ("pandas", ""), ("pdb", "")];
+    let (handles, state) = mk_multi_file_state(&files, Require::Exports, false);
+    let handle = handles.get("main").unwrap();
+    let position = extract_cursors_for_test(code)[0];
+    let completions =
+        state
+            .transaction()
+            .completion(handle, position, ImportFormat::Absolute, true, None);
+    assert!(
+        completions.is_empty(),
+        "import aliases should not receive completions, got {:?}",
+        completions
+            .iter()
+            .map(|item| item.label.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn from_import_alias_has_no_completions() {
+    let code = r#"
+from pandas import read_csv as pd
+#                                ^
+"#;
+    let files = [("main", code), ("pandas", "read_csv = 1\n")];
+    let (handles, state) = mk_multi_file_state(&files, Require::Exports, false);
+    let handle = handles.get("main").unwrap();
+    let position = extract_cursors_for_test(code)[0];
+    let completions =
+        state
+            .transaction()
+            .completion(handle, position, ImportFormat::Absolute, true, None);
+    assert!(
+        completions.is_empty(),
+        "from-import aliases should not receive completions, got {:?}",
+        completions
+            .iter()
+            .map(|item| item.label.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn autoimport_relative_on_builtins() {
     let code = r#"
 T = foooooo


### PR DESCRIPTION
# Summary

Fixes #4107

Import alias names are local binding targets, but completion treated them as import paths. This produced module suggestions for `import pandas as pd` and package-export suggestions for `from package import name as alias`.

Classify `Alias.asname` identifiers as `IdentifierContext::AliasDefinition` inside the shared `identifier_from_covering_nodes` path for both import forms. Completion now suppresses suggestions from that semantic context instead of performing a second AST match, while normal module and imported-name completions remain unchanged. Alias type and go-to-definition behavior continue through the existing definition-key paths.

**AI agent disclosure:** This PR was prepared by Hermes Agent, an AI coding agent, under the contributor's direction. The agent traced the relevant source paths, added and exercised regression tests, ran the repository validation commands listed below, and performed an independent automated code review. The contributor is aware of the AI-agent involvement.

# Test Plan

- `cargo test -p pyrefly import_alias_has_no_completions -- --nocapture` — 2 passed, 0 failed
- `cargo test -p pyrefly 'test::lsp::completion::' -- --nocapture` — 100 passed, 0 failed
- `cargo test -p pyrefly 'test::lsp::'` — 651 passed, 0 failed
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema` — formatting and linting passed
- `cargo fmt --all -- --check`
- `git diff --check`
