### PR TITLE
fix Unpacked TypeVarTuple in callable doesn't consider optional arguments #1269

### DIFF
--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -349,36 +349,55 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
                     Some(Param::Varargs(_, Type::Unpack(u))),
                 ) => {
                     let mut l_types = Vec::new();
+                    let mut l_optional_prefixes = Vec::new();
                     loop {
-                        if let Some(Param::PosOnly(_, l, _) | Param::Pos(_, l, _)) = l_arg {
+                        if let Some(Param::PosOnly(_, l, required) | Param::Pos(_, l, required)) =
+                            l_arg
+                        {
+                            // Each trailing optional positional parameter adds a valid shorter
+                            // sequence; a later required parameter makes earlier prefixes invalid.
+                            match required {
+                                Required::Required => l_optional_prefixes.clear(),
+                                Required::Optional(_) => l_optional_prefixes
+                                    .push(self.solver.heap.mk_concrete_tuple(l_types.clone())),
+                            }
                             l_types.push(l.clone());
                             l_arg = l_args.next();
                         } else if let Some(Param::Varargs(_, Type::Unpack(l))) = l_arg {
+                            l_optional_prefixes.push(self.solver.heap.mk_unpacked_tuple(
+                                l_types,
+                                (**l).clone(),
+                                Vec::new(),
+                            ));
+                            let accepted = unions(l_optional_prefixes, &self.solver.heap);
                             self.is_subset_eq(
-                                u,
-                                &self.solver.heap.mk_unpacked_tuple(
-                                    l_types,
-                                    (**l).clone(),
-                                    Vec::new(),
-                                ),
+                                canonical_vararg_unpack_inner(u, &accepted),
+                                &accepted,
                             )?;
                             l_arg = l_args.next();
                             u_arg = u_args.next();
                             break;
                         } else if let Some(Param::Varargs(_, l)) = l_arg {
+                            l_optional_prefixes.push(self.solver.heap.mk_unpacked_tuple(
+                                l_types,
+                                self.solver.heap.mk_unbounded_tuple(l.clone()),
+                                Vec::new(),
+                            ));
+                            let accepted = unions(l_optional_prefixes, &self.solver.heap);
                             self.is_subset_eq(
-                                u,
-                                &self.solver.heap.mk_unpacked_tuple(
-                                    l_types,
-                                    self.solver.heap.mk_unbounded_tuple(l.clone()),
-                                    Vec::new(),
-                                ),
+                                canonical_vararg_unpack_inner(u, &accepted),
+                                &accepted,
                             )?;
                             l_arg = l_args.next();
                             u_arg = u_args.next();
                             break;
                         } else {
-                            self.is_subset_eq(u, &self.solver.heap.mk_concrete_tuple(l_types))?;
+                            l_optional_prefixes.push(self.solver.heap.mk_concrete_tuple(l_types));
+                            let accepted = unions(l_optional_prefixes, &self.solver.heap);
+                            self.is_subset_eq(
+                                canonical_vararg_unpack_inner(u, &accepted),
+                                &accepted,
+                            )?;
                             u_arg = u_args.next();
                             break;
                         }

--- a/pyrefly/lib/test/type_var_tuple.rs
+++ b/pyrefly/lib/test/type_var_tuple.rs
@@ -239,6 +239,21 @@ assert_type(test(fun, 1), tuple[int])
 );
 
 testcase!(
+    test_type_var_tuple_callable_optional_parameter,
+    r#"
+from typing import Callable, assert_type
+
+def test[*Ts, T](f: Callable[[*Ts], T], *args: *Ts) -> tuple[*Ts]: ...
+def callback(x: int, y: str = "") -> None: ...
+
+assert_type(test(callback, 1), tuple[int])
+assert_type(test(callback, 1, ""), tuple[int, str])
+test(callback, 1, 1)  # E: Unpacked argument `tuple[Literal[1], Literal[1]]` is not assignable to parameter `*args` with type `tuple[*tuple[int] | tuple[int, str]]`
+test(callback, 1, "", "")  # E: Unpacked argument `tuple[Literal[1], Literal[''], Literal['']]` is not assignable to parameter `*args` with type `tuple[*tuple[int] | tuple[int, str]]`
+"#,
+);
+
+testcase!(
     test_type_var_tuple_resolves_to_empty,
     r#"
 from typing import Callable, assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1269

Callable inference now models every valid positional prefix introduced by optional parameters, allowing later *args evidence to select the correct Ts arity

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test