### PR TITLE
fix Preserve class-scoped type parameters when converting __new__ to a callable #4267

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -2085,6 +2085,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     }
 
     pub fn constructor_to_callable(&self, cls: &ClassType) -> Type {
+        let new_attr_ty = self.get_dunder_new(cls, false);
+        self.constructor_to_callable_impl(cls, new_attr_ty, false)
+    }
+
+    /// Convert a bare class definition while keeping its type parameters generic.
+    pub fn constructor_to_callable_for_class_def(&self, cls: &ClassType) -> Option<Type> {
+        let new_attr_ty = self.get_dunder_new_for_class_def(cls)?;
+        Some(self.constructor_to_callable_impl(cls, Some(new_attr_ty), true))
+    }
+
+    fn constructor_to_callable_impl(
+        &self,
+        cls: &ClassType,
+        new_attr_ty: Option<Type>,
+        preserve_class_tparams: bool,
+    ) -> Type {
         let class_type = self.heap.mk_class_type(cls.clone());
         if let Some(metaclass_call_attr_ty) = self.get_metaclass_dunder_call(cls) {
             // Use the metaclass __call__ directly (ignoring __new__ and __init__) when either:
@@ -2109,10 +2125,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             ))
         };
         // Check the __new__ method and whether it comes from object or has been overridden
-        let (new_attr_ty, overrides_new) = if let Some(t) = self
-            .get_dunder_new(cls, false)
-            .and_then(|t| self.bind_dunder_new(&t, cls.clone()))
-        {
+        let bind_new = |t: Type| {
+            if preserve_class_tparams {
+                self.bind_dunder_new_for_class_def(&t, cls.clone())
+            } else {
+                self.bind_dunder_new(&t, cls.clone())
+            }
+        };
+        let (new_attr_ty, overrides_new) = if let Some(t) = new_attr_ty.and_then(bind_new) {
             if t.callable_return_type(self.heap)
                 .is_some_and(|ret| !self.is_compatible_constructor_return(&ret, cls.class_object()))
             {

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -4850,6 +4850,37 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
+    /// Get `__new__` through class access when its non-receiver parameters use class type params.
+    pub fn get_dunder_new_for_class_def(&self, cls: &ClassType) -> Option<Type> {
+        let new_member =
+            self.get_class_member_with_defining_class(cls.class_object(), &dunder::NEW)?;
+        if new_member.is_defined_on("builtins", "object") {
+            None
+        } else {
+            let new_ty = self
+                .as_class_attribute(
+                    &dunder::NEW,
+                    &new_member.value,
+                    &ClassBase::ClassDef(cls.clone()),
+                )
+                .as_instance_method()?;
+            let class_tparams = self.get_class_tparams(cls.class_object());
+            let mut uses_class_tparam = false;
+            new_ty.visit_toplevel_callable(|callable| {
+                if let Some(callable) = callable.strip_first_param() {
+                    let mut quantifieds = SmallSet::new();
+                    callable
+                        .params
+                        .visit(&mut |ty| ty.collect_quantifieds(&mut quantifieds));
+                    uses_class_tparam |= class_tparams
+                        .iter()
+                        .any(|tparam| quantifieds.contains(tparam));
+                }
+            });
+            uses_class_tparam.then_some(new_ty)
+        }
+    }
+
     fn get_dunder_init_helper(&self, instance: &Instance, get_object_init: bool) -> Option<Type> {
         let init_method =
             self.get_class_member_with_defining_class(instance.class, &dunder::INIT)?;

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -2529,6 +2529,32 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         )
     }
 
+    /// Bind `__new__` while keeping class type parameters used by the constructor callable.
+    pub fn bind_dunder_new_for_class_def(&self, t: &Type, cls: ClassType) -> Option<Type> {
+        let mut bound = self.bind_function(
+            t,
+            &self.heap.mk_type_of(self.heap.mk_class_type(cls)),
+            false,
+            &mut |a, b| self.is_subset_eq(a, b),
+        )?;
+        self.expand_mut(&mut bound);
+        match bound {
+            Type::Forall(forall) => {
+                let Forall { tparams, body } = *forall;
+                let mut used = SmallSet::new();
+                body.visit(&mut |ty| ty.collect_quantifieds(&mut used));
+                let tparams = tparams
+                    .iter()
+                    .filter(|tparam| used.contains(*tparam))
+                    .cloned()
+                    .collect();
+                drop(used);
+                Some(body.forall(Arc::new(TParams::new(tparams))))
+            }
+            _ => Some(bound),
+        }
+    }
+
     /// Bind a `__init__` method for constructor callable conversion.
     /// Strips the first parameter and sets the return type to the first param's type.
     /// Does not instantiate type variables (they should be inferred at the call site).

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -2353,6 +2353,12 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
             {
                 self.is_subset_eq(&self.type_order.constructor_to_callable(got_cls), want)
             }
+            (Type::ClassDef(got), Type::BoundMethod(_) | Type::Callable(_) | Type::Function(_))
+                if let Some(constructor) =
+                    self.type_order.constructor_to_callable_for_class_def(got) =>
+            {
+                self.is_subset_eq(&constructor, want)
+            }
             (Type::ClassDef(got), Type::BoundMethod(_) | Type::Callable(_) | Type::Function(_)) => {
                 self.is_subset_eq(&Type::type_of(self.type_order.promote_silently(got)), want)
             }

--- a/pyrefly/lib/solver/type_order.rs
+++ b/pyrefly/lib/solver/type_order.rs
@@ -176,6 +176,11 @@ impl<'solver, Ans: LookupAnswer> TypeOrder<'solver, Ans> {
         self.0.constructor_to_callable(cls)
     }
 
+    pub fn constructor_to_callable_for_class_def(self, cls: &Class) -> Option<Type> {
+        self.0
+            .constructor_to_callable_for_class_def(&self.0.as_class_type_unchecked(cls))
+    }
+
     pub fn instantiate_fresh_forall(self, forall: Forall<Forallable>) -> (QuantifiedHandle, Type) {
         self.0.instantiate_fresh_forall(forall)
     }

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -1474,7 +1474,6 @@ def test(p4: Proto4[...], p7: Proto7):
 );
 
 testcase!(
-    bug = "conformance: Constructor to Callable conversion issues with overloads and __new__",
     test_constructor_callable_conversion,
     r#"
 from typing import Callable, ParamSpec, TypeVar, Self, assert_type, overload, Generic
@@ -1508,8 +1507,8 @@ class Class8(Generic[T]):
         return super().__new__(cls)
 
 r8 = accepts_callable(Class8)
-# pyrefly incorrectly errors on this - should be OK
-assert_type(r8([""], [""]), Class8[str])  # E: assert_type(Class8[Unknown], Class8[str]) failed
+assert_type(r8([""], [""]), Class8[str])
+r8([1], [""])  # E: Argument `list[str]` is not assignable to parameter `y` with type `list[int]`
 "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4267

Bare generic classes now preserve class-scoped type parameters when converting `__new__` to a callable.
 
Class8 correctly infers `Class8[str]` and rejects inconsistent constructor arguments.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added regression coverage and updated generated conformance results.
