### PR TITLE
fix Pandas locindexer for dataframes inspected as unknown #1678

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -95,6 +95,7 @@ use crate::alt::solve::TypeFormContext;
 use crate::alt::solve::UntypeContext;
 use crate::alt::unwrap::HintRef;
 use crate::alt::unwrap::ListElementHint;
+use crate::alt::unwrap::MAX_CALL_HINT_WIDTH;
 use crate::binding::binding::Binding;
 use crate::binding::binding::Key;
 use crate::binding::binding::KeyYield;
@@ -590,6 +591,24 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             Expr::BinOp(x) => self.binop_infer(x, hint, errors, type_form_context),
             Expr::UnaryOp(x) => self.unop_infer(x, errors),
             Expr::Lambda(lambda) => {
+                // Wide union hints are normally discarded to avoid combinatorial contextual
+                // inference. For lambdas, non-callable members cannot contribute, so retain a
+                // small callable subset (common in overloaded APIs such as pandas indexers).
+                let narrowed_hint_types = hint.and_then(|hint| {
+                    (hint.types().len() > MAX_CALL_HINT_WIDTH).then(|| {
+                        hint.types()
+                            .iter()
+                            .filter(|ty| ty.is_toplevel_callable())
+                            .cloned()
+                            .collect::<Vec<_>>()
+                    })
+                });
+                let hint = match narrowed_hint_types.as_deref() {
+                    Some(types) if !types.is_empty() && types.len() <= MAX_CALL_HINT_WIDTH => Some(
+                        HintRef::from_types(types, hint.and_then(|hint| hint.errors())),
+                    ),
+                    _ => hint,
+                };
                 let param_ids = if let Some(parameters) = &lambda.parameters {
                     parameters
                         .iter_non_variadic_params()

--- a/pyrefly/lib/alt/unwrap.rs
+++ b/pyrefly/lib/alt/unwrap.rs
@@ -64,6 +64,11 @@ impl<'a, 'b> HintRef<'a, 'b> {
         Self::new(hint, None)
     }
 
+    /// Construct a hint from an already-split collection of candidate types.
+    pub fn from_types(types: &'b [Type], errors: Option<&'a ErrorCollector>) -> Self {
+        Self(types, errors)
+    }
+
     pub fn with_ty_opt(hint: Option<Self>, ty: Option<&'b Type>) -> Option<Self> {
         let hint = hint?;
         let ty = ty?;
@@ -81,7 +86,7 @@ impl<'a, 'b> HintRef<'a, 'b> {
         self.0
     }
 
-    pub fn errors(&self) -> Option<&ErrorCollector> {
+    pub fn errors(&self) -> Option<&'a ErrorCollector> {
         self.1
     }
 }
@@ -365,7 +370,14 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             .collect::<Vec<_>>();
         let vararg_var = vararg_name.map(|_| self.fresh_var());
         let kwarg_var = kwarg_name.map(|_| self.fresh_var());
-        let return_ty = self.fresh_var();
+        // An unresolved generic return hint must be inferred from the lambda body. Relating a
+        // fresh return variable to it here can prematurely solve the generic before the body has
+        // an actual type.
+        let hinted_return = hint.callable_return_type(self.heap);
+        let return_var = match &hinted_return {
+            Some(ty) if !ty.collect_maybe_placeholder_vars().is_empty() => None,
+            _ => Some(self.fresh_var()),
+        };
         let mut params = Vec::with_capacity(
             param_names.len()
                 + usize::from(vararg_name.is_some())
@@ -380,9 +392,16 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         if let Some((name, var)) = kwarg_name.zip(kwarg_var) {
             params.push(Param::Kwargs(Some(name.clone()), var.to_type(self.heap)));
         }
-        let callable_ty = self
-            .heap
-            .mk_callable_from_vec(params, return_ty.to_type(self.heap));
+        let callable_ty = self.heap.mk_callable_from_vec(
+            params,
+            return_var
+                .map(|var| var.to_type(self.heap))
+                .unwrap_or_else(|| {
+                    hinted_return
+                        .clone()
+                        .expect("missing return variable requires a callable return hint")
+                }),
+        );
 
         // Decomposition reads contextual types from the hint; the inferred lambda callable is
         // responsible for instantiating any generics in the hint.
@@ -398,7 +417,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         let mut vararg_hint = vararg_var.and_then(|var| self.resolve_var_opt(hint, var));
         let mut kwarg_hint = kwarg_var.and_then(|var| self.resolve_var_opt(hint, var));
         let mut return_hint = if matched {
-            self.resolve_var_opt(hint, return_ty)
+            return_var.and_then(|var| self.resolve_var_opt(hint, var))
         } else {
             None
         };

--- a/pyrefly/lib/alt/unwrap.rs
+++ b/pyrefly/lib/alt/unwrap.rs
@@ -373,7 +373,10 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         // An unresolved generic return hint must be inferred from the lambda body. Relating a
         // fresh return variable to it here can prematurely solve the generic before the body has
         // an actual type.
-        let hinted_return = hint.callable_return_type(self.heap);
+        let hinted_return = hint.callable_return_type(self.heap).map(|mut ty| {
+            self.solver().expand_with_bounds(&mut ty);
+            ty
+        });
         let return_var = match &hinted_return {
             Some(ty) if !ty.collect_maybe_placeholder_vars().is_empty() => None,
             _ => Some(self.fresh_var()),

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -627,6 +627,28 @@ baz: Callable[[int | str | bytes], str] = foo  # E: not assignable
     "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/1678
+testcase!(
+    test_overload_contextually_types_lambda_in_wide_union,
+    r#"
+from typing import Callable, TypeVar, assert_type, overload
+
+class Frame: ...
+class Series: ...
+
+ScalarT = TypeVar("ScalarT", bound=int)
+
+@overload
+def select(key: Callable[[Frame], ScalarT] | str | bytes | float | None) -> Series: ...
+@overload
+def select(key: Callable[[Frame], list[bool]] | str | bytes | float | None) -> Frame: ...
+def select(key: object) -> object: ...
+
+assert_type(select(lambda frame: [True]), Frame)
+assert_type(select(lambda frame: 1), Series)
+    "#,
+);
+
 testcase!(
     test_overload_assignable_to_callable_union_multi_param,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1678

Preserve lambdas for contextual overload inference, narrow wide union hints to callable candidates, prevent unresolved generic return hints from prematurely satisfying bounded overloads.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
add test