### PR TITLE
Recognize typing_extensions.sentinel as a sentinel constructor

### DIFF
--- a/pyrefly/lib/export/special.rs
+++ b/pyrefly/lib/export/special.rs
@@ -234,7 +234,9 @@ impl SpecialExport {
             Self::ShapedArray => matches!(m.as_str(), "shape_extensions"),
             Self::ProxyMethod => matches!(m.as_str(), "shape_extensions"),
             Self::Sentinel => matches!(m.as_str(), "typing_extensions"),
-            Self::BuiltinsSentinel => matches!(m.as_str(), "builtins"),
+            // `builtins.sentinel` (3.15+) and its `typing_extensions.sentinel`
+            // backport are the same lowercase PEP 661 constructor.
+            Self::BuiltinsSentinel => matches!(m.as_str(), "builtins" | "typing_extensions"),
             Self::AttrsLegacyAttrib | Self::AttrsNextGenField | Self::AttrsNothing => {
                 matches!(m.as_str(), "attr" | "attrs")
             }

--- a/pyrefly/lib/test/sentinel.rs
+++ b/pyrefly/lib/test/sentinel.rs
@@ -188,6 +188,35 @@ A = sentinel("A")  # E: Could not find name `sentinel`
 );
 
 testcase!(
+    // typing_extensions backports the lowercase `sentinel` for pre-3.15, so
+    // importing it must behave exactly like the uppercase `Sentinel` and the
+    // builtin lowercase form, not fall back to the function's return type.
+    test_sentinel_lowercase_from_typing_extensions,
+    r#"
+from typing import Literal, assert_type
+from typing_extensions import sentinel
+
+A = sentinel("A")
+def foo(a: A | Literal[False]):
+    if a:
+        assert_type(a, A)
+    else:
+        assert_type(a, Literal[False])
+    "#,
+);
+
+testcase!(
+    test_sentinel_lowercase_from_typing_extensions_reveal,
+    r#"
+from typing import reveal_type
+from typing_extensions import sentinel
+
+Lower = sentinel("Lower")
+reveal_type(Lower)  # E: Lower
+    "#,
+);
+
+testcase!(
     test_sentinel_in_class_body,
     r#"
 from typing import assert_type


### PR DESCRIPTION
# Summary

`typing_extensions` 4.16.0 backported the lowercase PEP 661 `sentinel` (the form Python 3.15 exposes as `builtins.sentinel`), but Pyrefly only treated the lowercase name as a sentinel constructor when it came from `builtins`: the `BuiltinsSentinel` special export's `defined_in` gate listed only that module. So `from typing_extensions import sentinel; X = sentinel("X")` fell through to a plain function call, and `reveal_type(X)` showed `sentinel` instead of the unique sentinel type, diverging from the uppercase `Sentinel` it replaces. (As you noted on the issue, this just needed adding to the module gate.)

The fix widens `BuiltinsSentinel`'s `defined_in` to also allow `typing_extensions`. `Sentinel` and `BuiltinsSentinel` already route to the same sentinel-construction path in `binding/stmt.rs`, so the module gate was the only thing wrong.

Fixes #4225

# Test Plan

Added two cases to `pyrefly/lib/test/sentinel.rs`:

- `test_sentinel_lowercase_from_typing_extensions` — `from typing_extensions import sentinel` now narrows/`assert_type`s like the uppercase `Sentinel`.
- `test_sentinel_lowercase_from_typing_extensions_reveal` — the issue's repro: `reveal_type` reports the sentinel type, not `sentinel`.

`cargo test -p pyrefly sentinel` → 33 passed, 0 failed. Confirmed both new tests fail without the one-line fix (2 failed, "expected 0 errors, but got 3"). `cargo clippy -p pyrefly` and `cargo fmt --check` are clean.

Note: built and tested against the `1.95.0` stable toolchain (this environment couldn't download the pinned `stable`). I did not run `test.py`'s conformance regeneration — the change only widens a module gate for `typing_extensions.sentinel` and touches no behavior the python/typing conformance suite covers, so I don't expect generated changes, but flagging in case CI disagrees.

_Disclosure: this PR was prepared with the help of Claude Opus 4.8, an AI coding agent, under my direction and review._
