### PR TITLE
Resolve TSP type queries in files that aren't open (#4235)

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -6373,6 +6373,44 @@ impl Server {
         )
     }
 
+    /// Build a read transaction and the handle the type checker analyzes `path`
+    /// under, so `(uri, range)` queries resolve for any analyzable file rather
+    /// than only open documents.
+    ///
+    /// Open files are served from their in-memory overlay (already committed by
+    /// the recheck that ran on `didOpen`). For anything else we reuse the handle
+    /// the file was already analyzed under — an imported dependency's filesystem
+    /// handle, or a bundled stdlib stub's `BundledTypeshed` handle whose
+    /// `SysInfo` we can't reconstruct here, hence the by-path lookup — and force
+    /// a full solve (`Require::Everything` is the only level that retains
+    /// bindings/answers, which the type lookup reads) so narrowed/computed types
+    /// are available. A file that isn't analyzed yet falls back to a fresh
+    /// filesystem handle read from disk.
+    fn query_transaction_and_handle<'a>(&'a self, path: &Path) -> (Transaction<'a>, Handle) {
+        if self.open_files.read().contains_key(path) {
+            return (
+                self.state.transaction(),
+                make_open_handle(&self.state, path),
+            );
+        }
+        let mut transaction = self.state.transaction();
+        // Imported dependencies live under a filesystem handle we can rebuild
+        // directly; only scan when that misses (bundled stubs, unusual SysInfo).
+        let fs_handle =
+            handle_from_module_path(&self.state, ModulePath::filesystem(path.to_owned()));
+        let handle = if transaction.get_module_info(&fs_handle).is_some() {
+            fs_handle
+        } else {
+            transaction
+                .handles()
+                .into_iter()
+                .find(|h| !h.path().is_memory() && to_real_path(h.path()).as_deref() == Some(path))
+                .unwrap_or(fs_handle)
+        };
+        transaction.run(&[handle.dupe()], Require::Everything, None);
+        (transaction, handle)
+    }
+
     /// Open `uri` at `(line, character)`: resolve the path, build a handle, and
     /// start a transaction, returning it alongside the handle and the resolved
     /// in-file position.
@@ -6388,8 +6426,7 @@ impl Server {
         let path = self.path_for_uri_or_notebook_cell(&url)?;
         let notebook_cell = self.maybe_get_code_cell_index(&url);
 
-        let handle = make_open_handle(&self.state, &path);
-        let transaction = self.state.transaction();
+        let (transaction, handle) = self.query_transaction_and_handle(&path);
         let module_info = transaction.get_module_info(&handle)?;
         let position =
             module_info.from_lsp_position(lsp_types::Position { line, character }, notebook_cell);
@@ -6616,8 +6653,7 @@ impl TspInterface for Server {
         let path = self.path_for_uri_or_notebook_cell(&url)?;
         let notebook_cell = self.maybe_get_code_cell_index(&url);
 
-        let handle = make_open_handle(&self.state, &path);
-        let transaction = self.state.transaction();
+        let (transaction, handle) = self.query_transaction_and_handle(&path);
         let module_info = transaction.get_module_info(&handle)?;
         let start = module_info.from_lsp_position(
             lsp_types::Position {

--- a/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
@@ -12,6 +12,8 @@ use lsp_types::Url;
 use tempfile::TempDir;
 use tsp_types::TypeKind;
 
+use crate::module::bundled::BundledStub;
+use crate::module::typeshed::typeshed;
 use crate::test::tsp::tsp_interaction::object_model::TspInteraction;
 use crate::test::tsp::tsp_interaction::object_model::get_current_snapshot;
 use crate::test::tsp::tsp_interaction::object_model::write_pyproject;
@@ -397,6 +399,67 @@ fn test_get_computed_type_function_is_function_type() {
         result.get("returnType").is_some(),
         "Expected returnType field on FunctionType"
     );
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_computed_type_in_unopened_file() {
+    // Regression test for https://github.com/facebook/pyrefly/issues/4228:
+    // `getComputedType` is keyed by `(uri, range)` and must resolve nodes in any
+    // analyzable file, not only open documents. Here `lib.py` is on disk and
+    // imported by the open `main.py`, but is itself never `didOpen`ed; querying a
+    // node in it must still return a type rather than `null`.
+    // Keep `temp_dir` alive for the whole test so `lib.py` stays on disk while
+    // the (unopened) file is queried.
+    let temp_dir = TempDir::new().unwrap();
+    write_pyproject(temp_dir.path());
+    let lib_path = temp_dir.path().join("lib.py");
+    std::fs::write(&lib_path, "def g() -> None: ...\n").unwrap();
+    let lib_uri = Url::from_file_path(&lib_path).unwrap().to_string();
+
+    let main_path = temp_dir.path().join("main.py");
+    std::fs::write(&main_path, "import lib\nx = lib.g()\n").unwrap();
+
+    let mut tsp = TspInteraction::new();
+    tsp.set_root(temp_dir.path().to_path_buf());
+    tsp.initialize(Default::default());
+    tsp.server.did_open("main.py");
+    tsp.client.expect_any_message();
+    let snapshot = get_current_snapshot(&mut tsp, 2);
+
+    // Query the `g` function definition in the unopened `lib.py`.
+    let result = get_computed_type_ok(&mut tsp, &lib_uri, 0, 4, snapshot);
+    assert_kind(&result, TypeKind::Function);
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_computed_type_in_bundled_typeshed() {
+    // The real-world case behind #4228: Pylance never `didOpen`s bundled stdlib
+    // stubs, so nodes inside `builtins.pyi` (which no editor opens) must still
+    // resolve. This exercises the by-path lookup that reuses the bundled
+    // typeshed handle the checker already analyzed.
+    let builtins = typeshed()
+        .unwrap()
+        .materialized_path_on_disk()
+        .unwrap()
+        .join("builtins.pyi");
+    let builtins_uri = Url::from_file_path(&builtins).unwrap().to_string();
+    let content = std::fs::read_to_string(&builtins).unwrap();
+    // Target the `object` identifier in `class object` (version-stable).
+    let (line, character) = content
+        .lines()
+        .enumerate()
+        .find_map(|(i, l)| l.find("class object").map(|c| (i as u32, (c + 6) as u32)))
+        .expect("builtins.pyi should define `class object`");
+
+    // `builtins` is loaded implicitly by any check, without opening any file.
+    let (mut tsp, _file_uri, snapshot) = setup_project("x = 1\n");
+
+    let result = get_computed_type_ok(&mut tsp, &builtins_uri, line, character, snapshot);
+    assert_kind(&result, TypeKind::Class);
 
     tsp.shutdown();
 }


### PR DESCRIPTION
Summary:

TSP `getComputedType` (and `getDeclaredType`/`getExpectedType`) returned
`null` for any node in a file that wasn't open in the editor, even though
the file was on disk, reachable, and analyzed as a dependency of an open
file. Opening the same file made the identical `(uri, range)` query
succeed. This broke every node in Pyrefly's bundled stdlib stubs (e.g.
`builtins.pyi`), which clients like Pylance never `didOpen`.

Fixes #4228.

The root cause: `computed_type_at_range` and `open_at_position` built the
handle with `make_open_handle`, which always uses `ModulePath::memory`.
In-memory content only exists for opened files, so the memory-keyed handle
only matched open documents; closed files are keyed under `FileSystem` or
`BundledTypeshed` handles (whose `SysInfo` is inherited from the importer
and can't be reconstructed here), so the lookup missed and short-circuited
to `null`.

New helper `query_transaction_and_handle` resolves a path to the handle the
checker actually analyzes it under:
- open files -> in-memory overlay (unchanged fast path);
- otherwise reuse the already-loaded handle: the filesystem handle when it
  can be rebuilt directly, else a by-path scan that reuses the loaded
  `BundledTypeshed` handle so stdlib queries don't re-check typeshed;
- fall back to a fresh filesystem handle read from disk when the file
  hasn't been analyzed yet.

It then forces a full solve at `Require::Everything`, the only level that
retains bindings/answers — exactly the data the type lookup reads — so the
result is available regardless of what require level the file was loaded
at as a dependency. Open-file queries are unchanged; only the previously
`null` closed-file path does additional work, and bundled typeshed reuses
its already-solved handle.

Differential Revision: D113135763


