### PR TITLE
fix Narrowing lost after excluding the only None case #3374

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -86,6 +86,7 @@ use crate::binding::binding::TypeAliasRefBinding;
 use crate::binding::binding::TypeParameter;
 use crate::binding::expr::Usage;
 use crate::binding::metadata::BindingsMetadata;
+use crate::binding::narrow::AtomicNarrowOp;
 use crate::binding::narrow::NarrowOp;
 use crate::binding::narrow::NarrowOps;
 use crate::binding::pytest::PytestBindingInfo;
@@ -2088,15 +2089,36 @@ impl<'a> BindingsBuilder<'a> {
         use_location: NarrowUseLocation,
         usage: &Usage,
     ) {
-        for (name, (op, op_range)) in narrow_ops.0.iter_hashed() {
+        let mut ops: Vec<_> = narrow_ops
+            .0
+            .iter()
+            .map(|(name, (op, range))| (name.clone(), op.clone(), *range))
+            .collect();
+        let mut implied_names = SmallSet::new();
+        for (name, (op, range)) in narrow_ops.0.iter() {
+            if let Some(none_expr) = op.is_none_expr() {
+                for peer in self.scopes.excluded_none_peers(name) {
+                    if narrow_ops.0.contains_key(&peer) || !implied_names.insert(peer.clone()) {
+                        continue;
+                    }
+                    ops.push((
+                        peer,
+                        NarrowOp::Atomic(None, AtomicNarrowOp::IsNot(none_expr.clone())),
+                        *range,
+                    ));
+                }
+            }
+        }
+        for (name, op, op_range) in ops {
+            let name = Hashed::new(&name);
             // Narrowing operations should not pin partial types, but they also
             // should not permanently block pinning. Leave the first-use state
             // as Undetermined so a subsequent non-narrowing read can still pin.
             let mut narrowing_usage = Usage::non_pinning_value_from(usage);
             if let Some(initial_idx) = self.lookup_name(name, &mut narrowing_usage).found() {
                 let narrowed_idx = self.insert_binding(
-                    Key::Narrow(Box::new((name.into_key().clone(), *op_range, use_location))),
-                    Binding::Narrow(initial_idx, Box::new(op.clone()), use_location),
+                    Key::Narrow(Box::new((name.into_key().clone(), op_range, use_location))),
+                    Binding::Narrow(initial_idx, Box::new(op), use_location),
                 );
                 self.scopes.narrow_in_current_flow(name, narrowed_idx);
             }

--- a/pyrefly/lib/binding/narrow.rs
+++ b/pyrefly/lib/binding/narrow.rs
@@ -454,6 +454,45 @@ impl NarrowingSubject {
 }
 
 impl NarrowOp {
+    /// Return the `None` expression when this is a direct `x is None` narrow.
+    pub fn is_none_expr(&self) -> Option<&Expr> {
+        match self {
+            Self::Atomic(None, AtomicNarrowOp::Is(expr))
+                if matches!(expr, Expr::NoneLiteral(_)) =>
+            {
+                Some(expr)
+            }
+            _ => None,
+        }
+    }
+
+    fn excludes_none_or_is_unrelated(&self) -> bool {
+        match self {
+            Self::Or(ops) => {
+                ops.len() == 2
+                    && ops.iter().any(|op| {
+                        matches!(
+                            op,
+                            Self::Atomic(None, AtomicNarrowOp::IsNot(Expr::NoneLiteral(_)))
+                        )
+                    })
+                    && ops
+                        .iter()
+                        .any(|op| matches!(op, Self::Atomic(None, AtomicNarrowOp::Placeholder)))
+            }
+            Self::And(ops) => {
+                let mut meaningful = ops
+                    .iter()
+                    .filter(|op| !matches!(op, Self::Atomic(None, AtomicNarrowOp::Placeholder)));
+                meaningful
+                    .next()
+                    .is_some_and(Self::excludes_none_or_is_unrelated)
+                    && meaningful.next().is_none()
+            }
+            _ => false,
+        }
+    }
+
     /// Produce a Python-like snippet for hover display.
     ///
     /// `base_name` is the variable being narrowed. `snippet` converts a
@@ -742,6 +781,25 @@ impl NarrowOps {
     pub fn set_allow_never_collapse(&mut self) {
         for (op, _) in self.0.values_mut() {
             op.set_allow_never_collapse();
+        }
+    }
+
+    /// Recognize the surviving condition after a terminating
+    /// `if x is None and y is None` branch.
+    pub fn excluded_none_pair(&self) -> Option<(Name, Name)> {
+        if self.0.len() != 2 {
+            return None;
+        }
+        let mut entries = self.0.iter();
+        let (first, (first_op, _)) = entries.next().unwrap();
+        let (second, (second_op, _)) = entries.next().unwrap();
+        if first != second
+            && first_op.excludes_none_or_is_unrelated()
+            && second_op.excludes_none_or_is_unrelated()
+        {
+            Some((first.clone(), second.clone()))
+        } else {
+            None
         }
     }
 

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -570,6 +570,8 @@ impl Static {
 #[derive(Default, Clone, Debug)]
 pub struct Flow {
     info: SmallMap<Name, FlowInfo>,
+    /// Pairs for which the current flow excludes both values being `None`.
+    excluded_none_pairs: Vec<(Name, Name)>,
     // Have we seen control flow terminate?
     //
     // We continue to analyze the rest of the code after a flow terminates, but
@@ -2155,6 +2157,31 @@ impl Scopes {
         }
     }
 
+    /// Return names that cannot be `None` when `name` is `None` in the current flow.
+    pub fn excluded_none_peers(&self, name: &Name) -> Vec<Name> {
+        self.current()
+            .flow
+            .excluded_none_pairs
+            .iter()
+            .filter_map(|(first, second)| {
+                if first == name {
+                    Some(second.clone())
+                } else if second == name {
+                    Some(first.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn add_excluded_none_pair(&mut self, pair: (Name, Name)) {
+        let pairs = &mut self.current_mut().flow.excluded_none_pairs;
+        if !pairs.contains(&pair) && !pairs.contains(&(pair.1.clone(), pair.0.clone())) {
+            pairs.push(pair);
+        }
+    }
+
     /// Track the binding from assigning a name in the current flow. Here "define" means:
     /// - any operation that actually binds a value at runtime (e.g. `x = 5`,
     ///   `x := 5`, `for x in ...`)
@@ -2172,6 +2199,10 @@ impl Scopes {
         style: FlowStyle,
     ) -> Option<NameWriteInfo> {
         let in_loop = self.loop_depth() != 0;
+        self.current_mut()
+            .flow
+            .excluded_none_pairs
+            .retain(|(first, second)| first != *name.key() && second != *name.key());
         match self.current_mut().flow.info.entry_hashed(name.cloned()) {
             Entry::Vacant(e) => {
                 e.insert(FlowInfo::new_value(idx, style));
@@ -3795,6 +3826,23 @@ impl<'a> BindingsBuilder<'a> {
             }
         }
 
+        let excluded_none_pairs = flows
+            .first()
+            .map(|first| {
+                first
+                    .excluded_none_pairs
+                    .iter()
+                    .filter(|pair| {
+                        flows
+                            .iter()
+                            .skip(1)
+                            .all(|flow| flow.excluded_none_pairs.contains(pair))
+                    })
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+
         // Create a MergeItem for each flow being merged and each name appearing in any flow.
         let flow_infos: Vec<SmallMap<Name, FlowInfo>> = flows.into_iter().map(|f| f.info).collect();
         let mut merge_items: SmallMap<Name, MergeItem> = SmallMap::with_capacity(all_names.len());
@@ -3834,6 +3882,7 @@ impl<'a> BindingsBuilder<'a> {
         // The resulting flow has terminated only if all branches had terminated.
         let flow = Flow {
             info: merged_flow_infos,
+            excluded_none_pairs,
             has_terminated,
             is_definitely_unreachable: all_are_unreachable,
             last_stmt_expr: None,
@@ -4028,6 +4077,9 @@ impl<'a> BindingsBuilder<'a> {
             "A branch is started - did you forget to call `finish_branch`?"
         );
         let branches = fork.branches;
+        let excluded_none_pair = negated_prev_ops_if_nonexhaustive
+            .filter(|_| branches.iter().all(|flow| flow.has_terminated))
+            .and_then(|ops| ops.excluded_none_pair());
         if let Some(negated_prev_ops) = negated_prev_ops_if_nonexhaustive {
             self.scopes.current_mut().flow = fork.base.clone();
             self.bind_narrow_ops(
@@ -4051,6 +4103,9 @@ impl<'a> BindingsBuilder<'a> {
                     MergeStyle::Exclusive
                 },
             );
+        }
+        if let Some(pair) = excluded_none_pair {
+            self.scopes.add_excluded_none_pair(pair);
         }
     }
 

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -216,6 +216,36 @@ def f(x):
     "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/3374
+testcase!(
+    test_narrow_after_terminating_conjunction,
+    r#"
+from datetime import date
+from typing import assert_type
+
+def f(x: float | None, y: date | None, z: date) -> float:
+    if x is None and y is None:
+        raise ValueError()
+    if x is None:
+        assert_type(y, date)
+        return (y - z).days / 365.25
+    return x
+
+def reverse(x: float | None, y: date | None) -> None:
+    if x is None and y is None:
+        raise ValueError()
+    if y is None:
+        assert_type(x, float)
+
+def reassigned(x: float | None, y: date | None) -> None:
+    if x is None and y is None:
+        raise ValueError()
+    x = None
+    if x is None:
+        assert_type(y, date | None)
+"#,
+);
+
 // Regression test to ensure we don't forget to create loop recursion
 // bindings when the loop has early termination.
 testcase!(


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3374

Tracks when a terminating guard excludes both optional values being None.
Applies the implied narrowing when either value is subsequently proven None.
Invalidates the relationship on reassignment and preserves it only across valid flow merges.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test