### PR TITLE
fix --min-severity=info does not work

### DIFF
--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -1424,9 +1424,14 @@ impl CheckArgs {
             write_error_json_to_file(baseline_path, relative_to.as_path(), &new_baseline)?;
         }
 
-        // Count only ordinary errors for exit code determination. Directives
-        // (e.g. reveal_type) do not contribute to the error count.
-        let ordinary_errors_count = config_errors_count + ordinary_errors.len();
+        // Directives always display, but only affect the exit code when they
+        // meet the user's severity threshold.
+        let diagnostics_count = config_errors_count
+            + ordinary_errors.len()
+            + directives
+                .iter()
+                .filter(|e| e.severity() >= min_severity)
+                .count();
 
         // Merge directives into the display list, re-sorting by module
         // name, path, and source range so output preserves file/line
@@ -1463,7 +1468,7 @@ impl CheckArgs {
             } else {
                 "error"
             };
-            let mut parts = vec![count(ordinary_errors_count, label)];
+            let mut parts = vec![count(diagnostics_count, label)];
             if suppress_count > 0 {
                 parts.push(format!("{} suppressed", number_thousands(suppress_count)));
             }
@@ -1588,7 +1593,7 @@ impl CheckArgs {
         if self.behavior.expectations {
             loads.check_against_expectations()?;
             Ok((CommandExitStatus::Success, output_errors))
-        } else if ordinary_errors_count > 0 {
+        } else if diagnostics_count > 0 {
             Ok((CommandExitStatus::UserError, output_errors))
         } else {
             Ok((CommandExitStatus::Success, output_errors))

--- a/test/errors.md
+++ b/test/errors.md
@@ -140,6 +140,16 @@ $ echo "x: str = 0" > $TMPDIR/test.py && \
 [1]
 ```
 
+## `--min-severity info` causes nonzero exit on directives
+
+```scrut
+$ touch $TMPDIR/pyrefly.toml && \
+> printf "from typing import reveal_type\nreveal_type(1)\n" > $TMPDIR/test.py && \
+> $PYREFLY check $TMPDIR/test.py --min-severity=info --output-format=min-text
+ INFO */test.py:2:12-15: revealed type: Literal[1] [reveal-type] (glob)
+[1]
+```
+
 ## `--output-format junit-xml` emits well-formed XML
 
 ```scrut {output_stream: stdout}


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4305

now counts directives when they meet the effective severity threshold.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test