### PR TITLE
unify module prefix so __unknown__ files count under --public-only (#4157)

### DIFF
--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -1033,15 +1033,9 @@ impl ConfigFile {
         })
     }
 
+    /// Create a `Handle` for the given path, deriving its module name from the search paths,
+    /// falling back to `self.fallback_search_path` and finally `__unknown__`.
     pub fn handle_from_module_path(&self, module_path: ModulePath) -> Handle {
-        self.handle_from_module_path_with_fallback(module_path, &FallbackSearchPath::Empty)
-    }
-
-    pub fn handle_from_module_path_with_fallback(
-        &self,
-        module_path: ModulePath,
-        fallback_search_path: &FallbackSearchPath,
-    ) -> Handle {
         match &self
             .source_db
             .as_ref()
@@ -1055,25 +1049,20 @@ impl ConfigFile {
                 // root resolve from the site-package prefix, not from the
                 // heuristic project root, while still letting explicit search
                 // paths override when the user has configured them.
-                let all_paths: Vec<&PathBuf> = self
+                let search_paths = self
                     .explicit_search_path()
                     .chain(self.site_package_path())
-                    .chain(self.heuristic_search_path())
-                    .collect();
-                let module_kind = if fallback_search_path.is_empty() {
-                    let name = ModuleName::from_path(
-                        module_path.as_path(),
-                        all_paths.iter().copied(),
-                        &self.extra_file_extensions,
-                    )
-                    .unwrap_or_else(ModuleName::unknown);
-                    ModuleNameWithKind::guaranteed(name)
+                    .chain(self.heuristic_search_path());
+                let path = module_path.as_path();
+                let module_kind = if self.disable_search_path_heuristics {
+                    ModuleName::from_path(path, search_paths, &self.extra_file_extensions)
+                        .map(ModuleNameWithKind::guaranteed)
+                        .unwrap_or(ModuleNameWithKind::guaranteed(ModuleName::unknown()))
                 } else {
-                    let fallback_paths =
-                        fallback_search_path.for_directory(Some(module_path.as_path()));
+                    let fallback_paths = self.fallback_search_path.for_directory(Some(path));
                     ModuleName::from_path_with_fallback(
-                        module_path.as_path(),
-                        all_paths.iter().copied(),
+                        path,
+                        search_paths,
                         fallback_paths.iter(),
                         &self.extra_file_extensions,
                     )

--- a/pyrefly/lib/commands/config_finder.rs
+++ b/pyrefly/lib/commands/config_finder.rs
@@ -349,6 +349,7 @@ mod tests {
     use pyrefly_util::test_path::TestPath;
 
     use super::*;
+    use crate::commands::check::Handles;
     use crate::config::config::ConfigSource;
     use crate::config::environment::environment::PythonEnvironment;
 
@@ -533,6 +534,21 @@ mod tests {
                     .collect::<Vec<PathBuf>>()
             )),
         );
+    }
+
+    /// gh-4132: CLI handles must derive module names via the config's fallback
+    /// search path, so files in a config-less directory don't become `__unknown__`.
+    #[test]
+    fn test_handles_all_uses_fallback_search_path() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        TestPath::setup_test_directory(root, vec![TestPath::file("foo.py")]);
+
+        let finder = TestConfigurer::new_standard(|_, x, _| {
+            ConfigOverrideArgs::default().override_config(x)
+        });
+        let (handles, _, _) = Handles::new(vec![root.join("foo.py")]).all(&finder);
+        assert_eq!(handles[0].module(), ModuleName::from_str("foo"));
     }
 
     /// A real pyrefly.toml should always take priority over a pyproject.toml

--- a/pyrefly/lib/commands/coverage/collect.rs
+++ b/pyrefly/lib/commands/coverage/collect.rs
@@ -178,13 +178,9 @@ fn class_fqn(
     }
 }
 
-/// The module name with a trailing `.`, or empty for the unknown module; prefixed to symbol FQNs.
+/// The module name with a trailing `.`, prefixed to symbol FQNs.
 fn module_prefix(module: &Module) -> String {
-    if module.name() != ModuleName::unknown() {
-        format!("{}.", module.name())
-    } else {
-        String::new()
-    }
+    format!("{}.", module.name())
 }
 
 /// Merge overloads with the same qualified name into one entry,
@@ -2873,6 +2869,75 @@ def g(x: int) -> int:
         assert_eq!(report.symbols.n_method_params, 2);
         assert_eq!(report.symbols.n_classes, 1);
         assert_eq!(report.symbols.n_attrs, 0);
+    }
+
+    /// A config-less file whose path can't form a valid module name falls back to
+    /// `__unknown__`. Its symbol FQNs must carry the `__unknown__.` prefix, or
+    /// `--public-only` filtering (which rebuilds that prefix from the report name)
+    /// drops every symbol and reports "0 of N typable".
+    #[test]
+    fn test_unknown_module_public_only_keeps_symbols() {
+        let code = "def bar() -> int:\n    return 1\n";
+        let (state, handle_fn) = TestEnv::one_with_path("__unknown__", "__unknown__.py", code)
+            .with_default_require_level(Require::Everything)
+            .to_state();
+        let handle = handle_fn("__unknown__");
+        assert_eq!(handle.module(), ModuleName::unknown());
+
+        let transaction = state.transaction();
+        let symbols = ModuleSymbols::collect(&transaction, &handle, false).unwrap();
+        // The bug lives in symbol construction: FQNs must be prefixed with the module name.
+        assert_eq!(symbols.functions[0].name, "__unknown__.bar");
+
+        let (public_fqns, _) = compute_public_fqns(std::slice::from_ref(&handle), &transaction);
+        let mut report = build_module_report(
+            "__unknown__".to_owned(),
+            "__unknown__.py".to_owned(),
+            "__unknown__",
+            symbols.line_count(),
+            &symbols.functions,
+            &symbols.variables,
+            &symbols.classes,
+            symbols.suppressions,
+        );
+        filter_module_report_to_public(&mut report, &public_fqns);
+
+        assert!(
+            report.names.iter().any(|n| n == "__unknown__.bar"),
+            "public symbols in an __unknown__ module must survive --public-only filtering"
+        );
+    }
+
+    /// The `check`/untyped-error path (`collect_untyped_errors`) is the *other*
+    /// `--public-only` consumer: it rebuilds the `__unknown__.` prefix and matches
+    /// it against symbol FQNs. With bare FQNs an untyped public symbol in an
+    /// `__unknown__` module is silently never flagged, so the fix must reach this
+    /// path too — not just the report filter above.
+    #[test]
+    fn test_unknown_module_public_only_flags_untyped() {
+        let code = "def bar(x):\n    return x\n";
+        let (state, handle_fn) = TestEnv::one_with_path("__unknown__", "__unknown__.py", code)
+            .with_default_require_level(Require::Everything)
+            .to_state();
+        let handle = handle_fn("__unknown__");
+        let transaction = state.transaction();
+        let symbols = ModuleSymbols::collect(&transaction, &handle, false).unwrap();
+
+        let (public_fqns, _) = compute_public_fqns(std::slice::from_ref(&handle), &transaction);
+        let mut errors = Vec::new();
+        collect_untyped_errors(
+            &mut errors,
+            &symbols.module,
+            &symbols.functions,
+            &symbols.variables,
+            false,
+            Some(&public_fqns),
+        );
+
+        assert!(
+            !errors.is_empty(),
+            "an untyped public symbol in an __unknown__ module must be flagged under --public-only"
+        );
     }
 
     #[test]

--- a/pyrefly/lib/lsp/non_wasm/module_helpers.rs
+++ b/pyrefly/lib/lsp/non_wasm/module_helpers.rs
@@ -62,9 +62,7 @@ pub(crate) fn handle_from_module_path(state: &State, path: ModulePath) -> Handle
                 .unwrap_or(unknown);
             Handle::new(module_name, path, config.get_sys_info())
         }
-        _ => {
-            config.handle_from_module_path_with_fallback(path.dupe(), &config.fallback_search_path)
-        }
+        _ => config.handle_from_module_path(path.dupe()),
     }
 }
 


### PR DESCRIPTION
Summary:

Make coverage's `module_prefix()` unconditional so `__unknown__` fallback modules get the `__unknown__.` prefix like every other module.

Why: under `--public-only`, these files silently reported "0 of N typable" — symbols were stored bare while the public-FQN filter expects the prefixed form, so all got dropped.

Reviewed By: yangdanny97

Differential Revision: D112166629
