### PR TITLE
Remove redundant pieces of the IGNORE_COMMENT_REGEX

### DIFF
--- a/pyrefly/lib/error/suppress.rs
+++ b/pyrefly/lib/error/suppress.rs
@@ -43,13 +43,13 @@ use crate::state::errors::sorted_multi_line_string_ranges;
 /// Each consumes all non-`#` characters after its ignore pattern, so removing one
 /// suppression preserves any other pragma later on the same line.
 static PYREFLY_IGNORE_COMMENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"#\s*pyrefly:\s*ignore\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*").unwrap()
+    Regex::new(r"#\s*pyrefly:\s*ignore\s*(\[[^\]]*\])?[^#]*").unwrap()
 });
 static TYPE_IGNORE_COMMENT_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"#\s*type:\s*ignore\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*").unwrap());
+    LazyLock::new(|| Regex::new(r"#\s*type:\s*ignore\s*(\[[^\]]*\])?[^#]*").unwrap());
 static PYRE_IGNORE_COMMENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"#\s*pyre-(?:fixme|ignore)\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*|#\s*pyre:\s*ignore\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*",
+        r"#\s*pyre-(?:fixme|ignore)\s*(\[[^\]]*\])?[^#]*|#\s*pyre:\s*ignore\s*(\[[^\]]*\])?[^#]*",
     )
     .unwrap()
 });


### PR DESCRIPTION
# Summary

This is a no-op refactor.

Each branch of this regex contains a copy of the construct `\s*(?:;\s*)?[^#]*`, but the last part of it already covers everything that the other parts could possibly cover, so we remove them.

# Test Plan

No functionality is changed, so if all preexisting tests pass, that should be sufficient.
And in my brief manual usage of `pyrefly suppress` I didn't encounter any issues.