### PR TITLE
try fix Pyrefly crashes VSCode when allocating memory on glibc 2.17 #1636

### DIFF
--- a/pyrefly/Cargo.toml
+++ b/pyrefly/Cargo.toml
@@ -91,9 +91,11 @@ pyrefly_lsp_test = { path = "../crates/pyrefly_lsp_test" }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 backtrace-on-stack-overflow = { version = "0.3", optional = true }
+
+[target.'cfg(any(target_os = "macos", all(target_os = "linux", target_env = "gnu")))'.dependencies]
 tikv-jemallocator = "0.6.0"
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(any(target_os = "windows", target_env = "musl"))'.dependencies]
 mimalloc = { version = "0.1.46", default-features = false }
 
 [features]

--- a/pyrefly/Cargo.toml
+++ b/pyrefly/Cargo.toml
@@ -92,9 +92,11 @@ pyrefly_lsp_test = { path = "../crates/pyrefly_lsp_test" }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 backtrace-on-stack-overflow = { version = "0.3", optional = true }
+
+[target.'cfg(any(target_os = "macos", all(target_os = "linux", target_env = "gnu")))'.dependencies]
 tikv-jemallocator = "0.7.0"
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(any(target_os = "windows", target_env = "musl"))'.dependencies]
 mimalloc = { version = "0.1.52", default-features = false }
 
 [features]

--- a/pyrefly/bin/main.rs
+++ b/pyrefly/bin/main.rs
@@ -18,15 +18,17 @@ use pyrefly_util::args::get_args_expanded;
 use pyrefly_util::panic::exit_on_panic;
 use pyrefly_util::telemetry::NoTelemetry;
 
-// fbcode likes to set its own allocator in fbcode.default_allocator
-// So when we set our own allocator, buck build buck2 or buck2 build buck2 often breaks.
-// Making jemalloc the default only when we do a cargo build.
+// fbcode sets its own allocator, so only select a custom allocator for Cargo builds.
+// Cargo's musl binaries use mimalloc because jemalloc is not reliable on older Linux hosts.
 #[global_allocator]
-#[cfg(all(any(target_os = "linux", target_os = "macos"), not(fbcode_build)))]
+#[cfg(all(
+    any(target_os = "macos", all(target_os = "linux", target_env = "gnu")),
+    not(fbcode_build)
+))]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[global_allocator]
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_env = "musl"))]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 /// Main CLI entrypoint for Pyrefly.


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1636

Musl binaries, including the bundled Linux x64 VS Code binary, now use mimalloc instead of jemalloc, GNU Linux and macOS retain jemalloc.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
