### PR TITLE
fix Infer input type of lambda based on 2nd argument to map() #438

### DIFF
--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -79,10 +79,11 @@ impl CallWithTypes {
         errors: &ErrorCollector,
     ) -> TypeOrExpr<'a> {
         match x {
-            TypeOrExpr::Expr(e @ (Expr::Dict(_) | Expr::List(_) | Expr::Set(_))) => {
-                // Hack: don't flatten mutable builtin containers into types before calling a
-                // function, as we know these containers often need to be contextually typed using
-                // the function's parameter types.
+            TypeOrExpr::Expr(
+                e @ (Expr::Dict(_) | Expr::Lambda(_) | Expr::List(_) | Expr::Set(_)),
+            ) => {
+                // Keep expressions that need contextual types unevaluated until we inspect the
+                // function's parameter types.
                 TypeOrExpr::Expr(e)
             }
             TypeOrExpr::Expr(e) => {
@@ -742,6 +743,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let mut unpacked_vararg_matched_args = Vec::new();
         let mut variadic_name = None;
         let mut variadic_collected = Vec::new();
+        // Later arguments may provide the bounds needed to contextually type a lambda's parameters.
+        let mut deferred_lambdas = Vec::new();
 
         // Resolve a deferred ParamSpec Var into additional parameters.
         // Returns `Err(q)` when the Var resolved to a quantified ParamSpec `q`
@@ -835,18 +838,26 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         let unhinted_arg_ty = bound_args
                             .as_ref()
                             .map(|_| arg_pre.inferred_type(self, arg_errors));
-                        let arg_ty = arg_pre.post_check(
-                            self,
-                            callable_name,
-                            ty,
-                            name,
-                            false,
-                            arg.range(),
-                            arg_errors,
-                            call_errors,
-                            context,
-                            call_context,
-                        );
+                        let arg_ty = if matches!(arg_pre, CallArgPreEval::Expr(Expr::Lambda(_), _))
+                            && bound_args.is_none()
+                        {
+                            deferred_lambdas.push((arg_pre.clone(), ty, name, arg.range()));
+                            arg_pre.mark_done();
+                            None
+                        } else {
+                            arg_pre.post_check(
+                                self,
+                                callable_name,
+                                ty,
+                                name,
+                                false,
+                                arg.range(),
+                                arg_errors,
+                                call_errors,
+                                context,
+                                call_context,
+                            )
+                        };
                         if let Some(name) = name
                             && let Some(ty) = unhinted_arg_ty.or(arg_ty)
                         {
@@ -1409,6 +1420,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     ))
                 })
                 .with_call_context(call_context),
+            );
+        }
+        for (mut arg, hint, name, range) in deferred_lambdas {
+            let mut hint = hint.clone();
+            // Read the bounds collected from the other arguments without finalizing type variables
+            // that the lambda's return type may still need to constrain.
+            self.solver().expand_with_bounds(&mut hint);
+            arg.post_check(
+                self,
+                callable_name,
+                &hint,
+                name,
+                false,
+                range,
+                arg_errors,
+                call_errors,
+                context,
+                call_context,
             );
         }
         let num_extra_positional_args = extra_positional_args.len();

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -109,6 +109,7 @@ impl CallWithTypes {
         errors: &ErrorCollector,
     ) -> TypeOrExpr<'a> {
         match x {
+            TypeOrExpr::Expr(e @ Expr::Lambda(_)) => TypeOrExpr::Expr(e),
             TypeOrExpr::Expr(e @ (Expr::Dict(_) | Expr::List(_) | Expr::Set(_)))
                 if !nests_calls_to_depth(e, MIN_FLATTEN_CALL_DEPTH) =>
             {
@@ -874,6 +875,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let mut unpacked_vararg_matched_args = Vec::new();
         let mut variadic_name = None;
         let mut variadic_collected = Vec::new();
+        // Later arguments may provide the bounds needed to contextually type a lambda's parameters.
+        let mut deferred_lambdas = Vec::new();
 
         // Resolve a deferred ParamSpec Var into additional parameters.
         // Returns `Err(q)` when the Var resolved to a quantified ParamSpec `q`
@@ -967,18 +970,26 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         let unhinted_arg_ty = bound_args
                             .as_ref()
                             .map(|_| arg_pre.inferred_type(self, arg_errors));
-                        let arg_ty = arg_pre.post_check(
-                            self,
-                            callable_name,
-                            ty,
-                            name,
-                            false,
-                            arg.range(),
-                            arg_errors,
-                            call_errors,
-                            context,
-                            call_context,
-                        );
+                        let arg_ty = if matches!(arg_pre, CallArgPreEval::Expr(Expr::Lambda(_), _))
+                            && bound_args.is_none()
+                        {
+                            deferred_lambdas.push((arg_pre.clone(), ty, name, arg.range()));
+                            arg_pre.mark_done();
+                            None
+                        } else {
+                            arg_pre.post_check(
+                                self,
+                                callable_name,
+                                ty,
+                                name,
+                                false,
+                                arg.range(),
+                                arg_errors,
+                                call_errors,
+                                context,
+                                call_context,
+                            )
+                        };
                         if let Some(name) = name
                             && let Some(ty) = unhinted_arg_ty.or(arg_ty)
                         {
@@ -1576,6 +1587,28 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     ))
                 })
                 .with_call_context(call_context),
+            );
+        }
+        for (mut arg, hint, name, range) in deferred_lambdas {
+            let mut hint = hint.clone();
+            // Read parameter bounds collected from the other arguments while leaving the return
+            // type open for the lambda body to constrain.
+            if let Type::Callable(callable) = &mut hint {
+                callable
+                    .params
+                    .visit_mut(&mut |ty| self.solver().expand_with_bounds(ty));
+            }
+            arg.post_check(
+                self,
+                callable_name,
+                &hint,
+                name,
+                false,
+                range,
+                arg_errors,
+                call_errors,
+                context,
+                call_context,
             );
         }
         let num_extra_positional_args = extra_positional_args.len();

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -1868,9 +1868,7 @@ constrained_first(0, lambda x: None)
 "#,
 );
 
-// Lambda arguments are inferred before later arguments can constrain the generic parameter.
 testcase!(
-    bug = "Lambda context ignores later generic constraints",
     test_implicit_any_lambda_late_generic_context,
     TestEnv::new().enable_implicit_any_lambda_error(),
     r#"
@@ -1878,7 +1876,7 @@ from typing import Callable
 
 def constrained_later[T](f: Callable[[T], None], x: T) -> None: ...
 
-constrained_later(lambda x: None, 0)  # E: Type of lambda parameter `x` is unknown
+constrained_later(lambda x: None, 0)
 "#,
 );
 
@@ -2043,11 +2041,10 @@ f = lambda x=1: x
 );
 
 testcase!(
-    bug = "Pyrefly does not contextually type lambda parameters in generic callback arguments (e.g. `sorted(key=...)`), so they become implicit `Any` and are flagged, even though the type is derivable (Pyright infers `int` here)",
     test_implicit_any_lambda_in_generic_call,
     TestEnv::new().enable_implicit_any_lambda_error(),
     r#"
-xs = sorted([3, 1, 2], key=lambda x: x)  # E: Type of lambda parameter `x` is unknown
+xs = sorted([3, 1, 2], key=lambda x: x)
 "#,
 );
 

--- a/pyrefly/lib/test/calls.rs
+++ b/pyrefly/lib/test/calls.rs
@@ -288,6 +288,17 @@ takes(lambda x: x + "")  # E:  Argument `Literal['']` is not assignable to param
 );
 
 testcase!(
+    test_generic_callback_contextual_typing_from_later_argument,
+    r#"
+map(lambda x: x.does_not_exist(), [1])  # E: Object of class `int` has no attribute `does_not_exist`
+
+def takes_bool(value: bool) -> None: ...
+
+map(takes_bool, [1])  # E: is not assignable to parameter
+    "#,
+);
+
+testcase!(
     test_union_with_type,
     r#"
 from typing import assert_type

--- a/pyrefly/lib/test/calls.rs
+++ b/pyrefly/lib/test/calls.rs
@@ -337,6 +337,17 @@ takes(lambda x: x + "")  # E:  Argument `Literal['']` is not assignable to param
 );
 
 testcase!(
+    test_generic_callback_contextual_typing_from_later_argument,
+    r#"
+map(lambda x: x.does_not_exist(), [1])  # E: Object of class `int` has no attribute `does_not_exist`
+
+def takes_bool(value: bool) -> None: ...
+
+map(takes_bool, [1])  # E: is not assignable to parameter
+    "#,
+);
+
+testcase!(
     test_union_with_type,
     r#"
 from typing import assert_type

--- a/pyrefly/lib/test/pydantic/field.rs
+++ b/pyrefly/lib/test/pydantic/field.rs
@@ -328,7 +328,7 @@ from pydantic import BaseModel, Field
 class A(BaseModel):
     x: int = Field(default='oops')  # E: `str` is not assignable to `int`
 class B(BaseModel):
-    x: int = Field(default_factory=lambda: 'oops')  # E: `str` is not assignable to `int`
+    x: int = Field(default_factory=lambda: 'oops')  # E: `Literal['oops']` is not assignable to `int`
     "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #438

Lambdas remain unevaluated during overload preparation, and lambda checking is deferred until later arguments contribute generic bounds.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test