### PR TITLE
fix NewType inlay hint is not a valid annotation #2965

### DIFF
--- a/pyrefly/lib/lsp/wasm/inlay_hints.rs
+++ b/pyrefly/lib/lsp/wasm/inlay_hints.rs
@@ -188,8 +188,31 @@ impl<'a> Transaction<'a> {
                 }
                 key @ Key::Definition(_)
                     if inlay_hint_config.variable_types
-                        && let Some(ty) = self.get_type_for_display(handle, key) =>
+                        && let Some(mut ty) = self.get_type_for_display(handle, key) =>
                 {
+                    // NewType values are callable aliases, not class objects, so `type[N]` is not
+                    // a valid annotation. Show their constructor signature without offering to
+                    // insert it as an annotation.
+                    let mut insertable = true;
+                    if let Type::ClassDef(cls) = &ty
+                        && let Some(Some(constructor)) =
+                            self.ad_hoc_solve(handle, "inlay_hint_new_type", |solver| {
+                                solver.get_metadata_for_class(cls).is_new_type().then(|| {
+                                    let cls =
+                                        solver.promote_nontypeddict_silently_to_classtype(cls);
+                                    let new = solver
+                                        .get_dunder_new(&cls, false)
+                                        .expect("NewType has a synthesized __new__ method");
+                                    let constructor = solver
+                                        .bind_dunder_new(&new, cls)
+                                        .expect("NewType __new__ method can be bound");
+                                    solver.for_display(constructor)
+                                })
+                            })
+                    {
+                        ty = constructor;
+                        insertable = false;
+                    }
                     // For unpacked values, extract the element expression if available
                     let (e, is_unpacked) = match bindings.get(idx) {
                         // Pinned assignments (explicit annotation or
@@ -230,7 +253,12 @@ impl<'a> Transaction<'a> {
                         is_unpacked && !ty.is_any()
                     };
                     if should_show {
-                        res.push(make_type_hint(": ", key.range().end(), &ty, !is_unpacked));
+                        res.push(make_type_hint(
+                            ": ",
+                            key.range().end(),
+                            &ty,
+                            insertable && !is_unpacked,
+                        ));
                     }
                 }
                 _ => {}

--- a/pyrefly/lib/test/lsp/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/inlay_hint.rs
@@ -91,6 +91,34 @@ y = list([1, 2, 3])
 }
 
 #[test]
+fn test_new_type_inlay_hint() {
+    let code = r#"from typing import NewType
+
+N = NewType("N", int)
+x = N
+"#;
+    assert_eq!(
+        r#"
+# main.py
+4 | x = N
+     ^ inlay-hint: `: (_x: int) -> N`
+"#
+        .trim(),
+        generate_inlay_hint_report(code, Default::default()).trim()
+    );
+
+    let files = [("main", code)];
+    let (handles, state) = mk_multi_file_state_assert_no_errors(&files, Require::Exports);
+    let handle = handles.get("main").unwrap();
+    let hints = state
+        .transaction()
+        .inlay_hints(handle, Default::default())
+        .unwrap();
+    assert_eq!(hints.len(), 1);
+    assert!(!hints[0].insertable);
+}
+
+#[test]
 fn test_dunder_new_implicit_self_return_inlay_hint() {
     let code = r#"
 class A:


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2965

NewType variable hints now display the callable signature, e.g. (_x: int) -> N, instead of invalid type[N]

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test