### PR TITLE
Exclude privately-named classes from `pyrefly coverage`

### DIFF
--- a/pyrefly/lib/commands/coverage/collect.rs
+++ b/pyrefly/lib/commands/coverage/collect.rs
@@ -1345,7 +1345,7 @@ impl ModuleSymbols {
             &tco_classes,
         );
         merge_overloads(&mut functions);
-        let classes = parse_classes(&module, &bindings, &answers, &tco_classes);
+        let mut classes = parse_classes(&module, &bindings, &answers, &tco_classes);
         let mut variables = parse_variables(
             &module,
             &bindings,
@@ -1363,6 +1363,24 @@ impl ModuleSymbols {
             handle,
             &tco_classes,
         ));
+
+        // A private name hides its whole subtree, unless exported via `__all__` (issue #3578).
+        let prefix = module_prefix(&module);
+        let is_visible = |name: &str| {
+            let relative = name
+                .strip_prefix(&prefix)
+                .expect("symbol FQNs start with the module prefix");
+            let mut components = relative.split('.');
+            let top = components
+                .next()
+                .expect("split yields at least one component");
+            (is_public_name(top) || dunder_all.iter().any(|n| n == top))
+                && components.all(is_public_name)
+        };
+        functions.retain(|f| is_visible(&f.name));
+        classes.retain(|c| is_visible(&c.name));
+        variables.retain(|v| is_visible(&v.name));
+
         let suppressions = parse_suppressions(&module);
         let stub_merge = for_stub_merge.then(|| StubMergeData {
             class_members: collect_class_members(

--- a/pyrefly/lib/test/coverage/test_files/private_filtering.expected.json
+++ b/pyrefly/lib/test/coverage/test_files/private_filtering.expected.json
@@ -12,7 +12,7 @@
     "test.MyClass.__dunder_method__",
     "test.MyClass"
   ],
-  "line_count": 50,
+  "line_count": 63,
   "symbol_reports": [
     {
       "kind": "attr",
@@ -22,7 +22,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 26,
+        "line": 27,
         "column": 1
       }
     },
@@ -34,7 +34,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 34,
+        "line": 35,
         "column": 1
       }
     },
@@ -46,7 +46,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 39,
+        "line": 40,
         "column": 14
       }
     },
@@ -58,7 +58,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 14,
+        "line": 15,
         "column": 1
       }
     },
@@ -70,7 +70,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 22,
+        "line": 23,
         "column": 1
       }
     },
@@ -82,7 +82,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 38,
+        "line": 39,
         "column": 5
       }
     },
@@ -94,7 +94,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 42,
+        "line": 43,
         "column": 5
       }
     },
@@ -106,7 +106,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 48,
+        "line": 49,
         "column": 5
       }
     },
@@ -118,7 +118,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 37,
+        "line": 38,
         "column": 1
       }
     }

--- a/pyrefly/lib/test/coverage/test_files/private_filtering.py
+++ b/pyrefly/lib/test/coverage/test_files/private_filtering.py
@@ -7,6 +7,7 @@
 # - Non-public names (starting with _) are excluded
 # - Dunder names (__x__) are kept EXCEPT excluded module dunders
 # - Excluded module dunders: __all__, __dir__, __doc__, __getattr__
+# - Privately-named classes hide their whole subtree (methods, attrs, nested classes)
 
 from typing import List
 
@@ -47,3 +48,15 @@ class MyClass:
 
     def __dunder_method__(self) -> int:
         return 3
+
+    class _Inner:
+        def public_method(self) -> int:
+            return 4
+
+
+class _PrivateClass:
+    def __init__(self):
+        self.public_attr: int = 5
+
+    def public_method(self) -> int:
+        return 6

--- a/pyrefly/lib/test/coverage/test_files/private_in_all.expected.json
+++ b/pyrefly/lib/test/coverage/test_files/private_in_all.expected.json
@@ -3,9 +3,11 @@
   "path": "test.py",
   "names": [
     "test._X",
-    "test._foo"
+    "test._C.method",
+    "test._foo",
+    "test._C"
   ],
-  "line_count": 16,
+  "line_count": 21,
   "symbol_reports": [
     {
       "kind": "attr",
@@ -15,8 +17,20 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 14,
+        "line": 19,
         "column": 1
+      }
+    },
+    {
+      "kind": "function",
+      "name": "test._C.method",
+      "n_typable": 2,
+      "n_typed": 2,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 7,
+        "column": 5
       }
     },
     {
@@ -27,23 +41,35 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
+        "line": 11,
+        "column": 1
+      }
+    },
+    {
+      "kind": "class",
+      "name": "test._C",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
         "line": 6,
         "column": 1
       }
     }
   ],
   "type_ignores": [],
-  "n_typable": 3,
-  "n_typed": 3,
+  "n_typable": 5,
+  "n_typed": 5,
   "n_any": 0,
   "n_untyped": 0,
   "coverage": 100.0,
   "strict_coverage": 100.0,
   "n_functions": 1,
-  "n_methods": 0,
+  "n_methods": 1,
   "n_function_params": 1,
-  "n_method_params": 0,
-  "n_classes": 0,
+  "n_method_params": 1,
+  "n_classes": 1,
   "n_attrs": 1,
   "n_properties": 0,
   "n_type_ignores": 0

--- a/pyrefly/lib/test/coverage/test_files/private_in_all.py
+++ b/pyrefly/lib/test/coverage/test_files/private_in_all.py
@@ -1,6 +1,11 @@
 # Private names listed in __all__ should be reported as public (issue #3578).
 
-__all__ = ["_foo", "_X"]
+__all__ = ["_foo", "_X", "_C"]
+
+
+class _C:
+    def method(self, x: int) -> int:
+        return x
 
 
 def _foo(x: int) -> int:


### PR DESCRIPTION
# Summary

Privately-named functions, variables, methods, and attrs were already excluded, but privately-named classes weren't, so e.g. `_Foo.bar` was still reported.
A private name now hides its whole subtree unless exported via `__all__`, consistent with the other symbol kinds and with the documented behavior.

# Test Plan

Regression tests added.