### PR TITLE
Remove "experimental" warning on the `pyrefly coverage` docs

### DIFF
--- a/website/docs/report.mdx
+++ b/website/docs/report.mdx
@@ -20,10 +20,6 @@ description: Measure and enforce type coverage in your Python codebase with Pyre
 - [`pyrefly coverage report`](#generating-a-json-report) emits a JSON report with per-module
   statistics.
 
-:::warning Experimental
-The output format and behavior may change in future releases without notice.
-:::
-
 ## How coverage is measured
 
 Coverage is counted over _typables_: function return types, function parameters, module-level


### PR DESCRIPTION
`pyrefly coverage` is pretty stable now, and we can always introduce backwards-incompatible JSON schema changes safely using the schema versioning (i.e. by bumping the major schema version). But even so, at the moment I don't see any reason for wanting/needing to introduce a breaking change.