### PR TITLE
Report dict literal element type errors locally (#4275)

### DIFF
--- a/conformance/third_party/conformance.exp
+++ b/conformance/third_party/conformance.exp
@@ -735,13 +735,13 @@
   "aliases_recursive.py": [
     {
       "code": -2,
-      "column": 12,
-      "concise_description": "`dict[str, complex | int]` is not assignable to `dict[str, Json] | float | int | list[Json] | str | None`",
-      "description": "`dict[str, complex | int]` is not assignable to `dict[str, Json] | float | int | list[Json] | str | None`",
+      "column": 26,
+      "concise_description": "`complex` is not assignable to dict value type `Json`",
+      "description": "`complex` is not assignable to dict value type `Json`",
       "line": 19,
       "name": "bad-assignment",
       "severity": "error",
-      "stop_column": 29,
+      "stop_column": 28,
       "stop_line": 19
     },
     {
@@ -779,35 +779,35 @@
     },
     {
       "code": -2,
-      "column": 24,
-      "concise_description": "`dict[str, list[int]]` is not assignable to `Mapping[str, RecursiveMapping] | int | str`",
-      "description": "`dict[str, list[int]]` is not assignable to `Mapping[str, RecursiveMapping] | int | str`",
+      "column": 30,
+      "concise_description": "`list[int]` is not assignable to dict value type `RecursiveMapping`",
+      "description": "`list[int]` is not assignable to dict value type `RecursiveMapping`",
       "line": 50,
       "name": "bad-assignment",
       "severity": "error",
-      "stop_column": 34,
+      "stop_column": 33,
       "stop_line": 50
     },
     {
       "code": -2,
-      "column": 24,
-      "concise_description": "`dict[str, int | list[int] | str]` is not assignable to `Mapping[str, RecursiveMapping] | int | str`",
-      "description": "`dict[str, int | list[int] | str]` is not assignable to `Mapping[str, RecursiveMapping] | int | str`",
+      "column": 48,
+      "concise_description": "`list[int]` is not assignable to dict value type `RecursiveMapping`",
+      "description": "`list[int]` is not assignable to dict value type `RecursiveMapping`",
       "line": 51,
       "name": "bad-assignment",
       "severity": "error",
-      "stop_column": 55,
+      "stop_column": 54,
       "stop_line": 51
     },
     {
       "code": -2,
-      "column": 24,
-      "concise_description": "`dict[str, dict[str, int | list[int] | str] | int | str]` is not assignable to `Mapping[str, RecursiveMapping] | int | str`",
-      "description": "`dict[str, dict[str, int | list[int] | str] | int | str]` is not assignable to `Mapping[str, RecursiveMapping] | int | str`",
+      "column": 72,
+      "concise_description": "`list[int]` is not assignable to dict value type `RecursiveMapping`",
+      "description": "`list[int]` is not assignable to dict value type `RecursiveMapping`",
       "line": 52,
       "name": "bad-assignment",
       "severity": "error",
-      "stop_column": 83,
+      "stop_column": 81,
       "stop_line": 52
     },
     {

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -759,6 +759,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         &x.elt,
                         HintRef::with_ty_opt(hint, elem_hint.as_ref()),
                         errors,
+                        None,
                     );
                     self.heap.mk_class_type(self.stdlib.list(elem_ty))
                 },
@@ -772,6 +773,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         &x.elt,
                         HintRef::with_ty_opt(hint, elem_hint.as_ref()),
                         errors,
+                        None,
                     );
                     self.heap.mk_class_type(self.stdlib.set(elem_ty))
                 },
@@ -800,10 +802,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     // `key` is only `None` for a syntactically invalid dict comprehension
                     // (parser error recovery); the parser already reports the syntax error.
                     let key_ty = match &x.key {
-                        Some(key) => self.expr_infer_with_hint_promote(key, key_hint, errors),
+                        Some(key) => self.expr_infer_with_hint_promote(key, key_hint, errors, None),
                         None => self.heap.mk_any_error(),
                     };
-                    let value_ty = self.expr_infer_with_hint_promote(&x.value, value_hint, errors);
+                    let value_ty =
+                        self.expr_infer_with_hint_promote(&x.value, value_hint, errors, None);
                     self.heap.mk_class_type(self.stdlib.dict(key_ty, value_ty))
                 },
             ),
@@ -1049,17 +1052,31 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         x: &Expr,
         hint: Option<HintRef>,
         errors: &ErrorCollector,
+        tcc: Option<&dyn Fn() -> TypeCheckContext>,
     ) -> Type {
         let ty = self.expr_infer_with_hint(x, hint, errors);
-        if let Some(want) = hint {
+        if let Some(hint) = hint {
+            let use_hint = |want| {
+                if let Some(check_errors) = hint.errors()
+                    && let Some(tcc) = tcc
+                {
+                    // If this is a hard hint, always use it, reporting any check errors that
+                    // result from its use.
+                    self.check_type(&ty, want, x.range(), check_errors, tcc);
+                    true
+                } else {
+                    // Use a soft hint only if it is compatible.
+                    self.is_subset_eq(&ty, want)
+                }
+            };
             // Optimization: delay Type cloning until absolutely necessary.
-            if let &[want] = &want.types() {
-                if self.is_subset_eq(&ty, want) {
+            if let &[want] = &hint.types() {
+                if use_hint(want) {
                     return want.clone();
                 }
             } else {
-                let want = Type::union(want.types().to_vec());
-                if self.is_subset_eq(&ty, &want) {
+                let want = Type::union(hint.types().to_vec());
+                if use_hint(&want) {
                     return want;
                 }
             }
@@ -1618,6 +1635,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 .map(|hint| HintRef::new(key_hint, hint.errors()))
                         }),
                         errors,
+                        None,
                     );
                     let value_t = self.expr_infer_with_hint_promote(
                         &x.value,
@@ -1626,6 +1644,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 .map(|hint| HintRef::new(value_hint, hint.errors()))
                         }),
                         errors,
+                        None,
                     );
                     if !key_t.is_error() {
                         key_tys.push(key_t);
@@ -2689,6 +2708,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     value,
                     HintRef::with_ty_opt(elt_hint, star_hint.as_ref()),
                     errors,
+                    None,
                 );
                 if let Some(iterable_ty) = self.unwrap_iterable(&unpacked_ty) {
                     iterable_ty
@@ -2704,7 +2724,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     )
                 }
             }
-            _ => self.expr_infer_with_hint_promote(x, elt_hint, errors),
+            _ => self.expr_infer_with_hint_promote(x, elt_hint, errors, None),
         })
     }
 

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -708,7 +708,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Expr::List(x) => self.infer_with_decomposed_hint(
                 hint,
                 |hint| self.decompose_list(hint),
-                |elt_hint| {
+                |elt_hint, hint| {
                     if x.is_empty() {
                         let elem_ty = elt_hint.unwrap_or_else(|| {
                             self.solver()
@@ -731,7 +731,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Expr::Set(x) => self.infer_with_decomposed_hint(
                 hint,
                 |hint| self.decompose_set(hint),
-                |elem_hint| {
+                |elem_hint, hint| {
                     if x.is_empty() {
                         let elem_ty = elem_hint.unwrap_or_else(|| {
                             self.solver()
@@ -753,7 +753,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Expr::ListComp(x) => self.infer_with_decomposed_hint(
                 hint,
                 |hint| self.decompose_list(hint),
-                |elem_hint| {
+                |elem_hint, hint| {
                     self.ifs_infer(&x.generators, errors);
                     let elem_ty = self.expr_infer_with_hint_promote(
                         &x.elt,
@@ -766,7 +766,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Expr::SetComp(x) => self.infer_with_decomposed_hint(
                 hint,
                 |hint| self.decompose_set(hint),
-                |elem_hint| {
+                |elem_hint, hint| {
                     self.ifs_infer(&x.generators, errors);
                     let elem_ty = self.expr_infer_with_hint_promote(
                         &x.elt,
@@ -786,8 +786,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         Some((key_hint, value_hint))
                     }
                 },
-                |hints| {
-                    let (key_hint, value_hint) = hints.unwrap_or_default();
+                |decomposed_hints, hint| {
+                    let (key_hint, value_hint) = decomposed_hints.unwrap_or_default();
                     let key_hint = key_hint.as_ref().and_then(|key_hint| {
                         hint.as_ref()
                             .map(|hint| HintRef::new(key_hint, hint.errors()))
@@ -810,7 +810,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Expr::Generator(x) => self.infer_with_decomposed_hint(
                 hint,
                 |hint| self.decompose_generator(hint).map(|(y, _, _)| y),
-                |yield_hint| {
+                |yield_hint, hint| {
                     self.ifs_infer(&x.generators, errors);
                     let yield_ty = self
                         .expr_infer_impl(
@@ -1557,8 +1557,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     Some((key_hint, value_hint))
                 }
             },
-            |hints| {
-                let (key_hint, value_hint) = hints.unwrap_or_default();
+            |decomposed_hints, hint| {
+                let (key_hint, value_hint) = decomposed_hints.unwrap_or_default();
                 self.dict_items_infer_inner(range, &items, hint, key_hint, value_hint, errors)
             },
         )

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -96,6 +96,7 @@ use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
 use crate::error::context::ErrorContext;
 use crate::error::context::TypeCheckContext;
+use crate::error::context::TypeCheckKind;
 use crate::solver::solver::CallContext;
 use crate::types::callable::DefaultValue;
 use crate::types::callable::Param;
@@ -1635,7 +1636,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 .map(|hint| HintRef::new(key_hint, hint.errors()))
                         }),
                         errors,
-                        None,
+                        Some(&|| TypeCheckContext::of_kind(TypeCheckKind::DictKey)),
                     );
                     let value_t = self.expr_infer_with_hint_promote(
                         &x.value,
@@ -1644,7 +1645,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 .map(|hint| HintRef::new(value_hint, hint.errors()))
                         }),
                         errors,
-                        None,
+                        Some(&|| TypeCheckContext::of_kind(TypeCheckKind::DictValue)),
                     );
                     if !key_t.is_error() {
                         key_tys.push(key_t);

--- a/pyrefly/lib/alt/unwrap.rs
+++ b/pyrefly/lib/alt/unwrap.rs
@@ -13,7 +13,6 @@ use crate::alt::answers::LookupAnswer;
 use crate::alt::answers_solver::AnswersSolver;
 use crate::error::collector::ErrorCollector;
 use crate::solver::solver::SubsetError;
-use crate::solver::solver::SubsetWithSnapshotResult;
 use crate::types::callable::Param;
 use crate::types::callable::Required;
 use crate::types::class::ClassType;
@@ -431,7 +430,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         &self,
         hint: Option<HintRef<'_, '_>>,
         decompose: impl Fn(&Type) -> Option<D>,
-        infer: impl Fn(Option<D>) -> Type,
+        // The inputs to `infer` are the result of decomposing the hint, plus the original hint.
+        // The latter is passed in because we swap in a fresh error collector.
+        infer: impl Fn(Option<D>, Option<HintRef>) -> Type,
     ) -> Type {
         if let Some(hint) = hint {
             let raw_hints = hint.types();
@@ -439,26 +440,74 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             let hints = flattened_hints.as_ref().map_or(raw_hints, |x| x);
             let decomposable_width = hints.iter().filter(|h| !h.is_scalar()).count();
             if decomposable_width <= MAX_DECOMPOSE_HINT_WIDTH {
-                for (hint, vs) in self.solver().partial_sort_by_vars(hints) {
-                    if hint.is_scalar() {
+                let mut ret_with_errors = None;
+                for (branch_hint, vs) in self.solver().partial_sort_by_vars(hints) {
+                    if branch_hint.is_scalar() {
                         continue;
                     }
-                    let mut ret = None;
-                    match self.solver().with_snapshot(&vs, || {
-                        let d = decompose(hint);
-                        if d.is_none() {
-                            return Err(SubsetError::Other);
+                    if vs.is_empty() {
+                        // No placeholder vars to pin, so inference has no solver state to
+                        // roll back. Infer directly and collect this hint's errors against
+                        // a fresh collector; they are speculative until we commit to it.
+                        let Some(d) = decompose(branch_hint) else {
+                            continue;
+                        };
+                        let error_collectors = hint.errors().map(|e| (e, self.error_collector()));
+                        let ret = infer(
+                            Some(d),
+                            Some(HintRef(
+                                hint.types(),
+                                error_collectors
+                                    .as_ref()
+                                    .map(|(_, branch_errors)| branch_errors),
+                            )),
+                        );
+                        if !self.is_subset_eq(&ret, branch_hint) {
+                            continue;
                         }
-                        ret = Some(infer(d));
-                        self.is_subset_eq_with_reason(ret.as_ref().unwrap(), hint)
-                    }) {
-                        SubsetWithSnapshotResult::Ok => return ret.unwrap(),
-                        SubsetWithSnapshotResult::Err(_) => {}
+                        match error_collectors {
+                            // This hint matches but produces hard errors. Remember the first
+                            // such hint as a fallback and keep looking for a clean match.
+                            Some((errors, branch_errors)) if branch_errors.has_hard() => {
+                                if ret_with_errors.is_none() {
+                                    ret_with_errors = Some((ret, errors, branch_errors));
+                                }
+                            }
+                            // Matched with at most soft errors: commit, propagating them.
+                            Some((errors, branch_errors)) => {
+                                errors.extend(branch_errors);
+                                return ret;
+                            }
+                            None => return ret,
+                        }
+                    } else {
+                        // Pinning vars mutates solver state, so infer under a snapshot that
+                        // rolls back when the inferred type doesn't match the hint. Emitting
+                        // errors from possibly-partial var answers is unsafe, so pass none.
+                        let mut ret = None;
+                        let matched = self.solver().with_snapshot(&vs, || {
+                            let Some(d) = decompose(branch_hint) else {
+                                return Err(SubsetError::Other);
+                            };
+                            let ty = infer(Some(d), Some(HintRef(hint.types(), None)));
+                            let result = self.is_subset_eq_with_reason(&ty, branch_hint);
+                            ret = Some(ty);
+                            result
+                        });
+                        if matched.is_ok() {
+                            return ret.unwrap();
+                        }
                     }
+                }
+                // If we didn't find a completely successful result, take the first hint that
+                // matched but produced hard errors.
+                if let Some((ret, errors, branch_errors)) = ret_with_errors {
+                    errors.extend(branch_errors);
+                    return ret;
                 }
             }
         }
-        infer(None)
+        infer(None, hint)
     }
 
     /// Flatten the hint candidates produced by `HintRef::split`, additionally looking through type

--- a/pyrefly/lib/alt/unwrap.rs
+++ b/pyrefly/lib/alt/unwrap.rs
@@ -516,21 +516,25 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     fn flatten_alias_union_hints(&self, hints: &[Type]) -> Option<Vec<Type>> {
         if !hints
             .iter()
-            .any(|hint| matches!(hint, Type::UntypedAlias(_)))
+            .any(|hint| matches!(hint, Type::UntypedAlias(_) | Type::Union(_)))
         {
             return None;
         }
         let mut flattened_hints = Vec::new();
         for hint in hints {
-            if let Type::UntypedAlias(data) = hint {
-                let expanded_alias = self.untype_alias(data);
-                if let Type::Union(u) = expanded_alias {
-                    flattened_hints.extend(u.members);
-                } else {
-                    flattened_hints.push(expanded_alias);
+            match hint {
+                Type::UntypedAlias(data) => {
+                    let expanded_alias = self.untype_alias(data);
+                    if let Type::Union(u) = expanded_alias {
+                        flattened_hints.extend(u.members);
+                    } else {
+                        flattened_hints.push(expanded_alias);
+                    }
                 }
-            } else {
-                flattened_hints.push(hint.clone());
+                Type::Union(u) => {
+                    flattened_hints.extend(u.members.clone());
+                }
+                _ => flattened_hints.push(hint.clone()),
             }
         }
         Some(flattened_hints)

--- a/pyrefly/lib/error/context.rs
+++ b/pyrefly/lib/error/context.rs
@@ -169,6 +169,10 @@ pub enum TypeCheckKind {
     CallUnpackKwArg(Name, Option<FunctionKind>),
     /// Check of a parameter's default value against its type annotation.
     FunctionParameterDefault(Name),
+    /// Check against the key type of a dict.
+    DictKey,
+    /// Check against the value type of a dict.
+    DictValue,
     /// Check against type of a TypedDict key. The name may be None if the type comes from
     /// `extra_items` or some other non-literal-key source. The bool indicates whether the
     /// TypedDict was inferred (anonymous) rather than explicitly declared.
@@ -239,7 +243,7 @@ impl TypeCheckKind {
             Self::CallKwArgs(..) => ErrorKind::BadArgumentType,
             Self::CallUnpackKwArg(..) => ErrorKind::BadArgumentType,
             Self::FunctionParameterDefault(..) => ErrorKind::BadFunctionDefinition,
-            Self::TypedDictKey(_, _) => ErrorKind::BadAssignment,
+            Self::DictKey | Self::DictValue | Self::TypedDictKey(_, _) => ErrorKind::BadAssignment,
             Self::TypedDictUnpacking => ErrorKind::BadUnpacking,
             Self::TypedDictOpenUnpacking => ErrorKind::OpenUnpacking,
             Self::Attribute(..) => ErrorKind::BadAssignment,

--- a/pyrefly/lib/error/display.rs
+++ b/pyrefly/lib/error/display.rs
@@ -171,6 +171,16 @@ impl TypeCheckKind {
                 param,
                 ctx.display(want),
             ),
+            Self::DictKey => format!(
+                "`{}` is not assignable to dict key type `{}`",
+                ctx.display(got),
+                ctx.display(want),
+            ),
+            Self::DictValue => format!(
+                "`{}` is not assignable to dict value type `{}`",
+                ctx.display(got),
+                ctx.display(want),
+            ),
             Self::TypedDictKey(key, is_anonymous) => {
                 let key_str = if let Some(key) = key {
                     format!(" `{key}`")

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -908,7 +908,7 @@ def test1(*cmd: str, **keywords: str) -> None:
     cmd = ("mycmd",)
     cmd = (1,)  # E: `tuple[Literal[1]]` is not assignable to variable `cmd` with type `tuple[str, ...]`
     keywords = {"key": "value"}
-    keywords = {"key": 0}  # E: `dict[str, int]` is not assignable to variable `keywords` with type `dict[str, str]`
+    keywords = {"key": 0}  # E: `Literal[0]` is not assignable to dict value type `str`
 class MyDict(TypedDict):
     x: int
     y: int

--- a/pyrefly/lib/test/contextual.rs
+++ b/pyrefly/lib/test/contextual.rs
@@ -136,9 +136,11 @@ z: list[A] | list[B] = [B2() for _ in range(10)]
 testcase!(
     test_dict_union,
     r#"
+from typing import Sequence
 d1: dict[int, int] | dict[str, list[int]] = {"x": [True]}
 x: list[str] = []
 d2: dict[int, int] | dict[str, list[int]] = {k: [True] for k in x}
+d3: Sequence[dict[str, int]] | Sequence[dict[int, int]] = [{"x": 1}]
     "#,
 );
 
@@ -208,11 +210,11 @@ testcase!(
     r#"
 from typing import Iterable, MutableMapping, Literal
 x1: dict[str, int] = {"a": 1}
-x2: dict[str, int] = {"a": "oops"}  # E: `dict[str, str]` is not assignable to `dict[str, int]`
-x3: dict[str, Literal[1]] = {"a": 2} # E: `dict[str, int]` is not assignable to `dict[str, Literal[1]]`
+x2: dict[str, int] = {"a": "oops"}  # E: `Literal['oops']` is not assignable to dict value type `int`
+x3: dict[str, Literal[1]] = {"a": 2} # E: `Literal[2]` is not assignable to dict value type `Literal[1]`
 x4: MutableMapping[str, int] = {"a": 1}
 x5: Iterable[str] = {"a": 1}
-x6: Iterable[int] = {"oops": 1}  # E: `dict[str, int]` is not assignable to `Iterable[int]`
+x6: Iterable[int] = {"oops": 1}  # E: `Literal['oops']` is not assignable to dict key type `int`
 x7: Iterable[Literal[4]] = {4: "a"}
 x8: object = {"a": 1}
 x9: list[str] = {"a": 1}  # E: `dict[str, int]` is not assignable to `list[str]`
@@ -368,6 +370,7 @@ class B: ...
 class B2(B): ...
 f1: Callable[[], list[B]] = lambda: [B2()]
 f2: Callable[[], list[A]] | Callable[[], list[B]] = lambda: [B2()]
+f3: Callable[[], dict[int, A]] | Callable[[], dict[int, B]] = lambda: {0: B2()}
 "#,
 );
 

--- a/pyrefly/lib/test/contextual.rs
+++ b/pyrefly/lib/test/contextual.rs
@@ -900,3 +900,22 @@ class DB(TypedDict):
 f: Callable[[], DA] | Callable[[], DB] = lambda: {"x": B2()}
     "#,
 );
+
+testcase!(
+    test_nested_typeddict_in_union,
+    r#"
+from typing import TypedDict
+
+class A(TypedDict):
+    x: int
+
+class B(TypedDict, total=False):
+    x: str
+
+type X = list[A] | list[B]
+
+x1: X = [{"x": ""}]
+x2: X = [{}]
+x3: X = [{"x": 1.0}]  # E: `float` is not assignable to TypedDict key `x` with type `int`
+    "#,
+);

--- a/pyrefly/lib/test/dict.rs
+++ b/pyrefly/lib/test/dict.rs
@@ -15,6 +15,28 @@ dict(x = 1, y = "test")
 );
 
 testcase!(
+    bug = "Dict literal type errors should point to the bad entry, not the whole literal",
+    test_dict_literal_bad_value_range,
+    r#"
+mp: dict[int, int] = {  # E: `dict[int, int | str]` is not assignable to `dict[int, int]`
+    1: 2,
+    3: "test",
+}
+    "#,
+);
+
+testcase!(
+    bug = "Dict literal type errors should point to the bad entry, not the whole literal",
+    test_dict_literal_bad_key_range,
+    r#"
+mp: dict[int, int] = {  # E: `dict[int | str, int]` is not assignable to `dict[int, int]`
+    1: 2,
+    "test": 3,
+}
+    "#,
+);
+
+testcase!(
     test_anonymous_typed_dict_union_promotion,
     r#"
 from typing import assert_type

--- a/pyrefly/lib/test/dict.rs
+++ b/pyrefly/lib/test/dict.rs
@@ -15,24 +15,44 @@ dict(x = 1, y = "test")
 );
 
 testcase!(
-    bug = "Dict literal type errors should point to the bad entry, not the whole literal",
     test_dict_literal_bad_value_range,
     r#"
-mp: dict[int, int] = {  # E: `dict[int, int | str]` is not assignable to `dict[int, int]`
+mp: dict[int, int] = {
     1: 2,
-    3: "test",
+    3: "test",  # E: `Literal['test']` is not assignable to dict value type `int`
 }
     "#,
 );
 
 testcase!(
-    bug = "Dict literal type errors should point to the bad entry, not the whole literal",
     test_dict_literal_bad_key_range,
     r#"
-mp: dict[int, int] = {  # E: `dict[int | str, int]` is not assignable to `dict[int, int]`
+mp: dict[int, int] = {
     1: 2,
-    "test": 3,
+    "test": 3,  # E: `Literal['test']` is not assignable to dict key type `int`
 }
+    "#,
+);
+
+testcase!(
+    test_dict_literal_nested_alias_mapping_or_iterable,
+    r#"
+from typing import Generic, Iterable, Mapping, TypeAlias, TypeVar
+
+class Var: ...
+
+JsonScalar: TypeAlias = "Json | Mapping[str, object] | Var"
+JsonList: TypeAlias = JsonScalar | Iterable[JsonScalar]
+
+PythonTypes = TypeVar("PythonTypes")
+AcceptedTypes = TypeVar("AcceptedTypes")
+
+class Base(Generic[PythonTypes, AcceptedTypes]):
+    def __init__(self, value: AcceptedTypes | None = None) -> None: ...
+
+class Json(Base[Mapping[str, object], JsonList]): ...
+
+Json({"featureQuery": {"id": 1}})
     "#,
 );
 

--- a/pyrefly/lib/test/generic_basic.rs
+++ b/pyrefly/lib/test/generic_basic.rs
@@ -814,6 +814,15 @@ assert_type(A(0).f(""), A[int | str])
 );
 
 testcase!(
+    test_mapping_of_typevar,
+    r#"
+from typing import assert_type, Mapping
+def f[T](x: T, y: Mapping[str, T]) -> T: ...
+assert_type(f(0, {"x": "y"}), int | str)
+    "#,
+);
+
+testcase!(
     test_any_absorption,
     r#"
 from typing import Any, assert_type

--- a/pyrefly/lib/test/new_type.rs
+++ b/pyrefly/lib/test/new_type.rs
@@ -145,7 +145,7 @@ Thing = NewType("Thing", int)
 ThingType = type[Thing]  # E: NewType `Thing` is not a class and cannot be used with `type` or `Type`
 OtherThingType = Type[Thing]  # E: NewType `Thing` is not a class and cannot be used with `type` or `Type`
 
-mapping: dict[int, ThingType] = {1: Thing}  # E: `dict[int, type[Thing]]` is not assignable to `dict[int, type[Any]]`
+mapping: dict[int, ThingType] = {1: Thing}  # E: `type[Thing]` is not assignable to dict value type `type[Any]`
 
 def func(x: ThingType) -> None: ...
 func(Thing)  # E: Argument `type[Thing]` is not assignable to parameter `x` with type `type[Any]` in function `func`

--- a/pyrefly/lib/test/recursive_alias.rs
+++ b/pyrefly/lib/test/recursive_alias.rs
@@ -195,7 +195,7 @@ type X[K, V] = dict[K, V] | list[X[str, V]]
 
 x1: X = {0: 1}
 x2: X[int, int] = {0: 1}
-x3: X[str, int] = {0: 1}  # E: `dict[int, int]` is not assignable to `dict[str, int] | list[X[str, int]]`
+x3: X[str, int] = {0: 1}  # E: `Literal[0]` is not assignable to dict key type `str`
 
 x4: X = [{'ok': 1}]
 x5: X[int, int] = [{'ok': 1}]

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -732,7 +732,7 @@ testcase!(
     r#"
 from typing import assert_type
 x1: dict[str, int] = {"foo": 1, **{"bar": 2}}
-x2: dict[str, int] = {"foo": 1, **{"bar": "bar"}}  # E: `dict[str, int | str]` is not assignable to `dict[str, int]`
+x2: dict[str, int] = {"foo": 1, **{"bar": "bar"}}  # E: `Literal['bar']` is not assignable to dict value type `int`
 assert_type({"foo": 1, **{"bar": "bar"}}, dict[str, int | str])
 {"foo": 1, **1}  # E: Expected a mapping, got Literal[1]
 "#,
@@ -1533,7 +1533,7 @@ testcase!(
     test_typing_alias,
     r#"
 from typing import Dict, assert_type
-y: Dict[str, int] = {"test": "test"} # E: `dict[str, str]` is not assignable to `dict[str, int]`
+y: Dict[str, int] = {"test": "test"} # E: `Literal['test']` is not assignable to dict value type `int`
 assert_type(y, dict[str, int])
 "#,
 );

--- a/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
@@ -1884,16 +1884,14 @@ fn test_get_expected_type_list_element_falls_back_to_container_type() {
 }
 
 #[test]
-fn test_get_expected_type_dict_value_falls_back_to_container_type() {
-    // `d: dict[str, int | str] = {"k": 4}` — ideally the expected type
-    // at `4` would be `int | str`, but we currently return `dict[...]`.
+fn test_get_expected_type_dict_value() {
+    // `d: dict[str, int | str] = {"k": 4}` — the expected type is `int | str`.
     let source = "d: dict[str, int | str] = {\"k\": 4}\n";
     let (mut tsp, file_uri, snapshot) = setup_project(source);
 
     // Position 32 is the `4` value in the dict literal.
     let expected = get_expected_type_ok(&mut tsp, &file_uri, 0, 32, snapshot);
-    // TODO: should be TypeKind::Union for the value type.
-    assert_kind(&expected, TypeKind::Class);
+    assert_kind(&expected, TypeKind::Union);
 
     tsp.shutdown();
 }


### PR DESCRIPTION
Summary:

Fixes https://github.com/facebook/pyrefly/issues/893.

Makes `dict_items_infer_inner` immediately report errors when it encounters them on keys and values, so that errors are reported on the exact line at which the bad key or value appears, with a precise message.

As a side effect, this also causes all of these errors to be reported under [bad-assignment] instead of their original error kind, because we have to choose an error kind when creating a new TypeCheckContext. This is consistent with what we already do for TypedDict errors.

The error count increases reported by the error delta jobs are because we previously reported only a single error if a dict literal contained multiple items with incorrect types, and now we report one error per bad item.

Before:
```
ERROR `dict[str, int]` is not assignable to `dict[int, int]` [bad-assignment]
 --> empty.py:1:21
  |
1 | d: dict[int, int] = {"oops": 42}
  |    --------------   ^^^^^^^^^^^^
  |    |
  |    declared type
  |
```

After:
```
ERROR `Literal['oops']` is not assignable to dict key type `int` [bad-assignment]
 --> empty.py:1:22
  |
1 | d: dict[int, int] = {"oops": 42}
  |                      ^^^^^^
  |
```

Reviewed By: stroxler

Differential Revision: D108382364


