### PR TITLE
fix bug: generic ABC is mistakenly allowed to be instantiated by providing a type argument to the constructor #4263

### DIFF
--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -944,6 +944,12 @@ impl<'a> TypeDisplayContext<'a> {
                 output.write_qname(cls.qname())?;
                 output.write_str("]")
             }
+            Type::SpecializedClass(class_type) => {
+                output.write_str("type[")?;
+                output.write_qname(class_type.qname())?;
+                output.write_targs(class_type.targs())?;
+                output.write_str("]")
+            }
             Type::ClassType(class_type)
                 if class_type.qname().module_name().as_str() == "builtins"
                     && class_type.qname().id().as_str() == "tuple"

--- a/crates/pyrefly_types/src/type_alias.rs
+++ b/crates/pyrefly_types/src/type_alias.rs
@@ -65,6 +65,11 @@ impl TypeAlias {
     pub fn as_value(&self, stdlib: &Stdlib) -> Type {
         if self.style == TypeAliasStyle::Scoped {
             stdlib.type_alias_type().clone().to_type()
+        } else if let Type::Type(inner) = self.ty.as_ref()
+            && let Type::ClassType(cls) = inner.as_ref()
+            && !cls.targs().is_empty()
+        {
+            Type::SpecializedClass(cls.clone())
         } else {
             *self.ty.clone()
         }

--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -966,12 +966,14 @@ pub enum Type {
     /// up the class `tparams` and setting defaults using gradual types: for
     /// example `list` in an annotation position means `list[Any]`.
     ClassDef(Class),
+    /// An exact class object with explicit type arguments, such as the value of
+    /// the expression `C[int]`.
+    SpecializedClass(ClassType),
     /// A value that indicates a concrete, instantiated type with known type
     /// arguments that are validated against the class type parameters. If the
     /// class is not generic, the arguments are empty.
     ///
-    /// Instances of classes have this type, and a term of the form `C[arg1, arg2]`
-    /// would have the form `Type::Type(box Type::ClassType(C, [arg1, arg2]))`.
+    /// Instances of classes have this type.
     ClassType(ClassType),
     /// Instances of TypedDicts have this type, and a term of the form `TD[arg1, arg2]`
     /// would have the form `Type::Type(box Type::TypedDict(TD, [arg1, arg2]))`. Note
@@ -1102,6 +1104,7 @@ impl Visit for Type {
             Type::Union(x) => x.visit(f),
             Type::Intersect(x) => x.visit(f),
             Type::ClassDef(x) => x.visit(f),
+            Type::SpecializedClass(x) => x.visit(f),
             Type::ClassType(x) => x.visit(f),
             Type::TypedDict(x) => x.visit(f),
             Type::PartialTypedDict(x) => x.visit(f),
@@ -1165,6 +1168,7 @@ impl VisitMut for Type {
             Type::Union(x) => x.visit_mut(f),
             Type::Intersect(x) => x.visit_mut(f),
             Type::ClassDef(x) => x.visit_mut(f),
+            Type::SpecializedClass(x) => x.visit_mut(f),
             Type::ClassType(x) => x.visit_mut(f),
             Type::TypedDict(x) => x.visit_mut(f),
             Type::PartialTypedDict(x) => x.visit_mut(f),
@@ -1629,6 +1633,7 @@ impl Type {
             Type::Callable(_) | Type::CallableResidual(_) => Some(CalleeKind::Callable),
             Type::Function(func) => Some(CalleeKind::Function(func.metadata.kind.clone())),
             Type::ClassDef(c) => Some(CalleeKind::Class(c.kind())),
+            Type::SpecializedClass(c) => Some(CalleeKind::Class(c.class_object().kind())),
             Type::Forall(forall) => forall.body.clone().as_type().callee_kind(),
             Type::Overload(overload) => Some(CalleeKind::Function(overload.metadata.kind.clone())),
             Type::KwCall(call) => call.return_ty.callee_kind(),
@@ -2150,6 +2155,7 @@ impl Type {
     pub fn qname(&self) -> Option<&QName> {
         match self {
             Type::ClassDef(cls) => Some(cls.qname()),
+            Type::SpecializedClass(c) => Some(c.qname()),
             Type::ClassType(c) => Some(c.qname()),
             Type::TypedDict(TypedDict::TypedDict(c)) => Some(c.qname()),
             Type::PartialTypedDict(TypedDict::TypedDict(c)) => Some(c.qname()),
@@ -2170,7 +2176,7 @@ impl Type {
             Type::Literal(lit) if let Lit::Int(x) = &lit.value => Some(x.as_bool()),
             Type::Literal(lit) if let Lit::Bytes(x) = &lit.value => Some(!x.is_empty()),
             Type::Literal(lit) if let Lit::Str(x) = &lit.value => Some(!x.is_empty()),
-            Type::Type(_) => Some(true),
+            Type::SpecializedClass(_) | Type::Type(_) => Some(true),
             Type::None => Some(false),
             Type::Sentinel(_) => Some(true),
             Type::Tuple(Tuple::Concrete(elements)) => Some(!elements.is_empty()),

--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -2456,6 +2456,9 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             Type::ClassDef(cls) => acc.push(AttributeBase1::ClassObject(ClassBase::ClassDef(
                 self.as_class_type_unchecked(&cls),
             ))),
+            Type::SpecializedClass(class) => {
+                acc.push(AttributeBase1::GenericAlias(ClassBase::ClassType(class)));
+            }
             Type::SelfType(class_type) => acc.push(AttributeBase1::SelfType(class_type)),
             Type::Type(ty) => self.as_attribute_base1_of_type(*ty, acc),
             Type::TypedDict(TypedDict::TypedDict(td))
@@ -2709,6 +2712,9 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     /// `as_attribute_base1` helper for `Type::Type(ty)`.
     fn as_attribute_base1_of_type(&self, ty: Type, acc: &mut Vec<AttributeBase1>) {
         match ty {
+            Type::SpecializedClass(_) => acc.push(AttributeBase1::ClassObject(
+                ClassBase::ClassDef(self.stdlib.builtins_type().clone()),
+            )),
             Type::SelfType(class_type) => {
                 acc.push(AttributeBase1::ClassObject(ClassBase::SelfType(class_type)))
             }
@@ -2729,25 +2735,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 acc,
             ),
             Type::ClassType(class) => {
-                let class_base = AttributeBase1::ClassObject(ClassBase::ClassType(class.clone()));
-                if !class.targs().is_empty() {
-                    // If the class type has type arguments, at runtime it's also a GenericAlias
-
-                    // FIXME:
-                    // If `C` is a generic class, then the type of the expression `C` is `type[C]`.
-                    // We're relying on this behaviour to give `C[int]` the
-                    // runtime generic alias type, but this is technically
-                    // incorrect as `type[C[int]]` should be instances of `type`
-                    // and not `GenericAlias`.
-                    // Therefore, if we ever have a value of `type[C[int]]`
-                    // (e.g. via inheritance), we should not treat it as a
-                    // `GenericAlias`. However, such cases are rare in practice.
-                    acc.push(AttributeBase1::GenericAlias(ClassBase::ClassType(
-                        class.clone(),
-                    )));
-                } else {
-                    acc.push(class_base)
-                }
+                acc.push(AttributeBase1::ClassObject(ClassBase::ClassType(class)))
             }
             Type::ClassDef(class) => {
                 // type[ClassDef(C)] is C.__class__: C's metaclass, viewed as a class object.

--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -86,6 +86,8 @@ pub enum CallStyle<'a> {
 pub enum ConstructorKind {
     // `MyClass`
     BareClassName,
+    // `MyClass[int]`
+    SpecializedClass,
     // `type[MyClass]`
     TypeOfClass,
     // `type[Self]`
@@ -1459,7 +1461,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     );
                 }
                 let metadata = self.get_metadata_for_class(cls.class_object());
-                if metadata.is_protocol() && constructor_kind == ConstructorKind::BareClassName {
+                let is_direct_class = matches!(
+                    &constructor_kind,
+                    ConstructorKind::BareClassName | ConstructorKind::SpecializedClass
+                );
+                if metadata.is_protocol() && is_direct_class {
                     self.error_with_context(
                         errors,
                         arguments_range,
@@ -1474,9 +1480,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     let abstract_members = self.get_abstract_members_for_class(cls.class_object());
                     let unimplemented_abstract_methods =
                         abstract_members.unimplemented_abstract_methods();
-                    if constructor_kind == ConstructorKind::BareClassName
-                        && !unimplemented_abstract_methods.is_empty()
-                    {
+                    if is_direct_class && !unimplemented_abstract_methods.is_empty() {
                         self.error_with_context(
                             errors,
                             arguments_range,
@@ -1492,9 +1496,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             ),
                             context,
                         );
-                    } else if constructor_kind == ConstructorKind::BareClassName
-                        && metadata.is_explicitly_abstract()
-                    {
+                    } else if is_direct_class && metadata.is_explicitly_abstract() {
                         self.error_with_context(
                             errors,
                             arguments_range,
@@ -2113,6 +2115,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         &self,
         x: &ExprCall,
         mut callee_ty: Type,
+        direct_class_specialization: bool,
         hint: Option<HintRef>,
         errors: &ErrorCollector,
     ) -> Type {
@@ -2406,6 +2409,32 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     hint,
                     errors,
                 ),
+                _ if direct_class_specialization => {
+                    let mut call_target = self.as_call_target_or_error(
+                        ty.clone(),
+                        CallStyle::FreeForm,
+                        x.func.range(),
+                        errors,
+                        None,
+                    );
+                    if let CallTarget::Class(_, constructor_kind, _) = &mut call_target
+                        && *constructor_kind == ConstructorKind::TypeOfClass
+                    {
+                        *constructor_kind = ConstructorKind::SpecializedClass;
+                    }
+                    self.call_infer_with_callee_range(
+                        call_target,
+                        &args,
+                        &kws,
+                        x.arguments.range(),
+                        Some(x.func.range()),
+                        errors,
+                        errors,
+                        None,
+                        hint,
+                        None,
+                    )
+                }
                 _ => self.freeform_call_infer(ty.clone(), &args, &kws, x.func.range(), x.arguments.range(), hint, errors),
             }});
             // TypeIs and TypeGuard functions return bool at runtime

--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1496,7 +1496,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             ),
                             context,
                         );
-                    } else if is_direct_class && metadata.is_explicitly_abstract() {
+                    } else if constructor_kind == ConstructorKind::BareClassName
+                        && metadata.is_explicitly_abstract()
+                    {
                         self.error_with_context(
                             errors,
                             arguments_range,

--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -111,6 +111,8 @@ fn nests_calls(x: &Expr, depth: u32) -> bool {
 pub enum ConstructorKind {
     // `MyClass`
     BareClassName,
+    // `MyClass[int]`
+    SpecializedClass,
     // `type[MyClass]`
     TypeOfClass,
     // `type[Self]`
@@ -1652,7 +1654,11 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     );
                 }
                 let metadata = self.get_metadata_for_class(cls.class_object());
-                if metadata.is_protocol() && constructor_kind == ConstructorKind::BareClassName {
+                let is_direct_class = matches!(
+                    &constructor_kind,
+                    ConstructorKind::BareClassName | ConstructorKind::SpecializedClass
+                );
+                if metadata.is_protocol() && is_direct_class {
                     self.error_with_context(
                         errors,
                         arguments_range,
@@ -1667,9 +1673,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     let abstract_members = self.get_abstract_members_for_class(cls.class_object());
                     let unimplemented_abstract_methods =
                         abstract_members.unimplemented_abstract_methods();
-                    if constructor_kind == ConstructorKind::BareClassName
-                        && !unimplemented_abstract_methods.is_empty()
-                    {
+                    if is_direct_class && !unimplemented_abstract_methods.is_empty() {
                         self.error_with_context(
                             errors,
                             arguments_range,
@@ -1685,9 +1689,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                             ),
                             context,
                         );
-                    } else if constructor_kind == ConstructorKind::BareClassName
-                        && metadata.is_explicitly_abstract()
-                    {
+                    } else if is_direct_class && metadata.is_explicitly_abstract() {
                         self.error_with_context(
                             errors,
                             arguments_range,
@@ -2362,6 +2364,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         &self,
         x: &ExprCall,
         mut callee_ty: Type,
+        direct_class_specialization: bool,
         hint: Option<HintRef>,
         errors: &ErrorCollector,
     ) -> Type {
@@ -2646,6 +2649,32 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     hint,
                     errors,
                 ),
+                _ if direct_class_specialization => {
+                    let mut call_target = self.as_call_target_or_error(
+                        ty.clone(),
+                        CallStyle::FreeForm,
+                        x.func.range(),
+                        errors,
+                        None,
+                    );
+                    if let CallTarget::Class(_, constructor_kind, _) = &mut call_target
+                        && *constructor_kind == ConstructorKind::TypeOfClass
+                    {
+                        *constructor_kind = ConstructorKind::SpecializedClass;
+                    }
+                    self.call_infer_with_callee_range(
+                        call_target,
+                        &args,
+                        &kws,
+                        x.arguments.range(),
+                        Some(x.func.range()),
+                        errors,
+                        errors,
+                        None,
+                        hint,
+                        None,
+                    )
+                }
                 _ => self.freeform_call_infer(ty.clone(), &args, &kws, x.func.range(), x.arguments.range(), hint, errors),
             }});
             // TypeIs and TypeGuard functions return bool at runtime

--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1689,7 +1689,9 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                             ),
                             context,
                         );
-                    } else if is_direct_class && metadata.is_explicitly_abstract() {
+                    } else if constructor_kind == ConstructorKind::BareClassName
+                        && metadata.is_explicitly_abstract()
+                    {
                         self.error_with_context(
                             errors,
                             arguments_range,

--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -382,6 +382,11 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 }
                 _ => unreachable!(),
             },
+            Type::SpecializedClass(cls) => CallTargetLookup::Ok(Box::new(CallTarget::Class(
+                cls,
+                ConstructorKind::SpecializedClass,
+                None,
+            ))),
             Type::Type(f) if matches!(&*f, Type::ClassType(_)) => {
                 let Type::ClassType(cls) = *f else {
                     unreachable!("guarded by matches! above")
@@ -2366,7 +2371,6 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         &self,
         x: &ExprCall,
         mut callee_ty: Type,
-        direct_class_specialization: bool,
         hint: Option<HintRef>,
         errors: &ErrorCollector,
     ) -> Type {
@@ -2651,32 +2655,6 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     hint,
                     errors,
                 ),
-                _ if direct_class_specialization => {
-                    let mut call_target = self.as_call_target_or_error(
-                        ty.clone(),
-                        CallStyle::FreeForm,
-                        x.func.range(),
-                        errors,
-                        None,
-                    );
-                    if let CallTarget::Class(_, constructor_kind, _) = &mut call_target
-                        && *constructor_kind == ConstructorKind::TypeOfClass
-                    {
-                        *constructor_kind = ConstructorKind::SpecializedClass;
-                    }
-                    self.call_infer_with_callee_range(
-                        call_target,
-                        &args,
-                        &kws,
-                        x.arguments.range(),
-                        Some(x.func.range()),
-                        errors,
-                        errors,
-                        None,
-                        hint,
-                        None,
-                    )
-                }
                 _ => self.freeform_call_infer(ty.clone(), &args, &kws, x.func.range(), x.arguments.range(), hint, errors),
             }});
             // TypeIs and TypeGuard functions return bool at runtime

--- a/pyrefly/lib/alt/class/classdef.rs
+++ b/pyrefly/lib/alt/class/classdef.rs
@@ -181,6 +181,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     .map_or_else(TParams::default, |tparams| (**tparams).clone()),
                 self.instantiate(c),
             )),
+            Type::SpecializedClass(c) => Some((TParams::empty(), Type::ClassType(c.clone()))),
             Type::TypeAlias(ta) => {
                 self.unwrap_class_object_silently(&self.get_type_alias(ta).as_value(self.stdlib))
             }

--- a/pyrefly/lib/alt/class/dataclass.rs
+++ b/pyrefly/lib/alt/class/dataclass.rs
@@ -1023,6 +1023,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     pub(crate) fn constructor_to_callable_distributed(&self, ty: &Type) -> Option<Type> {
         let instance = match ty {
             Type::ClassDef(cls) => self.promote_silently(cls),
+            Type::SpecializedClass(cls) => Type::ClassType(cls.clone()),
             Type::Type(inner) => (**inner).clone(),
             _ => return None,
         };

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -130,13 +130,16 @@ pub enum TypeOrExpr<'a> {
 
 pub(crate) enum PreparedExprCall {
     Resolved(Type),
-    Callee(Type),
+    Callee {
+        ty: Type,
+        direct_class_specialization: bool,
+    },
 }
 
 impl PreparedExprCall {
     pub(crate) fn callee(&self) -> Option<&Type> {
         match self {
-            Self::Callee(callee) => Some(callee),
+            Self::Callee { ty, .. } => Some(ty),
             Self::Resolved(_) => None,
         }
     }
@@ -939,7 +942,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // Infer a method call's receiver once. A Polars column-algebra transform is a
         // pure function of the receiver schema and is dispatched here; any other
         // receiver is reused for ordinary callee inference rather than inferred again.
-        let callee_ty = if let Expr::Attribute(func) = &*x.func {
+        let (callee_ty, direct_class_specialization) = if let Expr::Attribute(func) = &*x.func {
             let base = self.expr_infer_impl(&func.value, None, errors);
             if let Some(ty) = self.polars_select(base.ty(), func, &x.arguments, errors) {
                 return PreparedExprCall::Resolved(ty);
@@ -961,11 +964,27 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             // and deprecation check here as that path would for any other expression.
             self.check_for_deprecated_call(attr.ty(), func.range(), errors);
             self.record_type_trace(func.range(), attr.ty());
-            attr.into_ty()
+            (attr.into_ty(), false)
+        } else if let Expr::Subscript(func) = &*x.func {
+            let base = self.expr_infer_impl(&func.value, None, errors);
+            let callee = self.subscript_infer(&base, &func.slice, func.range(), errors);
+            let direct_class_specialization = matches!(
+                base.ty(),
+                Type::ClassDef(cls) if !self.get_class_tparams(cls).is_empty()
+            ) && matches!(
+                callee.ty(),
+                Type::Type(inner) if matches!(&**inner, Type::ClassType(_))
+            );
+            self.check_for_deprecated_call(callee.ty(), func.range(), errors);
+            self.record_type_trace(func.range(), callee.ty());
+            (callee.into_ty(), direct_class_specialization)
         } else {
-            self.expr_infer(&x.func, errors)
+            (self.expr_infer(&x.func, errors), false)
         };
-        PreparedExprCall::Callee(callee_ty)
+        PreparedExprCall::Callee {
+            ty: callee_ty,
+            direct_class_specialization,
+        }
     }
 
     pub(crate) fn finish_prepared_expr_call(
@@ -975,9 +994,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         hint: Option<HintRef>,
         errors: &ErrorCollector,
     ) -> Type {
-        let callee_ty = match prepared {
+        let (callee_ty, direct_class_specialization) = match prepared {
             PreparedExprCall::Resolved(ty) => return ty,
-            PreparedExprCall::Callee(callee_ty) => callee_ty,
+            PreparedExprCall::Callee {
+                ty,
+                direct_class_specialization,
+            } => (ty, direct_class_specialization),
         };
 
         self.check_pytorch_tensor_item_call(x, &callee_ty, errors);
@@ -1022,12 +1044,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             } else {
                 obj_ty
                     .at_facet(&facet, || {
-                        self.expr_call_infer(x, callee_ty.clone(), hint, errors)
+                        self.expr_call_infer(
+                            x,
+                            callee_ty.clone(),
+                            direct_class_specialization,
+                            hint,
+                            errors,
+                        )
                     })
                     .into_ty()
             }
         } else {
-            self.expr_call_infer(x, callee_ty, hint, errors)
+            self.expr_call_infer(x, callee_ty, direct_class_specialization, hint, errors)
         }
     }
 

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -139,7 +139,19 @@ pub enum TypeOrExpr<'a> {
 
 pub(crate) enum PreparedExprCall {
     Resolved(Type),
-    Callee(Type),
+    Callee {
+        ty: Type,
+        direct_class_specialization: bool,
+    },
+}
+
+impl PreparedExprCall {
+    pub(crate) fn callee(&self) -> Option<&Type> {
+        match self {
+            Self::Callee { ty, .. } => Some(ty),
+            Self::Resolved(_) => None,
+        }
+    }
 }
 
 /// Where a dimension expression appears, which controls whether a plain
@@ -1067,7 +1079,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             return PreparedExprCall::Resolved(ty);
         }
         // Reuse the inferred receiver when schema specialization does not apply.
-        let callee_ty = if let Expr::Attribute(func) = &*x.func {
+        let (callee_ty, direct_class_specialization) = if let Expr::Attribute(func) = &*x.func {
             let base = self.expr_infer_impl(&func.value, None, errors, None);
             if let Some(ty) = self.polars_method_call(base.ty(), func, &x.arguments, errors) {
                 return PreparedExprCall::Resolved(ty);
@@ -1077,11 +1089,27 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             // and deprecation check here as that path would for any other expression.
             self.check_for_deprecated_call(attr.ty(), func.range(), errors);
             self.record_type_trace(func.range(), attr.ty());
-            attr.into_ty()
+            (attr.into_ty(), false)
+        } else if let Expr::Subscript(func) = &*x.func {
+            let base = self.expr_infer_impl(&func.value, None, errors);
+            let callee = self.subscript_infer(&base, &func.slice, func.range(), errors);
+            let direct_class_specialization = matches!(
+                base.ty(),
+                Type::ClassDef(cls) if !self.get_class_tparams(cls).is_empty()
+            ) && matches!(
+                callee.ty(),
+                Type::Type(inner) if matches!(&**inner, Type::ClassType(_))
+            );
+            self.check_for_deprecated_call(callee.ty(), func.range(), errors);
+            self.record_type_trace(func.range(), callee.ty());
+            (callee.into_ty(), direct_class_specialization)
         } else {
-            self.expr_infer(&x.func, errors)
+            (self.expr_infer(&x.func, errors), false)
         };
-        PreparedExprCall::Callee(callee_ty)
+        PreparedExprCall::Callee {
+            ty: callee_ty,
+            direct_class_specialization,
+        }
     }
 
     pub(crate) fn finish_prepared_expr_call(
@@ -1091,9 +1119,12 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         hint: Option<HintRef>,
         errors: &ErrorCollector,
     ) -> Type {
-        let mut callee_ty = match prepared {
+        let (mut callee_ty, direct_class_specialization) = match prepared {
             PreparedExprCall::Resolved(ty) => return ty,
-            PreparedExprCall::Callee(callee_ty) => callee_ty,
+            PreparedExprCall::Callee {
+                ty,
+                direct_class_specialization,
+            } => (ty, direct_class_specialization),
         };
 
         // Instantiating a subscripted generic whose type argument is an out-of-scope legacy
@@ -1147,7 +1178,13 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             } else {
                 obj_ty
                     .at_facet(&facet, || {
-                        self.expr_call_infer(x, callee_ty.clone(), hint, errors)
+                        self.expr_call_infer(
+                            x,
+                            callee_ty.clone(),
+                            direct_class_specialization,
+                            hint,
+                            errors,
+                        )
                     })
                     .into_ty()
             }
@@ -1155,7 +1192,13 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             let regex_pattern = Self::regex_pattern_argument(&x.arguments);
             let regex_flags_position =
                 regex_pattern.and_then(|_| self.regex_flags_position(&callee_ty));
-            let ret = self.expr_call_infer(x, callee_ty, hint, errors);
+            let ret = self.expr_call_infer(
+                x,
+                callee_ty,
+                direct_class_specialization,
+                hint,
+                errors,
+            );
             if let (Some(pattern), Some(flags_position)) = (regex_pattern, regex_flags_position) {
                 self.regex_validate_pattern_argument(pattern, &x.arguments, flags_position, errors);
             }

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -139,19 +139,7 @@ pub enum TypeOrExpr<'a> {
 
 pub(crate) enum PreparedExprCall {
     Resolved(Type),
-    Callee {
-        ty: Type,
-        direct_class_specialization: bool,
-    },
-}
-
-impl PreparedExprCall {
-    pub(crate) fn callee(&self) -> Option<&Type> {
-        match self {
-            Self::Callee { ty, .. } => Some(ty),
-            Self::Resolved(_) => None,
-        }
-    }
+    Callee(Type),
 }
 
 /// Where a dimension expression appears, which controls whether a plain
@@ -1079,7 +1067,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             return PreparedExprCall::Resolved(ty);
         }
         // Reuse the inferred receiver when schema specialization does not apply.
-        let (callee_ty, direct_class_specialization) = if let Expr::Attribute(func) = &*x.func {
+        let callee_ty = if let Expr::Attribute(func) = &*x.func {
             let base = self.expr_infer_impl(&func.value, None, errors, None);
             if let Some(ty) = self.polars_method_call(base.ty(), func, &x.arguments, errors) {
                 return PreparedExprCall::Resolved(ty);
@@ -1089,27 +1077,11 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             // and deprecation check here as that path would for any other expression.
             self.check_for_deprecated_call(attr.ty(), func.range(), errors);
             self.record_type_trace(func.range(), attr.ty());
-            (attr.into_ty(), false)
-        } else if let Expr::Subscript(func) = &*x.func {
-            let base = self.expr_infer_impl(&func.value, None, errors);
-            let callee = self.subscript_infer(&base, &func.slice, func.range(), errors);
-            let direct_class_specialization = matches!(
-                base.ty(),
-                Type::ClassDef(cls) if !self.get_class_tparams(cls).is_empty()
-            ) && matches!(
-                callee.ty(),
-                Type::Type(inner) if matches!(&**inner, Type::ClassType(_))
-            );
-            self.check_for_deprecated_call(callee.ty(), func.range(), errors);
-            self.record_type_trace(func.range(), callee.ty());
-            (callee.into_ty(), direct_class_specialization)
+            attr.into_ty()
         } else {
-            (self.expr_infer(&x.func, errors), false)
+            self.expr_infer(&x.func, errors)
         };
-        PreparedExprCall::Callee {
-            ty: callee_ty,
-            direct_class_specialization,
-        }
+        PreparedExprCall::Callee(callee_ty)
     }
 
     pub(crate) fn finish_prepared_expr_call(
@@ -1119,12 +1091,9 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         hint: Option<HintRef>,
         errors: &ErrorCollector,
     ) -> Type {
-        let (mut callee_ty, direct_class_specialization) = match prepared {
+        let mut callee_ty = match prepared {
             PreparedExprCall::Resolved(ty) => return ty,
-            PreparedExprCall::Callee {
-                ty,
-                direct_class_specialization,
-            } => (ty, direct_class_specialization),
+            PreparedExprCall::Callee(ty) => ty,
         };
 
         // Instantiating a subscripted generic whose type argument is an out-of-scope legacy
@@ -1178,13 +1147,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             } else {
                 obj_ty
                     .at_facet(&facet, || {
-                        self.expr_call_infer(
-                            x,
-                            callee_ty.clone(),
-                            direct_class_specialization,
-                            hint,
-                            errors,
-                        )
+                        self.expr_call_infer(x, callee_ty.clone(), hint, errors)
                     })
                     .into_ty()
             }
@@ -1192,13 +1155,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             let regex_pattern = Self::regex_pattern_argument(&x.arguments);
             let regex_flags_position =
                 regex_pattern.and_then(|_| self.regex_flags_position(&callee_ty));
-            let ret = self.expr_call_infer(
-                x,
-                callee_ty,
-                direct_class_specialization,
-                hint,
-                errors,
-            );
+            let ret = self.expr_call_infer(x, callee_ty, hint, errors);
             if let (Some(pattern), Some(flags_position)) = (regex_pattern, regex_flags_position) {
                 self.regex_validate_pattern_argument(pattern, &x.arguments, flags_position, errors);
             }
@@ -2659,6 +2616,9 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     // All other classes (including Tensor) get promoted and wrapped in type_form
                     *ty = self.heap.mk_type_of(self.promote(cls, range, errors));
                 }
+            }
+            Type::SpecializedClass(cls) => {
+                *ty = self.heap.mk_type_of(Type::ClassType(cls.clone()));
             }
             Type::ClassType(cls) if cls.is_builtin("type") => {
                 *ty = self.heap.mk_type_of(self.heap.mk_any_implicit());
@@ -4750,8 +4710,11 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             result
         } else {
             let targs = self.parse_class_type_args(cls, xs, type_form_context, errors);
-            self.heap
-                .mk_type_of(self.specialize(cls, targs, range, errors))
+            match self.specialize(cls, targs, range, errors) {
+                Type::ClassType(class_type) => Type::SpecializedClass(class_type),
+                Type::TypedDict(typed_dict) => self.heap.mk_type_of(Type::TypedDict(typed_dict)),
+                _ => unreachable!("specializing a class produces a class or TypedDict instance"),
+            }
         }
     }
 

--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -1488,6 +1488,9 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                             Type::ClassDef(cls) => {
                                 literal_types.push(Type::type_of(self.promote_silently(&cls)));
                             }
+                            Type::SpecializedClass(cls) => {
+                                literal_types.push(Type::type_of(Type::ClassType(cls)));
+                            }
                             // Already-wrapped type[X] expressions pass through.
                             Type::Type(ref f) if matches!(&**f, Type::ClassType(_)) => {
                                 literal_types.push(expr_ty);
@@ -1556,6 +1559,9 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                             // distribute_over_union below).
                             Type::ClassDef(cls) => {
                                 literal_types.push(Type::type_of(self.promote_silently(&cls)));
+                            }
+                            Type::SpecializedClass(cls) => {
+                                literal_types.push(Type::type_of(Type::ClassType(cls)));
                             }
                             Type::Type(ref f) if matches!(&**f, Type::ClassType(_)) => {
                                 literal_types.push(expr_ty);

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -2765,7 +2765,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     ) || matches!(&result_ty, Type::Type(f) if matches!(&**f, Type::ClassType(_))))
                         || {
                             let callable_ty = self.expr_infer(&call.func, &swallower);
-                            matches!(&callable_ty, Type::ClassDef(_))
+                            matches!(&callable_ty, Type::ClassDef(_) | Type::SpecializedClass(_))
                         }
                 } else {
                     false
@@ -5829,7 +5829,8 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         // when there is no annotation, so that `mylist = list` is treated
         // like a value assignment rather than a type alias?
         match ty {
-            Type::Type(_)
+            Type::SpecializedClass(_)
+            | Type::Type(_)
             | Type::TypeVar(_)
             | Type::ParamSpec(_)
             | Type::TypeVarTuple(_)

--- a/pyrefly/lib/alt/special_calls.rs
+++ b/pyrefly/lib/alt/special_calls.rs
@@ -572,7 +572,8 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     }
                 }
             } else if contains_subscript
-                && matches!(&class_info_ty, Type::Type(f) if matches!(&**f, Type::ClassType(cls) if !cls.targs().is_empty()))
+                && (matches!(&class_info_ty, Type::SpecializedClass(_))
+                    || matches!(&class_info_ty, Type::Type(f) if matches!(&**f, Type::ClassType(cls) if !cls.targs().is_empty())))
             {
                 // If the raw expression contains something that structurally looks like `A[T]` and
                 // part of the expression resolves to a parameterized class type, then we likely have a

--- a/pyrefly/lib/lsp/wasm/signature_help.rs
+++ b/pyrefly/lib/lsp/wasm/signature_help.rs
@@ -56,7 +56,7 @@ pub(crate) struct CallInfo {
 }
 
 pub(crate) fn is_constructor_call(callee_type: Type) -> bool {
-    matches!(callee_type, Type::ClassDef(_))
+    matches!(callee_type, Type::ClassDef(_) | Type::SpecializedClass(_))
         || matches!(callee_type, Type::Type(t) if matches!(*t, Type::ClassType(_)))
 }
 

--- a/pyrefly/lib/query.rs
+++ b/pyrefly/lib/query.rs
@@ -915,6 +915,7 @@ impl<'a> CalleesWithLocation<'a> {
     }
     fn init_or_new_from_type(&self, ty: &Type, callee_range: TextRange) -> Vec<Callee> {
         match ty {
+            Type::SpecializedClass(c) => self.find_init_or_new(c.class_object()),
             Type::SelfType(c) | Type::ClassType(c) => self.find_init_or_new(c.class_object()),
             Type::Quantified(q) => match &q.restriction {
                 Restriction::Bound(Type::ClassType(c)) => self.find_init_or_new(c.class_object()),
@@ -1019,6 +1020,7 @@ impl<'a> CalleesWithLocation<'a> {
             Type::Annotated(_, _) => vec![],
 
             Type::ClassDef(cls) => self.find_init_or_new(cls),
+            Type::SpecializedClass(cls) => self.find_init_or_new(cls.class_object()),
             Type::Forall(v) => match &v.body {
                 Forallable::Function(func) => {
                     vec![self.callee_from_function(func, call_target, call_arguments)]

--- a/pyrefly/lib/query/type_table.rs
+++ b/pyrefly/lib/query/type_table.rs
@@ -281,6 +281,10 @@ pub(super) fn type_to_indexed_shape(
             );
             insert_indexed_named(table, "typing.Type", vec![class_index], None, Vec::new())
         }
+        Type::SpecializedClass(class_type) => {
+            let inner = type_to_indexed_shape(context, &Type::ClassType(class_type.clone()), table);
+            insert_indexed_named(table, "typing.Type", vec![inner], None, Vec::new())
+        }
         Type::ClassType(class_type) => {
             let args = class_type
                 .targs()

--- a/pyrefly/lib/report/cinderx/convert.rs
+++ b/pyrefly/lib/report/cinderx/convert.rs
@@ -233,6 +233,14 @@ pub(crate) fn type_to_structured(
             let inner_idx = type_to_structured(inner, table, pending_class_traits);
             insert_wrapper_other_form("typing.Type", inner_idx, table)
         }
+        Type::SpecializedClass(class_type) => {
+            let inner_idx = type_to_structured(
+                &Type::ClassType(class_type.clone()),
+                table,
+                pending_class_traits,
+            );
+            insert_wrapper_other_form("typing.Type", inner_idx, table)
+        }
         Type::TypedDict(td) | Type::PartialTypedDict(td) => {
             let (qname, trait_name) = match (ty, td) {
                 (Type::PartialTypedDict(_), TypedDict::TypedDict(inner)) => {

--- a/pyrefly/lib/report/pysa/call_graph.rs
+++ b/pyrefly/lib/report/pysa/call_graph.rs
@@ -1451,7 +1451,10 @@ impl DirectCall {
                     Self::from_bool(false)
                 }
                 Some(Type::BoundMethod(bm))
-                    if matches!(bm.obj, Type::ClassDef(_) | Type::Type(_)) =>
+                    if matches!(
+                        bm.obj,
+                        Type::ClassDef(_) | Type::SpecializedClass(_) | Type::Type(_)
+                    ) =>
                 {
                     Self::from_bool(true)
                 }

--- a/pyrefly/lib/report/pysa/types.rs
+++ b/pyrefly/lib/report/pysa/types.rs
@@ -296,6 +296,10 @@ fn get_classes_of_type(type_: &Type, context: &ModuleContext) -> ClassNamesFromT
         Type::ClassDef(class) => {
             ClassNamesFromType::from_class(class, context).prepend_modifier(TypeModifier::Type)
         }
+        Type::SpecializedClass(class_type) => {
+            ClassNamesFromType::from_class(class_type.class_object(), context)
+                .prepend_modifier(TypeModifier::Type)
+        }
         Type::Type(inner) if let Type::ClassType(class_type) = &**inner => {
             ClassNamesFromType::from_class(class_type.class_object(), context)
                 .prepend_modifier(TypeModifier::Type)

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -1831,6 +1831,12 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
             (_, Type::ClassType(want)) if want.is_builtin("object") => {
                 Ok(()) // everything is an instance of `object`
             }
+            (Type::SpecializedClass(got), want) => {
+                self.is_subset_eq(&Type::type_of(Type::ClassType(got.clone())), want)
+            }
+            (got, Type::SpecializedClass(want)) => {
+                self.is_subset_eq(got, &Type::type_of(Type::ClassType(want.clone())))
+            }
             (got_ty, want_ty)
                 if let Some(got_alias) = as_type_alias(got_ty)
                     && let Some(want_alias) = as_type_alias(want_ty) =>

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -413,7 +413,7 @@ pub(crate) fn attribute_symbol_kind_from_type(ty: &Type) -> SymbolKind {
                 SymbolKind::Method
             }
         }
-        Type::ClassDef(_) | Type::Type(_) => SymbolKind::Class,
+        Type::ClassDef(_) | Type::SpecializedClass(_) | Type::Type(_) => SymbolKind::Class,
         Type::TypeAlias(_) | Type::UntypedAlias(_) => SymbolKind::TypeAlias,
         Type::Module(_) => SymbolKind::Module,
         _ => SymbolKind::Attribute,
@@ -2037,7 +2037,7 @@ impl<'a> Transaction<'a> {
             let symbol_kind = match type_ {
                 Type::Callable(_) | Type::Function(_) => SymbolKind::Function,
                 Type::BoundMethod(_) => SymbolKind::Method,
-                Type::ClassDef(_) | Type::Type(_) => SymbolKind::Class,
+                Type::ClassDef(_) | Type::SpecializedClass(_) | Type::Type(_) => SymbolKind::Class,
                 Type::Module(_) => SymbolKind::Module,
                 Type::TypeAlias(_) => SymbolKind::TypeAlias,
                 _ => *symbol_kind,

--- a/pyrefly/lib/test/abstract_methods.rs
+++ b/pyrefly/lib/test/abstract_methods.rs
@@ -24,6 +24,30 @@ shape = Shape()  # E: Cannot instantiate `Shape`
 );
 
 testcase!(
+    test_generic_abstract_class_instantiation_error,
+    r#"
+from abc import ABC, abstractmethod
+
+class Shape[T](ABC):
+    @abstractmethod
+    def area(self) -> T:
+        pass
+
+class ConcreteShape(Shape[int]):
+    def area(self) -> int:
+        return 0
+
+shape = Shape[int]()  # E: Cannot instantiate `Shape`
+
+def construct(cls: type[Shape[int]]) -> Shape[int]:
+    return cls()
+
+classes: tuple[type[Shape[int]], ...] = (ConcreteShape,)
+concrete_shape = classes[0]()
+"#,
+);
+
+testcase!(
     test_concrete_subclass_instantiation_ok,
     r#"
 from abc import ABC, abstractmethod

--- a/pyrefly/lib/test/abstract_methods.rs
+++ b/pyrefly/lib/test/abstract_methods.rs
@@ -83,10 +83,18 @@ class DirectABCMeta(metaclass=ABCMeta):
 class IndirectABCMeta(DirectABCMeta):
     pass
 
+class DirectGenericABC[T](ABC):
+    pass
+
+class DirectGenericABCMeta[T](metaclass=ABCMeta):
+    pass
+
 direct_abc = DirectABC()  # E: Cannot instantiate `DirectABC`
 indirect_abc = IndirectABC()
 direct_abc_meta = DirectABCMeta()  # E: Cannot instantiate `DirectABCMeta`
 indirect_abc_meta = IndirectABCMeta()
+direct_generic_abc = DirectGenericABC[int]()
+direct_generic_abc_meta = DirectGenericABCMeta[int]()
 "#,
 );
 

--- a/pyrefly/lib/test/abstract_methods.rs
+++ b/pyrefly/lib/test/abstract_methods.rs
@@ -38,6 +38,8 @@ class ConcreteShape(Shape[int]):
         return 0
 
 shape = Shape[int]()  # E: Cannot instantiate `Shape`
+ShapeCtor = Shape[int]
+shape_from_alias = ShapeCtor()  # E: Cannot instantiate `Shape`
 
 def construct(cls: type[Shape[int]]) -> Shape[int]:
     return cls()

--- a/pyrefly/lib/test/simple.rs
+++ b/pyrefly/lib/test/simple.rs
@@ -1110,13 +1110,12 @@ for a in A:  # E: Type `type[A]` is not iterable
 );
 
 testcase!(
-    bug = "Although A[int] is a generic alias and can be iterated over, type[A[int]] is a type and cannot be iterated over.",
     test_getitem_cannot_iterate_generic_class,
     r#"
 class A[T]:
     def __getitem__(self, i: int) -> int: ...
 def f(x: type[A[int]]):
-    for a in x:  # Expect an error here
+    for a in x:  # E: Type `type[A[int]]` is not iterable
         pass
     "#,
 );

--- a/pyrefly/lib/tsp/type_conversion.rs
+++ b/pyrefly/lib/tsp/type_conversion.rs
@@ -239,6 +239,9 @@ impl TypeConverter<'_> {
 
             // --- Class definitions (the class object itself, e.g. `type[int]`) ---
             PyreflyType::ClassDef(cls) => convert_class_def(cls),
+            PyreflyType::SpecializedClass(ct) => {
+                mark_instantiable(self.convert_class_type(ct, TypeFlags::INSTANCE))
+            }
 
             // --- Literals (Literal[42], Literal["hi"], etc.) ---
             PyreflyType::Literal(lit) => convert_literal(lit),


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4263

Preserves direct-class provenance for `GenericABC[int]()`, rejects direct specialized abstract/protocol construction.

Keeps `type[GenericABC[int]]` calls valid because they may reference concrete subclasses.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test