### PR TITLE
Fix semantic token highlighting for match captures

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -2256,7 +2256,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // ForwardToFirstUse is handled here too: the partial answer shortcut
         // lives in get_idx (before push), so by the time we reach solve_binding
         // the shortcut didn't match and we fall through to normal resolution.
-        if let Binding::Forward(fwd) | Binding::ForwardToFirstUse(fwd) = binding {
+        if let Binding::Forward(fwd)
+        | Binding::PatternCapture(fwd)
+        | Binding::ForwardToFirstUse(fwd) = binding
+        {
             return self.get_idx(*fwd);
         }
         if let Binding::PromoteForward(fwd) = binding {
@@ -5278,7 +5281,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
     fn binding_to_type_info(&self, binding: &Binding, errors: &ErrorCollector) -> TypeInfo {
         match binding {
-            Binding::Forward(k) => self.get_idx(*k).arc_clone(),
+            Binding::Forward(k) | Binding::PatternCapture(k) => self.get_idx(*k).arc_clone(),
             Binding::PromoteForward(k) => self.resolve_promote_forward(*k),
             Binding::ForwardToFirstUse(k) => {
                 if let Some(def_idx) = self.def_idx_for_forward_to_first_use(*k)
@@ -5736,6 +5739,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     fn binding_to_type(&self, binding: &Binding, errors: &ErrorCollector) -> Type {
         match binding {
             Binding::Forward(..)
+            | Binding::PatternCapture(..)
             | Binding::PromoteForward(..)
             | Binding::ForwardToFirstUse(..)
             | Binding::Phi(..)

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -2346,6 +2346,9 @@ pub enum Binding {
     ClassDef(Idx<KeyClass>, Box<[Idx<KeyDecorator>]>),
     /// A forward reference to another binding.
     Forward(Idx<Key>),
+    /// A definition boundary for a capture pattern. It forwards type information during solving,
+    /// but origin and definition lookups must not follow it through to the matched subject.
+    PatternCapture(Idx<Key>),
     /// Like Forward, but widens implicit literals.
     PromoteForward(Idx<Key>),
     /// A forward reference produced during first-use resolution of a partial type.
@@ -2555,6 +2558,7 @@ impl DisplayWith<Bindings> for Binding {
             }
             Self::ClassDef(x, _) => write!(f, "ClassDef({})", ctx.display(*x)),
             Self::Forward(k) => write!(f, "Forward({})", ctx.display(*k)),
+            Self::PatternCapture(k) => write!(f, "PatternCapture({})", ctx.display(*k)),
             Self::PromoteForward(k) => write!(f, "PromoteForward({})", ctx.display(*k)),
             Self::ForwardToFirstUse(k) => {
                 write!(f, "ForwardToFirstUse({})", ctx.display(*k))
@@ -2792,6 +2796,7 @@ impl Binding {
             Binding::LambdaParameter(..) | Binding::FunctionParameter(_) => {
                 Some(SymbolKind::Parameter)
             }
+            Binding::PatternCapture(_) => Some(SymbolKind::Variable),
             Binding::IterableValueComprehension(_, _, _) | Binding::IterableValueLoop(_, _, _) => {
                 Some(SymbolKind::Variable)
             }

--- a/pyrefly/lib/binding/pattern.rs
+++ b/pyrefly/lib/binding/pattern.rs
@@ -240,7 +240,11 @@ impl<'a> BindingsBuilder<'a> {
                 if let Some(name) = &p.name
                     && !Ast::is_synthesized_empty_identifier(name)
                 {
-                    self.bind_definition(name, Binding::Forward(subject_idx), FlowStyle::Other);
+                    self.bind_definition(
+                        name,
+                        Binding::PatternCapture(subject_idx),
+                        FlowStyle::Other,
+                    );
                     subject = MatchSubject::Single(NarrowingSubject::Name(name.id.clone()));
                 };
                 if let Some(pattern) = p.pattern {
@@ -370,8 +374,8 @@ impl<'a> BindingsBuilder<'a> {
                                 && !Ast::is_synthesized_empty_identifier(name)
                             {
                                 let position = UnpackedPosition::Slice(i, num_patterns - i - 1);
-                                self.bind_definition(
-                                    name,
+                                let unpacked_idx = self.insert_binding(
+                                    Key::Anon(p.range),
                                     Binding::UnpackedValue(
                                         None,
                                         subject_idx,
@@ -379,6 +383,10 @@ impl<'a> BindingsBuilder<'a> {
                                         position,
                                         None,
                                     ),
+                                );
+                                self.bind_definition(
+                                    name,
+                                    Binding::PatternCapture(unpacked_idx),
                                     FlowStyle::Other,
                                 );
                             }
@@ -523,7 +531,11 @@ impl<'a> BindingsBuilder<'a> {
                 if let Some(rest) = x.rest
                     && !Ast::is_synthesized_empty_identifier(&rest)
                 {
-                    self.bind_definition(&rest, Binding::Forward(subject_idx), FlowStyle::Other);
+                    self.bind_definition(
+                        &rest,
+                        Binding::PatternCapture(subject_idx),
+                        FlowStyle::Other,
+                    );
                 }
                 narrow_ops
             }
@@ -744,7 +756,11 @@ impl<'a> BindingsBuilder<'a> {
                 if let Some(name) = &p.name
                     && !Ast::is_synthesized_empty_identifier(name)
                 {
-                    self.bind_definition(name, Binding::Forward(subject_idx), FlowStyle::Other);
+                    self.bind_definition(
+                        name,
+                        Binding::PatternCapture(subject_idx),
+                        FlowStyle::Other,
+                    );
                 }
                 PatternNarrowOps::new()
             }

--- a/pyrefly/lib/lsp/wasm/inlay_hints.rs
+++ b/pyrefly/lib/lsp/wasm/inlay_hints.rs
@@ -190,8 +190,10 @@ impl<'a> Transaction<'a> {
                     if inlay_hint_config.variable_types
                         && let Some(ty) = self.get_type_for_display(handle, key) =>
                 {
-                    // For unpacked values, extract the element expression if available
-                    let (e, is_unpacked) = match bindings.get(idx) {
+                    // Inspect the value-producing binding before deciding whether to show a hint.
+                    let binding = bindings.get(idx);
+                    let is_pattern_capture = matches!(binding, Binding::PatternCapture(_));
+                    let (e, is_unpacked) = match Self::get_inlay_hint_source(&bindings, binding) {
                         // Pinned assignments (explicit annotation or
                         // receiver-constrained class rebind) are already
                         // authoritatively typed; suggesting an explicit
@@ -230,7 +232,12 @@ impl<'a> Transaction<'a> {
                         is_unpacked && !ty.is_any()
                     };
                     if should_show {
-                        res.push(make_type_hint(": ", key.range().end(), &ty, !is_unpacked));
+                        res.push(make_type_hint(
+                            ": ",
+                            key.range().end(),
+                            &ty,
+                            !is_unpacked && !is_pattern_capture,
+                        ));
                     }
                 }
                 _ => {}
@@ -298,6 +305,16 @@ impl<'a> Transaction<'a> {
         }
 
         Some(res)
+    }
+
+    /// Return the binding that carries the value provenance used to decide whether an inlay hint
+    /// should be shown. Pattern captures are definition boundaries for IDE navigation, but remain
+    /// transparent when examining how their type was produced.
+    fn get_inlay_hint_source<'b>(bindings: &'b Bindings, binding: &'b Binding) -> &'b Binding {
+        match binding {
+            Binding::PatternCapture(source_idx) => bindings.get(*source_idx),
+            _ => binding,
+        }
     }
 
     /// Helper to extract the element expression from an unpacked source.

--- a/pyrefly/lib/state/semantic_tokens.rs
+++ b/pyrefly/lib/state/semantic_tokens.rs
@@ -26,6 +26,7 @@ use ruff_python_ast::Expr;
 use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprContext;
 use ruff_python_ast::ModModule;
+use ruff_python_ast::Pattern;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtImport;
 use ruff_python_ast::StmtImportFrom;
@@ -346,6 +347,14 @@ impl SemanticTokenBuilder {
         }
     }
 
+    fn process_pattern(&mut self, pattern: &Pattern) {
+        Ast::pattern_lvalue(pattern, &mut |name| {
+            if !Ast::is_synthesized_empty_identifier(name) {
+                self.push_if_in_range(name.range(), SemanticTokenType::VARIABLE, Vec::new());
+            }
+        });
+    }
+
     fn process_attribute_expr(
         &mut self,
         attr: &ExprAttribute,
@@ -531,6 +540,12 @@ impl SemanticTokenBuilder {
                     if let Some(name) = &with_item.optional_vars {
                         self.push_if_in_range(name.range(), SemanticTokenType::VARIABLE, vec![]);
                     }
+                }
+                x.recurse(&mut |x| self.process_stmt(x, in_class, get_symbol_kind));
+            }
+            Stmt::Match(stmt_match) => {
+                for case in &stmt_match.cases {
+                    self.process_pattern(&case.pattern);
                 }
                 x.recurse(&mut |x| self.process_stmt(x, in_class, get_symbol_kind));
             }

--- a/pyrefly/lib/test/lsp/definition.rs
+++ b/pyrefly/lib/test/lsp/definition.rs
@@ -555,6 +555,36 @@ Definition Result:
 }
 
 #[test]
+fn pattern_capture_reference_test() {
+    let code = r#"
+def test(o: object):
+  match o:
+    case [head, *tail]:
+      return head, tail
+#            ^     ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert_eq!(
+        r#"
+# main.py
+5 |       return head, tail
+                 ^
+Definition Result:
+4 |     case [head, *tail]:
+              ^^^^
+
+5 |       return head, tail
+                       ^
+Definition Result:
+4 |     case [head, *tail]:
+                     ^^^^
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn keyword_argument_test_function() {
     let code = r#"
 def foo(x: int, y: str) -> None: pass

--- a/pyrefly/lib/test/lsp/semantic_tokens.rs
+++ b/pyrefly/lib/test/lsp/semantic_tokens.rs
@@ -265,6 +265,44 @@ token-type: keyword
 }
 
 #[test]
+fn pattern_capture_test() {
+    let code = r#"
+def unpack(value):
+    match value:
+        case [head, *tail]:
+            return head, tail
+"#;
+    // Capture names are plain variables, including names that look like constants or parameters.
+    // The class-pattern keyword `child` and the wildcards `_` and `*_` do not produce tokens.
+    assert_full_semantic_tokens(
+        &[("main", code)],
+        r#"
+# main.py
+line: 1, column: 4, length: 6, text: unpack
+token-type: function
+
+line: 1, column: 11, length: 5, text: value
+token-type: parameter
+
+line: 2, column: 10, length: 5, text: value
+token-type: parameter
+
+line: 3, column: 14, length: 4, text: head
+token-type: variable
+
+line: 3, column: 21, length: 4, text: tail
+token-type: variable
+
+line: 4, column: 19, length: 4, text: head
+token-type: variable
+
+line: 4, column: 25, length: 4, text: tail
+token-type: variable
+"#,
+    );
+}
+
+#[test]
 fn multiline_syntax_token_test() {
     let code = r##"x = """one
 two"""


### PR DESCRIPTION
# Summary

Match capture patterns bind regular variables, but Pyrefly’s semantic-token walker only handled expression names. This caused capture definitions and some references to be missing or inconsistently highlighted.

This change:

- Emits plain `variable` tokens for all capture patterns.
- Introduces a type-transparent `PatternCapture` binding that preserves the capture’s declaration identity.
- Keeps go-to-definition anchored at the capture site.
- Excludes wildcards and class-pattern keyword labels.
- Adds coverage for nested, starred, mapping, `as`, and OR patterns.

# Test Plan

- Semantic-token tests
- Pattern-matching tests
- Formatting and linting checks


# Screenshots

### Before this change
<img width="500" height="200" alt="image" src="https://github.com/user-attachments/assets/a128733d-a46d-45e5-b872-13260a337345" />

### After this change
<img width="500" height="200" alt="image" src="https://github.com/user-attachments/assets/182f4cc9-a7cb-4a47-b034-9ce1b37fe9a5" />