### PR TITLE
fix Support Pydantic validators in Annotated fields #4256

### DIFF
--- a/crates/pyrefly_python/src/module_name.rs
+++ b/crates/pyrefly_python/src/module_name.rs
@@ -267,6 +267,10 @@ impl ModuleName {
         Self::from_str("pydantic.alias_generators")
     }
 
+    pub fn pydantic_functional_validators() -> Self {
+        Self::from_str("pydantic.functional_validators")
+    }
+
     pub fn django_models_enums() -> Self {
         Self::from_str("django.db.models.enums")
     }

--- a/crates/pyrefly_python/src/module_name.rs
+++ b/crates/pyrefly_python/src/module_name.rs
@@ -269,6 +269,10 @@ impl ModuleName {
         Self::from_str("pydantic.alias_generators")
     }
 
+    pub fn pydantic_functional_validators() -> Self {
+        Self::from_str("pydantic.functional_validators")
+    }
+
     pub fn django_models_enums() -> Self {
         Self::from_str("django.db.models.enums")
     }

--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -98,6 +98,17 @@ impl Var {
     }
 }
 
+/// Semantic information retained for an item in `Annotated[T, ...]`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, TypeEq)]
+pub struct AnnotatedMetadata {
+    /// The inferred type of the metadata value.
+    pub ty: Type,
+    /// The callee's final name when the metadata is a call.
+    pub callee_name: Option<Name>,
+    /// The inferred type of the first positional argument when the metadata is a call.
+    pub first_arg: Option<Box<Type>>,
+}
+
 #[derive(PartialEq, Eq)]
 pub enum TParamsSource {
     Class,
@@ -850,7 +861,7 @@ pub enum Type {
     /// This is transparent when resolving annotations, but is not callable and
     /// cannot be assigned to `type[T]`.
     /// The second field carries the metadata items (the `...` in `Annotated[T, ...]`).
-    Annotated(Box<Type>, Box<[Type]>),
+    Annotated(Box<Type>, Box<[AnnotatedMetadata]>),
     Unpack(Box<Type>),
     TypeVar(TypeVar),
     ParamSpec(ParamSpec),

--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -99,6 +99,17 @@ impl Var {
     }
 }
 
+/// Semantic information retained for an item in `Annotated[T, ...]`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, TypeEq)]
+pub struct AnnotatedMetadata {
+    /// The inferred type of the metadata value.
+    pub ty: Type,
+    /// The callee's final name when the metadata is a call.
+    pub callee_name: Option<Name>,
+    /// The inferred type of the first positional argument when the metadata is a call.
+    pub first_arg: Option<Box<Type>>,
+}
+
 #[derive(PartialEq, Eq)]
 pub enum TParamsSource {
     Class,
@@ -968,7 +979,7 @@ pub enum Type {
     /// This is transparent when resolving annotations, but is not callable and
     /// cannot be assigned to `type[T]`.
     /// The second field carries the metadata items (the `...` in `Annotated[T, ...]`).
-    Annotated(Box<Type>, Box<[Type]>),
+    Annotated(Box<Type>, Box<[AnnotatedMetadata]>),
     Unpack(Box<Type>),
     TypeVar(TypeVar),
     ParamSpec(ParamSpec),

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1515,9 +1515,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         .is_some_and(|annot| annot.has_qualifier(&Qualifier::ClassVar))
                 {
                     ClassFieldInitialization::Magic
-                } else if let Some(flags) =
-                    self.extract_pydantic_field_from_annotation(*annot, name, &metadata)
-                {
+                } else if let Some(flags) = self.extract_pydantic_field_from_annotation(
+                    *annot,
+                    name,
+                    direct_annotation
+                        .as_ref()
+                        .and_then(|annotation| annotation.ty.as_ref()),
+                    &metadata,
+                ) {
                     ClassFieldInitialization::ClassBody(Some(Box::new(flags)))
                 } else {
                     ClassFieldInitialization::Uninitialized
@@ -1581,7 +1586,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         ),
                     );
                 }
-                let initialization = if let ExprOrBinding::Expr(e) = value.as_ref()
+                let mut initialization = if let ExprOrBinding::Expr(e) = value.as_ref()
                     && let Some(dm) = metadata.dataclass_metadata()
                     && let Expr::Call(call) = e
                 {
@@ -1718,6 +1723,31 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 } else {
                     ClassFieldInitialization::ClassBody(None)
                 };
+                if let Some(annot) = annot
+                    && let Some(mut annotation_flags) = self.extract_pydantic_field_from_annotation(
+                        *annot,
+                        name,
+                        direct_annotation
+                            .as_ref()
+                            .and_then(|annotation| annotation.ty.as_ref()),
+                        &metadata,
+                    )
+                    && let Some(converter_param) = annotation_flags.converter_param.take()
+                {
+                    match &mut initialization {
+                        ClassFieldInitialization::ClassBody(Some(flags)) => {
+                            flags.converter_param = Some(converter_param);
+                        }
+                        ClassFieldInitialization::ClassBody(None) => {
+                            annotation_flags.converter_param = Some(converter_param);
+                            annotation_flags.default = Some(self.heap.mk_any_implicit());
+                            initialization = ClassFieldInitialization::ClassBody(Some(Box::new(
+                                annotation_flags,
+                            )));
+                        }
+                        _ => unreachable!("class-body assignment has class-body initialization"),
+                    }
+                }
                 let (value_ty, annotation, is_inherited) = self.analyze_class_field_value(
                     value,
                     class,

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1588,9 +1588,14 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                         .is_some_and(|annot| annot.has_qualifier(&Qualifier::ClassVar))
                 {
                     ClassFieldInitialization::Magic
-                } else if let Some(flags) =
-                    self.extract_pydantic_field_from_annotation(*annot, name, metadata)
-                {
+                } else if let Some(flags) = self.extract_pydantic_field_from_annotation(
+                    *annot,
+                    name,
+                    direct_annotation
+                        .as_ref()
+                        .and_then(|annotation| annotation.ty.as_ref()),
+                    metadata,
+                ) {
                     ClassFieldInitialization::ClassBody(Some(Box::new(flags)))
                 } else {
                     ClassFieldInitialization::Uninitialized
@@ -1654,7 +1659,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                         ),
                     );
                 }
-                let initialization = if let ExprOrBinding::Expr(e) = value.as_ref()
+                let mut initialization = if let ExprOrBinding::Expr(e) = value.as_ref()
                     && let Some(dm) = metadata.dataclass_metadata()
                     && let Expr::Call(call) = e
                 {
@@ -1778,6 +1783,31 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 } else {
                     ClassFieldInitialization::ClassBody(None)
                 };
+                if let Some(annot) = annot
+                    && let Some(mut annotation_flags) = self.extract_pydantic_field_from_annotation(
+                        *annot,
+                        name,
+                        direct_annotation
+                            .as_ref()
+                            .and_then(|annotation| annotation.ty.as_ref()),
+                        metadata,
+                    )
+                    && let Some(converter_param) = annotation_flags.converter_param.take()
+                {
+                    match &mut initialization {
+                        ClassFieldInitialization::ClassBody(Some(flags)) => {
+                            flags.converter_param = Some(converter_param);
+                        }
+                        ClassFieldInitialization::ClassBody(None) => {
+                            annotation_flags.converter_param = Some(converter_param);
+                            annotation_flags.default = Some(self.heap.mk_any_implicit());
+                            initialization = ClassFieldInitialization::ClassBody(Some(Box::new(
+                                annotation_flags,
+                            )));
+                        }
+                        _ => unreachable!("class-body assignment has class-body initialization"),
+                    }
+                }
                 let (value_ty, annotation, is_inherited) = self.analyze_class_field_value(
                     value,
                     class,

--- a/pyrefly/lib/alt/class/pydantic.rs
+++ b/pyrefly/lib/alt/class/pydantic.rs
@@ -52,6 +52,7 @@ use crate::binding::pydantic::VALIDATE_BY_ALIAS;
 use crate::binding::pydantic::VALIDATE_BY_NAME;
 use crate::error::collector::ErrorCollector;
 use crate::types::class::Class;
+use crate::types::types::Forallable;
 use crate::types::types::Type;
 
 fn int_literal_from_type(ty: &Type) -> Option<&LitInt> {
@@ -600,13 +601,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
-    /// Extract Pydantic Field metadata from an annotation binding.
-    /// This handles the Pydantic-specific pattern where fields can be declared as:
-    /// `field: Annotated[some_type, Field(some_keyword=<value>)]`
+    /// Extract Pydantic field and validator metadata from an `Annotated` annotation.
     pub fn extract_pydantic_field_from_annotation(
         &self,
         annot: Idx<KeyAnnotation>,
         field_name: &Name,
+        annotated_field_ty: Option<&Type>,
         metadata: &ClassMetadata,
     ) -> Option<DataclassFieldKeywords> {
         let dm = metadata.dataclass_metadata()?;
@@ -619,17 +619,75 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 TypeFormContext::ClassVarAnnotation,
                 &self.error_swallower(),
             );
+            let mut result = None;
             // Look through metadata items and find a Field(...) call, then extract its keywords
             for metadata_item in &metadata_items {
                 if let Expr::Call(call) = metadata_item
                     && let Some(keywords) =
                         self.compute_dataclass_field_initialization(call, field_name, None, dm)
                 {
-                    return Some(keywords);
+                    result = Some(keywords);
+                    break;
                 }
             }
+            let errors = self.error_swallower();
+            let annotation_ty = self.expr_infer(annotation_expr, &errors);
+            if let Some(converter_param) =
+                self.pydantic_annotated_validator_input(&annotation_ty, annotated_field_ty)
+            {
+                result
+                    .get_or_insert_with(DataclassFieldKeywords::new)
+                    .converter_param = Some(converter_param);
+            }
+            return result;
         }
         None
+    }
+
+    fn pydantic_annotated_validator_input(
+        &self,
+        ty: &Type,
+        annotated_field_ty: Option<&Type>,
+    ) -> Option<Type> {
+        match ty {
+            // Before validators run right-to-left, so the rightmost one receives the raw input.
+            Type::Annotated(_, metadata) => metadata.iter().rev().find_map(|metadata| {
+                let is_validator_name = metadata.callee_name.as_ref().is_some_and(|name| {
+                    matches!(name.as_str(), "BeforeValidator" | "PlainValidator")
+                });
+                let is_validator_type = match &metadata.ty {
+                    Type::ClassType(cls) => {
+                        cls.has_qname(
+                            ModuleName::pydantic_functional_validators().as_str(),
+                            "BeforeValidator",
+                        ) || cls.has_qname(
+                            ModuleName::pydantic_functional_validators().as_str(),
+                            "PlainValidator",
+                        )
+                    }
+                    _ => false,
+                };
+                if !is_validator_name && !is_validator_type {
+                    return None;
+                }
+                metadata
+                    .first_arg
+                    .as_deref()
+                    .map(|func| self.get_converter_param(func, annotated_field_ty))
+            }),
+            Type::TypeAlias(alias) => {
+                let alias = self.get_type_alias(alias);
+                self.pydantic_annotated_validator_input(&alias.as_type(), annotated_field_ty)
+            }
+            Type::Forall(forall) => match &forall.body {
+                Forallable::TypeAlias(alias) => {
+                    let alias = self.get_type_alias(alias);
+                    self.pydantic_annotated_validator_input(&alias.as_type(), annotated_field_ty)
+                }
+                _ => None,
+            },
+            _ => None,
+        }
     }
 
     pub fn check_pydantic_argument_range_constraints(

--- a/pyrefly/lib/alt/class/pydantic.rs
+++ b/pyrefly/lib/alt/class/pydantic.rs
@@ -51,6 +51,7 @@ use crate::binding::pydantic::VALIDATE_BY_ALIAS;
 use crate::binding::pydantic::VALIDATE_BY_NAME;
 use crate::error::collector::ErrorCollector;
 use crate::types::class::Class;
+use crate::types::types::Forallable;
 use crate::types::types::Type;
 
 fn int_literal_from_type(ty: &Type) -> Option<&LitInt> {
@@ -622,13 +623,12 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         }
     }
 
-    /// Extract Pydantic Field metadata from an annotation binding.
-    /// This handles the Pydantic-specific pattern where fields can be declared as:
-    /// `field: Annotated[some_type, Field(some_keyword=<value>)]`
+    /// Extract Pydantic field and validator metadata from an `Annotated` annotation.
     pub fn extract_pydantic_field_from_annotation(
         &self,
         annot: Idx<KeyAnnotation>,
         field_name: &Name,
+        annotated_field_ty: Option<&Type>,
         metadata: &ClassMetadata,
     ) -> Option<DataclassFieldKeywords> {
         let dm = metadata.dataclass_metadata()?;
@@ -641,17 +641,75 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 TypeFormContext::ClassVarAnnotation,
                 &self.error_swallower(),
             );
+            let mut result = None;
             // Look through metadata items and find a Field(...) call, then extract its keywords
             for metadata_item in &metadata_items {
                 if let Expr::Call(call) = metadata_item
                     && let Some(keywords) =
                         self.compute_dataclass_field_initialization(call, field_name, None, dm)
                 {
-                    return Some(keywords);
+                    result = Some(keywords);
+                    break;
                 }
             }
+            let errors = self.error_swallower();
+            let annotation_ty = self.expr_infer(annotation_expr, &errors);
+            if let Some(converter_param) =
+                self.pydantic_annotated_validator_input(&annotation_ty, annotated_field_ty)
+            {
+                result
+                    .get_or_insert_with(DataclassFieldKeywords::new)
+                    .converter_param = Some(converter_param);
+            }
+            return result;
         }
         None
+    }
+
+    fn pydantic_annotated_validator_input(
+        &self,
+        ty: &Type,
+        annotated_field_ty: Option<&Type>,
+    ) -> Option<Type> {
+        match ty {
+            // Before validators run right-to-left, so the rightmost one receives the raw input.
+            Type::Annotated(_, metadata) => metadata.iter().rev().find_map(|metadata| {
+                let is_validator_name = metadata.callee_name.as_ref().is_some_and(|name| {
+                    matches!(name.as_str(), "BeforeValidator" | "PlainValidator")
+                });
+                let is_validator_type = match &metadata.ty {
+                    Type::ClassType(cls) => {
+                        cls.has_qname(
+                            ModuleName::pydantic_functional_validators().as_str(),
+                            "BeforeValidator",
+                        ) || cls.has_qname(
+                            ModuleName::pydantic_functional_validators().as_str(),
+                            "PlainValidator",
+                        )
+                    }
+                    _ => false,
+                };
+                if !is_validator_name && !is_validator_type {
+                    return None;
+                }
+                metadata
+                    .first_arg
+                    .as_deref()
+                    .map(|func| self.get_converter_param(func, annotated_field_ty))
+            }),
+            Type::TypeAlias(alias) => {
+                let alias = self.get_type_alias(alias);
+                self.pydantic_annotated_validator_input(&alias.as_type(), annotated_field_ty)
+            }
+            Type::Forall(forall) => match &forall.body {
+                Forallable::TypeAlias(alias) => {
+                    let alias = self.get_type_alias(alias);
+                    self.pydantic_annotated_validator_input(&alias.as_type(), annotated_field_ty)
+                }
+                _ => None,
+            },
+            _ => None,
+        }
     }
 
     pub fn check_pydantic_argument_range_constraints(

--- a/pyrefly/lib/alt/specials.rs
+++ b/pyrefly/lib/alt/specials.rs
@@ -32,6 +32,7 @@ use crate::types::lit_int::LitInt;
 use crate::types::literal::Lit;
 use crate::types::special_form::SpecialForm;
 use crate::types::tuple::Tuple;
+use crate::types::types::AnnotatedMetadata;
 use crate::types::types::AnyStyle;
 use crate::types::types::Type;
 
@@ -575,9 +576,23 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             ),
             SpecialForm::Annotated if arguments.len() > 1 => {
                 let inner = self.expr_untype(&arguments[0], TypeFormContext::TypeArgument, errors);
-                let metadata: Vec<Type> = arguments[1..]
+                let metadata: Vec<AnnotatedMetadata> = arguments[1..]
                     .iter()
-                    .map(|e| self.expr_infer(e, &self.error_swallower()))
+                    .map(|e| {
+                        let errors = self.error_swallower();
+                        AnnotatedMetadata {
+                            ty: self.expr_infer(e, &errors),
+                            callee_name: e.as_call_expr().and_then(|call| match &*call.func {
+                                Expr::Name(name) => Some(name.id.clone()),
+                                Expr::Attribute(attribute) => Some(attribute.attr.id.clone()),
+                                _ => None,
+                            }),
+                            first_arg: e
+                                .as_call_expr()
+                                .and_then(|call| call.arguments.args.first())
+                                .map(|arg| Box::new(self.expr_infer(arg, &errors))),
+                        }
+                    })
                     .collect();
                 Type::Annotated(Box::new(inner), metadata.into_boxed_slice())
             }

--- a/pyrefly/lib/alt/specials.rs
+++ b/pyrefly/lib/alt/specials.rs
@@ -32,6 +32,7 @@ use crate::types::lit_int::LitInt;
 use crate::types::literal::Lit;
 use crate::types::special_form::SpecialForm;
 use crate::types::tuple::Tuple;
+use crate::types::types::AnnotatedMetadata;
 use crate::types::types::AnyStyle;
 use crate::types::types::Type;
 
@@ -591,13 +592,33 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             ),
             SpecialForm::Annotated if arguments.len() > 1 => {
                 let mut inner = self.expr_untype(&arguments[0], type_argument_context, errors);
-                let metadata: Vec<Type> = arguments[1..]
+                let metadata_types: Vec<Type> = arguments[1..]
                     .iter()
                     .map(|e| self.expr_infer(e, &self.error_swallower()))
                     .collect();
-                if let Some(dataframe) = self.polars_dataframe_annotated_type(&inner, &metadata) {
+                if let Some(dataframe) =
+                    self.polars_dataframe_annotated_type(&inner, &metadata_types)
+                {
                     inner = dataframe;
                 }
+                let metadata: Vec<AnnotatedMetadata> = arguments[1..]
+                    .iter()
+                    .zip(metadata_types)
+                    .map(|(e, ty)| AnnotatedMetadata {
+                        ty,
+                        callee_name: e.as_call_expr().and_then(|call| match &*call.func {
+                            Expr::Name(name) => Some(name.id.clone()),
+                            Expr::Attribute(attribute) => Some(attribute.attr.id.clone()),
+                            _ => None,
+                        }),
+                        first_arg: e.as_call_expr().and_then(|call| {
+                            call.arguments.args.first().map(|arg| {
+                                let errors = self.error_swallower();
+                                Box::new(self.expr_infer(arg, &errors))
+                            })
+                        }),
+                    })
+                    .collect();
                 Type::Annotated(Box::new(inner), metadata.into_boxed_slice())
             }
             SpecialForm::Annotated => self.error(

--- a/pyrefly/lib/alt/types/class_bases.rs
+++ b/pyrefly/lib/alt/types/class_bases.rs
@@ -210,7 +210,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             if let Type::Annotated(_, metadata) = alias.as_type() {
                 return metadata
                     .iter()
-                    .any(|metadata| self.is_pydantic_strict_metadata(metadata));
+                    .any(|metadata| self.is_pydantic_strict_metadata(&metadata.ty));
             }
         }
         false

--- a/pyrefly/lib/alt/types/class_bases.rs
+++ b/pyrefly/lib/alt/types/class_bases.rs
@@ -227,7 +227,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             if let Type::Annotated(_, metadata) = alias.as_type() {
                 return metadata
                     .iter()
-                    .any(|metadata| self.is_pydantic_strict_metadata(metadata));
+                    .any(|metadata| self.is_pydantic_strict_metadata(&metadata.ty));
             }
         }
         false

--- a/pyrefly/lib/query/type_table.rs
+++ b/pyrefly/lib/query/type_table.rs
@@ -390,7 +390,7 @@ pub(super) fn type_to_indexed_shape(
             args.extend(
                 metadata
                     .iter()
-                    .map(|ty| type_to_indexed_shape(context, ty, table)),
+                    .map(|metadata| type_to_indexed_shape(context, &metadata.ty, table)),
             );
             insert_indexed_named(table, "typing.Annotated", args, None, Vec::new())
         }

--- a/pyrefly/lib/query/type_table.rs
+++ b/pyrefly/lib/query/type_table.rs
@@ -389,7 +389,7 @@ pub(super) fn type_to_indexed_shape(
             args.extend(
                 metadata
                     .iter()
-                    .map(|ty| type_to_indexed_shape(context, ty, table)),
+                    .map(|metadata| type_to_indexed_shape(context, &metadata.ty, table)),
             );
             insert_indexed_named(table, "typing.Annotated", args, None, Vec::new())
         }

--- a/pyrefly/lib/test/pydantic/field.rs
+++ b/pyrefly/lib/test/pydantic/field.rs
@@ -494,6 +494,44 @@ P(x=42)
 );
 
 pydantic_testcase!(
+    test_annotated_before_validator,
+    r#"
+from typing import Annotated, TypeAlias, reveal_type
+from pydantic import BaseModel, BeforeValidator
+
+def join_ints(values: list[int]) -> str:
+    return ",".join(str(value) for value in values)
+
+def split_ints(value: str) -> list[int]:
+    return [int(part) for part in value.split(",")]
+
+ValidatedStr: TypeAlias = Annotated[str, BeforeValidator(join_ints)]
+ChainedStr: TypeAlias = Annotated[
+    str,
+    BeforeValidator(join_ints),
+    BeforeValidator(split_ints),
+]
+
+class Model(BaseModel):
+    direct: Annotated[str, BeforeValidator(join_ints)]
+    aliased: ValidatedStr
+    chained: ChainedStr
+    defaulted: ValidatedStr = "not validated by default"
+
+model = Model(direct=[1, 2], aliased=[3, 4], chained="5,6", defaulted=[7])
+reveal_type(model.direct)  # E: revealed type: str
+reveal_type(model.aliased)  # E: revealed type: str
+reveal_type(model.chained)  # E: revealed type: str
+reveal_type(model.defaulted)  # E: revealed type: str
+Model(direct=[1, 2], aliased=[3, 4], chained="5,6")
+Model(direct="1,2", aliased=[3, 4], chained="5,6")  # E: Argument `Literal['1,2']` is not assignable to parameter `direct` with type `list[int]` in function `Model.__init__`
+Model(direct=[1, 2], aliased="3,4", chained="5,6")  # E: Argument `Literal['3,4']` is not assignable to parameter `aliased` with type `list[int]` in function `Model.__init__`
+Model(direct=[1, 2], aliased=[3, 4], chained=[5, 6])  # E: Argument `list[int]` is not assignable to parameter `chained` with type `str` in function `Model.__init__`
+Model(direct=[1, 2], aliased=[3, 4], chained="5,6", defaulted="7")  # E: Argument `Literal['7']` is not assignable to parameter `defaulted` with type `list[int]` in function `Model.__init__`
+    "#,
+);
+
+pydantic_testcase!(
     test_field_without_annotation,
     r#"
 from pydantic import BaseModel, Field

--- a/pyrefly/lib/test/pydantic/field.rs
+++ b/pyrefly/lib/test/pydantic/field.rs
@@ -461,6 +461,44 @@ P(x=42)
 );
 
 pydantic_testcase!(
+    test_annotated_before_validator,
+    r#"
+from typing import Annotated, TypeAlias, reveal_type
+from pydantic import BaseModel, BeforeValidator
+
+def join_ints(values: list[int]) -> str:
+    return ",".join(str(value) for value in values)
+
+def split_ints(value: str) -> list[int]:
+    return [int(part) for part in value.split(",")]
+
+ValidatedStr: TypeAlias = Annotated[str, BeforeValidator(join_ints)]
+ChainedStr: TypeAlias = Annotated[
+    str,
+    BeforeValidator(join_ints),
+    BeforeValidator(split_ints),
+]
+
+class Model(BaseModel):
+    direct: Annotated[str, BeforeValidator(join_ints)]
+    aliased: ValidatedStr
+    chained: ChainedStr
+    defaulted: ValidatedStr = "not validated by default"
+
+model = Model(direct=[1, 2], aliased=[3, 4], chained="5,6", defaulted=[7])
+reveal_type(model.direct)  # E: revealed type: str
+reveal_type(model.aliased)  # E: revealed type: str
+reveal_type(model.chained)  # E: revealed type: str
+reveal_type(model.defaulted)  # E: revealed type: str
+Model(direct=[1, 2], aliased=[3, 4], chained="5,6")
+Model(direct="1,2", aliased=[3, 4], chained="5,6")  # E: Argument `Literal['1,2']` is not assignable to parameter `direct` with type `list[int]` in function `Model.__init__`
+Model(direct=[1, 2], aliased="3,4", chained="5,6")  # E: Argument `Literal['3,4']` is not assignable to parameter `aliased` with type `list[int]` in function `Model.__init__`
+Model(direct=[1, 2], aliased=[3, 4], chained=[5, 6])  # E: Argument `list[int]` is not assignable to parameter `chained` with type `str` in function `Model.__init__`
+Model(direct=[1, 2], aliased=[3, 4], chained="5,6", defaulted="7")  # E: Argument `Literal['7']` is not assignable to parameter `defaulted` with type `list[int]` in function `Model.__init__`
+    "#,
+);
+
+pydantic_testcase!(
     test_field_without_annotation,
     r#"
 from pydantic import BaseModel, Field


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4256

BeforeValidator and PlainValidator constructor input inference.
Support across reusable TypeAlias annotations.
Correct right-to-left ordering for chained before validators, matching Pydantic's behavior (https://pydantic.dev/docs/validation/latest/concepts/validators/#ordering-of-validators).
Support for fields with defaults while preserving the stored field type.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test