### PR TITLE
Fix False positive "Function declared to return Never but is missing an explicit return"

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -10832,17 +10832,6 @@
   "specialtypes_never.py": [
     {
       "code": -2,
-      "column": 22,
-      "concise_description": "Function declared to return `NoReturn` but is missing an explicit `return`",
-      "description": "Function declared to return `NoReturn` but is missing an explicit `return`",
-      "line": 19,
-      "name": "bad-return",
-      "severity": "error",
-      "stop_column": 30,
-      "stop_line": 19
-    },
-    {
-      "code": -2,
       "column": 21,
       "concise_description": "`list[Never]` is not assignable to `list[int]`",
       "description": "`list[Never]` is not assignable to `list[int]`",

--- a/conformance/third_party/conformance.result
+++ b/conformance/third_party/conformance.result
@@ -137,7 +137,9 @@
   "qualifiers_final_annotation.py": [],
   "qualifiers_final_decorator.py": [],
   "specialtypes_any.py": [],
-  "specialtypes_never.py": [],
+  "specialtypes_never.py": [
+    "Line 19: Expected 1 errors"
+  ],
   "specialtypes_none.py": [],
   "specialtypes_promotions.py": [],
   "specialtypes_type.py": [],

--- a/conformance/third_party/results.json
+++ b/conformance/third_party/results.json
@@ -1,9 +1,9 @@
 {
   "total": 140,
-  "pass": 134,
-  "fail": 6,
-  "pass_rate": 0.96,
-  "differences": 13,
+  "pass": 133,
+  "fail": 7,
+  "pass_rate": 0.95,
+  "differences": 14,
   "passing": [
     "aliases_explicit.py",
     "aliases_implicit.py",
@@ -117,7 +117,6 @@
     "qualifiers_final_annotation.py",
     "qualifiers_final_decorator.py",
     "specialtypes_any.py",
-    "specialtypes_never.py",
     "specialtypes_none.py",
     "specialtypes_promotions.py",
     "specialtypes_type.py",
@@ -146,7 +145,8 @@
     "constructors_callable.py": 2,
     "dataclasses_descriptors.py": 2,
     "exceptions_context_managers.py": 2,
-    "generics_scoping.py": 4
+    "generics_scoping.py": 4,
+    "specialtypes_never.py": 1
   },
   "comment": "@generated"
 }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -5435,6 +5435,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 );
             }
         } else {
+            // If the annotation is `NoReturn` or `Never` and there is no explicit return, there is no need to check further.
+            if annotation.is_never() && !has_explicit_returns {
+                return;
+            }
             self.check_type(implicit_return.ty(), annotation, range, errors, &|| {
                 TypeCheckContext::of_kind(TypeCheckKind::ImplicitFunctionReturn(
                     has_explicit_returns,

--- a/pyrefly/lib/test/returns.rs
+++ b/pyrefly/lib/test/returns.rs
@@ -398,7 +398,6 @@ def f() -> Never:
 "#,
 );
 
-
 testcase!(
     test_return_no_error,
     r#"

--- a/pyrefly/lib/test/returns.rs
+++ b/pyrefly/lib/test/returns.rs
@@ -389,6 +389,17 @@ def g():
 );
 
 testcase!(
+    test_no_explicit_return_if_return_type_is_never,
+    r#"
+from typing import Never
+
+def f() -> Never:
+    print("hello")
+"#,
+);
+
+
+testcase!(
     test_return_no_error,
     r#"
 def B() -> None:


### PR DESCRIPTION
# Summary

When a function annotation is `-> Never` and there is no explicit `return` in the body, don't warn about lacking an explicit `return`.

In practice, we don't proceed to `check_type()` in `check_implicit_return_against_annotation()` since `got` and `want` are indeed mismatched but we don't want to emit an error.

Fixes #4176. 

# Test Plan

Added `test_no_explicit_return_if_return_type_is_never` to `lib/test/returns.rs` which fails before the change in `lib/alt/solve.rs`, and passes afterwards.

I've run `test.py` and committed the resulting changes - I am not sure how this should work so any feedback would be appreciated!