### PR TITLE
fix panic: Key Anon already exists with value ClassDef w/ NamedTuple and with #4177

### DIFF
--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -902,6 +902,8 @@ pub enum Key {
     StmtExpr(TextRange),
     /// I am an expression that appears in a `with` context.
     ContextExpr(TextRange),
+    /// I am the context manager value for a `with` item without an assignment target.
+    ContextValue(TextRange),
     /// I am the result of joining several branches.
     Phi(Box<(Name, TextRange)>),
     /// I am the result of narrowing a type. The two ranges are the range at which the operation is
@@ -960,6 +962,7 @@ impl Ranged for Key {
             Self::InvalidTarget(r) => *r,
             Self::StmtExpr(r) => *r,
             Self::ContextExpr(r) => *r,
+            Self::ContextValue(r) => *r,
             Self::Phi(x) => x.1,
             Self::Narrow(x) => x.1,
             Self::Anywhere(x) => x.1,
@@ -990,6 +993,7 @@ impl DisplayWith<ModuleInfo> for Key {
             Self::InvalidTarget(r) => write!(f, "Key::InvalidTarget({})", ctx.display(r)),
             Self::StmtExpr(r) => write!(f, "Key::StmtExpr({})", ctx.display(r)),
             Self::ContextExpr(r) => write!(f, "Key::ContextExpr({})", ctx.display(r)),
+            Self::ContextValue(r) => write!(f, "Key::ContextValue({})", ctx.display(r)),
             Self::Phi(x) => write!(f, "Key::Phi({} {})", x.0, ctx.display(&x.1)),
             Self::Narrow(x) => {
                 write!(

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -1368,7 +1368,7 @@ impl<'a> BindingsBuilder<'a> {
                         self.bind_target_no_expr(&mut opts, &make_binding);
                     } else {
                         self.insert_binding(
-                            Key::Anon(item_range),
+                            Key::ContextValue(item_range),
                             Binding::ContextValue(None, context_idx, expr_range, kind),
                         );
                     }

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -739,6 +739,18 @@ fn test_named_tuple_in_malformed_for_target() {
     );
 }
 
+// Regression test for https://github.com/facebook/pyrefly/issues/4177
+#[test]
+fn test_named_tuple_in_malformed_with_item() {
+    // Keep the malformed source exact: adding inline expectations changes the unterminated string.
+    let _ = testcase_for_macro(
+        TestEnv::new(),
+        "from typing import NamedTuple\n\nwith NamedTuple('\n",
+        file!(),
+        line!(),
+    );
+}
+
 testcase!(
     test_named_tuple_dynamic_fields,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4177

Added a role-specific Key::ContextValue to prevent collisions with synthesized NamedTuple class bindings in malformed with statements, and updated with binding handling.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test