### PR TITLE
Fix undeclared loop variables in Pyrefly debugger

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -90,9 +90,9 @@ function render(keep) {
     const $keys = document.getElementById("keys");
     $errors.innerHTML = "";
     $keys.innerHTML = "";
-    for (module_name in data.modules) {
+    for (const module_name in data.modules) {
         const module_data = data.modules[module_name];
-        for (error in module_data.errors) {
+        for (const error in module_data.errors) {
             error = module_data.errors[error];
             if (keep(error.location, error.message)) {
                 const item = document.createElement("li");
@@ -102,7 +102,7 @@ function render(keep) {
                 ]));
             }
         }
-        for (binding in module_data.bindings) {
+        for (const binding in module_data.bindings) {
             binding = module_data.bindings[binding];
             if (keep(binding.location, binding.key + " " + binding.binding + " " + binding.result)) {
                 const item = document.createElement("li");
@@ -121,12 +121,12 @@ function render(keep) {
 function assertEq(a, b) {
     if (Array.isArray(a) && Array.isArray(b)) {
         assertEq(a.length, b.length);
-        for (i = 0; i < a.length; i++) {
+        for (let i = 0; i < a.length; i++) {
             assertEq(a[i], b[i]);
         }
     } else if (typeof a === "object" && typeof b === "object") {
         assertEq(Object.keys(a), Object.keys(b))
-        for (k in a) {
+        for (const k in a) {
             assertEq(a[k], b[k]);
         }
     }


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #XXXX

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

## Description

Declare loop variables explicitly in the Pyrefly debugger JavaScript code.

This change replaces implicitly created global variables with `const` and `let` declarations in the `render()` and `assertEq()` functions.

## Changes

- Declared `module_name`, `error`, and `binding` using `const`.
- Declared the `i` loop variable using `let`.
- Declared `k` using `const`.

This prevents accidental global variable creation and improves code safety and readability.