### PR TITLE
fix support the + - in hover panel #2974

### DIFF
--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -1520,8 +1520,20 @@ impl Type {
         fallback_name: Option<&str>,
         mode: LspDisplayMode,
     ) -> String {
+        self.as_lsp_string_with_fallback_name_and_expanded_unions(fallback_name, mode, false)
+    }
+
+    pub fn as_lsp_string_with_fallback_name_and_expanded_unions(
+        &self,
+        fallback_name: Option<&str>,
+        mode: LspDisplayMode,
+        expand_unions: bool,
+    ) -> String {
         let mut c = TypeDisplayContext::new(&[self]);
         c.set_lsp_display_mode(mode);
+        if expand_unions {
+            c.always_display_expanded_unions();
+        }
         let rendered = c.display(self).to_string();
         if let Some(name) = fallback_name
             && self.is_toplevel_callable()

--- a/lsp/package-lock.json
+++ b/lsp/package-lock.json
@@ -28,7 +28,7 @@
                 "typescript": "^4.4.3"
             },
             "engines": {
-                "vscode": "^1.94.0"
+                "vscode": "^1.103.0"
             }
         },
         "node_modules/@azure/abort-controller": {

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -29,8 +29,11 @@
         "lint"
     ],
     "engines": {
-        "vscode": "^1.94.0"
+        "vscode": "^1.103.0"
     },
+    "enabledApiProposals": [
+        "editorHoverVerbosityLevel"
+    ],
     "main": "./dist/extension",
     "activationEvents": [
         "onLanguage:python",

--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -28,6 +28,7 @@ import {
 } from './status-bar';
 import {runDocstringFoldingCommand} from './docstring';
 import {registerCodeLensCommands} from './codeLens';
+import {registerHoverProvider} from './hover';
 import {PythonEnvironment} from './python-environment';
 import {
   triggerMsPythonRefreshLanguageServersIfInstalled,
@@ -126,6 +127,9 @@ export async function activate(context: ExtensionContext) {
   const rawInitialisationOptions = JSON.parse(
     JSON.stringify(vscode.workspace.getConfiguration('pyrefly') ?? {}),
   );
+  // Proposed APIs are omitted at runtime when the editor has not granted access.
+  // In that case, let vscode-languageclient register the ordinary LSP hover provider.
+  const supportsHoverVerbosity = vscode.VerboseHover !== undefined;
 
   // Opt into the V2 wire shape for the typeErrorDisplayStatus request.
   // An older binary that doesn't know V2 still returns its V1 bare
@@ -138,6 +142,7 @@ export async function activate(context: ExtensionContext) {
     pyrefly: {
       ...((rawInitialisationOptions as any).pyrefly ?? {}),
       typeErrorDisplayStatusVersion: TYPE_ERROR_DISPLAY_STATUS_VERSION,
+      customHoverProvider: supportsHoverVerbosity,
     },
   };
 
@@ -194,6 +199,9 @@ export async function activate(context: ExtensionContext) {
     serverOptions,
     clientOptions,
   );
+  if (supportsHoverVerbosity) {
+    registerHoverProvider(context, () => client);
+  }
 
   context.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor(async () => {

--- a/lsp/src/hover.ts
+++ b/lsp/src/hover.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import * as vscode from 'vscode';
+import {
+  HoverParams,
+  HoverRequest,
+  LanguageClient,
+} from 'vscode-languageclient/node';
+
+type HoverWithVerbosity = HoverParams & {
+  verbosityLevel: number;
+};
+
+/** Register the VS Code-specific hover provider that supports +/- controls. */
+export function registerHoverProvider(
+  context: vscode.ExtensionContext,
+  getClient: () => LanguageClient,
+): void {
+  let lastHoverAndLevel: [vscode.Hover, number] | undefined;
+
+  context.subscriptions.push(
+    vscode.languages.registerHoverProvider(
+      [
+        {scheme: 'file', language: 'python'},
+        {scheme: 'untitled', language: 'python'},
+        {scheme: 'vscode-notebook-cell', language: 'python'},
+        {scheme: 'inmemory', language: 'python'},
+      ],
+      ({
+        async provideHover(
+          document: vscode.TextDocument,
+          position: vscode.Position,
+          token: vscode.CancellationToken,
+          hoverContext?: vscode.HoverContext,
+        ) {
+          const client = getClient();
+          const previousLevel =
+            hoverContext?.previousHover &&
+            lastHoverAndLevel?.[0] === hoverContext.previousHover
+              ? lastHoverAndLevel![1]
+              : 0;
+          const verbosityLevel = Math.max(
+            0,
+            previousLevel + (hoverContext?.verbosityDelta ?? 0),
+          );
+          const params = {
+            ...client.code2ProtocolConverter.asTextDocumentPositionParams(
+              document,
+              position,
+            ),
+            verbosityLevel,
+          } as HoverWithVerbosity;
+          const result = await client.sendRequest(
+            HoverRequest.type,
+            params,
+            token,
+          );
+          if (!result || token.isCancellationRequested) {
+            return undefined;
+          }
+
+          const canIncreaseVerbosity =
+            (result as typeof result & {canIncreaseVerbosity?: boolean})
+              .canIncreaseVerbosity ?? false;
+          const hover = client.protocol2CodeConverter.asHover(result);
+          if (!hover) {
+            return undefined;
+          }
+          const verboseHover = new vscode.VerboseHover(
+            hover.contents,
+            hover.range,
+            canIncreaseVerbosity,
+            verbosityLevel > 0,
+          );
+          lastHoverAndLevel = [verboseHover, verbosityLevel];
+          return verboseHover;
+        },
+      } as unknown as vscode.HoverProvider),
+    ),
+  );
+}

--- a/lsp/src/vscode.proposed.editorHoverVerbosityLevel.d.ts
+++ b/lsp/src/vscode.proposed.editorHoverVerbosityLevel.d.ts
@@ -1,0 +1,18 @@
+declare module 'vscode' {
+  export class VerboseHover extends Hover {
+    canIncreaseVerbosity?: boolean;
+    canDecreaseVerbosity?: boolean;
+
+    constructor(
+      contents: MarkdownString | MarkedString | Array<MarkdownString | MarkedString>,
+      range?: Range,
+      canIncreaseVerbosity?: boolean,
+      canDecreaseVerbosity?: boolean,
+    );
+  }
+
+  export interface HoverContext {
+    readonly verbosityDelta?: number;
+    readonly previousHover?: Hover;
+  }
+}

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -254,6 +254,7 @@ use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
+use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
@@ -330,7 +331,8 @@ use crate::lsp::non_wasm::workspace::Workspace;
 use crate::lsp::non_wasm::workspace::Workspaces;
 use crate::lsp::wasm::completion::CompletionOptions as CompletionRequestOptions;
 use crate::lsp::wasm::completion::supports_snippet_completions;
-use crate::lsp::wasm::hover::get_hover;
+use crate::lsp::wasm::hover::HoverResult;
+use crate::lsp::wasm::hover::get_hover_with_verbosity;
 use crate::lsp::wasm::notebook::DidChangeNotebookDocument;
 use crate::lsp::wasm::notebook::DidChangeNotebookDocumentParams;
 use crate::lsp::wasm::notebook::DidCloseNotebookDocument;
@@ -794,8 +796,11 @@ fn format_diagnostic_message_for_markdown(message: &str) -> String {
 #[cfg(test)]
 mod tests {
     use lsp_types::CodeActionKind;
+    use lsp_types::InitializeParams;
+    use serde_json::json;
 
     use super::SOURCE_FIX_ALL_PYREFLY;
+    use super::client_uses_custom_hover_provider;
     use super::format_diagnostic_message_for_markdown;
     use super::matches_fix_all_kind;
 
@@ -857,6 +862,16 @@ mod tests {
         )));
         assert!(!matches_fix_all_kind(&CodeActionKind::QUICKFIX));
         assert!(!matches_fix_all_kind(&CodeActionKind::REFACTOR_EXTRACT));
+    }
+
+    #[test]
+    fn test_custom_hover_provider_requires_explicit_opt_in() {
+        let mut params = InitializeParams::default();
+        assert!(!client_uses_custom_hover_provider(&params));
+        params.initialization_options = Some(json!({
+            "pyrefly": {"customHoverProvider": true}
+        }));
+        assert!(client_uses_custom_hover_provider(&params));
     }
 }
 
@@ -1069,6 +1084,31 @@ pub struct ServerCapabilitiesWithTypeHierarchy {
     type_hierarchy_provider: Option<bool>,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HoverParamsWithVerbosity {
+    #[serde(flatten)]
+    params: HoverParams,
+    #[serde(default)]
+    verbosity_level: usize,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HoverWithVerbosity {
+    #[serde(flatten)]
+    hover: Hover,
+    can_increase_verbosity: bool,
+}
+
+enum HoverRequestWithVerbosity {}
+
+impl lsp_types::request::Request for HoverRequestWithVerbosity {
+    type Params = HoverParamsWithVerbosity;
+    type Result = Option<HoverWithVerbosity>;
+    const METHOD: &'static str = HoverRequest::METHOD;
+}
+
 impl ServerCapabilitiesWithTypeHierarchy {
     pub fn set_experimental(&mut self, value: Value) {
         self.base.experimental = Some(value);
@@ -1258,6 +1298,16 @@ fn client_augments_syntax_tokens(initialization_params: &InitializeParams) -> bo
         .unwrap_or(false)
 }
 
+fn client_uses_custom_hover_provider(initialization_params: &InitializeParams) -> bool {
+    initialization_params
+        .initialization_options
+        .as_ref()
+        .and_then(|opts| opts.get("pyrefly"))
+        .and_then(|pyrefly| pyrefly.get("customHoverProvider"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
 pub fn capabilities(
     indexing_mode: IndexingMode,
     initialization_params: &InitializeParams,
@@ -1336,7 +1386,10 @@ pub fn capabilities(
             trigger_characters: Some(vec!["(".to_owned(), ",".to_owned()]),
             ..Default::default()
         }),
-        hover_provider: Some(HoverProviderCapability::Simple(true)),
+        // The extension registers its richer provider only when VS Code grants the proposed API.
+        hover_provider: Some(HoverProviderCapability::Simple(
+            !client_uses_custom_hover_provider(initialization_params),
+        )),
         inlay_hint_provider: Some(OneOf::Left(true)),
         document_symbol_provider: Some(OneOf::Left(true)),
         workspace_symbol_provider: Some(OneOf::Left(true)),
@@ -2265,17 +2318,24 @@ impl Server {
                         };
                         self.send_response(new_response(x.id, Ok(response)));
                     }
-                } else if let Some(params) = as_request::<HoverRequest>(&x) {
+                } else if let Some(params) = as_request::<HoverRequestWithVerbosity>(&x) {
                     if let Some(params) = self
-                        .extract_request_params_or_send_err_response::<HoverRequest>(params, &x.id)
+                        .extract_request_params_or_send_err_response::<HoverRequestWithVerbosity>(
+                            params, &x.id,
+                        )
                     {
-                        let response = match self.hover(&transaction, params) {
-                            Ok(response) => response,
-                            Err(reason) => {
-                                telemetry_event.set_empty_response_reason(reason);
-                                None
+                        let response =
+                            match self.hover(&transaction, params.params, params.verbosity_level) {
+                                Ok(response) => response,
+                                Err(reason) => {
+                                    telemetry_event.set_empty_response_reason(reason);
+                                    None
+                                }
                             }
-                        };
+                            .map(|result| HoverWithVerbosity {
+                                hover: result.hover,
+                                can_increase_verbosity: result.can_increase_verbosity,
+                            });
                         self.send_response(new_response(x.id, Ok(response)));
                     }
                 } else if let Some(params) = as_request::<InlayHintRequest>(&x) {
@@ -5123,7 +5183,8 @@ impl Server {
         &self,
         transaction: &Transaction<'_>,
         params: HoverParams,
-    ) -> Result<Option<Hover>, EmptyResponseReason> {
+        verbosity_level: usize,
+    ) -> Result<Option<HoverResult>, EmptyResponseReason> {
         let uri = &params.text_document_position_params.text_document.uri;
         let (handle, lsp_config) =
             self.make_handle_with_lsp_analysis_config_if_enabled(uri, Some(HoverRequest::METHOD))?;
@@ -5135,7 +5196,13 @@ impl Server {
         let show_go_to_links = lsp_config
             .and_then(|c| c.show_hover_go_to_links)
             .unwrap_or(true);
-        Ok(get_hover(transaction, &handle, position, show_go_to_links))
+        Ok(get_hover_with_verbosity(
+            transaction,
+            &handle,
+            position,
+            show_go_to_links,
+            verbosity_level,
+        ))
     }
 
     /// How long an inlay hint request should be deferred to debounce it, or

--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -84,6 +84,14 @@ pub struct HoverValue {
     pub show_go_to_links: bool,
 }
 
+/// Hover contents and whether another verbosity request can reveal more detail.
+///
+/// Hover verbosity currently has two states: named nested unions or fully expanded unions.
+pub struct HoverResult {
+    pub hover: Hover,
+    pub can_increase_verbosity: bool,
+}
+
 impl HoverValue {
     #[cfg(not(target_arch = "wasm32"))]
     fn format_symbol_def_locations(t: &Type) -> Option<String> {
@@ -538,6 +546,7 @@ fn class_hover_display(
     solver: &AnswersSolver<TransactionHandle<'_>>,
     type_: &Type,
     name_for_display: Option<&str>,
+    expand_unions: bool,
 ) -> Option<String> {
     let enum_class = match type_ {
         Type::ClassDef(cls) => Some(cls),
@@ -562,8 +571,11 @@ fn class_hover_display(
             solver.heap.mk_union(members)
         };
         return Some(
-            enum_display_type
-                .as_lsp_string_with_fallback_name(name_for_display, LspDisplayMode::Hover),
+            enum_display_type.as_lsp_string_with_fallback_name_and_expanded_unions(
+                name_for_display,
+                LspDisplayMode::Hover,
+                expand_unions,
+            ),
         );
     }
 
@@ -581,7 +593,23 @@ fn class_hover_display(
     }?;
     constructor.transform_toplevel_callable(|c| expand_callable_kwargs_for_hover(solver, c));
     constructor = solver.for_display(constructor);
-    Some(constructor.as_lsp_string_with_fallback_name(name_for_display, LspDisplayMode::Hover))
+    Some(
+        constructor.as_lsp_string_with_fallback_name_and_expanded_unions(
+            name_for_display,
+            LspDisplayMode::Hover,
+            expand_unions,
+        ),
+    )
+}
+
+/// A nested union with a display name is rendered as that name in compact hovers.
+fn has_expandable_named_union(ty: &Type) -> bool {
+    let mut result = false;
+    // Top-level unions are already expanded, so only inspect their descendants.
+    ty.recurse(&mut |child| {
+        result |= child.any(|ty| matches!(ty, Type::Union(union) if union.display_name.is_some()));
+    });
+    result
 }
 
 fn parameter_documentation_for_callee(
@@ -692,6 +720,18 @@ pub fn get_hover(
     position: TextSize,
     show_go_to_links: bool,
 ) -> Option<Hover> {
+    get_hover_with_verbosity(transaction, handle, position, show_go_to_links, 0)
+        .map(|result| result.hover)
+}
+
+/// Build hover contents and report whether the compact type display can be expanded.
+pub fn get_hover_with_verbosity(
+    transaction: &Transaction<'_>,
+    handle: &Handle,
+    position: TextSize,
+    show_go_to_links: bool,
+    verbosity_level: usize,
+) -> Option<HoverResult> {
     let module_info = transaction.get_module_info(handle);
 
     // Handle hovering over an ignore comment
@@ -719,7 +759,10 @@ pub fn get_hover(
                     suppression_line,
                     module.ignore(),
                 );
-                return Some(format_suppressed_errors_hover(suppressed_errors));
+                return Some(HoverResult {
+                    hover: format_suppressed_errors_hover(suppressed_errors),
+                    can_increase_verbosity: false,
+                });
             }
         }
     }
@@ -734,15 +777,18 @@ pub fn get_hover(
         && let Some(iterable_type) =
             transaction.get_type_at_for_display(handle, iterable_range.start())
     {
-        return Some(Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value: format!(
-                    "```python\n(keyword) in\n```\n---\nIteration over `{}`",
-                    iterable_type
-                ),
-            }),
-            range: None,
+        return Some(HoverResult {
+            hover: Hover {
+                contents: HoverContents::Markup(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: format!(
+                        "```python\n(keyword) in\n```\n---\nIteration over `{}`",
+                        iterable_type
+                    ),
+                }),
+                range: None,
+            },
+            can_increase_verbosity: false,
         });
     }
 
@@ -865,27 +911,40 @@ pub fn get_hover(
         && hover_identifier
             .as_ref()
             .is_some_and(|id| !matches!(id.context, IdentifierContext::ClassDef { .. }));
-    let type_display = transaction.ad_hoc_solve(handle, "hover_display", {
-        let mut cloned = type_.clone();
-        move |solver| {
-            if let Some(owner) = &type_parameter_owner_class
-                && let Some(display) = type_parameter_hover_display(&solver, &cloned, owner)
-            {
-                return display;
+    let (type_display, can_increase_verbosity) =
+        transaction.ad_hoc_solve(handle, "hover_display", {
+            let mut cloned = type_.clone();
+            move |solver| {
+                let unions_expanded = verbosity_level > 0;
+                let can_increase_verbosity =
+                    !unions_expanded && has_expandable_named_union(&cloned);
+                if let Some(owner) = &type_parameter_owner_class
+                    && let Some(display) = type_parameter_hover_display(&solver, &cloned, owner)
+                {
+                    return (display, can_increase_verbosity);
+                }
+                if show_constructor
+                    && let Some(display) = class_hover_display(
+                        &solver,
+                        &cloned,
+                        name_for_display.as_deref(),
+                        unions_expanded,
+                    )
+                {
+                    return (display, can_increase_verbosity);
+                }
+                cloned
+                    .transform_toplevel_callable(|c| expand_callable_kwargs_for_hover(&solver, c));
+                (
+                    cloned.as_lsp_string_with_fallback_name_and_expanded_unions(
+                        name_for_display.as_deref(),
+                        LspDisplayMode::Hover,
+                        unions_expanded,
+                    ),
+                    can_increase_verbosity,
+                )
             }
-            if show_constructor
-                && let Some(display) =
-                    class_hover_display(&solver, &cloned, name_for_display.as_deref())
-            {
-                return display;
-            }
-            cloned.transform_toplevel_callable(|c| expand_callable_kwargs_for_hover(&solver, c));
-            cloned.as_lsp_string_with_fallback_name(
-                name_for_display.as_deref(),
-                LspDisplayMode::Hover,
-            )
-        }
-    });
+        })?;
 
     let docstring = if let (Some(docstring), Some(module)) = (docstring_range, module) {
         Some(Docstring(docstring, module))
@@ -918,8 +977,8 @@ pub fn get_hover(
         }
     }
 
-    Some(
-        HoverValue {
+    Some(HoverResult {
+        hover: HoverValue {
             kind,
             name,
             type_,
@@ -927,11 +986,12 @@ pub fn get_hover(
             docstring,
             parameter_doc,
             type_sources: type_sources_for_hover(transaction, handle, position),
-            display: type_display,
+            display: Some(type_display),
             show_go_to_links,
         }
         .format(transaction, handle),
-    )
+        can_increase_verbosity,
+    })
 }
 
 #[cfg(test)]

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -14,6 +14,7 @@ use pyrefly_build::handle::Handle;
 use ruff_text_size::TextSize;
 
 use crate::lsp::wasm::hover::get_hover;
+use crate::lsp::wasm::hover::get_hover_with_verbosity;
 use crate::state::require::Require;
 use crate::state::state::State;
 use crate::test::util::TestEnv;
@@ -29,6 +30,54 @@ fn get_test_report(state: &State, handle: &Handle, position: TextSize) -> String
         }) => markup.value,
         _ => "None".to_owned(),
     }
+}
+
+fn get_test_report_at_verbosity(
+    state: &State,
+    handle: &Handle,
+    position: TextSize,
+    verbosity_level: usize,
+) -> (String, bool) {
+    match get_hover_with_verbosity(
+        &state.transaction(),
+        handle,
+        position,
+        true,
+        verbosity_level,
+    ) {
+        Some(result) => match result.hover {
+            Hover {
+                contents: HoverContents::Markup(markup),
+                ..
+            } => (markup.value, result.can_increase_verbosity),
+            _ => ("None".to_owned(), false),
+        },
+        _ => ("None".to_owned(), false),
+    }
+}
+
+#[test]
+fn hover_verbosity_expands_named_unions() {
+    let code = r#"
+type A = int | str
+x: list[A] = []
+#^
+"#;
+    let mut env = TestEnv::new();
+    env.add("main", code);
+    let (state, handle_for_name) = env.to_state();
+    let handle = handle_for_name("main");
+    let position = extract_cursors_for_test(code)[0];
+
+    let (compact, compact_can_increase) =
+        get_test_report_at_verbosity(&state, &handle, position, 0);
+    let (expanded, expanded_can_increase) =
+        get_test_report_at_verbosity(&state, &handle, position, 1);
+
+    assert!(compact.contains("x: list[A]"), "got: {compact}");
+    assert!(compact_can_increase);
+    assert!(expanded.contains("x: list[int | str]"), "got: {expanded}");
+    assert!(!expanded_can_increase);
 }
 
 fn assert_sphinx_resolved_as_link(report: &str, role: &str, target: &str) {


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2974

Added VS Code +/- hover verbosity controls.

Compact hovers preserve named union aliases; expanded hovers reveal their members.

Added the custom client/server hover protocol while preserving standard LSP behavior.

Raised the extension requirement to VS Code 1.103 for hover verbosity support.

---

why there is an extra `.d.ts`:

Because hover verbosity is still a proposed VS Code API. The stable @types/vscode package does not declare VerboseHover, HoverContext and the fourth provideHover argument.

In TypeScript, there are multiple expand levels.

Here we simplified it to only compact and expand.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test