### PR TITLE
Add `[coverage]` config overrides for the `pyrefly coverage` globs

### DIFF
--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -53,12 +53,14 @@ use pyrefly_util::telemetry::TelemetrySourceDbRebuildStats;
 use pyrefly_util::watch_pattern::WatchPattern;
 use serde::Deserialize;
 use serde::Serialize;
+use serde_with::skip_serializing_none;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 use tracing::debug;
 use tracing::error;
 
 use crate::base::ConfigBase;
+use crate::base::ExtraConfigs;
 use crate::base::InferReturnTypes;
 use crate::base::Preset;
 use crate::base::RecursionLimitConfig;
@@ -88,6 +90,44 @@ impl SubConfig {
     fn rewrite_with_path_to_config(&mut self, config_root: &Path) {
         self.matches = self.matches.clone().from_root(config_root);
     }
+}
+
+/// Config overrides for the `pyrefly coverage` commands.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct CoverageConfig {
+    /// Takes precedence over `project_includes` when set.
+    pub includes: Option<Globs>,
+
+    /// Takes precedence over `project_excludes` when set; `--project-excludes` still wins.
+    pub excludes: Option<Globs>,
+
+    /// Any unknown config items
+    #[serde(default, flatten)]
+    pub(crate) extras: ExtraConfigs,
+}
+
+impl CoverageConfig {
+    fn is_empty(&self) -> bool {
+        self.includes.is_none() && self.excludes.is_none()
+    }
+
+    fn rewrite_with_path_to_config(&mut self, config_root: &Path) {
+        for globs in [&mut self.includes, &mut self.excludes] {
+            *globs = globs.take().map(|g| g.from_root(config_root));
+        }
+    }
+}
+
+/// Which scope of the config a command reads its settings from.
+/// Currently only affects file-glob selection.
+#[derive(Debug, Clone, Copy)]
+pub enum ConfigScope {
+    /// The top-level settings.
+    Default,
+    /// The `[coverage]` overrides, falling back to top-level.
+    Coverage,
 }
 
 /// Why a `ConfigFile` was synthesized rather than loaded from a real config
@@ -587,6 +627,10 @@ pub struct ConfigFile {
              )]
     pub sub_configs: Vec<SubConfig>,
 
+    /// Include/exclude overrides for `pyrefly coverage` commands.
+    #[serde(default, skip_serializing_if = "CoverageConfig::is_empty")]
+    pub coverage: CoverageConfig,
+
     /// Whether to respect ignore files (.gitignore, .ignore, .git/exclude).
     #[serde(
         default = "ConfigFile::default_true",
@@ -658,6 +702,7 @@ impl Default for ConfigFile {
             preset: None,
             root: Default::default(),
             sub_configs: Default::default(),
+            coverage: Default::default(),
             build_system: Default::default(),
             source_db: Default::default(),
             use_ignore_files: true,
@@ -712,7 +757,30 @@ impl ConfigFile {
     /// Gets a [`FilteredGlobs`] from the optional `custom_excludes` or this
     /// [`ConfigFile`]s `project_excludes`, adding all `site_package_path` entries
     /// as extra exclude items.
-    pub fn get_filtered_globs(&self, custom_excludes: Option<Globs>) -> FilteredGlobs {
+    /// Under [`ConfigScope::Coverage`] the `[coverage]` overrides apply, so `custom_excludes` still
+    /// wins over `coverage.excludes`.
+    /// The include globs the given scope selects.
+    pub fn includes(&self, scope: ConfigScope) -> &Globs {
+        match scope {
+            ConfigScope::Default => &self.project_includes,
+            ConfigScope::Coverage => self
+                .coverage
+                .includes
+                .as_ref()
+                .unwrap_or(&self.project_includes),
+        }
+    }
+
+    pub fn get_filtered_globs(
+        &self,
+        custom_excludes: Option<Globs>,
+        scope: ConfigScope,
+    ) -> FilteredGlobs {
+        let includes = self.includes(scope).clone();
+        let custom_excludes = match scope {
+            ConfigScope::Default => custom_excludes,
+            ConfigScope::Coverage => custom_excludes.or_else(|| self.coverage.excludes.clone()),
+        };
         let project_excludes = match custom_excludes {
             None => self.project_excludes.clone(),
             Some(custom_excludes) if !self.disable_project_excludes_heuristics => {
@@ -733,12 +801,7 @@ impl ConfigFile {
                 None => HiddenDirFilter::All,
             }
         };
-        FilteredGlobs::new(
-            self.project_includes.clone(),
-            project_excludes,
-            root,
-            hidden_dir_filter,
-        )
+        FilteredGlobs::new(includes, project_excludes, root, hidden_dir_filter)
     }
 }
 
@@ -1505,6 +1568,7 @@ impl ConfigFile {
     pub fn rewrite_with_path_to_config(&mut self, config_root: &Path) {
         self.project_includes = self.project_includes.clone().from_root(config_root);
         self.project_excludes = self.project_excludes.clone().from_root(config_root);
+        self.coverage.rewrite_with_path_to_config(config_root);
         self.search_path_from_file
             .iter_mut()
             .for_each(|search_root| {
@@ -1597,6 +1661,12 @@ impl ConfigFile {
                 let extra_keys = config.root.extras.0.keys().join(", ");
                 errors.push(ConfigError::warn(anyhow!(
                     "Extra keys found in config: {extra_keys}"
+                )));
+            }
+            if !config.coverage.extras.0.is_empty() {
+                let extra_keys = config.coverage.extras.0.keys().join(", ");
+                errors.push(ConfigError::warn(anyhow!(
+                    "Extra keys found in coverage config: {extra_keys}"
                 )));
             }
             for sub_config in &config.sub_configs {
@@ -1713,6 +1783,10 @@ mod tests {
              assert-type = true
              bad-return = false
 
+             [coverage]
+             includes = ["implementation/**"]
+             excludes = ["implementation/vendored/**"]
+
              [[sub-config]]
              matches = "sub/project/**"
 
@@ -1818,6 +1892,13 @@ mod tests {
                         spec_compliant_overloads: None,
                     }
                 }],
+                coverage: CoverageConfig {
+                    includes: Some(Globs::new(vec!["implementation/**".to_owned()]).unwrap()),
+                    excludes: Some(
+                        Globs::new(vec!["implementation/vendored/**".to_owned()]).unwrap()
+                    ),
+                    extras: Default::default(),
+                },
                 typeshed_path: None,
                 baseline: None,
                 min_severity: None,
@@ -1885,6 +1966,9 @@ mod tests {
              laszewo = "good kids"
              python_platform = "windows"
 
+             [coverage]
+             subtronics = 1
+
              [[sub_config]]
              matches = "abcd"
 
@@ -1894,6 +1978,10 @@ mod tests {
         assert_eq!(
             config.root.extras.0,
             Table::from_iter([("laszewo".to_owned(), Value::String("good kids".to_owned())),])
+        );
+        assert_eq!(
+            config.coverage.extras.0,
+            Table::from_iter([("subtronics".to_owned(), Value::Integer(1))])
         );
         assert_eq!(
             config.sub_configs[0].settings.extras.0,
@@ -1909,6 +1997,9 @@ mod tests {
                  python_platform = "darwin"
                  python_version = "1.2.3"
                  output-format = "json"
+
+            [tool.pyrefly.coverage]
+            includes = ["./implementation/**"]
                  "#;
         let config = ConfigFile::parse_pyproject_toml(config_str)
             .unwrap()
@@ -1936,6 +2027,11 @@ mod tests {
                         .clone(),
                 },
                 output_format: Some(OutputFormat::Json),
+                coverage: CoverageConfig {
+                    includes: Some(Globs::new(vec!["./implementation/**".to_owned()]).unwrap()),
+                    excludes: None,
+                    extras: Default::default(),
+                },
                 ..Default::default()
             }
         );
@@ -2061,6 +2157,11 @@ mod tests {
                 matches: Glob::new("sub/project/**".to_owned()).unwrap(),
                 settings: Default::default(),
             }],
+            coverage: CoverageConfig {
+                includes: Some(Globs::new(vec!["covered/**".to_owned()]).unwrap()),
+                excludes: Some(Globs::new(vec!["covered/vendored/**".to_owned()]).unwrap()),
+                extras: Default::default(),
+            },
             typeshed_path: Some(PathBuf::from(typeshed)),
             baseline: Some(PathBuf::from("baseline.json")),
             min_severity: None,
@@ -2094,6 +2195,8 @@ mod tests {
                 .into_owned(),
         )
         .unwrap();
+        let globs_at =
+            |glob: &str| Globs::new(vec![test_path.join(glob).to_string_lossy().into_owned()]);
 
         config.rewrite_with_path_to_config(&test_path);
 
@@ -2125,6 +2228,11 @@ mod tests {
                 matches: sub_config_matches,
                 settings: Default::default(),
             }],
+            coverage: CoverageConfig {
+                includes: Some(globs_at("covered/**").unwrap()),
+                excludes: Some(globs_at("covered/vendored/**").unwrap()),
+                extras: Default::default(),
+            },
             typeshed_path: Some(expected_typeshed),
             baseline: Some(test_path.join("baseline.json")),
             min_severity: None,
@@ -2904,7 +3012,7 @@ output-format = "omit-errors"
         expected_site_package_path.pop();
 
         assert_eq!(
-            config.get_filtered_globs(None),
+            config.get_filtered_globs(None, ConfigScope::Default),
             FilteredGlobs::new(
                 config.project_includes.clone(),
                 Globs::new(
@@ -2928,9 +3036,10 @@ output-format = "omit-errors"
             )
         );
         assert_eq!(
-            config.get_filtered_globs(Some(
-                Globs::new(vec!["custom_excludes".to_owned()]).unwrap()
-            )),
+            config.get_filtered_globs(
+                Some(Globs::new(vec!["custom_excludes".to_owned()]).unwrap()),
+                ConfigScope::Default,
+            ),
             FilteredGlobs::new(
                 config.project_includes.clone(),
                 Globs::new(
@@ -2948,6 +3057,63 @@ output-format = "omit-errors"
                 None,
                 HiddenDirFilter::All,
             )
+        );
+    }
+
+    #[test]
+    fn test_get_filtered_globs_coverage_scope() {
+        let globs = |patterns: &[&str]| {
+            Globs::new(patterns.iter().map(|p| (*p).to_owned()).collect::<Vec<_>>()).unwrap()
+        };
+        // Expected coverage-scope result: `coverage.includes` plus the given
+        // excludes with the required excludes and site packages appended.
+        let expected = |excludes: &[&str]| {
+            let mut excludes = excludes.to_vec();
+            excludes.extend([
+                "**/node_modules",
+                "**/__pycache__",
+                "**/venv/**",
+                "site_packages",
+            ]);
+            FilteredGlobs::new(
+                globs(&["covered/**"]),
+                globs(&excludes),
+                None,
+                HiddenDirFilter::All,
+            )
+        };
+
+        let mut config = ConfigFile::default();
+        config.interpreters.skip_interpreter_query = true;
+        config.python_environment.site_package_path = Some(vec![PathBuf::from("site_packages")]);
+        config.project_includes = globs(&["project/**"]);
+        config.project_excludes = globs(&["project/excluded/**"]);
+        config.configure();
+
+        // No [coverage] overrides: identical to the plain project globs.
+        assert_eq!(
+            config.get_filtered_globs(None, ConfigScope::Coverage),
+            config.get_filtered_globs(None, ConfigScope::Default)
+        );
+
+        // `includes` takes precedence over `project_includes`; unset `excludes` falls back.
+        config.coverage.includes = Some(globs(&["covered/**"]));
+        assert_eq!(
+            config.get_filtered_globs(None, ConfigScope::Coverage),
+            expected(&["project/excluded/**"])
+        );
+
+        // `excludes` gets the same required-excludes treatment as `--project-excludes`.
+        config.coverage.excludes = Some(globs(&["covered/vendored/**"]));
+        assert_eq!(
+            config.get_filtered_globs(None, ConfigScope::Coverage),
+            expected(&["covered/vendored/**"])
+        );
+
+        // `--project-excludes` wins over `coverage.excludes`.
+        assert_eq!(
+            config.get_filtered_globs(Some(globs(&["custom_excludes"])), ConfigScope::Coverage),
+            expected(&["custom_excludes"])
         );
     }
 

--- a/pyrefly/lib/commands/coverage/check.rs
+++ b/pyrefly/lib/commands/coverage/check.rs
@@ -19,6 +19,7 @@ use crate::commands::coverage::collect::collect_module_reports;
 use crate::commands::coverage::types::SlotCounts;
 use crate::commands::files::FilesArgs;
 use crate::commands::util::CommandExitStatus;
+use crate::config::config::ConfigScope;
 
 /// Gate type-annotation coverage against a threshold.
 #[deny(clippy::missing_docs_in_private_items)]
@@ -67,7 +68,8 @@ impl CheckArgs {
         }
 
         let (files_to_check, config_finder, _) =
-            self.files.resolve(self.config_override, wrapper)?;
+            self.files
+                .resolve_scoped(self.config_override, wrapper, ConfigScope::Coverage)?;
         let (module_reports, errors) = collect_module_reports(
             files_to_check,
             config_finder,

--- a/pyrefly/lib/commands/coverage/report.rs
+++ b/pyrefly/lib/commands/coverage/report.rs
@@ -15,6 +15,7 @@ use crate::commands::coverage::collect::collect_module_reports;
 use crate::commands::coverage::types::FullReport;
 use crate::commands::files::FilesArgs;
 use crate::commands::util::CommandExitStatus;
+use crate::config::config::ConfigScope;
 
 /// `(major, minor)` version for the report JSON schema.
 const REPORT_SCHEMA_VERSION: (u32, u32) = (0, 2);
@@ -59,8 +60,11 @@ impl ReportArgs {
             anyhow::bail!("--module and --public-only cannot be combined");
         }
 
-        let (files_to_check, config_finder, _) =
-            self.files.resolve(self.config_override.into(), wrapper)?;
+        let (files_to_check, config_finder, _) = self.files.resolve_scoped(
+            self.config_override.into(),
+            wrapper,
+            ConfigScope::Coverage,
+        )?;
         let (module_reports, _) = collect_module_reports(
             files_to_check,
             config_finder,

--- a/pyrefly/lib/commands/files.rs
+++ b/pyrefly/lib/commands/files.rs
@@ -28,6 +28,7 @@ use crate::commands::config_finder::ConfigConfigurerWrapper;
 use crate::commands::config_finder::apply_unconfigured_resolver_if_applicable;
 use crate::commands::config_finder::default_config_finder_with_overrides;
 use crate::config::config::ConfigFile;
+use crate::config::config::ConfigScope;
 use crate::config::config::ConfigSource;
 use crate::config::config::ProjectLayout;
 use crate::config::config::SynthesizedPresetReason;
@@ -179,6 +180,7 @@ fn get_globs_and_config_for_project(
     project_excludes: Option<Globs>,
     args: ConfigOverrideArgs,
     wrapper: Option<ConfigConfigurerWrapper>,
+    scope: ConfigScope,
 ) -> anyhow::Result<(Box<dyn Includes>, ConfigFinder, UpsellDecision)> {
     let (config, mut errors) = match config {
         Some(explicit) => get_explicit_config(&explicit, args),
@@ -208,7 +210,7 @@ fn get_globs_and_config_for_project(
     if let Some(project_dir) = config.source.root().or(current_dir.as_deref())
         && let Some(home_dir) = std::env::home_dir()
         && home_dir.starts_with(project_dir)
-        && config.project_includes == ConfigFile::default_project_includes().from_root(project_dir)
+        && *config.includes(scope) == ConfigFile::default_project_includes().from_root(project_dir)
     {
         // Trying to type-check your entire home directory doesn't usually end well.
         warn!(
@@ -227,7 +229,7 @@ fn get_globs_and_config_for_project(
 
     debug!("Config is: {}", config);
 
-    let mut filtered_globs = config.get_filtered_globs(project_excludes);
+    let mut filtered_globs = config.get_filtered_globs(project_excludes, scope);
     filtered_globs
         .errors()
         .into_iter()
@@ -333,6 +335,16 @@ impl FilesArgs {
         config_override: ConfigOverrideArgs,
         wrapper: Option<ConfigConfigurerWrapper>,
     ) -> anyhow::Result<(Box<dyn Includes>, ConfigFinder, UpsellDecision)> {
+        self.resolve_scoped(config_override, wrapper, ConfigScope::Default)
+    }
+
+    /// [`FilesArgs::resolve`], reading the project-mode globs from `scope`.
+    pub fn resolve_scoped(
+        self,
+        config_override: ConfigOverrideArgs,
+        wrapper: Option<ConfigConfigurerWrapper>,
+        scope: ConfigScope,
+    ) -> anyhow::Result<(Box<dyn Includes>, ConfigFinder, UpsellDecision)> {
         let project_excludes = if let Some(project_excludes) = self.project_excludes {
             Some(absolutize(Globs::new(project_excludes)?))
         } else {
@@ -344,8 +356,10 @@ impl FilesArgs {
                 project_excludes,
                 config_override,
                 wrapper,
+                scope,
             )
         } else {
+            // File mode bypasses the config's globs, so `scope` is intentionally unused.
             get_globs_and_config_for_files(
                 self.config,
                 Globs::new(self.files)?,

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -270,6 +270,7 @@ use crate::binding::binding::KeyUndecoratedFunctionRange;
 use crate::commands::config_finder::ConfigConfigurerWrapper;
 use crate::commands::lsp::IndexingMode;
 use crate::config::config::ConfigFile;
+use crate::config::config::ConfigScope;
 use crate::error::error::Error;
 use crate::lsp::module_helpers::to_real_path;
 use crate::lsp::non_wasm::build_system::should_requery_build_system;
@@ -3311,7 +3312,7 @@ impl Server {
 
         info!("Populating all files in the config ({:?}).", config.source);
 
-        let project_path_blobs = config.get_filtered_globs(None);
+        let project_path_blobs = config.get_filtered_globs(None, ConfigScope::Default);
         let mut handles = Vec::new();
         if let Ok(paths) = project_path_blobs.files_iter() {
             for path in paths {

--- a/schemas/pyrefly.json
+++ b/schemas/pyrefly.json
@@ -277,6 +277,26 @@
             }
           ]
         },
+        "coverage": {
+          "description": "Include/exclude overrides used only by the pyrefly coverage commands. Each field falls back to the corresponding project glob setting when unset.",
+          "type": "object",
+          "properties": {
+            "includes": {
+              "description": "The glob patterns describing which files the coverage commands report on. Takes precedence over project-includes when set.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "excludes": {
+              "description": "The glob patterns describing which files the coverage commands skip. Takes precedence over project-excludes when set, and the --project-excludes flag over both.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "sub-config": {
           "description": "Override specific config values for matched paths in your project. SubConfigs allow fine-grained configuration based on filepath glob matching.",
           "type": "array",

--- a/schemas/test-pyproject.toml
+++ b/schemas/test-pyproject.toml
@@ -54,6 +54,11 @@ bad-return = true
 missing-import = "warn"
 invalid-argument = "error"
 
+# Coverage command include/exclude overrides
+[tool.pyrefly.coverage]
+includes = ["src/**"]
+excludes = ["src/vendored/**"]
+
 # SubConfig example 1: Test files
 [[tool.pyrefly.sub-config]]
 matches = "**/tests/**"

--- a/schemas/test-pyrefly.toml
+++ b/schemas/test-pyrefly.toml
@@ -53,6 +53,11 @@ bad-return = true
 missing-import = "warn"
 invalid-argument = "error"
 
+# Coverage command include/exclude overrides
+[coverage]
+includes = ["src/**"]
+excludes = ["src/vendored/**"]
+
 # SubConfig example 1: Test files
 [[sub-config]]
 matches = "**/tests/**"

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -218,6 +218,23 @@ so you can fully specify your `project-excludes` in case we get it wrong.
 - Default: `false`
 - Flag equivalent: `--disable-project-excludes-heuristics`
 
+### `coverage`
+
+Include/exclude overrides used only by the `pyrefly coverage` commands, for when the set of
+files to report coverage on differs from the set of files to type check (e.g. to skip tests or
+vendored code). `coverage.includes` takes precedence over [`project-includes`](#project-includes)
+and `coverage.excludes` over [`project-excludes`](#project-excludes); each falls back to the
+project setting when unset.
+
+- Type: table with `includes` and `excludes` keys, each a list of
+  [filesystem glob patterns](#filesystem-globbing)
+- Default: `project-includes` / `project-excludes`
+- Flag equivalent: none, though `--project-excludes` takes precedence over `coverage.excludes`
+- Notes:
+    - Like the project globs, these are not consulted when passing in `FILES...`.
+    - `coverage.excludes` gets the same default excludes appended as `project-excludes` does,
+      unless [`disable-project-excludes-heuristics`](#disable-project-excludes-heuristics) is set.
+
 ### `search-path`
 
 A file path describing the roots from which imports should be


### PR DESCRIPTION
# Summary

`pyrefly coverage {check, report}` used the same `project-{includes,excludes}` as `pyrefly check`, so measuring coverage on a different file set (e.g. skipping tests, vendored code, or publically-namespaced private API) required repeatedly specifiying `--project-excludes` for every `pyrefly coverage` call. 

This adds an optional `[coverage]` config table with `includes` and `excludes` that override the project globs when using `pyrefly coverage` (and only then).
Each field defaults to its top-level `project-` counterpart when unset (like it does now).
The `--project-excludes` flag takes precedence over `coverage.excludes`, and positional `FILES...` args also do (just like with the `project-` globs).
Unknown keys inside `[coverage]` are reported in a warning message in the same way as with the other config tables.

# Test Plan

Config tests added for parsing, path rewriting, and glob resolution (for both the "default" and "coverage" config scopes), and verified that a `[coverage]` config indeed narrows `pyrefly coverage report` without affecting `pyrefly check` and explicit `FILES...` ("file mode" I believe it's called).