### PR TITLE
Optimise `venv` discovery for mid/large-sized directory trees

### DIFF
--- a/crates/pyrefly_config/src/environment/finder.rs
+++ b/crates/pyrefly_config/src/environment/finder.rs
@@ -40,8 +40,19 @@ static PYTHON_INTERPRETER_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 /// to be found at either `.venv/bin/python(\d(\.\d)?)?` or `.venv/python(\d(\.\d)?)?`.
 ///
 /// Note: we do not follow links. For `venv`s, the symlink path contains important
-/// information the Python interpreter needs to proplrly execute.
+/// information the Python interpreter needs to properly execute.
 pub fn walk_interpreter(start: &Path, depth: usize) -> impl Iterator<Item = PathBuf> {
+    walk_interpreter_pruned(start, depth, |_| true)
+}
+
+/// Like [`walk_interpreter`], but skips descending into any directory for which
+/// `should_descend` returns `false`, pruning that subtree; use this to avoid
+/// walking source trees that *cannot* hold an interpreter.
+pub fn walk_interpreter_pruned(
+    start: &Path,
+    depth: usize,
+    should_descend: impl Fn(&walkdir::DirEntry) -> bool,
+) -> impl Iterator<Item = PathBuf> {
     let walker = WalkDir::new(start)
         .min_depth(1)
         .max_depth(depth)
@@ -60,7 +71,10 @@ pub fn walk_interpreter(start: &Path, depth: usize) -> impl Iterator<Item = Path
         Some(entry.path().to_path_buf())
     }
 
-    walker.into_iter().filter_map(filter_map)
+    walker
+        .into_iter()
+        .filter_entry(move |e| !e.file_type().is_dir() || should_descend(e))
+        .filter_map(filter_map)
 }
 
 #[cfg(test)]

--- a/crates/pyrefly_config/src/environment/venv.rs
+++ b/crates/pyrefly_config/src/environment/venv.rs
@@ -8,7 +8,7 @@
 use std::path::Path;
 use std::path::PathBuf;
 
-use crate::environment::finder::walk_interpreter;
+use crate::environment::finder::walk_interpreter_pruned;
 
 const CONFIG_FILE: &str = "pyvenv.cfg";
 /// How deep within a project root should we attempt to search for a valid Python executable?
@@ -16,6 +16,11 @@ const CONFIG_FILE: &str = "pyvenv.cfg";
 const SEARCH_DEPTH: usize = 3;
 const CANDIDATE_DIRS: &[&str] = &[".venv", "venv"];
 pub const ENV_VAR: &str = "VIRTUAL_ENV";
+
+/// A venv root is any directory holding a `pyvenv.cfg`.
+fn is_venv_root(dir: &Path) -> bool {
+    dir.join(CONFIG_FILE).exists()
+}
 
 fn has_standard_relative_config(interp: &Path) -> bool {
     interp
@@ -50,13 +55,17 @@ fn find_standard_interpreter(root: &Path) -> Option<PathBuf> {
 }
 
 fn find_in_dir(root: &Path) -> Option<PathBuf> {
-    if root.join(CONFIG_FILE).exists()
+    if is_venv_root(root)
         && let Some(interpreter) = find_standard_interpreter(root)
     {
         return Some(interpreter);
     }
 
-    let interpreters = walk_interpreter(root, SEARCH_DEPTH).collect::<Vec<PathBuf>>();
+    let interpreters = walk_interpreter_pruned(root, SEARCH_DEPTH, |entry| {
+        let dir = entry.path();
+        entry.depth() <= 1 || is_venv_root(dir) || dir.parent().is_some_and(is_venv_root)
+    })
+    .collect::<Vec<PathBuf>>();
 
     if interpreters.is_empty() {
         return None;
@@ -75,14 +84,14 @@ fn find_in_dir(root: &Path) -> Option<PathBuf> {
 }
 
 fn find_in_root(root: &Path) -> Option<PathBuf> {
-    if root.join(CONFIG_FILE).exists() {
+    if is_venv_root(root) {
         return find_in_dir(root);
     }
 
     CANDIDATE_DIRS
         .iter()
         .map(|candidate| root.join(candidate))
-        .filter(|path| path.join(CONFIG_FILE).exists())
+        .filter(|path| is_venv_root(path))
         .find_map(|path| find_in_dir(&path))
 }
 
@@ -387,6 +396,90 @@ mod tests {
         );
 
         assert_eq!(find(&project_root), None);
+    }
+
+    #[test]
+    fn test_find_venv_nested_in_subdir() {
+        // A venv in a subdirectory (not at the root or a `.venv`/`venv` candidate) is reached
+        // only by the walk, so the prune must descend into a depth-2 dir that is itself a venv
+        // root. Reachability is still bounded by `max_depth`, measured from the search root:
+        //   * `subdir/.venv/python`     -> interpreter at depth 3 => found (nonstandard layout)
+        //   * `subdir/.venv/bin/python` -> interpreter at depth 4 => not found (exceeds depth)
+        let interp_name = interp_name("");
+
+        // Standard layout: interpreter under `bin`.
+        // (depth 4 > max_depth, so not found).
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        TestPath::setup_test_directory(
+            root,
+            vec![
+                TestPath::file("pyrefly.toml"),
+                TestPath::dir(
+                    "subdir",
+                    vec![TestPath::dir(
+                        ".venv",
+                        vec![
+                            TestPath::file(CONFIG_FILE),
+                            TestPath::dir("bin", vec![TestPath::file(&interp_name)]),
+                        ],
+                    )],
+                ),
+            ],
+        );
+        assert_eq!(find(root), None);
+
+        // Nonstandard layout: interpreter directly under the nested venv root.
+        // (depth 3 <= max_depth, still found).
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        TestPath::setup_test_directory(
+            root,
+            vec![
+                TestPath::file("pyrefly.toml"),
+                TestPath::dir(
+                    "subdir",
+                    vec![TestPath::dir(
+                        ".venv",
+                        vec![TestPath::file(CONFIG_FILE), TestPath::file(&interp_name)],
+                    )],
+                ),
+            ],
+        );
+        assert_eq!(
+            find(root),
+            Some(root.join("subdir/.venv").join(&interp_name)),
+        );
+    }
+
+    #[test]
+    fn test_find_venv_beside_deep_source_tree() {
+        // A nonstandard venv name doesn't take the `CANDIDATE_DIRS` fast path; the pruned
+        // walk still needs to find the venv while pruning the deep sibling source tree.
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        let interp_name = interp_name("");
+        TestPath::setup_test_directory(
+            root,
+            vec![
+                TestPath::file("pyrefly.toml"),
+                TestPath::dir(
+                    "src",
+                    vec![TestPath::dir(
+                        "pkg",
+                        vec![TestPath::dir("sub", vec![TestPath::file("mod.py")])],
+                    )],
+                ),
+                TestPath::dir(
+                    "my-venv",
+                    vec![
+                        TestPath::file(CONFIG_FILE),
+                        TestPath::dir("bin", vec![TestPath::file(&interp_name)]),
+                    ],
+                ),
+            ],
+        );
+        assert_eq!(find(root), Some(root.join("my-venv/bin").join(interp_name)));
     }
 
     #[test]


### PR DESCRIPTION
# Summary

### Overview

* When `pyrefly check` runs over a package _without a configured interpreter_, it auto-discovers a project's `venv`.

* If "pyvenv.cfg" isn't immediately found in the project root or ".venv" / "venv", it falls back to an unfiltered `WalkDir` (to depth 3) over the entire project, testing every filename against the interpreter regex.

* This check is single-threaded, and runs _before_ everything else gets parallelised.

* For large projects, this can be a **significant** fixed cost. For example, local profiling showed it taking up ~20% of the total runtime for checking `homeassistant`, as that package has ~2,700 directories (!!).


### Solution

* `walk_interpreter` gains a simple "should_descend" predicate that prunes a directory's subtree when the predicate rejects it; a venv-aware pruning rule is supplied to it in `find_in_dir`.

* The prune is a strict superset of the reachable interpreters, so which interpreter the `find` resolves is unchanged, **but** the _non-venv_ source fan-out is completely skipped.

* In the extreme `homeassistant` case, this reduces **~2,700** `opendir` calls down to only **~15**, making the check essentially free (instead of ~20% of the runtime) 🚀 

# Test Plan

All existing tests pass, and two new `venv` discovery tests were added (which actually represent the majority of this PR as the code change itself is small).

# Benchmarks[^1]

Timed across a sample of  the `mypy_primer` projects. Speedup is (broadly) proportional to directory-tree size; significant on large nested trees, negligible on small flat projects.

`dirs ≤ 3` = how many directories (with depth ≤ 3) in the project.
`modules` = how many modules in the project.
`before` = pyrefly on main branch.
`after` = main + this PR. 

| project | dirs ≤ 3 | modules | before | after | Δ% |
|:--|--:|--:|--:|--:|--:|
| homeassistant | 2,736 | 9,811 | 2.010 | 1.611 | -19.8% |
| poetry | 124 | 191 | 0.172 | 0.151 | -12.6% |
| sphinx | 360 | 243 | 0.253 | 0.229 | -9.4% |
| pylint | 129 | 51 | 0.178 | 0.162 | -9.0% |
| hypothesis | 66 | 103 | 0.172 | 0.157 | -8.7% |
| sympy | 153 | 1,560 | 0.358 | 0.334 | -6.6% |
| pydantic | 60 | 104 | 0.170 | 0.164 | -3.4% |
| pandas | 129 | 1,459 | 0.407 | 0.396 | -2.6% |
| mypy | 61 | 1,098 | 0.394 | 0.384 | -2.5% |
| scipy | 137 | 925 | 0.429 | 0.425 | -1.0% |

[^1]: Test machine: Apple Silicon M3 Max (16 cores).