### PR TITLE
fix Django: ForeignKey("app_label.Model") string refs are not resolved (no <fk>_id / relation typed Any) #3932

### DIFF
--- a/pyrefly/lib/alt/class/django.rs
+++ b/pyrefly/lib/alt/class/django.rs
@@ -262,9 +262,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if value.to_str() == "self" {
                     Some(self.instantiate(class))
                 } else {
-                    // Handle forward reference - look up the model by name in the current module
-                    // This requires that the model class is imported or defined in the current module
-                    let class_name = Name::new(value.to_str());
+                    // Django string references may include an app label, but the imported model is
+                    // still looked up by its class name in the current module.
+                    let target = value.to_str();
+                    let class_name = Name::new(
+                        target
+                            .rsplit_once('.')
+                            .map_or(target, |(_, model_name)| model_name),
+                    );
                     let module_name = class.module_name();
 
                     if self.exports.export_exists(module_name, &class_name) {

--- a/pyrefly/lib/test/django/foreign_key.rs
+++ b/pyrefly/lib/test/django/foreign_key.rs
@@ -111,6 +111,26 @@ assert_type(article.reporter_id, int)
 );
 
 testcase!(
+    test_foreign_key_app_label_string_literal,
+    django_env_with_model_import(),
+    r#"
+from typing import assert_type, TYPE_CHECKING
+from django.db import models
+
+if TYPE_CHECKING:
+    from .reporter import Reporter
+
+class Article(models.Model):
+    reporter = models.ForeignKey('news.Reporter', on_delete=models.CASCADE)
+
+article = Article()
+assert_type(article.reporter, Reporter)
+assert_type(article.reporter.full_name, str)
+assert_type(article.reporter_id, int)
+"#,
+);
+
+testcase!(
     test_foreign_key_module_alias,
     django_env_with_model_import(),
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3932

Django "app_label.Model" references now resolve using the imported model class name.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test