### PR TITLE
Print config warnings in `pyrefly coverage`

### DIFF
--- a/crates/pyrefly_config/src/finder.rs
+++ b/crates/pyrefly_config/src/finder.rs
@@ -229,6 +229,13 @@ impl ConfigFinder {
         self.errors.lock().extend(errors);
     }
 
+    /// Print and clear all accumulated config errors.
+    pub fn print_errors(&self) {
+        for error in self.errors() {
+            error.print();
+        }
+    }
+
     /// Get the config file associated with a (non-Python) file. If no config exists
     /// on disk, return `None`.
     ///
@@ -280,9 +287,7 @@ impl ConfigFinder {
     /// to ensure that config errors are still surfaced if we exit early.
     pub fn checkpoint<R, E>(&self, result: Result<R, E>) -> Result<R, E> {
         if result.is_err() {
-            for error in self.errors() {
-                error.print();
-            }
+            self.print_errors();
         }
         result
     }

--- a/pyrefly/lib/commands/coverage/collect.rs
+++ b/pyrefly/lib/commands/coverage/collect.rs
@@ -1852,6 +1852,9 @@ pub fn collect_module_reports(
     module_reports.sort_by(|a, b| (&a.name, &a.path).cmp(&(&b.name, &b.path)));
     errors.sort_by_key(|e| (e.path().to_string(), e.range().start()));
 
+    // Surface config warnings, like `check` does.
+    config_finder.print_errors();
+
     Ok((module_reports, errors))
 }
 

--- a/pyrefly/lib/commands/dump_config.rs
+++ b/pyrefly/lib/commands/dump_config.rs
@@ -120,9 +120,7 @@ fn dump_config(
             .or_default()
             .push(path.clone());
     }
-    for error in config_finder.errors() {
-        error.print();
-    }
+    config_finder.print_errors();
     for (config, files) in configs_to_files.into_iter() {
         let config_env = clap_env("CONFIG");
         match &config.source {

--- a/test/config.md
+++ b/test/config.md
@@ -13,6 +13,18 @@ $ mkdir $TMPDIR/test && echo "" > $TMPDIR/test/empty.py && \
 [0]
 ```
 
+## Coverage commands also warn on a non-existent search-path/site-package-path
+
+```scrut {output_stream: stderr}
+$ mkdir $TMPDIR/covwarn && echo "def f(): pass" > $TMPDIR/covwarn/f.py && \
+> echo -e "project_includes = [\"$TMPDIR/covwarn/f.py\"]\nsite_package_path = [\"$TMPDIR/covwarn/abcd\"]\nsearch_path = [\"$TMPDIR/covwarn/efgh\"]" > $TMPDIR/covwarn/pyrefly.toml && \
+> $PYREFLY coverage report -c $TMPDIR/covwarn/pyrefly.toml > /dev/null
+ INFO Checking project configured at `*/pyrefly.toml` (glob)
+ WARN */pyrefly.toml: Invalid site-package-path: */abcd` does not exist (glob)
+ WARN */pyrefly.toml: Invalid search-path: */efgh` does not exist (glob)
+[0]
+```
+
 ## Dump config
 
 ```scrut


### PR DESCRIPTION
# Summary

Config warnings are printed when using `pyrefly check` (e.g. invalid `site-package-path`), but the `pyrefly coverage` commands didn't. So now they do :)

Spotted while working on #4146.

# Test Plan

Scrut test added, and manually verified that `pyrefly coverage report`'s stdout stays valid json.