### PR TITLE
Add test for NotIterable error in starred tuple unpacking (#4189)

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1316,7 +1316,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                     format!("Expected an iterable, got `{}`", self.for_display(ty)),
                                 );
                                 encountered_invalid_star = true;
-                                hint_ts_iter.nth(usize::MAX); // TODO: missing test
+                                hint_ts_iter.nth(usize::MAX);
                             }
                         }
                     }

--- a/pyrefly/lib/test/tuple.rs
+++ b/pyrefly/lib/test/tuple.rs
@@ -161,6 +161,15 @@ def test(y: int):
 );
 
 testcase!(
+    test_unpack_starred_not_iterable_in_tuple,
+    r#"
+def test():
+    x: int = 42
+    y = (*x,)  # E: Expected an iterable, got `int`
+"#,
+);
+
+testcase!(
     test_unpack_index_out_of_bounds,
     r#"
 def test(x: tuple[int]) -> None:


### PR DESCRIPTION
Summary:

The error path in `expr.rs` that reports `Expected an iterable, got ...`
when a non-iterable type is used with star (`*`) unpacking in a tuple
display (e.g. `(*x,)`) carried a `// TODO: missing test` marker and had no
dedicated test coverage.

This adds `test_unpack_starred_not_iterable_in_tuple`, which unpacks an `int`
into a tuple display and expects the `NotIterable` error, and removes the
now-resolved TODO comment.

Differential Revision: D112538198


