### PR TITLE
fix TypeVarTuple generics are turned into tuple[object, ...] too early. #4072

### DIFF
--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -2779,7 +2779,17 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
 
         for (got_arg, want_arg, param) in izip!(got, want, params.iter()) {
             if param.kind() == QuantifiedKind::TypeVarTuple {
-                self.is_consistent(got_arg, want_arg)?;
+                let as_tuple_carrier = |arg: &Type| {
+                    // A symbolic variadic argument represents the whole tuple, like `tuple[*Ts]`.
+                    if matches!(arg, Type::Var(_)) || arg.is_kind_type_var_tuple() {
+                        self.solver
+                            .heap
+                            .mk_unpacked_tuple(Vec::new(), arg.clone(), Vec::new())
+                    } else {
+                        arg.clone()
+                    }
+                };
+                self.is_consistent(&as_tuple_carrier(got_arg), &as_tuple_carrier(want_arg))?;
             } else if param.kind() == QuantifiedKind::IntVar {
                 let got_arg = Self::intvar_targ_for_compare(got_arg)?;
                 let want_arg = Self::intvar_targ_for_compare(want_arg)?;

--- a/pyrefly/lib/test/type_var_tuple.rs
+++ b/pyrefly/lib/test/type_var_tuple.rs
@@ -134,6 +134,30 @@ assert_type(test((1, 2, 3)), tuple[int, int, int])
 );
 
 testcase!(
+    test_type_var_tuple_constructor_inference_from_generic,
+    r#"
+from collections.abc import Callable
+
+class Codec[*Ts]:
+    def map[T](
+        self,
+        f: Callable[[*Ts], T],
+        inv_f: Callable[[T], tuple[*Ts]],
+    ) -> Map[T, *Ts]:
+        return Map(self, f, inv_f)
+
+class Map[T, *Ts](Codec[T]):
+    def __init__(
+        self,
+        parser: Codec[*Ts],
+        f: Callable[[*Ts], T],
+        inv_f: Callable[[T], tuple[*Ts]],
+    ) -> None:
+        ...
+"#,
+);
+
+testcase!(
     test_type_var_tuple_subtype,
     r#"
 from typing import assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4072

Normalized symbolic TypeVarTuple class arguments into tuple carriers before invariant comparison, preventing premature widening to `tuple[object, ...]`

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test