### PR TITLE
Run benchmarks on CodSpeed in CI

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,68 @@
+name: CodSpeed
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  # workflow_dispatch lets CodSpeed trigger backtest runs to seed baseline data.
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write # OpenID Connect auth with CodSpeed (no token secret required)
+jobs:
+  # Instruction-count (Valgrind) measurement of the small, deterministic
+  # microbenchmarks. They are single-threaded and fast, so callgrind's overhead
+  # is bounded and the instruction counts are stable run-to-run.
+  simulation:
+    name: Microbenchmarks (simulation)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+    - name: set up rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: pyrefly-codspeed
+    - name: install cargo-codspeed
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-codspeed
+    - name: build benchmarks
+      run: cargo codspeed build -p pyrefly --bench micro
+    - name: run benchmarks
+      uses: CodSpeedHQ/action@v4
+      with:
+        mode: simulation
+        run: cargo codspeed run -p pyrefly --bench micro
+  # Wall-clock measurement of the heavy, real-world PyTorch benchmarks. They drive
+  # the full LSP server over all cores against the pinned PyTorch checkout, so they
+  # must not run under Valgrind (which serializes threads and inflates the ~GB cold
+  # start past any reasonable timeout). Walltime mode tolerates threads, I/O, and
+  # long cold starts. CodSpeed's dedicated `codspeed-macro` runners give the lowest
+  # variance for walltime; `ubuntu-latest` also works if they aren't provisioned.
+  walltime:
+    name: PyTorch benchmarks (walltime)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    # No submodule checkout: in OSS the benchmark clones the pinned PyTorch itself
+    # (rev from benches/pytorch_pin.bzl) on first run. The runner has github egress.
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+    - name: set up rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: pyrefly-codspeed-walltime
+    - name: install cargo-codspeed
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-codspeed
+    - name: build benchmarks
+      run: cargo codspeed build -p pyrefly --bench pytorch
+    - name: run benchmarks
+      uses: CodSpeedHQ/action@v4
+      with:
+        mode: walltime
+        run: cargo codspeed run -p pyrefly --bench pytorch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "codspeed"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f4cce9c27c49c4f101fffeebb1826f41a9df2e7498b7cd4d95c0658b796c6c"
+dependencies = [
+ "colored",
+ "libc",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c23d880a28a2aab52d38ca8481dd7a3187157d0a952196b6db1db3c8499725"
+dependencies = [
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0a2f7365e347f4f22a67e9ea689bf7bc89900a354e22e26cf8a531a42c8fbb"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "collection_literals"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +523,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "compact_str"
@@ -550,32 +611,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
 ]
 
 [[package]]
@@ -2086,7 +2121,7 @@ dependencies = [
  "blake3",
  "capnp",
  "clap",
- "criterion",
+ "codspeed-criterion-compat",
  "crossbeam-channel",
  "dashmap",
  "dupe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,15 @@ strip = "debuginfo"
 [profile.dev]
 debug = 1
 
+# Benchmarks don't need release's whole-program LTO with a single codegen unit.
+# Disabling LTO and using multiple codegen units keeps the CodSpeed build within
+# the memory budget of standard CI runners (and builds much faster) without
+# affecting CodSpeed's deterministic instruction-count measurements.
+[profile.bench]
+inherits = "release"
+lto = false
+codegen-units = 16
+
 [profile.dbg]
 debug = true
 inherits = "dev"

--- a/pyrefly/Cargo.toml
+++ b/pyrefly/Cargo.toml
@@ -85,7 +85,7 @@ xxhash-rust = { version = "0.8.15", features = ["xxh64"] }
 yansi = { version = "1.0.0-rc.1", features = ["hyperlink"] }
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { package = "codspeed-criterion-compat", version = "2" }
 pretty_assertions = { version = "1.4.1", features = ["alloc"], default-features = false }
 pyrefly_lsp_test = { path = "../crates/pyrefly_lsp_test" }
 


### PR DESCRIPTION
Add a CodSpeed GitHub Actions workflow so the landed criterion benchmarks run continuously: instruction-count (simulation) mode for the deterministic microbenchmarks, walltime mode for the heavy real-world PyTorch benchmarks (which must not run under Valgrind).

Swap the `criterion` dev-dependency to `codspeed-criterion-compat` (aliased back to `criterion`) so the existing bench harness emits CodSpeed measurements under `cargo codspeed` while behaving like plain criterion otherwise, and add a `[profile.bench]` that drops LTO/single-codegen-unit to keep the CI build within runner memory limits.

# Summary

<!-- Describe the change in this PR -->

Fixes #XXXX

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
