### PR TITLE
Run benchmarks on CodSpeed in CI

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,67 @@
+name: CodSpeed
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  # workflow_dispatch lets CodSpeed trigger backtest runs to seed baseline data.
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write # OpenID Connect auth with CodSpeed (no token secret required)
+jobs:
+  # Instruction-count (Valgrind) measurement of the small, deterministic
+  # microbenchmarks. They are single-threaded and fast, so callgrind's overhead
+  # is bounded and the instruction counts are stable run-to-run.
+  simulation:
+    name: Microbenchmarks (simulation)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+    - name: set up rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: pyrefly-codspeed
+    - name: install cargo-codspeed
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-codspeed
+    - name: build benchmarks
+      run: cargo codspeed build -p pyrefly --bench micro
+    - name: run benchmarks
+      uses: CodSpeedHQ/action@v4
+      with:
+        mode: simulation
+        run: cargo codspeed run -p pyrefly --bench micro
+  # Wall-clock measurement of the heavy, real-world PyTorch benchmarks. They drive
+  # the full LSP server over all cores against the pinned PyTorch checkout, so they
+  # must not run under Valgrind (which serializes threads and inflates the ~GB cold
+  # start past any reasonable timeout). Walltime mode tolerates threads, I/O, and
+  # long cold starts.
+  walltime:
+    name: PyTorch benchmarks (walltime)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    # No submodule checkout: in OSS the benchmark clones the pinned PyTorch itself
+    # (rev from benches/pytorch_pin.bzl) on first run. The runner has github egress.
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+    - name: set up rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: pyrefly-codspeed-walltime
+    - name: install cargo-codspeed
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-codspeed
+    - name: build benchmarks
+      run: cargo codspeed build -m walltime -p pyrefly --bench pytorch
+    - name: run benchmarks
+      uses: CodSpeedHQ/action@v4
+      with:
+        mode: walltime
+        run: cargo codspeed run -p pyrefly --bench pytorch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2114736faba96bcd79595c700d03183f61357b9fbce14852515e59f3bee4ed4a"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,7 +250,7 @@ checksum = "7fd2d70527f3737a1ad17355e260706c1badebabd1fa06a7a053407380df841b"
 dependencies = [
  "backtrace",
  "libc",
- "nix",
+ "nix 0.23.1",
 ]
 
 [[package]]
@@ -371,6 +380,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +477,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "codspeed"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7083f253260bcb4aaa3b4aa4c52973703dabc1a85c2f193997e2689aafa8a919"
+dependencies = [
+ "anyhow",
+ "cc",
+ "colored",
+ "getrandom 0.4.2",
+ "glob",
+ "libc",
+ "nix 0.31.3",
+ "serde",
+ "serde_json",
+ "statrs",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f24251445188c69d50f10179d795424bd71b533b7e3f84fc03f26893b01af0"
+dependencies = [
+ "clap",
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored",
+ "regex",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c38205d56e2cb4fe04b708de7f9653a3f1b89edbe3a20b28f21e9e525e9e061"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "collection_literals"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +545,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "compact_str"
@@ -550,32 +632,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
 ]
 
 [[package]]
@@ -1716,6 +1772,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,7 +2154,7 @@ dependencies = [
  "blake3",
  "capnp",
  "clap",
- "criterion",
+ "codspeed-criterion-compat",
  "crossbeam-channel",
  "dashmap",
  "dupe",
@@ -2991,6 +3059,16 @@ dependencies = [
  "dupe",
  "equivalent",
  "lock_free_hashtable",
+]
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ strip = "debuginfo"
 [profile.dev]
 debug = 1
 
+[profile.bench]
+lto = false
+codegen-units = 16
+inherits = "release"
+
 [profile.dbg]
 debug = true
 inherits = "dev"

--- a/pyrefly/Cargo.toml
+++ b/pyrefly/Cargo.toml
@@ -85,7 +85,7 @@ xxhash-rust = { version = "0.8.15", features = ["xxh64"] }
 yansi = { version = "1.0.0-rc.1", features = ["hyperlink"] }
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { package = "codspeed-criterion-compat", version = "5", features = ["html_reports"] }
 pretty_assertions = { version = "1.4.1", features = ["alloc"], default-features = false }
 pyrefly_lsp_test = { path = "../crates/pyrefly_lsp_test" }
 


### PR DESCRIPTION
Summary:
Wires the benchmark suite into CodSpeed so type-checker performance is tracked continuously in CI. All benchmarks are written against criterion, so this swaps the plain `criterion` dev-dependency for CodSpeed's drop-in `codspeed-criterion-compat` (aliased back to `criterion`, so no benchmark source changes): under `cargo codspeed` it emits instrumented measurements, and otherwise it behaves exactly like criterion.

Adds `.github/workflows/codspeed.yml` with two jobs, matched to each benchmark's nature:
- `simulation` runs the `micro` benchmarks under CodSpeed's instruction-count (Valgrind) mode. They are small, deterministic, and single-threaded, so callgrind's overhead is bounded and the counts are stable run-to-run.
- `walltime` runs the `pytorch` benchmarks in wall-clock mode. They drive the full LSP server over all cores against the pinned PyTorch checkout (threads, I/O, a multi-gigabyte cold start), none of which survive Valgrind.

The workflow runs on every `pull_request` and on `main` pushes (to seed baseline data for PR comparisons), plus `workflow_dispatch`. Both jobs run on `ubuntu-latest`; any dedicated-runner change is left to a separate diff.

Both jobs authenticate to CodSpeed over OIDC (`id-token: write`, no token secret) and use `CodSpeedHQ/action@v4`. A `[profile.bench]` in the root Cargo.toml disables release LTO and uses multiple codegen units, keeping the CodSpeed build within standard CI runners' memory budget without affecting instruction-count measurements.

Differential Revision: D112014630


