### PR TITLE
Fix duplicate module auto-import completions

### DIFF
--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -39,6 +39,7 @@ use ruff_text_size::TextSize;
 use starlark_map::small_set::SmallSet;
 
 use crate::alt::attr::AttrInfo;
+use crate::binding::binding::Binding;
 use crate::binding::binding::Key;
 use crate::export::exports::Export;
 use crate::export::exports::ExportLocation;
@@ -518,8 +519,12 @@ impl Transaction<'_> {
         {
             for idx in bindings.available_definitions(position) {
                 let key = bindings.idx_to_key(idx);
+                let binding = bindings.get(idx);
                 let label = match key {
                     Key::Definition(id) => module_info.code_at(id.range()),
+                    Key::Import(import) if matches!(binding, Binding::Module(_)) => {
+                        import.0.as_str()
+                    }
                     Key::Anywhere(x, ..) => &x.0,
                     _ => continue,
                 };
@@ -530,7 +535,6 @@ impl Transaction<'_> {
                 {
                     continue;
                 }
-                let binding = bindings.get(idx);
                 let ty = self.get_type(handle, key);
                 let export_info = self.key_to_export(handle, key, FindPreference::default());
 

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -2324,6 +2324,65 @@ T = spio
 }
 
 #[test]
+fn autoimport_does_not_duplicate_existing_module_import() {
+    let code = r#"
+import json
+
+jso
+#  ^
+"#;
+    let files = [("main", code), ("json", "def dumps(value): ...\n")];
+    let (handles, state) = mk_multi_file_state(&files, Require::Exports, false);
+    let handle = handles.get("main").unwrap();
+    let position = extract_cursors_for_test(code)[0];
+    let completions =
+        state
+            .transaction()
+            .completion(handle, position, ImportFormat::Absolute, true, None);
+    let json = completions
+        .iter()
+        .filter(|item| item.label == "json")
+        .collect::<Vec<_>>();
+    assert_eq!(json.len(), 1, "expected one completion for imported module");
+    assert!(
+        json[0].additional_text_edits.is_none(),
+        "existing module import should not produce another import edit"
+    );
+}
+
+#[test]
+fn autoimport_does_not_duplicate_existing_module_import_after_another_import() {
+    let code = r#"
+import os
+import json
+
+jso
+#  ^
+"#;
+    let files = [
+        ("main", code),
+        ("os", "name = 'posix'\n"),
+        ("json", "def dumps(value): ...\n"),
+    ];
+    let (handles, state) = mk_multi_file_state(&files, Require::Exports, false);
+    let handle = handles.get("main").unwrap();
+    let position = extract_cursors_for_test(code)[0];
+    let completions =
+        state
+            .transaction()
+            .completion(handle, position, ImportFormat::Absolute, true, None);
+    let json = completions
+        .iter()
+        .filter(|item| item.label == "json")
+        .collect::<Vec<_>>();
+    assert_eq!(json.len(), 1, "expected one completion for imported module");
+    assert!(
+        json[0].additional_text_edits.is_none(),
+        "existing module import should not produce another import edit"
+    );
+}
+
+#[test]
 fn autoimport_common_alias_bypasses_min_char_threshold() {
     let code = r#"
 T = np


### PR DESCRIPTION
# Summary

Ensure modules imported with regular imopr statements, such as import json, are treated as local completion candidates to avoid double import.

Fixes #4109 

# Test Plan

Added regression test for duplicate module auto-import completions.

