### PR TITLE
Resolve bundled modules with import semantics

### DIFF
--- a/pyrefly/lib/module/bundled.rs
+++ b/pyrefly/lib/module/bundled.rs
@@ -25,6 +25,7 @@ use pyrefly_python::module_path::ModulePath;
 use pyrefly_util::arc_id::ArcId;
 use pyrefly_util::fs_anyhow;
 use pyrefly_util::lock::Mutex;
+use starlark_map::small_map::SmallMap;
 use tempfile::NamedTempFile;
 
 pub fn set_readonly(path: &Path, value: bool) -> anyhow::Result<()> {
@@ -32,6 +33,118 @@ pub fn set_readonly(path: &Path, value: bool) -> anyhow::Result<()> {
     permissions.set_readonly(value);
     fs::set_permissions(path, permissions)?;
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BundleFile {
+    pub(crate) import_path: PathBuf,
+    pub(crate) storage_path: PathBuf,
+    pub(crate) contents: String,
+}
+
+#[derive(Debug)]
+struct Candidate {
+    path: PathBuf,
+    is_package: bool,
+}
+
+/// An eagerly resolved view of one virtual import root.
+///
+/// Package initializers take precedence over same-name modules, and modules block descendants.
+#[derive(Debug, Clone)]
+pub(crate) struct Bundle {
+    find: SmallMap<ModuleName, PathBuf>,
+    load: SmallMap<PathBuf, Arc<String>>,
+}
+
+impl Bundle {
+    pub(crate) fn new<Files>(files: Files) -> anyhow::Result<Self>
+    where
+        Files: IntoIterator<Item = BundleFile>,
+    {
+        let mut candidates: SmallMap<ModuleName, Candidate> = SmallMap::new();
+        let mut load = SmallMap::new();
+        for file in files {
+            let module = ModuleName::from_relative_path(&file.import_path)?;
+            let is_package = file
+                .import_path
+                .file_stem()
+                .is_some_and(|stem| stem == "__init__");
+            if let Some(candidate) = candidates.get_mut(&module) {
+                if is_package && !candidate.is_package {
+                    candidate.path = file.storage_path.clone();
+                    candidate.is_package = true;
+                }
+            } else {
+                candidates.insert(
+                    module,
+                    Candidate {
+                        path: file.storage_path.clone(),
+                        is_package,
+                    },
+                );
+            }
+            load.insert(file.storage_path, Arc::new(file.contents));
+        }
+
+        let mut find = SmallMap::new();
+        'modules: for (module, candidate) in &candidates {
+            let mut ancestor = *module;
+            while let Some(parent) = ancestor.parent() {
+                ancestor = parent;
+                if candidates
+                    .get(&parent)
+                    .is_some_and(|candidate| !candidate.is_package)
+                {
+                    continue 'modules;
+                }
+            }
+            find.insert(*module, candidate.path.clone());
+        }
+        Ok(Self { find, load })
+    }
+
+    pub(crate) fn find(&self, module: ModuleName) -> Option<&PathBuf> {
+        self.find.get(&module)
+    }
+
+    pub(crate) fn load(&self, path: &Path) -> Option<Arc<String>> {
+        self.load.get(path).cloned()
+    }
+
+    pub(crate) fn modules(&self) -> impl Iterator<Item = ModuleName> + '_ {
+        self.find.keys().copied()
+    }
+
+    pub(crate) fn load_map(&self) -> impl Iterator<Item = (&PathBuf, &Arc<String>)> {
+        self.load.iter()
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn assert_bundle_order_independent(files: impl IntoIterator<Item = BundleFile>) {
+    fn loaded_modules(bundle: &Bundle) -> Vec<(ModuleName, PathBuf, Arc<String>)> {
+        let mut modules = bundle.modules().collect::<Vec<_>>();
+        modules.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+        modules
+            .into_iter()
+            .map(|module| {
+                let path = bundle
+                    .find(module)
+                    .expect("bundle modules have selected paths");
+                let contents = bundle
+                    .load(path)
+                    .expect("selected bundle paths have contents");
+                (module, path.clone(), contents)
+            })
+            .collect()
+    }
+
+    let files = files.into_iter().collect::<Vec<_>>();
+    let forward = Bundle::new(files.clone()).expect("static bundle files should be valid");
+    let reverse =
+        Bundle::new(files.into_iter().rev()).expect("static bundle files should be valid");
+    assert_eq!(loaded_modules(&forward), loaded_modules(&reverse));
 }
 
 /// Creates a base config file for bundled stubs with common settings.
@@ -165,4 +278,88 @@ pub trait BundledStub {
     }
     fn get_path_name(&self) -> String;
     fn load_map(&self) -> impl Iterator<Item = (&PathBuf, &Arc<String>)>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bundle(files: &[(&str, &str)]) -> Bundle {
+        Bundle::new(files.iter().map(|(module_path, path)| BundleFile {
+            import_path: PathBuf::from(module_path),
+            storage_path: PathBuf::from(path),
+            contents: path.to_string(),
+        }))
+        .unwrap()
+    }
+
+    fn assert_found(bundle: &Bundle, module: &str, path: &str) {
+        let path = PathBuf::from(path);
+        assert_eq!(bundle.find(ModuleName::from_str(module)), Some(&path));
+        assert_eq!(
+            bundle.load(&path).as_deref().map(String::as_str),
+            path.to_str()
+        );
+    }
+
+    #[test]
+    fn test_bundled_package_initializer_precedes_module_file() {
+        let module_then_package = bundle(&[
+            ("foo.pyi", "foo.pyi"),
+            ("foo/__init__.pyi", "foo/__init__.pyi"),
+        ]);
+        let package_then_module = bundle(&[
+            ("foo/__init__.pyi", "foo/__init__.pyi"),
+            ("foo.pyi", "foo.pyi"),
+        ]);
+        assert_found(&module_then_package, "foo", "foo/__init__.pyi");
+        assert_found(&package_then_module, "foo", "foo/__init__.pyi");
+    }
+
+    #[test]
+    fn test_bundled_module_parent_blocks_child_module() {
+        let bundle = bundle(&[("foo/bar.pyi", "foo/bar.pyi"), ("foo.pyi", "foo.pyi")]);
+        assert_found(&bundle, "foo", "foo.pyi");
+        assert!(bundle.find(ModuleName::from_str("foo.bar")).is_none());
+    }
+
+    #[test]
+    fn test_bundled_namespace_package_merges_files() {
+        let bundle = bundle(&[
+            ("ns/left.pyi", "first/ns/left.pyi"),
+            ("ns/right.pyi", "second/ns/right.pyi"),
+        ]);
+        assert_found(&bundle, "ns.left", "first/ns/left.pyi");
+        assert_found(&bundle, "ns.right", "second/ns/right.pyi");
+    }
+
+    #[test]
+    fn test_bundled_equal_kind_candidates_follow_file_order() {
+        let bundle = bundle(&[
+            ("duplicate.pyi", "first/duplicate.pyi"),
+            ("duplicate.pyi", "second/duplicate.pyi"),
+        ]);
+        assert_found(&bundle, "duplicate", "first/duplicate.pyi");
+    }
+
+    #[test]
+    fn test_bundled_regular_package_includes_all_children_in_the_root() {
+        let bundle = bundle(&[
+            ("pkg/__init__.pyi", "first/pkg/__init__.pyi"),
+            ("pkg/child.pyi", "second/pkg/child.pyi"),
+        ]);
+        assert_found(&bundle, "pkg", "first/pkg/__init__.pyi");
+        assert_found(&bundle, "pkg.child", "second/pkg/child.pyi");
+    }
+
+    #[test]
+    fn test_bundled_regular_package_preserves_overlaid_namespace_children() {
+        let bundle = bundle(&[
+            ("ns/left.pyi", "first/ns/left.pyi"),
+            ("ns/__init__.pyi", "second/ns/__init__.pyi"),
+            ("ns/right.pyi", "second/ns/right.pyi"),
+        ]);
+        assert_found(&bundle, "ns.left", "first/ns/left.pyi");
+        assert_found(&bundle, "ns.right", "second/ns/right.pyi");
+    }
 }

--- a/pyrefly/lib/module/third_party.rs
+++ b/pyrefly/lib/module/third_party.rs
@@ -18,15 +18,15 @@ use pyrefly_config::config::ConfigFile;
 use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::module_path::ModulePath;
 use pyrefly_util::arc_id::ArcId;
-use starlark_map::small_map::SmallMap;
 
+use crate::module::bundled::Bundle;
+use crate::module::bundled::BundleFile;
 use crate::module::bundled::BundledStub;
 use crate::module::bundled::create_bundled_stub_config;
 
 #[derive(Debug, Clone)]
 pub struct BundledThirdParty {
-    pub find: SmallMap<ModuleName, PathBuf>,
-    pub load: SmallMap<PathBuf, Arc<String>>,
+    bundle: Bundle,
 }
 
 /// Unlike typeshed stubs, other third-party stubs have -stubs suffixes
@@ -53,31 +53,30 @@ fn strip_stubs_suffix_from_path(path: &Path) -> PathBuf {
 impl BundledStub for BundledThirdParty {
     fn new() -> anyhow::Result<Self> {
         let contents = bundled_third_party()?;
-        let mut res = Self {
-            find: SmallMap::new(),
-            load: SmallMap::new(),
-        };
-        for (relative_path, contents) in contents {
-            let adjusted_path = strip_stubs_suffix_from_path(&relative_path);
-            let module_name = ModuleName::from_relative_path(&adjusted_path)?;
-            res.find.insert(module_name, relative_path.clone());
-            res.load.insert(relative_path, Arc::new(contents));
-        }
-        Ok(res)
+        let files = contents
+            .into_iter()
+            .map(|(relative_path, contents)| BundleFile {
+                import_path: strip_stubs_suffix_from_path(&relative_path),
+                storage_path: relative_path,
+                contents,
+            });
+        Ok(Self {
+            bundle: Bundle::new(files)?,
+        })
     }
 
     fn find(&self, module: ModuleName) -> Option<ModulePath> {
-        self.find
-            .get(&module)
+        self.bundle
+            .find(module)
             .map(|path| ModulePath::bundled_third_party(path.clone()))
     }
 
     fn load(&self, path: &Path) -> Option<Arc<String>> {
-        self.load.get(path).cloned()
+        self.bundle.load(path)
     }
 
     fn modules(&self) -> impl Iterator<Item = ModuleName> {
-        self.find.keys().copied()
+        self.bundle.modules()
     }
 
     fn config() -> ArcId<ConfigFile> {
@@ -96,7 +95,7 @@ impl BundledStub for BundledThirdParty {
     }
 
     fn load_map(&self) -> impl Iterator<Item = (&PathBuf, &Arc<String>)> {
-        self.load.iter()
+        self.bundle.load_map()
     }
 }
 
@@ -115,6 +114,7 @@ mod tests {
     use pyrefly_python::module_path::ModulePathDetails;
 
     use super::*;
+    use crate::module::bundled::assert_bundle_order_independent;
 
     #[test]
     fn test_bundled_third_party_materialize() {
@@ -171,5 +171,15 @@ mod tests {
             "third_party path should exist: {:?}",
             third_party_path
         );
+    }
+
+    #[test]
+    fn test_bundled_third_party_lookup_is_file_order_independent() {
+        let stub = get_bundled_third_party().unwrap();
+        assert_bundle_order_independent(stub.load_map().map(|(path, contents)| BundleFile {
+            import_path: strip_stubs_suffix_from_path(path),
+            storage_path: path.clone(),
+            contents: contents.as_str().to_owned(),
+        }));
     }
 }

--- a/pyrefly/lib/module/typeshed.rs
+++ b/pyrefly/lib/module/typeshed.rs
@@ -20,49 +20,49 @@ use pyrefly_config::error_kind::Severity;
 use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::module_path::ModulePath;
 use pyrefly_util::arc_id::ArcId;
-use starlark_map::small_map::SmallMap;
 
 use crate::config::config::ConfigFile;
+use crate::module::bundled::Bundle;
+use crate::module::bundled::BundleFile;
 use crate::module::bundled::BundledStub;
 use crate::module::bundled::create_bundled_stub_config;
 
 #[derive(Debug, Clone)]
 pub struct BundledTypeshedStdlib {
-    pub find: SmallMap<ModuleName, PathBuf>,
-    pub load: SmallMap<PathBuf, Arc<String>>,
+    bundle: Bundle,
 }
 
 impl BundledStub for BundledTypeshedStdlib {
     fn new() -> anyhow::Result<Self> {
         let contents = bundled_typeshed()?;
-        let mut res = Self {
-            find: SmallMap::new(),
-            load: SmallMap::new(),
-        };
-        for (relative_path, contents) in contents {
-            let module_name = ModuleName::from_relative_path(&relative_path)?;
-            res.find.insert(module_name, relative_path.clone());
-            res.load.insert(relative_path, Arc::new(contents));
-        }
-        Ok(res)
+        let provider = contents
+            .into_iter()
+            .map(|(relative_path, contents)| BundleFile {
+                import_path: relative_path.clone(),
+                storage_path: relative_path,
+                contents,
+            });
+        Ok(Self {
+            bundle: Bundle::new(provider)?,
+        })
     }
 
     fn find(&self, module: ModuleName) -> Option<ModulePath> {
-        self.find
-            .get(&module)
+        self.bundle
+            .find(module)
             .map(|path| ModulePath::bundled_typeshed(path.clone()))
     }
 
     fn load(&self, path: &Path) -> Option<Arc<String>> {
-        self.load.get(path).cloned()
+        self.bundle.load(path)
     }
 
     fn load_map(&self) -> impl Iterator<Item = (&PathBuf, &Arc<String>)> {
-        self.load.iter()
+        self.bundle.load_map()
     }
 
     fn modules(&self) -> impl Iterator<Item = ModuleName> {
-        self.find.keys().copied()
+        self.bundle.modules()
     }
 
     fn get_path_name(&self) -> String {
@@ -134,6 +134,7 @@ pub fn stdlib_search_path() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::module::bundled::assert_bundle_order_independent;
 
     #[test]
     fn test_typeshed_materialize() {
@@ -142,5 +143,15 @@ mod tests {
         // Do it twice, to check that works.
         typeshed.materialized_path_on_disk().unwrap();
         typeshed.write(&path).unwrap();
+    }
+
+    #[test]
+    fn test_typeshed_lookup_is_file_order_independent() {
+        let typeshed = typeshed().unwrap();
+        assert_bundle_order_independent(typeshed.load_map().map(|(path, contents)| BundleFile {
+            import_path: path.clone(),
+            storage_path: path.clone(),
+            contents: contents.as_str().to_owned(),
+        }));
     }
 }

--- a/pyrefly/lib/module/typeshed_third_party.rs
+++ b/pyrefly/lib/module/typeshed_third_party.rs
@@ -19,55 +19,63 @@ use pyrefly_python::module_path::ModulePath;
 use pyrefly_util::arc_id::ArcId;
 use starlark_map::small_map::SmallMap;
 
+use crate::module::bundled::Bundle;
+use crate::module::bundled::BundleFile;
 use crate::module::bundled::BundledStub;
 use crate::module::bundled::create_bundled_stub_config;
 
 #[derive(Debug, Clone)]
 pub struct BundledTypeshedThirdParty {
-    /// Maps module name to (stub path, typeshed package name).
-    /// The package name is needed for correct `types-{package}` recommendations,
-    /// since the module name often differs from the package name
-    /// (e.g., module `dateutil` comes from package `python-dateutil`).
-    pub find: SmallMap<ModuleName, (PathBuf, ModuleName)>,
-    pub load: SmallMap<PathBuf, Arc<String>>,
+    bundle: Bundle,
+    package_names: SmallMap<ModuleName, ModuleName>,
 }
 
 impl BundledStub for BundledTypeshedThirdParty {
     fn new() -> anyhow::Result<Self> {
         let (contents, path_to_package) = bundled_third_party_stubs()?;
-        let mut res = Self {
-            find: SmallMap::new(),
-            load: SmallMap::new(),
-        };
-        for (relative_path, contents) in contents {
-            let module_name = ModuleName::from_relative_path(&relative_path)?;
-            let package_name = path_to_package
-                .get(&relative_path)
-                .map(|s| ModuleName::from_str(s))
-                .unwrap_or_else(|| ModuleName::from_name(&module_name.first_component()));
-            res.find
-                .insert(module_name, (relative_path.clone(), package_name));
-            res.load.insert(relative_path, Arc::new(contents));
-        }
-        Ok(res)
+        let files = contents
+            .into_iter()
+            .map(|(relative_path, contents)| BundleFile {
+                import_path: relative_path.clone(),
+                storage_path: relative_path,
+                contents,
+            });
+        let bundle = Bundle::new(files)?;
+        let package_names = bundle
+            .modules()
+            .map(|module| {
+                let path = bundle
+                    .find(module)
+                    .expect("bundle modules have selected paths");
+                let package_name = path_to_package
+                    .get(path)
+                    .map(|name| ModuleName::from_str(name))
+                    .unwrap_or_else(|| ModuleName::from_name(&module.first_component()));
+                (module, package_name)
+            })
+            .collect();
+        Ok(Self {
+            bundle,
+            package_names,
+        })
     }
 
     fn find(&self, module: ModuleName) -> Option<ModulePath> {
-        self.find
-            .get(&module)
-            .map(|(path, _)| ModulePath::bundled_typeshed_third_party(path.clone()))
+        self.bundle
+            .find(module)
+            .map(|path| ModulePath::bundled_typeshed_third_party(path.clone()))
     }
 
     fn load(&self, path: &Path) -> Option<Arc<String>> {
-        self.load.get(path).cloned()
+        self.bundle.load(path)
     }
 
     fn load_map(&self) -> impl Iterator<Item = (&PathBuf, &Arc<String>)> {
-        self.load.iter()
+        self.bundle.load_map()
     }
 
     fn modules(&self) -> impl Iterator<Item = ModuleName> {
-        self.find.keys().copied()
+        self.bundle.modules()
     }
 
     fn get_path_name(&self) -> String {
@@ -88,7 +96,7 @@ impl BundledStub for BundledTypeshedThirdParty {
 
 impl BundledTypeshedThirdParty {
     pub fn package_name(&self, module: ModuleName) -> Option<&ModuleName> {
-        self.find.get(&module).map(|(_, pkg)| pkg)
+        self.package_names.get(&module)
     }
 }
 
@@ -105,6 +113,7 @@ pub fn typeshed_third_party() -> anyhow::Result<&'static BundledTypeshedThirdPar
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::module::bundled::assert_bundle_order_independent;
 
     #[test]
     fn test_typeshed_materialize() {
@@ -129,5 +138,15 @@ mod tests {
             .expect("google.cloud.ndb should have a package name");
         assert_eq!(protobuf_pkg.as_str(), "protobuf");
         assert_eq!(ndb_pkg.as_str(), "google-cloud-ndb");
+    }
+
+    #[test]
+    fn test_typeshed_third_party_lookup_is_file_order_independent() {
+        let typeshed = typeshed_third_party().unwrap();
+        assert_bundle_order_independent(typeshed.load_map().map(|(path, contents)| BundleFile {
+            import_path: path.clone(),
+            storage_path: path.clone(),
+            contents: contents.as_str().to_owned(),
+        }));
     }
 }


### PR DESCRIPTION
Summary:
Before this diff, the bundled stubs were created by simply inserting file paths in order directly into a module map. This means the modules depend on the order of files in the archive, but two different paths can sometimes provide the same module, and Python's own precedence rules do not match.

In practice, there is only one example where this is a problem, which is exactly the issue in https://github.com/facebook/pyrefly/issues/1819: `pandas/io/parsers.pyi` vs `pandas/io/parsers/__init__.pyi`.

While the contents of the archives is fixed at compile time, we are not fully in control of the archives -- they come from typeshed or stubs repos written by someone else. This PR implements a new `Bundle` abstraction that takes an archive and uses Python runtime lookup rules to create the accurate module map.

I added tests for other cases which don't currently exist in the current archives, but if they ever appear we will handle them correctly.

This is an alternative approach to https://github.com/facebook/pyrefly/pull/4185

Fixes https://github.com/facebook/pyrefly/issues/1819

Differential Revision: D113606265


