### PR TITLE
[pyrefly] Expose inferred type hints as quick fixes

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -4474,6 +4474,7 @@ impl Server {
             Some(CodeActionRequest::METHOD),
         )?;
         let import_format = lsp_config.and_then(|c| c.import_format).unwrap_or_default();
+        let inlay_hint_config = lsp_config.and_then(|c| c.inlay_hints).unwrap_or_default();
         let module_info = transaction
             .get_module_info(&handle)
             .ok_or(EmptyResponseReason::ModuleInfoNotFound)?;
@@ -4564,6 +4565,32 @@ impl Server {
                         ..Default::default()
                     }))
                 }));
+            }
+            if let Some(inlay_hints) = transaction.inlay_hints(&handle, inlay_hint_config) {
+                for hint in inlay_hints {
+                    let is_type_hint = hint
+                        .label_parts
+                        .first()
+                        .is_some_and(|(text, _)| text == ": " || text == " -> ");
+                    if !hint.insertable || !range.contains_inclusive(hint.position) || !is_type_hint
+                    {
+                        continue;
+                    }
+                    let position = module_info.to_lsp_position(hint.position);
+                    let edit = TextEdit {
+                        range: Range::new(position, position),
+                        new_text: hint.label_parts.into_iter().map(|(text, _)| text).collect(),
+                    };
+                    actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                        title: "Insert inferred type annotation".to_owned(),
+                        kind: Some(CodeActionKind::QUICKFIX),
+                        edit: Some(WorkspaceEdit {
+                            changes: Some(HashMap::from([(uri.clone(), vec![edit])])),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }));
+                }
             }
             record_code_action_telemetry("quickfix", start);
         }

--- a/pyrefly/lib/test/lsp/lsp_interaction/insert_type_annotation_code_action.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/insert_type_annotation_code_action.rs
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use lsp_types::CodeActionKind;
+use lsp_types::CodeActionOrCommand;
+use lsp_types::Url;
+use lsp_types::request::CodeActionRequest;
+use pyrefly_lsp_test::object_model::InitializeSettings;
+use pyrefly_lsp_test::object_model::LspInteraction;
+use serde_json::json;
+
+use crate::test::lsp::lsp_interaction::util::get_test_files_root;
+
+const TEST_FILE: &str = "insert_type_annotation_code_action.py";
+const ACTION_TITLE: &str = "Insert inferred type annotation";
+
+fn request_has_type_annotation_edit(
+    interaction: &LspInteraction,
+    uri: &Url,
+    request_line: u32,
+    request_start: u32,
+    request_end: u32,
+    edit_line: u32,
+    edit_character: u32,
+    new_text: &'static str,
+) {
+    let uri = uri.clone();
+    interaction
+        .client
+        .send_request::<CodeActionRequest>(json!({
+            "textDocument": { "uri": uri },
+            "range": {
+                "start": { "line": request_line, "character": request_start },
+                "end": { "line": request_line, "character": request_end }
+            },
+            "context": {
+                "diagnostics": [],
+                "only": ["quickfix"]
+            }
+        }))
+        .expect_response_with(move |response: Option<Vec<CodeActionOrCommand>>| {
+            response.is_some_and(|actions| {
+                actions.iter().any(|action| {
+                    let CodeActionOrCommand::CodeAction(action) = action else {
+                        return false;
+                    };
+                    action.title == ACTION_TITLE
+                        && action.kind == Some(CodeActionKind::QUICKFIX)
+                        && action
+                            .edit
+                            .as_ref()
+                            .and_then(|edit| edit.changes.as_ref())
+                            .and_then(|changes| changes.get(&uri))
+                            .is_some_and(|edits| {
+                                edits.iter().any(|edit| {
+                                    edit.range.start.line == edit_line
+                                        && edit.range.start.character == edit_character
+                                        && edit.range.end == edit.range.start
+                                        && edit.new_text == new_text
+                                })
+                            })
+                })
+            })
+        })
+        .unwrap();
+}
+
+fn request_has_no_type_annotation_action(
+    interaction: &LspInteraction,
+    uri: &Url,
+    line: u32,
+    character: u32,
+    only: &str,
+) {
+    interaction
+        .client
+        .send_request::<CodeActionRequest>(json!({
+            "textDocument": { "uri": uri },
+            "range": {
+                "start": { "line": line, "character": character },
+                "end": { "line": line, "character": character }
+            },
+            "context": {
+                "diagnostics": [],
+                "only": [only]
+            }
+        }))
+        .expect_response_with(|response: Option<Vec<CodeActionOrCommand>>| {
+            response.is_none_or(|actions| {
+                actions.iter().all(|action| {
+                    let CodeActionOrCommand::CodeAction(action) = action else {
+                        return true;
+                    };
+                    action.title != ACTION_TITLE
+                })
+            })
+        })
+        .unwrap();
+}
+
+#[test]
+fn test_insert_inferred_type_annotation_code_actions() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(json!([{
+                "pyrefly": {"displayTypeErrors": "force-on"},
+                "analysis": {
+                    "inlayHints": {
+                        "callArgumentNames": "all"
+                    }
+                }
+            }]))),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open(TEST_FILE);
+    let uri = Url::from_file_path(root.path().join(TEST_FILE)).unwrap();
+
+    // Code actions are matched at the inlay hint's insertion position. A selection ending at
+    // that position also matches because the check is inclusive.
+    request_has_type_annotation_edit(&interaction, &uri, 6, 16, 16, 6, 16, " -> list[int]");
+    request_has_type_annotation_edit(&interaction, &uri, 10, 0, 5, 10, 5, ": list[int]");
+    request_has_type_annotation_edit(&interaction, &uri, 15, 18, 18, 15, 18, ": list[int]");
+
+    // Unpacked annotations are invalid Python, call-argument hints are not types, and an
+    // explicitly annotated variable has no inferred annotation to insert.
+    request_has_no_type_annotation_action(&interaction, &uri, 18, 4, "quickfix");
+    request_has_no_type_annotation_action(&interaction, &uri, 25, 8, "quickfix");
+    request_has_no_type_annotation_action(&interaction, &uri, 28, 2, "quickfix");
+
+    // The action must honor the client's requested code-action kind.
+    request_has_no_type_annotation_action(&interaction, &uri, 10, 2, "refactor");
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_insert_inferred_type_annotation_in_notebook_cell() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.open_notebook(
+        "notebook.ipynb",
+        vec!["def make_items():\n    return [1, 2, 3]\n\nitems = make_items()"],
+    );
+    let cell_uri = interaction.cell_uri("notebook.ipynb", "cell1");
+
+    interaction
+        .inlay_hint_cell("notebook.ipynb", "cell1", 0, 0, 4, 0)
+        .expect_response_with(|hints| {
+            hints.is_some_and(|hints| {
+                hints.iter().any(|hint| {
+                    hint.position.line == 3
+                        && hint.position.character == 5
+                        && hint.text_edits.as_ref().is_some_and(|edits| {
+                            edits.iter().any(|edit| edit.new_text == ": list[int]")
+                        })
+                })
+            })
+        })
+        .unwrap();
+    request_has_type_annotation_edit(&interaction, &cell_uri, 3, 5, 5, 3, 5, ": list[int]");
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_insert_inferred_type_annotation_respects_inlay_hint_config() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(json!([{
+                "pyrefly": {"displayTypeErrors": "force-on"},
+                "analysis": {
+                    "inlayHints": {
+                        "functionReturnTypes": false,
+                        "variableTypes": false
+                    }
+                }
+            }]))),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open(TEST_FILE);
+    let uri = Url::from_file_path(root.path().join(TEST_FILE)).unwrap();
+
+    request_has_no_type_annotation_action(&interaction, &uri, 6, 16, "quickfix");
+    request_has_no_type_annotation_action(&interaction, &uri, 10, 5, "quickfix");
+    request_has_no_type_annotation_action(&interaction, &uri, 15, 18, "quickfix");
+
+    interaction.shutdown().unwrap();
+}

--- a/pyrefly/lib/test/lsp/lsp_interaction/mod.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/mod.rs
@@ -27,6 +27,7 @@ mod folding_range;
 mod hover;
 mod implementation;
 mod inlay_hint;
+mod insert_type_annotation_code_action;
 mod io;
 mod move_symbol_new_file;
 mod no_config_warnings;

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/insert_type_annotation_code_action.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/insert_type_annotation_code_action.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+def make_items():
+    return [1, 2, 3]
+
+
+items = make_items()
+
+
+class Box:
+    def __init__(self):
+        self.items = make_items()
+
+
+left, right = (items, items)
+
+
+def consume(value: list[int]) -> None:
+    pass
+
+
+consume(items)
+
+
+annotated: list[int] = make_items()


### PR DESCRIPTION
Reuse insertable inlay hint edits in the quick-fix menu so users can materialize inferred annotations through code actions instead of double-clicking the rendered hint. Keep the initial behavior scoped to existing type hints while preserving their configuration and safety filters.

# Summary

- Reuse `Transaction::inlay_hints` from the existing quick-fix handler.
- Offer “Insert inferred type annotation” for existing variable, class-attribute, and function-return type hints.
- Reuse the exact label text and insertion position already used by inlay-hint edits.
- Exclude non-insertable hints, such as annotations on unpacked variables.
- Exclude call-argument name hints such as `value=`, since they are not type annotations.
- Respect the existing inlay-hint configuration for variable and function-return types.
- Support both regular Python files and notebook cells.

The implementation obtains the configured inlay hints during `textDocument/codeAction`, filters for safely insertable type hints whose insertion position is covered by the requested range, and converts the matching hint into a `CodeActionKind::QUICKFIX` containing a zero-width `TextEdit`.

Fixes #4231 


# Test Plan

- Added LSP integration coverage for:
  - Function-return annotations.
  - Variable annotations.
  - Class-attribute annotations.
  - Notebook-cell edits.
  - Non-insertable unpacked variables.
  - Call-argument name hints.
  - Already annotated variables.
  - Code-action kind filtering.
  - Disabled variable and return inlay-hint configuration.
- Ran:

  `cargo test insert_inferred_type_annotation`

- Ran the required formatting and lint checks:

  `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`

<!-- Run test.py and commit any changes to generated files -->