### PR TITLE
Fix `__unknown__` module names for files without a config

### DIFF
--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -1031,15 +1031,9 @@ impl ConfigFile {
         })
     }
 
+    /// Create a `Handle` for the given path, deriving its module name from the search paths,
+    /// falling back to `self.fallback_search_path` and finally `__unknown__`.
     pub fn handle_from_module_path(&self, module_path: ModulePath) -> Handle {
-        self.handle_from_module_path_with_fallback(module_path, &FallbackSearchPath::Empty)
-    }
-
-    pub fn handle_from_module_path_with_fallback(
-        &self,
-        module_path: ModulePath,
-        fallback_search_path: &FallbackSearchPath,
-    ) -> Handle {
         match &self
             .source_db
             .as_ref()
@@ -1053,30 +1047,19 @@ impl ConfigFile {
                 // root resolve from the site-package prefix, not from the
                 // heuristic project root, while still letting explicit search
                 // paths override when the user has configured them.
-                let all_paths: Vec<&PathBuf> = self
+                let search_paths = self
                     .explicit_search_path()
                     .chain(self.site_package_path())
-                    .chain(self.heuristic_search_path())
-                    .collect();
-                let module_kind = if fallback_search_path.is_empty() {
-                    let name = ModuleName::from_path(
-                        module_path.as_path(),
-                        all_paths.iter().copied(),
-                        &self.extra_file_extensions,
-                    )
-                    .unwrap_or_else(ModuleName::unknown);
-                    ModuleNameWithKind::guaranteed(name)
-                } else {
-                    let fallback_paths =
-                        fallback_search_path.for_directory(Some(module_path.as_path()));
-                    ModuleName::from_path_with_fallback(
-                        module_path.as_path(),
-                        all_paths.iter().copied(),
-                        fallback_paths.iter(),
-                        &self.extra_file_extensions,
-                    )
-                    .unwrap_or(ModuleNameWithKind::guaranteed(ModuleName::unknown()))
-                };
+                    .chain(self.heuristic_search_path());
+                let path = module_path.as_path();
+                let fallback_paths = self.fallback_search_path.for_directory(Some(path));
+                let module_kind = ModuleName::from_path_with_fallback(
+                    path,
+                    search_paths,
+                    fallback_paths.iter(),
+                    &self.extra_file_extensions,
+                )
+                .unwrap_or(ModuleNameWithKind::guaranteed(ModuleName::unknown()));
                 Handle::from_with_module_name_kind(module_kind, module_path, self.get_sys_info())
             }
         }

--- a/pyrefly/lib/commands/config_finder.rs
+++ b/pyrefly/lib/commands/config_finder.rs
@@ -349,6 +349,7 @@ mod tests {
     use pyrefly_util::test_path::TestPath;
 
     use super::*;
+    use crate::commands::check::Handles;
     use crate::config::config::ConfigSource;
     use crate::config::environment::environment::PythonEnvironment;
 
@@ -533,6 +534,21 @@ mod tests {
                     .collect::<Vec<PathBuf>>()
             )),
         );
+    }
+
+    /// gh-4132: CLI handles must derive module names via the config's fallback
+    /// search path, so files in a config-less directory don't become `__unknown__`.
+    #[test]
+    fn test_handles_all_uses_fallback_search_path() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        TestPath::setup_test_directory(root, vec![TestPath::file("foo.py")]);
+
+        let finder = TestConfigurer::new_standard(|_, x, _| {
+            ConfigOverrideArgs::default().override_config(x)
+        });
+        let (handles, _, _) = Handles::new(vec![root.join("foo.py")]).all(&finder);
+        assert_eq!(handles[0].module(), ModuleName::from_str("foo"));
     }
 
     /// A real pyrefly.toml should always take priority over a pyproject.toml

--- a/pyrefly/lib/lsp/non_wasm/module_helpers.rs
+++ b/pyrefly/lib/lsp/non_wasm/module_helpers.rs
@@ -62,9 +62,7 @@ pub(crate) fn handle_from_module_path(state: &State, path: ModulePath) -> Handle
                 .unwrap_or(unknown);
             Handle::new(module_name, path, config.get_sys_info())
         }
-        _ => {
-            config.handle_from_module_path_with_fallback(path.dupe(), &config.fallback_search_path)
-        }
+        _ => config.handle_from_module_path(path.dupe()),
     }
 }
 


### PR DESCRIPTION
# Summary

CLI handles were named without checking the config's `fallback_search_path`, so in a directory without a config every file was `__unknown__`, and no symbol FQN could match the public FQNs in `pyrefly coverage {check, report} --public-only`.
`ConfigFile::handle_from_module_path` now applies its own `fallback_search_path` (i.e. what the LSP already did), so that `handle_from_module_path_with_fallback` is now no longer needed.

Fixes #4132

# Test Plan

Regression test added, and verified that `pyrefly coverage check --public-only` in a directory without pyrefly config now reports the same as without `--public-only`.