### PR TITLE
Fix false "Expected a callable" on directly-imported package attributes that shadow a submodule (pyrefly #322) (#4139)

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -2096,6 +2096,32 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         self.apply_getattr_fallback(attr_name, direct_lookup_result)
     }
 
+    /// Whether accessing `attr_name` on the package `module_name` should resolve to the
+    /// directly-imported same-named submodule, shadowing any package export of that name.
+    ///
+    /// A directly-imported submodule normally shadows the package namespace, because the import
+    /// system binds the submodule onto its package *after* the package's `__init__` toplevel has
+    /// executed. The exception is when `__init__` re-exports the same-named symbol *from* the
+    /// same-named submodule (e.g. unittest's `from .main import main as main`, where
+    /// `main = TestProgram`): the `from .main` loads the submodule as a side effect of
+    /// `__init__`, so it is already in `sys.modules` and the subsequent `main = ...` binding
+    /// wins; a later `import pkg.main` in user code is then a no-op for the attribute. The
+    /// re-export must originate from the same-named submodule for this to hold: a re-export
+    /// sourced from a *different* module (`from .other import main as main`) does not trigger
+    /// that side-effect load, so the directly-imported submodule still shadows it — even when
+    /// `__init__` also happens to import the submodule via an unrelated statement.
+    /// See https://github.com/facebook/pyrefly/issues/322
+    fn direct_submodule_shadows_export(
+        &self,
+        submodule: &ModuleType,
+        module_name: ModuleName,
+        attr_name: &Name,
+    ) -> bool {
+        submodule.is_submodules_imported_directly()
+            && self.exports.reexport_source(module_name, attr_name)
+                != Some(module_name.append(attr_name))
+    }
+
     fn get_module_attr(&self, module: &ModuleType, attr_name: &Name) -> Option<Attribute> {
         // `module_name` could refer to a package, in which case we need to check if
         // `module_name.attr_name`:
@@ -2110,11 +2136,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // would always bind the submodule name `attr_name` to the namespace of `module_name` *after* the module
         // toplevel of `module_name` has been executed.
         let submodule = module.push_part(attr_name.clone());
-        if submodule.is_submodules_imported_directly() {
+        let module_name = ModuleName::from_parts(module.parts());
+
+        if self.direct_submodule_shadows_export(&submodule, module_name, attr_name) {
             return Some(Attribute::simple(submodule.to_type(self.heap)));
         }
-
-        let module_name = ModuleName::from_parts(module.parts());
 
         match self.exports.module_exists(module_name) {
             FindingOrError::Finding(_) => (),
@@ -2915,10 +2941,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) {
         // Check for submodule access first (takes precedence over exports, same as get_module_attr).
         // This handles cases like `a.b.c` where `import a.b.c` was used - accessing `b` on `a`
-        // should resolve to the submodule `a.b`, not look for an export named `b` in `a`.
+        // should resolve to the submodule `a.b`, not look for an export named `b` in `a`. The
+        // `direct_submodule_shadows_export` exception (a re-export from the same-named submodule
+        // wins over the submodule binding) applies here identically.
         if let Some(attr_name) = expected_attribute_name {
             let submodule = module.push_part(attr_name.clone());
-            if submodule.is_submodules_imported_directly() {
+            let module_name = ModuleName::from_parts(module.parts());
+            if self.direct_submodule_shadows_export(&submodule, module_name, attr_name) {
                 res.push(AttrInfo {
                     name: attr_name.clone(),
                     ty: None,
@@ -2943,7 +2972,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         definition: AttrDefinition::PartiallyResolvedImportedModuleAttribute {
                             module_name,
                         },
-                        is_reexport: self.exports.is_reexport(module_name, name),
+                        is_reexport: self.exports.reexport_source(module_name, name).is_some(),
                     });
                 }
             }
@@ -2956,7 +2985,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         definition: AttrDefinition::PartiallyResolvedImportedModuleAttribute {
                             module_name,
                         },
-                        is_reexport: self.exports.is_reexport(module_name, name),
+                        is_reexport: self.exports.reexport_source(module_name, name).is_some(),
                     }));
                 }
             }

--- a/pyrefly/lib/export/exports.rs
+++ b/pyrefly/lib/export/exports.rs
@@ -55,8 +55,8 @@ pub trait LookupExport {
     /// Get deprecation info for an export. Records a dependency on `name` from `module` regardless of if it exists.
     fn get_deprecated(&self, module: ModuleName, name: &Name) -> Option<Deprecation>;
 
-    /// Check if an export is a re-export from another module. Records a dependency on `name` from `module` regardless of if it exists.
-    fn is_reexport(&self, module: ModuleName, name: &Name) -> bool;
+    /// If `name` is a re-export, return the module it is re-exported from. Records a dependency on `name` from `module` regardless of if it exists.
+    fn reexport_source(&self, module: ModuleName, name: &Name) -> Option<ModuleName>;
 
     /// Check if an export is a special export. Records a dependency on `name` from `module` regardless of if it exists.
     fn is_special_export(&self, module: ModuleName, name: &Name) -> Option<SpecialExport>;
@@ -497,8 +497,8 @@ mod tests {
             None
         }
 
-        fn is_reexport(&self, _module: ModuleName, _name: &Name) -> bool {
-            false
+        fn reexport_source(&self, _module: ModuleName, _name: &Name) -> Option<ModuleName> {
+            None
         }
 
         fn docstring_range(&self, _module: ModuleName, _name: &Name) -> Option<TextRange> {

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -186,7 +186,7 @@ pub struct ModuleChanges(pub ModuleDeps);
 
 // A single dependency, passed during lookup. Can be merged into ModuleDeps.
 //
-// The metadata-flavored lookups (`is_special_export`, `is_reexport`,
+// The metadata-flavored lookups (`is_special_export`, `reexport_source`,
 // `get_deprecated`, `is_final`, `docstring_range`,
 // `is_submodule_imported_implicitly`) all record "depends on the
 // metadata of this name" and funnel into the same `ModuleDeps` slot.
@@ -208,8 +208,8 @@ pub enum ModuleDep {
     NameMetadata(Name),
     /// `LookupExport::is_special_export`.
     IsSpecialExport(Name),
-    /// `LookupExport::is_reexport`.
-    IsReexport(Name),
+    /// `LookupExport::reexport_source`.
+    ReexportSource(Name),
     /// `LookupExport::get_deprecated`.
     GetDeprecated(Name),
     /// `LookupExport::export_origin`.
@@ -329,7 +329,7 @@ impl ModuleDeps {
             }
             ModuleDep::NameMetadata(name)
             | ModuleDep::IsSpecialExport(name)
-            | ModuleDep::IsReexport(name)
+            | ModuleDep::ReexportSource(name)
             | ModuleDep::GetDeprecated(name)
             | ModuleDep::ExportOrigin(name)
             | ModuleDep::DocstringRange(name)
@@ -426,7 +426,7 @@ impl ModuleDep {
             ModuleDep::NameExists(_) => "export_exists",
             ModuleDep::NameMetadata(_) => "name_metadata",
             ModuleDep::IsSpecialExport(_) => "is_special_export",
-            ModuleDep::IsReexport(_) => "is_reexport",
+            ModuleDep::ReexportSource(_) => "reexport_source",
             ModuleDep::GetDeprecated(_) => "get_deprecated",
             ModuleDep::ExportOrigin(_) => "export_origin",
             ModuleDep::DocstringRange(_) => "docstring_range",
@@ -2868,18 +2868,16 @@ impl<'a> LookupExport for TransactionHandle<'a> {
         )?
     }
 
-    fn is_reexport(&self, module: ModuleName, name: &Name) -> bool {
+    fn reexport_source(&self, module: ModuleName, name: &Name) -> Option<ModuleName> {
         self.with_exports(
             module,
-            |exports, lookup| {
-                matches!(
-                    exports.exports(lookup).get(name),
-                    Some(ExportLocation::OtherModule(..))
-                )
+            |exports, lookup| match exports.exports(lookup).get(name) {
+                Some(ExportLocation::OtherModule(other_module, _)) => Some(*other_module),
+                _ => None,
             },
-            ModuleDep::IsReexport(name.clone()),
+            ModuleDep::ReexportSource(name.clone()),
         )
-        .unwrap_or(false)
+        .flatten()
     }
 
     fn is_special_export(&self, mut module: ModuleName, name: &Name) -> Option<SpecialExport> {

--- a/pyrefly/lib/test/imports.rs
+++ b/pyrefly/lib/test/imports.rs
@@ -1098,18 +1098,96 @@ unittest.main()
 );
 
 testcase!(
-    bug = "In the presence of collisions, the runtime result can be order-dependent",
     test_ambiguous_pkg_attribute_vs_submodule,
     r#"
-# The behavior when a package `__init__` attribute and a submodule collide can
-# be ambiguous. We currently do not model this fully, and instead use the distinction
-# between `import pkg.xyz` vs `from pkg import xyz` (which is correlated with the
-# runtime behavior but not entirely the same) to approximate.
-#
-# One example where this leads us astray is with unittest.main; the following
-# snippet works at runtime:
+# When a package `__init__` attribute and a same-named submodule collide, the
+# runtime result can be order-dependent. When the colliding name is explicitly
+# re-exported by the package (as `unittest` does with
+# `from .main import main as main`, where `main = TestProgram`), that binding wins
+# at runtime even if the submodule is imported directly, so the call below is valid.
+# See https://github.com/facebook/pyrefly/issues/322
 import unittest.main
-unittest.main()  # E: Expected a callable, got `Module[unittest.main]`
+unittest.main()
+    "#,
+);
+
+fn env_reexport_from_same_submodule() -> TestEnv {
+    let mut t = TestEnv::new();
+    // Synthetic version of the `unittest.main` case, independent of typeshed: `pkg.__init__`
+    // re-exports `name` *from* the same-named submodule `pkg.name`. The `from .name` load is a
+    // side effect of `__init__`, so the `name = ...` binding wins even after a direct
+    // `import pkg.name`, and `pkg.name()` resolves to the callable rather than the module.
+    t.add_with_path("pkg", "pkg/__init__.py", "from .name import name as name");
+    t.add_with_path("pkg.name", "pkg/name.py", "def name() -> int: ...");
+    t
+}
+
+testcase!(
+    test_reexport_from_same_submodule_shadows,
+    env_reexport_from_same_submodule(),
+    r#"
+# `pkg.__init__` re-exports `name` from the same-named submodule `pkg.name`, so at runtime
+# the re-exported callable wins over the submodule binding even after `import pkg.name`, and
+# the call below is valid. See https://github.com/facebook/pyrefly/issues/322
+import pkg.name
+pkg.name()
+    "#,
+);
+
+fn env_reexport_from_other_submodule() -> TestEnv {
+    let mut t = TestEnv::new();
+    // `pkg.__init__` re-exports `name` from `pkg.other`, NOT from `pkg.name`. At runtime
+    // this does not trigger a side-effect import of `pkg.name`, so a subsequent
+    // `import pkg.name` binds the submodule onto `pkg` after `__init__` executes, and
+    // the submodule wins over the re-exported attribute.
+    t.add_with_path("pkg", "pkg/__init__.py", "from .other import name as name");
+    t.add_with_path("pkg.other", "pkg/other.py", "def name() -> int: ...");
+    t.add_with_path("pkg.name", "pkg/name.py", "");
+    t
+}
+
+testcase!(
+    test_reexport_from_other_submodule_does_not_shadow,
+    env_reexport_from_other_submodule(),
+    r#"
+# `pkg.__init__` re-exports `name` from `pkg.other` (a *different* module than the
+# same-named submodule `pkg.name`), so at runtime the direct `import pkg.name`
+# below binds the submodule onto `pkg` after `__init__` and the submodule wins.
+# See https://github.com/facebook/pyrefly/issues/322
+import pkg.name
+pkg.name()  # E: Expected a callable, got `Module[pkg.name]`
+    "#,
+);
+
+fn env_reexport_from_other_submodule_with_implicit_import() -> TestEnv {
+    let mut t = TestEnv::new();
+    // `pkg.__init__` re-exports `name` from `pkg.other` and *also* imports the same-named
+    // submodule `pkg.name` in an unrelated statement. The re-export does not originate from
+    // `pkg.name`, so at runtime the submodule binding still wins even though `pkg.name` is
+    // implicitly imported by `__init__`. The two facts "`name` is re-exported" and "`pkg.name`
+    // is implicitly imported" must not be combined: only a re-export *sourced from* the
+    // same-named submodule shadows it. See https://github.com/facebook/pyrefly/issues/322
+    t.add_with_path(
+        "pkg",
+        "pkg/__init__.py",
+        "from .other import name as name\nimport pkg.name",
+    );
+    t.add_with_path("pkg.other", "pkg/other.py", "def name() -> int: ...");
+    t.add_with_path("pkg.name", "pkg/name.py", "");
+    t
+}
+
+testcase!(
+    test_reexport_from_other_submodule_with_implicit_import_does_not_shadow,
+    env_reexport_from_other_submodule_with_implicit_import(),
+    r#"
+# `pkg.__init__` re-exports `name` from `pkg.other` but separately imports the same-named
+# submodule `pkg.name`, so the submodule wins at runtime and the call below is invalid.
+# The re-export (`name`) and the implicit submodule import (`pkg.name`) come from unrelated
+# statements, so they must not be combined to suppress the error.
+# See https://github.com/facebook/pyrefly/issues/322
+import pkg.name
+pkg.name()  # E: Expected a callable, got `Module[pkg.name]`
     "#,
 );
 

--- a/pyrefly/lib/test/incremental.rs
+++ b/pyrefly/lib/test/incremental.rs
@@ -2055,7 +2055,7 @@ fn test_class_deprecation_metadata_change_invalidates() {
 
 /// Test that when an export changes from direct definition to re-export, dependents are invalidated.
 ///
-/// This tests the `is_reexport` metadata dependency. When an export changes from being
+/// This tests the `reexport_source` metadata dependency. When an export changes from being
 /// defined in this module to being re-exported from another module, dependents should
 /// be recomputed.
 #[test]


### PR DESCRIPTION
Summary:

When a package `__init__` explicitly re-exports a symbol whose name collides with a same-named submodule, calling that symbol after `import pkg.sub` was wrongly reported as `Expected a callable, got Module[...]`. The canonical case is `import unittest.main; unittest.main()`: `unittest.main` is both a submodule and a re-export (`from .main import main as main`, where `main = TestProgram`), and the call is valid at runtime.

`get_module_attr` shortcut-resolved any directly-imported submodule to the submodule type before consulting the package's exports, so the re-exported callable was never considered. The fix skips that shortcut when the name is an explicit re-export of the package: at runtime the import system binds a directly-imported submodule onto its package only after `__init__` has executed, so a re-export performed while importing the submodule wins. In that case we fall through to the normal export lookup, which resolves `unittest.main` to the `TestProgram` class.

The change is guarded by `is_reexport`, so packages that merely contain a submodule (with no colliding re-export) still resolve `pkg.sub` to the submodule as before. The previously `bug`-marked `test_ambiguous_pkg_attribute_vs_submodule` now passes without the error annotation.

Reviewed By: grievejia

Differential Revision: D110472788


