### PR TITLE
fix find-references sometimes does go-to-def #2574

### DIFF
--- a/pyrefly/lib/state/ide.rs
+++ b/pyrefly/lib/state/ide.rs
@@ -41,7 +41,8 @@ const KEY_TO_DEFINITION_INITIAL_GAS: Gas = Gas::new(100);
 pub enum IntermediateDefinition {
     Local(Export),
     NamedImport(TextRange, ModuleName, Name, Option<TextRange>),
-    Module(TextRange, ModuleName),
+    /// The flag records whether the module was bound to an explicit alias.
+    Module(TextRange, ModuleName, bool),
 }
 
 /// An edit that imports a single name into a module.
@@ -173,6 +174,7 @@ fn create_intermediate_definition_from(
                 return Some(IntermediateDefinition::Module(
                     def_key.range(),
                     imported_module_name,
+                    matches!(def_key, Key::Definition(..)),
                 ));
             }
             Binding::Function(idx, ..) => {

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -1673,8 +1673,13 @@ impl<'a> Transaction<'a> {
                     Some((def_handle, export))
                 }
             }
-            IntermediateDefinition::Module(import_range, name) => {
-                if matches!(preference.import_behavior, ImportBehavior::StopAtEverything) {
+            IntermediateDefinition::Module(import_range, name, is_renamed_import) => {
+                if matches!(preference.import_behavior, ImportBehavior::StopAtEverything)
+                    || matches!(
+                        preference.import_behavior,
+                        ImportBehavior::StopAtRenamedImports if is_renamed_import
+                    )
+                {
                     return Some((
                         handle.dupe(),
                         Export {

--- a/pyrefly/lib/test/lsp/definition.rs
+++ b/pyrefly/lib/test/lsp/definition.rs
@@ -838,14 +838,14 @@ Definition Result:
 4 | import import_provider as ip
                               ^
 Definition Result:
-1 | 
-    ^
+4 | import import_provider as ip
+                              ^^
 
 7 | def f(x: ip.Foo, y: F):
              ^
 Definition Result:
-1 | 
-    ^
+4 | import import_provider as ip
+                              ^^
 
 7 | def f(x: ip.Foo, y: F):
                         ^

--- a/pyrefly/lib/test/lsp/local_find_refs.rs
+++ b/pyrefly/lib/test/lsp/local_find_refs.rs
@@ -97,6 +97,72 @@ References:
 }
 
 #[test]
+fn references_to_aliased_submodule_stop_at_import() {
+    let main = r#"
+from xxx import yyy as zzz
+#                      ^
+
+zzz.f()
+"#;
+    let report = get_batched_lsp_operations_report(
+        &[("main", main), ("xxx", ""), ("xxx.yyy", "def f(): ...\n")],
+        |state, handle, position| get_test_report(state, handle, position, true),
+    );
+    assert_eq!(
+        r#"
+# main.py
+2 | from xxx import yyy as zzz
+                           ^
+References:
+2 | from xxx import yyy as zzz
+                           ^^^
+5 | zzz.f()
+    ^^^
+
+
+# xxx.py
+
+# xxx.yyy.py
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
+fn references_to_aliased_module_stop_at_import() {
+    let main = r#"
+import xxx.yyy as zzz
+#                 ^
+
+zzz.f()
+"#;
+    let report = get_batched_lsp_operations_report(
+        &[("main", main), ("xxx", ""), ("xxx.yyy", "def f(): ...\n")],
+        |state, handle, position| get_test_report(state, handle, position, true),
+    );
+    assert_eq!(
+        r#"
+# main.py
+2 | import xxx.yyy as zzz
+                      ^
+References:
+2 | import xxx.yyy as zzz
+                      ^^^
+5 | zzz.f()
+    ^^^
+
+
+# xxx.py
+
+# xxx.yyy.py
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn pytest_fixture_references_include_injected_parameters() {
     let code = r#"
 import pytest  # type: ignore


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2574

Module bindings now retain whether they use an explicit alias.
Find-references stops at renamed module imports instead of navigating into the imported module.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added regression coverage for both from x import y as z and import x.y as z.
