### PR TITLE
fix Hover shows @NNN at SQLAlchemy type pos #3240

### DIFF
--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -578,6 +578,7 @@ fn class_hover_display(
         _ => None,
     }?;
     constructor.transform_toplevel_callable(|c| expand_callable_kwargs_for_hover(solver, c));
+    constructor = solver.for_display(constructor);
     Some(constructor.as_lsp_string_with_fallback_name(name_for_display, LspDisplayMode::Hover))
 }
 

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -1668,6 +1668,28 @@ Box[str]("hello")
     );
 }
 
+// Regression test for https://github.com/facebook/pyrefly/issues/3240
+#[test]
+fn hover_on_generic_metaclass_constructor_does_not_show_inference_var() {
+    let code = r#"
+class DeclarativeAttributeIntercept(type):
+    pass
+
+class DCTransformDeclarative(DeclarativeAttributeIntercept):
+#                            ^
+    pass
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert!(
+        !report.contains("-> @"),
+        "Hover must not expose an internal inference variable, got: {report}"
+    );
+    assert!(
+        report.contains(") -> Self@DeclarativeAttributeIntercept: ..."),
+        "Hover should resolve the constructor's return type, got: {report}"
+    );
+}
+
 #[test]
 fn hover_on_class_type_parameter_shows_variance_covariant() {
     let code = r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3240

Constructor hover types are resolved before rendering, preventing internal `@NNN` variables from leaking:

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test