### PR TITLE
fix part of Autocompletion for Polars/Pandas Data Frame Column names in function calls #2139

### DIFF
--- a/pyrefly/lib/alt/polars_specials.rs
+++ b/pyrefly/lib/alt/polars_specials.rs
@@ -56,6 +56,14 @@ pub fn is_pandas_dataframe(cls: &Class) -> bool {
     cls.has_toplevel_qname("pandas.core.frame", "DataFrame")
 }
 
+/// DataFrame methods whose arguments may refer to existing columns.
+pub fn is_dataframe_column_method(method: &str) -> bool {
+    matches!(
+        method,
+        "select" | "drop" | "with_columns" | "filter" | "sort" | "group_by" | "groupby"
+    )
+}
+
 /// Whether a `select`/`drop` string is a `pl.col` selector (`"*"` or `"^regex$"`) rather than an
 /// exact column name.
 fn is_polars_selector_string(arg: &Expr) -> bool {

--- a/pyrefly/lib/state/lsp/dict_completions.rs
+++ b/pyrefly/lib/state/lsp/dict_completions.rs
@@ -38,9 +38,8 @@ enum DictKeyLiteralContext {
         base_expr: Expr,
         literal: ExprStringLiteral,
     },
-    /// A string literal in a call argument whose completions should come from
-    /// surrounding container expressions.
-    /// Examples: `lookup(data, "na|")`, `df.select(col("na|"))`.
+    /// A string literal in a call containing a DataFrame expression.
+    /// Examples: `df.select("na|")`, `df.select(col("na|"))`.
     CallArgument {
         source_exprs: Vec<Expr>,
         literal: ExprStringLiteral,
@@ -85,10 +84,23 @@ impl<'a> Transaction<'a> {
         }
     }
 
+    fn type_contains_dataframe(ty: &Type) -> bool {
+        match ty {
+            Type::DataFrame(_) => true,
+            Type::Union(u) => u.members.iter().any(Self::type_contains_dataframe),
+            _ => false,
+        }
+    }
+
     fn expr_has_typed_dict_type(&self, handle: &Handle, expr: &Expr) -> bool {
         self.get_type_trace(handle, expr.range())
             .map(|ty| Self::type_contains_typed_dict(&ty))
             .unwrap_or(false)
+    }
+
+    fn expr_has_dataframe_type(&self, handle: &Handle, expr: &Expr) -> bool {
+        self.get_type_trace(handle, expr.range())
+            .is_some_and(|ty| Self::type_contains_dataframe(&ty))
     }
 
     /// Extracts typed dict access from `.get()` method calls.
@@ -201,7 +213,7 @@ impl<'a> Transaction<'a> {
         {
             Some(DictKeyLiteralContext::DictLiteral { dict, literal })
         } else if let Some((source_exprs, literal)) =
-            Self::call_argument_string_literal_at(module, position)
+            self.dataframe_call_argument_string_literal_at(handle, module, position)
         {
             Some(DictKeyLiteralContext::CallArgument {
                 source_exprs,
@@ -213,7 +225,9 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    fn call_argument_string_literal_at(
+    fn dataframe_call_argument_string_literal_at(
+        &self,
+        handle: &Handle,
         module: &ModModule,
         position: TextSize,
     ) -> Option<(Vec<Expr>, ExprStringLiteral)> {
@@ -244,6 +258,7 @@ impl<'a> Transaction<'a> {
             };
 
             if let Expr::Attribute(attr) = call.func.as_ref()
+                && self.expr_has_dataframe_type(handle, attr.value.as_ref())
                 && !source_exprs
                     .iter()
                     .any(|existing: &Expr| existing.range() == attr.value.range())
@@ -251,9 +266,10 @@ impl<'a> Transaction<'a> {
                 source_exprs.push(attr.value.as_ref().clone());
             }
             for expr in call.arguments.args.iter().take(positional_count) {
-                if !source_exprs
-                    .iter()
-                    .any(|existing| existing.range() == expr.range())
+                if self.expr_has_dataframe_type(handle, expr)
+                    && !source_exprs
+                        .iter()
+                        .any(|existing| existing.range() == expr.range())
                 {
                     source_exprs.push(expr.clone());
                 }
@@ -342,12 +358,12 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    fn collect_typed_dict_keys(
+    fn collect_container_keys(
         &self,
         handle: &Handle,
         base_type: Type,
     ) -> Option<BTreeMap<String, Type>> {
-        self.ad_hoc_solve(handle, "typed_dict_keys", |solver| {
+        self.ad_hoc_solve(handle, "container_keys", |solver| {
             let mut map = BTreeMap::new();
             let mut stack = vec![base_type];
             while let Some(ty) = stack.pop() {
@@ -356,6 +372,11 @@ impl<'a> Transaction<'a> {
                         for (name, field) in solver.type_order().typed_dict_fields(&td) {
                             map.entry(name.to_string())
                                 .or_insert_with(|| field.ty.clone());
+                        }
+                    }
+                    Type::DataFrame(schema) => {
+                        for (name, ty) in schema.columns {
+                            map.entry(name.to_string()).or_insert(ty);
                         }
                     }
                     Type::Union(u) => {
@@ -441,7 +462,7 @@ impl<'a> Transaction<'a> {
     }
 
     /// Adds known string keys for a dict-like base: explicit keys recorded as facets
-    /// on the base's binding, plus TypedDict fields from the base's type.
+    /// on the base's binding, plus TypedDict fields or DataFrame columns from its type.
     fn extend_dict_key_suggestions(
         &self,
         handle: &Handle,
@@ -493,7 +514,7 @@ impl<'a> Transaction<'a> {
         // For key access we query the container expression; for literals we query the
         // literal itself to pick up contextual TypedDict typing from assignments.
         if let Some(base_type) = self.get_type_trace(handle, base_range)
-            && let Some(typed_keys) = self.collect_typed_dict_keys(handle, base_type)
+            && let Some(typed_keys) = self.collect_container_keys(handle, base_type)
         {
             for (key, ty) in typed_keys {
                 let entry = suggestions.entry(key).or_insert(None);

--- a/pyrefly/lib/state/lsp/dict_completions.rs
+++ b/pyrefly/lib/state/lsp/dict_completions.rs
@@ -38,6 +38,13 @@ enum DictKeyLiteralContext {
         base_expr: Expr,
         literal: ExprStringLiteral,
     },
+    /// A string literal in a call argument whose completions should come from
+    /// surrounding container expressions.
+    /// Examples: `lookup(data, "na|")`, `df.select(col("na|"))`.
+    CallArgument {
+        source_exprs: Vec<Expr>,
+        literal: ExprStringLiteral,
+    },
     /// A key literal inside a dict literal being constructed.
     /// Example: `{"na|": 1}`.
     DictLiteral {
@@ -55,31 +62,10 @@ impl DictKeyLiteralContext {
     /// `None` for `BareSubscript`, where there is no string to bound the cursor to.
     fn literal_range(&self) -> Option<TextRange> {
         match self {
-            Self::KeyAccess { literal, .. } | Self::DictLiteral { literal, .. } => {
-                Some(literal.range())
-            }
+            Self::KeyAccess { literal, .. }
+            | Self::CallArgument { literal, .. }
+            | Self::DictLiteral { literal, .. } => Some(literal.range()),
             Self::BareSubscript { .. } => None,
-        }
-    }
-
-    fn base_range(&self) -> TextRange {
-        // For key access, we want the container expression's type.
-        // For dict literals, we want the literal's contextual type (e.g. a TypedDict in
-        // `cfg: Config = {"na|": 1}`), which is attached to the literal's range.
-        match self {
-            Self::KeyAccess { base_expr, .. } | Self::BareSubscript { base_expr } => {
-                base_expr.range()
-            }
-            Self::DictLiteral { dict, .. } => dict.range(),
-        }
-    }
-
-    fn base_expr(&self) -> Option<&Expr> {
-        match self {
-            Self::KeyAccess { base_expr, .. } | Self::BareSubscript { base_expr } => {
-                Some(base_expr)
-            }
-            Self::DictLiteral { .. } => None,
         }
     }
 
@@ -205,8 +191,8 @@ impl<'a> Transaction<'a> {
         position: TextSize,
     ) -> Option<DictKeyLiteralContext> {
         // Prefer direct key access (`d["k"]` / `d.get("k")`) so we can reuse the base
-        // expression for facet-based completions, then dict literal keys, and finally
-        // an empty subscript slot (`d[|]`) with no key string typed yet.
+        // expression for facet-based completions, then dict literal keys, surrounding
+        // calls, and finally an empty subscript slot (`d[|]`) with no key string typed yet.
         if let Some((base_expr, literal)) =
             self.dict_key_string_literal_at(handle, module, position)
         {
@@ -214,10 +200,67 @@ impl<'a> Transaction<'a> {
         } else if let Some((dict, literal)) = Self::dict_literal_string_literal_at(module, position)
         {
             Some(DictKeyLiteralContext::DictLiteral { dict, literal })
+        } else if let Some((source_exprs, literal)) =
+            Self::call_argument_string_literal_at(module, position)
+        {
+            Some(DictKeyLiteralContext::CallArgument {
+                source_exprs,
+                literal,
+            })
         } else {
             Self::bare_subscript_base_at(module, position)
                 .map(|base_expr| DictKeyLiteralContext::BareSubscript { base_expr })
         }
+    }
+
+    fn call_argument_string_literal_at(
+        module: &ModModule,
+        position: TextSize,
+    ) -> Option<(Vec<Expr>, ExprStringLiteral)> {
+        let nodes = Ast::locate_node(module, position);
+        let literal = nodes.iter().find_map(|node| match node {
+            AnyNodeRef::ExprStringLiteral(literal) => Some((*literal).clone()),
+            _ => None,
+        })?;
+        let literal_range = literal.range();
+        let mut source_exprs = Vec::new();
+
+        for node in nodes {
+            let AnyNodeRef::ExprCall(call) = node else {
+                continue;
+            };
+            let positional_count = if let Some(idx) = call.arguments.args.iter().position(|arg| {
+                arg.range().start() <= literal_range.start()
+                    && literal_range.end() <= arg.range().end()
+            }) {
+                idx
+            } else if call.arguments.keywords.iter().any(|kw| {
+                kw.value.range().start() <= literal_range.start()
+                    && literal_range.end() <= kw.value.range().end()
+            }) {
+                call.arguments.args.len()
+            } else {
+                continue;
+            };
+
+            if let Expr::Attribute(attr) = call.func.as_ref()
+                && !source_exprs
+                    .iter()
+                    .any(|existing: &Expr| existing.range() == attr.value.range())
+            {
+                source_exprs.push(attr.value.as_ref().clone());
+            }
+            for expr in call.arguments.args.iter().take(positional_count) {
+                if !source_exprs
+                    .iter()
+                    .any(|existing| existing.range() == expr.range())
+                {
+                    source_exprs.push(expr.clone());
+                }
+            }
+        }
+
+        (!source_exprs.is_empty()).then_some((source_exprs, literal))
     }
 
     fn dict_literal_string_literal_at(
@@ -353,8 +396,30 @@ impl<'a> Transaction<'a> {
                 return false;
             }
         }
-        let suggestions =
-            self.dict_key_suggestions(handle, context.base_expr(), context.base_range());
+        let mut suggestions = BTreeMap::new();
+        match &context {
+            DictKeyLiteralContext::KeyAccess { base_expr, .. }
+            | DictKeyLiteralContext::BareSubscript { base_expr } => self
+                .extend_dict_key_suggestions(
+                    handle,
+                    Some(base_expr),
+                    base_expr.range(),
+                    &mut suggestions,
+                ),
+            DictKeyLiteralContext::CallArgument { source_exprs, .. } => {
+                for expr in source_exprs {
+                    self.extend_dict_key_suggestions(
+                        handle,
+                        Some(expr),
+                        expr.range(),
+                        &mut suggestions,
+                    );
+                }
+            }
+            DictKeyLiteralContext::DictLiteral { dict, .. } => {
+                self.extend_dict_key_suggestions(handle, None, dict.range(), &mut suggestions)
+            }
+        }
         if suggestions.is_empty() {
             return false;
         }
@@ -375,16 +440,15 @@ impl<'a> Transaction<'a> {
         None
     }
 
-    /// Collects the known string keys for a dict-like base: explicit keys recorded as
-    /// facets on the base's binding, plus TypedDict fields from the base's type.
-    fn dict_key_suggestions(
+    /// Adds known string keys for a dict-like base: explicit keys recorded as facets
+    /// on the base's binding, plus TypedDict fields from the base's type.
+    fn extend_dict_key_suggestions(
         &self,
         handle: &Handle,
         base_expr: Option<&Expr>,
         base_range: TextRange,
-    ) -> BTreeMap<String, Option<Type>> {
-        let mut suggestions: BTreeMap<String, Option<Type>> = BTreeMap::new();
-
+        suggestions: &mut BTreeMap<String, Option<Type>>,
+    ) {
         if let Some(base_expr) = base_expr
             && let Some(bindings) = self.get_bindings(handle)
         {
@@ -438,8 +502,6 @@ impl<'a> Transaction<'a> {
                 }
             }
         }
-
-        suggestions
     }
 
     fn push_dict_key_completions(

--- a/pyrefly/lib/state/lsp/dict_completions.rs
+++ b/pyrefly/lib/state/lsp/dict_completions.rs
@@ -6,6 +6,7 @@
  */
 
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 
 use lsp_types::CompletionItem;
 use lsp_types::CompletionItemKind;
@@ -24,6 +25,7 @@ use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
 
+use crate::alt::polars_specials::is_dataframe_column_method;
 use crate::binding::binding::Key;
 use crate::binding::narrow::int_from_slice;
 use crate::lsp::wasm::completion::RankedCompletion;
@@ -41,7 +43,7 @@ enum DictKeyLiteralContext {
     /// A string literal in a call containing a DataFrame expression.
     /// Examples: `df.select("na|")`, `df.select(col("na|"))`.
     CallArgument {
-        source_exprs: Vec<Expr>,
+        source_expr: Expr,
         literal: ExprStringLiteral,
     },
     /// A key literal inside a dict literal being constructed.
@@ -84,10 +86,16 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    fn type_contains_dataframe(ty: &Type) -> bool {
+    fn type_is_dataframe(ty: &Type) -> bool {
         match ty {
             Type::DataFrame(_) => true,
-            Type::Union(u) => u.members.iter().any(Self::type_contains_dataframe),
+            Type::Union(u) => {
+                let (first, rest) = u
+                    .members
+                    .split_first()
+                    .expect("a union must contain at least one member");
+                Self::type_is_dataframe(first) && rest.iter().all(Self::type_is_dataframe)
+            }
             _ => false,
         }
     }
@@ -100,7 +108,7 @@ impl<'a> Transaction<'a> {
 
     fn expr_has_dataframe_type(&self, handle: &Handle, expr: &Expr) -> bool {
         self.get_type_trace(handle, expr.range())
-            .is_some_and(|ty| Self::type_contains_dataframe(&ty))
+            .is_some_and(|ty| Self::type_is_dataframe(&ty))
     }
 
     /// Extracts typed dict access from `.get()` method calls.
@@ -212,11 +220,11 @@ impl<'a> Transaction<'a> {
         } else if let Some((dict, literal)) = Self::dict_literal_string_literal_at(module, position)
         {
             Some(DictKeyLiteralContext::DictLiteral { dict, literal })
-        } else if let Some((source_exprs, literal)) =
+        } else if let Some((source_expr, literal)) =
             self.dataframe_call_argument_string_literal_at(handle, module, position)
         {
             Some(DictKeyLiteralContext::CallArgument {
-                source_exprs,
+                source_expr,
                 literal,
             })
         } else {
@@ -230,53 +238,42 @@ impl<'a> Transaction<'a> {
         handle: &Handle,
         module: &ModModule,
         position: TextSize,
-    ) -> Option<(Vec<Expr>, ExprStringLiteral)> {
+    ) -> Option<(Expr, ExprStringLiteral)> {
         let nodes = Ast::locate_node(module, position);
         let literal = nodes.iter().find_map(|node| match node {
             AnyNodeRef::ExprStringLiteral(literal) => Some((*literal).clone()),
             _ => None,
         })?;
         let literal_range = literal.range();
-        let mut source_exprs = Vec::new();
+        let mut best: Option<(TextSize, Expr)> = None;
 
         for node in nodes {
             let AnyNodeRef::ExprCall(call) = node else {
                 continue;
             };
-            let positional_count = if let Some(idx) = call.arguments.args.iter().position(|arg| {
-                arg.range().start() <= literal_range.start()
-                    && literal_range.end() <= arg.range().end()
-            }) {
-                idx
-            } else if call.arguments.keywords.iter().any(|kw| {
-                kw.value.range().start() <= literal_range.start()
-                    && literal_range.end() <= kw.value.range().end()
-            }) {
-                call.arguments.args.len()
-            } else {
+            if !(call.range().start() <= literal_range.start()
+                && literal_range.end() <= call.range().end())
+            {
+                continue;
+            }
+            let Expr::Attribute(attr) = call.func.as_ref() else {
                 continue;
             };
-
-            if let Expr::Attribute(attr) = call.func.as_ref()
-                && self.expr_has_dataframe_type(handle, attr.value.as_ref())
-                && !source_exprs
-                    .iter()
-                    .any(|existing: &Expr| existing.range() == attr.value.range())
+            if !is_dataframe_column_method(attr.attr.id.as_str())
+                || !self.expr_has_dataframe_type(handle, attr.value.as_ref())
             {
-                source_exprs.push(attr.value.as_ref().clone());
+                continue;
             }
-            for expr in call.arguments.args.iter().take(positional_count) {
-                if self.expr_has_dataframe_type(handle, expr)
-                    && !source_exprs
-                        .iter()
-                        .any(|existing| existing.range() == expr.range())
-                {
-                    source_exprs.push(expr.clone());
-                }
+            let call_len = call.range().len();
+            if best
+                .as_ref()
+                .is_none_or(|(best_len, _)| call_len < *best_len)
+            {
+                best = Some((call_len, attr.value.as_ref().clone()));
             }
         }
 
-        (!source_exprs.is_empty()).then_some((source_exprs, literal))
+        best.map(|(_, source_expr)| (source_expr, literal))
     }
 
     fn dict_literal_string_literal_at(
@@ -358,12 +355,12 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    fn collect_container_keys(
+    fn collect_typed_dict_keys(
         &self,
         handle: &Handle,
         base_type: Type,
     ) -> Option<BTreeMap<String, Type>> {
-        self.ad_hoc_solve(handle, "container_keys", |solver| {
+        self.ad_hoc_solve(handle, "typed_dict_keys", |solver| {
             let mut map = BTreeMap::new();
             let mut stack = vec![base_type];
             while let Some(ty) = stack.pop() {
@@ -374,11 +371,6 @@ impl<'a> Transaction<'a> {
                                 .or_insert_with(|| field.ty.clone());
                         }
                     }
-                    Type::DataFrame(schema) => {
-                        for (name, ty) in schema.columns {
-                            map.entry(name.to_string()).or_insert(ty);
-                        }
-                    }
                     Type::Union(u) => {
                         stack.extend(u.members);
                     }
@@ -387,6 +379,31 @@ impl<'a> Transaction<'a> {
             }
             map
         })
+    }
+
+    fn collect_dataframe_columns(ty: &Type) -> Option<BTreeSet<String>> {
+        match ty {
+            Type::DataFrame(schema) => Some(
+                schema
+                    .columns
+                    .iter()
+                    .map(|(name, _)| name.to_string())
+                    .collect(),
+            ),
+            Type::Union(u) => {
+                let (first, rest) = u
+                    .members
+                    .split_first()
+                    .expect("a union must contain at least one member");
+                let mut columns = Self::collect_dataframe_columns(first)?;
+                for member in rest {
+                    let member_columns = Self::collect_dataframe_columns(member)?;
+                    columns.retain(|name| member_columns.contains(name));
+                }
+                Some(columns)
+            }
+            _ => None,
+        }
     }
 
     /// Adds dict key completions for the given position. Handles a key string being
@@ -427,16 +444,13 @@ impl<'a> Transaction<'a> {
                     base_expr.range(),
                     &mut suggestions,
                 ),
-            DictKeyLiteralContext::CallArgument { source_exprs, .. } => {
-                for expr in source_exprs {
-                    self.extend_dict_key_suggestions(
-                        handle,
-                        Some(expr),
-                        expr.range(),
-                        &mut suggestions,
-                    );
-                }
-            }
+            DictKeyLiteralContext::CallArgument { source_expr, .. } => self
+                .extend_dict_key_suggestions(
+                    handle,
+                    Some(source_expr),
+                    source_expr.range(),
+                    &mut suggestions,
+                ),
             DictKeyLiteralContext::DictLiteral { dict, .. } => {
                 self.extend_dict_key_suggestions(handle, None, dict.range(), &mut suggestions)
             }
@@ -461,8 +475,8 @@ impl<'a> Transaction<'a> {
         None
     }
 
-    /// Adds known string keys for a dict-like base: explicit keys recorded as facets
-    /// on the base's binding, plus TypedDict fields or DataFrame columns from its type.
+    /// Adds known string keys for a dict-like base: explicit keys recorded as facets,
+    /// TypedDict fields, and DataFrame columns that are safe across every union member.
     fn extend_dict_key_suggestions(
         &self,
         handle: &Handle,
@@ -513,13 +527,18 @@ impl<'a> Transaction<'a> {
 
         // For key access we query the container expression; for literals we query the
         // literal itself to pick up contextual TypedDict typing from assignments.
-        if let Some(base_type) = self.get_type_trace(handle, base_range)
-            && let Some(typed_keys) = self.collect_container_keys(handle, base_type)
-        {
-            for (key, ty) in typed_keys {
-                let entry = suggestions.entry(key).or_insert(None);
-                if entry.is_none() {
-                    *entry = Some(ty);
+        if let Some(base_type) = self.get_type_trace(handle, base_range) {
+            if let Some(typed_keys) = self.collect_typed_dict_keys(handle, base_type.clone()) {
+                for (key, ty) in typed_keys {
+                    let entry = suggestions.entry(key).or_insert(None);
+                    if entry.is_none() {
+                        *entry = Some(ty);
+                    }
+                }
+            }
+            if let Some(columns) = Self::collect_dataframe_columns(&base_type) {
+                for column in columns {
+                    suggestions.entry(column).or_insert(None);
                 }
             }
         }

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -148,6 +148,54 @@ fn dict_field_labels(txn: &Transaction<'_>, handle: &Handle, position: TextSize)
         .collect()
 }
 
+fn polars_column_completion_labels(code: &str) -> Vec<String> {
+    let mut env = TestEnv::new();
+    env.add_with_path(
+        "polars.dataframe.frame",
+        "polars/dataframe/frame.pyi",
+        r#"
+class DataFrame:
+    def __init__(self, data: object = None) -> None: ...
+    def select(self, *exprs: object) -> "DataFrame": ...
+"#,
+    );
+    env.add(
+        "polars",
+        r#"
+from polars.dataframe.frame import DataFrame as DataFrame
+class Expr: ...
+def col(name: str) -> Expr: ...
+"#,
+    );
+    env.add("main", code);
+    let (state, handle_for) = env.to_state();
+    let handle = handle_for("main");
+    let position = extract_cursors_for_test(code)[0];
+    dict_field_labels(&state.transaction(), &handle, position)
+}
+
+fn pandas_column_completion_labels(code: &str) -> Vec<String> {
+    let mut env = TestEnv::new();
+    env.add_with_path(
+        "pandas.core.frame",
+        "pandas/core/frame.pyi",
+        r#"
+class DataFrame:
+    def __init__(self, data: object = None) -> None: ...
+    def groupby(self, by: object) -> object: ...
+"#,
+    );
+    env.add(
+        "pandas",
+        "from pandas.core.frame import DataFrame as DataFrame",
+    );
+    env.add("main", code);
+    let (state, handle_for) = env.to_state();
+    let handle = handle_for("main");
+    let position = extract_cursors_for_test(code)[0];
+    dict_field_labels(&state.transaction(), &handle, position)
+}
+
 #[test]
 fn dot_complete_basic_test() {
     let code = r#"
@@ -354,55 +402,62 @@ cfg: Config = {"": 1}
 }
 
 #[test]
-fn dict_key_completion_from_prior_call_argument() {
+fn dataframe_column_completion_from_method_argument() {
     let code = r#"
-def lookup(data: dict[str, int], key: str) -> int:
-    return data[key]
-
-payload = {"foo": 1, "bar": 2}
-lookup(payload, "")
-#                ^
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+df.select("")
+#          ^
 "#;
-    let report =
-        get_batched_lsp_operations_report_allow_error(&[("main", code)], get_default_test_report());
-    let report = strip_ansi(&report);
-    assert!(
-        report.contains(
-            r#"
-Completion Results:
-- (Field) bar: Literal[2]
-- (Field) foo: Literal[1]
-"#
-            .trim()
-        ),
-        "{report}"
+    assert_eq!(
+        polars_column_completion_labels(code),
+        vec!["bar".to_owned(), "foo".to_owned()]
     );
 }
 
 #[test]
-fn dict_key_completion_from_enclosing_call_argument() {
+fn dataframe_column_completion_from_nested_call_argument() {
+    let code = r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+df.select(pl.col(""))
+#                 ^
+"#;
+    assert_eq!(
+        polars_column_completion_labels(code),
+        vec!["bar".to_owned(), "foo".to_owned()]
+    );
+}
+
+#[test]
+fn pandas_column_completion_from_method_argument() {
+    let code = r#"
+import pandas as pd
+df = pd.DataFrame({"foo": [1], "bar": [2]})
+df.groupby("")
+#           ^
+"#;
+    assert_eq!(
+        pandas_column_completion_labels(code),
+        vec!["bar".to_owned(), "foo".to_owned()]
+    );
+}
+
+#[test]
+fn no_column_completion_from_unrelated_call_argument() {
     let code = r#"
 def select(data: dict[str, int], expr: object) -> None: ...
-def col(name: str) -> str:
-    return name
+def col(name: str) -> str: ...
 
 payload = {"foo": 1, "bar": 2}
 select(payload, col(""))
 #                   ^
 "#;
-    let report =
-        get_batched_lsp_operations_report_allow_error(&[("main", code)], get_default_test_report());
-    let report = strip_ansi(&report);
-    assert!(
-        report.contains(
-            r#"
-Completion Results:
-- (Field) bar: Literal[2]
-- (Field) foo: Literal[1]
-"#
-            .trim()
-        ),
-        "{report}"
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, false);
+    let position = extract_cursors_for_test(code)[0];
+    assert_eq!(
+        dict_field_labels(&state.transaction(), handles.get("main").unwrap(), position),
+        Vec::<String>::new()
     );
 }
 

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -157,6 +157,7 @@ fn polars_column_completion_labels(code: &str) -> Vec<String> {
 class DataFrame:
     def __init__(self, data: object = None) -> None: ...
     def select(self, *exprs: object) -> "DataFrame": ...
+    def write_csv(self, file: str) -> None: ...
 "#,
     );
     env.add(
@@ -446,19 +447,38 @@ df.groupby("")
 #[test]
 fn no_column_completion_from_unrelated_call_argument() {
     let code = r#"
-def select(data: dict[str, int], expr: object) -> None: ...
-def col(name: str) -> str: ...
-
-payload = {"foo": 1, "bar": 2}
-select(payload, col(""))
-#                   ^
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+def f(frame: object, value: str) -> None: ...
+f(df, "")
+#      ^
 "#;
-    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, false);
-    let position = extract_cursors_for_test(code)[0];
-    assert_eq!(
-        dict_field_labels(&state.transaction(), handles.get("main").unwrap(), position),
-        Vec::<String>::new()
-    );
+    assert_eq!(polars_column_completion_labels(code), Vec::<String>::new());
+}
+
+#[test]
+fn no_column_completion_from_non_column_dataframe_method() {
+    let code = r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+df.write_csv("")
+#             ^
+"#;
+    assert_eq!(polars_column_completion_labels(code), Vec::<String>::new());
+}
+
+#[test]
+fn dataframe_union_completion_intersects_columns() {
+    let code = r#"
+import polars as pl
+def f(cond: bool) -> None:
+    a = pl.DataFrame({"id": [1], "x": [1]})
+    b = pl.DataFrame({"id": [1], "y": [1]})
+    df = a if cond else b
+    df.select("")
+#              ^
+"#;
+    assert_eq!(polars_column_completion_labels(code), vec!["id".to_owned()]);
 }
 
 #[test]

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -354,6 +354,59 @@ cfg: Config = {"": 1}
 }
 
 #[test]
+fn dict_key_completion_from_prior_call_argument() {
+    let code = r#"
+def lookup(data: dict[str, int], key: str) -> int:
+    return data[key]
+
+payload = {"foo": 1, "bar": 2}
+lookup(payload, "")
+#                ^
+"#;
+    let report =
+        get_batched_lsp_operations_report_allow_error(&[("main", code)], get_default_test_report());
+    let report = strip_ansi(&report);
+    assert!(
+        report.contains(
+            r#"
+Completion Results:
+- (Field) bar: Literal[2]
+- (Field) foo: Literal[1]
+"#
+            .trim()
+        ),
+        "{report}"
+    );
+}
+
+#[test]
+fn dict_key_completion_from_enclosing_call_argument() {
+    let code = r#"
+def select(data: dict[str, int], expr: object) -> None: ...
+def col(name: str) -> str:
+    return name
+
+payload = {"foo": 1, "bar": 2}
+select(payload, col(""))
+#                   ^
+"#;
+    let report =
+        get_batched_lsp_operations_report_allow_error(&[("main", code)], get_default_test_report());
+    let report = strip_ansi(&report);
+    assert!(
+        report.contains(
+            r#"
+Completion Results:
+- (Field) bar: Literal[2]
+- (Field) foo: Literal[1]
+"#
+            .trim()
+        ),
+        "{report}"
+    );
+}
+
+#[test]
 fn dot_complete_with_deprecated_method() {
     let code = r#"
 from warnings import deprecated


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes part of #2139

adds schema-aware column completion for Polars and pandas DataFrames.

detects DataFrame-typed receivers or earlier call arguments and reads column names directly from the inferred DataFrameSchema. This supports both direct calls such as `df.select("")` and nested expressions such as `df.select(pl.col(""))`.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test