### PR TITLE
fix panic: Key Anon already exists with value ClassDef with fuzzed NamedTuple code #3354

### DIFF
--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -894,6 +894,8 @@ pub enum Key {
     BoundName(ShortIdentifier),
     /// I am an expression that does not have a simple name but needs its type inferred.
     Anon(TextRange),
+    /// I am the assigned value for a structurally invalid assignment target.
+    InvalidTarget(TextRange),
     /// I am a narrowing operation created by a pattern in a match statement
     PatternNarrow(TextRange),
     /// I am an expression that appears in a statement. The range for this key is the range of the expr itself, which is different than the range of the stmt expr.
@@ -955,6 +957,7 @@ impl Ranged for Key {
             Self::ReturnType(x) => x.range(),
             Self::BoundName(x) => x.range(),
             Self::Anon(r) => *r,
+            Self::InvalidTarget(r) => *r,
             Self::StmtExpr(r) => *r,
             Self::ContextExpr(r) => *r,
             Self::Phi(x) => x.1,
@@ -984,6 +987,7 @@ impl DisplayWith<ModuleInfo> for Key {
             Self::FacetAssign(x) => write!(f, "Key::FacetAssign({})", short(x)),
             Self::BoundName(x) => write!(f, "Key::BoundName({})", short(x)),
             Self::Anon(r) => write!(f, "Key::Anon({})", ctx.display(r)),
+            Self::InvalidTarget(r) => write!(f, "Key::InvalidTarget({})", ctx.display(r)),
             Self::StmtExpr(r) => write!(f, "Key::StmtExpr({})", ctx.display(r)),
             Self::ContextExpr(r) => write!(f, "Key::ContextExpr({})", ctx.display(r)),
             Self::Phi(x) => write!(f, "Key::Phi({} {})", x.0, ctx.display(&x.1)),

--- a/pyrefly/lib/binding/target.rs
+++ b/pyrefly/lib/binding/target.rs
@@ -352,7 +352,9 @@ impl<'a> BindingsBuilder<'a> {
                     },
                 );
                 // Make sure the RHS is properly bound, so that we can report errors there.
-                let mut user = self.declare_current_idx(Key::Anon(illegal_target.range()));
+                // `ensure_expr` may itself create a `Key::Anon` for this range (for example,
+                // functional NamedTuple syntax recovered as an invalid `for` target).
+                let mut user = self.declare_current_idx(Key::InvalidTarget(illegal_target.range()));
                 if ensure_assigned && let Some(assigned) = &mut assigned {
                     self.ensure_expr(assigned, user.usage());
                 }

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -6,6 +6,7 @@
  */
 
 use crate::test::util::TestEnv;
+use crate::test::util::testcase_for_macro;
 use crate::testcase;
 
 testcase!(
@@ -725,6 +726,18 @@ class E(NamedTuple("E", 42)):  # E: Expected valid functional named tuple defini
     pass
     "#,
 );
+
+// Regression test for https://github.com/facebook/pyrefly/issues/3354
+#[test]
+fn test_named_tuple_in_malformed_for_target() {
+    // Keep the malformed source exact: adding inline expectations changes the unterminated string.
+    let _ = testcase_for_macro(
+        TestEnv::new(),
+        "from typing import NamedTuple\n\nfor NamedTuple(\"\n",
+        file!(),
+        line!(),
+    );
+}
 
 testcase!(
     test_named_tuple_dynamic_fields,


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3354

Added a distinct binding key for invalid assignment targets, preventing collisions with synthesized functional NamedTuple bindings.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test