### PR TITLE
Fix first auto-import completion for unloaded modules

### DIFF
--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -706,7 +706,7 @@ impl Transaction<'_> {
                 });
             }
 
-            for module_name in self.search_modules_fuzzy(identifier_text) {
+            for module_name in self.search_modules_fuzzy(handle, identifier_text) {
                 if module_name == handle.module() {
                     continue;
                 }

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -2969,11 +2969,15 @@ impl<'a> Transaction<'a> {
         .map(|item| TextRangeWithModule::new(item.module, item.definition_range))
     }
 
-    pub(crate) fn search_modules_fuzzy(&self, pattern: &str) -> Vec<ModuleName> {
+    pub(crate) fn search_modules_fuzzy(&self, handle: &Handle, pattern: &str) -> Vec<ModuleName> {
         let matcher = SkimMatcherV2::default().smart_case();
         let mut results = Vec::new();
+        // `self.modules()` only contains modules that have already been loaded. Include modules
+        // discoverable from the active file's import paths so auto-import works on the first try.
+        let mut module_names: HashSet<_> = self.modules().into_iter().collect();
+        module_names.extend(self.import_prefixes(handle, ModuleName::from_str(pattern)));
 
-        for module_name in self.modules() {
+        for module_name in module_names {
             let module_name_str = module_name.as_str();
 
             // Skip builtins module
@@ -3064,7 +3068,7 @@ impl<'a> Transaction<'a> {
                         &mut import_actions,
                         unknown_name,
                     );
-                    for module_name in self.search_modules_fuzzy(unknown_name) {
+                    for module_name in self.search_modules_fuzzy(handle, unknown_name) {
                         if module_name == handle.module() {
                             continue;
                         }

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -2527,6 +2527,41 @@ jso
 }
 
 #[test]
+fn autoimport_suggests_unloaded_stdlib_module() {
+    let code = r#"
+jso
+#  ^
+"#;
+    let mut env = TestEnv::new().with_default_require_level(Require::Exports);
+    env.add("main", code);
+    let (state, handle_for) = env.to_state();
+    let handle = handle_for("main");
+    let position = extract_cursors_for_test(code)[0];
+
+    let completions =
+        state
+            .transaction()
+            .completion(&handle, position, ImportFormat::Absolute, true, None);
+    let json = completions
+        .iter()
+        .find(|item| item.label == "json")
+        .expect("expected an auto-import completion for the unloaded json module");
+    assert!(
+        json.detail
+            .as_ref()
+            .is_some_and(|detail| detail.contains("import json")),
+        "expected json completion to add an import, got {:?}",
+        json.detail
+    );
+    assert!(
+        json.additional_text_edits
+            .as_ref()
+            .is_some_and(|edits| !edits.is_empty()),
+        "expected json completion to include an import edit"
+    );
+}
+
+#[test]
 fn autoimport_does_not_duplicate_existing_module_import_after_another_import() {
     let code = r#"
 import os


### PR DESCRIPTION
## Summary

- include modules discoverable from the active file's import paths in fuzzy module auto-import completion
- deduplicate discoverable modules with modules already loaded in the transaction
- add a regression test for completing `json` before the module has been imported or loaded

## Root cause

Module auto-import completion only searched `Transaction::modules()`, which contains modules already loaded into state. A standard-library or site-package module therefore appeared only after an explicit import caused it to be loaded. The existing import-prefix resolver already discovers matching modules from the active config's search paths and typeshed, so the fix merges those candidates into the fuzzy search.

## Testing

- `cargo test -p pyrefly autoimport --lib` (15 passed)
- `cargo fmt -p pyrefly -- --check`
- `python test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema` (run with Python 3.11 and the GNU Rust toolchain on Windows)

Fixes #4108

This contribution was prepared by an AI coding agent (Codex) working through the contributor's account.