### PR TITLE
Report when overload argument-type expansion hits its limit

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -329,6 +329,9 @@ pub enum ErrorKind {
     NotRequiredKeyAccess,
     /// Unpacking an open TypedDict that may contain a bad key via inheritance.
     OpenUnpacking,
+    /// Argument type expansion for an overloaded call reached its limit, so some argument
+    /// type combinations were left unchecked.
+    OverloadArgumentExpansionLimit,
     /// An error related to parsing or syntax.
     ParseError,
     /// A potential conflict between an explicit keyword argument and a NotRequired
@@ -560,6 +563,7 @@ impl ErrorKind {
             ErrorKind::NonConvergentRecursion => Severity::Warn,
             ErrorKind::NotRequiredKeyAccess => Severity::Ignore,
             ErrorKind::OpenUnpacking => Severity::Ignore,
+            ErrorKind::OverloadArgumentExpansionLimit => Severity::Warn,
             ErrorKind::PytorchEfficiencyLintCudaCall => Severity::Ignore,
             ErrorKind::PytorchEfficiencyLintItemCall => Severity::Ignore,
             ErrorKind::PytorchEfficiencyLintPrintTensor => Severity::Ignore,

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -88,6 +88,8 @@ pub struct ArgsExpander<'a, Ans: LookupAnswer> {
     arg_lists: Vec<(Vec<CallArg<'a>>, Vec<CallKeyword<'a>>)>,
     /// Hard-coded limit to how many times we'll expand.
     gas: Gas,
+    /// Set once `gas` is exhausted, so the caller can report the truncated expansion.
+    limit_hit: bool,
     solver: &'a AnswersSolver<'a, Ans>,
 }
 
@@ -107,6 +109,7 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
             },
             arg_lists: vec![(posargs, keywords)],
             gas: Gas::new(Self::GAS as isize),
+            limit_hit: false,
             solver,
         }
     }
@@ -172,6 +175,7 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
                     if self.gas.stop() {
                         // We've hit our hard-coded limit; stop expanding, and move `idx` past the
                         // end of the keywords so that subsequent `expand` calls know we're done.
+                        self.limit_hit = true;
                         self.idx = Either::Right(keywords.len());
                         return None;
                     }
@@ -403,6 +407,21 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         matched = true;
                         break;
                     }
+                }
+                if args_expander.limit_hit && !matched {
+                    // Expansion stopped early at the hard limit without finding a match, so we may
+                    // have given up on a call that would otherwise match. Surface it rather than
+                    // silently truncating. (When `matched` is already set we only truncated a
+                    // return-type refinement, which does not change the result, so stay quiet.)
+                    self.error(
+                        errors,
+                        arguments_range,
+                        ErrorKind::OverloadArgumentExpansionLimit,
+                        format!(
+                            "Argument type expansion for this overloaded call hit the limit of {} expansions; some argument type combinations were not checked",
+                            ArgsExpander::<Ans>::GAS
+                        ),
+                    );
                 }
                 (
                     closest_overload,

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -21,7 +21,6 @@ use pyrefly_types::type_output::TypeOutput;
 use pyrefly_types::types::TArgs;
 use pyrefly_util::display::Fmt;
 use pyrefly_util::display::count;
-use pyrefly_util::gas::Gas;
 use pyrefly_util::owner::Owner;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::prelude::VecExt;
@@ -138,9 +137,7 @@ pub struct ArgsExpander<'a, Ans: LookupAnswer> {
     idx: Either<usize, usize>,
     /// Current argument lists.
     arg_lists: Vec<(Vec<CallArg<'a>>, Vec<CallKeyword<'a>>)>,
-    /// Hard-coded limit to how many times we'll expand.
-    gas: Gas,
-    /// Set once `gas` is exhausted, so the caller can report the truncated expansion.
+    /// Set once the expansion budget is exceeded, so the caller can report the truncated expansion.
     limit_hit: bool,
     /// Which positional / keyword arguments are worth expanding. Both default to all-`true`
     /// (expand everything); `call_overloads` narrows them once the candidate overloads are known.
@@ -150,6 +147,7 @@ pub struct ArgsExpander<'a, Ans: LookupAnswer> {
 }
 
 impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
+    /// The most argument-type combinations we are willing to check for a single call.
     const GAS: usize = 100;
 
     pub fn new(
@@ -166,7 +164,6 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
                 Either::Left(0)
             },
             arg_lists: vec![(posargs, keywords)],
-            gas: Gas::new(Self::GAS as isize),
             limit_hit: false,
             expandable_pos,
             expandable_kw,
@@ -218,7 +215,7 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
                 // A single argument's expansion (e.g. a large concrete tuple's cartesian product)
                 // can exceed the budget on its own. Skip it like `NotExpandable` and try the next
                 // argument, but record the truncation so a call that ultimately fails to match still
-                // reports it. Only the per-round budget below (`gas.stop`) aborts expansion entirely.
+                // reports it. Only an over-budget round below aborts expansion entirely.
                 self.limit_hit = true;
                 Vec::new()
             }
@@ -226,6 +223,12 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
         if expanded_types.is_empty() {
             // Nothing to expand here (or this position cannot disambiguate), try the next argument.
             self.expand(errors, owner)
+        } else if self.arg_lists.len().saturating_mul(expanded_types.len()) > Self::GAS {
+            // Splitting this argument would take us past the budget. Stop expanding, and move `idx`
+            // past the end of the keywords so that subsequent `expand` calls know we're done.
+            self.limit_hit = true;
+            self.idx = Either::Right(keywords.len());
+            None
         } else {
             let expanded_types = expanded_types.into_map(|t| owner.push(t));
             let mut new_arg_lists = Vec::new();
@@ -251,13 +254,6 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
                         }
                     }
                     new_arg_lists.push((new_posargs, new_keywords));
-                    if self.gas.stop() {
-                        // We've hit our hard-coded limit; stop expanding, and move `idx` past the
-                        // end of the keywords so that subsequent `expand` calls know we're done.
-                        self.limit_hit = true;
-                        self.idx = Either::Right(keywords.len());
-                        return None;
-                    }
                 }
             }
             self.arg_lists = new_arg_lists.clone();
@@ -430,21 +426,23 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     .then(|| ArgsExpander::new(args.clone(), keywords.clone(), self));
                 // Prune expansion of arguments that cannot change the outcome. Leaving a position
                 // un-split is safe exactly when every candidate binds it to an equivalent parameter
-                // type `p` *and* the argument is already assignable to `p`: then splitting cannot
-                // discriminate between candidates (they all check against the same `p`), and it
-                // cannot rescue the call either, because every expanded member is a subtype of the
-                // argument and so stays assignable. Both halves are load-bearing — an argument that
-                // only checks out once split (`tuple[str | None, str]` against
-                // `tuple[str, str] | tuple[None, str]`) must keep expanding even when it binds the
-                // same parameter everywhere. Conservative elsewhere: a position whose binding isn't
-                // statically determinable (call-site unpacking, `*args`/`**kwargs` absorption,
-                // `ParamSpec`, differing arities) stays expandable, and generic overloads are
-                // excluded entirely because expansion also drives their type-variable solving.
-                if let Some(args_expander) = args_expander.as_mut()
-                    && !arity_compatible_overloads
-                        .iter()
-                        .any(|o| o.0.as_ref().is_some_and(|tparams| !tparams.is_empty()))
-                {
+                // type `p` that mentions no type variable, *and* the argument is already assignable
+                // to `p`. All three conditions are load-bearing:
+                // - equivalent `p`: splitting cannot discriminate between candidates, since they all
+                //   check the argument against the same `p`;
+                // - argument already assignable to `p`: splitting cannot rescue the call, since every
+                //   expanded member is a subtype of the argument and so stays assignable (an argument
+                //   that only checks out once split, `tuple[str | None, str]` against
+                //   `tuple[str, str] | tuple[None, str]`, must keep expanding even here);
+                // - `p` type-variable-free: splitting cannot change type-variable solving, since a
+                //   type-variable-free `p` adds no constraints to any type variable. This condition
+                //   is per-argument, so a generic overload set is still pruned for its shared,
+                //   type-variable-free arguments, while a type-variable-bearing discriminator (the
+                //   jax/ibis class, whose solving the expansion drives) stays expandable.
+                // Conservative elsewhere: a position whose binding isn't statically determinable
+                // (call-site unpacking, `*args`/`**kwargs` absorption, `ParamSpec`, differing
+                // arities) stays expandable.
+                if let Some(args_expander) = args_expander.as_mut() {
                     // Parameter types can mention placeholder vars owned by the receiver (an empty
                     // `{}` passed as `self`, say), and the probes below solve vars, so snapshot
                     // around them exactly as `find_closest_overload` does for speculative calls.
@@ -467,7 +465,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         let Some(Some(first)) = param_tys.next() else {
                             return false;
                         };
-                        param_tys.all(|t| t.is_some_and(|t| self.is_equivalent(first, t)))
+                        // `first` must mention no type variable: an equivalent, type-variable-free
+                        // parameter contributes no constraints to solving, so pruning it is sound
+                        // even when other parameters of these overloads are generic. A parameter
+                        // that mentions a type variable stays expandable so expansion can drive it.
+                        !first.contains_type_variable()
+                            && param_tys.all(|t| t.is_some_and(|t| self.is_equivalent(first, t)))
                             && self.is_subset_eq(arg_ty, first)
                     };
                     // A call-site `*args` splat makes positional-slot correspondence unreliable, so

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -25,6 +25,7 @@ use pyrefly_util::gas::Gas;
 use pyrefly_util::owner::Owner;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::prelude::VecExt;
+use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use starlark_map::small_set::SmallSet;
@@ -80,6 +81,57 @@ impl CalledOverload<'_> {
     }
 }
 
+enum TypeExpansion {
+    Expanded(Vec<Type>),
+    NotExpandable,
+    LimitExceeded,
+}
+
+/// The parameter type that a plain argument at `slot` (a positional index, or a keyword name)
+/// binds to in `sig`. Returns `None` when this cannot be determined cheaply and unambiguously —
+/// variadic/`**kwargs` absorption, `ParamSpec`/`Ellipsis`/`Partial` signatures, or an index/name
+/// with no matching plain parameter — in which case the caller must assume the position matters and
+/// keep expanding. This deliberately under-approximates the real argument matcher
+/// (`callable_infer_params`): it only pins a type for the unambiguous positional-run / named-param
+/// cases.
+fn simple_param_type<'s>(sig: &'s Callable, slot: Either<usize, &Name>) -> Option<&'s Type> {
+    let Params::List(params) = &sig.params else {
+        return None;
+    };
+    match slot {
+        Either::Left(pos) => {
+            let mut idx = 0;
+            for p in params.items() {
+                match p {
+                    Param::PosOnly(_, ty, _) | Param::Pos(_, ty, _) => {
+                        if idx == pos {
+                            return Some(ty);
+                        }
+                        idx += 1;
+                    }
+                    // A `*args` could absorb this position, so no single type is pinned.
+                    Param::Varargs(..) => return None,
+                    Param::KwOnly(..) | Param::Kwargs(..) => {}
+                }
+            }
+            None
+        }
+        Either::Right(name) => {
+            for p in params.items() {
+                match p {
+                    Param::Pos(n, ty, _) | Param::KwOnly(n, ty, _) if n == name => {
+                        return Some(ty);
+                    }
+                    // A `**kwargs` could absorb this name, so no single type is pinned.
+                    Param::Kwargs(..) => return None,
+                    _ => {}
+                }
+            }
+            None
+        }
+    }
+}
+
 /// Performs argument type expansion for arguments to an overloaded function.
 pub struct ArgsExpander<'a, Ans: LookupAnswer> {
     /// The index of the next argument to expand. Left is positional args; right, keyword args.
@@ -90,6 +142,10 @@ pub struct ArgsExpander<'a, Ans: LookupAnswer> {
     gas: Gas,
     /// Set once `gas` is exhausted, so the caller can report the truncated expansion.
     limit_hit: bool,
+    /// Which positional / keyword arguments are worth expanding. Both default to all-`true`
+    /// (expand everything); `call_overloads` narrows them once the candidate overloads are known.
+    expandable_pos: Vec<bool>,
+    expandable_kw: Vec<bool>,
     solver: &'a AnswersSolver<'a, Ans>,
 }
 
@@ -101,6 +157,8 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
         keywords: Vec<CallKeyword<'a>>,
         solver: &'a AnswersSolver<'a, Ans>,
     ) -> Self {
+        let expandable_pos = vec![true; posargs.len()];
+        let expandable_kw = vec![true; keywords.len()];
         Self {
             idx: if posargs.is_empty() {
                 Either::Right(0)
@@ -110,6 +168,8 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
             arg_lists: vec![(posargs, keywords)],
             gas: Gas::new(Self::GAS as isize),
             limit_hit: false,
+            expandable_pos,
+            expandable_kw,
             solver,
         }
     }
@@ -143,9 +203,28 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
                 return None;
             }
         };
-        let expanded_types = self.expand_type(value.infer(self.solver, errors));
+        let expand_here = match idx {
+            Either::Left(i) => self.expandable_pos[i],
+            Either::Right(i) => self.expandable_kw[i],
+        };
+        let expanded_types = match if expand_here {
+            self.expand_type(value.infer(self.solver, errors))
+        } else {
+            TypeExpansion::NotExpandable
+        } {
+            TypeExpansion::Expanded(types) => types,
+            TypeExpansion::NotExpandable => Vec::new(),
+            TypeExpansion::LimitExceeded => {
+                // A single argument's expansion (e.g. a large concrete tuple's cartesian product)
+                // can exceed the budget on its own. Skip it like `NotExpandable` and try the next
+                // argument, but record the truncation so a call that ultimately fails to match still
+                // reports it. Only the per-round budget below (`gas.stop`) aborts expansion entirely.
+                self.limit_hit = true;
+                Vec::new()
+            }
+        };
         if expanded_types.is_empty() {
-            // Nothing to expand here, try the next argument.
+            // Nothing to expand here (or this position cannot disambiguate), try the next argument.
             self.expand(errors, owner)
         } else {
             let expanded_types = expanded_types.into_map(|t| owner.push(t));
@@ -187,71 +266,82 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
     }
 
     /// Expands a type according to https://typing.python.org/en/latest/spec/overload.html#argument-type-expansion.
-    fn expand_type(&self, ty: Type) -> Vec<Type> {
+    fn expand_type(&self, ty: Type) -> TypeExpansion {
         match ty {
-            Type::Union(f) => f.members,
-            Type::ClassType(cls) if cls.is_builtin("bool") => {
-                vec![
-                    Lit::Bool(true).to_implicit_type(),
-                    Lit::Bool(false).to_implicit_type(),
-                ]
-            }
+            Type::Union(f) => TypeExpansion::Expanded(f.members),
+            Type::ClassType(cls) if cls.is_builtin("bool") => TypeExpansion::Expanded(vec![
+                Lit::Bool(true).to_implicit_type(),
+                Lit::Bool(false).to_implicit_type(),
+            ]),
             Type::ClassType(cls)
                 if self
                     .solver
                     .get_metadata_for_class(cls.class_object())
                     .is_enum() =>
             {
-                self.solver
+                let members = self
+                    .solver
                     .get_enum_members(cls.class_object())
                     .into_iter()
                     .map(Lit::to_implicit_type)
-                    .collect()
+                    .collect::<Vec<_>>();
+                if members.is_empty() {
+                    TypeExpansion::NotExpandable
+                } else {
+                    TypeExpansion::Expanded(members)
+                }
             }
             Type::Type(f) if matches!(&*f, Type::Union(_)) => {
                 // Repeated match because pattern guards cannot move out of bindings.
                 let Type::Union(u) = *f else {
                     unreachable!("guarded by matches! above")
                 };
-                u.members.into_map(|t| self.solver.heap.mk_type_of(t))
+                TypeExpansion::Expanded(u.members.into_map(|t| self.solver.heap.mk_type_of(t)))
             }
             Type::Tuple(Tuple::Concrete(elements)) => {
                 let mut count: usize = 1;
                 let mut changed = false;
                 let mut element_expansions = Vec::new();
                 for e in elements {
-                    let element_expansion = self.expand_type(e.clone());
-                    if element_expansion.is_empty() {
-                        element_expansions.push(vec![e].into_iter());
-                    } else {
-                        let len = element_expansion.len();
-                        count = count.saturating_mul(len);
-                        if count > Self::GAS {
-                            return Vec::new();
+                    match self.expand_type(e.clone()) {
+                        TypeExpansion::Expanded(element_expansion) => {
+                            count = count.saturating_mul(element_expansion.len());
+                            if count > Self::GAS {
+                                return TypeExpansion::LimitExceeded;
+                            }
+                            changed = true;
+                            element_expansions.push(element_expansion.into_iter());
                         }
-                        changed = true;
-                        element_expansions.push(element_expansion.into_iter());
+                        TypeExpansion::NotExpandable => {
+                            element_expansions.push(vec![e].into_iter());
+                        }
+                        TypeExpansion::LimitExceeded => {
+                            return TypeExpansion::LimitExceeded;
+                        }
                     }
                 }
-                // Enforce a hard-coded limit on the number of expansions for perf reasons.
-                if count <= Self::GAS && changed {
-                    element_expansions
-                        .into_iter()
-                        .multi_cartesian_product()
-                        .map(|x| self.solver.heap.mk_concrete_tuple(x))
-                        .collect()
+                if changed {
+                    TypeExpansion::Expanded(
+                        element_expansions
+                            .into_iter()
+                            .multi_cartesian_product()
+                            .map(|x| self.solver.heap.mk_concrete_tuple(x))
+                            .collect(),
+                    )
                 } else {
-                    Vec::new()
+                    TypeExpansion::NotExpandable
                 }
             }
 
             // a constraind typevar argument is one of its constraints, so expand like a union ie try each constraint against overloads + union the matched returns
             Type::Quantified(q) => match q.restriction() {
-                Restriction::Constraints(constraints) => constraints.clone(),
-                _ => Vec::new(),
+                Restriction::Constraints(constraints) => {
+                    TypeExpansion::Expanded(constraints.clone())
+                }
+                _ => TypeExpansion::NotExpandable,
             },
 
-            _ => Vec::new(),
+            _ => TypeExpansion::NotExpandable,
         }
     }
 }
@@ -336,9 +426,76 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 let refine = matched
                     && self.solver().legacy_overload_expansion
                     && matches!(&closest_overload.res, Type::Union(_));
-                let mut args_expander = ArgsExpander::new(args.clone(), keywords.clone(), self);
+                let mut args_expander = (!matched || refine)
+                    .then(|| ArgsExpander::new(args.clone(), keywords.clone(), self));
+                // Prune expansion of arguments that cannot change the outcome. Leaving a position
+                // un-split is safe exactly when every candidate binds it to an equivalent parameter
+                // type `p` *and* the argument is already assignable to `p`: then splitting cannot
+                // discriminate between candidates (they all check against the same `p`), and it
+                // cannot rescue the call either, because every expanded member is a subtype of the
+                // argument and so stays assignable. Both halves are load-bearing — an argument that
+                // only checks out once split (`tuple[str | None, str]` against
+                // `tuple[str, str] | tuple[None, str]`) must keep expanding even when it binds the
+                // same parameter everywhere. Conservative elsewhere: a position whose binding isn't
+                // statically determinable (call-site unpacking, `*args`/`**kwargs` absorption,
+                // `ParamSpec`, differing arities) stays expandable, and generic overloads are
+                // excluded entirely because expansion also drives their type-variable solving.
+                if let Some(args_expander) = args_expander.as_mut()
+                    && !arity_compatible_overloads
+                        .iter()
+                        .any(|o| o.0.as_ref().is_some_and(|tparams| !tparams.is_empty()))
+                {
+                    // Parameter types can mention placeholder vars owned by the receiver (an empty
+                    // `{}` passed as `self`, say), and the probes below solve vars, so snapshot
+                    // around them exactly as `find_closest_overload` does for speculative calls.
+                    let placeholder_vars =
+                        self.collect_placeholder_vars(self_obj.as_ref(), &args, &keywords);
+                    let snapshot = self.solver().snapshot_vars(&placeholder_vars);
+                    let self_offset = self_obj.is_some() as usize;
+                    let has_star = args.iter().any(|a| matches!(a, CallArg::Star(..)));
+                    let has_kwargs_splat = keywords.iter().any(|kw| kw.arg.is_none());
+                    let prunable = |slot: Either<usize, &Name>, value: &TypeOrExpr| {
+                        // `CallWithTypes` deliberately leaves container literals as expressions so
+                        // they can be typed against a parameter. Inferring one here would both
+                        // report errors and pin vars, so treat it as expandable.
+                        let TypeOrExpr::Type(arg_ty, _) = value else {
+                            return false;
+                        };
+                        let mut param_tys = arity_compatible_overloads
+                            .iter()
+                            .map(|o| simple_param_type(&o.1.signature, slot));
+                        let Some(Some(first)) = param_tys.next() else {
+                            return false;
+                        };
+                        param_tys.all(|t| t.is_some_and(|t| self.is_equivalent(first, t)))
+                            && self.is_subset_eq(arg_ty, first)
+                    };
+                    // A call-site `*args` splat makes positional-slot correspondence unreliable, so
+                    // keep every positional expandable; keyword-by-name binding is unaffected by it
+                    // (and is guarded separately by `has_kwargs_splat`).
+                    args_expander.expandable_pos = args
+                        .iter()
+                        .enumerate()
+                        .map(|(i, arg)| match arg {
+                            CallArg::Arg(value) if !has_star => {
+                                !prunable(Either::Left(i + self_offset), value)
+                            }
+                            _ => true,
+                        })
+                        .collect();
+                    args_expander.expandable_kw = keywords
+                        .iter()
+                        .map(|kw| match kw.arg {
+                            Some(id) if !has_kwargs_splat => {
+                                !prunable(Either::Right(&id.id), &kw.value)
+                            }
+                            _ => true,
+                        })
+                        .collect();
+                    self.solver().restore_vars(snapshot);
+                }
                 let owner = Owner::new();
-                'outer: while (!matched || refine)
+                'outer: while let Some(args_expander) = args_expander.as_mut()
                     && let Some(arg_lists) = args_expander.expand(errors, &owner)
                 {
                     // Expand by one argument (for example, try splitting up union types), and try the call with each
@@ -408,11 +565,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         break;
                     }
                 }
-                if args_expander.limit_hit && !matched {
-                    // Expansion stopped early at the hard limit without finding a match, so we may
+                if args_expander
+                    .as_ref()
+                    .is_some_and(|args_expander| args_expander.limit_hit)
+                    && !(matched || arity_compatible_overloads.len() == 1)
+                {
+                    // Expansion stopped early at the hard limit without resolving the call, so we may
                     // have given up on a call that would otherwise match. Surface it rather than
-                    // silently truncating. (When `matched` is already set we only truncated a
-                    // return-type refinement, which does not change the result, so stay quiet.)
+                    // silently truncating. Stay quiet when the call did resolve — either `matched`,
+                    // or a single arity-compatible overload (which is treated as the match below);
+                    // in those cases any truncation only affected return-type refinement.
                     self.error(
                         errors,
                         arguments_range,

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -21,7 +21,6 @@ use pyrefly_types::type_output::TypeOutput;
 use pyrefly_types::types::TArgs;
 use pyrefly_util::display::Fmt;
 use pyrefly_util::display::count;
-use pyrefly_util::gas::Gas;
 use pyrefly_util::owner::Owner;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::prelude::VecExt;
@@ -138,9 +137,7 @@ pub struct ArgsExpander<'a, Ans: LookupAnswer> {
     idx: Either<usize, usize>,
     /// Current argument lists.
     arg_lists: Vec<(Vec<CallArg<'a>>, Vec<CallKeyword<'a>>)>,
-    /// Hard-coded limit to how many times we'll expand.
-    gas: Gas,
-    /// Set once `gas` is exhausted, so the caller can report the truncated expansion.
+    /// Set once the expansion budget is exceeded, so the caller can report the truncated expansion.
     limit_hit: bool,
     /// Which positional / keyword arguments are worth expanding. Both default to all-`true`
     /// (expand everything); `call_overloads` narrows them once the candidate overloads are known.
@@ -150,6 +147,7 @@ pub struct ArgsExpander<'a, Ans: LookupAnswer> {
 }
 
 impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
+    /// The most argument-type combinations we are willing to check for a single call.
     const GAS: usize = 100;
 
     pub fn new(
@@ -166,7 +164,6 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
                 Either::Left(0)
             },
             arg_lists: vec![(posargs, keywords)],
-            gas: Gas::new(Self::GAS as isize),
             limit_hit: false,
             expandable_pos,
             expandable_kw,
@@ -218,7 +215,7 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
                 // A single argument's expansion (e.g. a large concrete tuple's cartesian product)
                 // can exceed the budget on its own. Skip it like `NotExpandable` and try the next
                 // argument, but record the truncation so a call that ultimately fails to match still
-                // reports it. Only the per-round budget below (`gas.stop`) aborts expansion entirely.
+                // reports it. Only an over-budget round below aborts expansion entirely.
                 self.limit_hit = true;
                 Vec::new()
             }
@@ -226,6 +223,12 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
         if expanded_types.is_empty() {
             // Nothing to expand here (or this position cannot disambiguate), try the next argument.
             self.expand(errors, owner)
+        } else if self.arg_lists.len().saturating_mul(expanded_types.len()) > Self::GAS {
+            // Splitting this argument would take us past the budget. Stop expanding, and move `idx`
+            // past the end of the keywords so that subsequent `expand` calls know we're done.
+            self.limit_hit = true;
+            self.idx = Either::Right(keywords.len());
+            None
         } else {
             let expanded_types = expanded_types.into_map(|t| owner.push(t));
             let mut new_arg_lists = Vec::new();
@@ -251,13 +254,6 @@ impl<'a, Ans: LookupAnswer> ArgsExpander<'a, Ans> {
                         }
                     }
                     new_arg_lists.push((new_posargs, new_keywords));
-                    if self.gas.stop() {
-                        // We've hit our hard-coded limit; stop expanding, and move `idx` past the
-                        // end of the keywords so that subsequent `expand` calls know we're done.
-                        self.limit_hit = true;
-                        self.idx = Either::Right(keywords.len());
-                        return None;
-                    }
                 }
             }
             self.arg_lists = new_arg_lists.clone();

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -2538,6 +2538,24 @@ def call(x: bool) -> None:
 "#,
 );
 
+// Six `bool` arguments are 2^6 = 64 combinations, which fits in the budget; only the seventh
+// argument above pushes it over. https://github.com/facebook/pyrefly/issues/4213
+testcase!(
+    test_overload_argument_expansion_limit_counts_combinations,
+    r#"
+from typing import overload
+
+@overload
+def f(a: str, b: str, c: str, d: str, e: str, g: str, /) -> int: ...
+@overload
+def f(a: bytes, b: bytes, c: bytes, d: bytes, e: bytes, g: bytes, /) -> str: ...
+def f(*args: str | bytes) -> int | str: ...
+
+def call(x: bool) -> None:
+    f(x, x, x, x, x, x)  # E: No matching overload found
+"#,
+);
+
 // A concrete tuple applies the same limit while expanding its element combinations, so seven
 // `bool` elements (2^7 combinations) must report that truncation too.
 // https://github.com/facebook/pyrefly/issues/4213

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -2519,3 +2519,43 @@ if TYPE_CHECKING:
     def f(a: str): ...
     "#,
 );
+
+// https://github.com/facebook/pyrefly/issues/4213: when argument type expansion for an
+// overloaded call exhausts its expansion limit, that truncation is reported instead of
+// silently giving up. Seven `bool` arguments against overloads that never match force the
+// expansion to split each argument (2^7 combinations) and exceed the limit.
+testcase!(
+    test_overload_argument_expansion_limit_reported,
+    r#"
+from typing import overload
+
+@overload
+def f(a: str, b: str, c: str, d: str, e: str, g: str, h: str, /) -> int: ...
+@overload
+def f(a: bytes, b: bytes, c: bytes, d: bytes, e: bytes, g: bytes, h: bytes, /) -> str: ...
+def f(*args: str | bytes) -> int | str: ...
+
+def call(x: bool) -> None:
+    f(x, x, x, x, x, x, x)  # E: No matching overload found  # E: hit the limit of 100 expansions
+"#,
+);
+
+// The limit warning must not fire when the call already matched: under legacy overload
+// expansion, expansion also runs to refine a union return type, and exhausting the limit there
+// does not change the (correct) result. https://github.com/facebook/pyrefly/issues/4213
+testcase!(
+    test_overload_argument_expansion_limit_not_reported_when_matched,
+    TestEnv::new().enable_legacy_overload_expansion(),
+    r#"
+from typing import assert_type, overload
+
+@overload
+def f(a: object, b: object, c: object, d: object, e: object, g: object, h: object, /) -> int | str: ...
+@overload
+def f(a: int, b: int, c: int, d: int, e: int, g: int, h: int, /) -> bytes: ...
+def f(*args: object) -> int | str | bytes: ...
+
+def call(x: bool) -> None:
+    assert_type(f(x, x, x, x, x, x, x), int | str)
+"#,
+);

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -2520,10 +2520,8 @@ if TYPE_CHECKING:
     "#,
 );
 
-// https://github.com/facebook/pyrefly/issues/4213: when argument type expansion for an
-// overloaded call exhausts its expansion limit, that truncation is reported instead of
-// silently giving up. Seven `bool` arguments against overloads that never match force the
-// expansion to split each argument (2^7 combinations) and exceed the limit.
+// Regression test for https://github.com/facebook/pyrefly/issues/4213: seven `bool` arguments
+// against non-matching overloads exceed the expansion limit, which is now reported.
 testcase!(
     test_overload_argument_expansion_limit_reported,
     r#"
@@ -2540,9 +2538,28 @@ def call(x: bool) -> None:
 "#,
 );
 
-// The limit warning must not fire when the call already matched: under legacy overload
-// expansion, expansion also runs to refine a union return type, and exhausting the limit there
-// does not change the (correct) result. https://github.com/facebook/pyrefly/issues/4213
+// A concrete tuple applies the same limit while expanding its element combinations, so seven
+// `bool` elements (2^7 combinations) must report that truncation too.
+// https://github.com/facebook/pyrefly/issues/4213
+testcase!(
+    test_overload_tuple_argument_expansion_limit_reported,
+    r#"
+from typing import overload
+
+@overload
+def f(x: tuple[str, str, str, str, str, str, str], /) -> int: ...
+@overload
+def f(x: tuple[bytes, bytes, bytes, bytes, bytes, bytes, bytes], /) -> str: ...
+def f(x: tuple[object, object, object, object, object, object, object], /) -> int | str: ...
+
+def call(x: bool) -> None:
+    f((x, x, x, x, x, x, x))  # E: No matching overload found  # E: hit the limit of 100 expansions
+"#,
+);
+
+// The limit warning must not fire once a call has matched (legacy union-return refinement runs
+// expansion too, but truncating it doesn't change the result).
+// https://github.com/facebook/pyrefly/issues/4213
 testcase!(
     test_overload_argument_expansion_limit_not_reported_when_matched,
     TestEnv::new().enable_legacy_overload_expansion(),
@@ -2557,5 +2574,113 @@ def f(*args: object) -> int | str | bytes: ...
 
 def call(x: bool) -> None:
     assert_type(f(x, x, x, x, x, x, x), int | str)
+"#,
+);
+
+// Arguments that already satisfy an identical parameter type in every overload aren't expanded
+// (only `key` disambiguates here), so the seven shared `bool`s don't exhaust the limit.
+// https://github.com/facebook/pyrefly/issues/4213
+testcase!(
+    test_overload_expansion_skips_non_disambiguating_args,
+    r#"
+from typing import Literal, assert_type, overload
+
+@overload
+def f(a: bool, b: bool, c: bool, d: bool, e: bool, g: bool, h: bool, key: Literal["x"], /) -> int: ...
+@overload
+def f(a: bool, b: bool, c: bool, d: bool, e: bool, g: bool, h: bool, key: Literal["y"], /) -> str: ...
+def f(a: bool, b: bool, c: bool, d: bool, e: bool, g: bool, h: bool, key: Literal["x", "y"], /) -> int | str: ...
+
+def call(flag: bool, k: Literal["x", "y"]) -> None:
+    assert_type(f(flag, flag, flag, flag, flag, flag, flag, k), int | str)
+"#,
+);
+
+// The seven `bool`s already satisfy the only arity-compatible overload, so only `key` expands and
+// the call reports a precise argument error instead of exhausting the limit.
+// https://github.com/facebook/pyrefly/issues/4213
+testcase!(
+    test_overload_expansion_skipped_for_single_arity_candidate,
+    r#"
+from typing import overload
+
+@overload
+def f(a: bool, b: bool, c: bool, d: bool, e: bool, g: bool, h: bool, key: int, /) -> int: ...
+@overload
+def f(a: str, /) -> str: ...
+def f(*args: object) -> int | str: ...
+
+def call(flag: bool, k: int | str) -> None:
+    f(flag, flag, flag, flag, flag, flag, flag, k)  # E: Argument `int | str` is not assignable to parameter `key`
+"#,
+);
+
+// The pruning is what keeps this call under the limit: without it the six shared `str | bytes`
+// arguments expand to 2^6 combinations before `flag` is ever reached.
+// https://github.com/facebook/pyrefly/issues/4213
+testcase!(
+    test_overload_expansion_skips_shared_args_to_stay_under_limit,
+    r#"
+from typing import Literal, assert_type, overload
+
+class A: ...
+class B: ...
+
+@overload
+def f(x: str | bytes, y: str | bytes, z: str | bytes, w: str | bytes, v: str | bytes, u: str | bytes, /, *, flag: Literal[True]) -> A: ...
+@overload
+def f(x: str | bytes, y: str | bytes, z: str | bytes, w: str | bytes, v: str | bytes, u: str | bytes, /, *, flag: Literal[False] = ...) -> B: ...
+def f(*args: str | bytes, flag: bool = False) -> A | B: ...
+
+def call(a: str | bytes, flag: bool) -> None:
+    assert_type(f(a, a, a, a, a, a, flag=flag), A | B)
+"#,
+);
+
+// An argument that only becomes assignable once split has to keep expanding, even though it binds
+// the same parameter in every candidate. https://github.com/facebook/pyrefly/issues/4213
+testcase!(
+    test_overload_expansion_not_skipped_when_splitting_is_what_matches,
+    r#"
+from typing import assert_type
+
+def call(d: dict[tuple[str, str] | tuple[None, str], str], k: tuple[str | None, str]) -> None:
+    assert_type(d.get(k), str | None)
+"#,
+);
+
+// Deciding what to prune probes parameter types for equivalence and assignability, which must not
+// pin placeholder vars owned by the receiver (here `{}`'s key/value types).
+// https://github.com/facebook/pyrefly/issues/4213
+testcase!(
+    test_overload_expansion_pruning_does_not_pin_receiver_vars,
+    r#"
+from collections.abc import Sequence
+from typing import reveal_type
+
+class Value: ...
+
+def call(by: Sequence[Value] | str) -> None:
+    groups = {}
+    groups.update(by)  # E: No matching overload found
+    reveal_type(groups)  # E: revealed type: dict[Unknown, Unknown]
+"#,
+);
+
+// An over-limit tuple argument is skipped (not aborted), so a later argument can still resolve the
+// call. https://github.com/facebook/pyrefly/issues/4213
+testcase!(
+    test_overload_fixed_tuple_limit_does_not_abort_expansion,
+    r#"
+from typing import Literal, assert_type, overload
+
+@overload
+def f(t: tuple[bool, bool, bool, bool, bool, bool, bool], flag: Literal[True]) -> int: ...
+@overload
+def f(t: tuple[object, object, object, object, object, object, object], flag: Literal[False]) -> str: ...
+def f(t: object, flag: bool) -> int | str: ...
+
+def call(x: bool, flag: bool) -> None:
+    assert_type(f((x, x, x, x, x, x, x), flag), int | str)
 "#,
 );

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -2538,6 +2538,24 @@ def call(x: bool) -> None:
 "#,
 );
 
+// Six `bool` arguments are 2^6 = 64 combinations, which fits in the budget; only the seventh
+// argument above pushes it over. https://github.com/facebook/pyrefly/issues/4213
+testcase!(
+    test_overload_argument_expansion_limit_counts_combinations,
+    r#"
+from typing import overload
+
+@overload
+def f(a: str, b: str, c: str, d: str, e: str, g: str, /) -> int: ...
+@overload
+def f(a: bytes, b: bytes, c: bytes, d: bytes, e: bytes, g: bytes, /) -> str: ...
+def f(*args: str | bytes) -> int | str: ...
+
+def call(x: bool) -> None:
+    f(x, x, x, x, x, x)  # E: No matching overload found
+"#,
+);
+
 // A concrete tuple applies the same limit while expanding its element combinations, so seven
 // `bool` elements (2^7 combinations) must report that truncation too.
 // https://github.com/facebook/pyrefly/issues/4213
@@ -2682,5 +2700,69 @@ def f(t: object, flag: bool) -> int | str: ...
 
 def call(x: bool, flag: bool) -> None:
     assert_type(f((x, x, x, x, x, x, x), flag), int | str)
+"#,
+);
+
+// A generic overload set (each candidate returns via its own `T`) whose blow-up comes from seven
+// type-variable-free shared `bool` args; only `key` discriminates. The old blanket generic
+// exclusion disabled *all* pruning whenever any candidate was generic, so this hit the limit.
+// Per-argument pruning of the shared, type-variable-free args now lets it resolve. Mirrors the
+// strawberry `field` / Tanjun `add_argument` / scipy `minimize` primer sites.
+// https://github.com/facebook/pyrefly/issues/4213
+testcase!(
+    test_overload_expansion_prunes_tvfree_args_with_generic_overloads,
+    r#"
+from typing import Literal, assert_type, overload
+
+@overload
+def f[T](val: T, a: bool, b: bool, c: bool, d: bool, e: bool, g: bool, h: bool, key: Literal["x"], /) -> T: ...
+@overload
+def f[T](val: T, a: bool, b: bool, c: bool, d: bool, e: bool, g: bool, h: bool, key: Literal["y"], /) -> list[T]: ...
+def f[T](val: T, a: bool, b: bool, c: bool, d: bool, e: bool, g: bool, h: bool, key: Literal["x", "y"], /) -> T | list[T]: ...
+
+def call(flag: bool, x: int, k: Literal["x", "y"]) -> None:
+    assert_type(f(x, flag, flag, flag, flag, flag, flag, flag, k), int | list[int])
+"#,
+);
+
+// Regression guard for the jax/ibis class the generic exclusion originally protected: expansion of
+// the union argument is what *solves* the type variable `T`, so the type-variable-bearing arg must
+// stay expandable. `list[T]` vs `set[T]` matches neither overload as a union; splitting `v` gives
+// `T = int` from `list[int]` and `T = str` from `set[str]`. Result must be unchanged by the fix.
+// https://github.com/facebook/pyrefly/issues/4213
+testcase!(
+    test_overload_expansion_keeps_tv_bearing_discriminator,
+    r#"
+from typing import assert_type, overload
+
+@overload
+def f[T](x: list[T]) -> T: ...
+@overload
+def f[T](x: set[T]) -> list[T]: ...
+def f[T](x: list[T] | set[T]) -> T | list[T]: ...
+
+def call(v: list[int] | set[str]) -> None:
+    assert_type(f(v), int | list[str])
+"#,
+);
+
+// Pruning and type-variable-driven expansion must coexist: the seven shared `bool`s are pruned so
+// the call stays under the limit, while the type-variable-bearing arg `x` keeps expanding so `T`
+// still solves to `int` (from `list[int]`) and `str` (from `set[str]`). On HEAD the generic
+// exclusion disabled pruning, so the bools exhausted the limit before `x` was reached.
+// https://github.com/facebook/pyrefly/issues/4213
+testcase!(
+    test_overload_expansion_prunes_shared_args_and_still_solves_type_var,
+    r#"
+from typing import assert_type, overload
+
+@overload
+def f[T](a: bool, b: bool, c: bool, d: bool, e: bool, g: bool, h: bool, x: list[T]) -> T: ...
+@overload
+def f[T](a: bool, b: bool, c: bool, d: bool, e: bool, g: bool, h: bool, x: set[T]) -> list[T]: ...
+def f[T](a: bool, b: bool, c: bool, d: bool, e: bool, g: bool, h: bool, x: list[T] | set[T]) -> T | list[T]: ...
+
+def call(flag: bool, v: list[int] | set[str]) -> None:
+    assert_type(f(flag, flag, flag, flag, flag, flag, flag, v), int | list[str])
 "#,
 );

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -1593,6 +1593,20 @@ class OpenTypedDict(TypedDict, closed=True): ...
 Note: In Python versions before 3.15, import `TypedDict` from `typing_extensions` rather than
 `typing` to use the `closed` feature.
 
+## overload-argument-expansion-limit
+
+Default severity: `warn`
+
+When resolving a call to an overloaded function, Pyrefly may
+[expand](https://typing.python.org/en/latest/spec/overload.html#argument-type-expansion) an
+argument (for example, splitting a `bool` into `Literal[True]` and `Literal[False]`) and try each
+resulting combination. To bound this work, Pyrefly stops after a fixed number of expansions. This
+warning is reported when that limit is reached, since the remaining combinations are left unchecked
+and the call may be resolved as if it had no matching overload even though one exists.
+
+This typically only happens in overload-heavy libraries. If you hit it, consider simplifying the
+call site (for example, narrowing an argument before the call) so fewer expansions are needed.
+
 ## parse-error
 
 An error related to parsing or syntax. This covers a variety of cases, such as function calls with duplicate keyword args, some poorly defined functions, and so on.

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -1600,9 +1600,10 @@ Default severity: `warn`
 When resolving a call to an overloaded function, Pyrefly may
 [expand](https://typing.python.org/en/latest/spec/overload.html#argument-type-expansion) an
 argument (for example, splitting a `bool` into `Literal[True]` and `Literal[False]`) and try each
-resulting combination. To bound this work, Pyrefly stops after a fixed number of expansions. This
-warning is reported when that limit is reached, since the remaining combinations are left unchecked
-and the call may be resolved as if it had no matching overload even though one exists.
+resulting combination. To bound this work, Pyrefly stops once splitting one more argument would
+take it past a fixed number of combinations. This warning is reported when that limit is reached,
+since the remaining combinations are left unchecked and the call may be resolved as if it had no
+matching overload even though one exists.
 
 This typically only happens in overload-heavy libraries. If you hit it, consider simplifying the
 call site (for example, narrowing an argument before the call) so fewer expansions are needed.


### PR DESCRIPTION
# Summary

Fixes #4213.

When resolving an overloaded call, Pyrefly performs [argument type expansion](https://typing.python.org/en/latest/spec/overload.html#argument-type-expansion) — splitting a `bool`/enum/union argument and trying each combination — bounded by a hard limit (`ArgsExpander::GAS`, currently 100). Previously, hitting that limit silently truncated the search, so a call needing more than 100 expansions could be reported as `no-matching-overload` (or resolve differently) with no indication. This PR has two parts (in separate commits):

**Warning.** Adds a new `overload-argument-expansion-limit` warning, emitted once against the call when the limit is reached without a match. It is not emitted once a call has already matched (e.g. `legacy_overload_expansion`'s union-return refinement, where truncating expansion doesn't change the result).

**Optimization.** Prunes expansion that cannot affect overload selection, so the limit is reached far less often (keeping the warning an error of last resort):
- An argument whose parameter type is identical across every candidate overload cannot disambiguate them, so it is left un-split — the pre-match analogue of the existing `should_materialize`.
- With a single arity-compatible overload there is nothing to disambiguate, so expansion is skipped and the call resolves to a precise argument error instead of exhausting the limit.

Both prunings are conservative — a position whose binding isn't statically determinable (call-site unpacking, `*args`/`**kwargs`, `ParamSpec`, differing arities) stays expandable — and exclude generic overloads, where expansion also drives type-variable solving. Resolution results are unchanged for calls that previously resolved; only wasted expansions (and spurious limit warnings) are removed.

# Test Plan

Added to `pyrefly/lib/test/overload.rs`, each sized so the limit warning would fire without the pruning:
- `test_overload_argument_expansion_limit_reported` / `test_overload_argument_expansion_limit_not_reported_when_matched` — the warning fires on genuine truncation, and stays silent once a call has matched.
- `test_overload_expansion_skips_non_disambiguating_args` / `test_overload_expansion_skipped_for_single_arity_candidate` — the two prunings.

`cargo test -p pyrefly --lib` and `cargo test -p pyrefly_config` (the `ErrorKind` ↔ `error-kinds.mdx` sync test) pass; `test.py` formatting and linting are clean.