### PR TITLE
Add method-assign diagnostic for method rebinding

### DIFF
--- a/crates/pyrefly_config/src/base.rs
+++ b/crates/pyrefly_config/src/base.rs
@@ -178,6 +178,7 @@ impl Preset {
             Preset::Strict => {
                 let errors = HashMap::from([
                     (ErrorKind::ImplicitAny, Severity::Error),
+                    (ErrorKind::MethodAssign, Severity::Error),
                     (ErrorKind::MissingOverrideDecorator, Severity::Error),
                     (ErrorKind::PotentialBadKeywordArgument, Severity::Error),
                     (ErrorKind::UnusedIgnore, Severity::Error),

--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -270,6 +270,8 @@ pub enum ErrorKind {
     /// Attempting to use `yield` in a way that is not allowed.
     /// e.g. `yield from` with something that's not an iterable.
     InvalidYield,
+    /// Cannot assign to a method (rebinding a method, e.g. `A.f = ...`).
+    MethodAssign,
     /// A file-level `# pyrefly: ignore-errors` (or `ignore-errors[code]`) directive
     /// appears after the first line of code, where it is silently inert. File-level
     /// suppressions are only honored in the preamble, at the top of the file.
@@ -538,6 +540,7 @@ impl ErrorKind {
             ErrorKind::IncompatibleComparison => Severity::Ignore,
             ErrorKind::InvalidAbstractMethod => Severity::Ignore,
             ErrorKind::InvalidDecorator => Severity::Warn,
+            ErrorKind::MethodAssign => Severity::Ignore,
             ErrorKind::MisplacedIgnore => Severity::Warn,
             ErrorKind::MissingOverrideDecorator => Severity::Ignore,
             ErrorKind::MissingSuperCall => Severity::Ignore,

--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -1629,6 +1629,13 @@ impl Type {
         self.visit_toplevel_func_metadata(&|meta| meta.flags.is_abstract_method)
     }
 
+    /// True if this is a (top-level) `@staticmethod`. Used to exclude static
+    /// methods from method-rebinding checks, since they are stored as
+    /// `ClassFieldInner::Method` but should not be flagged as methods there.
+    pub fn is_staticmethod(&self) -> bool {
+        self.visit_toplevel_func_metadata(&|meta| meta.flags.is_staticmethod)
+    }
+
     pub fn is_override(&self) -> bool {
         self.visit_toplevel_func_metadata(&|meta| meta.flags.is_override)
     }

--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -1335,7 +1335,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             return None;
         };
         let ty = match class_attr {
-            ClassAttribute::ReadWrite(ty) | ClassAttribute::ReadOnly(ty, _) => ty,
+            ClassAttribute::ReadWrite(ty, _) | ClassAttribute::ReadOnly(ty, _) => ty,
             _ => return None,
         };
         let Type::BoundMethod(bound_method) = ty else {
@@ -1358,7 +1358,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         new_bound_method.func = BoundMethodType::Overload(filtered_overload);
         let new_method = self.heap.mk_bound_method(new_bound_method);
         Some(Attribute::ClassAttribute(match class_attr {
-            ClassAttribute::ReadWrite(_) => ClassAttribute::ReadWrite(new_method),
+            ClassAttribute::ReadWrite(_, is_method) => {
+                ClassAttribute::ReadWrite(new_method, *is_method)
+            }
             ClassAttribute::ReadOnly(_, reason) => {
                 ClassAttribute::ReadOnly(new_method, reason.clone())
             }
@@ -3055,7 +3057,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     .into_iter()
                     .filter_map(|(attr, _)| {
                         match &attr {
-                            Attribute::ClassAttribute(ClassAttribute::ReadWrite(ty))
+                            Attribute::ClassAttribute(ClassAttribute::ReadWrite(ty, _))
                             | Attribute::ClassAttribute(ClassAttribute::ReadOnly(ty, _))
                             | Attribute::Simple(ty)
                             | Attribute::ClassAttribute(ClassAttribute::Property(ty, _, _))

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -115,7 +115,9 @@ use crate::types::types::Type;
 #[derive(Debug, Clone)]
 pub enum ClassAttribute {
     /// A read-write attribute with a closed form type for both get and set actions.
-    ReadWrite(Type),
+    /// The flag is `true` when the attribute originated as a method
+    /// (`ClassFieldInner::Method`), used to flag method-rebinding assignments.
+    ReadWrite(Type, bool),
     /// A read-only attribute with a closed form type for get actions.
     ReadOnly(Type, ReadOnlyReason),
     /// A `NoAccess` attribute indicates that the attribute is well-defined, but does
@@ -131,7 +133,13 @@ pub enum ClassAttribute {
 
 impl ClassAttribute {
     pub fn read_write(ty: Type) -> Self {
-        Self::ReadWrite(ty)
+        Self::ReadWrite(ty, false)
+    }
+
+    /// Like [`read_write`](Self::read_write) but marks the attribute as having
+    /// originated as a method (`ClassFieldInner::Method`).
+    pub fn read_write_method(ty: Type) -> Self {
+        Self::ReadWrite(ty, true)
     }
 
     pub fn read_only(ty: Type, reason: ReadOnlyReason) -> Self {
@@ -152,7 +160,7 @@ impl ClassAttribute {
 
     pub fn read_only_equivalent(self, reason: ReadOnlyReason) -> Self {
         match self {
-            Self::ReadWrite(ty) => Self::ReadOnly(ty, reason),
+            Self::ReadWrite(ty, _) => Self::ReadOnly(ty, reason),
             Self::Property(getter, _, cls) => Self::Property(getter, None, cls),
             Self::Descriptor(descriptor, base) => Self::Descriptor(
                 Descriptor {
@@ -173,7 +181,7 @@ impl ClassAttribute {
         match self {
             // TODO(stroxler): ReadWrite attributes are not actually methods but limiting access to
             // ReadOnly breaks unit tests; we should investigate callsites to understand this better.
-            ClassAttribute::ReadWrite(ty) | ClassAttribute::ReadOnly(ty, _) => Some(ty),
+            ClassAttribute::ReadWrite(ty, _) | ClassAttribute::ReadOnly(ty, _) => Some(ty),
             ClassAttribute::NoAccess(..)
             | ClassAttribute::Property(..)
             | ClassAttribute::Descriptor(..) => None,
@@ -1258,10 +1266,13 @@ fn bind_class_attribute(
     cls: &ClassBase,
     attr: Type,
     read_only_reason: Option<ReadOnlyReason>,
+    is_method: bool,
 ) -> ClassAttribute {
     let ty = make_bound_classmethod(heap, cls, attr).into_inner();
     if let Some(reason) = read_only_reason {
         ClassAttribute::read_only(ty, reason)
+    } else if is_method {
+        ClassAttribute::read_write_method(ty)
     } else {
         ClassAttribute::read_write(ty)
     }
@@ -3357,12 +3368,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if let Some(quantified) = self_quantified {
                     ty = self.wrap_with_quantified(ty, quantified);
                 }
-                ClassAttribute::read_write(
-                    make_bound_method(self.heap, instance, ty).unwrap_or_else(|ty| {
-                        make_bound_classmethod(self.heap, &instance.to_class_base(), ty)
-                            .into_inner()
-                    }),
-                )
+                // Exclude `@staticmethod`: it is stored as `ClassFieldInner::Method`
+                // (see `is_method`) but must not be flagged as a method rebind (B2).
+                let is_method = !ty.is_staticmethod();
+                let bound = make_bound_method(self.heap, instance, ty).unwrap_or_else(|ty| {
+                    make_bound_classmethod(self.heap, &instance.to_class_base(), ty).into_inner()
+                });
+                if is_method {
+                    ClassAttribute::read_write_method(bound)
+                } else {
+                    ClassAttribute::read_write(bound)
+                }
             }
             ClassFieldInner::ProxyMethod { target, .. } => {
                 match self.get_class_member(instance.class, &target) {
@@ -3448,7 +3464,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             ClassFieldInner::Property { mut ty, .. } => {
                 // When accessing a property on a class (not instance), you get the property object itself
                 ty = self.normalize_attr_ty(ty);
-                bind_class_attribute(self.heap, cls, ty, None)
+                bind_class_attribute(self.heap, cls, ty, None, false)
             }
             ClassFieldInner::Descriptor { descriptor, .. } => {
                 ClassAttribute::descriptor(descriptor, DescriptorBase::ClassDef(cls.clone()))
@@ -3471,7 +3487,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if let Some(quantified) = self_quantified {
                     ty = self.wrap_with_quantified(ty, quantified);
                 }
-                bind_class_attribute(self.heap, cls, ty, None)
+                // Exclude `@staticmethod` (see the instance-attribute arm).
+                let is_method = !ty.is_staticmethod();
+                bind_class_attribute(self.heap, cls, ty, None, is_method)
             }
             ClassFieldInner::ProxyMethod { .. } => ClassAttribute::no_access(
                 NoAccessReason::ProxyMethodClassAccess(cls.class_object().dupe()),
@@ -3484,6 +3502,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     cls,
                     ty,
                     Some(ReadOnlyReason::ClassObjectInitializedOnBody),
+                    false,
                 )
             }
             ClassFieldInner::ClassAttribute {
@@ -3503,7 +3522,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         cls.class_object().dupe(),
                     ))
                 } else {
-                    bind_class_attribute(self.heap, cls, ty, read_only_reason)
+                    bind_class_attribute(self.heap, cls, ty, read_only_reason, false)
                 }
             }
             ClassFieldInner::InstanceAttribute { .. } => {
@@ -3992,7 +4011,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     });
                 };
                 match &mut attr {
-                    ClassAttribute::ReadOnly(ty, _) | ClassAttribute::ReadWrite(ty)
+                    ClassAttribute::ReadOnly(ty, _) | ClassAttribute::ReadWrite(ty, _)
                         if ty.has_toplevel_func_metadata() =>
                     {
                         relax_ty(ty);
@@ -5012,7 +5031,21 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     *should_narrow = false;
                 }
             }
-            ClassAttribute::ReadWrite(attr_ty) => {
+            ClassAttribute::ReadWrite(attr_ty, is_method) => {
+                // The attribute originated as a method (`ClassFieldInner::Method`),
+                // so rebinding it via assignment is a method-rebinding. Emit before
+                // the type-compat check below so an incompatible rebind yields BOTH
+                // `method-assign` and `BadAssignment`, and before any narrowing
+                // decision so narrowing behavior is unaffected.
+                if is_method {
+                    errors
+                        .error_builder(
+                            range,
+                            ErrorKind::MethodAssign,
+                            "Cannot assign to a method".to_owned(),
+                        )
+                        .emit();
+                }
                 // If the attribute has a converter, then `want` should be the type expected by the converter.
                 let attr_ty = match instance_class {
                     Some(cls) => match self.get_dataclass_member(cls.class_object(), attr_name) {
@@ -5205,7 +5238,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         };
         match attr {
-            ClassAttribute::ReadWrite(ty) => Some(ClassAttribute::ReadWrite(filter_type(ty)?)),
+            ClassAttribute::ReadWrite(ty, is_method) => {
+                Some(ClassAttribute::ReadWrite(filter_type(ty)?, is_method))
+            }
             ClassAttribute::ReadOnly(ty, reason) => {
                 Some(ClassAttribute::ReadOnly(filter_type(ty)?, reason))
             }
@@ -5252,13 +5287,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             ) => Err(Box::new(AttrSubsetError::Property)),
             (
                 ClassAttribute::ReadOnly(..),
-                ClassAttribute::Property(_, Some(_), _) | ClassAttribute::ReadWrite(_),
+                ClassAttribute::Property(_, Some(_), _) | ClassAttribute::ReadWrite(..),
             ) => Err(Box::new(AttrSubsetError::ReadOnly)),
             (
                 // TODO(stroxler): Investigate this case more: methods should be ReadOnly, but
                 // in some cases for unknown reasons they wind up being ReadWrite.
-                ClassAttribute::ReadWrite(got),
-                ClassAttribute::ReadWrite(want),
+                ClassAttribute::ReadWrite(got, _),
+                ClassAttribute::ReadWrite(want, _),
             ) if got.has_toplevel_func_metadata() && want.has_toplevel_func_metadata() => {
                 is_subset(got, want).map_err(|subset_error| {
                     Box::new(AttrSubsetError::Covariant {
@@ -5270,7 +5305,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     })
                 })
             }
-            (ClassAttribute::ReadWrite(got), ClassAttribute::ReadWrite(want)) => {
+            (ClassAttribute::ReadWrite(got, _), ClassAttribute::ReadWrite(want, _)) => {
                 let subset_error = is_subset(got, want)
                     .map_or_else(Some, |_| is_subset(want, got).map_or_else(Some, |_| None));
                 if let Some(subset_error) = subset_error {
@@ -5284,7 +5319,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
             }
             (
-                ClassAttribute::ReadWrite(got) | ClassAttribute::ReadOnly(got, ..),
+                ClassAttribute::ReadWrite(got, _) | ClassAttribute::ReadOnly(got, ..),
                 ClassAttribute::ReadOnly(want, _),
             ) => is_subset(got, want).map_err(|subset_error| {
                 Box::new(AttrSubsetError::Covariant {
@@ -5311,7 +5346,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     })
                 })
             }
-            (ClassAttribute::ReadWrite(got), ClassAttribute::Property(want, want_setter, _)) => {
+            (ClassAttribute::ReadWrite(got, _), ClassAttribute::Property(want, want_setter, _)) => {
                 is_subset(
                     // Synthesize a getter method
                     &self.heap.mk_callable_ellipsis(got.clone()),
@@ -5412,7 +5447,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Result<Type, NoAccessReason> {
         match class_attr {
             ClassAttribute::NoAccess(reason) => Err(reason),
-            ClassAttribute::ReadWrite(ty) | ClassAttribute::ReadOnly(ty, _) => Ok(ty),
+            ClassAttribute::ReadWrite(ty, _) | ClassAttribute::ReadOnly(ty, _) => Ok(ty),
             ClassAttribute::Property(getter, ..) => {
                 self.record_property_getter(range, &getter);
                 Ok(self.call_property_getter(getter, range, errors, context))

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -319,6 +319,79 @@ def foo(x: Callable[[int], str], c: C, c2: C2, c3: C3):
     "#,
 );
 
+// `method-assign` (issue #4161): rebinding a method via direct assignment is
+// flagged when the kind is enabled. Method-ness keys off `ClassFieldInner::Method`
+// (instance methods + classmethods); `@staticmethod`, plain data attributes, and
+// `Callable`-typed attributes are NOT methods and stay clean. Instance rebinds
+// additionally keep their existing `bad-assignment` signal (I7 coexistence); the
+// final group makes that coexistence explicit with a type-incompatible value.
+testcase!(
+    test_method_assign_diagnostic,
+    TestEnv::new().enable_method_assign_error(),
+    r#"
+from typing import Callable
+
+class A:
+    def f(self) -> int:
+        return 1
+    @classmethod
+    def cm(cls) -> int:
+        return 2
+    @staticmethod
+    def sm() -> int:
+        return 3
+    data: int
+    cb: Callable[[], int]
+
+class B(A):
+    pass
+
+a = A()
+b = B()
+
+def inst_method(self: A) -> int: ...
+def cls_method(cls: type[A]) -> int: ...
+def free_fn() -> int: ...
+def free_callable() -> int: ...
+
+# Flagged: rebinding instance methods (class + instance), classmethods, inherited.
+A.f = inst_method  # E: Cannot assign to a method
+a.f = inst_method  # E: Cannot assign to a method  # E: `(self: A) -> int` is not assignable to attribute `f` with type `(self: A) -> int`
+A.cm = cls_method  # E: Cannot assign to a method  # E: `(cls: type[A]) -> int` is not assignable to attribute `cm` with type `(cls: type[A]) -> int`
+a.cm = cls_method  # E: Cannot assign to a method  # E: `(cls: type[A]) -> int` is not assignable to attribute `cm` with type `(cls: type[A]) -> int`
+B.f = inst_method  # E: Cannot assign to a method
+b.f = inst_method  # E: Cannot assign to a method  # E: `(self: A) -> int` is not assignable to attribute `f` with type `(self: B) -> int`
+
+# NOT flagged: staticmethod, plain data attr, Callable-typed attr.
+A.sm = free_fn
+a.sm = free_fn
+A.data = 1
+a.data = 1
+A.cb = free_callable
+a.cb = free_callable
+
+# setattr bypasses the attribute-set check path entirely (matches mypy).
+setattr(A, "f", inst_method)
+setattr(a, "f", inst_method)
+
+# A type-INCOMPATIBLE method rebind yields BOTH method-assign and BadAssignment.
+A.f = ""  # E: Cannot assign to a method  # E: `Literal['']` is not assignable to attribute `f` with type `(self: A) -> int`
+    "#,
+);
+
+// `method-assign` is off by default (I3): a method rebind that WOULD be flagged
+// in strict mode emits nothing under the default configuration.
+testcase!(
+    test_method_assign_off_by_default,
+    r#"
+class A:
+    def f(self) -> int:
+        return 1
+def g(self: A) -> int: ...
+A.f = g  # no method-assign under default config
+    "#,
+);
+
 testcase!(
     test_bound_classmethod_explicit_targs,
     r#"

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -135,6 +135,7 @@ pub struct TestEnv {
     implicit_any_lambda_error: bool,
     invalid_abstract_method_error: bool,
     empty_body_error: bool,
+    method_assign_error: bool,
     unknown_argument_type_error: bool,
     unknown_variable_type_error: bool,
     implicit_reexport_error: bool,
@@ -186,6 +187,7 @@ impl TestEnv {
             implicit_any_lambda_error: false,
             invalid_abstract_method_error: false,
             empty_body_error: false,
+            method_assign_error: false,
             unknown_argument_type_error: false,
             unknown_variable_type_error: false,
             implicit_reexport_error: false,
@@ -426,6 +428,11 @@ impl TestEnv {
         self
     }
 
+    pub fn enable_method_assign_error(mut self) -> Self {
+        self.method_assign_error = true;
+        self
+    }
+
     pub fn enable_unknown_argument_type_error(mut self) -> Self {
         self.unknown_argument_type_error = true;
         self
@@ -616,6 +623,9 @@ impl TestEnv {
         }
         if self.empty_body_error {
             errors.set_error_severity(ErrorKind::EmptyBody, Severity::Error);
+        }
+        if self.method_assign_error {
+            errors.set_error_severity(ErrorKind::MethodAssign, Severity::Error);
         }
         if self.unknown_variable_type_error {
             errors.set_error_severity(ErrorKind::UnknownVariableType, Severity::Error);

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -587,7 +587,7 @@ The default Pyrefly configuration. Equivalent to having no preset at all.
 Enables additional error codes on top of the default for stricter checking.
 
 - Sets [`strict-callable-subtyping`](#strict-callable-subtyping) `= true`
-- Enables (as errors): [`implicit-any`](./error-kinds.mdx#implicit-any) (covers every implicit-`Any` sub-kind), [`missing-override-decorator`](./error-kinds.mdx#missing-override-decorator), [`potential-bad-keyword-argument`](./error-kinds.mdx#potential-bad-keyword-argument), [`unused-ignore`](./error-kinds.mdx#unused-ignore)
+- Enables (as errors): [`implicit-any`](./error-kinds.mdx#implicit-any) (covers every implicit-`Any` sub-kind), [`method-assign`](./error-kinds.mdx#method-assign), [`missing-override-decorator`](./error-kinds.mdx#missing-override-decorator), [`potential-bad-keyword-argument`](./error-kinds.mdx#potential-bad-keyword-argument), [`unused-ignore`](./error-kinds.mdx#unused-ignore)
 
 #### Preset: `all`
 

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -1123,6 +1123,28 @@ def bad_yield_from() -> Generator[int, None, None]:
   yield from 1
 ```
 
+## method-assign
+
+Default severity: `ignore`
+
+Rebinding a method by direct assignment — to the class object or to an instance
+(a.k.a. monkey-patching) — is ambiguous: the method's bound signature no longer
+matches what the class declares. Pyrefly flags such assignments when this kind
+is enabled (it is on in strict mode).
+
+```python
+class A:
+    def f(self) -> int: ...
+A.f = lambda self: 2  # Cannot assign to a method [method-assign]
+a = A()
+a.f = lambda self: 2  # Cannot assign to a method [method-assign]
+```
+
+Direct assignment that rebinds an instance method or a `classmethod` is flagged.
+`@staticmethod`, properties, plain data attributes, and `Callable`-typed
+attributes are not methods and are not flagged. Rebinding via `setattr` is out
+of scope.
+
 ## misplaced-ignore
 
 Default severity: `warn`


### PR DESCRIPTION
## Summary

Adds mypy-equivalent `method-assign` diagnostic (issue #4161): direct assignment that rebinds a method (`A.f = ...`, `a.f = ...`) is type-ambiguous and now flagged when the kind is enabled.

**Why:** pyrefly had no signal for method rebinding — a type-*compatible* rebind was silently allowed, and an incompatible one only surfaced the generic `bad-assignment`. mypy's `method-assign` exists precisely for this.

## Approach

- New top-level, addressable `ErrorKind::MethodAssign`, off by default (`Severity::Ignore`), enabled in `Preset::Strict` (auto-promoted in `Preset::All`). Independently suppressible via `# pyrefly: ignore[method-assign]`; does not silence the existing type check.
- Detection keys off the authoritative `ClassFieldInner::Method` origin, threaded as a provenance flag on `ClassAttribute::ReadWrite(Type, bool)` (mirroring the existing `ReadOnly(Type, ReadOnlyReason)` precedent) from the two Method construction sites to the single attribute-write chokepoint `check_class_attr_set_and_infer_narrow`. That one dispatcher covers both class-object (`A.f=`) and instance (`a.f=`) writes. Emitting before the type-compat check means an incompatible rebind yields both `method-assign` and `bad-assignment`.
- `@staticmethod` is also stored as `ClassFieldInner::Method` (per `is_method()`), so the flag is guarded with `!ty.is_staticmethod()` (new `Type::is_staticmethod()` helper, following the `is_abstract_method()` precedent). This excludes staticmethods, plain data attributes, properties, and `Callable`-typed attributes — matching the method-rebinding intent without false positives on `Callable`-typed class attributes (which flatten to `Type::Function` indistinguishably from a real method).

## Behavior matrix

| Target | Flagged |
|---|---|
| instance method (class + instance rebind) | ✅ |
| `@classmethod` (class + instance rebind) | ✅ |
| inherited method (via MRO) | ✅ |
| `@staticmethod` | ❌ |
| property / descriptor / nested class | ❌ |
| plain data attribute | ❌ |
| `Callable`-typed attribute | ❌ |
| `setattr(A, "f", x)` | ❌ (out of scope, matches mypy) |

`setattr` rebinding is out of scope by construction (dispatches to `__setattr__`, bypassing the attribute-set check path).

## Test plan

- [x] `test_method_assign_diagnostic` — full fidelity matrix (flagged + not-flagged + inherited + setattr + coexistence with `bad-assignment`)
- [x] `test_method_assign_off_by_default` — kind silent under default config
- [x] `test_doc_headers` / `test_doc_severities` / `test_preset_doc` — doc + sort + preset coupling
- [x] regression sweep: attributes, class_overrides, typed_dict, dataclass, enums, decorators, protocol, callable, assign — all green (1152 lib tests)
- [x] `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema` — clean (no new lint errors)

Closes #4161.