### PR TITLE
Fix relative imports when renaming files

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/will_rename_files.rs
+++ b/pyrefly/lib/lsp/non_wasm/will_rename_files.rs
@@ -26,6 +26,8 @@ use pyrefly_util::lock::RwLock;
 use rayon::prelude::*;
 use ruff_python_ast::Stmt;
 use ruff_text_size::Ranged;
+use ruff_text_size::TextRange;
+use ruff_text_size::TextSize;
 use tracing::info;
 
 use crate::lsp::non_wasm::module_helpers::PathRemapper;
@@ -102,31 +104,45 @@ impl<'a> RenameUsageVisitor<'a> {
                 let Some(replacement) = self.replacement_for_module(imported_module) else {
                     return;
                 };
-                let new_import_name = if import_from.level == 0 {
-                    replacement
+                let (range, new_text) = if import_from.level == 0 {
+                    (module.range(), replacement)
                 } else {
-                    let Some(current_package) = self.current_module_name.new_maybe_relative(
-                        self.is_init,
-                        import_from.level,
-                        None,
-                    ) else {
-                        return;
-                    };
+                    let current_package = self
+                        .current_module_name
+                        .new_maybe_relative(self.is_init, import_from.level, None)
+                        .expect("resolved above with the same number of dots");
                     let current_package_prefix = if current_package.as_str().is_empty() {
                         String::new()
                     } else {
                         format!("{}.", current_package.as_str())
                     };
-                    let Some(relative_replacement) =
-                        replacement.strip_prefix(&current_package_prefix)
-                    else {
-                        return;
-                    };
-                    relative_replacement.to_owned()
+                    match replacement.strip_prefix(&current_package_prefix) {
+                        Some(relative_replacement) => {
+                            (module.range(), relative_replacement.to_owned())
+                        }
+                        // Keeping the original dots would resolve against the wrong package.
+                        // Ruff stores their count but not their range, so we can just locate them
+                        // in the source before replacing the whole path.
+                        None => {
+                            let before_module =
+                                TextRange::new(import_from.range().start(), module.range().start());
+                            let dots_offset = self
+                                .lined_buffer
+                                .code_at(before_module)
+                                .find('.')
+                                .expect("relative import has a dot before the module name");
+                            let dots_start = before_module.start()
+                                + TextSize::try_from(dots_offset).expect("offset fits in u32");
+                            (
+                                TextRange::new(dots_start, module.range().end()),
+                                replacement,
+                            )
+                        }
+                    }
                 };
                 self.edits.push(TextEdit {
-                    range: self.lined_buffer.to_lsp_range(module.range(), None),
-                    new_text: new_import_name,
+                    range: self.lined_buffer.to_lsp_range(range, None),
+                    new_text,
                 });
             }
             _ => {}

--- a/pyrefly/lib/lsp/non_wasm/will_rename_files.rs
+++ b/pyrefly/lib/lsp/non_wasm/will_rename_files.rs
@@ -40,6 +40,8 @@ struct RenameUsageVisitor<'a> {
     edits: Vec<TextEdit>,
     old_module_name: &'a ModuleName,
     new_module_name: &'a ModuleName,
+    current_module_name: ModuleName,
+    is_init: bool,
     lined_buffer: &'a LinedBuffer,
 }
 
@@ -47,13 +49,27 @@ impl<'a> RenameUsageVisitor<'a> {
     fn new(
         old_module_name: &'a ModuleName,
         new_module_name: &'a ModuleName,
+        current_module_name: ModuleName,
+        is_init: bool,
         lined_buffer: &'a LinedBuffer,
     ) -> Self {
         Self {
             edits: Vec::new(),
             old_module_name,
             new_module_name,
+            current_module_name,
+            is_init,
             lined_buffer,
+        }
+    }
+
+    fn replacement_for_module(&self, imported_module: ModuleName) -> Option<String> {
+        if imported_module == *self.old_module_name {
+            Some(self.new_module_name.as_str().to_owned())
+        } else {
+            let old_prefix = format!("{}.", self.old_module_name.as_str());
+            let suffix = imported_module.as_str().strip_prefix(&old_prefix)?;
+            Some(format!("{}.{}", self.new_module_name.as_str(), suffix))
         }
     }
 
@@ -62,22 +78,7 @@ impl<'a> RenameUsageVisitor<'a> {
             Stmt::Import(import) => {
                 for alias in &import.names {
                     let imported_module = ModuleName::from_name(&alias.name.id);
-                    if imported_module == *self.old_module_name
-                        || imported_module
-                            .as_str()
-                            .starts_with(&format!("{}.", self.old_module_name.as_str()))
-                    {
-                        // Replace the module name
-                        let new_import_name = if imported_module == *self.old_module_name {
-                            self.new_module_name.as_str().to_owned()
-                        } else {
-                            // Replace the prefix
-                            imported_module.as_str().replace(
-                                self.old_module_name.as_str(),
-                                self.new_module_name.as_str(),
-                            )
-                        };
-
+                    if let Some(new_import_name) = self.replacement_for_module(imported_module) {
                         self.edits.push(TextEdit {
                             range: self.lined_buffer.to_lsp_range(alias.name.range(), None),
                             new_text: new_import_name,
@@ -86,30 +87,47 @@ impl<'a> RenameUsageVisitor<'a> {
                 }
             }
             Stmt::ImportFrom(import_from) => {
-                if let Some(module) = &import_from.module {
-                    let imported_module = ModuleName::from_name(&module.id);
-                    if imported_module == *self.old_module_name
-                        || imported_module
-                            .as_str()
-                            .starts_with(&format!("{}.", self.old_module_name.as_str()))
-                    {
-                        // Replace the module name
-                        let new_import_name = if imported_module == *self.old_module_name {
-                            self.new_module_name.as_str().to_owned()
-                        } else {
-                            // Replace the prefix
-                            imported_module.as_str().replace(
-                                self.old_module_name.as_str(),
-                                self.new_module_name.as_str(),
-                            )
-                        };
-
-                        self.edits.push(TextEdit {
-                            range: self.lined_buffer.to_lsp_range(module.range(), None),
-                            new_text: new_import_name,
-                        });
-                    }
-                }
+                // `from . import name` binds `name` directly, so updating it would also require
+                // a semantic rename of references to that binding.
+                let Some(module) = &import_from.module else {
+                    return;
+                };
+                let Some(imported_module) = self.current_module_name.new_maybe_relative(
+                    self.is_init,
+                    import_from.level,
+                    Some(&module.id),
+                ) else {
+                    return;
+                };
+                let Some(replacement) = self.replacement_for_module(imported_module) else {
+                    return;
+                };
+                let new_import_name = if import_from.level == 0 {
+                    replacement
+                } else {
+                    let Some(current_package) = self.current_module_name.new_maybe_relative(
+                        self.is_init,
+                        import_from.level,
+                        None,
+                    ) else {
+                        return;
+                    };
+                    let current_package_prefix = if current_package.as_str().is_empty() {
+                        String::new()
+                    } else {
+                        format!("{}.", current_package.as_str())
+                    };
+                    let Some(relative_replacement) =
+                        replacement.strip_prefix(&current_package_prefix)
+                    else {
+                        return;
+                    };
+                    relative_replacement.to_owned()
+                };
+                self.edits.push(TextEdit {
+                    range: self.lined_buffer.to_lsp_range(module.range(), None),
+                    new_text: new_import_name,
+                });
             }
             _ => {}
         }
@@ -258,6 +276,8 @@ pub fn will_rename_files(
                 let mut visitor = RenameUsageVisitor::new(
                     &old_module_name,
                     &new_module_name,
+                    rdep_handle.module(),
+                    rdep_handle.path().is_init(),
                     module_info.lined_buffer(),
                 );
 

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/package_relative_rename/pkg/__init__.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/package_relative_rename/pkg/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/package_relative_rename/pkg/a.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/package_relative_rename/pkg/a.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+def foo() -> None:
+    pass

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/package_relative_rename/pkg/b.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/package_relative_rename/pkg/b.py
@@ -1,0 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .a import foo
+
+foo()

--- a/pyrefly/lib/test/lsp/lsp_interaction/will_rename_files.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/will_rename_files.rs
@@ -390,6 +390,50 @@ fn test_will_rename_files_without_config_with_workspace_folder() {
 }
 
 #[test]
+fn test_will_rename_files_updates_relative_package_import() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new_with_args(LspInteractionArgs {
+        args: LspArgs {
+            indexing_mode: IndexingMode::LazyBlocking,
+            ..LspInteractionArgs::default().args
+        },
+        ..Default::default()
+    });
+    let root_path = root.path().join("package_relative_rename");
+    let scope_uri = Url::from_file_path(&root_path).unwrap();
+
+    interaction.set_root(root_path.clone());
+    interaction
+        .initialize(InitializeSettings {
+            workspace_folders: Some(vec![("test".to_owned(), scope_uri)]),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open("pkg/a.py");
+
+    interaction
+        .client
+        .will_rename_files("pkg/a.py", "pkg/a2.py")
+        .expect_response(json!({
+            "changes": {
+                Url::from_file_path(root_path.join("pkg/b.py")).unwrap().to_string(): [
+                    {
+                        "newText": "a2",
+                        "range": {
+                            "start": {"line": 5, "character": 6},
+                            "end": {"line": 5, "character": 7}
+                        }
+                    },
+                ],
+            }
+        }))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
 fn test_will_rename_files_document_changes() {
     let root = get_test_files_root();
     let mut interaction = LspInteraction::new_with_args(LspInteractionArgs {

--- a/pyrefly/lib/test/lsp/lsp_interaction/will_rename_files.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/will_rename_files.rs
@@ -434,6 +434,50 @@ fn test_will_rename_files_updates_relative_package_import() {
 }
 
 #[test]
+fn test_will_rename_files_rewrites_relative_import_as_absolute_on_move() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new_with_args(LspInteractionArgs {
+        args: LspArgs {
+            indexing_mode: IndexingMode::LazyBlocking,
+            ..LspInteractionArgs::default().args
+        },
+        ..Default::default()
+    });
+    let root_path = root.path().join("package_relative_rename");
+    let scope_uri = Url::from_file_path(&root_path).unwrap();
+
+    interaction.set_root(root_path.clone());
+    interaction
+        .initialize(InitializeSettings {
+            workspace_folders: Some(vec![("test".to_owned(), scope_uri)]),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open("pkg/a.py");
+
+    interaction
+        .client
+        .will_rename_files("pkg/a.py", "other/a.py")
+        .expect_response(json!({
+            "changes": {
+                Url::from_file_path(root_path.join("pkg/b.py")).unwrap().to_string(): [
+                    {
+                        "newText": "other.a",
+                        "range": {
+                            "start": {"line": 5, "character": 5},
+                            "end": {"line": 5, "character": 7}
+                        }
+                    },
+                ],
+            }
+        }))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
 fn test_will_rename_files_document_changes() {
     let root = get_test_files_root();
     let mut interaction = LspInteraction::new_with_args(LspInteractionArgs {


### PR DESCRIPTION
# Summary

Fixes https://github.com/facebook/pyrefly/issues/4055

- We resolve relative imports against the importing module when updating imports for `willRenameFiles`.
- This fixes renames like `pkg/a.py` to `pkg/a2.py`, where `from .a import foo` should become `from .a2 import foo`.
- If a move takes the module outside the package targeted by the leading dots, we update the import to an absolute path instead.

# Test Plan

- `uv run --with jsonschema --with toml test.py`
- Added regression tests for renaming within a package and moving outside it.