### PR TITLE
solve generic function converters against the field type

### DIFF
--- a/pyrefly/lib/alt/class/dataclass.rs
+++ b/pyrefly/lib/alt/class/dataclass.rs
@@ -59,6 +59,7 @@ use crate::types::keywords::ConverterMap;
 use crate::types::keywords::DataclassFieldKeywords;
 use crate::types::keywords::TypeMap;
 use crate::types::literal::Lit;
+use crate::types::types::Forallable;
 use crate::types::types::Type;
 
 /// Which constructor-copy builtin `call_dataclasses_replace` is serving. Chosen by the caller so the
@@ -989,6 +990,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Type {
         let solved = match (converter, annotated_field_ty) {
             (Type::ClassDef(cls), Some(hint)) => self.solve_generic_class_converter(cls, hint),
+            (Type::Forall(_), Some(hint)) => self.solve_generic_function_converter(converter, hint),
             _ => None,
         };
         let converter = solved.as_ref().unwrap_or(converter);
@@ -1031,6 +1033,27 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // is best-effort param inference with no call site to report them against.
         let _ = self.finish_quantified(vs, self.solver().infer_with_first_use);
         matched.then(|| self.heap.mk_type(self.heap.mk_class_type(class_type)))
+    }
+
+    /// A generic function converter is solved by constraining its return type against the declared
+    /// field `hint`, so the `__init__` param is the solved input, not a leaked type variable.
+    fn solve_generic_function_converter(&self, converter: &Type, hint: &Type) -> Option<Type> {
+        let Type::Forall(forall) = converter else {
+            return None;
+        };
+        if !matches!(forall.body, Forallable::Function(_)) {
+            return None;
+        }
+        let (vs, instantiated) = self.solver().fresh_quantified(
+            &forall.tparams,
+            forall.body.clone().as_type(),
+            self.uniques,
+        );
+        if let Some(ret) = instantiated.callable_return_type(self.heap) {
+            self.is_subset_eq(&ret, hint);
+        }
+        let _ = self.finish_quantified(vs, self.solver().infer_with_first_use);
+        Some(self.solver().expand(instantiated))
     }
 
     fn get_default(&self, map: &TypeMap) -> Option<Type> {

--- a/pyrefly/lib/test/attrs/fields.rs
+++ b/pyrefly/lib/test/attrs/fields.rs
@@ -287,6 +287,85 @@ Sub(["1", 2, 3])  # E: not assignable to parameter `a` with type `Iterable[int]`
 "#,
 );
 
+// A generic function converter (`def identity[T](x: T) -> T`) is type-preserving, so solving its
+// return against the `int` annotation gives an `__init__` param of `int` rather than a leaked `T`.
+attrs_testcase!(
+    test_attrs_field_generic_function_converter,
+    r#"
+from typing import assert_type, reveal_type
+from attrs import define, field
+
+def identity[T](x: T) -> T:
+    return x
+
+@define
+class C:
+    x: int = field(converter=identity)
+
+reveal_type(C.__init__)  # E: revealed type: (self: C, x: int) -> None
+assert_type(C(42).x, int)
+C("nope")  # E: not assignable to parameter `x`
+"#,
+);
+
+// A stdlib generic function converter is solved the same way, so its input is the field type
+// instead of a leaked type variable.
+attrs_testcase!(
+    test_attrs_field_deepcopy_converter,
+    r#"
+import copy
+from attrs import define, field
+
+@define
+class C:
+    x: int = field(converter=copy.deepcopy)
+
+C(42)     # OK
+C("no")   # E: not assignable to parameter `x`
+"#,
+);
+
+// A type argument is substituted into nested positions of the converter input, so a
+// `(list[T]) -> list[T]` converter against a `list[int]` field gives a `list[int]` param.
+attrs_testcase!(
+    test_attrs_field_generic_function_converter_nested_typevar,
+    r#"
+from attrs import define, field
+
+def clone_all[T](xs: list[T]) -> list[T]:
+    return list(xs)
+
+@define
+class C:
+    xs: list[int] = field(converter=clone_all)
+
+C([1, 2])   # OK
+C(["a"])    # E: not assignable to parameter `xs`
+"#,
+);
+
+// The solved generic-function converter input carries over to a field inherited from a base class.
+attrs_testcase!(
+    test_attrs_field_generic_function_converter_inherited,
+    r#"
+from attrs import define, field
+
+def identity[T](x: T) -> T:
+    return x
+
+@define
+class Base:
+    x: int = field(converter=identity)
+
+@define
+class Sub(Base):
+    pass
+
+Sub(5)       # OK
+Sub("nope")  # E: not assignable to parameter `x`
+"#,
+);
+
 // `attr.converters.optional(c)` makes the `__init__` param the inner converter's input type
 // unioned with `None`.
 attrs_testcase!(


### PR DESCRIPTION
Summary:
Goal: A generic function used as an attrs converter, such as copy.deepcopy, no longer produces a spurious error when you construct the class.

Background: attrs lets a field declare a converter that transforms the constructor argument before it is stored, and pyrefly types the generated `__init__` parameter as the converter's input type. When the converter is a generic function like, whose type is `(_T) -> _T`, that input is a bare type variable `_T` that escapes its function scope, so every argument was rejected with a message about a parameter of type `_T`. 

How: We add a parallel arm that recognizes a generic function converter and solves it the same way the class path does, by instantiating the function with fresh variables, constraining its return type against the declared field type, and reading back the solved input as the `__init__` parameter. A variable that cannot be solved is finalized to a gradual type so uncertain cases fall back instead of erroring.

fixes https://github.com/facebook/pyrefly/issues/4155

Differential Revision: D112165450


