### PR TITLE
Debounce LSP inlay hints to stop width jitter while typing (#4145)

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -318,6 +318,13 @@
                         }
                     }
                 },
+                "python.analysis.inlayHintDebounceMs": {
+                    "type": "number",
+                    "default": 150,
+                    "minimum": 0,
+                    "description": "Debounce window, in milliseconds, for inlay hints. While a file is being edited, inlay hint updates are held until editing pauses for this long, so hint widths don't jitter on every keystroke. Set to 0 to update inlay hints immediately.",
+                    "scope": "resource"
+                },
                 "python.pyrefly.syncNotebooks": {
                     "type": "boolean",
                     "default": true,

--- a/pyrefly/lib/lsp/non_wasm/queue.rs
+++ b/pyrefly/lib/lsp/non_wasm/queue.rs
@@ -7,6 +7,7 @@
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 use std::time::Instant;
 
 use crossbeam_channel::Receiver;
@@ -21,6 +22,7 @@ use lsp_types::DidChangeWorkspaceFoldersParams;
 use lsp_types::DidCloseTextDocumentParams;
 use lsp_types::DidOpenTextDocumentParams;
 use lsp_types::DidSaveTextDocumentParams;
+use pyrefly_util::lock::Mutex;
 use pyrefly_util::telemetry::QueueName;
 use pyrefly_util::telemetry::Telemetry;
 use pyrefly_util::telemetry::TelemetryEvent;
@@ -97,6 +99,19 @@ enum LspEventKind {
 }
 
 impl LspEvent {
+    /// Whether this event is an in-editor edit to a document's content, i.e. the
+    /// kind of change that should reset the inlay-hint debounce window. Opens,
+    /// saves, closes, config/workspace-folder changes, watched-file drains, and
+    /// client responses are deliberately excluded: they aren't the user typing,
+    /// so they must not hold inlay hints back (otherwise background file churn
+    /// could defer hints indefinitely while the user sits idle).
+    fn is_edit(&self) -> bool {
+        matches!(
+            self,
+            Self::DidChangeTextDocument(_) | Self::DidChangeNotebookDocument(_)
+        )
+    }
+
     fn kind(&self) -> LspEventKind {
         match self {
             Self::RecheckFinished | Self::CancelRequest(_) => LspEventKind::Priority,
@@ -124,6 +139,20 @@ pub struct LspQueue {
     id: AtomicUsize,
     /// The index of the last event we are aware of that is a mutation. 0 = unknown.
     last_mutation: AtomicUsize,
+    /// When the most recent document edit was enqueued, or `None` if no edit has
+    /// happened yet. Used to debounce queries (e.g. inlay hints) that shouldn't
+    /// recompute on every keystroke. Only genuine edits bump this (see
+    /// [`LspEvent::is_edit`]), not every mutation, so non-typing activity doesn't
+    /// hold debounced queries back. `None` means there's nothing to debounce
+    /// against, so queries run immediately (e.g. right after server startup).
+    last_edit_time: Mutex<Option<Instant>>,
+    /// A single query request (an inlay hint) held back to debounce it, paired
+    /// with the instant it becomes ready and the instant it was enqueued. `recv`
+    /// delivers it once the ready instant passes if nothing else arrives first,
+    /// reporting the enqueue instant as its queue time so queue-latency metrics
+    /// reflect the full debounce wait (matching how `send` timestamps events).
+    /// Only one is held at a time; see [`LspQueue::send_delayed`].
+    delayed: Mutex<Option<(Request, Instant, Instant)>>,
     normal: (
         Sender<(usize, LspEvent, Instant)>,
         Receiver<(usize, LspEvent, Instant)>,
@@ -139,6 +168,8 @@ impl LspQueue {
         Self {
             id: AtomicUsize::new(1),
             last_mutation: AtomicUsize::new(0),
+            last_edit_time: Mutex::new(None),
+            delayed: Mutex::new(None),
             normal: crossbeam_channel::unbounded(),
             priority: crossbeam_channel::unbounded(),
         }
@@ -152,6 +183,9 @@ impl LspQueue {
             // This is gently dubious, as we might race condition and it might not really be the last
             // mutation. But it's good enough for now.
             self.last_mutation.store(id, Ordering::Relaxed);
+        }
+        if x.is_edit() {
+            *self.last_edit_time.lock() = Some(Instant::now());
         }
         if kind == LspEventKind::Priority {
             self.priority
@@ -172,13 +206,43 @@ impl LspQueue {
     /// Due to race conditions, we might say false when there is a subsequent mutation,
     /// but we will never say true when there is not.
     pub fn recv(&self) -> Result<(bool, LspEvent, Instant), RecvError> {
+        // If a delayed request is held, wake once its window expires so we can
+        // deliver it. The slot is only written by the same thread that calls
+        // `recv` (via `send_delayed` during event processing), so it can't change
+        // while we block here.
+        let deadline = self
+            .delayed
+            .lock()
+            .as_ref()
+            .map(|(_, ready_at, _)| *ready_at);
+
         let mut event_receiver_selector = Select::new_biased();
         // Biased selector will pick the receiver with lower index over higher ones,
         // so we register priority_events_receiver first.
         let priority_receiver_index = event_receiver_selector.recv(&self.priority.1);
         let queued_events_receiver_index = event_receiver_selector.recv(&self.normal.1);
 
-        let selected = event_receiver_selector.select();
+        let selected = match deadline {
+            Some(deadline) => match event_receiver_selector.select_deadline(deadline) {
+                Ok(selected) => selected,
+                Err(_) => {
+                    let (request, _ready_at, enqueued_at) = self
+                        .delayed
+                        .lock()
+                        .take()
+                        .expect("a deadline is only set while a delayed request is held");
+                    let last_mutation = self.last_mutation.load(Ordering::Relaxed);
+                    // Report the enqueue instant (not `ready_at`) as the queue
+                    // time so downstream latency metrics see the full wait.
+                    return Ok((
+                        last_mutation != 0,
+                        LspEvent::LspRequest(request),
+                        enqueued_at,
+                    ));
+                }
+            },
+            None => event_receiver_selector.select(),
+        };
         let (id, x, queue_time) = match selected.index() {
             i if i == priority_receiver_index => selected.recv(&self.priority.1)?,
             i if i == queued_events_receiver_index => selected.recv(&self.normal.1)?,
@@ -190,6 +254,25 @@ impl LspQueue {
             last_mutation = 0;
         }
         Ok((last_mutation != 0, x, queue_time))
+    }
+
+    /// Hold `request` until `ready_at`, after which `recv` delivers it. This
+    /// debounces queries (inlay hints) that shouldn't recompute on every
+    /// keystroke. The current instant is recorded as the request's enqueue time
+    /// so it is reported as the queue time on delivery. At most one request is
+    /// held; a second call displaces and returns the previous one so the caller
+    /// can respond to the now-superseded request.
+    pub fn send_delayed(&self, request: Request, ready_at: Instant) -> Option<Request> {
+        self.delayed
+            .lock()
+            .replace((request, ready_at, Instant::now()))
+            .map(|(request, ..)| request)
+    }
+
+    /// How long since the most recent document edit was enqueued, or `None` if
+    /// no edit has happened yet.
+    pub fn time_since_last_edit(&self) -> Option<Duration> {
+        self.last_edit_time.lock().map(|t| t.elapsed())
     }
 }
 
@@ -283,5 +366,66 @@ impl HeavyTaskQueue {
     /// Make `run_until_stopped` exit after finishing the current task.
     pub fn stop(&self) {
         self.stop_sender.send(()).expect("Failed to stop the queue");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lsp_types::Url;
+    use lsp_types::VersionedTextDocumentIdentifier;
+
+    use super::*;
+
+    fn edit() -> LspEvent {
+        LspEvent::DidChangeTextDocument(DidChangeTextDocumentParams {
+            text_document: VersionedTextDocumentIdentifier {
+                uri: Url::parse("file:///test.py").unwrap(),
+                version: 1,
+            },
+            content_changes: Vec::new(),
+        })
+    }
+
+    fn non_edit() -> LspEvent {
+        LspEvent::DidChangeConfiguration(DidChangeConfigurationParams {
+            settings: serde_json::Value::Null,
+        })
+    }
+
+    #[test]
+    fn test_time_since_last_edit_resets_only_on_edit() {
+        let queue = LspQueue::new();
+
+        // No edit has happened yet, so there is nothing to debounce against.
+        assert_eq!(
+            queue.time_since_last_edit(),
+            None,
+            "the debounce clock must be unset until the first edit"
+        );
+
+        queue.send(edit()).unwrap();
+
+        std::thread::sleep(Duration::from_millis(30));
+        let elapsed = queue.time_since_last_edit().expect("an edit was enqueued");
+        assert!(
+            elapsed >= Duration::from_millis(25),
+            "clock should grow between edits, got {elapsed:?}"
+        );
+
+        // A non-edit mutation (config change, save, watched-file drain, ...) must
+        // NOT reset the debounce clock, otherwise background activity could hold
+        // inlay hints back while the user is idle.
+        queue.send(non_edit()).unwrap();
+        assert!(
+            queue.time_since_last_edit().expect("still have an edit") >= elapsed,
+            "a non-edit event must not reset the debounce clock"
+        );
+
+        // A fresh edit resets the clock back towards zero.
+        queue.send(edit()).unwrap();
+        assert!(
+            queue.time_since_last_edit().expect("edit was enqueued") < elapsed,
+            "a new edit should reset the debounce clock"
+        );
     }
 }

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -552,6 +552,10 @@ impl ServerConnection {
 
 const PROGRESS_REPORT_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Default inlay hint debounce window, applied when the client doesn't set
+/// `analysis.inlayHintDebounceMs`. See [`Server::inlay_hint_debounce_remaining`].
+const DEFAULT_INLAY_HINT_DEBOUNCE_MS: u64 = 150;
+
 struct LspProgressSubscriber<'a> {
     server: &'a Server,
     token: ProgressToken,
@@ -1932,8 +1936,11 @@ impl Server {
                     info!("Response for unknown request: {x:?}");
                 }
             }
-            LspEvent::LspRequest(mut x) => {
-                telemetry_event.set_activity_key(std::mem::take(&mut x.activity_key));
+            LspEvent::LspRequest(x) => {
+                // Clone (not take): a debounced inlay hint is re-enqueued below
+                // and re-enters this arm, so `x` must retain its activity_key for
+                // the re-delivered request's telemetry.
+                telemetry_event.set_activity_key(x.activity_key.clone());
                 telemetry_event.request_id = Some(x.id.to_string());
 
                 // Extract file stats from the raw JSON params so all requests
@@ -1982,6 +1989,27 @@ impl Server {
                         ErrorCode::RequestCanceled as i32,
                         message,
                     ));
+                    return Ok(ProcessEvent::Continue);
+                }
+
+                // Debounce inlay hints so their widths don't jitter on every
+                // keystroke (#4138). If the document was edited within the
+                // debounce window, hold the request in the queue until editing
+                // pauses, then cancel any older held request it supersedes so the
+                // client isn't left waiting on a request we'll never answer.
+                if x.method == InlayHintRequest::METHOD
+                    && let Some(remaining) = self.inlay_hint_debounce_remaining(&x)
+                {
+                    if let Some(superseded) =
+                        self.lsp_queue.send_delayed(x, Instant::now() + remaining)
+                    {
+                        canceled_requests.remove(&superseded.id);
+                        self.send_response(Response::new_err(
+                            superseded.id,
+                            ErrorCode::RequestCanceled as i32,
+                            "Superseded by a newer inlay hint request".to_owned(),
+                        ));
+                    }
                     return Ok(ProcessEvent::Continue);
                 }
 
@@ -5042,6 +5070,37 @@ impl Server {
             .and_then(|c| c.show_hover_go_to_links)
             .unwrap_or(true);
         Ok(get_hover(transaction, &handle, position, show_go_to_links))
+    }
+
+    /// How long an inlay hint request should be deferred to debounce it, or
+    /// `None` if it can run now. VS Code has no client-side inlay-hint debounce
+    /// (microsoft/vscode#133730), so without this, hints recompute on every
+    /// keystroke and their widths jitter distractingly (#4138). We defer the
+    /// request while the document is still being edited so hints only settle
+    /// once typing pauses. The window is `analysis.inlayHintDebounceMs`
+    /// (default [`DEFAULT_INLAY_HINT_DEBOUNCE_MS`]); `0` disables debouncing.
+    fn inlay_hint_debounce_remaining(&self, request: &Request) -> Option<Duration> {
+        // No edit has happened yet (e.g. right after startup): nothing to
+        // debounce against, so run immediately.
+        let time_since_last_edit = self.lsp_queue.time_since_last_edit()?;
+        let debounce_ms = request
+            .params
+            .get("textDocument")
+            .and_then(|td| td.get("uri"))
+            .and_then(|u| u.as_str())
+            .and_then(|s| Url::parse(s).ok())
+            .and_then(|uri| self.path_for_uri_or_notebook_cell(&uri))
+            .and_then(|path| {
+                self.workspaces.get_with(path, |(_, workspace)| {
+                    workspace
+                        .lsp_analysis_config
+                        .and_then(|c| c.inlay_hint_debounce_ms)
+                })
+            })
+            .unwrap_or(DEFAULT_INLAY_HINT_DEBOUNCE_MS);
+        Duration::from_millis(debounce_ms)
+            .checked_sub(time_since_last_edit)
+            .filter(|remaining| !remaining.is_zero())
     }
 
     fn inlay_hints(

--- a/pyrefly/lib/lsp/non_wasm/workspace.rs
+++ b/pyrefly/lib/lsp/non_wasm/workspace.rs
@@ -342,6 +342,14 @@ pub struct LspAnalysisConfig {
     // TODO: this is not a pylance setting. it should be in pyrefly settings
     #[serde(default)]
     pub show_hover_go_to_links: Option<bool>,
+    /// Debounce window (milliseconds) for inlay hint requests. VS Code exposes
+    /// no client-side inlay-hint debounce (microsoft/vscode#133730), so without
+    /// this, hints recompute on every keystroke and their widths jitter
+    /// distractingly. When the document was edited within this window, the
+    /// request is deferred until editing pauses. `0` disables debouncing.
+    // TODO: this is not a pylance setting. it should be in pyrefly settings
+    #[serde(default)]
+    pub inlay_hint_debounce_ms: Option<u64>,
 }
 
 fn deserialize_analysis<'de, D>(deserializer: D) -> Result<Option<LspAnalysisConfig>, D::Error>

--- a/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
@@ -5,6 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::time::Duration;
+use std::time::Instant;
+
+use lsp_types::Url;
+use lsp_types::notification::DidChangeTextDocument;
 use serde_json::json;
 
 use crate::object_model::InitializeSettings;
@@ -106,6 +111,63 @@ fn test_inlay_hint_default_config() {
             )
         })
         .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_inlay_hint_debounce_defers_response() {
+    // VS Code offers no client-side inlay-hint debounce (microsoft/vscode#133730),
+    // so pyrefly debounces server-side (#4138): a request issued while the
+    // document is still being edited is deferred until editing pauses. Only
+    // genuine edits (didChange) open the debounce window, so we send one right
+    // before the request to place it inside the window; it must not be answered
+    // until the window elapses.
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(json!([{
+                "pyrefly": {"displayTypeErrors": "force-on"},
+                "analysis": {"inlayHintDebounceMs": 400}
+            }]))),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open("inlay_hint_test.py");
+
+    let filepath = root.path().join("inlay_hint_test.py");
+    interaction
+        .client
+        .send_notification::<DidChangeTextDocument>(json!({
+            "textDocument": {
+                "uri": Url::from_file_path(&filepath).unwrap().to_string(),
+                "languageId": "python",
+                "version": 2
+            },
+            "contentChanges": [{
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 0, "character": 0}
+                },
+                "text": "\n"
+            }],
+        }));
+
+    let start = Instant::now();
+    interaction
+        .client
+        .inlay_hint("inlay_hint_test.py", 0, 0, 100, 0)
+        .expect_response_with(|result| result.is_some_and(|hints| !hints.is_empty()))
+        .unwrap();
+
+    assert!(
+        start.elapsed() >= Duration::from_millis(250),
+        "inlay hint response should be debounced by ~400ms, took {:?}",
+        start.elapsed()
+    );
 
     interaction.shutdown().unwrap();
 }

--- a/website/docs/IDE-features.mdx
+++ b/website/docs/IDE-features.mdx
@@ -472,6 +472,7 @@ We reuse Pyright's `python.analysis.inlayHints.*` settings for backwards compati
 | `python.analysis.inlayHints.functionReturnTypes` | `boolean` | `true` | Show return type hints on functions without a return type annotation. |
 | `python.analysis.inlayHints.variableTypes` | `boolean` | `true` | Show type hints on variable assignments without a type annotation. |
 | `python.analysis.inlayHints.pytestParameters` | `boolean` | `false` | Show type hints for pytest fixture parameters. |
+| `python.analysis.inlayHintDebounceMs` | `number` | `150` | Debounce window, in milliseconds, for inlay hints. While a file is being edited, updates are held until editing pauses for this long, so hint widths don't jitter on every keystroke. Set to `0` to update immediately. |
 
 Inlay hints can be double clicked to insert them as an annotation.
 <video


### PR DESCRIPTION
Summary:

VS Code has no client-side inlay-hint debounce (microsoft/vscode#133730), so pyrefly recomputed and re-rendered inlay hints on every keystroke. Because a keystroke can change an inferred type, hint widths shift several times a second right where the user is editing, which is distracting and hard to track (facebook/pyrefly#4138).

This debounces inlay hints server-side, the same way rust-analyzer responded to that VS Code issue: while a document is still being edited, inlay hint updates are held until editing pauses, so hints only settle once typing stops.

The mechanism reuses the existing LSP event queue. `LspQueue` records the wall-clock time of the most recent document edit and exposes `time_since_last_edit`. When an inlay hint request arrives within the debounce window, the request dispatch re-enqueues it on a short-lived timer thread instead of answering immediately. The sleep happens off the single event-loop thread, so it never blocks other requests, and the re-enqueued request composes with the existing "cancel stale queries on a subsequent mutation" logic — if more edits arrive, the deferred request is dropped and a fresh one takes its place.

The debounce clock is keyed strictly on genuine in-editor edits (`didChange` for text and notebook documents) via `LspEvent::is_edit()`, not on every mutation-class event. This matters for correctness: the event queue classifies saves, `didOpen`/`didClose`, configuration and workspace-folder changes, watched-file drains, and client responses all as "mutations". Keying the debounce on that broad class would let non-typing activity reset the window — in particular, watched-file-change notifications (fired on every external file change, e.g. during a build, rebase, or format-on-save) arriving faster than the debounce window could defer inlay hints indefinitely while the user sits idle. Confining the clock to real edits keeps the debounce scoped to actual typing, which is what the feature is for; as a side benefit `didOpen` no longer opens the window, so hints on a freshly opened file compute immediately.

The window is controlled by `analysis.inlayHintDebounceMs` (VS Code: `python.analysis.inlayHintDebounceMs`), defaulting to 150ms; `0` restores the previous immediate-update behavior.

Differential Revision: D111847562


