### PR TITLE
Preserve `Self` when narrowing a self-type to a subclass

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -223,13 +223,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         | (Type::SelfType(self_cls), Type::ClassType(cls)) = (left, right)
             && self.as_superclass(cls, self_cls.class_object()).as_ref() == Some(self_cls)
         {
-            // ClassType(C) & SelfType(Parent) simplifies to ClassType(C) when C
-            // is a subclass of Parent with a matching inherited instantiation,
-            // because Self[Parent] represents "Parent or any subclass" and
-            // ClassType(C) is already such a subclass.
-            // Without this, an unsimplified Intersect(ClassType, SelfType) can
-            // leak to downstream consumers that don't handle Intersect types.
-            self.heap.mk_class_type(cls.clone())
+            // ClassType(C) & SelfType(Parent) simplifies to SelfType(C) when C
+            // is a subclass of Parent with a matching inherited instantiation.
+            // Self[Parent] represents "Parent or any subclass", so narrowing it
+            // to the subclass C keeps it a self-type anchored at C: attribute and
+            // constructor lookups resolve through C, while the value stays
+            // assignable back to Self[Parent] (all self-types are mutually
+            // assignable). Collapsing to a plain ClassType(C) instead would drop
+            // the self-ness and spuriously reject `return self`/`return cls()`
+            // against a declared `-> Self`.
+            // Producing a SelfType (rather than an unsimplified Intersect) also
+            // avoids leaking Intersect types to downstream consumers that don't
+            // handle them.
+            self.heap.mk_self_type(cls.clone())
         } else if left.is_scalar() || right.is_scalar() {
             // The only inhabited intersections of literals are things like
             // `Literal[0] & Literal[0]` or `Literal[0] & int` that would have already been

--- a/pyrefly/lib/test/typing_self.rs
+++ b/pyrefly/lib/test/typing_self.rs
@@ -621,10 +621,11 @@ def test(c: MyClass) -> None:
 "#,
 );
 
-// Regression test for a previously unhandled crash when computing intersection
-// of SelfType and ClassType (after removing SelfType <: ClassType)
+// Narrowing `cls` (a `type[Self]`) via `issubclass` intersects `SelfType(Parent)`
+// with `ClassType(Child)`. That intersection stays a self-type anchored at `Child`,
+// so `cls(...)` resolves through `Child`'s constructor while its result remains
+// assignable to the declared `-> Self`.
 testcase!(
-    bug = "Should not error",
     test_classmethod_self_return_with_issubclass_narrowing,
     r#"
 from typing import Self, assert_type
@@ -633,8 +634,7 @@ class Parent:
     @classmethod
     def decode(cls, data: dict) -> Self:
         if issubclass(cls, Child):
-            # This narrowing creates an intersection of a Self type with a concrete type
-            return cls(data, legacy=True) # E: Returned type `Child` is not assignable to declared return type `Self@Parent`
+            return cls(data, legacy=True)
         return cls(data)
 
     def __init__(self, data: dict) -> None:
@@ -646,6 +646,26 @@ class Child(Parent):
 
 assert_type(Parent.decode({}), Parent)
 assert_type(Child.decode({}), Child)
+"#,
+);
+
+// `isinstance(self, Child)` narrows `self` (a `SelfType(Parent)`) by intersecting
+// with `ClassType(Child)`. The result stays a self-type anchored at `Child`, so
+// `Child`-only members are accessible and `return self` still satisfies `-> Self`.
+testcase!(
+    test_instance_method_self_return_with_isinstance_narrowing,
+    r#"
+from typing import Self, assert_type
+
+class Parent:
+    def widen(self) -> Self:
+        if isinstance(self, Child):
+            assert_type(self.extra, int)
+            return self
+        return self
+
+class Child(Parent):
+    extra: int = 0
 "#,
 );
 


### PR DESCRIPTION
Summary:
Pyrefly narrows `self`/`cls` by intersecting a `SelfType` with a `ClassType`. When the class is a subclass of the self-type's class (e.g. `isinstance(self, Child)` or `issubclass(cls, Child)`), the intersection was collapsing to a plain `ClassType(Child)`, discarding the fact that the value is still the receiver's `Self`. Code as ordinary as

    class Parent:
        def widen(self) -> Self:
            if isinstance(self, Child):
                return self  # spurious: `Child` is not assignable to `Self@Parent`
            return self

was rejected with a false positive, because `Child` is genuinely not assignable to `Self@Parent`.

This intersection only fires when one operand is already a `SelfType`, so the value provably *is* a self. Narrowing it to the subclass therefore yields a self-type anchored at the subclass: `SelfType(Child)`. Attribute and constructor lookups still resolve through `Child`, but the value stays assignable back to `Self@Parent` since all self-types are mutually assignable. This is both more precise and correct, matching mypy and pyright.

Updates the previously `bug`-marked `issubclass` regression test (the error is gone) and adds an `isinstance` instance-method regression test.

Differential Revision: D110890742


