### PR TITLE
fix Feature suggestion: ban implicit bool conversion in conditional expressions #3959

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -193,6 +193,8 @@ pub enum ErrorKind {
     /// to `Any`.
     /// This is a sub-kind of [ImplicitAny]: suppressing `implicit-any` also suppresses this error.
     ImplicitAnyTypeArgument,
+    /// A non-`bool` value is used in a boolean context, such as an `if` condition.
+    ImplicitBool,
     /// Usage of a module that was not actually imported, but does exist.
     ImplicitImport,
     /// Importing a name from a module that only made it available via a plain
@@ -527,6 +529,7 @@ impl ErrorKind {
             ErrorKind::ImplicitAnyEmptyContainer => Severity::Ignore,
             ErrorKind::ImplicitAnyParameter => Severity::Ignore,
             ErrorKind::ImplicitAnyTypeArgument => Severity::Ignore,
+            ErrorKind::ImplicitBool => Severity::Ignore,
             ErrorKind::ImplicitImport => Severity::Warn,
             ErrorKind::ImplicitReexport => Severity::Ignore,
             ErrorKind::ImplicitlyDefinedAttribute => Severity::Ignore,

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -500,6 +500,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 let condition_type = self.expr_infer(&x.test, errors);
                 self.check_dunder_bool_is_callable(&condition_type, x.range(), errors);
                 self.check_redundant_condition(&condition_type, x.range(), errors);
+                self.check_implicit_bool(&condition_type, x.test.range(), errors);
                 match self
                     .bindings()
                     .sys_info()
@@ -1907,6 +1908,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             // result; both operations require us to force `Var` first or they become unpredictable.
             if i < last_index {
                 t = self.force_for_narrowing(&t, value.range(), errors);
+                self.check_implicit_bool(&t, value.range(), errors);
             }
             if i < last_index && should_shortcircuit(&t, value.range()) {
                 t_acc = self.union(t_acc, t);
@@ -1939,6 +1941,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             for if_clause in comp.ifs.iter() {
                 let ty = self.expr_infer(if_clause, errors);
                 self.check_redundant_condition(&ty, if_clause.range(), errors);
+                self.check_implicit_bool(&ty, if_clause.range(), errors);
             }
         }
     }
@@ -4439,6 +4442,32 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 range,
                 ErrorKind::RedundantCondition,
                 format!("{reason}"),
+            );
+        }
+    }
+
+    /// Report a non-`bool` type used where Python implicitly tests truthiness.
+    pub fn check_implicit_bool(
+        &self,
+        condition_type: &Type,
+        range: TextRange,
+        errors: &ErrorCollector,
+    ) {
+        if !condition_type.is_any()
+            && !condition_type.is_never()
+            && !self.is_subset_eq(
+                condition_type,
+                &self.heap.mk_class_type(self.stdlib.bool().clone()),
+            )
+        {
+            self.error(
+                errors,
+                range,
+                ErrorKind::ImplicitBool,
+                format!(
+                    "Implicit conversion of `{}` to `bool` is not allowed",
+                    self.for_display(condition_type.clone())
+                ),
             );
         }
     }

--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -896,6 +896,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
     pub fn unop_infer(&self, x: &ExprUnaryOp, errors: &ErrorCollector) -> Type {
         let t = self.expr_infer(&x.operand, errors);
+        if x.op == UnaryOp::Not {
+            self.check_implicit_bool(&t, x.operand.range(), errors);
+        }
         let unop = |t: &Type, f: &dyn Fn(&Lit) -> Option<Type>, method: &Name| {
             let operand_range = x.operand.range();
             let context = || {

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -2438,6 +2438,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 let ty = self.expr_infer(x, errors);
                 self.check_dunder_bool_is_callable(&ty, x.range(), errors);
                 self.check_redundant_condition(&ty, x.range(), errors);
+                self.check_implicit_bool(&ty, x.range(), errors);
             }
             BindingExpect::UnpackedLength(b, range, expect) => {
                 let iterable_ty = self.get_idx(*b);

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -13,6 +13,10 @@ use crate::test::util::TestEnv;
 use crate::test::util::testcase_for_macro;
 use crate::testcase;
 
+fn implicit_bool_env() -> TestEnv {
+    TestEnv::new().enable_implicit_bool_error()
+}
+
 testcase!(
     test_if_simple,
     r#"
@@ -993,6 +997,49 @@ if foo:  # E: Function object `foo` used as condition
 while foo:  # E: Function object `foo` used as condition
     ...
 [x for x in range(42) if foo]  # E: Function object `foo` used as condition
+    "#,
+);
+
+testcase!(
+    test_implicit_bool,
+    implicit_bool_env(),
+    r#"
+from typing import Any
+
+def conditions(
+    optional_int: int | None,
+    items: list[int],
+    flag: bool,
+    dynamic: Any,
+) -> None:
+    if optional_int:  # E: Implicit conversion of `int | None` to `bool` is not allowed
+        ...
+    if not optional_int:  # E: Implicit conversion of `int | None` to `bool` is not allowed
+        ...
+    while items:  # E: Implicit conversion of `list[int]` to `bool` is not allowed
+        break
+    assert items  # E: Implicit conversion of `list[int]` to `bool` is not allowed
+    [x for x in items if x]  # E: Implicit conversion of `int` to `bool` is not allowed
+    value = 1 if items else 0  # E: Implicit conversion of `list[int]` to `bool` is not allowed
+    fallback = optional_int or 0  # E: Implicit conversion of `int | None` to `bool` is not allowed
+
+    if flag:
+        ...
+    if not flag:
+        ...
+    if bool(items):
+        ...
+    if dynamic:
+        ...
+    "#,
+);
+
+testcase!(
+    test_implicit_bool_disabled_by_default,
+    r#"
+def f(x: int | None) -> None:
+    if x:
+        ...
     "#,
 );
 

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -113,6 +113,7 @@ pub struct TestEnv {
     unannotated_return_error: bool,
     implicit_any_parameter_error: bool,
     implicit_any_attribute_error: bool,
+    implicit_bool_error: bool,
     unknown_attribute_type_error: bool,
     implicit_abstract_class_error: bool,
     open_unpacking_error: bool,
@@ -162,6 +163,7 @@ impl TestEnv {
             unannotated_return_error: false,
             implicit_any_parameter_error: false,
             implicit_any_attribute_error: false,
+            implicit_bool_error: false,
             unknown_attribute_type_error: false,
             implicit_abstract_class_error: false,
             open_unpacking_error: false,
@@ -299,6 +301,11 @@ impl TestEnv {
 
     pub fn enable_implicit_any_attribute_error(mut self) -> Self {
         self.implicit_any_attribute_error = true;
+        self
+    }
+
+    pub fn enable_implicit_bool_error(mut self) -> Self {
+        self.implicit_bool_error = true;
         self
     }
 
@@ -535,6 +542,9 @@ impl TestEnv {
         }
         if self.implicit_any_attribute_error {
             errors.set_error_severity(ErrorKind::ImplicitAnyAttribute, Severity::Error);
+        }
+        if self.implicit_bool_error {
+            errors.set_error_severity(ErrorKind::ImplicitBool, Severity::Error);
         }
         if self.unknown_attribute_type_error {
             errors.set_error_severity(ErrorKind::UnknownAttributeType, Severity::Error);

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -655,6 +655,27 @@ def f(xs: list[int]) -> tuple[int, ...]:
     return tuple(xs)
 ```
 
+## implicit-bool
+
+Default severity: `ignore`
+
+This error is emitted when a non-`bool` value is used in a boolean context. Enable it to require
+explicit checks for values whose truthiness could conflate distinct cases, such as `None` and zero
+or `None` and an empty container. An explicit `bool(...)` conversion is allowed.
+
+```python
+def get_temperature() -> int | None:
+    return 0
+
+temperature = get_temperature()
+if not temperature:  # implicit-bool
+    raise RuntimeError("Temperature sensor unavailable")
+
+# Fix:
+if temperature is None:
+    raise RuntimeError("Temperature sensor unavailable")
+```
+
 ## implicit-import
 
 Default severity: `warn`


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3959

Added opt-in implicit-bool diagnostic, disabled by default.

Detects non-bool values in conditions, not, assertions, comprehensions, ternaries, and boolean operators.

Allows explicit bool(...), actual bool values, and Any.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added tests and doc.