### PR TITLE
fix(stubgen): extract statements from `try` blocks and expand `TYPE_CHECKING` recognition

### DIFF
--- a/pyrefly/lib/stubgen/extract.rs
+++ b/pyrefly/lib/stubgen/extract.rs
@@ -29,6 +29,7 @@ use pyrefly_types::types::Forallable;
 use pyrefly_types::types::Overload;
 use pyrefly_types::types::OverloadType;
 use pyrefly_types::types::Type;
+use ruff_python_ast::BoolOp;
 use ruff_python_ast::Expr;
 use ruff_python_ast::Operator;
 use ruff_python_ast::Stmt;
@@ -249,6 +250,9 @@ fn extract_stmts(
             Stmt::If(if_stmt) if is_type_checking_guard(&if_stmt.test) => {
                 items.extend(extract_stmts(&if_stmt.body, ctx, in_class, in_enum));
             }
+            Stmt::Try(try_stmt) => {
+                items.extend(extract_stmts(&try_stmt.body, ctx, in_class, in_enum));
+            }
             _ => {}
         }
     }
@@ -260,6 +264,9 @@ fn is_type_checking_guard(expr: &Expr) -> bool {
     match expr {
         Expr::Name(name) => name.id == "TYPE_CHECKING",
         Expr::Attribute(attr) => attr.attr.as_str() == "TYPE_CHECKING",
+        Expr::BoolOp(bool_op) if bool_op.op == BoolOp::Or => {
+            bool_op.values.iter().any(is_type_checking_guard)
+        }
         _ => false,
     }
 }

--- a/pyrefly/lib/stubgen/mod.rs
+++ b/pyrefly/lib/stubgen/mod.rs
@@ -217,6 +217,16 @@ class BaseModel:
     }
 
     #[test]
+    fn test_stubgen_try_except_imports() {
+        assert_stubgen_snapshot("try_except_imports");
+    }
+
+    #[test]
+    fn test_stubgen_type_checking_or_guard() {
+        assert_stubgen_snapshot("type_checking_or_guard");
+    }
+
+    #[test]
     fn test_stubgen_mixed() {
         assert_stubgen_snapshot("mixed");
     }

--- a/pyrefly/lib/test/stubgen/try_except_imports/expected.pyi
+++ b/pyrefly/lib/test/stubgen/try_except_imports/expected.pyi
@@ -1,0 +1,8 @@
+# @generated
+import os
+from typing import ClassVar
+from pkg._impl import Extra, obj1
+
+
+class Feature:
+    MY_VAR: ClassVar[str]

--- a/pyrefly/lib/test/stubgen/try_except_imports/input.py
+++ b/pyrefly/lib/test/stubgen/try_except_imports/input.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+from typing import ClassVar
+
+try:
+    from pkg._impl import Extra, obj1
+except ImportError:
+    from pkg._fallback_impl import Extra, obj2
+
+
+class Feature:
+    try:
+        MY_VAR: ClassVar[str] = os.environ["MY_VAR"]
+    except KeyError:
+        MY_VAR = ""

--- a/pyrefly/lib/test/stubgen/type_checking_or_guard/expected.pyi
+++ b/pyrefly/lib/test/stubgen/type_checking_or_guard/expected.pyi
@@ -1,0 +1,9 @@
+# @generated
+from typing import TYPE_CHECKING
+
+USE_EXTENSIONS: Literal[True] = True
+
+
+class Guards:
+    from pkg._impl import LeftOrImport
+    from pkg._impl import RightOrImport

--- a/pyrefly/lib/test/stubgen/type_checking_or_guard/input.py
+++ b/pyrefly/lib/test/stubgen/type_checking_or_guard/input.py
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import TYPE_CHECKING
+
+USE_EXTENSIONS = True
+
+
+class Guards:
+    if TYPE_CHECKING or not USE_EXTENSIONS:
+        from pkg._impl import LeftOrImport
+
+    if not USE_EXTENSIONS or TYPE_CHECKING:
+        from pkg._impl import RightOrImport
+
+    if TYPE_CHECKING and USE_EXTENSIONS:
+        from pkg._impl import AndImport


### PR DESCRIPTION
# Summary
Updates stubgen to address two of the three limitations identified in #3888:

- `TYPE_CHECKING` guards which are part of a larger boolean expression, e.g. `if TYPE_CHECKING or not USE_EXTENSIONS`, should have statements extracted.
- Statements in `try` blocks should be extracted.

Works towards fixing #3888.

I'd prefer to handle the third limitation (`sys` conditionals) in a separate PR, as it's considerably more complex.

# Test Plan
- [x] Added snapshot tests for stubgen demonstrating the desired behavioural changes
- [x] `python3 test.py`
