### PR TITLE
Add test for splatting an unpacked tuple into a hinted tuple literal

### DIFF
--- a/pyrefly/lib/test/type_var_tuple.rs
+++ b/pyrefly/lib/test/type_var_tuple.rs
@@ -442,6 +442,23 @@ assert_type(infer3, Callable[[], None])
 );
 
 testcase!(
+    test_type_var_tuple_splat_unpacked_with_hint,
+    r#"
+from typing import TypeVarTuple, Unpack, assert_type
+
+Ts = TypeVarTuple("Ts")
+
+def test(rest: tuple[int, Unpack[Ts], str]) -> None:
+    # Splatting `rest` yields a `Tuple::Unpacked` (prefix `int`, variadic middle, suffix `str`).
+    # With a tuple hint on the LHS, inference must advance past every remaining per-element hint
+    # slot so the trailing annotation element lines up with the splatted suffix instead of the
+    # variadic middle.
+    x: tuple[bool, int, Unpack[Ts], str] = (True, *rest)
+    assert_type(x, tuple[bool, int, *Ts, str])
+"#,
+);
+
+testcase!(
     test_different_types_ok,
     r#"
 from typing import TypeVarTuple


### PR DESCRIPTION
Summary:
Why: `tuple_infer` in `pyrefly/lib/alt/expr.rs` has a branch that fires when a
starred element in a tuple literal resolves to a `Tuple::Unpacked` type (prefix,
variadic middle, suffix). In that case it calls `hint_ts_iter.nth(usize::MAX)`
to advance past every remaining per-element hint slot, keeping the LHS
annotation aligned with the splatted suffix. This path — and the neighboring
`nth(usize::MAX)` calls flagged by the `// TODO: missing test` comment at
`expr.rs:1314` — had no direct test coverage.

What: Add `test_type_var_tuple_splat_unpacked_with_hint` to the existing
`type_var_tuple` test module. A function parameter typed `tuple[int, Unpack[Ts], str]`
is a `Tuple::Unpacked`; splatting it into a literal assigned to a wider tuple
hint (`tuple[bool, int, Unpack[Ts], str]`) drives the hint iterator past the
consumed slots.

Why it works: `assert_type` pins the inferred result to
`tuple[bool, int, *Ts, str]`, which only holds if the hint slots are advanced
correctly; a regression in the slot-advancing logic would misalign the trailing
`str` and fail the assertion.

Reviewed By: stroxler

Differential Revision: D112731011


