### PR TITLE
Always print coverage findings in `pyrefly coverage check --fail-under=`

### DIFF
--- a/pyrefly/lib/commands/coverage/check.rs
+++ b/pyrefly/lib/commands/coverage/check.rs
@@ -48,8 +48,8 @@ pub struct CheckArgs {
     public_only: bool,
 
     /// Format for the untyped-symbol findings.
-    #[arg(long, value_enum)]
-    output_format: Option<OutputFormat>,
+    #[arg(long, value_enum, default_value_t)]
+    output_format: OutputFormat,
 }
 
 impl CheckArgs {
@@ -101,7 +101,7 @@ impl CheckArgs {
         );
 
         let root = std::env::current_dir().unwrap_or_default();
-        write_errors_to_console(self.output_format.unwrap_or_default(), &root, &errors)?;
+        write_errors_to_console(self.output_format, &root, &errors)?;
 
         if coverage + 1e-9 >= self.fail_under {
             eprintln!("{} {summary}", Severity::Info.painted());

--- a/pyrefly/lib/commands/coverage/check.rs
+++ b/pyrefly/lib/commands/coverage/check.rs
@@ -100,12 +100,13 @@ impl CheckArgs {
             number_thousands(total.n_typable),
         );
 
+        let root = std::env::current_dir().unwrap_or_default();
+        write_errors_to_console(self.output_format.unwrap_or_default(), &root, &errors)?;
+
         if coverage + 1e-9 >= self.fail_under {
             eprintln!("{} {summary}", Severity::Info.painted());
             Ok(CommandExitStatus::Success)
         } else {
-            let root = std::env::current_dir().unwrap_or_default();
-            write_errors_to_console(self.output_format.unwrap_or_default(), &root, &errors)?;
             eprintln!(
                 "{} {summary} is below the {:.2}% threshold",
                 Severity::Error.painted(),

--- a/website/docs/report.mdx
+++ b/website/docs/report.mdx
@@ -45,14 +45,8 @@ reachable from public modules via re-export chains count: the library's public A
 pyrefly coverage check robot/ --fail-under 60
 ```
 
-On success it prints a one-line summary and exits 0:
-
-```
- INFO type coverage 66.67% (4 of 6 typable)
-```
-
-Otherwise it exits non-zero and reports every offending symbol in the same style as
-`pyrefly check`, as `coverage-missing` (no annotations at all) or `coverage-partial` (only some):
+It reports every offending symbol in the same style as `pyrefly check`, as `coverage-missing`
+(no annotations at all) or `coverage-partial` (only some), followed by a one-line summary:
 
 ```
  WARN `walk` is not fully typed [coverage-partial]
@@ -72,8 +66,16 @@ Otherwise it exits non-zero and reports every offending symbol in the same style
 ERROR type coverage 66.67% (4 of 6 typable) is below the 100.00% threshold
 ```
 
-With `--strict`, annotations that resolve to `Any` count as untyped. The findings format is
-configurable with `--output-format`. See `pyrefly coverage check --help` for all flags.
+When coverage meets the threshold, the findings are printed but the summary is INFO and the exit
+code is 0:
+
+```
+ INFO type coverage 66.67% (4 of 6 typable)
+```
+
+Findings go to stdout, the summary to stderr. With `--strict`, annotations that resolve to `Any`
+count as untyped. `--output-format` controls the findings format.
+See `pyrefly coverage check --help` for all flags.
 
 ## Generating a JSON report
 


### PR DESCRIPTION
# Summary

Right now, `pyrefly coverage report --fail-under=<something below 100>` does not print the findings if the coverage is above the threshold. I think it would be more useful if those findings would be printed regardless of whether it passes (i.e. exits 0). And if the user doesn't want to see those findings for some reason, then they could always use the existing `--output-format=omit-errors` flag to disable this.

# Test Plan

Manually verified that the missing coverage warnings are now always  emitted.