### PR TITLE
fix dict([...]) config tree: type-checking a single function takes ~40s and grows steeply with nesting depth #3653

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -24,6 +24,7 @@ use pyrefly_types::types::TArgs;
 use pyrefly_types::types::TParams;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::prelude::VecExt;
+use pyrefly_util::visit::Visit;
 use ruff_python_ast::Arguments;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprCall;
@@ -2163,10 +2164,59 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         } else {
             self.expand_mut(&mut callee_ty);
 
+            // Overload handling normally preserves mutable literals for contextual typing. For a
+            // list of pairs passed to dict/OrderedDict, however, that makes every constructor
+            // overload recursively re-infer every nested constructor (see #3653). This shape is
+            // sufficient to infer the key and value types once when there is no narrow hint or
+            // empty container that requires contextual typing.
+            let dict_pairs_ty = if matches!(
+                &callee_ty,
+                Type::ClassDef(cls)
+                    if cls.is_builtin("dict")
+                        || cls.has_toplevel_qname("collections", "OrderedDict")
+            ) && let [Expr::List(items)] = &*x.arguments.args
+                && !items.elts.is_empty()
+                && items.elts.iter().all(|item| match item {
+                    Expr::Tuple(pair) => {
+                        if pair.elts.len() != 2
+                            || pair.elts.iter().any(|x| matches!(x, Expr::Starred(_)))
+                        {
+                            false
+                        } else {
+                            let mut contains_empty_container = false;
+                            pair.elts.iter().for_each(|elt| {
+                                elt.visit(&mut |x| {
+                                    contains_empty_container |= match x {
+                                        Expr::List(x) => x.elts.is_empty(),
+                                        Expr::Dict(x) => x.items.is_empty(),
+                                        _ => false,
+                                    }
+                                })
+                            });
+                            !contains_empty_container
+                        }
+                    }
+                    _ => false,
+                })
+                && hint.is_none_or(|hint| {
+                    self.decompose_hint(hint, |ty| {
+                        let (key, value) = self.unwrap_mapping(ty)?;
+                        (key.is_any() && value.is_any()).then_some(())
+                    })
+                    .len()
+                        == hint.types().len()
+                }) {
+                Some(self.expr_infer(&x.arguments.args[0], errors))
+            } else {
+                None
+            };
             let args;
             let kws;
             let call = CallWithTypes::new();
-            if callee_ty.is_union() {
+            if let Some(arg_ty) = &dict_pairs_ty {
+                args = vec![CallArg::ty(arg_ty, x.arguments.args[0].range())];
+                kws = x.arguments.keywords.map(CallKeyword::new);
+            } else if callee_ty.is_union() {
                 // If we have a union we will distribute over it, and end up duplicating each function call.
                 args = x
                     .arguments

--- a/pyrefly/lib/test/dict.rs
+++ b/pyrefly/lib/test/dict.rs
@@ -258,6 +258,88 @@ from typing import assert_type
 
 x = {"a": {"b": {"c": {"d": {"e": {"f": {"g": {"h": {"i": {"j": {"k": {"l": {"m": {"n": {"o": "deep"}}}}}}}}}}}}}}}
 assert_type(x, dict[str, dict[str, dict[str, dict[str, dict[str, dict[str, dict[str, dict[str, dict[str, dict[str, dict[str, dict[str, dict[str, dict[str, dict[str, str]]]]]]]]]]]]]]])
+    "#,
+);
+
+// https://github.com/facebook/pyrefly/issues/3653
+// Keep enough heterogeneous values and branching to exercise constructor overload inference.
+// Re-inferring each list of pairs for every overload makes this grow exponentially with depth.
+testcase!(
+    test_nested_dict_constructor_from_list_of_pairs,
+    r#"
+from collections import OrderedDict
+from typing import assert_type
+
+def dict_tree() -> dict:
+    return dict([
+        ("name", "root"),
+        ("count", 1),
+        ("items", [1, 2]),
+        ("metadata", {"enabled": True}),
+        ("left", dict([
+            ("name", "left"),
+            ("count", 2),
+            ("items", [3, 4]),
+            ("metadata", {"enabled": False}),
+            ("left", dict([
+                ("name", "leaf"),
+                ("count", 3),
+                ("items", [5, 6]),
+                ("metadata", {"enabled": True}),
+            ])),
+            ("right", dict([
+                ("name", "leaf"),
+                ("count", 4),
+                ("items", [7, 8]),
+                ("metadata", {"enabled": False}),
+            ])),
+        ])),
+        ("right", dict([
+            ("name", "right"),
+            ("count", 5),
+            ("items", [9, 10]),
+            ("metadata", {"enabled": True}),
+            ("left", dict([
+                ("name", "leaf"),
+                ("count", 6),
+                ("items", [11, 12]),
+                ("metadata", {"enabled": False}),
+            ])),
+            ("right", dict([
+                ("name", "leaf"),
+                ("count", 7),
+                ("items", [13, 14]),
+                ("metadata", {"enabled": True}),
+            ])),
+        ])),
+    ])
+
+def ordered_tree() -> OrderedDict:
+    return OrderedDict([
+        ("name", "root"),
+        ("count", 1),
+        ("left", OrderedDict([
+            ("name", "left"),
+            ("count", 2),
+            ("items", [1, 2]),
+        ])),
+        ("right", OrderedDict([
+            ("name", "right"),
+            ("count", 3),
+            ("items", [3, 4]),
+        ])),
+    ])
+
+ordered = OrderedDict([("name", "root"), ("count", 1)])
+assert_type(ordered, OrderedDict[str, int | str])
+
+with_keyword = dict([("first", 1)], second="two")
+assert_type(with_keyword, dict[str, int | str])
+
+class Base: ...
+class Child(Base): ...
+contextual: dict[str, list[Base]] = dict([("items", [Child()])])
+assert_type(contextual, dict[str, list[Base]])
 "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3653

Dict-like constructors now infer valid list-of-tuple arguments once, avoiding exponential overload re-inference.

Narrow contextual hints and empty containers retain the existing contextual-inference path.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

Added test for nested dict, OrderedDict, keyword arguments, and contextual typing.