### PR TITLE
fix match on tuple subject not narrowed to Never for assert_never exhaustiveness #4066

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -2019,6 +2019,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     range,
                     errors,
                 );
+                // A match-arm negation may build on a facet narrow from an earlier arm.
+                // If the accumulated facet is impossible, the whole subject is impossible.
+                if facet_subject.origin == FacetOrigin::MatchSubject
+                    && facet_subject.allow_never_collapse
+                    && ty.is_never()
+                {
+                    return type_info.clone().with_ty(ty);
+                }
                 let mut narrowed = type_info.with_narrow(resolved_chain.facets(), ty);
                 // For certain types of narrows, we can also narrow the parent of the current subject
                 // If `.get()` on a dict or TypedDict is falsy, the key may not be present at all
@@ -2081,12 +2089,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     type_info.clone()
                 }
             }
-            NarrowOp::Or(ops) => TypeInfo::join(
-                ops.map(|op| self.narrow(type_info, op, range, errors)),
-                &|tys| self.unions(tys),
-                &|got, want| self.is_subset_eq(got, want),
-                JoinStyle::SimpleMerge,
-            ),
+            NarrowOp::Or(ops) => {
+                let mut branches = ops.map(|op| self.narrow(type_info, op, range, errors));
+                if ops.iter().any(NarrowOp::has_match_subject_facet) {
+                    branches.retain(|branch| !branch.ty().is_never());
+                }
+                TypeInfo::join(
+                    branches,
+                    &|tys| self.unions(tys),
+                    &|got, want| self.is_subset_eq(got, want),
+                    JoinStyle::SimpleMerge,
+                )
+            }
         }
     }
 

--- a/pyrefly/lib/binding/narrow.rs
+++ b/pyrefly/lib/binding/narrow.rs
@@ -403,6 +403,8 @@ pub enum FacetOrigin {
     Direct,
     // This facet came from a call to a `get` method, like `x.get("key")`
     GetMethod,
+    // This facet belongs to the evaluated tuple in a multi-subject match.
+    MatchSubject,
 }
 
 #[derive(Clone, Debug)]
@@ -519,6 +521,17 @@ impl NarrowOp {
         }
     }
 
+    /// Whether this operation narrows an element of a multi-subject match tuple.
+    pub(crate) fn has_match_subject_facet(&self) -> bool {
+        match self {
+            Self::Atomic(Some(facet_subject), _) => {
+                facet_subject.origin == FacetOrigin::MatchSubject
+            }
+            Self::Atomic(None, _) => false,
+            Self::And(ops) | Self::Or(ops) => ops.iter().any(Self::has_match_subject_facet),
+        }
+    }
+
     fn and(&mut self, other: Self) {
         match self {
             Self::And(ops) => ops.push(other),
@@ -573,6 +586,9 @@ impl NarrowOp {
             chain.extend(extra.chain.facets().clone());
             let origin = match (base.origin, extra.origin) {
                 (FacetOrigin::GetMethod, _) | (_, FacetOrigin::GetMethod) => FacetOrigin::GetMethod,
+                (FacetOrigin::MatchSubject, _) | (_, FacetOrigin::MatchSubject) => {
+                    FacetOrigin::MatchSubject
+                }
                 _ => FacetOrigin::Direct,
             };
             FacetSubject {

--- a/pyrefly/lib/binding/pattern.rs
+++ b/pyrefly/lib/binding/pattern.rs
@@ -74,12 +74,20 @@ impl MatchSubject {
         matches!(self, MatchSubject::Synthetic { .. })
     }
 
+    /// Whether narrowing can be stored on the evaluated match subject itself.
+    fn has_local_subject(&self) -> bool {
+        matches!(
+            self,
+            MatchSubject::Synthetic { .. } | MatchSubject::Tuple(_)
+        )
+    }
+
     fn subject_narrow_op(&self, op: NarrowOp, range: TextRange) -> PatternNarrowOps {
         if let Some(subject) = self.as_single() {
             let mut scope = NarrowOps::new();
             scope.and_for_subject(subject, op.for_subject(subject), range);
             PatternNarrowOps::from_scope(scope)
-        } else if self.is_synthetic() {
+        } else if self.has_local_subject() {
             PatternNarrowOps::from_subject(op, range)
         } else {
             PatternNarrowOps::new()
@@ -276,7 +284,7 @@ impl<'a> BindingsBuilder<'a> {
                                 alias_op.for_subject(original_subject),
                                 range,
                             );
-                        } else if original_subject.is_synthetic() {
+                        } else if original_subject.has_local_subject() {
                             narrow_ops.and_subject(Some((alias_op, range)));
                         }
                     }
@@ -327,6 +335,11 @@ impl<'a> BindingsBuilder<'a> {
                     NarrowOp::Atomic(None, len_narrow_op.clone()),
                 ]);
                 let element_facet_ops: Vec<NarrowOp> = if num_patterns == num_non_star_patterns {
+                    let facet_origin = if matches!(match_subject, MatchSubject::Tuple(_)) {
+                        FacetOrigin::MatchSubject
+                    } else {
+                        FacetOrigin::Direct
+                    };
                     x.patterns
                         .iter()
                         .enumerate()
@@ -337,7 +350,7 @@ impl<'a> BindingsBuilder<'a> {
                                         chain: UnresolvedFacetChain::new(Vec1::new(
                                             UnresolvedFacetKind::Index(i as i64),
                                         )),
-                                        origin: FacetOrigin::Direct,
+                                        origin: facet_origin,
                                         allow_never_collapse: false,
                                     }),
                                     atomic,
@@ -380,7 +393,7 @@ impl<'a> BindingsBuilder<'a> {
                         NarrowOp::Atomic(facet, len_narrow_op.clone()),
                     ]);
                     narrow_ops.scope.0.insert(name, (scope_narrow_op, x.range));
-                } else if match_subject.is_synthetic() {
+                } else if match_subject.has_local_subject() {
                     let subject_op = if all_subpatterns_irrefutable {
                         combined_narrow_op
                     } else if sequence_fully_characterized {
@@ -517,7 +530,7 @@ impl<'a> BindingsBuilder<'a> {
                         NarrowUseLocation::Span(x.range()),
                     ),
                 );
-                let subject_op = if match_subject.is_synthetic() && !x.keys.is_empty() {
+                let subject_op = if match_subject.has_local_subject() && !x.keys.is_empty() {
                     NarrowOp::And(vec![
                         NarrowOp::Atomic(None, narrow_op),
                         NarrowOp::Atomic(None, AtomicNarrowOp::Placeholder),
@@ -933,6 +946,12 @@ impl<'a> BindingsBuilder<'a> {
                     Binding::Expr(None, Box::new(*guard)),
                 );
                 new_narrow_ops.and_all(PatternNarrowOps::from_scope(guard_narrow_ops))
+            }
+            if has_guard && match_subject.has_local_subject() {
+                new_narrow_ops.and_subject(Some((
+                    NarrowOp::Atomic(None, AtomicNarrowOp::Placeholder),
+                    case_range,
+                )));
             }
             // Only accumulate narrows for the match subject. Alias names
             // from MatchAs were already copied to the subject via

--- a/pyrefly/lib/test/pattern_match.rs
+++ b/pyrefly/lib/test/pattern_match.rs
@@ -1511,6 +1511,35 @@ def f(t: tuple[int, str] | tuple[str, int]) -> int:  # E: one or more paths are 
 "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/4066
+testcase!(
+    test_match_tuple_subject_exhaustive_rows,
+    r#"
+from typing import assert_never
+class RQ: pass
+class QQ: pass
+class RA: pass
+class QA: pass
+def f(q: RQ | QQ, a: RA | QA) -> None:
+    match q, a:
+        case RQ(), RA(): return
+        case RQ(), _: return
+        case QQ(), QA(): return
+        case QQ(), _: return
+        case unreachable:
+            assert_never(unreachable)
+
+def guarded(q: RQ | QQ, a: RA | QA, flag: bool) -> None:
+    match q, a:
+        case RQ(), RA(): return
+        case RQ(), _ if flag: return
+        case QQ(), QA(): return
+        case QQ(), _: return
+        case reachable:
+            assert_never(reachable)  # E: not assignable to parameter `arg` with type `Never`
+"#,
+);
+
 testcase!(
     test_match_sequence_nested_element_not_exhaustive,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4066

Preserved tuple-level narrowing across multi-subject match arms, and correctly collapses exhausted tuple subjects to Never.

Conservatively handles guarded cases.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test