### PR TITLE
fix LiteralString inference on dict keys #2517

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -803,7 +803,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     // `key` is only `None` for a syntactically invalid dict comprehension
                     // (parser error recovery); the parser already reports the syntax error.
                     let key_ty = match &x.key {
-                        Some(key) => self.expr_infer_with_hint_promote(key, key_hint, errors, None),
+                        Some(key) => {
+                            self.dict_key_infer_with_hint(key, key_hint, errors, None)
+                        }
                         None => self.heap.mk_any_error(),
                     };
                     let value_ty =
@@ -1083,6 +1085,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         }
         ty.promote_implicit_literals(self.stdlib)
+    }
+
+    fn dict_key_infer_with_hint(
+        &self,
+        x: &Expr,
+        hint: Option<HintRef>,
+        errors: &ErrorCollector,
+        tcc: Option<&dyn Fn() -> TypeCheckContext>,
+    ) -> Type {
+        self.expr_infer_with_hint_promote(x, hint, errors, tcc)
+            .transform(&mut |ty| match ty {
+                Type::LiteralString(_) => {
+                    *ty = self.heap.mk_class_type(self.stdlib.str().clone());
+                }
+                _ => {}
+            })
     }
 
     /// Check whether a type corresponds to a deprecated function or method, and if so, log a deprecation warning.
@@ -1629,7 +1647,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             let mut value_tys = Vec::new();
             items.iter().for_each(|x| match &x.key {
                 Some(key) => {
-                    let key_t = self.expr_infer_with_hint_promote(
+                    let key_t = self.dict_key_infer_with_hint(
                         key,
                         key_hint.as_ref().and_then(|key_hint| {
                             hint.as_ref()

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -803,9 +803,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     // `key` is only `None` for a syntactically invalid dict comprehension
                     // (parser error recovery); the parser already reports the syntax error.
                     let key_ty = match &x.key {
-                        Some(key) => {
-                            self.dict_key_infer_with_hint(key, key_hint, errors, None)
-                        }
+                        Some(key) => self.dict_key_infer_with_hint(key, key_hint, errors, None),
                         None => self.heap.mk_any_error(),
                     };
                     let value_ty =

--- a/pyrefly/lib/test/imports.rs
+++ b/pyrefly/lib/test/imports.rs
@@ -681,6 +681,24 @@ assert_type(x, LiteralString)
 "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/2517
+testcase!(
+    test_import_string_ascii_uppercase_dict_keys,
+    r#"
+from string import ascii_uppercase
+from typing import assert_type
+
+letter_to_index = {char: i for i, char in enumerate(ascii_uppercase)}
+assert_type(letter_to_index, dict[str, int])
+
+def encode(message: str) -> list[int]:
+    result = []
+    for letter in message:
+        result.append(letter_to_index[letter])
+    return result
+"#,
+);
+
 fn env_from_self_import_mod_in_package() -> TestEnv {
     let mut env = TestEnv::new();
     env.add_with_path(


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2517

changes dict key inference so inferred dict keys are widened to their natural runtime type (str for string-like keys, and similarly for other literals) instead of staying pinned to literal precision.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test