### PR TITLE
fix Renaming Protocol renames __init__ method instead of class #4170

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -4852,6 +4852,7 @@ impl Server {
         handle: Handle,
         uri: &Url,
         position: Position,
+        find_preference: FindPreference,
         include_declaration: bool,
         activity_key: Option<ActivityKey>,
         map_result: impl FnOnce(Vec<(Url, Vec<Range>)>) -> V + Send + Sync + 'static,
@@ -4867,10 +4868,7 @@ impl Server {
             handle,
             uri,
             position,
-            FindPreference {
-                import_behavior: ImportBehavior::StopAtRenamedImports,
-                ..Default::default()
-            },
+            find_preference,
             activity_key,
             move |transaction, handle, definition, telemetry, telemetry_event| {
                 let qualified_name =
@@ -4970,6 +4968,10 @@ impl Server {
             handle,
             uri,
             params.text_document_position.position,
+            FindPreference {
+                import_behavior: ImportBehavior::StopAtRenamedImports,
+                ..Default::default()
+            },
             params.context.include_declaration,
             activity_key,
             move |results| {
@@ -5002,6 +5004,11 @@ impl Server {
             handle,
             uri,
             params.text_document_position.position,
+            FindPreference {
+                import_behavior: ImportBehavior::StopAtRenamedImports,
+                resolve_call_dunders: false,
+                ..Default::default()
+            },
             true,
             activity_key,
             move |results| {

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3628,7 +3628,14 @@ impl<'a> Transaction<'a> {
         let identifier_context = self.identifier_at(handle, position);
 
         let definitions = self
-            .find_definition(handle, position, FindPreference::default())
+            .find_definition(
+                handle,
+                position,
+                FindPreference {
+                    resolve_call_dunders: false,
+                    ..Default::default()
+                },
+            )
             .map(Vec1::into_vec)
             .unwrap_or_default();
 

--- a/pyrefly/lib/test/lsp/lsp_interaction/rename.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/rename.rs
@@ -9,10 +9,80 @@ use lsp_types::Url;
 use lsp_types::request::PrepareRenameRequest;
 use lsp_types::request::Rename;
 use serde_json::json;
+use tempfile::TempDir;
 
 use crate::object_model::InitializeSettings;
 use crate::object_model::LspInteraction;
 use crate::util::get_test_files_root;
+
+#[test]
+fn test_rename_constructor_call_renames_class() {
+    let root = TempDir::new().unwrap();
+    let path = root.path().join("main.py");
+    std::fs::write(
+        &path,
+        r#"from typing import Protocol
+
+class WorkbookAction(Protocol):
+    def __call__(self, value: int) -> None: ...
+
+class FooAction(WorkbookAction):
+    def __init__(self, sheet_name: str) -> None:
+        self.sheet_name = sheet_name
+
+    def __call__(self, value: int) -> None:
+        print(f"FooAction: {value} on sheet {self.sheet_name}")
+
+FooAction("test")
+"#,
+    )
+    .unwrap();
+
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            workspace_folders: Some(vec![(
+                "test".to_owned(),
+                Url::from_file_path(root.path()).unwrap(),
+            )]),
+            configuration: Some(Some(json!([{ "indexing_mode": "lazy_blocking" }]))),
+            ..Default::default()
+        })
+        .unwrap();
+    interaction.client.did_open("main.py");
+
+    interaction
+        .client
+        .send_request::<Rename>(json!({
+            "textDocument": {"uri": Url::from_file_path(&path).unwrap().to_string()},
+            "position": {"line": 12, "character": 1},
+            "newName": "BarAction"
+        }))
+        .expect_response(json!({
+            "changes": {
+                Url::from_file_path(&path).unwrap().to_string(): [
+                    {
+                        "newText": "BarAction",
+                        "range": {
+                            "start": {"line": 5, "character": 6},
+                            "end": {"line": 5, "character": 15}
+                        }
+                    },
+                    {
+                        "newText": "BarAction",
+                        "range": {
+                            "start": {"line": 12, "character": 0},
+                            "end": {"line": 12, "character": 9}
+                        }
+                    }
+                ]
+            }
+        }))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
 
 #[test]
 fn test_prepare_rename() {


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4170

Rename now resolves constructor calls to the class symbol, while find-references still follows `__init__`/`__new__` as intended.

prepareRename uses the same raw-symbol behavior.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test