### PR TITLE
fix Type Narrowing Depends on Order of Keyword Arguments #4187

### DIFF
--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -1791,6 +1791,10 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
             // Therefore try these quantified cases, but only pick them if they work.
             (Type::Quantified(q), u)
                 if let Restriction::Bound(bound) = q.restriction()
+                    // A bare inference variable can preserve the quantified type itself. Expanding
+                    // it to its bound here would make inference depend on which argument is checked
+                    // first (https://github.com/facebook/pyrefly/issues/4187).
+                    && !matches!(u, Type::Union(union) if union.members.iter().any(|t| matches!(t, Type::Var(_))))
                     && self
                         .solver
                         .with_snapshot(&u.collect_maybe_placeholder_vars(), || {

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -1815,6 +1815,10 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
             // Therefore try these quantified cases, but only pick them if they work.
             (Type::Quantified(q), u)
                 if let Restriction::Bound(bound) = q.restriction()
+                    // A bare inference variable can preserve the quantified type itself. Expanding
+                    // it to its bound here would make inference depend on which argument is checked
+                    // first (https://github.com/facebook/pyrefly/issues/4187).
+                    && !matches!(u, Type::Union(union) if union.members.iter().any(|t| matches!(t, Type::Var(_))))
                     && self
                         .solver
                         .with_snapshot(&u.collect_maybe_placeholder_vars(), || {

--- a/pyrefly/lib/test/generic_basic.rs
+++ b/pyrefly/lib/test/generic_basic.rs
@@ -705,6 +705,30 @@ assert_type(bad(Sub), Sub)
 "#,
 );
 
+// Regression test for https://github.com/facebook/pyrefly/issues/4187
+testcase!(
+    test_generic_keyword_inference_is_order_independent,
+    r#"
+class P: ...
+
+class Controller[T: P]:
+    value: T
+
+def target[T: P](
+    value: T | None = None,
+    *,
+    controller: Controller[T] | None = None,
+) -> None: ...
+
+def caller[T: P](
+    value: T | None,
+    controller: Controller[T] | None,
+) -> None:
+    target(value=value, controller=controller)
+    target(controller=controller, value=value)
+"#,
+);
+
 testcase!(
     test_generic_alias_fields,
     r#"

--- a/pyrefly/lib/test/generic_basic.rs
+++ b/pyrefly/lib/test/generic_basic.rs
@@ -705,6 +705,30 @@ assert_type(bad(Sub), Sub)
 "#,
 );
 
+// Regression test for https://github.com/facebook/pyrefly/issues/4187
+testcase!(
+    test_generic_keyword_inference_is_order_independent,
+    r#"
+class P: ...
+
+class Controller[T: P]:
+    value: T
+
+def target[T: P](
+    value: T | None = None,
+    *,
+    controller: Controller[T] | None = None,
+) -> None: ...
+
+def caller[T: P](
+    value: T | None,
+    controller: Controller[T] | None,
+) -> None:
+    target(value=value, controller=controller)
+    target(controller=controller, value=value)
+"#,
+);
+
 testcase!(
     test_typevar_union_with_type_of_specialized_generic_alias,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4187

Updated subtype inference to preserve quantified types when a union contains a bare inference variable, preventing argument-order-dependent widening to the TypeVar bound.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test