### PR TITLE
Contextually type comprehension arguments during overload resolution

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -876,7 +876,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Option<Type> {
         let ty;
         let got = match got {
-            ExprOrBinding::Expr(value) => TypeOrExpr::Expr(value),
+            ExprOrBinding::Expr(value) => TypeOrExpr::Expr(value, false),
             ExprOrBinding::Binding(got) => {
                 ty = self.solve_binding(got, range, errors);
                 TypeOrExpr::Type(ty.ty(), range)
@@ -1134,7 +1134,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         narrowed_types: &mut Vec<Type>,
     ) {
         let ty = match &got {
-            TypeOrExpr::Expr(got) => self.expr_check(
+            TypeOrExpr::Expr(got, _) => self.expr_check(
                 got,
                 Some((&attr_ty, &|| {
                     TypeCheckContext::of_kind(TypeCheckKind::Attribute(attr_name.clone()))

--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1011,8 +1011,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             self.get_dunder_new(cls, preserve_self).is_some()
                 && self.get_dunder_init(cls, false).is_some()
         };
-        let is_deeply_nested =
-            |x: &TypeOrExpr| matches!(x, TypeOrExpr::Expr(e) if nests_calls(e, FLATTEN_CALL_DEPTH));
+        let is_deeply_nested = |x: &TypeOrExpr| matches!(x, TypeOrExpr::Expr(e, _) if nests_calls(e, FLATTEN_CALL_DEPTH));
 
         // Infer deeply nested arguments once, up front. Shallower nesting costs only a constant
         // factor, and flattening it would discard the parameter hint for no benefit.
@@ -1345,7 +1344,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let infer_type_or_expr = |toe: TypeOrExpr, errors: &ErrorCollector| -> Type {
             let ty = match toe {
                 TypeOrExpr::Type(ty, _) => ty.clone(),
-                TypeOrExpr::Expr(e) => self.expr_infer(e, errors),
+                TypeOrExpr::Expr(e, _) => self.expr_infer(e, errors),
             };
             // NNModule fields carry captured constructor args (e.g., padding=Literal[1]) that DSL
             // forward functions need as literals to compute output shapes.

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -117,6 +117,7 @@ impl CallWithTypes {
                 | Expr::SetComp(_)
                 | Expr::DictComp(_)
                 | Expr::Generator(_)),
+                _,
             ) if !nests_calls_to_depth(e, MIN_FLATTEN_CALL_DEPTH) => {
                 // Hack: keep mutable builtin containers as expressions, since they often need to be
                 // contextually typed against the function's parameter types, unless nesting depth
@@ -124,9 +125,13 @@ impl CallWithTypes {
                 // Comprehensions and generators are included for the same reason: their
                 // element/key/value types must be inferred against the parameter hint (e.g. to
                 // narrow a literal element) rather than eagerly here.
-                TypeOrExpr::Expr(e)
+                //
+                // Mark the expression as deliberately deferred: this call is evaluated more than
+                // once (overload / union-callee resolution), so argument checking must apply the
+                // guard that keeps a provisional generic hint from widening it.
+                TypeOrExpr::Expr(e, true)
             }
-            TypeOrExpr::Expr(e) => {
+            TypeOrExpr::Expr(e, _) => {
                 let t = solver.expr_infer(e, errors);
                 TypeOrExpr::Type(self.0.push(t), e.range())
             }
@@ -142,7 +147,24 @@ impl CallWithTypes {
     ) -> CallArg<'a> {
         match x {
             CallArg::Arg(x) => CallArg::Arg(self.type_or_expr(*x, solver, errors)),
-            CallArg::Star(x, r) => CallArg::Star(self.type_or_expr(*x, solver, errors), *r),
+            CallArg::Star(x, r) => {
+                // In starred position only container literals benefit from staying an expression
+                // (`pre_eval`'s fixed-length special case). A comprehension or generator cannot be
+                // fixed-length, and `pre_eval` infers non-literal starred args to a type before any
+                // parameter is matched, so deferring one buys no contextual narrowing and only forces
+                // per-candidate re-inference. Infer it to a type up front instead.
+                let flattened = match x {
+                    TypeOrExpr::Expr(
+                        e @ (Expr::ListComp(_)
+                        | Expr::SetComp(_)
+                        | Expr::DictComp(_)
+                        | Expr::Generator(_)),
+                        _,
+                    ) => TypeOrExpr::Type(self.0.push(solver.expr_infer(e, errors)), e.range()),
+                    _ => self.type_or_expr(*x, solver, errors),
+                };
+                CallArg::Star(flattened, *r)
+            }
         }
     }
 
@@ -196,7 +218,7 @@ impl<'a> CallKeyword<'a> {
         Self {
             range: x.range,
             arg: x.arg.as_ref(),
-            value: TypeOrExpr::Expr(&x.value),
+            value: TypeOrExpr::Expr(&x.value, false),
         }
     }
 
@@ -273,7 +295,7 @@ impl<'a> CallArg<'a> {
     }
 
     pub fn expr(x: &'a Expr) -> Self {
-        Self::Arg(TypeOrExpr::Expr(x))
+        Self::Arg(TypeOrExpr::Expr(x, false))
     }
 
     pub fn ty(ty: &'a Type, range: TextRange) -> Self {
@@ -282,7 +304,7 @@ impl<'a> CallArg<'a> {
 
     pub fn expr_maybe_starred(x: &'a Expr) -> Self {
         match x {
-            Expr::Starred(inner) => Self::Star(TypeOrExpr::Expr(&inner.value), x.range()),
+            Expr::Starred(inner) => Self::Star(TypeOrExpr::Expr(&inner.value, false), x.range()),
             _ => Self::expr(x),
         }
     }
@@ -327,11 +349,11 @@ impl<'a> CallArg<'a> {
     ) -> CallArgPreEval<'_> {
         match self {
             Self::Arg(TypeOrExpr::Type(ty, _)) => CallArgPreEval::Type(ty, false),
-            Self::Arg(TypeOrExpr::Expr(e)) => CallArgPreEval::Expr(e, false),
+            Self::Arg(TypeOrExpr::Expr(e, deferred)) => CallArgPreEval::Expr(e, *deferred, false),
             Self::Star(e, _range) => {
                 // Special-case list/set/tuple literals with statically known element count.
                 // Only do this if there are no starred elements inside the literal.
-                if let TypeOrExpr::Expr(expr) = e {
+                if let TypeOrExpr::Expr(expr, _) = e {
                     let literal_elts: Option<&[Expr]> = match expr {
                         Expr::List(list_expr) => Some(&list_expr.elts),
                         Expr::Set(set_expr) => Some(&set_expr.elts),
@@ -405,12 +427,13 @@ impl<'a> CallArg<'a> {
     }
 }
 
-// Pre-evaluated args are iterable. Type/Expr/Star variants iterate once (tracked via bool field),
-// Fixed variant iterates over the vec (tracked via usize field).
+// Pre-evaluated args are iterable. Type/Expr/Star variants iterate once (tracked via the trailing
+// `done` bool), Fixed variant iterates over the vec (tracked via usize field). The `Expr` variant's
+// first bool records whether the expression was deliberately deferred (see `TypeOrExpr::Expr`).
 #[derive(Clone, Debug)]
 enum CallArgPreEval<'a> {
     Type(&'a Type, bool),
-    Expr(&'a Expr, bool),
+    Expr(&'a Expr, bool, bool),
     Star {
         prefix: Vec<Type>,
         middle: Type,
@@ -424,7 +447,7 @@ enum CallArgPreEval<'a> {
 impl CallArgPreEval<'_> {
     fn step(&self) -> bool {
         match self {
-            Self::Type(_, done) | Self::Expr(_, done) | Self::Star { done, .. } => !*done,
+            Self::Type(_, done) | Self::Expr(_, _, done) | Self::Star { done, .. } => !*done,
             Self::Fixed(tys, i) => *i < tys.len(),
         }
     }
@@ -460,7 +483,7 @@ impl CallArgPreEval<'_> {
     ) -> Type {
         match self {
             Self::Type(ty, _) => (*ty).clone(),
-            Self::Expr(expr, _) => solver.expr_infer(expr, arg_errors),
+            Self::Expr(expr, _, _) => solver.expr_infer(expr, arg_errors),
             Self::Star {
                 prefix,
                 middle,
@@ -506,7 +529,7 @@ impl CallArgPreEval<'_> {
                 solver.maybe_error_unknown_argument_type(ty, range, arg_errors);
                 Some((*ty).clone())
             }
-            Self::Expr(x, done) => {
+            Self::Expr(x, deferred, done) => {
                 *done = true;
                 // PEP 747: when the parameter type is TypeForm, evaluate
                 // string literal arguments as forward-reference type forms.
@@ -537,6 +560,21 @@ impl CallArgPreEval<'_> {
                         TypeCheckOptions::new(call_errors, tcc).with_call_context(call_context),
                     );
                     solver.maybe_error_unknown_argument_type(&ty, range, arg_errors);
+                    return Some(ty);
+                }
+                // A deferred comprehension matched against a provisional generic hint keeps its
+                // known element type; only the deferral path (overload / union-callee resolution)
+                // applies this, so ordinary generic calls still type it contextually below.
+                if let Some(ty) = solver.deferred_comprehension_without_widening(
+                    x,
+                    *deferred,
+                    hint,
+                    range,
+                    arg_errors,
+                    call_errors,
+                    tcc,
+                    call_context,
+                ) {
                     return Some(ty);
                 }
                 let ty = solver
@@ -589,7 +627,7 @@ impl CallArgPreEval<'_> {
     // Intended for arguments matched to unpack-annotated *args, which are typechecked separately later
     fn post_skip(&mut self) {
         match self {
-            Self::Type(_, done) | Self::Expr(_, done) | Self::Star { done, .. } => {
+            Self::Type(_, done) | Self::Expr(_, _, done) | Self::Star { done, .. } => {
                 *done = true;
             }
             Self::Fixed(_, i) => {
@@ -601,7 +639,7 @@ impl CallArgPreEval<'_> {
     // Similar to post_skip but it skips to the end of any fixed length arguments.
     fn mark_done(&mut self) {
         match self {
-            Self::Type(_, done) | Self::Expr(_, done) | Self::Star { done, .. } => {
+            Self::Type(_, done) | Self::Expr(_, _, done) | Self::Star { done, .. } => {
                 *done = true;
             }
             Self::Fixed(tys, i) => {
@@ -616,7 +654,7 @@ impl CallArgPreEval<'_> {
         arg_errors: &ErrorCollector,
     ) {
         match self {
-            Self::Expr(x, _) => {
+            Self::Expr(x, _, _) => {
                 solver.expr_infer(x, arg_errors);
             }
             _ => {}
@@ -731,6 +769,55 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 "The type of this argument is unknown".to_owned(),
             );
         }
+    }
+
+    /// For a deliberately deferred comprehension or generator argument matched against a still
+    /// provisional generic parameter `hint`, return its type inferred without context when doing so
+    /// avoids widening; otherwise return `None` so the caller types it contextually.
+    ///
+    /// A generic hint is provisional until every argument has constrained its variables, so typing a
+    /// comprehension against it can widen an already-known element type (for example, `str` to
+    /// `object` in `filter`). Inferring once without context and, when that result is fully resolved
+    /// (no `Any`, no unsolved var), using it to constrain the generic preserves the precise element
+    /// type. When the context-free result is incomplete the hint is load-bearing — it types
+    /// otherwise-unknown elements such as a bare lambda's parameter, including the case where an
+    /// earlier argument already pinned the variable — so we fall back to contextual typing. The
+    /// `deferred` flag scopes this to calls evaluated more than once (overload / union-callee
+    /// resolution); ordinary calls always type the comprehension contextually.
+    fn deferred_comprehension_without_widening(
+        &self,
+        x: &Expr,
+        deferred: bool,
+        hint: &Type,
+        range: TextRange,
+        arg_errors: &ErrorCollector,
+        call_errors: &ErrorCollector,
+        tcc: &dyn Fn() -> TypeCheckContext,
+        call_context: &CallContext<'_>,
+    ) -> Option<Type> {
+        if !(deferred
+            && matches!(
+                x,
+                Expr::ListComp(_) | Expr::SetComp(_) | Expr::DictComp(_) | Expr::Generator(_)
+            )
+            && hint
+                .collect_maybe_placeholder_vars()
+                .into_iter()
+                .any(|var| self.solver().var_is_quantified(var)))
+        {
+            return None;
+        }
+        let ty = self.expr_infer(x, arg_errors);
+        if ty.any(|t| t.is_any()) || !ty.collect_maybe_placeholder_vars().is_empty() {
+            return None;
+        }
+        self.check_type_with_options(
+            &ty,
+            hint,
+            range,
+            TypeCheckOptions::new(call_errors, tcc).with_call_context(call_context),
+        );
+        Some(ty)
     }
 
     fn is_param_spec_args(&self, x: &CallArg, q: &Quantified, errors: &ErrorCollector) -> bool {
@@ -1086,7 +1173,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             suffix.push(ty.clone())
                         }
                     }
-                    CallArgPreEval::Expr(e, _) => {
+                    CallArgPreEval::Expr(e, _, _) => {
                         if middle.is_empty() {
                             prefix.push(self.expr_infer(e, arg_errors))
                         } else {
@@ -1455,21 +1542,42 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         .with_context(context.map(|ctx| ctx()))
                     };
                     let arg_ty = match kw.value {
-                        TypeOrExpr::Expr(x) => self
-                            .expr_with_options(
-                                x,
-                                match hint {
-                                    Some((_, ty)) => ExprOptions::check(
-                                        ty,
-                                        arg_errors,
-                                        call_errors,
-                                        tcc,
-                                        Some(call_context),
-                                    ),
-                                    None => ExprOptions::infer(arg_errors, None),
-                                },
-                            )
-                            .into_ty(),
+                        TypeOrExpr::Expr(x, deferred) => {
+                            // Keyword arguments are checked here rather than through `post_check`, so
+                            // apply the same deferral-scoped guard that keeps a provisional generic
+                            // hint from widening a deferred comprehension.
+                            let resolved = match &hint {
+                                Some((_, ty)) => self.deferred_comprehension_without_widening(
+                                    x,
+                                    deferred,
+                                    ty,
+                                    kw.range,
+                                    arg_errors,
+                                    call_errors,
+                                    tcc,
+                                    call_context,
+                                ),
+                                None => None,
+                            };
+                            match resolved {
+                                Some(ty) => ty,
+                                None => self
+                                    .expr_with_options(
+                                        x,
+                                        match hint {
+                                            Some((_, ty)) => ExprOptions::check(
+                                                ty,
+                                                arg_errors,
+                                                call_errors,
+                                                tcc,
+                                                Some(call_context),
+                                            ),
+                                            None => ExprOptions::infer(arg_errors, None),
+                                        },
+                                    )
+                                    .into_ty(),
+                            }
+                        }
                         TypeOrExpr::Type(x, range) => {
                             if let Some((_, hint)) = &hint
                                 && !hint.is_any()

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -109,12 +109,21 @@ impl CallWithTypes {
         errors: &ErrorCollector,
     ) -> TypeOrExpr<'a> {
         match x {
-            TypeOrExpr::Expr(e @ (Expr::Dict(_) | Expr::List(_) | Expr::Set(_)))
-                if !nests_calls_to_depth(e, MIN_FLATTEN_CALL_DEPTH) =>
-            {
+            TypeOrExpr::Expr(
+                e @ (Expr::Dict(_)
+                | Expr::List(_)
+                | Expr::Set(_)
+                | Expr::ListComp(_)
+                | Expr::SetComp(_)
+                | Expr::DictComp(_)
+                | Expr::Generator(_)),
+            ) if !nests_calls_to_depth(e, MIN_FLATTEN_CALL_DEPTH) => {
                 // Hack: keep mutable builtin containers as expressions, since they often need to be
                 // contextually typed against the function's parameter types, unless nesting depth
                 // reaches or exceeds `MIN_FLATTEN_CALL_DEPTH` to avoid exponential blowup.
+                // Comprehensions and generators are included for the same reason: their
+                // element/key/value types must be inferred against the parameter hint (e.g. to
+                // narrow a literal element) rather than eagerly here.
                 TypeOrExpr::Expr(e)
             }
             TypeOrExpr::Expr(e) => {

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -460,6 +460,28 @@ impl CallArgPreEval<'_> {
                     solver.maybe_error_unknown_argument_type(&ty, range, arg_errors);
                     return Some(ty);
                 }
+                if matches!(
+                    x,
+                    Expr::ListComp(_) | Expr::SetComp(_) | Expr::DictComp(_) | Expr::Generator(_)
+                ) && hint
+                    .collect_maybe_placeholder_vars()
+                    .into_iter()
+                    .any(|var| solver.solver().var_is_quantified(var))
+                {
+                    // A generic parameter hint is provisional until all arguments have
+                    // constrained its variables. Inferring a comprehension from that hint can
+                    // widen a known element type (for example, `str` to `object` in `filter`).
+                    // Infer it once without context, then use the result to constrain the generic.
+                    let ty = solver.expr_infer(x, arg_errors);
+                    solver.check_type_with_options(
+                        &ty,
+                        hint,
+                        range,
+                        TypeCheckOptions::new(call_errors, tcc).with_call_context(call_context),
+                    );
+                    solver.maybe_error_unknown_argument_type(&ty, range, arg_errors);
+                    return Some(ty);
+                }
                 let ty = solver
                     .expr_with_options(
                         x,

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -82,10 +82,20 @@ impl CallWithTypes {
         errors: &ErrorCollector,
     ) -> TypeOrExpr<'a> {
         match x {
-            TypeOrExpr::Expr(e @ (Expr::Dict(_) | Expr::List(_) | Expr::Set(_))) => {
+            TypeOrExpr::Expr(
+                e @ (Expr::Dict(_)
+                | Expr::List(_)
+                | Expr::Set(_)
+                | Expr::ListComp(_)
+                | Expr::SetComp(_)
+                | Expr::DictComp(_)
+                | Expr::Generator(_)),
+            ) => {
                 // Hack: don't flatten mutable builtin containers into types before calling a
                 // function, as we know these containers often need to be contextually typed using
-                // the function's parameter types.
+                // the function's parameter types. Comprehensions and generators are included for
+                // the same reason: their element/key/value types must be inferred against the
+                // parameter hint (e.g. to narrow a literal element) rather than eagerly here.
                 TypeOrExpr::Expr(e)
             }
             TypeOrExpr::Expr(e) => {

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -807,10 +807,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         {
             return None;
         }
-        let ty = self.expr_infer(x, arg_errors);
+        // Probe the context-free type in a throwaway collector: on the fallback path the caller
+        // re-infers `x` into `arg_errors`, so emitting body diagnostics here too would duplicate
+        // them. If the result isn't fully resolved we return `None` and discard the probe, leaving
+        // the caller's re-inference as the sole source of those diagnostics.
+        let probe = self.error_collector();
+        let ty = self.expr_infer(x, &probe);
         if ty.any(|t| t.is_any()) || !ty.collect_maybe_placeholder_vars().is_empty() {
             return None;
         }
+        // Committed to keeping the known element type here, so surface the body diagnostics the
+        // probe found (this path does not re-infer `x`, so they would otherwise be lost).
+        arg_errors.extend(probe);
         self.check_type_with_options(
             &ty,
             hint,

--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -648,7 +648,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .map(|(name, value)| CallKeyword {
                 range: name.range(),
                 arg: Some(name),
-                value: TypeOrExpr::Expr(value),
+                value: TypeOrExpr::Expr(value, false),
             })
             .collect::<Vec<_>>();
         self.call_infer(

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -127,7 +127,12 @@ use crate::types::types::Type;
 pub enum TypeOrExpr<'a> {
     /// Bundles a `Type` with a `TextRange`, allowing us to give good errors.
     Type(&'a Type, TextRange),
-    Expr(&'a Expr),
+    /// An expression whose type is inferred lazily. The `bool` records whether
+    /// `CallWithTypes::type_or_expr` deliberately deferred it so that a call
+    /// evaluated more than once (overload / union-callee resolution) can type it
+    /// contextually per candidate. Argument checking gates the deferral-specific
+    /// widening guard on this flag so ordinary calls always type it contextually.
+    Expr(&'a Expr, bool),
 }
 
 pub(crate) enum PreparedExprCall {
@@ -172,7 +177,7 @@ impl Ranged for TypeOrExpr<'_> {
     fn range(&self) -> TextRange {
         match self {
             TypeOrExpr::Type(_, range) => *range,
-            TypeOrExpr::Expr(expr) => expr.range(),
+            TypeOrExpr::Expr(expr, _) => expr.range(),
         }
     }
 }
@@ -187,7 +192,7 @@ impl<'a> TypeOrExpr<'a> {
     ) -> Type {
         match self {
             TypeOrExpr::Type(ty, _) => ty.clone(),
-            TypeOrExpr::Expr(x) => solver.expr_infer(x, errors),
+            TypeOrExpr::Expr(x, _) => solver.expr_infer(x, errors),
         }
     }
 

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -2609,3 +2609,106 @@ def f(keys: list[str]) -> None:
     assert_type(gen([k] for k in keys), str)
 "#,
 );
+
+// A generic overload may provide only a provisional contextual type. Do not let that type widen
+// a comprehension whose element type is already known. Regression test for a Zulip primer failure.
+testcase!(
+    test_overload_generic_hint_does_not_widen_comprehension,
+    r#"
+from collections.abc import Collection
+from typing import assert_type
+
+def validated_emails(emails: Collection[str]) -> list[str]:
+    result = list(filter(bool, {email.strip() for email in emails}))
+    assert_type(result, list[str])
+    return result
+"#,
+);
+
+// A comprehension whose element type depends on the generic hint (here a bare lambda whose
+// parameter is typed by the hint) is inferred without context only when a context-free pass would
+// already be fully resolved; otherwise the hint is applied, narrowing it like the list literal.
+// https://github.com/facebook/pyrefly/issues/4167
+testcase!(
+    test_overload_generic_hint_narrows_comprehension_lambda,
+    r#"
+from collections.abc import Callable, Iterable
+from typing import assert_type
+
+def g[T](it: Iterable[Callable[[int], T]]) -> T: ...
+
+def call() -> None:
+    assert_type(g([lambda a: a]), int)
+    assert_type(g([lambda a: a for _ in range(1)]), int)
+"#,
+);
+
+// An ordinary generic function is not an overload, so its comprehension argument must be typed
+// contextually against the parameter, exactly like a list literal. Deferral (and the widening guard
+// it enables) applies only to calls evaluated more than once (overload / union-callee resolution).
+// https://github.com/facebook/pyrefly/pull/4224
+testcase!(
+    test_generic_comprehension_typed_contextually,
+    r#"
+from typing import TypedDict
+class TD(TypedDict):
+    x: int
+def take[T](xs: list[T]) -> list[T]: ...
+def f(ks: list[int]) -> None:
+    a: list[TD] = take([{"x": k} for k in ks])
+    b: list[TD] = take([{"x": 1}])
+"#,
+);
+
+// Keyword comprehension arguments to an overload are checked on a separate path from positional
+// ones, so the widening guard must apply there too: a deferred set comprehension keeps its known
+// element type against a provisional generic hint whether passed positionally or by keyword.
+testcase!(
+    test_overload_generic_hint_does_not_widen_comprehension_keyword,
+    r#"
+from collections.abc import Callable, Iterable, Iterator
+from typing import Any, assert_type, overload
+@overload
+def myfilter[T](function: None, iterable: Iterable[T | None]) -> Iterator[T]: ...
+@overload
+def myfilter[T](function: Callable[[T], Any], iterable: Iterable[T]) -> Iterator[T]: ...
+def myfilter(function, iterable) -> Iterator[Any]: ...
+def f(emails: list[str]) -> None:
+    assert_type(list(myfilter(bool, {e.strip() for e in emails})), list[str])
+    assert_type(list(myfilter(bool, iterable={e.strip() for e in emails})), list[str])
+"#,
+);
+
+// A generator in starred position into an overload is flattened (inferred once) rather than
+// deferred: deferral there buys no contextual narrowing and would re-infer it per candidate.
+testcase!(
+    test_overload_starred_generator,
+    r#"
+from typing import assert_type, overload
+@overload
+def f(x: int, y: int) -> int: ...
+@overload
+def f(x: str, y: str) -> str: ...
+def f(x: int | str, y: int | str) -> int | str: return x
+def g(xs: list[int]) -> None:
+    assert_type(f(*(x for x in xs)), int)
+"#,
+);
+
+// When an earlier argument pins the generic, the deferred comprehension's elements genuinely depend
+// on that binding (the lambda parameter is typed by it), so context-free inference is incomplete and
+// the pinned hint narrows the comprehension. `var_is_quantified` alone would wrongly discard it.
+testcase!(
+    test_overload_generic_hint_pinned_by_earlier_arg,
+    r#"
+from collections.abc import Callable, Iterable
+from typing import Any, assert_type, overload
+@overload
+def g[T](b: T, a: Iterable[Callable[[int], T]]) -> T: ...
+@overload
+def g(b: None, a: None) -> None: ...
+def g(b: Any, a: Any) -> Any: ...
+def call() -> None:
+    assert_type(g(0, [lambda x: x for _ in range(1)]), int)
+"#,
+);

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -2609,3 +2609,36 @@ def f(keys: list[str]) -> None:
     assert_type(gen([k] for k in keys), str)
 "#,
 );
+
+// A generic overload may provide only a provisional contextual type. Do not let that type widen
+// a comprehension whose element type is already known. Regression test for a Zulip primer failure.
+testcase!(
+    test_overload_generic_hint_does_not_widen_comprehension,
+    r#"
+from collections.abc import Collection
+from typing import assert_type
+
+def validated_emails(emails: Collection[str]) -> list[str]:
+    result = list(filter(bool, {email.strip() for email in emails}))
+    assert_type(result, list[str])
+    return result
+"#,
+);
+
+// A comprehension argument to a generic parameter is inferred without context, unlike the
+// equivalent list literal, so hint-dependent elements (here a lambda) are not narrowed.
+// https://github.com/facebook/pyrefly/issues/4167
+testcase!(
+    bug = "comprehension is not contextually typed against a generic parameter hint",
+    test_overload_generic_hint_does_not_narrow_comprehension_lambda,
+    r#"
+from collections.abc import Callable, Iterable
+from typing import assert_type
+
+def g[T](it: Iterable[Callable[[int], T]]) -> T: ...
+
+def call() -> None:
+    assert_type(g([lambda a: a]), int)
+    assert_type(g([lambda a: a for _ in range(1)]), int)  # E: assert_type(Unknown, int) failed
+"#,
+);

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -2712,3 +2712,16 @@ def call() -> None:
     assert_type(g(0, [lambda x: x for _ in range(1)]), int)
 "#,
 );
+
+// A comprehension deferred during overload resolution still reports errors inside its body when the
+// widening guard keeps its (fully resolved) element type. Guards against dropping those diagnostics.
+testcase!(
+    test_overload_deferred_comprehension_reports_body_errors,
+    r#"
+from collections.abc import Collection
+def need_int(a: int) -> str:
+    return ""
+def validated(emails: Collection[str]) -> list[str]:
+    return list(filter(bool, {need_int() for _ in emails}))  # E: Missing argument `a`
+"#,
+);

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -2519,3 +2519,93 @@ if TYPE_CHECKING:
     def f(a: str): ...
     "#,
 );
+
+// Regression test for https://github.com/facebook/pyrefly/issues/4167: a comprehension argument is
+// contextually typed per candidate overload, so its literal element narrows and the call matches.
+testcase!(
+    test_overload_literal_narrowing_through_comprehension,
+    r#"
+from collections.abc import Sequence
+from typing import Literal, overload, reveal_type
+
+Order = Literal["ascending", "descending"]
+
+@overload
+def sort_indices(sort_keys: Sequence[tuple[str, Order]]) -> str: ...
+@overload
+def sort_indices(sort_keys: str) -> int: ...
+def sort_indices(sort_keys: Sequence[tuple[str, Order]] | str) -> str | int:
+    return 0
+
+def f(names: list[str]) -> None:
+    reveal_type(sort_indices([(name, "ascending") for name in names]))  # E: revealed type: str
+"#,
+);
+
+// Set/dict comprehensions and generator expressions share the same un-flattened arm, so a
+// literal element is likewise narrowed against the candidate overload's parameter.
+// https://github.com/facebook/pyrefly/issues/4167
+testcase!(
+    test_overload_literal_narrowing_through_set_dict_generator,
+    r#"
+from collections.abc import Iterable
+from typing import Literal, overload, reveal_type
+
+Order = Literal["ascending", "descending"]
+
+@overload
+def take_set(x: set[Order]) -> str: ...
+@overload
+def take_set(x: int) -> int: ...
+def take_set(x: set[Order] | int) -> str | int: return 0
+
+@overload
+def take_dict(x: dict[str, Order]) -> str: ...
+@overload
+def take_dict(x: int) -> int: ...
+def take_dict(x: dict[str, Order] | int) -> str | int: return 0
+
+@overload
+def take_iter(x: Iterable[Order]) -> str: ...
+@overload
+def take_iter(x: int) -> int: ...
+def take_iter(x: Iterable[Order] | int) -> str | int: return 0
+
+def f(keys: list[str]) -> None:
+    reveal_type(take_set({"ascending" for _ in keys}))  # E: revealed type: str
+    reveal_type(take_dict({k: "ascending" for k in keys}))  # E: revealed type: str
+    reveal_type(take_iter("ascending" for _ in keys))  # E: revealed type: str
+"#,
+);
+
+// Every overload here accepts the argument, so the assertions pin down *which* one wins: only a
+// hint that reaches the element selects the narrower one. Without contextual typing these still
+// resolve, just to the wider overload, so the test fails loudly rather than merely erroring.
+// https://github.com/facebook/pyrefly/issues/4167
+testcase!(
+    test_overload_comprehension_hint_selects_narrower_overload,
+    r#"
+from collections.abc import Iterable
+from typing import Literal, assert_type, overload
+
+Order = Literal["ascending", "descending"]
+
+@overload
+def g(x: list[Order]) -> int: ...
+@overload
+def g(x: list[str]) -> str: ...
+def g(x: list[Order] | list[str]) -> int | str: return 0
+
+@overload
+def gen(x: Iterable[list[Order]]) -> int: ...
+@overload
+def gen(x: Iterable[list[str]]) -> str: ...
+def gen(x: Iterable[list[Order]] | Iterable[list[str]]) -> int | str: return 0
+
+def f(keys: list[str]) -> None:
+    assert_type(g(["ascending" for _ in keys]), int)
+    assert_type(g([k for k in keys]), str)
+    assert_type(gen(["ascending"] for _ in keys), int)
+    assert_type(gen([k] for k in keys), str)
+"#,
+);


### PR DESCRIPTION
# Summary

Fixes #4167.

When resolving an overloaded call, container **literals** (`list`/`set`/`dict`) are kept as expressions rather than eagerly inferred, so each candidate overload can contextually type them against its parameter (and narrow element literals). Comprehensions and generator expressions were not — they fell through to a context-free `expr_infer` in `CallWithTypes::type_or_expr`, so:

```py
from collections.abc import Sequence
from typing import Literal, overload

Order = Literal["ascending", "descending"]

@overload
def sort_indices(sort_keys: Sequence[tuple[str, Order]]) -> str: ...
@overload
def sort_indices(sort_keys: str) -> int: ...
def sort_indices(sort_keys: Sequence[tuple[str, Order]] | str) -> str | int:
    return 0

names = ["a", "b"]
result = sort_indices([(name, "ascending") for name in names])
```

was inferred as `list[tuple[str, str]]` and reported `no-matching-overload`, even though mypy, pyright, and ty all accept it (reported against [Narwhals](https://github.com/narwhals-dev/narwhals)).

The fix adds `Expr::ListComp | Expr::SetComp | Expr::DictComp | Expr::Generator` to the same un-flattened arm. These variants already support hint-directed inference via `infer_with_decomposed_hint` / `decompose_list`, so deferring their inference lets the existing per-overload contextual-typing path narrow their element/key/value types exactly as it does for container literals. When a hint doesn't decompose (e.g. a generator against a non-`Sequence` param), inference falls back to the previous context-free behaviour, so no path is worse than before.

# Test Plan

Added `test_overload_literal_narrowing_through_comprehension` (the reported repro) and `test_overload_literal_narrowing_through_set_dict_generator` (set/dict comprehensions and generators) to `pyrefly/lib/test/overload.rs`. Both fail before the change (`no-matching-overload`, `reveal_type` = `Unknown`) and pass after (`reveal_type` = `str`).

`cargo test -p pyrefly --lib` passes; `test.py` formatting and linting are clean.