### PR TITLE
Dedupe redundant serde attributes in `pyrefly_config`

### DIFF
--- a/crates/pyrefly_config/src/base.rs
+++ b/crates/pyrefly_config/src/base.rs
@@ -13,6 +13,7 @@ use enum_iterator::all;
 use pyrefly_python::ignore::Tool;
 use serde::Deserialize;
 use serde::Serialize;
+use serde_with::skip_serializing_none;
 use starlark_map::small_set::SmallSet;
 use toml::Table;
 
@@ -208,25 +209,22 @@ impl Preset {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct ConfigBase {
     /// Errors to silence (or not) when printing errors.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub errors: Option<ErrorDisplayConfig>,
 
     /// Consider any ignore (including from other tools) to ignore an error.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub permissive_ignores: Option<bool>,
 
     /// Respect ignore directives from only these tools.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled_ignores: Option<SmallSet<Tool>>,
 
     /// Modules from which import errors should be ignored
     /// and the module should always be replaced with `typing.Any`
     #[serde(
-        default,
         skip_serializing_if = "crate::util::none_or_empty",
         // TODO(connernilsen): DON'T COPY THIS TO NEW FIELDS. This is a temporary
         // alias while we migrate existing fields from snake case to kebab case.
@@ -236,14 +234,12 @@ pub struct ConfigBase {
 
     /// Modules from which import errors should be
     /// ignored. The module is only replaced with `typing.Any` if it can't be found.
-    #[serde(default, skip_serializing_if = "crate::util::none_or_empty")]
+    #[serde(skip_serializing_if = "crate::util::none_or_empty")]
     pub(crate) ignore_missing_imports: Option<Vec<ModuleWildcard>>,
 
     /// Deprecated: use `check-unannotated-defs` and `infer-return-types` instead.
     /// How should we handle analyzing and inferring the function signature if it's untyped?
     #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
         // TODO(connernilsen): DON'T COPY THIS TO NEW FIELDS. This is a temporary
         // alias while we migrate existing fields from snake case to kebab case.
         alias = "untyped_def_behavior"
@@ -252,7 +248,6 @@ pub struct ConfigBase {
 
     /// Whether to type check the bodies of unannotated function definitions.
     /// Defaults to true.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub check_unannotated_defs: Option<bool>,
 
     /// Controls when Pyrefly infers return types for functions without explicit return annotations.
@@ -261,18 +256,14 @@ pub struct ConfigBase {
     /// - `checked`: infer return types for all checked functions (default).
     ///   Only applies to functions whose bodies are checked; unannotated functions
     ///   are only eligible when `check-unannotated-defs` is true.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub infer_return_types: Option<InferReturnTypes>,
 
     /// Whether to disable type errors in language server. By default errors will be shown in IDEs.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disable_type_errors_in_ide: Option<bool>,
 
     /// Whether to ignore type errors in generated code. By default this is disabled.
     /// Generated code is defined as code that contains the marker string `@` immediately followed by `generated`.
     #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
         // TODO(connernilsen): DON'T COPY THIS TO NEW FIELDS. This is a temporary
         // alias while we migrate existing fields from snake case to kebab case.
         alias = "ignore_errors_in_generated_code"
@@ -281,47 +272,40 @@ pub struct ConfigBase {
 
     /// Whether to infer empty container types as Any instead of creating type variables.
     /// By default this is enabled.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub infer_with_first_use: Option<bool>,
 
     /// Enable PyTorch efficiency lints that detect common GPU performance anti-patterns.
     /// When true, all `pytorch-efficiency-lint-*` error kinds are set to `Warn` severity
     /// unless individually overridden in `[errors]`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pytorch_efficiency_lints: Option<bool>,
 
     /// Maximum recursion depth before triggering overflow protection.
     /// Set to 0 to disable (default). This helps detect potential stack overflow situations.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recursion_depth_limit: Option<u32>,
 
     /// How to handle when recursion depth limit is exceeded.
     /// Only used when `recursion-depth-limit` is set to a non-zero value.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recursion_overflow_handler: Option<RecursionOverflowHandler>,
 
     /// Whether to strictly check callable subtyping for signatures with `*args: Any, **kwargs: Any`.
     /// When false (the default), callables with `*args: Any, **kwargs: Any` are treated as
     /// compatible with any signature (similar to `...` behavior).
     /// When true, parameter list compatibility is checked strictly even when `*args: Any, **kwargs: Any` is present.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub strict_callable_subtyping: Option<bool>,
 
     /// Whether to strictly check the parameters of a `functools.partial(...)` residual when it is
     /// assigned to a callable. When false (the default), the residual is treated as gradual (like
     /// `...`) for subtyping, matching the typeshed `partial` stub. When true, the residual's
     /// parameter types and arity are checked precisely.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub strict_partial_subtyping: Option<bool>,
 
     /// Whether to use spec-compliant overload evaluation semantics.
     /// When false (the default), Pyrefly attempts to resolve ambiguous calls precisely.
     /// When true, overload evaluation follows the typing spec exactly, falling back to `Any` more frequently.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spec_compliant_overloads: Option<bool>,
 
     /// Any unknown config items
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub(crate) extras: ExtraConfigs,
 }
 

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -53,6 +53,7 @@ use pyrefly_util::telemetry::TelemetrySourceDbRebuildStats;
 use pyrefly_util::watch_pattern::WatchPattern;
 use serde::Deserialize;
 use serde::Serialize;
+use serde_with::skip_serializing_none;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 use tracing::debug;
@@ -465,6 +466,7 @@ impl ImportLookupPathPart<'_> {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Deserialize, Serialize, Clone, Derivative)]
 #[serde(rename_all = "kebab-case")]
 #[derivative(PartialEq, Eq)]
@@ -525,7 +527,7 @@ pub struct ConfigFile {
     /// Not exposed to the user. When we aren't able to determine the root of a
     /// project, we guess some fallback search paths that are checked after
     /// typeshed (so we don't clobber the stdlib) and before site_package_path.
-    #[serde(default, skip)]
+    #[serde(skip)]
     pub fallback_search_path: FallbackSearchPath,
 
     /// Disable Pyrefly default heuristics, specifically those around
@@ -543,16 +545,13 @@ pub struct ConfigFile {
     pub enable_fallback_search_path: bool,
 
     /// Override the bundled typeshed with a custom path.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub typeshed_path: Option<PathBuf>,
 
     /// Path to baseline file for comparing type errors.
     /// Errors matching the baseline are suppressed.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub baseline: Option<PathBuf>,
 
     /// Default error output format for CLI checks when `--output-format` is not set.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_format: Option<OutputFormat>,
 
     /// Pyrefly's configurations around interpreter querying/finding.
@@ -568,11 +567,10 @@ pub struct ConfigFile {
 
     /// Named preset that provides default error severities and behavior settings.
     /// User-specified settings override the preset.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preset: Option<Preset>,
 
     /// The `ConfigBase` values for the whole project.
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub root: ConfigBase,
 
     /// Sub-configs that can override specific `ConfigBase` settings
@@ -595,19 +593,17 @@ pub struct ConfigFile {
     pub use_ignore_files: bool,
 
     /// Should this config use a build system? If so, which one?
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build_system: Option<BuildSystem>,
 
     /// Database understanding the mapping between source files and import paths,
     /// especially within the context of a build system. This is used for getting handles
     /// for a path and doing module finding.
-    #[serde(skip, default)]
+    #[serde(skip)]
     #[derivative(PartialEq = "ignore")]
     pub source_db: Option<ArcId<Box<dyn SourceDatabase>>>,
 
     /// Minimum severity level for errors to be displayed.
     /// Errors below this severity will not be shown. Defaults to "error".
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub min_severity: Option<Severity>,
 
     /// Should we let Pyrefly try to index the project's files? Disabling this

--- a/crates/pyrefly_config/src/environment/environment.rs
+++ b/crates/pyrefly_config/src/environment/environment.rs
@@ -21,6 +21,7 @@ use pyrefly_util::lock::Mutex;
 use pyrefly_util::stdlib::register_stdlib_paths;
 use serde::Deserialize;
 use serde::Serialize;
+use serde_with::skip_serializing_none;
 use starlark_map::small_map::SmallMap;
 use tracing::warn;
 
@@ -37,13 +38,12 @@ static INTERPRETER_ENV_REGISTRY: LazyLock<
 /// on config parsing, since we also won't know if an executable
 /// other than the first available on the path should be used (i.e.
 /// should we always look at a venv/conda environment instead?)
+#[skip_serializing_none]
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct PythonEnvironment {
     /// The platform any `sys.platform` check should evaluate against.
     #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
         // TODO(connernilsen): DON'T COPY THIS TO NEW FIELDS. This is a temporary
         // alias while we migrate existing fields from snake case to kebab case.
         alias = "python_platform"
@@ -52,8 +52,6 @@ pub struct PythonEnvironment {
 
     /// The platform any `sys.version` check should evaluate against.
     #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
         // TODO(connernilsen): DON'T COPY THIS TO NEW FIELDS. This is a temporary
         // alias while we migrate existing fields from snake case to kebab case.
         alias = "python_version"
@@ -63,15 +61,13 @@ pub struct PythonEnvironment {
     /// Directories containing third-party package imports, searched
     /// after first checking `search_path` and `typeshed`.
     #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
         // TODO(connernilsen): DON'T COPY THIS TO NEW FIELDS. This is a temporary
         // alias while we migrate existing fields from snake case to kebab case.
         alias = "site_package_path"
     )]
     pub site_package_path: Option<Vec<PathBuf>>,
 
-    #[serde(skip, default)]
+    #[serde(skip)]
     pub interpreter_site_package_path: Vec<PathBuf>,
 
     #[serde(alias = "stdlib_paths", default, skip_serializing)]

--- a/crates/pyrefly_config/src/environment/interpreters.rs
+++ b/crates/pyrefly_config/src/environment/interpreters.rs
@@ -12,6 +12,7 @@ use std::sync::LazyLock;
 
 use serde::Deserialize;
 use serde::Serialize;
+use serde_with::skip_serializing_none;
 #[cfg(not(target_arch = "wasm32"))]
 use which::which;
 
@@ -20,24 +21,22 @@ use crate::environment::conda;
 use crate::environment::venv;
 use crate::util::ConfigOrigin;
 
+#[skip_serializing_none]
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Interpreters {
     #[serde(
-                default,
-                skip_serializing_if = "ConfigOrigin::should_skip_serializing_option",
-                // TODO(connernilsen): DON'T COPY THIS TO NEW FIELDS. This is a temporary
-                // alias while we migrate existing fields from snake case to kebab case.
-                alias = "python_interpreter",
-                alias = "python-interpreter",
-            )]
+        skip_serializing_if = "ConfigOrigin::should_skip_serializing_option",
+        // TODO(connernilsen): DON'T COPY THIS TO NEW FIELDS. This is a temporary
+        // alias while we migrate existing fields from snake case to kebab case.
+        alias = "python_interpreter",
+        alias = "python-interpreter",
+    )]
     pub(crate) python_interpreter_path: Option<ConfigOrigin<PathBuf>>,
 
     /// Should we turn a generic command into a `python_interpreter` path?
-    #[serde(default)]
     pub(crate) fallback_python_interpreter_name: Option<ConfigOrigin<String>>,
 
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) conda_environment: Option<ConfigOrigin<String>>,
 
     /// Should we do any querying of an interpreter?

--- a/crates/pyrefly_config/src/pyproject.rs
+++ b/crates/pyrefly_config/src/pyproject.rs
@@ -22,18 +22,16 @@ const PYTHON_TOOL_NAMES: &[&str] = &["ruff", "mypy", "pyright"];
 /// Wrapper used to (de)serialize pyrefly configs from pyproject.toml files.
 #[derive(Debug, Serialize, Deserialize)]
 struct Tool {
-    #[serde(default)]
     pyrefly: Option<ConfigFile>,
     /// Catch-all for other `[tool.*]` sections. We check this for known
     /// Python tool names (see `PYTHON_TOOL_NAMES`) to detect Python project roots.
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     other_tools: HashMap<String, toml::Value>,
 }
 
 /// Wrapper used to (de)serialize pyrefly configs from pyproject.toml files.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PyProject {
-    #[serde(default)]
     tool: Option<Tool>,
 }
 


### PR DESCRIPTION
# Summary

Every `Option` field in the config structs repeated `#[serde(default, skip_serializing_if = "Option::is_none")]`, and some `flatten` and `skip` fields also had a `default` that serde ignores or already implicitly uses.
This updates the config structs to use `#[skip_serializing_none]` from `serde_with` for the entire struct, and removes the redundant serde stuff. 

Spotted while working on #4146.

# Test Plan

Tests still pass; no behavior changes.