### PR TITLE
Add implicit-relative-import diagnostic

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -201,6 +201,13 @@ pub enum ErrorKind {
     /// only re-exported when redundantly aliased (`from x import y as y`),
     /// listed in `__all__`, or brought in via a wildcard import.
     ImplicitReexport,
+    /// An unqualified `import` resolved only via the directory-upward fallback
+    /// search path, not through any configured absolute root. Such imports are
+    /// fragile (they break when the importing file moves and can unexpectedly
+    /// shadow installed packages). Prefer an explicit relative import
+    /// (`from . import ...`) or add the module's root to the configured search
+    /// path.
+    ImplicitRelativeImport,
     /// An attribute was implicitly defined by assignment to `self` in a method that we
     /// do not recognize as always executing (we recognize constructors and some test setup
     /// methods).
@@ -534,6 +541,7 @@ impl ErrorKind {
             ErrorKind::ImplicitAnyTypeArgument => Severity::Ignore,
             ErrorKind::ImplicitImport => Severity::Warn,
             ErrorKind::ImplicitReexport => Severity::Ignore,
+            ErrorKind::ImplicitRelativeImport => Severity::Ignore,
             ErrorKind::ImplicitlyDefinedAttribute => Severity::Ignore,
             ErrorKind::IncompatibleComparison => Severity::Ignore,
             ErrorKind::InvalidAbstractMethod => Severity::Ignore,

--- a/crates/pyrefly_config/src/migration/pyright.rs
+++ b/crates/pyrefly_config/src/migration/pyright.rs
@@ -541,7 +541,7 @@ impl RuleOverrides {
         // Import rules
         add(
             self.report_implicit_relative_import,
-            ErrorKind::MissingImport,
+            ErrorKind::ImplicitRelativeImport,
         );
 
         // Type argument rules
@@ -646,6 +646,36 @@ mod tests {
             }
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_pyright_implicit_relative_import_maps_to_its_own_kind() {
+        // Pyright's `reportImplicitRelativeImport` must migrate to the dedicated
+        // `ImplicitRelativeImport` kind (not `MissingImport`), while
+        // `reportMissingImports` stays on `MissingImport`. The two kinds are
+        // independent after migration (I6).
+        let overrides = RuleOverrides {
+            report_implicit_relative_import: Some(Severity::Warn),
+            report_missing_imports: Some(Severity::Error),
+            ..Default::default()
+        };
+        let config = overrides.to_config().expect("expected an error config");
+        assert_eq!(
+            config.severity(ErrorKind::ImplicitRelativeImport),
+            Severity::Warn,
+            "reportImplicitRelativeImport must map to ImplicitRelativeImport"
+        );
+        assert_eq!(
+            config.severity(ErrorKind::MissingImport),
+            Severity::Error,
+            "reportMissingImports must still map to MissingImport"
+        );
+        // The implicit-relative kind is NOT a sub-kind of missing-import, so its
+        // severity is reported independently of the missing-import entry.
+        assert_ne!(
+            config.severity(ErrorKind::ImplicitRelativeImport),
+            config.severity(ErrorKind::MissingImport),
+        );
     }
 
     #[test]

--- a/pyrefly/lib/module/finder.rs
+++ b/pyrefly/lib/module/finder.rs
@@ -500,7 +500,25 @@ pub fn find_import_internal(
             timing,
         )
     {
-        path
+        // This tier is the directory-upward fallback. A successful resolution here
+        // means the module was found by walking the importing file's directory
+        // ancestors, not through any configured absolute root — surface the
+        // implicit-relative caveat via the same non-fatal-error channel used by
+        // UntypedImport/MissingSource so the emitter can report it.
+        //
+        // `with_error` is a no-op when a caveat is already attached: a fallback
+        // hit that also lacks stubs already carries `UntypedImport` (set by
+        // `combine_normal_and_stub_results`), and that more actionable signal
+        // takes precedence over the implicit-relative one. Both describe the
+        // same successful resolution; the co-occurrence is rare.
+        //
+        // Cache-safety invariant: the implicit-relative signal is origin-dependent,
+        // but it is safe to attach here because fallback-tier hits are filesystem
+        // paths (never bundled typeshed variants), so `is_bundled()` is false and
+        // they are never promoted to the origin-independent `(module, None)` cache
+        // entry — see `LoaderFindCache::find_import`. Do not widen `is_bundled`
+        // without revisiting this.
+        path.with_error(FindError::ImplicitRelativeImport(module))
     } else if let Some(path) = find_module(
         module,
         config.site_package_path(),
@@ -656,12 +674,15 @@ fn suggest_stdlib_import_uncached(missing: ModuleName) -> Option<ModuleName> {
 #[cfg(test)]
 mod tests {
     use pyrefly_config::config::ConfigSource;
+    use pyrefly_config::config::DirectoryRelativeFallbackSearchPathCache;
+    use pyrefly_config::config::FallbackSearchPath;
     use pyrefly_config::environment::environment::PythonEnvironment;
     use pyrefly_config::environment::interpreters::Interpreters;
     use pyrefly_python::module_path::ModulePathDetails;
     use pyrefly_util::test_path::TestPath;
 
     use super::*;
+    use crate::state::loader::FindError;
     use crate::state::loader::Finding;
 
     #[test]
@@ -4026,5 +4047,206 @@ mod tests {
             .unwrap(),
             FindingOrError::new_finding(ModulePath::filesystem(root.join("rules/if.config.cconf")))
         );
+    }
+
+    /// Build a config whose only way to resolve `module` is the directory-upward
+    /// fallback tier. `search_path` is empty and site packages are empty, so no
+    /// absolute tier can satisfy the lookup. `fallback_search_path` walks the
+    /// importing file's ancestors toward `fallback_root` (or to `/` if `None`).
+    fn fallback_config(
+        search_path: Vec<PathBuf>,
+        fallback_root: Option<PathBuf>,
+        disable_search_path_heuristics: bool,
+    ) -> ConfigFile {
+        let mut interpreters = Interpreters::default();
+        interpreters.skip_interpreter_query = true;
+        let mut config = ConfigFile {
+            search_path_from_file: search_path,
+            interpreters,
+            python_environment: PythonEnvironment {
+                site_package_path: Some(vec![]),
+                ..Default::default()
+            },
+            // Configure() leaves an already-set DirectoryRelative fallback alone
+            // (it only auto-populates the Empty case), so set it directly here.
+            fallback_search_path: FallbackSearchPath::DirectoryRelative(
+                DirectoryRelativeFallbackSearchPathCache::new(fallback_root),
+            ),
+            disable_search_path_heuristics,
+            ..Default::default()
+        };
+        config.configure();
+        config
+    }
+
+    /// I2/I4: a module resolved only via the directory-upward fallback tier
+    /// carries `FindError::ImplicitRelativeImport` as a non-fatal caveat, while
+    /// the resolution itself still succeeds (the module path is found).
+    #[test]
+    fn test_implicit_relative_import_attached_on_fallback_resolution() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        // `src/main.py` imports `sibling`, which lives next to it but is on no
+        // configured search path, so only the directory walk finds it.
+        TestPath::setup_test_directory(
+            root,
+            vec![TestPath::dir(
+                "src",
+                vec![TestPath::file("main.py"), TestPath::file("sibling.py")],
+            )],
+        );
+        let config = fallback_config(vec![], None, false);
+        let origin = ModulePath::filesystem(root.join("src/main.py"));
+        let result = find_import_filtered(
+            &config,
+            ModuleName::from_str("sibling"),
+            Some(&origin),
+            None,
+            &DirEntryCache::new(),
+            None,
+        );
+        match result {
+            FindingOrError::Finding(Finding {
+                finding,
+                error: Some(FindError::ImplicitRelativeImport(module)),
+            }) => {
+                assert_eq!(finding, ModulePath::filesystem(root.join("src/sibling.py")));
+                assert_eq!(module, ModuleName::from_str("sibling"));
+            }
+            other => {
+                panic!("expected a Finding with ImplicitRelativeImport attached, got: {other:?}")
+            }
+        }
+    }
+
+    /// I1: when an earlier (absolute) tier resolves the module, the
+    /// implicit-relative caveat is NOT attached — no false positive.
+    #[test]
+    fn test_no_implicit_relative_import_when_search_path_resolves() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        TestPath::setup_test_directory(
+            root,
+            vec![TestPath::dir(
+                "src",
+                vec![TestPath::file("main.py"), TestPath::file("sibling.py")],
+            )],
+        );
+        // Put `src/` on the configured search path: now the search_path tier
+        // (tier 3) resolves `sibling` before the fallback tier is consulted.
+        let config = fallback_config(vec![root.join("src")], None, false);
+        let origin = ModulePath::filesystem(root.join("src/main.py"));
+        let result = find_import_filtered(
+            &config,
+            ModuleName::from_str("sibling"),
+            Some(&origin),
+            None,
+            &DirEntryCache::new(),
+            None,
+        );
+        match result {
+            FindingOrError::Finding(Finding { finding, error }) => {
+                assert_eq!(finding, ModulePath::filesystem(root.join("src/sibling.py")));
+                assert!(
+                    error.is_none(),
+                    "no caveat expected when search path resolves, got: {error:?}"
+                );
+            }
+            other => panic!("expected a clean Finding, got: {other:?}"),
+        }
+    }
+
+    /// I3: with `disable_search_path_heuristics = true`, the fallback tier is
+    /// never consulted, so the implicit-relative caveat can never be attached.
+    /// The module either resolves via an earlier tier or fails to resolve.
+    #[test]
+    fn test_no_implicit_relative_import_when_heuristics_disabled() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        TestPath::setup_test_directory(
+            root,
+            vec![TestPath::dir(
+                "src",
+                vec![TestPath::file("main.py"), TestPath::file("sibling.py")],
+            )],
+        );
+        let config = fallback_config(vec![], None, true);
+        let origin = ModulePath::filesystem(root.join("src/main.py"));
+        let result = find_import_filtered(
+            &config,
+            ModuleName::from_str("sibling"),
+            Some(&origin),
+            None,
+            &DirEntryCache::new(),
+            None,
+        );
+        // The fallback tier is gated off, so the module is unresolvable and the
+        // result is a fatal MissingImport error (never a Finding carrying the
+        // implicit-relative caveat).
+        match result {
+            FindingOrError::Error(FindError::MissingImport(..)) => {}
+            FindingOrError::Finding(Finding { error, .. }) => {
+                assert!(
+                    !matches!(error, Some(FindError::ImplicitRelativeImport(..))),
+                    "ImplicitRelativeImport must not be attached when heuristics are disabled, \
+                     got error: {error:?}"
+                );
+            }
+            other => panic!("expected MissingImport (or a non-implicit finding), got: {other:?}"),
+        }
+    }
+
+    /// I7 (scoped-out limitation): a namespace package resolved via the fallback
+    /// tier is NOT flagged today. Provenance threading through the cross-tier
+    /// namespace accumulator is a larger follow-up; this test pins the current
+    /// behavior so the gap is visible.
+    ///
+    /// BUG: namespace packages resolved via the fallback tier are not flagged
+    /// (tracked separately); see PLAN.md "Namespace packages (scoped out)".
+    ///
+    /// This is a plain `#[test]` rather than a `testcase!`-with-`bug` marker:
+    /// `testcase!` embeds Python source and asserts *type-checking* diagnostics,
+    /// whereas this asserts a *module-resolution tier* property
+    /// (`find_import_filtered` provenance) that `testcase!` cannot express. The
+    /// `BUG:` line above documents the limitation in the same spirit.
+    #[test]
+    fn test_namespace_package_via_fallback_not_flagged() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        // `ns/` has NO `__init__.py`, so importing `ns` itself resolves it as a
+        // namespace package. Namespace packages are accumulated across tiers and
+        // materialized at the end of the cascade via `ModulePath::namespace(...)`
+        // with no per-tier provenance, so the implicit-relative caveat is absent.
+        TestPath::setup_test_directory(
+            root,
+            vec![TestPath::dir(
+                "src",
+                vec![
+                    TestPath::file("main.py"),
+                    TestPath::dir("ns", vec![TestPath::file("mod.py")]),
+                ],
+            )],
+        );
+        let config = fallback_config(vec![], None, false);
+        let origin = ModulePath::filesystem(root.join("src/main.py"));
+        let result = find_import_filtered(
+            &config,
+            ModuleName::from_str("ns"),
+            Some(&origin),
+            None,
+            &DirEntryCache::new(),
+            None,
+        );
+        match result {
+            FindingOrError::Finding(Finding { error, .. }) => {
+                assert!(
+                    !matches!(error, Some(FindError::ImplicitRelativeImport(..))),
+                    "namespace packages via fallback are not flagged today, but got: {error:?}"
+                );
+            }
+            FindingOrError::Error(e) => {
+                panic!("expected the namespace package to resolve, got error: {e:?}")
+            }
+        }
     }
 }

--- a/pyrefly/lib/state/loader.rs
+++ b/pyrefly/lib/state/loader.rs
@@ -45,6 +45,11 @@ pub enum FindError {
     UntypedImport(ModuleName, Arc<String>),
     /// This is the condition where we are using stubs but we do not have the source files
     MissingSourceForStubs(ModuleName),
+    /// The module resolved successfully, but only via the directory-upward fallback
+    /// search path (not through any configured absolute root). This is a non-fatal
+    /// caveat on a successful resolution: the module is still usable, but the import
+    /// is fragile (breaks when the importing file moves, can shadow installed packages).
+    ImplicitRelativeImport(ModuleName),
 }
 
 impl FindError {
@@ -123,6 +128,14 @@ impl FindError {
                 Some(Box::new(|| ErrorContext::ImportNotTyped(*source_package))),
                 vec1![format!("Hint: install the `{stubs_package}` package")],
             ),
+            Self::ImplicitRelativeImport(module) => (
+                None,
+                vec1![format!(
+                    "Module `{module}` was imported using an implicit relative import. \
+                    Prefer an explicit relative import (`from . import {module}`) or add the \
+                    module's root to the configured search path."
+                )],
+            ),
         }
     }
 
@@ -132,6 +145,7 @@ impl FindError {
             Self::MissingSource(..) => Some(ErrorKind::MissingSource),
             Self::MissingSourceForStubs(..) => Some(ErrorKind::MissingSourceForStubs),
             Self::UntypedImport(..) => Some(ErrorKind::UntypedImport),
+            Self::ImplicitRelativeImport(..) => Some(ErrorKind::ImplicitRelativeImport),
             Self::Ignored => None,
         }
     }
@@ -365,6 +379,8 @@ mod tests {
 
     use pyrefly_build::source_db::map_db::MapDatabase;
 
+    use crate::config::config::DirectoryRelativeFallbackSearchPathCache;
+
     use super::*;
 
     #[test]
@@ -412,6 +428,115 @@ mod tests {
             keys,
             vec![None],
             "missing shape_extensions should be cached once under the origin-independent key"
+        );
+    }
+
+    /// Precedence: when a successful resolution already carries a more specific
+    /// caveat (`UntypedImport`), attaching `ImplicitRelativeImport` afterwards
+    /// is a no-op. Both describe the same resolution, and `UntypedImport`
+    /// ("install stubs") is strictly more actionable. This is the contract the
+    /// fallback-tier attach in `find_import_internal` relies on: it calls
+    /// `with_error(ImplicitRelativeImport)` unconditionally, and this test pins
+    /// that an existing error is preserved rather than clobbered.
+    #[test]
+    fn test_with_error_implicit_relative_does_not_clobber_existing_caveat() {
+        let module = ModuleName::from_str("sibling");
+        let path = ModulePath::filesystem(PathBuf::from("src/sibling.py"));
+        // Simulate a fallback-tier hit whose resolution already lacks stubs.
+        let with_untyped = FindingOrError::Finding(Finding {
+            finding: path,
+            error: Some(FindError::UntypedImport(
+                module,
+                "types-sibling".to_owned().into(),
+            )),
+        });
+        let after_implicit = with_untyped.with_error(FindError::ImplicitRelativeImport(module));
+        match after_implicit {
+            FindingOrError::Finding(Finding {
+                error: Some(FindError::UntypedImport(..)),
+                ..
+            }) => {}
+            other => panic!("expected UntypedImport to be preserved, got: {other:?}"),
+        }
+        // And the reverse ordering invariant: a clean implicit-relative finding
+        // does get the caveat attached (the no-existing-error case).
+        let clean = FindingOrError::<ModulePath>::new_finding(ModulePath::filesystem(
+            PathBuf::from("src/sibling.py"),
+        ));
+        match clean.with_error(FindError::ImplicitRelativeImport(module)) {
+            FindingOrError::Finding(Finding {
+                error: Some(FindError::ImplicitRelativeImport(m)),
+                ..
+            }) => assert_eq!(m, module),
+            other => panic!("expected ImplicitRelativeImport to attach, got: {other:?}"),
+        }
+    }
+
+    /// Cache-safety: an origin-dependent implicit-relative resolution must be
+    /// cached under `(module, Some(origin))` and NEVER promoted to the
+    /// origin-independent `(module, None)` key. The `(module, None)` fast-path
+    /// (`find_import`, above) returns to ANY origin, so a promotion there would
+    /// leak the implicit-relative caveat to origins where the module actually
+    /// resolves through a configured absolute root.
+    ///
+    /// Today the promotion gate is `import.finding.is_bundled()` (typeshed-only,
+    /// `module_path.rs`), so a filesystem fallback hit is never promoted. This
+    /// test pins that invariant against a future widening of `is_bundled` (or a
+    /// new promotion path) that would reintroduce the leak.
+    #[test]
+    fn test_implicit_relative_resolution_not_promoted_to_origin_independent_key() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        // `src/main.py` imports `sibling`, which lives next to it and is on no
+        // configured search path — so it resolves only via the directory walk
+        // (fallback tier) and carries the implicit-relative caveat.
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/main.py"), "import sibling").unwrap();
+        std::fs::write(root.join("src/sibling.py"), "x: int = 1").unwrap();
+
+        let mut config = ConfigFile {
+            search_path_from_file: vec![],
+            fallback_search_path: FallbackSearchPath::DirectoryRelative(
+                DirectoryRelativeFallbackSearchPathCache::new(None),
+            ),
+            ..ConfigFile::default()
+        };
+        config.python_environment.set_empty_to_default();
+        config.configure();
+
+        let loader = LoaderFindCache::new(ArcId::new(config));
+        let module = ModuleName::from_str("sibling");
+        let origin = ModulePath::filesystem(root.join("src/main.py"));
+
+        // Resolve from `origin`. The fallback tier finds `src/sibling.py` and
+        // attaches the implicit-relative caveat.
+        let result = loader.find_import(module, Some(&origin), None);
+        assert!(
+            matches!(
+                result,
+                FindingOrError::Finding(Finding {
+                    error: Some(FindError::ImplicitRelativeImport(..)),
+                    ..
+                })
+            ),
+            "expected the fallback resolution to carry the caveat, got: {result:?}"
+        );
+
+        // The resolution must be cached under the origin-keyed entry, NOT the
+        // origin-independent `(module, None)` entry. The `(module, None)` key
+        // is the fast-path that any future origin would hit, so a promotion
+        // here would leak the caveat across origins.
+        let keys: Vec<Option<ModulePath>> = loader
+            .cache
+            .keys()
+            .filter(|(m, _)| *m == module)
+            .map(|(_, o)| o.dupe())
+            .collect();
+        assert_eq!(
+            keys,
+            vec![Some(origin.clone())],
+            "implicit-relative resolution must cache under (module, Some(origin)) only, \
+             never (module, None); got keys: {keys:?}"
         );
     }
 }

--- a/test/implicit_relative_import.md
+++ b/test/implicit_relative_import.md
@@ -1,0 +1,85 @@
+# Tests for the `implicit-relative-import` diagnostic
+
+These tests exercise the diagnostic end-to-end through `pyrefly check`. The
+diagnostic fires when an unqualified `import` resolves *only* via the
+directory-upward fallback search path, not through any configured absolute
+root. It defaults to `ignore`, so each surfacing test enables it explicitly.
+
+To force the fallback tier to be the resolver, each tree uses two sibling
+subdirectories (`a/` and `b/`). That makes pyrefly infer the project root
+(their common parent) as the import root, so a module living in `a/` is NOT
+covered by the inferred root and resolves only via the directory walk from
+the importing file in `a/`.
+
+## Fires when an import resolves only via the fallback path
+
+```scrut
+$ mkdir -p $TMPDIR/on_fallback/a $TMPDIR/on_fallback/b && \
+> printf 'enable-fallback-search-path = true\n[errors]\nimplicit-relative-import = "error"\n' > $TMPDIR/on_fallback/pyrefly.toml && \
+> echo "x: int = 1" > $TMPDIR/on_fallback/a/sibling.py && \
+> echo "import sibling" > $TMPDIR/on_fallback/a/main.py && \
+> echo "y: int = 2" > $TMPDIR/on_fallback/b/other.py && \
+> $PYREFLY check -c $TMPDIR/on_fallback/pyrefly.toml --output-format=min-text $TMPDIR/on_fallback/a/main.py
+*/a/main.py:1:8-15: Module `sibling` was imported using an implicit relative import. Prefer an explicit relative import (`from . import sibling`) or add the module's root to the configured search path. [implicit-relative-import] (glob)
+ INFO * (glob)
+[1]
+```
+
+## Does NOT fire when the module is on the configured search path
+
+When `sibling` is discoverable through a configured absolute root, the
+fallback tier never runs, so no caveat is attached (no false positive).
+
+```scrut
+$ mkdir -p $TMPDIR/on_search_path/a $TMPDIR/on_search_path/b && \
+> printf 'enable-fallback-search-path = true\nsearch_path = ["%s/on_search_path/a"]\n[errors]\nimplicit-relative-import = "error"\n' "$TMPDIR" > $TMPDIR/on_search_path/pyrefly.toml && \
+> echo "x: int = 1" > $TMPDIR/on_search_path/a/sibling.py && \
+> echo "import sibling" > $TMPDIR/on_search_path/a/main.py && \
+> echo "y: int = 2" > $TMPDIR/on_search_path/b/other.py && \
+> $PYREFLY check -c $TMPDIR/on_search_path/pyrefly.toml --output-format=min-text $TMPDIR/on_search_path/a/main.py
+ INFO * (glob)
+[0]
+```
+
+## Default severity is ignore (no output unless explicitly enabled)
+
+```scrut
+$ mkdir -p $TMPDIR/default_ignore/a $TMPDIR/default_ignore/b && \
+> printf 'enable-fallback-search-path = true\n' > $TMPDIR/default_ignore/pyrefly.toml && \
+> echo "x: int = 1" > $TMPDIR/default_ignore/a/sibling.py && \
+> echo "import sibling" > $TMPDIR/default_ignore/a/main.py && \
+> echo "y: int = 2" > $TMPDIR/default_ignore/b/other.py && \
+> $PYREFLY check -c $TMPDIR/default_ignore/pyrefly.toml --output-format=min-text $TMPDIR/default_ignore/a/main.py
+ INFO * (glob)
+[0]
+```
+
+## `[missing-import]` suppression does not silence `implicit-relative-import`
+
+The two kinds are independent (no `parent_kind`), so ignoring
+`missing-import` has no effect on `implicit-relative-import`.
+
+```scrut
+$ mkdir -p $TMPDIR/independent/a $TMPDIR/independent/b && \
+> printf 'enable-fallback-search-path = true\n[errors]\nimplicit-relative-import = "error"\n' > $TMPDIR/independent/pyrefly.toml && \
+> echo "x: int = 1" > $TMPDIR/independent/a/sibling.py && \
+> printf '# pyrefly: ignore[missing-import]\nimport sibling\n' > $TMPDIR/independent/a/main.py && \
+> echo "y: int = 2" > $TMPDIR/independent/b/other.py && \
+> $PYREFLY check -c $TMPDIR/independent/pyrefly.toml --output-format=min-text $TMPDIR/independent/a/main.py
+*/a/main.py:2:8-15: Module `sibling` was imported using an implicit relative import. Prefer an explicit relative import (`from . import sibling`) or add the module's root to the configured search path. [implicit-relative-import] (glob)
+ INFO * (glob)
+[1]
+```
+
+## `[implicit-relative-import]` suppression does silence it
+
+```scrut
+$ mkdir -p $TMPDIR/suppressed/a $TMPDIR/suppressed/b && \
+> printf 'enable-fallback-search-path = true\n[errors]\nimplicit-relative-import = "error"\n' > $TMPDIR/suppressed/pyrefly.toml && \
+> echo "x: int = 1" > $TMPDIR/suppressed/a/sibling.py && \
+> printf '# pyrefly: ignore[implicit-relative-import]\nimport sibling\n' > $TMPDIR/suppressed/a/main.py && \
+> echo "y: int = 2" > $TMPDIR/suppressed/b/other.py && \
+> $PYREFLY check -c $TMPDIR/suppressed/pyrefly.toml --output-format=min-text $TMPDIR/suppressed/a/main.py
+ INFO * (glob)
+[0]
+```

--- a/test/implicit_relative_import.md
+++ b/test/implicit_relative_import.md
@@ -11,6 +11,11 @@ subdirectories (`a/` and `b/`). That makes pyrefly infer the project root
 covered by the inferred root and resolves only via the directory walk from
 the importing file in `a/`.
 
+Note on streams: with `--output-format=min-text`, diagnostic lines are written
+to **stdout** while the ` INFO N errors` summary is written to **stderr**.
+So the "fires" cases capture stdout (the diagnostic), and the clean cases
+capture stderr (the summary).
+
 ## Fires when an import resolves only via the fallback path
 
 ```scrut
@@ -21,7 +26,6 @@ $ mkdir -p $TMPDIR/on_fallback/a $TMPDIR/on_fallback/b && \
 > echo "y: int = 2" > $TMPDIR/on_fallback/b/other.py && \
 > $PYREFLY check -c $TMPDIR/on_fallback/pyrefly.toml --output-format=min-text $TMPDIR/on_fallback/a/main.py
 */a/main.py:1:8-15: Module `sibling` was imported using an implicit relative import. Prefer an explicit relative import (`from . import sibling`) or add the module's root to the configured search path. [implicit-relative-import] (glob)
- INFO * (glob)
 [1]
 ```
 
@@ -30,27 +34,27 @@ $ mkdir -p $TMPDIR/on_fallback/a $TMPDIR/on_fallback/b && \
 When `sibling` is discoverable through a configured absolute root, the
 fallback tier never runs, so no caveat is attached (no false positive).
 
-```scrut
+```scrut {output_stream: stderr}
 $ mkdir -p $TMPDIR/on_search_path/a $TMPDIR/on_search_path/b && \
 > printf 'enable-fallback-search-path = true\nsearch_path = ["%s/on_search_path/a"]\n[errors]\nimplicit-relative-import = "error"\n' "$TMPDIR" > $TMPDIR/on_search_path/pyrefly.toml && \
 > echo "x: int = 1" > $TMPDIR/on_search_path/a/sibling.py && \
 > echo "import sibling" > $TMPDIR/on_search_path/a/main.py && \
 > echo "y: int = 2" > $TMPDIR/on_search_path/b/other.py && \
 > $PYREFLY check -c $TMPDIR/on_search_path/pyrefly.toml --output-format=min-text $TMPDIR/on_search_path/a/main.py
- INFO * (glob)
+ INFO 0 errors
 [0]
 ```
 
 ## Default severity is ignore (no output unless explicitly enabled)
 
-```scrut
+```scrut {output_stream: stderr}
 $ mkdir -p $TMPDIR/default_ignore/a $TMPDIR/default_ignore/b && \
 > printf 'enable-fallback-search-path = true\n' > $TMPDIR/default_ignore/pyrefly.toml && \
 > echo "x: int = 1" > $TMPDIR/default_ignore/a/sibling.py && \
 > echo "import sibling" > $TMPDIR/default_ignore/a/main.py && \
 > echo "y: int = 2" > $TMPDIR/default_ignore/b/other.py && \
 > $PYREFLY check -c $TMPDIR/default_ignore/pyrefly.toml --output-format=min-text $TMPDIR/default_ignore/a/main.py
- INFO * (glob)
+ INFO 0 errors
 [0]
 ```
 
@@ -67,19 +71,18 @@ $ mkdir -p $TMPDIR/independent/a $TMPDIR/independent/b && \
 > echo "y: int = 2" > $TMPDIR/independent/b/other.py && \
 > $PYREFLY check -c $TMPDIR/independent/pyrefly.toml --output-format=min-text $TMPDIR/independent/a/main.py
 */a/main.py:2:8-15: Module `sibling` was imported using an implicit relative import. Prefer an explicit relative import (`from . import sibling`) or add the module's root to the configured search path. [implicit-relative-import] (glob)
- INFO * (glob)
 [1]
 ```
 
 ## `[implicit-relative-import]` suppression does silence it
 
-```scrut
+```scrut {output_stream: stderr}
 $ mkdir -p $TMPDIR/suppressed/a $TMPDIR/suppressed/b && \
 > printf 'enable-fallback-search-path = true\n[errors]\nimplicit-relative-import = "error"\n' > $TMPDIR/suppressed/pyrefly.toml && \
 > echo "x: int = 1" > $TMPDIR/suppressed/a/sibling.py && \
 > printf '# pyrefly: ignore[implicit-relative-import]\nimport sibling\n' > $TMPDIR/suppressed/a/main.py && \
 > echo "y: int = 2" > $TMPDIR/suppressed/b/other.py && \
 > $PYREFLY check -c $TMPDIR/suppressed/pyrefly.toml --output-format=min-text $TMPDIR/suppressed/a/main.py
- INFO * (glob)
+ INFO 0 errors (1 suppressed)
 [0]
 ```

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -704,6 +704,36 @@ from bar import a  # error: `a` is not exported from module `bar`
 from foo import a as a  # or add `a` to `__all__`
 ```
 
+## implicit-relative-import
+
+Default severity: `ignore`
+
+This error is emitted when an unqualified `import` resolves only via the
+directory-upward fallback search path (walking the importing file's directory
+ancestors toward the configured execution root), and not through any configured
+absolute root. Such imports are fragile: they break when the importing file
+moves to another directory, and they can unexpectedly shadow installed packages
+of the same name.
+
+Pyrefly only reports this when the module is found *exclusively* through the
+fallback path. If the module is also discoverable through a configured search
+path root, no error is reported.
+
+```python
+# src/main.py
+import sibling  # error: `sibling` resolved only via the implicit directory walk
+
+# Fix option 1 — use an explicit relative import:
+from . import sibling
+
+# Fix option 2 — add `src/` to the configured search path
+# (so `sibling` resolves through a configured absolute root).
+```
+
+Suppress with `# pyrefly: ignore [implicit-relative-import]`. Note that
+suppressing `missing-import` does **not** suppress this kind — the two are
+independently configurable.
+
 ## implicitly-defined-attribute
 
 Default severity: `ignore`


### PR DESCRIPTION
Fixes #4174

## Summary

Adds a first-class `implicit-relative-import` diagnostic that fires when an unqualified `import` resolves *only* via the directory-upward fallback search path, not through any configured absolute root. Such imports are fragile (they break when the importing file moves and can unexpectedly shadow installed packages).

Today `reportImplicitRelativeImport` from pyright configs collapses onto the generic `missing-import` kind, giving users no way to tune implicit-relative imports apart from genuine missing imports. This PR gives the condition its own independently configurable kind.

## Approach

- New `ErrorKind::ImplicitRelativeImport` (default `Severity::Ignore`), inserted in its lexicographically-correct slot, with its own `default_severity` arm and **no `parent_kind`** — so `[missing-import]` suppression does not silence it.
- New `FindError::ImplicitRelativeImport(module)` threaded via the existing non-fatal-error channel (`Finding.error` through `with_error`) — the same idiom already used for `UntypedImport`/`MissingSource`. The emitter already reads this channel, so there is zero new plumbing through loader/bindings/solver.
- The attach lives **entirely inside** the `!disable_search_path_heuristics` fallback arm of `find_import_internal`, so earlier (absolute) tiers and the disabled-heuristics case never flag. The `with_error` no-op-when-set guard means an existing `UntypedImport` caveat correctly takes precedence.
- Retargets the pyright migration: `reportImplicitRelativeImport` → `ImplicitRelativeImport`; `reportMissingImports` stays on `missing-import`.
- Documents the kind in `website/docs/error-kinds.mdx`.

## Out of scope (known limitation)

Namespace packages resolved via the fallback tier are **not** flagged by this PR. Threading provenance through the cross-tier namespace accumulator (which merges namespaces from all tiers) is a larger change with disproportionate blast radius for an initial PR. A `bug`-marked test documents this limitation so the gap is visible and trackable for a follow-up.

## Cache safety

The implicit-relative signal is origin-dependent. It is safe to attach via the non-fatal channel because fallback-tier hits are filesystem paths (never bundled typeshed variants), so `is_bundled()` is `false` and they are never promoted to the origin-independent `(module, None)` cache entry. This invariant is documented in a code comment at the attach site and pinned by a cache-safety test.

## Testing

- **Inline Rust**: finder tests for I1 (no false positive when search path resolves), I2/I4 (caveat attached on fallback resolution, deterministic), I3 (no flag when heuristics disabled), precedence (UntypedImport wins), namespace `bug` test (scoped-out limitation); loader tests for the `with_error` precedence contract and cache-safety (no promotion to origin-independent key); config test for the pyright migration mapping.
- **Scrut e2e** (`test/implicit_relative_import.md`): surfacing, no-false-positive when on search path, default-ignore, independent suppression (`[missing-import]` does not silence; `[implicit-relative-import]` does).
- `test_doc_headers` / `test_doc_severities` pass (mdx parity).

All new tests pass; `./test.py` format + lint introduces no new lint errors.