### PR TITLE
impl selectionRange

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -114,6 +114,9 @@ use lsp_types::RenameFilesParams;
 use lsp_types::RenameOptions;
 use lsp_types::RenameParams;
 use lsp_types::SaveOptions;
+use lsp_types::SelectionRange;
+use lsp_types::SelectionRangeParams;
+use lsp_types::SelectionRangeProviderCapability;
 use lsp_types::SemanticTokens;
 use lsp_types::SemanticTokensFullOptions;
 use lsp_types::SemanticTokensOptions;
@@ -194,6 +197,7 @@ use lsp_types::request::RegisterCapability;
 use lsp_types::request::Rename;
 use lsp_types::request::Request as _;
 use lsp_types::request::ResolveCompletionItem;
+use lsp_types::request::SelectionRangeRequest;
 use lsp_types::request::SemanticTokensFullRequest;
 use lsp_types::request::SemanticTokensRangeRequest;
 use lsp_types::request::SemanticTokensRefresh;
@@ -1337,6 +1341,7 @@ pub fn capabilities(
         document_symbol_provider: Some(OneOf::Left(true)),
         workspace_symbol_provider: Some(OneOf::Left(true)),
         folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
+        selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
         // Call hierarchy needs indexing to find cross-file callers/callees
         call_hierarchy_provider: match indexing_mode {
             IndexingMode::None => None,
@@ -2431,6 +2436,21 @@ impl Server {
                             }
                         };
                         self.send_response(new_response(x.id, Ok(result)));
+                    }
+                } else if let Some(params) = as_request::<SelectionRangeRequest>(&x) {
+                    if let Some(params) = self
+                        .extract_request_params_or_send_err_response::<SelectionRangeRequest>(
+                            params, &x.id,
+                        )
+                    {
+                        let response = match self.selection_ranges(&transaction, params) {
+                            Ok(response) => response,
+                            Err(reason) => {
+                                telemetry_event.set_empty_response_reason(reason);
+                                None
+                            }
+                        };
+                        self.send_response(new_response(x.id, Ok(response)));
                     }
                 } else if let Some(params) = as_request::<CallHierarchyPrepare>(&x) {
                     if let Some(params) = self
@@ -5598,6 +5618,60 @@ impl Server {
                         kind,
                         collapsed_text: None,
                     })
+                })
+                .collect(),
+        ))
+    }
+
+    fn selection_ranges(
+        &self,
+        transaction: &Transaction<'_>,
+        params: SelectionRangeParams,
+    ) -> Result<Option<Vec<SelectionRange>>, EmptyResponseReason> {
+        let uri = &params.text_document.uri;
+        let handle = self.make_handle_if_enabled(uri, Some(SelectionRangeRequest::METHOD))?;
+        let module = transaction
+            .get_module_info(&handle)
+            .ok_or(EmptyResponseReason::ModuleInfoNotFound)?;
+        let ast = transaction
+            .get_ast(&handle)
+            .ok_or(EmptyResponseReason::AstNotFound)?;
+        let notebook_cell = self.maybe_get_code_cell_index(uri);
+
+        Ok(Some(
+            params
+                .positions
+                .into_iter()
+                .map(|position| {
+                    let position = self.from_lsp_position(uri, &module, position);
+                    let document_range = if let Some(cell) = notebook_cell {
+                        module
+                            .notebook()
+                            .expect("a notebook cell URI should map to a notebook module")
+                            .cell_offsets()
+                            .content_ranges()
+                            .nth(cell)
+                            .expect("a notebook cell URI should have a matching code cell")
+                    } else {
+                        TextRange::up_to(TextSize::of(module.lined_buffer().contents().as_str()))
+                    };
+                    let mut selection = SelectionRange {
+                        range: module.to_lsp_range(document_range),
+                        parent: None,
+                    };
+                    let mut last_range = Some(document_range);
+                    for node in Ast::locate_node(&ast, position).into_iter().rev() {
+                        let range = node.range();
+                        if !document_range.contains_range(range) || last_range == Some(range) {
+                            continue;
+                        }
+                        selection = SelectionRange {
+                            range: module.to_lsp_range(range),
+                            parent: Some(Box::new(selection)),
+                        };
+                        last_range = Some(range);
+                    }
+                    selection
                 })
                 .collect(),
         ))

--- a/pyrefly/lib/test/lsp/lsp_interaction/basic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/basic.rs
@@ -60,6 +60,7 @@ fn test_initialize_basic() {
             "notebookDocumentSync":{"notebookSelector":[{"cells":[{"language":"python"}]}]},
             "documentSymbolProvider": true,
             "foldingRangeProvider":true,
+            "selectionRangeProvider": true,
             "workspaceSymbolProvider": true,
             "workspace": {
                 "workspaceFolders": {

--- a/pyrefly/lib/test/lsp/lsp_interaction/mod.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/mod.rs
@@ -53,6 +53,7 @@ mod provide_type;
 mod references;
 mod rename;
 mod safe_delete_file;
+mod selection_range;
 mod semantic_tokens;
 mod type_definition;
 mod type_hierarchy;

--- a/pyrefly/lib/test/lsp/lsp_interaction/selection_range.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/selection_range.rs
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use lsp_types::Position;
+use lsp_types::Range;
+use lsp_types::SelectionRange;
+use lsp_types::Url;
+use lsp_types::request::SelectionRangeRequest;
+use pyrefly_lsp_test::object_model::InitializeSettings;
+use pyrefly_lsp_test::object_model::LspInteraction;
+use serde_json::json;
+use tempfile::TempDir;
+
+#[test]
+fn selection_range_includes_enclosing_scopes() {
+    let root = TempDir::new().unwrap();
+    std::fs::write(
+        root.path().join("test.py"),
+        "\
+def outer():
+    if enabled:
+        value = transform(source)
+    return value
+result = outer()
+",
+    )
+    .unwrap();
+
+    let root_uri = Url::from_file_path(root.path()).unwrap();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            workspace_folders: Some(vec![("test".to_owned(), root_uri)]),
+            ..Default::default()
+        })
+        .unwrap();
+    interaction.client.did_open("test.py");
+
+    let uri = Url::from_file_path(root.path().join("test.py")).unwrap();
+    interaction
+        .client
+        .send_request::<SelectionRangeRequest>(json!({
+            "textDocument": {"uri": uri},
+            "positions": [{"line": 2, "character": 28}],
+        }))
+        .expect_response_with(|response: Option<Vec<SelectionRange>>| {
+            let Some(mut selection) = response.and_then(|ranges| ranges.into_iter().next()) else {
+                return false;
+            };
+            let mut ranges = Vec::new();
+            loop {
+                ranges.push(selection.range);
+                let Some(parent) = selection.parent else {
+                    break;
+                };
+                selection = *parent;
+            }
+
+            let expected_scopes = [
+                Range::new(Position::new(2, 8), Position::new(2, 33)),
+                Range::new(Position::new(1, 4), Position::new(2, 33)),
+                Range::new(Position::new(0, 0), Position::new(3, 16)),
+                Range::new(Position::new(0, 0), Position::new(5, 0)),
+            ];
+            expected_scopes
+                .iter()
+                .try_fold(0, |start, expected| {
+                    ranges[start..]
+                        .iter()
+                        .position(|range| range == expected)
+                        .map(|offset| start + offset + 1)
+                })
+                .is_some()
+        })
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

https://github.com/facebook/pyrefly/issues/2207#issuecomment-5056111638

cc @5j9

Expand Selection now follows AST nesting: expression -> statement -> control scope -> function/class -> document.

Added notebook cell boundary handling and duplicate-range removal.

Advertised selectionRangeProvider in server capabilities.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test