### PR TITLE
Avoid duplicate completions while defining methods

### DIFF
--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -1186,7 +1186,7 @@ impl Transaction<'_> {
                 let skip_value_completions = covering_nodes
                     .as_deref()
                     .is_some_and(|nodes| Self::is_typing_keyword_argument_name(nodes, position));
-                if !skip_value_completions {
+                if !skip_value_completions && !is_method_def {
                     let at_statement_start = matches!(
                         covering_nodes.as_deref().and_then(|nodes| nodes.get(1)),
                         Some(AnyNodeRef::StmtExpr(_))

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -71,6 +71,30 @@ class Foo:
     }
 }
 
+#[test]
+fn completion_method_definition_has_unique_suggestions() {
+    let code = r#"
+class Foo:
+    def get_value(self) -> int:
+        return 1
+
+    def get_
+#           ^
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, true);
+    let handle = handles.get("main").unwrap();
+    let position = extract_cursors_for_test(code)[0];
+    let labels = state
+        .transaction()
+        .completion(handle, position, ImportFormat::Absolute, true, None)
+        .into_iter()
+        .filter(|item| item.label.starts_with("get_"))
+        .map(|item| item.label)
+        .collect::<Vec<_>>();
+
+    assert_eq!(labels, vec!["get_value"]);
+}
+
 fn get_default_test_report() -> impl Fn(&State, &Handle, TextSize) -> String {
     get_test_report(ResultsFilter::default(), ImportFormat::Absolute)
 }


### PR DESCRIPTION
Method-name completion was combining the dedicated class/magic-method candidates with ordinary value completions. That caused existing methods to appear twice and leaked unrelated names into the list.

This change keeps method definitions on the dedicated completion paths and adds a focused regression test proving that a prefixed existing method is returned exactly once.

Fixes #4126.

## Validation
- `cargo fmt --check` passes
- targeted regression coverage added for method-definition completion deduplication

AI disclosure: this change was developed with Codex assistance and reviewed against the repository contribution guidance.