### PR TITLE
[pyrefly] Parse forward references without source padding

### DIFF
--- a/crates/pyrefly_python/src/ast.rs
+++ b/crates/pyrefly_python/src/ast.rs
@@ -34,7 +34,6 @@ use ruff_python_ast::PythonVersion as RuffPythonVersion;
 use ruff_python_ast::Singleton;
 use ruff_python_ast::Stmt;
 use ruff_python_ast::StmtIf;
-use ruff_python_ast::StringFlags;
 use ruff_python_ast::StringLiteral;
 use ruff_python_ast::StringLiteralFlags;
 use ruff_python_ast::StringLiteralValue;
@@ -49,6 +48,7 @@ use ruff_python_parser::Parsed;
 use ruff_python_parser::UnsupportedSyntaxError;
 use ruff_python_parser::parse_expression_range;
 use ruff_python_parser::parse_unchecked;
+use ruff_python_parser::typing::parse_type_annotation;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
@@ -178,20 +178,8 @@ impl Ast {
             .body)
     }
 
-    pub fn parse_type_literal(x: &StringLiteral) -> anyhow::Result<Expr> {
-        let mut s = &*x.value;
-        let buffer;
-        let mut add = x.flags.prefix().text_len() + TextSize::new(1);
-
-        if x.flags.is_triple_quoted() {
-            // Implicitly bracketed, so add them explicitly
-            buffer = format!("({s})");
-            s = &buffer;
-            add += TextSize::new(1); // 3 for the quotes, minus 1 for the bracket, minus 1 for the raw quote
-        }
-        // Make sure the range is precise, so that we get the right UTF8 indices.
-        // We might have a problem with \ escapes moving indices, but if necessary we can ban those.
-        Ast::parse_expr(s, x.range.start() + add)
+    pub fn parse_type_literal(x: &ExprStringLiteral, source: &str) -> anyhow::Result<Expr> {
+        Ok(parse_type_annotation(x, source)?.expression().clone())
     }
 
     pub fn unpack_slice(x: &Expr) -> &[Expr] {

--- a/pyrefly/lib/binding/expr.rs
+++ b/pyrefly/lib/binding/expr.rs
@@ -1360,8 +1360,8 @@ impl<'a> BindingsBuilder<'a> {
                     allow_proxy_method,
                 );
             }
-            Expr::StringLiteral(literal)
-                if let Some(literal) = as_forward_ref(literal, in_string_literal) =>
+            Expr::StringLiteral(expr_literal)
+                if let Some(literal) = as_forward_ref(expr_literal, in_string_literal) =>
             {
                 if literal.flags.prefix().is_raw() {
                     self.error(
@@ -1370,7 +1370,7 @@ impl<'a> BindingsBuilder<'a> {
                         "Raw string literals are not allowed in type expressions".to_owned(),
                     );
                 }
-                match Ast::parse_type_literal(literal) {
+                match Ast::parse_type_literal(expr_literal, self.module_info.contents()) {
                     Ok(expr) => {
                         *x = expr;
                         self.ensure_type_impl(


### PR DESCRIPTION
# Summary

Forward-reference parsing previously prefixed each annotation with spaces up to its source offset, making allocation volume depend on where the annotation appeared in the file. Use Ruff's source-aware annotation parser so ranges remain correct without constructing the prefix. This also delegates escaped and triple-quoted handling to Ruff.

# Test Plan

- `uv run --with jsonschema --with toml python test.py`
