### PR TITLE
Reuse fuzzy matcher across completion candidates

### DIFF
--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -455,10 +455,10 @@ impl Transaction<'_> {
             .finding()
         {
             let builtin_exports = self.get_exports(&builtin_handle);
+            let matcher = SkimMatcherV2::default().smart_case();
             for (name, location) in builtin_exports.iter() {
                 if let Some(identifier) = identifier
-                    && SkimMatcherV2::default()
-                        .smart_case()
+                    && matcher
                         .fuzzy_match(name.as_str(), identifier.as_str())
                         .is_none()
                 {
@@ -516,6 +516,7 @@ impl Transaction<'_> {
         if let Some(bindings) = self.get_bindings(handle)
             && let Some(module_info) = self.get_module_info(handle)
         {
+            let matcher = SkimMatcherV2::default();
             for idx in bindings.available_definitions(position) {
                 let key = bindings.idx_to_key(idx);
                 let label = match key {
@@ -524,9 +525,7 @@ impl Transaction<'_> {
                     _ => continue,
                 };
                 if let Some(identifier) = identifier
-                    && SkimMatcherV2::default()
-                        .fuzzy_match(label, identifier.as_str())
-                        .is_none()
+                    && matcher.fuzzy_match(label, identifier.as_str()).is_none()
                 {
                     continue;
                 }


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

add_builtins_autoimport_completions and add_local_variable_completions constructed a new SkimMatcherV2 for every candidate; SkimMatcherV2 carries thread-local caches meant to be reused across fuzzy_match calls so rebuilding it per candidate allocates those caches repeatedly and prevents DP-matrix cache from ever being reused. Matcher is taken out of the loop and reused, similar to state/lsp.rs.

I think this will speed up the completion popup appearance, but I don't know if that's true or by how much as I didn't add a benchmark and neither typecheck_benchmark.py nor lsp_benchmark.py measures this. The change doesn't break anything in cargo test

Related: issue #2296

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

cargo test passes the same as before edits, cargo clippy and cargo fmt are clean

I don't think there's an existing benchmark that covers completions, but I'm happy to try to write one as a follow-up to this if it'd be useful