### PR TITLE
fix(stubgen): regenerate type_checking_or_guard snapshot for Literal import

### DIFF
--- a/pyrefly/lib/test/stubgen/type_checking_or_guard/expected.pyi
+++ b/pyrefly/lib/test/stubgen/type_checking_or_guard/expected.pyi
@@ -1,4 +1,6 @@
 # @generated
+from typing import Literal
+
 from typing import TYPE_CHECKING
 
 USE_EXTENSIONS: Literal[True] = True


### PR DESCRIPTION
## Problem
`stubgen::tests::test_stubgen_type_checking_or_guard` panics on `main`. The `type_checking_or_guard` snapshot referenced `Literal[True]` **without importing `Literal`** (an invalid stub). Once #4144 made stubgen emit `from typing import Literal` when it adds a `Literal[...]` annotation, this fixture went stale and the snapshot assertion started failing.

## Fix
Regenerate the `type_checking_or_guard` `expected.pyi` to include the now-emitted `from typing import Literal`, keeping the `# @generated` header used by the other fixtures. This is a pure test-fixture update — no stubgen logic change.

## Testing
`cargo test --lib -p pyrefly stubgen::` → all 24 stubgen tests pass (was 1 failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)