### PR TITLE
Fix false positive possibly-unbound for tuple-subject match with catch-all arm

### DIFF
--- a/pyrefly/lib/binding/pattern.rs
+++ b/pyrefly/lib/binding/pattern.rs
@@ -93,6 +93,44 @@ impl MatchSubject {
     }
 }
 
+/// Whether a sequence pattern is a catch-all against a literal-tuple subject of
+/// known arity. Ruff's `Pattern::is_irrefutable` only recognizes wildcards, bare
+/// captures, and `or` patterns; it can't tell that a sequence pattern always
+/// matches a fixed-length tuple subject. But `match x, y:` always builds a
+/// 2-tuple, so `case _, _:` (or `case a, b:`, `case a, *rest:`, ...) is a
+/// catch-all: it matches whenever every sub-pattern is irrefutable and the
+/// pattern's length is compatible with the subject's arity.
+fn sequence_pattern_covers_tuple(pattern: &Pattern, tuple_arity: Option<usize>) -> bool {
+    let Some(arity) = tuple_arity else {
+        return false;
+    };
+    let Pattern::MatchSequence(seq) = pattern else {
+        return false;
+    };
+    // A `*rest` / `*_` star element always matches the remaining elements, so it
+    // is irrefutable in this context even though `is_irrefutable` does not
+    // classify it as such.
+    if !seq
+        .patterns
+        .iter()
+        .all(|p| matches!(p, Pattern::MatchStar(_)) || p.is_irrefutable() || p.is_wildcard())
+    {
+        return false;
+    }
+    let num_non_star = seq
+        .patterns
+        .iter()
+        .filter(|p| !matches!(p, Pattern::MatchStar(_)))
+        .count();
+    // A `*rest` absorbs any extra elements, so it matches any tuple with at
+    // least `num_non_star` elements; without one, the lengths must match exactly.
+    if num_non_star != seq.patterns.len() {
+        num_non_star <= arity
+    } else {
+        num_non_star == arity
+    }
+}
+
 #[derive(Debug, Default)]
 struct PatternNarrowOps {
     scope: NarrowOps,
@@ -644,6 +682,15 @@ impl<'a> BindingsBuilder<'a> {
                 },
             }
         };
+        // A literal-tuple subject with no unpacking has a statically-known arity,
+        // which lets us recognize sequence patterns that are catch-alls (see
+        // `sequence_pattern_covers_tuple`). Starred elements make the arity dynamic.
+        let tuple_subject_arity = match &*x.subject {
+            Expr::Tuple(t) if !t.elts.iter().any(|e| matches!(e, Expr::Starred(_))) => {
+                Some(t.elts.len())
+            }
+            _ => None,
+        };
         let mut exhaustive = false;
         self.start_fork(x.range);
         // Type narrowing operations that are carried over from one case to the next. For example, in:
@@ -665,7 +712,12 @@ impl<'a> BindingsBuilder<'a> {
                 ..
             } = case;
             self.start_branch();
-            let case_is_irrefutable = pattern.is_wildcard() || pattern.is_irrefutable();
+            // A guard makes even an irrefutable pattern refutable, so it can't
+            // establish exhaustiveness on its own.
+            let case_is_irrefutable = pattern.is_wildcard()
+                || pattern.is_irrefutable()
+                || (guard.is_none()
+                    && sequence_pattern_covers_tuple(&pattern, tuple_subject_arity));
             if case_is_irrefutable {
                 exhaustive = true;
             }

--- a/pyrefly/lib/test/pattern_match.rs
+++ b/pyrefly/lib/test/pattern_match.rs
@@ -1447,7 +1447,6 @@ def example(a: list[int] | None, b: list[int] | None) -> list[int]:
 
 // https://github.com/facebook/pyrefly/issues/2932
 testcase!(
-    bug = "variables assigned in every non-raising match arm are still reported as possibly-unbound after the match",
     test_match_false_positive_unbound_name,
     r#"
 from typing import assert_type
@@ -1463,7 +1462,63 @@ def test(x: int | None, y: int | None) -> None:
             v = n // 3
         case _, _:
             raise ValueError
-    assert_type(u, int)  # E: `u` may be uninitialized
-    assert_type(v, int)  # E: `v` may be uninitialized
+    assert_type(u, int)
+    assert_type(v, int)
+"#,
+);
+
+// A guard on the catch-all sequence arm makes it refutable, so it cannot
+// establish exhaustiveness and the fall-through remains reachable.
+testcase!(
+    test_match_tuple_guarded_catch_all_not_exhaustive,
+    r#"
+def test(x: int | None, y: int | None) -> None:
+    match x, y:
+        case int(m), int(n):
+            u = m + n
+        case _, _ if x is None:
+            u = 0
+    print(u)  # E: `u` may be uninitialized
+"#,
+);
+
+// A sequence pattern whose length is incompatible with the tuple subject's
+// arity is not a catch-all, so the match stays non-exhaustive.
+testcase!(
+    test_match_tuple_arity_mismatch_not_exhaustive,
+    r#"
+def test(x: int | None, y: int | None) -> None:
+    match x, y:
+        case a, b, c:
+            u = 1
+    print(u)  # E: `u` may be uninitialized
+"#,
+);
+
+// The literal-tuple arity path only applies to literal-tuple subjects. A
+// variable of tuple type has no statically-known arity here, but the match is
+// still correctly seen as exhaustive via type narrowing of the subject, so no
+// false positive is reported.
+testcase!(
+    test_match_tuple_variable_subject_exhaustive,
+    r#"
+def test(t: tuple[int, int]) -> None:
+    match t:
+        case _, _:
+            u = 1
+    print(u)
+"#,
+);
+
+// A `*rest` element absorbs the remaining elements, so `case a, *rest:` covers
+// any tuple with at least one element and is a catch-all for the 2-tuple.
+testcase!(
+    test_match_tuple_star_rest_exhaustive,
+    r#"
+def test(x: int | None, y: int | None) -> None:
+    match x, y:
+        case a, *rest:
+            u = 1
+    print(u)
 "#,
 );


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/pyrefly/issues/2932.

Variables assigned in every non-raising arm of a `match` were still reported as possibly-unbound after the match when the subject was a literal tuple and the catch-all arm raised. For example:

```
def test(x: int | None, y: int | None) -> None:
    match x, y:
        case None, None:
            raise ValueError
        case int(m), None:
            u = m * 3
        case None, int(n):
            u = n
        case _, _:
            raise ValueError
    print(u)  # was: `u` may be uninitialized
```

The root cause is exhaustiveness detection in the binding step. Because the match has no bare wildcard arm, it is treated as non-exhaustive, so a synthetic fall-through branch (in which `u` is unbound) is added to the flow merge. That branch's reachability is deferred to solve time, where it is discharged only if the `Exhaustive` binding narrows the residual subject to `Never`. For a tuple subject the per-case negated narrows are dropped, leaving the exhaustive binding with no narrow entries, so it resolves to a non-`Never` type and the fall-through is treated as reachable — producing the spurious error.

The real issue is that `case _, _:` is a catch-all here but is not recognized as irrefutable: ruff's `Pattern::is_irrefutable` only knows about wildcards, bare captures, and `or` patterns, and can't tell that a sequence pattern always matches a fixed-length tuple subject.

A `match x, y:` subject always builds a 2-tuple, so its arity is statically known. We use that to recognize a sequence pattern as a catch-all — all sub-patterns irrefutable and length compatible with the subject arity (exact, or fewer with a `*rest`). Such an arm marks the match exhaustive, so no fall-through branch is created and the merge correctly sees `u` defined in every surviving (non-raising) arm. A guard disqualifies the arm, since a guard can fail regardless of the pattern.

Differential Revision: D111563413


