### PR TITLE
feat(suppress): support removal of `# type: ignore` suppressions with `pyrefly suppress --remove-unused`

### DIFF
--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -77,6 +77,7 @@ use crate::error::summarize::print_error_summary;
 use crate::error::suppress;
 use crate::error::suppress::CommentLocation;
 use crate::error::suppress::SerializedError;
+use crate::error::suppress::UnusedIgnoreKind;
 use crate::module::typeshed::stdlib_search_path;
 use crate::report;
 use crate::state::load::FileContents;
@@ -232,8 +233,7 @@ impl SnippetCheckArgs {
                 check_all: false,
                 suppress_errors: false,
                 expectations: false,
-                remove_unused_ignores: false,
-                remove_unused_type_ignores: false,
+                remove_unused_ignores: None,
             },
         };
         let (status, check_result) =
@@ -418,12 +418,17 @@ struct BehaviorArgs {
     /// Check against any `E:` lines in the file.
     #[arg(long)]
     expectations: bool,
-    /// Remove unused ignores from the input files.
-    #[arg(long)]
-    remove_unused_ignores: bool,
-    /// Remove unused `# type: ignore` comments in addition to unused Pyrefly ignores.
-    #[arg(long)]
-    remove_unused_type_ignores: bool,
+    /// Remove unused ignores from the input files, optionally selecting `pyrefly`, `type`, or `all`.
+    /// Defaults to `pyrefly` when no kind is specified.
+    #[arg(
+        long,
+        value_enum,
+        value_name = "KIND",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "pyrefly"
+    )]
+    remove_unused_ignores: Option<UnusedIgnoreKind>,
 }
 
 fn write_errors_to_file(
@@ -1319,14 +1324,11 @@ impl CheckArgs {
                 .collect();
             suppress::suppress_errors(serialized_errors, CommentLocation::LineBefore);
         }
-        if self.behavior.remove_unused_ignores || self.behavior.remove_unused_type_ignores {
+        if let Some(kind) = self.behavior.remove_unused_ignores {
             // TODO: Deprecate this in favor of `pyrefly suppress`
             let collected = loads.collect_errors();
             let unused_errors = loads.collect_unused_ignore_errors(&collected);
-            suppress::remove_unused_ignores(
-                unused_errors,
-                self.behavior.remove_unused_type_ignores,
-            );
+            suppress::remove_unused_ignores(unused_errors, kind);
         }
 
         // We update the baseline file if requested, after reporting any new
@@ -1707,6 +1709,35 @@ mod tests {
         output.inherit_defaults_from_config(&config);
 
         assert_eq!(output.output_format(), OutputFormat::Json);
+    }
+
+    #[test]
+    fn remove_unused_ignores_cli_values() {
+        for (argument, expected) in [
+            (None, None),
+            (
+                Some("--remove-unused-ignores"),
+                Some(UnusedIgnoreKind::Pyrefly),
+            ),
+            (
+                Some("--remove-unused-ignores=pyrefly"),
+                Some(UnusedIgnoreKind::Pyrefly),
+            ),
+            (
+                Some("--remove-unused-ignores=type"),
+                Some(UnusedIgnoreKind::Type),
+            ),
+            (
+                Some("--remove-unused-ignores=all"),
+                Some(UnusedIgnoreKind::All),
+            ),
+        ] {
+            let args = argument.map_or_else(
+                || CheckArgs::parse_from(["check"]),
+                |argument| CheckArgs::parse_from(["check", argument]),
+            );
+            assert_eq!(args.behavior.remove_unused_ignores, expected);
+        }
     }
 
     fn upsell_string(reason: SynthesizedPresetReason) -> String {

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -233,6 +233,7 @@ impl SnippetCheckArgs {
                 suppress_errors: false,
                 expectations: false,
                 remove_unused_ignores: false,
+                remove_unused_type_ignores: false,
             },
         };
         let (status, check_result) =
@@ -420,6 +421,9 @@ struct BehaviorArgs {
     /// Remove unused ignores from the input files.
     #[arg(long)]
     remove_unused_ignores: bool,
+    /// Remove unused `# type: ignore` comments in addition to unused Pyrefly ignores.
+    #[arg(long)]
+    remove_unused_type_ignores: bool,
 }
 
 fn write_errors_to_file(
@@ -1315,11 +1319,14 @@ impl CheckArgs {
                 .collect();
             suppress::suppress_errors(serialized_errors, CommentLocation::LineBefore);
         }
-        if self.behavior.remove_unused_ignores {
+        if self.behavior.remove_unused_ignores || self.behavior.remove_unused_type_ignores {
             // TODO: Deprecate this in favor of `pyrefly suppress`
             let collected = loads.collect_errors();
             let unused_errors = loads.collect_unused_ignore_errors(&collected);
-            suppress::remove_unused_ignores(unused_errors);
+            suppress::remove_unused_ignores(
+                unused_errors,
+                self.behavior.remove_unused_type_ignores,
+            );
         }
 
         // We update the baseline file if requested, after reporting any new

--- a/pyrefly/lib/commands/suppress.rs
+++ b/pyrefly/lib/commands/suppress.rs
@@ -18,6 +18,7 @@ use crate::commands::util::CommandExitStatus;
 use crate::error::suppress;
 use crate::error::suppress::CommentLocation;
 use crate::error::suppress::SerializedError;
+use crate::error::suppress::UnusedIgnoreKind;
 
 /// Suppress type errors by adding ignore comments to source files.
 #[derive(Clone, Debug, Parser)]
@@ -35,13 +36,17 @@ pub struct SuppressArgs {
     #[arg(long)]
     json: Option<PathBuf>,
 
-    /// Remove unused ignore comments instead of adding suppressions.
-    #[arg(long)]
-    remove_unused: bool,
-
-    /// Remove unused `# type: ignore` comments in addition to unused Pyrefly ignores.
-    #[arg(long)]
-    remove_unused_type_ignores: bool,
+    /// Remove unused ignores instead of adding suppressions, optionally selecting `pyrefly`, `type`, or `all`.
+    /// Defaults to `pyrefly` when no kind is specified.
+    #[arg(
+        long,
+        value_enum,
+        value_name = "KIND",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "pyrefly"
+    )]
+    remove_unused: Option<UnusedIgnoreKind>,
 
     /// Where to place suppression comments: on the line before the error
     /// (`line-before`, the default) or on the same line (`same-line`).
@@ -55,7 +60,7 @@ impl SuppressArgs {
         wrapper: Option<ConfigConfigurerWrapper>,
         thread_count: ThreadCount,
     ) -> anyhow::Result<CommandExitStatus> {
-        if self.remove_unused || self.remove_unused_type_ignores {
+        if let Some(kind) = self.remove_unused {
             // Remove unused ignores mode
             let unused_errors: Vec<SerializedError> = if let Some(json_path) = &self.json {
                 // Parse errors from JSON file, filtering for unused suppression errors only.
@@ -64,12 +69,12 @@ impl SuppressArgs {
                 errors
                     .into_iter()
                     .filter(|e| {
-                        e.is_unused_ignore()
-                            || (self.remove_unused_type_ignores && e.is_unused_type_ignore())
+                        kind.includes_pyrefly_or_pyre() && e.is_unused_ignore()
+                            || kind.includes_type() && e.is_unused_type_ignore()
                     })
                     .collect()
             } else {
-                // Delegate to `check --remove-unused-[type-]ignores`, which
+                // Delegate to `check --remove-unused-ignores`, which
                 // collects unused ignore errors directly (bypassing severity
                 // filtering) and handles removal in one step.
                 self.config_override.validate()?;
@@ -78,10 +83,10 @@ impl SuppressArgs {
                     .clone()
                     .resolve(self.config_override.clone(), wrapper.clone())?;
 
-                let remove_unused_flag = if self.remove_unused_type_ignores {
-                    "--remove-unused-type-ignores"
-                } else {
-                    "--remove-unused-ignores"
+                let remove_unused_flag = match kind {
+                    UnusedIgnoreKind::Pyrefly => "--remove-unused-ignores=pyrefly",
+                    UnusedIgnoreKind::Type => "--remove-unused-ignores=type",
+                    UnusedIgnoreKind::All => "--remove-unused-ignores=all",
                 };
                 let check_args = CheckArgs::parse_from([
                     "check",
@@ -94,10 +99,7 @@ impl SuppressArgs {
             };
 
             // Remove unused ignores (JSON path only)
-            suppress::remove_unused_ignores_from_serialized(
-                unused_errors,
-                self.remove_unused_type_ignores,
-            );
+            suppress::remove_unused_ignores_from_serialized(unused_errors, kind);
         } else {
             // Add suppressions mode (existing behavior)
             let serialized_errors: Vec<SerializedError> = if let Some(json_path) = &self.json {
@@ -135,5 +137,30 @@ impl SuppressArgs {
         }
 
         Ok(CommandExitStatus::Success)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remove_unused_cli_values() {
+        for (argument, expected) in [
+            (None, None),
+            (Some("--remove-unused"), Some(UnusedIgnoreKind::Pyrefly)),
+            (
+                Some("--remove-unused=pyrefly"),
+                Some(UnusedIgnoreKind::Pyrefly),
+            ),
+            (Some("--remove-unused=type"), Some(UnusedIgnoreKind::Type)),
+            (Some("--remove-unused=all"), Some(UnusedIgnoreKind::All)),
+        ] {
+            let args = argument.map_or_else(
+                || SuppressArgs::parse_from(["suppress"]),
+                |argument| SuppressArgs::parse_from(["suppress", argument]),
+            );
+            assert_eq!(args.remove_unused, expected);
+        }
     }
 }

--- a/pyrefly/lib/commands/suppress.rs
+++ b/pyrefly/lib/commands/suppress.rs
@@ -39,6 +39,10 @@ pub struct SuppressArgs {
     #[arg(long)]
     remove_unused: bool,
 
+    /// Remove unused `# type: ignore` comments in addition to unused Pyrefly ignores.
+    #[arg(long)]
+    remove_unused_type_ignores: bool,
+
     /// Where to place suppression comments: on the line before the error
     /// (`line-before`, the default) or on the same line (`same-line`).
     #[arg(long, default_value = "line-before")]
@@ -51,19 +55,22 @@ impl SuppressArgs {
         wrapper: Option<ConfigConfigurerWrapper>,
         thread_count: ThreadCount,
     ) -> anyhow::Result<CommandExitStatus> {
-        if self.remove_unused {
+        if self.remove_unused || self.remove_unused_type_ignores {
             // Remove unused ignores mode
             let unused_errors: Vec<SerializedError> = if let Some(json_path) = &self.json {
-                // Parse errors from JSON file, filtering for UnusedIgnore errors only
+                // Parse errors from JSON file, filtering for unused suppression errors only.
                 let json_content = std::fs::read_to_string(json_path)?;
                 let errors: Vec<SerializedError> = serde_json::from_str(&json_content)?;
                 errors
                     .into_iter()
-                    .filter(|e| e.is_unused_ignore())
+                    .filter(|e| {
+                        e.is_unused_ignore()
+                            || (self.remove_unused_type_ignores && e.is_unused_type_ignore())
+                    })
                     .collect()
             } else {
-                // Delegate to `check --remove-unused-ignores`, which calls
-                // collect_unused_ignore_errors directly (bypassing severity
+                // Delegate to `check --remove-unused-[type-]ignores`, which
+                // collects unused ignore errors directly (bypassing severity
                 // filtering) and handles removal in one step.
                 self.config_override.validate()?;
                 let (files_to_check, config_finder, upsell) = self
@@ -71,18 +78,26 @@ impl SuppressArgs {
                     .clone()
                     .resolve(self.config_override.clone(), wrapper.clone())?;
 
+                let remove_unused_flag = if self.remove_unused_type_ignores {
+                    "--remove-unused-type-ignores"
+                } else {
+                    "--remove-unused-ignores"
+                };
                 let check_args = CheckArgs::parse_from([
                     "check",
                     "--output-format",
                     "omit-errors",
-                    "--remove-unused-ignores",
+                    remove_unused_flag,
                 ]);
                 check_args.run_once(files_to_check, config_finder, upsell, thread_count)?;
                 return Ok(CommandExitStatus::Success);
             };
 
             // Remove unused ignores (JSON path only)
-            suppress::remove_unused_ignores_from_serialized(unused_errors);
+            suppress::remove_unused_ignores_from_serialized(
+                unused_errors,
+                self.remove_unused_type_ignores,
+            );
         } else {
             // Add suppressions mode (existing behavior)
             let serialized_errors: Vec<SerializedError> = if let Some(json_path) = &self.json {

--- a/pyrefly/lib/error/suppress.rs
+++ b/pyrefly/lib/error/suppress.rs
@@ -38,13 +38,17 @@ use crate::state::errors::sorted_backslash_continuation_ranges;
 use crate::state::errors::sorted_bracketed_continuation_ranges;
 use crate::state::errors::sorted_multi_line_string_ranges;
 
-/// Regex to match pyrefly/type/pyre ignore comments with optional error codes and trailing text.
-/// Consumes all non-`#` characters after the ignore pattern, so trailing comment text is
-/// removed, but a separate `# ...` comment is preserved
-/// (e.g., "# pyrefly: ignore [x] # other" -> "# other").
-static IGNORE_COMMENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+/// Regexes to match ignore comments with optional error codes and trailing text.
+/// Each consumes all non-`#` characters after its ignore pattern, so removing one
+/// suppression preserves any other pragma later on the same line.
+static PYREFLY_IGNORE_COMMENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"#\s*pyrefly:\s*ignore\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*").unwrap()
+});
+static TYPE_IGNORE_COMMENT_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"#\s*type:\s*ignore\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*").unwrap());
+static PYRE_IGNORE_COMMENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"#\s*pyrefly:\s*ignore\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*|#\s*type:\s*ignore\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*|#\s*pyre-(?:fixme|ignore)\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*|#\s*pyre:\s*ignore\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*",
+        r"#\s*pyre-(?:fixme|ignore)\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*|#\s*pyre:\s*ignore\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*",
     )
     .unwrap()
 });
@@ -96,6 +100,11 @@ impl SerializedError {
     /// Returns true if this error is an UnusedIgnore error.
     pub fn is_unused_ignore(&self) -> bool {
         self.name == ErrorKind::UnusedIgnore.to_name()
+    }
+
+    /// Returns true if this error is an UnusedTypeIgnore error.
+    pub fn is_unused_type_ignore(&self) -> bool {
+        self.name == ErrorKind::UnusedTypeIgnore.to_name()
     }
 
     /// Returns true if this error is a directive (e.g. reveal_type) that
@@ -519,8 +528,8 @@ fn update_ignore_comment_with_used_codes(
 
     // If there are no used codes, remove the entire comment
     if used_codes.is_empty() {
-        if IGNORE_COMMENT_REGEX.is_match(comment_part) {
-            let new_comment = IGNORE_COMMENT_REGEX.replace_all(comment_part, "");
+        if PYREFLY_IGNORE_COMMENT_REGEX.is_match(comment_part) {
+            let new_comment = PYREFLY_IGNORE_COMMENT_REGEX.replace(comment_part, "");
             let result = format!("{}{}", code_part, new_comment);
             return Some(result.trim_end().to_owned());
         }
@@ -553,20 +562,27 @@ fn update_ignore_comment_with_used_codes(
 /// Takes a list of UnusedIgnore errors (from collect_unused_ignore_errors) and uses
 /// the error location and message to determine what to remove:
 /// - "Unused `# pyrefly: ignore` comment" -> remove entire comment
+/// - "Unused `# type: ignore` comment" -> remove entire comment when opted in
 /// - "Unused `# pyrefly: ignore` comment for code(s): X, Y" -> remove entire comment
 /// - "Unused error code(s) in `# pyrefly: ignore`: X, Y" -> remove only those codes
-pub fn remove_unused_ignores(unused_ignore_errors: Vec<Error>) -> usize {
+pub fn remove_unused_ignores(
+    unused_ignore_errors: Vec<Error>,
+    remove_unused_type_ignores: bool,
+) -> usize {
     let serialized: Vec<SerializedError> = unused_ignore_errors
         .iter()
         .filter_map(SerializedError::from_error)
         .collect();
-    remove_unused_ignores_from_serialized(serialized)
+    remove_unused_ignores_from_serialized(serialized, remove_unused_type_ignores)
 }
 
 /// Removes unused ignore comments from source files using SerializedError.
 /// This is similar to remove_unused_ignores but works with SerializedError instead of Error,
 /// allowing it to be used with errors parsed from JSON.
-pub fn remove_unused_ignores_from_serialized(unused_ignore_errors: Vec<SerializedError>) -> usize {
+pub fn remove_unused_ignores_from_serialized(
+    unused_ignore_errors: Vec<SerializedError>,
+    remove_unused_type_ignores: bool,
+) -> usize {
     if unused_ignore_errors.is_empty() {
         return 0;
     }
@@ -574,6 +590,11 @@ pub fn remove_unused_ignores_from_serialized(unused_ignore_errors: Vec<Serialize
     // Group errors by file path
     let mut errors_by_path: SmallMap<PathBuf, Vec<&SerializedError>> = SmallMap::new();
     for error in &unused_ignore_errors {
+        if !(error.is_unused_ignore()
+            || remove_unused_type_ignores && error.is_unused_type_ignore())
+        {
+            continue;
+        }
         errors_by_path
             .entry(error.path.clone())
             .or_default()
@@ -583,10 +604,11 @@ pub fn remove_unused_ignores_from_serialized(unused_ignore_errors: Vec<Serialize
     let mut removed_ignores: SmallMap<PathBuf, usize> = SmallMap::new();
 
     for (path, path_errors) in &errors_by_path {
-        // Build a map from line number to the error
-        let mut line_errors: SmallMap<usize, &SerializedError> = SmallMap::new();
+        // Build a map from line number to its errors. Multiple unused suppressions
+        // may appear on the same line and must each be handled independently.
+        let mut line_errors: SmallMap<usize, Vec<&SerializedError>> = SmallMap::new();
         for error in path_errors {
-            line_errors.insert(error.line, *error);
+            line_errors.entry(error.line).or_default().push(*error);
         }
 
         if let Ok((file, _ast)) = read_and_validate_file(path) {
@@ -596,62 +618,75 @@ pub fn remove_unused_ignores_from_serialized(unused_ignore_errors: Vec<Serialize
             let mut unused_count = 0;
 
             for (idx, line) in lines.iter().enumerate() {
-                if let Some(error) = line_errors.get(&idx) {
-                    // Use string-aware comment detection instead of raw regex
-                    if let Some(comment_start) = find_comment_start_in_line(line) {
-                        let comment_part = &line[comment_start..];
-                        if IGNORE_COMMENT_REGEX.is_match(comment_part) {
-                            let msg = &error.message;
+                if let Some(errors) = line_errors.get(&idx) {
+                    let mut updated_line = (*line).to_owned();
+                    let mut line_changed = false;
 
-                            // Determine action based on error message.
-                            // Pyrefly messages start with "Unused `# pyrefly: ignore`".
-                            // Pyre messages are "Unused pyre-fixme comment".
-                            if msg.starts_with("Unused `# pyrefly: ignore` comment")
-                                || msg.starts_with("Unused pyre-fixme comment")
-                            {
-                                // Remove entire comment (blanket unused or all codes unused)
-                                let code_part = &line[..comment_start];
-                                let new_comment =
-                                    IGNORE_COMMENT_REGEX.replace_all(comment_part, "");
-                                let new_line = format!("{}{}", code_part, new_comment);
-                                let new_line = new_line.trim_end();
-                                unused_count += 1;
-                                if !new_line.is_empty() {
-                                    buf.push_str(new_line);
-                                    buf.push_str(line_ending);
-                                }
-                                continue;
-                            } else if msg.starts_with("Unused error code(s)") {
-                                // Partially unused - extract codes from message and remove only those
-                                // Message format: "Unused error code(s) in `# pyrefly: ignore`: code1, code2"
-                                if let Some(codes_part) = msg.split(": ").last() {
-                                    let unused_codes: SmallSet<String> = codes_part
-                                        .split(", ")
-                                        .map(|s| s.trim().to_owned())
+                    for error in errors {
+                        // Use string-aware comment detection instead of raw regex.
+                        let Some(comment_start) = find_comment_start_in_line(&updated_line) else {
+                            continue;
+                        };
+                        let comment_part = &updated_line[comment_start..];
+                        let msg = &error.message;
+
+                        let ignore_regex = if error.is_unused_type_ignore() {
+                            Some(&*TYPE_IGNORE_COMMENT_REGEX)
+                        } else if msg.starts_with("Unused `# pyrefly: ignore` comment") {
+                            Some(&*PYREFLY_IGNORE_COMMENT_REGEX)
+                        } else if msg.starts_with("Unused pyre-fixme comment") {
+                            Some(&*PYRE_IGNORE_COMMENT_REGEX)
+                        } else {
+                            None
+                        };
+
+                        if let Some(ignore_regex) = ignore_regex {
+                            if ignore_regex.is_match(comment_part) {
+                                let code_part = &updated_line[..comment_start];
+                                let new_comment = ignore_regex.replace(comment_part, "");
+                                updated_line = format!("{}{}", code_part, new_comment)
+                                    .trim_end()
+                                    .to_owned();
+                                line_changed = true;
+                            }
+                            continue;
+                        }
+
+                        if msg.starts_with("Unused error code(s)") {
+                            // Partially unused - extract codes from message and remove only those.
+                            // Message format: "Unused error code(s) in `# pyrefly: ignore`: code1, code2"
+                            if let Some(codes_part) = msg.split(": ").last() {
+                                let unused_codes: SmallSet<String> = codes_part
+                                    .split(", ")
+                                    .map(|s| s.trim().to_owned())
+                                    .collect();
+
+                                if let Some(existing_codes) = parse_ignore_comment(&updated_line) {
+                                    let used_codes: SmallSet<String> = existing_codes
+                                        .into_iter()
+                                        .filter(|c| !unused_codes.contains(c))
                                         .collect();
 
-                                    if let Some(existing_codes) = parse_ignore_comment(line) {
-                                        let used_codes: SmallSet<String> = existing_codes
-                                            .into_iter()
-                                            .filter(|c| !unused_codes.contains(c))
-                                            .collect();
-
-                                        if let Some(updated) = update_ignore_comment_with_used_codes(
-                                            line,
-                                            &used_codes,
-                                            &unused_codes,
-                                        ) {
-                                            unused_count += 1;
-                                            if !updated.trim().is_empty() {
-                                                buf.push_str(&updated);
-                                                buf.push_str(line_ending);
-                                            }
-                                            continue;
-                                        }
+                                    if let Some(updated) = update_ignore_comment_with_used_codes(
+                                        &updated_line,
+                                        &used_codes,
+                                        &unused_codes,
+                                    ) {
+                                        updated_line = updated;
+                                        line_changed = true;
                                     }
                                 }
                             }
                         }
+                    }
+
+                    if line_changed {
+                        unused_count += 1;
+                        if !updated_line.trim().is_empty() {
+                            buf.push_str(&updated_line);
+                            buf.push_str(line_ending);
+                        }
+                        continue;
                     }
                 }
                 buf.push_str(line);
@@ -734,7 +769,7 @@ mod tests {
         let (errors, tdir) = get_errors(before);
         let collected = errors.collect_errors();
         let unused_errors = errors.collect_unused_ignore_errors(&collected);
-        let removals = suppress::remove_unused_ignores(unused_errors);
+        let removals = suppress::remove_unused_ignores(unused_errors, false);
         let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
         assert_eq!(after, got_file);
         assert_eq!(removals, expected_removals);
@@ -751,7 +786,7 @@ mod tests {
         let (errors, tdir) = get_errors(before);
         let collected = errors.collect_errors();
         let unused_errors = errors.collect_unused_ignore_errors(&collected);
-        let removals = suppress::remove_unused_ignores(unused_errors);
+        let removals = suppress::remove_unused_ignores(unused_errors, false);
         let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
         assert_eq!(after, got_file);
         assert_eq!(removals, expected_removals);
@@ -1141,6 +1176,21 @@ def f() -> int:
     }
 
     #[test]
+    fn test_remove_unused_type_ignore_when_enabled() {
+        let input = "a = 1  # pyrefly: ignore\nb = 2  # type: ignore\n";
+        let want = "a = 1\nb = 2\n";
+        let (errors, tdir) = get_errors(input);
+        let collected = errors.collect_errors();
+        let unused_errors = errors.collect_unused_ignore_errors(&collected);
+
+        let removals = suppress::remove_unused_ignores(unused_errors, true);
+
+        let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
+        assert_eq!(want, got_file);
+        assert_eq!(removals, 2);
+    }
+
+    #[test]
     fn test_errors_deduped() {
         let file_contents = r#"
 # pyrefly: ignore [bad-return]
@@ -1437,9 +1487,25 @@ def f() -> int:
     // Helper function to test remove_unused_ignores_from_serialized
     fn assert_remove_ignores_from_serialized(
         file_content: &str,
+        serialized_errors: Vec<SerializedError>,
+        expected_content: &str,
+        expected_removals: usize,
+    ) {
+        assert_remove_ignores_from_serialized_with_flag(
+            file_content,
+            serialized_errors,
+            expected_content,
+            expected_removals,
+            false,
+        );
+    }
+
+    fn assert_remove_ignores_from_serialized_with_flag(
+        file_content: &str,
         mut serialized_errors: Vec<SerializedError>,
         expected_content: &str,
         expected_removals: usize,
+        remove_unused_type_ignores: bool,
     ) {
         let tdir = tempfile::tempdir().unwrap();
         let path = get_path(&tdir);
@@ -1450,11 +1516,65 @@ def f() -> int:
             error.path = path.clone();
         }
 
-        let removals = suppress::remove_unused_ignores_from_serialized(serialized_errors);
+        let removals = suppress::remove_unused_ignores_from_serialized(
+            serialized_errors,
+            remove_unused_type_ignores,
+        );
 
         let got_file = fs_anyhow::read_to_string(&path).unwrap();
         assert_eq!(expected_content, got_file);
         assert_eq!(removals, expected_removals);
+    }
+
+    #[test]
+    fn test_used_type_ignore_preserved_when_removing_pyrefly_ignore() {
+        // An unused Pyrefly suppression must not remove a still-used type suppression
+        // from the same line when type-ignore removal was not requested.
+        let input = "x = 1  # pyrefly: ignore  # type: ignore\n";
+        let want = "x = 1  # type: ignore\n";
+        let errors = vec![SerializedError {
+            path: PathBuf::from("test.py"),
+            line: 0,
+            name: "unused-ignore".to_owned(),
+            message: "Unused `# pyrefly: ignore` comment".to_owned(),
+        }];
+        assert_remove_ignores_from_serialized_with_flag(input, errors, want, 1, false);
+    }
+
+    #[test]
+    fn test_used_pyrefly_ignore_preserved_when_removing_type_ignore() {
+        // An unused type suppression must not remove a still-used Pyrefly suppression
+        // from the same line when type-ignore removal was requested.
+        let input = "x = 1  # type: ignore  # pyrefly: ignore\n";
+        let want = "x = 1  # pyrefly: ignore\n";
+        let errors = vec![SerializedError {
+            path: PathBuf::from("test.py"),
+            line: 0,
+            name: "unused-type-ignore".to_owned(),
+            message: "Unused `# type: ignore` comment".to_owned(),
+        }];
+        assert_remove_ignores_from_serialized_with_flag(input, errors, want, 1, true);
+    }
+
+    #[test]
+    fn test_remove_multiple_unused_suppressions_from_same_line() {
+        let input = "x = 1  # pyrefly: ignore  # type: ignore\n";
+        let want = "x = 1\n";
+        let errors = vec![
+            SerializedError {
+                path: PathBuf::from("test.py"),
+                line: 0,
+                name: "unused-ignore".to_owned(),
+                message: "Unused `# pyrefly: ignore` comment".to_owned(),
+            },
+            SerializedError {
+                path: PathBuf::from("test.py"),
+                line: 0,
+                name: "unused-type-ignore".to_owned(),
+                message: "Unused `# type: ignore` comment".to_owned(),
+            },
+        ];
+        assert_remove_ignores_from_serialized_with_flag(input, errors, want, 1, true);
     }
 
     #[test]
@@ -1560,7 +1680,7 @@ def g() -> str:
             },
         ];
 
-        let removals = suppress::remove_unused_ignores_from_serialized(errors);
+        let removals = suppress::remove_unused_ignores_from_serialized(errors, false);
 
         assert_eq!(fs_anyhow::read_to_string(&path1).unwrap(), "x = 1\n");
         assert_eq!(fs_anyhow::read_to_string(&path2).unwrap(), "y = 2\n");
@@ -1570,7 +1690,7 @@ def g() -> str:
     #[test]
     fn test_remove_unused_ignores_from_serialized_empty_list() {
         let errors: Vec<SerializedError> = vec![];
-        let removals = suppress::remove_unused_ignores_from_serialized(errors);
+        let removals = suppress::remove_unused_ignores_from_serialized(errors, false);
         assert_eq!(removals, 0);
     }
 
@@ -2074,7 +2194,7 @@ build_query(
             name: "unused-ignore".to_owned(),
             message: "Unused pyre-fixme comment".to_owned(),
         }];
-        let removals = suppress::remove_unused_ignores_from_serialized(errors);
+        let removals = suppress::remove_unused_ignores_from_serialized(errors, false);
         let got = fs_anyhow::read_to_string(&path).unwrap();
         assert_eq!(want, got);
         assert_eq!(removals, 1);

--- a/pyrefly/lib/error/suppress.rs
+++ b/pyrefly/lib/error/suppress.rs
@@ -623,35 +623,7 @@ pub fn remove_unused_ignores_from_serialized(
                     let mut updated_line = Cow::Borrowed(*line);
 
                     for error in errors {
-                        // Use string-aware comment detection instead of raw regex.
-                        let Some(comment_start) = find_comment_start_in_line(&updated_line) else {
-                            continue;
-                        };
-                        let comment_part = &updated_line[comment_start..];
                         let msg = &error.message;
-
-                        let ignore_regex = if error.is_unused_type_ignore() {
-                            Some(&*TYPE_IGNORE_COMMENT_REGEX)
-                        } else if msg.starts_with("Unused `# pyrefly: ignore` comment") {
-                            Some(&*PYREFLY_IGNORE_COMMENT_REGEX)
-                        } else if msg.starts_with("Unused pyre-fixme comment") {
-                            Some(&*PYRE_IGNORE_COMMENT_REGEX)
-                        } else {
-                            None
-                        };
-
-                        if let Some(ignore_regex) = ignore_regex {
-                            if ignore_regex.is_match(comment_part) {
-                                let code_part = &updated_line[..comment_start];
-                                let new_comment = ignore_regex.replace(comment_part, "");
-                                updated_line = Cow::Owned(
-                                    format!("{}{}", code_part, new_comment)
-                                        .trim_end()
-                                        .to_owned(),
-                                );
-                            }
-                            continue;
-                        }
 
                         if msg.starts_with("Unused error code(s)") {
                             // Partially unused - extract codes from message and remove only those.
@@ -677,6 +649,31 @@ pub fn remove_unused_ignores_from_serialized(
                                     }
                                 }
                             }
+                            continue;
+                        }
+
+                        let ignore_regex = if error.is_unused_type_ignore() {
+                            &*TYPE_IGNORE_COMMENT_REGEX
+                        } else if msg.starts_with("Unused `# pyrefly: ignore` comment") {
+                            &*PYREFLY_IGNORE_COMMENT_REGEX
+                        } else if msg.starts_with("Unused pyre-fixme comment") {
+                            &*PYRE_IGNORE_COMMENT_REGEX
+                        } else {
+                            continue;
+                        };
+
+                        // Use string-aware comment detection instead of raw regex.
+                        let Some(comment_start) = find_comment_start_in_line(&updated_line) else {
+                            continue;
+                        };
+                        let comment_part = &updated_line[comment_start..];
+                        if let Cow::Owned(new_comment) = ignore_regex.replace(comment_part, "") {
+                            let code_part = &updated_line[..comment_start];
+                            updated_line = Cow::Owned(
+                                format!("{}{}", code_part, new_comment)
+                                    .trim_end()
+                                    .to_owned(),
+                            );
                         }
                     }
 

--- a/pyrefly/lib/error/suppress.rs
+++ b/pyrefly/lib/error/suppress.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
@@ -619,8 +620,7 @@ pub fn remove_unused_ignores_from_serialized(
 
             for (idx, line) in lines.iter().enumerate() {
                 if let Some(errors) = line_errors.get(&idx) {
-                    let mut updated_line = (*line).to_owned();
-                    let mut line_changed = false;
+                    let mut updated_line = Cow::Borrowed(*line);
 
                     for error in errors {
                         // Use string-aware comment detection instead of raw regex.
@@ -644,10 +644,11 @@ pub fn remove_unused_ignores_from_serialized(
                             if ignore_regex.is_match(comment_part) {
                                 let code_part = &updated_line[..comment_start];
                                 let new_comment = ignore_regex.replace(comment_part, "");
-                                updated_line = format!("{}{}", code_part, new_comment)
-                                    .trim_end()
-                                    .to_owned();
-                                line_changed = true;
+                                updated_line = Cow::Owned(
+                                    format!("{}{}", code_part, new_comment)
+                                        .trim_end()
+                                        .to_owned(),
+                                );
                             }
                             continue;
                         }
@@ -672,15 +673,14 @@ pub fn remove_unused_ignores_from_serialized(
                                         &used_codes,
                                         &unused_codes,
                                     ) {
-                                        updated_line = updated;
-                                        line_changed = true;
+                                        updated_line = Cow::Owned(updated);
                                     }
                                 }
                             }
                         }
                     }
 
-                    if line_changed {
+                    if let Cow::Owned(updated_line) = updated_line {
                         unused_count += 1;
                         if !updated_line.trim().is_empty() {
                             buf.push_str(&updated_line);
@@ -1558,23 +1558,27 @@ def f() -> int:
 
     #[test]
     fn test_remove_multiple_unused_suppressions_from_same_line() {
-        let input = "x = 1  # pyrefly: ignore  # type: ignore\n";
         let want = "x = 1\n";
-        let errors = vec![
-            SerializedError {
-                path: PathBuf::from("test.py"),
-                line: 0,
-                name: "unused-ignore".to_owned(),
-                message: "Unused `# pyrefly: ignore` comment".to_owned(),
-            },
-            SerializedError {
-                path: PathBuf::from("test.py"),
-                line: 0,
-                name: "unused-type-ignore".to_owned(),
-                message: "Unused `# type: ignore` comment".to_owned(),
-            },
-        ];
-        assert_remove_ignores_from_serialized_with_flag(input, errors, want, 1, true);
+        for input in [
+            "x = 1  # pyrefly: ignore  # type: ignore\n",
+            "x = 1  # type: ignore  # pyrefly: ignore\n",
+        ] {
+            let errors = vec![
+                SerializedError {
+                    path: PathBuf::from("test.py"),
+                    line: 0,
+                    name: "unused-ignore".to_owned(),
+                    message: "Unused `# pyrefly: ignore` comment".to_owned(),
+                },
+                SerializedError {
+                    path: PathBuf::from("test.py"),
+                    line: 0,
+                    name: "unused-type-ignore".to_owned(),
+                    message: "Unused `# type: ignore` comment".to_owned(),
+                },
+            ];
+            assert_remove_ignores_from_serialized_with_flag(input, errors, want, 1, true);
+        }
     }
 
     #[test]

--- a/pyrefly/lib/error/suppress.rs
+++ b/pyrefly/lib/error/suppress.rs
@@ -646,6 +646,7 @@ pub fn remove_unused_ignores_from_serialized(
                                         &unused_codes,
                                     ) {
                                         updated_line = Cow::Owned(updated);
+                                        unused_count += 1;
                                     }
                                 }
                             }
@@ -674,11 +675,11 @@ pub fn remove_unused_ignores_from_serialized(
                                     .trim_end()
                                     .to_owned(),
                             );
+                            unused_count += 1;
                         }
                     }
 
                     if let Cow::Owned(updated_line) = updated_line {
-                        unused_count += 1;
                         if !updated_line.trim().is_empty() {
                             buf.push_str(&updated_line);
                             buf.push_str(line_ending);
@@ -1574,7 +1575,7 @@ def f() -> int:
                     message: "Unused `# type: ignore` comment".to_owned(),
                 },
             ];
-            assert_remove_ignores_from_serialized_with_flag(input, errors, want, 1, true);
+            assert_remove_ignores_from_serialized_with_flag(input, errors, want, 2, true);
         }
     }
 

--- a/pyrefly/lib/error/suppress.rs
+++ b/pyrefly/lib/error/suppress.rs
@@ -64,6 +64,30 @@ pub enum CommentLocation {
     SameLine,
 }
 
+/// Which kinds of unused ignore comments to remove.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum UnusedIgnoreKind {
+    /// Remove unused Pyrefly and Pyre ignores (default).
+    #[default]
+    Pyrefly,
+    /// Remove unused `# type: ignore` comments.
+    Type,
+    /// Remove unused Pyrefly, Pyre, and `# type: ignore` comments.
+    All,
+}
+
+impl UnusedIgnoreKind {
+    /// Whether unused Pyrefly and Pyre ignores should be removed.
+    pub fn includes_pyrefly_or_pyre(self) -> bool {
+        matches!(self, Self::Pyrefly | Self::All)
+    }
+
+    /// Whether unused `# type: ignore` comments should be removed.
+    pub fn includes_type(self) -> bool {
+        matches!(self, Self::Type | Self::All)
+    }
+}
+
 /// A serializable representation of an error for JSON input/output.
 /// This struct holds the fields needed to add or remove a suppression comment.
 #[derive(Deserialize, Serialize)]
@@ -566,15 +590,12 @@ fn update_ignore_comment_with_used_codes(
 /// - "Unused `# type: ignore` comment" -> remove entire comment when opted in
 /// - "Unused `# pyrefly: ignore` comment for code(s): X, Y" -> remove entire comment
 /// - "Unused error code(s) in `# pyrefly: ignore`: X, Y" -> remove only those codes
-pub fn remove_unused_ignores(
-    unused_ignore_errors: Vec<Error>,
-    remove_unused_type_ignores: bool,
-) -> usize {
+pub fn remove_unused_ignores(unused_ignore_errors: Vec<Error>, kind: UnusedIgnoreKind) -> usize {
     let serialized: Vec<SerializedError> = unused_ignore_errors
         .iter()
         .filter_map(SerializedError::from_error)
         .collect();
-    remove_unused_ignores_from_serialized(serialized, remove_unused_type_ignores)
+    remove_unused_ignores_from_serialized(serialized, kind)
 }
 
 /// Removes unused ignore comments from source files using SerializedError.
@@ -582,7 +603,7 @@ pub fn remove_unused_ignores(
 /// allowing it to be used with errors parsed from JSON.
 pub fn remove_unused_ignores_from_serialized(
     unused_ignore_errors: Vec<SerializedError>,
-    remove_unused_type_ignores: bool,
+    kind: UnusedIgnoreKind,
 ) -> usize {
     if unused_ignore_errors.is_empty() {
         return 0;
@@ -591,8 +612,8 @@ pub fn remove_unused_ignores_from_serialized(
     // Group errors by file path
     let mut errors_by_path: SmallMap<PathBuf, Vec<&SerializedError>> = SmallMap::new();
     for error in &unused_ignore_errors {
-        if !(error.is_unused_ignore()
-            || remove_unused_type_ignores && error.is_unused_type_ignore())
+        if !((kind.includes_pyrefly_or_pyre() && error.is_unused_ignore())
+            || (kind.includes_type() && error.is_unused_type_ignore()))
         {
             continue;
         }
@@ -767,7 +788,7 @@ mod tests {
         let (errors, tdir) = get_errors(before);
         let collected = errors.collect_errors();
         let unused_errors = errors.collect_unused_ignore_errors(&collected);
-        let removals = suppress::remove_unused_ignores(unused_errors, false);
+        let removals = suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::Pyrefly);
         let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
         assert_eq!(after, got_file);
         assert_eq!(removals, expected_removals);
@@ -784,7 +805,7 @@ mod tests {
         let (errors, tdir) = get_errors(before);
         let collected = errors.collect_errors();
         let unused_errors = errors.collect_unused_ignore_errors(&collected);
-        let removals = suppress::remove_unused_ignores(unused_errors, false);
+        let removals = suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::Pyrefly);
         let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
         assert_eq!(after, got_file);
         assert_eq!(removals, expected_removals);
@@ -1181,7 +1202,7 @@ def f() -> int:
         let collected = errors.collect_errors();
         let unused_errors = errors.collect_unused_ignore_errors(&collected);
 
-        let removals = suppress::remove_unused_ignores(unused_errors, true);
+        let removals = suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::All);
 
         let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
         assert_eq!(want, got_file);
@@ -1489,21 +1510,21 @@ def f() -> int:
         expected_content: &str,
         expected_removals: usize,
     ) {
-        assert_remove_ignores_from_serialized_with_flag(
+        assert_remove_ignores_from_serialized_with_kind(
             file_content,
             serialized_errors,
             expected_content,
             expected_removals,
-            false,
+            UnusedIgnoreKind::Pyrefly,
         );
     }
 
-    fn assert_remove_ignores_from_serialized_with_flag(
+    fn assert_remove_ignores_from_serialized_with_kind(
         file_content: &str,
         mut serialized_errors: Vec<SerializedError>,
         expected_content: &str,
         expected_removals: usize,
-        remove_unused_type_ignores: bool,
+        kind: UnusedIgnoreKind,
     ) {
         let tdir = tempfile::tempdir().unwrap();
         let path = get_path(&tdir);
@@ -1514,10 +1535,7 @@ def f() -> int:
             error.path = path.clone();
         }
 
-        let removals = suppress::remove_unused_ignores_from_serialized(
-            serialized_errors,
-            remove_unused_type_ignores,
-        );
+        let removals = suppress::remove_unused_ignores_from_serialized(serialized_errors, kind);
 
         let got_file = fs_anyhow::read_to_string(&path).unwrap();
         assert_eq!(expected_content, got_file);
@@ -1536,7 +1554,13 @@ def f() -> int:
             name: "unused-ignore".to_owned(),
             message: "Unused `# pyrefly: ignore` comment".to_owned(),
         }];
-        assert_remove_ignores_from_serialized_with_flag(input, errors, want, 1, false);
+        assert_remove_ignores_from_serialized_with_kind(
+            input,
+            errors,
+            want,
+            1,
+            UnusedIgnoreKind::Pyrefly,
+        );
     }
 
     #[test]
@@ -1551,7 +1575,38 @@ def f() -> int:
             name: "unused-type-ignore".to_owned(),
             message: "Unused `# type: ignore` comment".to_owned(),
         }];
-        assert_remove_ignores_from_serialized_with_flag(input, errors, want, 1, true);
+        assert_remove_ignores_from_serialized_with_kind(
+            input,
+            errors,
+            want,
+            1,
+            UnusedIgnoreKind::Type,
+        );
+    }
+
+    #[test]
+    fn test_remove_only_selected_suppression_kind() {
+        let input = "x = 1  # pyrefly: ignore  # type: ignore\n";
+        for (kind, want) in [
+            (UnusedIgnoreKind::Pyrefly, "x = 1  # type: ignore\n"),
+            (UnusedIgnoreKind::Type, "x = 1  # pyrefly: ignore\n"),
+        ] {
+            let errors = vec![
+                SerializedError {
+                    path: PathBuf::from("test.py"),
+                    line: 0,
+                    name: "unused-ignore".to_owned(),
+                    message: "Unused `# pyrefly: ignore` comment".to_owned(),
+                },
+                SerializedError {
+                    path: PathBuf::from("test.py"),
+                    line: 0,
+                    name: "unused-type-ignore".to_owned(),
+                    message: "Unused `# type: ignore` comment".to_owned(),
+                },
+            ];
+            assert_remove_ignores_from_serialized_with_kind(input, errors, want, 1, kind);
+        }
     }
 
     #[test]
@@ -1575,7 +1630,13 @@ def f() -> int:
                     message: "Unused `# type: ignore` comment".to_owned(),
                 },
             ];
-            assert_remove_ignores_from_serialized_with_flag(input, errors, want, 2, true);
+            assert_remove_ignores_from_serialized_with_kind(
+                input,
+                errors,
+                want,
+                2,
+                UnusedIgnoreKind::All,
+            );
         }
     }
 
@@ -1682,7 +1743,8 @@ def g() -> str:
             },
         ];
 
-        let removals = suppress::remove_unused_ignores_from_serialized(errors, false);
+        let removals =
+            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly);
 
         assert_eq!(fs_anyhow::read_to_string(&path1).unwrap(), "x = 1\n");
         assert_eq!(fs_anyhow::read_to_string(&path2).unwrap(), "y = 2\n");
@@ -1692,7 +1754,8 @@ def g() -> str:
     #[test]
     fn test_remove_unused_ignores_from_serialized_empty_list() {
         let errors: Vec<SerializedError> = vec![];
-        let removals = suppress::remove_unused_ignores_from_serialized(errors, false);
+        let removals =
+            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly);
         assert_eq!(removals, 0);
     }
 
@@ -2196,7 +2259,8 @@ build_query(
             name: "unused-ignore".to_owned(),
             message: "Unused pyre-fixme comment".to_owned(),
         }];
-        let removals = suppress::remove_unused_ignores_from_serialized(errors, false);
+        let removals =
+            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly);
         let got = fs_anyhow::read_to_string(&path).unwrap();
         assert_eq!(want, got);
         assert_eq!(removals, 1);

--- a/test/suppress.md
+++ b/test/suppress.md
@@ -1,5 +1,37 @@
 # Tests for `--suppress-errors`
 
+## `suppress --remove-unused` preserves unused `# type: ignore` comments by default
+
+```scrut
+$ mkdir $TMPDIR/suppress_remove_unused_default && \
+> printf 'a = 1  # pyrefly: ignore\nb = 2  # type: ignore\n' > $TMPDIR/suppress_remove_unused_default/main.py && \
+> : > $TMPDIR/suppress_remove_unused_default/pyrefly.toml && \
+> $PYREFLY suppress $TMPDIR/suppress_remove_unused_default/main.py \
+>     --config $TMPDIR/suppress_remove_unused_default/pyrefly.toml \
+>     --remove-unused \
+>     >/dev/null 2>/dev/null && \
+> cat $TMPDIR/suppress_remove_unused_default/main.py
+a = 1
+b = 2  # type: ignore
+[0]
+```
+
+## `suppress --remove-unused-type-ignores` also removes unused `# type: ignore` comments
+
+```scrut
+$ mkdir $TMPDIR/suppress_remove_unused_type_ignores && \
+> printf 'a = 1  # pyrefly: ignore\nb = 2  # type: ignore\n' > $TMPDIR/suppress_remove_unused_type_ignores/main.py && \
+> : > $TMPDIR/suppress_remove_unused_type_ignores/pyrefly.toml && \
+> $PYREFLY suppress $TMPDIR/suppress_remove_unused_type_ignores/main.py \
+>     --config $TMPDIR/suppress_remove_unused_type_ignores/pyrefly.toml \
+>     --remove-unused-type-ignores \
+>     >/dev/null 2>/dev/null && \
+> cat $TMPDIR/suppress_remove_unused_type_ignores/main.py
+a = 1
+b = 2
+[0]
+```
+
 ## `--suppress-errors` should not rewrite warnings hidden by `--min-severity`
 
 Use an explicit empty config so the repro does not depend on any ancestor

--- a/test/suppress.md
+++ b/test/suppress.md
@@ -16,17 +16,33 @@ b = 2  # type: ignore
 [0]
 ```
 
-## `suppress --remove-unused-type-ignores` also removes unused `# type: ignore` comments
+## `suppress --remove-unused=type` removes only unused `# type: ignore` comments
 
 ```scrut
-$ mkdir $TMPDIR/suppress_remove_unused_type_ignores && \
-> printf 'a = 1  # pyrefly: ignore\nb = 2  # type: ignore\n' > $TMPDIR/suppress_remove_unused_type_ignores/main.py && \
-> : > $TMPDIR/suppress_remove_unused_type_ignores/pyrefly.toml && \
-> $PYREFLY suppress $TMPDIR/suppress_remove_unused_type_ignores/main.py \
->     --config $TMPDIR/suppress_remove_unused_type_ignores/pyrefly.toml \
->     --remove-unused-type-ignores \
+$ mkdir $TMPDIR/suppress_remove_unused_type && \
+> printf 'a = 1  # pyrefly: ignore\nb = 2  # type: ignore\n' > $TMPDIR/suppress_remove_unused_type/main.py && \
+> : > $TMPDIR/suppress_remove_unused_type/pyrefly.toml && \
+> $PYREFLY suppress $TMPDIR/suppress_remove_unused_type/main.py \
+>     --config $TMPDIR/suppress_remove_unused_type/pyrefly.toml \
+>     --remove-unused=type \
 >     >/dev/null 2>/dev/null && \
-> cat $TMPDIR/suppress_remove_unused_type_ignores/main.py
+> cat $TMPDIR/suppress_remove_unused_type/main.py
+a = 1  # pyrefly: ignore
+b = 2
+[0]
+```
+
+## `suppress --remove-unused=all` removes both kinds of unused ignore
+
+```scrut
+$ mkdir $TMPDIR/suppress_remove_unused_all && \
+> printf 'a = 1  # pyrefly: ignore\nb = 2  # type: ignore\n' > $TMPDIR/suppress_remove_unused_all/main.py && \
+> : > $TMPDIR/suppress_remove_unused_all/pyrefly.toml && \
+> $PYREFLY suppress $TMPDIR/suppress_remove_unused_all/main.py \
+>     --config $TMPDIR/suppress_remove_unused_all/pyrefly.toml \
+>     --remove-unused=all \
+>     >/dev/null 2>/dev/null && \
+> cat $TMPDIR/suppress_remove_unused_all/main.py
 a = 1
 b = 2
 [0]

--- a/website/docs/error-suppressions.mdx
+++ b/website/docs/error-suppressions.mdx
@@ -156,12 +156,12 @@ Repeat the steps above until you get a clean formatting run and a clean type che
 
 This will add ` # pyrefly: ignore` comments to your code that will enable you to silence errors, and come back and fix them at a later date. This can make the process of upgrading a large codebase much more manageable.
 
-By default, `--remove-unused` preserves `# type: ignore` comments because they may be shared with other type checkers. To remove unused `# type: ignore` comments as well, use `pyrefly suppress --remove-unused-type-ignores` instead.
+By default, `--remove-unused` removes Pyrefly and Pyre ignores and preserves `# type: ignore` comments because they may be shared with other type checkers. `--remove-unused=pyrefly` is equivalent to the bare flag. Use `pyrefly suppress --remove-unused=type` to remove only unused `# type: ignore` comments, or `pyrefly suppress --remove-unused=all` to remove all three kinds.
 
 :::tip
 If your project uses other tools that place suppression comments on the line before the error (e.g. other type checkers or linters), use `pyrefly suppress --comment-location=same-line` in step 1 to avoid conflicts.
 :::
 
 :::note
-`pyrefly suppress` is equivalent to `pyrefly check --suppress-errors`, `pyrefly suppress --remove-unused` is equivalent to `pyrefly check --remove-unused-ignores`, and `pyrefly suppress --remove-unused-type-ignores` is equivalent to `pyrefly check --remove-unused-type-ignores`.
+`pyrefly suppress` is equivalent to `pyrefly check --suppress-errors`, and `pyrefly suppress --remove-unused[=KIND]` is equivalent to `pyrefly check --remove-unused-ignores[=KIND]`.
 :::

--- a/website/docs/error-suppressions.mdx
+++ b/website/docs/error-suppressions.mdx
@@ -156,10 +156,12 @@ Repeat the steps above until you get a clean formatting run and a clean type che
 
 This will add ` # pyrefly: ignore` comments to your code that will enable you to silence errors, and come back and fix them at a later date. This can make the process of upgrading a large codebase much more manageable.
 
+By default, `--remove-unused` preserves `# type: ignore` comments because they may be shared with other type checkers. To remove unused `# type: ignore` comments as well, use `pyrefly suppress --remove-unused-type-ignores` instead.
+
 :::tip
 If your project uses other tools that place suppression comments on the line before the error (e.g. other type checkers or linters), use `pyrefly suppress --comment-location=same-line` in step 1 to avoid conflicts.
 :::
 
 :::note
-`pyrefly suppress` is equivalent to `pyrefly check --suppress-errors`, and `pyrefly suppress --remove-unused` is equivalent to `pyrefly check --remove-unused-ignores`.
+`pyrefly suppress` is equivalent to `pyrefly check --suppress-errors`, `pyrefly suppress --remove-unused` is equivalent to `pyrefly check --remove-unused-ignores`, and `pyrefly suppress --remove-unused-type-ignores` is equivalent to `pyrefly check --remove-unused-type-ignores`.
 :::


### PR DESCRIPTION
## Summary
Changes `pyrefly suppress --remove-unused` and `pyrefly check --remove-unused-ignores` so that users can specify `--remove-unused=type` / `--remove-unused=all` to instead / additionally remove `# type: ignore` comments, rather than just `# pyrefly: ignore` comments.

The default remains unchanged, so as to not surprise users previously relying on `pyrefly suppress --remove-unused` suddenly removing load-bearing `# type: ignore` comments.

Resolves #3984.