### PR TITLE
fix support psuedo generic classes when unannnotated #1157

### DIFF
--- a/crates/pyrefly_types/src/quantified.rs
+++ b/crates/pyrefly_types/src/quantified.rs
@@ -48,6 +48,8 @@ pub enum QuantifiedOrigin {
     MapIntTuplesParameter,
     /// De Bruijn sentinel used only while comparing `MapIntTuples` lambdas.
     NormalizedMapIntTuplesParameter,
+    /// Hidden class type parameter inferred from an unannotated `__init__` parameter.
+    SyntheticPseudoGeneric,
 }
 
 impl QuantifiedOrigin {
@@ -428,6 +430,9 @@ impl Quantified {
     pub(crate) fn normalized_map_int_tuples_parameter_depth(&self) -> Option<u32> {
         (self.identity.origin == QuantifiedOrigin::NormalizedMapIntTuplesParameter)
             .then_some(self.identity.anchor.index)
+    }
+    pub fn is_pseudo_generic(&self) -> bool {
+        self.identity.origin == QuantifiedOrigin::SyntheticPseudoGeneric
     }
 
     pub fn as_gradual_type_helper(kind: QuantifiedKind, default: Option<&Type>) -> Type {

--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -173,6 +173,11 @@ impl TParams {
         self.0.is_empty()
     }
 
+    /// Whether these are the hidden parameters of a pseudo-generic class.
+    pub fn is_pseudo_generic(&self) -> bool {
+        !self.0.is_empty() && self.0.iter().all(Quantified::is_pseudo_generic)
+    }
+
     pub fn iter(&self) -> impl ExactSizeIterator<Item = &Quantified> {
         self.0.iter()
     }
@@ -307,6 +312,9 @@ impl TArgs {
     /// Returns the number of type arguments to display, stripping trailing args
     /// that match their parameter defaults (WYSIWYG display per issue #2461).
     pub fn display_count(&self) -> usize {
+        if self.tparams().is_pseudo_generic() {
+            return 0;
+        }
         let mut last_non_default = 0;
         for (i, (param, arg)) in self.iter_paired().enumerate() {
             if param.default().is_none() || arg != &param.as_gradual_type() {

--- a/pyrefly/lib/alt/class/classdef.rs
+++ b/pyrefly/lib/alt/class/classdef.rs
@@ -11,8 +11,14 @@ use dupe::Dupe;
 use pyrefly_python::nesting_context::NestingContext;
 use pyrefly_types::callable::Callable;
 use pyrefly_types::class::PrecomputedTParams;
+use pyrefly_types::quantified::AnchorIndex;
 use pyrefly_types::quantified::Quantified;
+use pyrefly_types::quantified::QuantifiedIdentity;
+use pyrefly_types::quantified::QuantifiedKind;
+use pyrefly_types::quantified::QuantifiedOrigin;
 use pyrefly_types::special_form::SpecialForm;
+use pyrefly_types::type_var::PreInferenceVariance;
+use pyrefly_types::type_var::Restriction;
 use ruff_python_ast::Identifier;
 use ruff_python_ast::name::Name;
 use starlark_map::small_map::SmallMap;
@@ -75,15 +81,47 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         // Legacy type variables can produce a cycle, so their tparams are left to
         // the class's `KeyTParams` binding. Everything else is computed here, and
         // a class that turns out to declare nothing records no tparams at all.
+        let pseudo_generic_params = self
+            .bindings()
+            .get_pseudo_generic_params(def_index)
+            .expect("class definition must have binding metadata");
         let precomputed_tparams = if tparams_require_binding {
+            assert!(
+                pseudo_generic_params.is_empty(),
+                "legacy generic classes cannot be pseudo-generic"
+            );
             PrecomputedTParams::FromBinding
         } else {
             let tparams =
                 self.calculate_class_tparams_no_legacy(&x.name, x.type_params.as_deref(), errors);
-            if tparams.is_empty() {
+            if pseudo_generic_params.is_empty() && tparams.is_empty() {
                 PrecomputedTParams::NotGeneric
-            } else {
+            } else if pseudo_generic_params.is_empty() {
                 PrecomputedTParams::Precomputed(Arc::new(tparams))
+            } else {
+                assert!(
+                    tparams.is_empty(),
+                    "pseudo-generic classes cannot have declared type parameters"
+                );
+                PrecomputedTParams::Precomputed(Arc::new(TParams::new(
+                    pseudo_generic_params
+                        .iter()
+                        .map(|param| {
+                            Quantified::new(
+                                QuantifiedIdentity::new(
+                                    self.module().name(),
+                                    AnchorIndex::first(param.range),
+                                    QuantifiedOrigin::SyntheticPseudoGeneric,
+                                ),
+                                param.id.clone(),
+                                QuantifiedKind::TypeVar,
+                                None,
+                                Restriction::Unrestricted,
+                                PreInferenceVariance::Undefined,
+                            )
+                        })
+                        .collect(),
+                )))
             }
         };
         Class::new(

--- a/pyrefly/lib/alt/class/classdef.rs
+++ b/pyrefly/lib/alt/class/classdef.rs
@@ -116,7 +116,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                                 param.id.clone(),
                                 QuantifiedKind::TypeVar,
                                 None,
-                                Restriction::Unrestricted,
+                                Restriction::Bound(Type::any_implicit()),
                                 PreInferenceVariance::Undefined,
                             )
                         })

--- a/pyrefly/lib/alt/class/targs.rs
+++ b/pyrefly/lib/alt/class/targs.rs
@@ -87,12 +87,13 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         range: TextRange,
         errors: &ErrorCollector,
     ) -> ClassType {
-        let targs = match self.get_class_tparams(cls) {
-            Some(tparams) => {
-                self.create_targs(cls.name(), tparams.dupe(), targs, range, true, errors)
-            }
+        let tparams = self.get_class_tparams(cls).cloned();
+        let pseudo_targs =
+            self.create_pseudo_generic_targs(cls.name(), tparams.dupe(), &targs, range, errors);
+        let targs = pseudo_targs.unwrap_or_else(|| match tparams {
+            Some(tparams) => self.create_targs(cls.name(), tparams, targs, range, true, errors),
             None => self.reject_targs_without_tparams(cls.name(), &targs, range, errors),
-        };
+        });
         ClassType::new(cls.dupe(), targs)
     }
 
@@ -105,7 +106,13 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         errors: &ErrorCollector,
     ) -> Type {
         let metadata = self.get_metadata_for_class(cls);
-        let tparams = self.get_class_tparams(cls).dupe();
+        let tparams = self.get_class_tparams(cls).cloned();
+
+        if let Some(targs) =
+            self.create_pseudo_generic_targs(cls.name(), tparams.dupe(), &targs, range, errors)
+        {
+            return self.type_of_instance(cls, targs);
+        }
 
         // We didn't find any type parameters for this class, but it may have ones we don't know about if:
         // - the class inherits from Any, or
@@ -238,18 +245,23 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             return self.type_of_instance(cls, TArgs::default());
         };
         let tparams_for_error = tparams.dupe();
+        let on_fallback_to_gradual = |tparam: &Quantified| {
+            if ignored_implicit_any != Some(tparam) {
+                Self::add_implicit_any_error(
+                    errors,
+                    range,
+                    format_generic_entity("class", cls.name(), &tparams_for_error),
+                    Some(tparam.name().as_str()),
+                );
+            }
+        };
         let targs = self.create_default_targs(
             tparams,
-            Some(&|tparam: &Quantified| {
-                if ignored_implicit_any != Some(tparam) {
-                    Self::add_implicit_any_error(
-                        errors,
-                        range,
-                        format_generic_entity("class", cls.name(), &tparams_for_error),
-                        Some(tparam.name().as_str()),
-                    );
-                }
-            }),
+            if tparams_for_error.is_pseudo_generic() {
+                None
+            } else {
+                Some(&on_fallback_to_gradual)
+            },
         );
         self.type_of_instance(cls, targs)
     }
@@ -450,6 +462,35 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 .collect();
             TArgs::new(tparams, tys)
         }
+    }
+
+    /// Pseudo-generic parameters participate in inference but cannot be explicitly specialized.
+    fn create_pseudo_generic_targs(
+        &self,
+        name: &Name,
+        tparams: Option<Arc<TParams>>,
+        explicit_targs: &[Type],
+        range: TextRange,
+        errors: &ErrorCollector,
+    ) -> Option<TArgs> {
+        let tparams = tparams?;
+        if !tparams.is_pseudo_generic() {
+            return None;
+        }
+        if !explicit_targs.is_empty() {
+            self.error(
+                errors,
+                range,
+                ErrorKind::BadSpecialization,
+                format!(
+                    "Expected {} for `{}`, got {}",
+                    count(0, "type argument"),
+                    name,
+                    explicit_targs.len(),
+                ),
+            );
+        }
+        Some(self.create_default_targs(tparams, None))
     }
 
     fn type_of_instance(&self, cls: &Class, targs: TArgs) -> Type {

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -632,6 +632,12 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             def,
             flags.facts().is_stub(),
             &mut self_type,
+            defining_cls
+                .as_ref()
+                .filter(|_| def.name.id == dunder::INIT)
+                .and_then(|cls| self.get_class_tparams(cls))
+                .filter(|tparams| tparams.is_pseudo_generic())
+                .map(|tparams| tparams.as_ref()),
             &mut decorator_param_hints,
             &mut parent_param_hints,
             errors,
@@ -1184,6 +1190,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         default: Option<&Expr>,
         is_stub: bool,
         self_type: &mut Option<Type>,
+        pseudo_generic_type: Option<Type>,
         hint: Option<Type>,
         errors: &ErrorCollector,
     ) -> ParamTypeResult {
@@ -1228,6 +1235,8 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 // Otherwise, it will be Any.
                 let ty = if let Some(ty) = self_type {
                     ty.clone()
+                } else if let Some(ty) = pseudo_generic_type {
+                    ty
                 } else if let Some(hint) = hint {
                     hint.clone()
                 } else if let Required::Optional(Some(default_val)) = &required {
@@ -1260,6 +1269,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         def: &FunctionDefData,
         is_stub: bool,
         self_type: &mut Option<Type>,
+        pseudo_generic_tparams: Option<&TParams>,
         decorator_param_hints: &mut Option<DecoratorParamHints>,
         parent_param_hints: &mut Option<ParentParamHints>,
         errors: &ErrorCollector,
@@ -1268,6 +1278,11 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         let mut paramspec_kwargs = None;
         let mut resolved_param_types = SmallMap::new();
         let mut params = Vec::with_capacity(def.parameters.len());
+        let pseudo_generic_type = |name: &Identifier| {
+            pseudo_generic_tparams
+                .and_then(|tparams| tparams.iter().find(|param| param.name() == &name.id))
+                .map(|param| param.clone().to_type(self.heap))
+        };
         params.extend(def.parameters.posonlyargs.iter().map(|x| {
             let decorator_hint = decorator_param_hints
                 .as_mut()
@@ -1288,6 +1303,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 x.default.as_deref(),
                 is_stub,
                 self_type,
+                pseudo_generic_type(&x.parameter.name),
                 decorator_hint.or(parent_hint),
                 errors,
             );
@@ -1322,6 +1338,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 x.default.as_deref(),
                 is_stub,
                 self_type,
+                pseudo_generic_type(&x.parameter.name),
                 decorator_hint.or(parent_hint),
                 errors,
             );
@@ -1366,6 +1383,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 None,
                 is_stub,
                 &mut None,
+                pseudo_generic_type(&x.name),
                 parent_hint,
                 errors,
             );
@@ -1403,6 +1421,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 x.default.as_deref(),
                 is_stub,
                 self_type,
+                pseudo_generic_type(&x.parameter.name),
                 parent_hint,
                 errors,
             );
@@ -1422,6 +1441,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 None,
                 is_stub,
                 self_type,
+                pseudo_generic_type(&x.name),
                 parent_hint,
                 errors,
             );

--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -1194,7 +1194,12 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                         &FacetChain::new(Vec1::new(facet.clone())),
                         range,
                     );
-                    if Self::is_literal(&right) && !self.is_subset_eq(&right, &facet_ty) {
+                    // A pseudo-generic facet may have any constructor-inferred specialization,
+                    // so it cannot prove that the receiver is impossible.
+                    if Self::is_literal(&right)
+                        && !matches!(&facet_ty, Type::Quantified(q) if q.is_pseudo_generic())
+                        && !self.is_subset_eq(&right, &facet_ty)
+                    {
                         self.heap.mk_never()
                     } else {
                         t.clone()

--- a/pyrefly/lib/alt/special_calls.rs
+++ b/pyrefly/lib/alt/special_calls.rs
@@ -59,7 +59,25 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 TypeFormContext::FunctionArgument,
                 errors,
             ));
-            if !b.is_error() && !self.is_equivalent(&a, &b) {
+            // Pseudo-generic arguments are an inference detail, not part of the user-visible type.
+            let erase_pseudo_generic_args = |ty: &Type| {
+                ty.clone().transform(&mut |ty| {
+                    if let Type::ClassType(class_type) = ty
+                        && class_type.tparams().is_pseudo_generic()
+                    {
+                        for arg in class_type.targs_mut().as_mut() {
+                            *arg = Type::any_implicit();
+                        }
+                    }
+                })
+            };
+            if !b.is_error()
+                && !self.is_equivalent(&a, &b)
+                && !self.is_equivalent(
+                    &erase_pseudo_generic_args(&a),
+                    &erase_pseudo_generic_args(&b),
+                )
+            {
                 self.error(
                     errors,
                     range,

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -419,6 +419,16 @@ impl Bindings {
         Some(&self.0.metadata.get_class_checked(idx)?.fields)
     }
 
+    pub fn get_pseudo_generic_params(&self, idx: ClassDefIndex) -> Option<&[Identifier]> {
+        Some(
+            &self
+                .0
+                .metadata
+                .get_class_checked(idx)?
+                .pseudo_generic_params,
+        )
+    }
+
     /// Per-module class index for a class definition statement (`ClassDefIndex`),
     /// used for `KeyClassField` / `ClassFields` lookups.
     pub fn class_def_index(&self, class_def: &StmtClassDef) -> Option<ClassDefIndex> {

--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -12,7 +12,9 @@ use dupe::Dupe as _;
 use pyrefly_graph::index::Idx;
 use pyrefly_python::ast::Ast;
 use pyrefly_python::docstring::Docstring;
+use pyrefly_python::dunder;
 use pyrefly_python::keywords::is_valid_identifier;
+use pyrefly_python::module_path::ModuleStyle;
 use pyrefly_python::nesting_context::NestingContext;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_util::prelude::SliceExt;
@@ -250,6 +252,34 @@ impl<'a> BindingsBuilder<'a> {
         let (mut class_object, class_indices) = self.class_object_and_indices(&x.name);
         let mut pydantic_config_dict = PydanticConfigDict::default();
         let docstring_range = Docstring::range_from_stmts(x.body.as_slice());
+        // Required parameters of a wholly unannotated `__init__` act as hidden class type
+        // parameters, provided the class is not already generic.
+        let mut init_methods = x.body.iter().filter_map(|stmt| match stmt {
+            Stmt::FunctionDef(def) if def.name.id == dunder::INIT => Some(def),
+            _ => None,
+        });
+        let pseudo_generic_params = if self.module_info.path().style() == ModuleStyle::Executable
+            && x.type_params.is_none()
+            && let Some(init) = init_methods.next()
+            && init_methods.next().is_none()
+            && init.parameters.len() > 1
+            && init
+                .parameters
+                .iter()
+                .all(|param| param.annotation().is_none())
+        {
+            init.parameters
+                .posonlyargs
+                .iter()
+                .chain(&init.parameters.args)
+                .skip(1)
+                .chain(&init.parameters.kwonlyargs)
+                .filter(|param| param.default.is_none())
+                .map(|param| param.parameter.name.clone())
+                .collect::<Box<[_]>>()
+        } else {
+            Box::default()
+        };
         let body = mem::take(&mut x.body);
         let field_docstrings = self.extract_field_docstrings(&body);
         let pydantic_before_validator_fields = self.extract_field_validator_fields(&body);
@@ -537,7 +567,13 @@ impl<'a> BindingsBuilder<'a> {
         }
 
         fields.reserve(0); // Attempt to shrink to capacity
-        self.metadata.get_class_mut(class_indices.def_index).fields = ClassFields::new(fields);
+        let class_metadata = self.metadata.get_class_mut(class_indices.def_index);
+        class_metadata.fields = ClassFields::new(fields);
+        class_metadata.pseudo_generic_params = if tparams_require_binding {
+            Box::default()
+        } else {
+            pseudo_generic_params
+        };
         self.insert_binding_idx(
             class_indices.class_idx,
             BindingClass::ClassDef(ClassBinding {

--- a/pyrefly/lib/binding/metadata.rs
+++ b/pyrefly/lib/binding/metadata.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use pyrefly_types::class::ClassDefIndex;
 use pyrefly_types::class::ClassFields;
 use pyrefly_types::meta_shape_dsl::ShapeDslFunction;
+use ruff_python_ast::Identifier;
 use ruff_python_ast::name::Name;
 
 /// Metadata for a single class definition, populated during binding.
@@ -31,6 +32,8 @@ pub struct ClassMetadata {
     /// because at binding time we cannot know that so we have to treat assignment
     /// as potentially defining a field that would not otherwise exist.
     pub fields: ClassFields,
+    /// Required unannotated `__init__` parameters represented as hidden class type parameters.
+    pub pseudo_generic_params: Box<[Identifier]>,
 }
 
 /// Metadata collected during the binding phase for all classes in a module.

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -82,6 +82,49 @@ def f(a: A):
 );
 
 testcase!(
+    test_unannotated_constructor_attribute_inferred_from_call,
+    r#"
+from typing import assert_type
+class A:
+    def __init__(self, t):
+        self.t = t
+
+assert_type(A(1).t, int)
+assert_type(A("x").t, str)
+assert_type(A(1), A)
+A[int]  # E: Expected 0 type arguments for `A`, got 1
+    "#,
+);
+
+testcase!(
+    test_pseudo_generic_constructor_eligibility,
+    r#"
+from typing import Any, assert_type
+
+class Pair:
+    def __init__(self, left, *, right):
+        self.left = left
+        self.right = right
+
+pair = Pair(1, right="x")
+assert_type(pair.left, int)
+assert_type(pair.right, str)
+
+class PartiallyAnnotated:
+    def __init__(self, value, flag: bool):
+        self.value = value
+
+assert_type(PartiallyAnnotated(1, True).value, Any)
+
+class AlreadyGeneric[T]:
+    def __init__(self, value):
+        self.value = value
+
+assert_type(AlreadyGeneric[int](1).value, Any)
+    "#,
+);
+
+testcase!(
     test_unannotated_attribute_bad_assignment,
     r#"
 class A:

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -97,6 +97,23 @@ A[int]  # E: Expected 0 type arguments for `A`, got 1
 );
 
 testcase!(
+    test_pseudo_generic_attribute_use_in_method,
+    r#"
+class A:
+    def __init__(self, x):
+        self.x = x
+        self.flag = False
+
+    def call_member(self):
+        self.x.foo()
+
+    def compare(self):
+        if self.x == 0:
+            self.flag = True
+    "#,
+);
+
+testcase!(
     test_pseudo_generic_constructor_eligibility,
     r#"
 from typing import Any, assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1157

based on Pyright's pseudo-generic behavior https://github.com/microsoft/pyright/blob/4c60ea9967d2633894e873c1b53145a28106f9a8/packages/pyright-internal/src/analyzer/typeEvaluator.ts#L18112

 A(1).t infers int; A("x").t infers str.
 Hidden type parameters are created only for eligible unannotated constructors.
 Pseudo-generic arguments remain user-invisible.
 Explicit A[int] specialization is rejected.

todo:

```py
  class A:
      def __init__(self, x):
          self.x = x

      def f(self):
          self.x.foo()
```

```py
  class A:
      def __init__(self, x):
          self.x = x
          self.flag = False

      def f(self):
          if self.x == 0:
              self.flag = True

```


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test