### PR TITLE
[pyrefly] Preserve wildcard include patterns with ignore files

### DIFF
--- a/crates/pyrefly_util/src/globs.rs
+++ b/crates/pyrefly_util/src/globs.rs
@@ -744,7 +744,12 @@ impl Globs {
             // default `**/*.ipynb` include when the user sets
             // `project-excludes = ["**/*.ipynb"]`). Warn so the user knows
             // this pattern is not being used, but don't abort discovery.
-            if filter.is_excluded(pattern.as_path()) {
+            let is_excluded = if pattern.has_no_wildcards() {
+                filter.is_excluded(pattern.as_path())
+            } else {
+                filter.excludes.matches(pattern.as_path())
+            };
+            if is_excluded {
                 warn!(
                     "Skipping include pattern `{}` because it is matched by \
                      `project-excludes` or an ignore file.\n{}",
@@ -2238,6 +2243,32 @@ mod tests {
                 .unwrap()
                 .collect::<Vec<_>>(),
             vec![root.join("ok.py")]
+        );
+    }
+
+    #[test]
+    fn test_gitignore_does_not_match_include_pattern_syntax() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path();
+        TestPath::setup_test_directory(
+            root,
+            vec![
+                TestPath::file_with_contents(".gitignore", "?.py\n"),
+                TestPath::dir("src", vec![TestPath::file("module.py")]),
+            ],
+        );
+
+        let includes = Globs::new_with_root(root, vec!["src/**/*.py".to_owned()]).unwrap();
+        let filtered = FilteredGlobs::new(
+            includes,
+            Globs::empty(),
+            Some(root),
+            HiddenDirFilter::Disabled,
+        );
+
+        assert_eq!(
+            filtered.files_iter().unwrap().collect::<Vec<_>>(),
+            vec![root.join("src/module.py")],
         );
     }
 

--- a/test/find.md
+++ b/test/find.md
@@ -43,10 +43,6 @@ $ mkdir $TMPDIR/ignores && echo "*" > $TMPDIR/ignores/.gitignore && \
 > touch $TMPDIR/ignores/pyrefly.toml && \
 > $PYREFLY check --python-version 3.13.0 -c $TMPDIR/ignores/pyrefly.toml --output-format=min-text
  INFO Checking project configured at * (glob)
- WARN Skipping include pattern `*` because it is matched by `project-excludes` or an ignore file. (glob)
-`project-excludes`: [*], ignore files [*/.gitignore, */.ignore, */.git/info/exclude] (glob)
- WARN Skipping include pattern `*` because it is matched by `project-excludes` or an ignore file. (glob)
-`project-excludes`: * (glob)
 No Python files matched patterns `*` (glob)
 [1]
 ```


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Prevent ignore files from evaluating wildcard syntax in `project-includes` as though it were a concrete path. Discovered files still pass through the normal ignore-file filtering. This also adds regression coverage for a `?.py` ignore rule combined with `src/**/*.py`.

This pull request was prepared with an AI coding agent and reviewed and tested against the repository's contribution requirements.

Fixes #4302

# Test Plan

<!-- Describe how you tested this PR -->

- `cargo test -p pyrefly_util` (73 passed; 5 doctests ignored)
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`
- `scrut test test/find.md` (10 passed)

<!-- Run test.py and commit any changes to generated files -->
