### PR TITLE
fix False positive for torch.register_* #3988

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -503,6 +503,17 @@ impl ClassField {
         Self::new_synthesized_inner(ty, false)
     }
 
+    pub fn new_synthesized_instance_attribute(ty: Type) -> Self {
+        ClassField(
+            ClassFieldInner::InstanceAttribute {
+                ty,
+                annotation: None,
+                read_only_reason: None,
+            },
+            IsInherited::Maybe,
+        )
+    }
+
     /// Like `new_synthesized`, but marks the field as a ClassVar.
     pub fn new_synthesized_classvar(ty: Type) -> Self {
         Self::new_synthesized_inner(ty, true)

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -533,6 +533,17 @@ impl ClassField {
         Self::new_synthesized_inner(ty, false)
     }
 
+    pub fn new_synthesized_instance_attribute(ty: Type) -> Self {
+        ClassField(
+            ClassFieldInner::InstanceAttribute {
+                ty,
+                annotation: None,
+                read_only_reason: None,
+            },
+            IsInherited::Maybe,
+        )
+    }
+
     /// Like `new_synthesized`, but marks the field as a ClassVar.
     pub fn new_synthesized_classvar(ty: Type) -> Self {
         Self::new_synthesized_inner(ty, true)

--- a/pyrefly/lib/alt/nn_module_specials.rs
+++ b/pyrefly/lib/alt/nn_module_specials.rs
@@ -26,15 +26,19 @@ use ruff_python_ast::Expr;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
+use starlark_map::small_map::SmallMap;
 
 use crate::alt::answers::LookupAnswer;
 use crate::alt::answers_solver::AnswersSolver;
 use crate::alt::call::CallStyle;
 use crate::alt::callable::CallArg;
 use crate::alt::class::class_field::ClassAttribute;
+use crate::alt::types::class_metadata::ClassSynthesizedField;
+use crate::alt::types::class_metadata::ClassSynthesizedFields;
 use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
 use crate::error::context::ErrorContext;
+use crate::types::class::Class;
 use crate::types::class::ClassType;
 
 pub fn is_nn_module_dict(cls: &ClassType) -> bool {
@@ -48,6 +52,43 @@ pub fn is_nn_sequential(cls: &ClassType) -> bool {
 }
 
 impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
+    /// Synthesize attributes created by `nn.Module.register_buffer` and
+    /// `nn.Module.register_parameter` calls in a constructor.
+    pub fn get_nn_module_synthesized_fields(
+        &self,
+        cls: &Class,
+        registrations: &SmallMap<Name, Vec<Expr>>,
+    ) -> Option<ClassSynthesizedFields> {
+        if registrations.is_empty()
+            || !self
+                .get_mro_for_class(cls)
+                .ancestors_no_object()
+                .iter()
+                .any(|base| {
+                    let base = base.class_object();
+                    base.has_toplevel_qname("torch.nn", "Module")
+                        || base.has_toplevel_qname("torch.nn.modules.module", "Module")
+                })
+        {
+            return None;
+        }
+
+        let errors = self.error_swallower();
+        let mut fields = SmallMap::with_capacity(registrations.len());
+        for (name, values) in registrations {
+            let mut types = values.iter().map(|value| self.expr_infer(value, &errors));
+            let first = types
+                .next()
+                .expect("registration map values are never empty");
+            let ty = types.fold(first, |left, right| self.union(left, right));
+            fields.insert(
+                name.clone(),
+                ClassSynthesizedField::new_instance_attribute(ty),
+            );
+        }
+        Some(ClassSynthesizedFields::new(fields))
+    }
+
     /// Chain input through each module in an `nn.Sequential`.
     ///
     /// When `Sequential[M1, M2, M3]` is called with input `x`, threads `x` through

--- a/pyrefly/lib/alt/nn_module_specials.rs
+++ b/pyrefly/lib/alt/nn_module_specials.rs
@@ -26,15 +26,19 @@ use ruff_python_ast::Expr;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
+use starlark_map::small_map::SmallMap;
 
 use crate::alt::answers::LookupAnswer;
 use crate::alt::answers_solver::AnswersSolver;
 use crate::alt::call::CallStyle;
 use crate::alt::callable::CallArg;
 use crate::alt::class::class_field::ClassAttribute;
+use crate::alt::types::class_metadata::ClassSynthesizedField;
+use crate::alt::types::class_metadata::ClassSynthesizedFields;
 use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
 use crate::error::context::ErrorContext;
+use crate::types::class::Class;
 use crate::types::class::ClassType;
 
 pub fn is_nn_module_dict(cls: &ClassType) -> bool {
@@ -48,6 +52,43 @@ pub fn is_nn_sequential(cls: &ClassType) -> bool {
 }
 
 impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
+    /// Synthesize attributes created by `nn.Module.register_buffer` and
+    /// `nn.Module.register_parameter` calls in a constructor.
+    pub fn get_nn_module_synthesized_fields(
+        &self,
+        cls: &Class,
+        registrations: &SmallMap<Name, Vec<Expr>>,
+    ) -> Option<ClassSynthesizedFields> {
+        if registrations.is_empty()
+            || !self
+                .get_mro_for_class(cls)
+                .ancestors_no_object()
+                .iter()
+                .any(|base| {
+                    let base = base.class_object();
+                    base.has_toplevel_qname("torch.nn", "Module")
+                        || base.has_toplevel_qname("torch.nn.modules.module", "Module")
+                })
+        {
+            return None;
+        }
+
+        let errors = self.error_swallower();
+        let mut fields = SmallMap::with_capacity(registrations.len());
+        for (name, values) in registrations {
+            let mut types = values.iter().map(|value| self.expr_infer(value, &errors));
+            let first = types
+                .next()
+                .expect("registration map values are never empty");
+            let ty = types.fold(first, |left, right| self.union(left, right));
+            fields.insert(
+                name.clone(),
+                ClassSynthesizedField::new_instance_attribute(ty),
+            );
+        }
+        Some(ClassSynthesizedFields::new(fields))
+    }
+
     /// Chain input through each module in an `nn.Sequential`.
     ///
     /// When `Sequential[M1, M2, M3]` is called with input `x`, threads `x` through

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -3122,12 +3122,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     pub fn solve_class_synthesized_fields(
         &self,
         errors: &ErrorCollector,
-        fields: &BindingClassSynthesizedFields,
+        binding: &BindingClassSynthesizedFields,
     ) -> Arc<ClassSynthesizedFields> {
-        let fields = match &self.get_idx(fields.0).0 {
+        let fields = match &self.get_idx(binding.class_idx).0 {
             None => ClassSynthesizedFields::default(),
             Some(cls) => {
                 let mut fields = ClassSynthesizedFields::default();
+                if let Some(registrations) = binding.nn_module_registrations.as_deref()
+                    && let Some(new_fields) =
+                        self.get_nn_module_synthesized_fields(cls, registrations)
+                {
+                    fields = fields.combine(new_fields);
+                }
                 if let Some(new_fields) = self.get_typed_dict_synthesized_fields(cls) {
                     fields = fields.combine(new_fields);
                 }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -3132,12 +3132,18 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     pub fn solve_class_synthesized_fields(
         &self,
         errors: &ErrorCollector,
-        fields: &BindingClassSynthesizedFields,
+        binding: &BindingClassSynthesizedFields,
     ) -> ClassSynthesizedFields {
-        match &self.get_idx(fields.0).0 {
+        match &self.get_idx(binding.class_idx).0 {
             None => ClassSynthesizedFields::default(),
             Some(cls) => {
                 let mut fields = ClassSynthesizedFields::default();
+                if let Some(registrations) = binding.nn_module_registrations.as_deref()
+                    && let Some(new_fields) =
+                        self.get_nn_module_synthesized_fields(cls, registrations)
+                {
+                    fields = fields.combine(new_fields);
+                }
                 if let Some(new_fields) = self.get_typed_dict_synthesized_fields(cls) {
                     fields = fields.combine(new_fields);
                 }

--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -492,6 +492,12 @@ impl ClassSynthesizedField {
             inner: Arc::new(ClassField::new_synthesized_classvar(ty)),
         }
     }
+
+    pub fn new_instance_attribute(ty: Type) -> Self {
+        Self {
+            inner: Arc::new(ClassField::new_synthesized_instance_attribute(ty)),
+        }
+    }
 }
 
 /// A class's synthesized fields, such as a dataclass's `__init__` method.

--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -507,6 +507,12 @@ impl ClassSynthesizedField {
             inner: Arc::new(ClassField::new_synthesized_classvar(ty)),
         }
     }
+
+    pub fn new_instance_attribute(ty: Type) -> Self {
+        Self {
+            inner: Arc::new(ClassField::new_synthesized_instance_attribute(ty)),
+        }
+    }
 }
 
 /// A class's synthesized fields, such as a dataclass's `__init__` method.

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -50,6 +50,7 @@ use ruff_python_ast::TypeParams;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
+use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 use vec1::Vec1;
 
@@ -133,7 +134,7 @@ assert_bytes!(BindingClassDisjointBase, 4);
 assert_bytes!(BindingAbstractClassCheck, 4);
 assert_bytes!(BindingClassSubscriptSymmetry, 4);
 assert_words!(BindingClassField, 11);
-assert_bytes!(BindingClassSynthesizedFields, 4);
+assert_words!(BindingClassSynthesizedFields, 2);
 assert_bytes!(BindingLegacyTypeParam, 16);
 assert_words!(BindingYield, 4);
 assert_words!(BindingYieldFrom, 4);
@@ -561,7 +562,7 @@ impl Keyed for KeyClassSynthesizedFields {
     where
         BindingTable: TableKeyed<Self, Value = BindingEntry<Self>>,
     {
-        bindings.idx_to_key(bindings.get(idx).0).range()
+        bindings.idx_to_key(bindings.get(idx).class_idx).range()
     }
     fn try_to_anykey(&self) -> Option<AnyExportedKey> {
         Some(AnyExportedKey::KeyClassSynthesizedFields(self.clone()))
@@ -3212,11 +3213,18 @@ pub enum MethodSelfKind {
 /// has to be its own key/binding type because of the dependencies between the various pieces of
 /// information about a class: ClassDef -> ClassMetadata -> ClassField -> ClassSynthesizedFields.
 #[derive(Clone, Debug)]
-pub struct BindingClassSynthesizedFields(pub Idx<KeyClass>);
+pub struct BindingClassSynthesizedFields {
+    pub class_idx: Idx<KeyClass>,
+    pub nn_module_registrations: Option<Box<SmallMap<Name, Vec<Expr>>>>,
+}
 
 impl DisplayWith<Bindings> for BindingClassSynthesizedFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, ctx: &Bindings) -> fmt::Result {
-        write!(f, "BindingClassSynthesizedFields({})", ctx.display(self.0))
+        write!(
+            f,
+            "BindingClassSynthesizedFields({})",
+            ctx.display(self.class_idx)
+        )
     }
 }
 

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -51,6 +51,7 @@ use ruff_python_ast::TypeParams;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
+use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 use vec1::Vec1;
 
@@ -138,7 +139,7 @@ assert_bytes!(BindingClassDisjointBase, 4);
 assert_bytes!(BindingAbstractClassCheck, 4);
 assert_bytes!(BindingClassSubscriptSymmetry, 4);
 assert_words!(BindingClassField, 11);
-assert_bytes!(BindingClassSynthesizedFields, 4);
+assert_words!(BindingClassSynthesizedFields, 2);
 assert_bytes!(BindingLegacyTypeParam, 16);
 assert_words!(BindingYield, 4);
 assert_words!(BindingYieldFrom, 4);
@@ -575,7 +576,7 @@ impl Keyed for KeyClassSynthesizedFields {
     where
         BindingTable: TableKeyed<Self, Value = BindingEntry<Self>>,
     {
-        bindings.idx_to_key(bindings.get(idx).0).range()
+        bindings.idx_to_key(bindings.get(idx).class_idx).range()
     }
     fn try_to_anykey(&self) -> Option<AnyExportedKey> {
         Some(AnyExportedKey::KeyClassSynthesizedFields(self.clone()))
@@ -3336,11 +3337,18 @@ pub enum MethodSelfKind {
 /// has to be its own key/binding type because of the dependencies between the various pieces of
 /// information about a class: ClassDef -> ClassMetadata -> ClassField -> ClassSynthesizedFields.
 #[derive(Clone, Debug)]
-pub struct BindingClassSynthesizedFields(pub Idx<KeyClass>);
+pub struct BindingClassSynthesizedFields {
+    pub class_idx: Idx<KeyClass>,
+    pub nn_module_registrations: Option<Box<SmallMap<Name, Vec<Expr>>>>,
+}
 
 impl DisplayWith<Bindings> for BindingClassSynthesizedFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, ctx: &Bindings) -> fmt::Result {
-        write!(f, "BindingClassSynthesizedFields({})", ctx.display(self.0))
+        write!(
+            f,
+            "BindingClassSynthesizedFields({})",
+            ctx.display(self.class_idx)
+        )
     }
 }
 

--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -420,11 +420,6 @@ impl<'a> BindingsBuilder<'a> {
                 class_idx: class_indices.class_idx,
             },
         );
-        self.insert_binding_idx(
-            class_indices.synthesized_fields_idx,
-            BindingClassSynthesizedFields(class_indices.class_idx),
-        );
-
         let legacy_tparam_collector = legacy.unwrap();
         self.add_name_definitions(&legacy_tparam_collector);
 
@@ -448,7 +443,16 @@ impl<'a> BindingsBuilder<'a> {
             body,
             &NestingContext::class(ShortIdentifier::new(&x.name), parent.dupe()),
         );
-        let field_definitions = self.scopes.finish_class_and_get_field_definitions();
+        let (field_definitions, nn_module_registrations) =
+            self.scopes.finish_class_and_get_field_definitions();
+        self.insert_binding_idx(
+            class_indices.synthesized_fields_idx,
+            BindingClassSynthesizedFields {
+                class_idx: class_indices.class_idx,
+                nn_module_registrations: (!nn_module_registrations.is_empty())
+                    .then(|| Box::new(nn_module_registrations)),
+            },
+        );
 
         let django_field_info = self.extract_django_fields_from_class_body(&field_definitions);
         let mut fields = SmallMap::with_capacity(field_definitions.len());
@@ -1204,7 +1208,10 @@ impl<'a> BindingsBuilder<'a> {
         );
         self.insert_binding_idx(
             class_indices.synthesized_fields_idx,
-            BindingClassSynthesizedFields(class_indices.class_idx),
+            BindingClassSynthesizedFields {
+                class_idx: class_indices.class_idx,
+                nn_module_registrations: None,
+            },
         );
 
         let mut fields = SmallMap::new();

--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -408,11 +408,6 @@ impl<'a> BindingsBuilder<'a> {
                 class_idx: class_indices.class_idx,
             },
         );
-        self.insert_binding_idx(
-            class_indices.synthesized_fields_idx,
-            BindingClassSynthesizedFields(class_indices.class_idx),
-        );
-
         self.add_name_definitions(&legacy);
 
         self.scopes.push(Scope::class_body(
@@ -435,7 +430,16 @@ impl<'a> BindingsBuilder<'a> {
             body,
             &NestingContext::class(ShortIdentifier::new(&x.name), parent.dupe()),
         );
-        let field_definitions = self.scopes.finish_class_and_get_field_definitions();
+        let (field_definitions, nn_module_registrations) =
+            self.scopes.finish_class_and_get_field_definitions();
+        self.insert_binding_idx(
+            class_indices.synthesized_fields_idx,
+            BindingClassSynthesizedFields {
+                class_idx: class_indices.class_idx,
+                nn_module_registrations: (!nn_module_registrations.is_empty())
+                    .then(|| Box::new(nn_module_registrations)),
+            },
+        );
 
         let django_field_info = self.extract_django_fields_from_class_body(&field_definitions);
         let mut fields = SmallMap::with_capacity(field_definitions.len());
@@ -1047,7 +1051,10 @@ impl<'a> BindingsBuilder<'a> {
         );
         self.insert_binding_idx(
             class_indices.synthesized_fields_idx,
-            BindingClassSynthesizedFields(class_indices.class_idx),
+            BindingClassSynthesizedFields {
+                class_idx: class_indices.class_idx,
+                nn_module_registrations: None,
+            },
         );
 
         let mut fields = SmallMap::new();

--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -170,6 +170,7 @@ impl<'a, 'b> SourceOrderVisitor<'a> for SuperMethodCallFinder<'b> {
 pub struct SelfAssignments {
     pub method_name: Name,
     pub instance_attributes: SmallMap<Name, InstanceAttribute>,
+    pub nn_module_registrations: SmallMap<Name, Vec<Expr>>,
 }
 
 /// Determine whether a function definition is annotated.
@@ -274,6 +275,7 @@ impl<'a> SelfAttrNames<'a> {
         Some(SelfAssignments {
             method_name: func_name.id.clone(),
             instance_attributes,
+            nn_module_registrations: SmallMap::new(),
         })
     }
 }

--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -173,6 +173,7 @@ impl<'a, 'b> SourceOrderVisitor<'a> for SuperMethodCallFinder<'b> {
 pub struct SelfAssignments {
     pub method_name: Name,
     pub instance_attributes: SmallMap<Name, InstanceAttribute>,
+    pub nn_module_registrations: SmallMap<Name, Vec<Expr>>,
 }
 
 /// Determine whether a function definition is annotated.
@@ -277,6 +278,7 @@ impl<'a> SelfAttrNames<'a> {
         Some(SelfAssignments {
             method_name: func_name.id.clone(),
             instance_attributes,
+            nn_module_registrations: SmallMap::new(),
         })
     }
 }

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -987,6 +987,7 @@ struct ScopeClass {
     indices: ClassIndices,
     attributes_from_recognized_methods: SmallMap<Name, SmallMap<Name, InstanceAttribute>>,
     attributes_from_other_methods: SmallMap<Name, SmallMap<Name, InstanceAttribute>>,
+    nn_module_registrations: SmallMap<Name, Vec<Expr>>,
     has_protocol_base: bool,
 }
 
@@ -997,6 +998,7 @@ impl ScopeClass {
             indices,
             attributes_from_recognized_methods: SmallMap::new(),
             attributes_from_other_methods: SmallMap::new(),
+            nn_module_registrations: SmallMap::new(),
             has_protocol_base,
         }
     }
@@ -1005,10 +1007,19 @@ impl ScopeClass {
         &mut self,
         method_name: Name,
         attributes: SmallMap<Name, InstanceAttribute>,
+        nn_module_registrations: SmallMap<Name, Vec<Expr>>,
     ) {
         if is_attribute_defining_method(&method_name, &self.name.id) {
             self.attributes_from_recognized_methods
-                .insert(method_name, attributes);
+                .insert(method_name.clone(), attributes);
+            if method_name == dunder::INIT || method_name == dunder::POST_INIT {
+                for (name, values) in nn_module_registrations {
+                    self.nn_module_registrations
+                        .entry(name)
+                        .or_default()
+                        .extend(values);
+                }
+            }
         } else {
             self.attributes_from_other_methods
                 .insert(method_name, attributes);
@@ -1101,6 +1112,7 @@ struct ScopeMethod {
     name: Identifier,
     self_name: Option<Identifier>,
     instance_attributes: SmallMap<Name, InstanceAttribute>,
+    nn_module_registrations: SmallMap<Name, Vec<Expr>>,
     parameters: SmallMap<Name, ParameterUsage>,
     yields_and_returns: YieldsAndReturns,
     is_async: bool,
@@ -1172,6 +1184,7 @@ impl ScopeMethod {
             name,
             self_name: None,
             instance_attributes: SmallMap::new(),
+            nn_module_registrations: SmallMap::new(),
             parameters: SmallMap::new(),
             yields_and_returns: Default::default(),
             is_async,
@@ -1942,6 +1955,7 @@ impl Scopes {
                 Some(SelfAssignments {
                     method_name: method_scope.name.id,
                     instance_attributes: method_scope.instance_attributes,
+                    nn_module_registrations: method_scope.nn_module_registrations,
                 }),
                 Self::collect_unused_parameters(method_scope.parameters),
                 unused_variables,
@@ -2008,6 +2022,29 @@ impl Scopes {
             }
         }
         false
+    }
+
+    /// Record the value of `self.register_buffer(...)` or `self.register_parameter(...)`.
+    /// The enclosing class is checked for `torch.nn.Module` ancestry during solving.
+    pub fn record_nn_module_registration(&mut self, receiver: &Expr, name: Name, value: Expr) {
+        for scope in self.iter_rev_mut() {
+            match &mut scope.kind {
+                ScopeKind::Method(method_scope) => {
+                    if let Some(self_name) = &method_scope.self_name
+                        && matches!(receiver, Expr::Name(receiver_name) if receiver_name.id == self_name.id)
+                    {
+                        method_scope
+                            .nn_module_registrations
+                            .entry(name)
+                            .or_default()
+                            .push(value);
+                    }
+                    return;
+                }
+                ScopeKind::Function(_) => return,
+                _ => {}
+            }
+        }
     }
 
     pub fn method_that_sets_attr(&self, x: &ExprAttribute) -> Option<MethodThatSetsAttr> {
@@ -2694,6 +2731,7 @@ impl Scopes {
             class_scope.add_attributes_defined_by_method(
                 self_assignments.method_name,
                 self_assignments.instance_attributes,
+                self_assignments.nn_module_registrations,
             );
         }
     }
@@ -2787,10 +2825,13 @@ impl Scopes {
     /// - Panics if the current scope is not a class body.
     pub fn finish_class_and_get_field_definitions(
         &mut self,
-    ) -> SmallMap<Name, (ClassFieldDefinition, TextRange)> {
+    ) -> (
+        SmallMap<Name, (ClassFieldDefinition, TextRange)>,
+        SmallMap<Name, Vec<Expr>>,
+    ) {
         let mut field_definitions = SmallMap::new();
         let class_body = self.pop();
-        let class_scope = {
+        let mut class_scope = {
             if let ScopeKind::Class(class_scope) = class_body.kind {
                 class_scope
             } else {
@@ -2803,6 +2844,7 @@ impl Scopes {
         // are initialized in a recognized instance method (e.g. `__init__`) before building
         // field definitions — a Final field is legally uninitialized in the class body if it
         // appears in such a method.
+        let nn_module_registrations = mem::take(&mut class_scope.nn_module_registrations);
         let method_attrs: Vec<_> = class_scope.method_defined_attributes().collect();
         let recognized_instance_attrs: SmallSet<Name> = method_attrs
             .iter()
@@ -2931,7 +2973,7 @@ impl Scopes {
                 }
             },
         );
-        field_definitions
+        (field_definitions, nn_module_registrations)
     }
 
     /// Return a pair Some((method_name, class_key)) if we are currently in a method

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -1036,6 +1036,7 @@ struct ScopeClass {
     indices: ClassIndices,
     attributes_from_recognized_methods: SmallMap<Name, SmallMap<Name, InstanceAttribute>>,
     attributes_from_other_methods: SmallMap<Name, SmallMap<Name, InstanceAttribute>>,
+    nn_module_registrations: SmallMap<Name, Vec<Expr>>,
     has_protocol_base: bool,
 }
 
@@ -1046,6 +1047,7 @@ impl ScopeClass {
             indices,
             attributes_from_recognized_methods: SmallMap::new(),
             attributes_from_other_methods: SmallMap::new(),
+            nn_module_registrations: SmallMap::new(),
             has_protocol_base,
         }
     }
@@ -1054,10 +1056,19 @@ impl ScopeClass {
         &mut self,
         method_name: Name,
         attributes: SmallMap<Name, InstanceAttribute>,
+        nn_module_registrations: SmallMap<Name, Vec<Expr>>,
     ) {
         if is_attribute_defining_method(&method_name, &self.name.id) {
             self.attributes_from_recognized_methods
-                .insert(method_name, attributes);
+                .insert(method_name.clone(), attributes);
+            if method_name == dunder::INIT || method_name == dunder::POST_INIT {
+                for (name, values) in nn_module_registrations {
+                    self.nn_module_registrations
+                        .entry(name)
+                        .or_default()
+                        .extend(values);
+                }
+            }
         } else {
             self.attributes_from_other_methods
                 .insert(method_name, attributes);
@@ -1150,6 +1161,7 @@ struct ScopeMethod {
     name: Identifier,
     self_name: Option<Identifier>,
     instance_attributes: SmallMap<Name, InstanceAttribute>,
+    nn_module_registrations: SmallMap<Name, Vec<Expr>>,
     parameters: SmallMap<Name, ParameterUsage>,
     yields_and_returns: YieldsAndReturns,
     is_async: bool,
@@ -1221,6 +1233,7 @@ impl ScopeMethod {
             name,
             self_name: None,
             instance_attributes: SmallMap::new(),
+            nn_module_registrations: SmallMap::new(),
             parameters: SmallMap::new(),
             yields_and_returns: Default::default(),
             is_async,
@@ -2097,6 +2110,7 @@ impl Scopes {
                 Some(SelfAssignments {
                     method_name: method_scope.name.id,
                     instance_attributes: method_scope.instance_attributes,
+                    nn_module_registrations: method_scope.nn_module_registrations,
                 }),
                 Self::collect_unused_parameters(method_scope.parameters),
                 unused_variables,
@@ -2163,6 +2177,29 @@ impl Scopes {
             }
         }
         false
+    }
+
+    /// Record the value of `self.register_buffer(...)` or `self.register_parameter(...)`.
+    /// The enclosing class is checked for `torch.nn.Module` ancestry during solving.
+    pub fn record_nn_module_registration(&mut self, receiver: &Expr, name: Name, value: Expr) {
+        for scope in self.iter_rev_mut() {
+            match &mut scope.kind {
+                ScopeKind::Method(method_scope) => {
+                    if let Some(self_name) = &method_scope.self_name
+                        && matches!(receiver, Expr::Name(receiver_name) if receiver_name.id == self_name.id)
+                    {
+                        method_scope
+                            .nn_module_registrations
+                            .entry(name)
+                            .or_default()
+                            .push(value);
+                    }
+                    return;
+                }
+                ScopeKind::Function(_) => return,
+                _ => {}
+            }
+        }
     }
 
     pub fn method_that_sets_attr(&self, x: &ExprAttribute) -> Option<MethodThatSetsAttr> {
@@ -2893,6 +2930,7 @@ impl Scopes {
             class_scope.add_attributes_defined_by_method(
                 self_assignments.method_name,
                 self_assignments.instance_attributes,
+                self_assignments.nn_module_registrations,
             );
         }
     }
@@ -2986,10 +3024,13 @@ impl Scopes {
     /// - Panics if the current scope is not a class body.
     pub fn finish_class_and_get_field_definitions(
         &mut self,
-    ) -> SmallMap<Name, (ClassFieldDefinition, TextRange)> {
+    ) -> (
+        SmallMap<Name, (ClassFieldDefinition, TextRange)>,
+        SmallMap<Name, Vec<Expr>>,
+    ) {
         let mut field_definitions = SmallMap::new();
         let class_body = self.pop();
-        let class_scope = {
+        let mut class_scope = {
             if let ScopeKind::Class(class_scope) = class_body.kind {
                 class_scope
             } else {
@@ -3002,6 +3043,7 @@ impl Scopes {
         // are initialized in a recognized instance method (e.g. `__init__`) before building
         // field definitions — a Final field is legally uninitialized in the class body if it
         // appears in such a method.
+        let nn_module_registrations = mem::take(&mut class_scope.nn_module_registrations);
         let method_attrs: Vec<_> = class_scope.method_defined_attributes().collect();
         let recognized_instance_attrs: SmallSet<Name> = method_attrs
             .iter()
@@ -3130,7 +3172,7 @@ impl Scopes {
                 }
             },
         );
-        field_definitions
+        (field_definitions, nn_module_registrations)
     }
 
     /// Return a pair Some((method_name, class_key)) if we are currently in a method

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -1700,6 +1700,42 @@ impl<'a> BindingsBuilder<'a> {
                 } else {
                     None
                 };
+                // PyTorch nn.Module registers buffers and parameters as instance attributes.
+                // Collect literal-name candidates now; solving later verifies nn.Module ancestry.
+                if let Expr::Call(call) = x.value.as_ref()
+                    && let Expr::Attribute(func) = call.func.as_ref()
+                    && let Some(value_keyword) = match func.attr.id.as_str() {
+                        "register_buffer" => Some("tensor"),
+                        "register_parameter" => Some("param"),
+                        _ => None,
+                    }
+                {
+                    let name = call.arguments.args.first().or_else(|| {
+                        call.arguments.keywords.iter().find_map(|keyword| {
+                            (keyword
+                                .arg
+                                .as_ref()
+                                .is_some_and(|arg| arg.as_str() == "name"))
+                            .then_some(&keyword.value)
+                        })
+                    });
+                    let value = call.arguments.args.get(1).or_else(|| {
+                        call.arguments.keywords.iter().find_map(|keyword| {
+                            (keyword
+                                .arg
+                                .as_ref()
+                                .is_some_and(|arg| arg.as_str() == value_keyword))
+                            .then_some(&keyword.value)
+                        })
+                    });
+                    if let (Some(Expr::StringLiteral(name)), Some(value)) = (name, value) {
+                        self.scopes.record_nn_module_registration(
+                            &func.value,
+                            Name::new(name.value.to_str()),
+                            value.clone(),
+                        );
+                    }
+                }
                 let special_export = if let Expr::Call(ExprCall { func, .. }) = &*x.value {
                     self.as_special_export(func)
                 } else {

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -1658,6 +1658,42 @@ impl<'a> BindingsBuilder<'a> {
                 } else {
                     None
                 };
+                // PyTorch nn.Module registers buffers and parameters as instance attributes.
+                // Collect literal-name candidates now; solving later verifies nn.Module ancestry.
+                if let Expr::Call(call) = x.value.as_ref()
+                    && let Expr::Attribute(func) = call.func.as_ref()
+                    && let Some(value_keyword) = match func.attr.id.as_str() {
+                        "register_buffer" => Some("tensor"),
+                        "register_parameter" => Some("param"),
+                        _ => None,
+                    }
+                {
+                    let name = call.arguments.args.first().or_else(|| {
+                        call.arguments.keywords.iter().find_map(|keyword| {
+                            (keyword
+                                .arg
+                                .as_ref()
+                                .is_some_and(|arg| arg.as_str() == "name"))
+                            .then_some(&keyword.value)
+                        })
+                    });
+                    let value = call.arguments.args.get(1).or_else(|| {
+                        call.arguments.keywords.iter().find_map(|keyword| {
+                            (keyword
+                                .arg
+                                .as_ref()
+                                .is_some_and(|arg| arg.as_str() == value_keyword))
+                            .then_some(&keyword.value)
+                        })
+                    });
+                    if let (Some(Expr::StringLiteral(name)), Some(value)) = (name, value) {
+                        self.scopes.record_nn_module_registration(
+                            &func.value,
+                            Name::new(name.value.to_str()),
+                            value.clone(),
+                        );
+                    }
+                }
                 let special_export = if let Expr::Call(ExprCall { func, .. }) = &*x.value {
                     self.as_special_export(func)
                 } else {

--- a/pyrefly/lib/test/mod.rs
+++ b/pyrefly/lib/test/mod.rs
@@ -52,6 +52,7 @@ mod named_tuple;
 mod narrow;
 mod natural;
 mod new_type;
+mod nn_module;
 mod operators;
 mod overload;
 mod pandas;

--- a/pyrefly/lib/test/nn_module.rs
+++ b/pyrefly/lib/test/nn_module.rs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::test::util::TestEnv;
+use crate::testcase;
+
+fn torch_env() -> TestEnv {
+    TestEnv::one(
+        "torch.nn",
+        r#"
+class Tensor:
+    def tolist(self) -> list[int]: ...
+
+class Parameter(Tensor): ...
+
+class Module:
+    def register_buffer(
+        self, name: str, tensor: Tensor | None, persistent: bool = True
+    ) -> None: ...
+    def register_parameter(self, name: str, param: Parameter | None) -> None: ...
+"#,
+    )
+}
+
+testcase!(
+    test_nn_module_register_buffer_and_parameter,
+    torch_env(),
+    r#"
+from torch.nn import Module, Parameter, Tensor
+from typing import assert_type
+
+class Model(Module):
+    def __init__(self) -> None:
+        self.register_buffer("values", Tensor())
+        self.register_parameter(name="weight", param=Parameter())
+
+model = Model()
+assert_type(model.values, Tensor)
+assert_type(model.weight, Parameter)
+model.values.tolist()
+Model.values  # E: Instance-only attribute `values` of class `Model` is not visible on the class
+"#,
+);
+
+testcase!(
+    test_register_buffer_is_only_special_for_nn_module,
+    torch_env(),
+    r#"
+from torch.nn import Tensor
+
+class NotAModule:
+    def register_buffer(self, name: str, value: Tensor) -> None: ...
+
+    def __init__(self) -> None:
+        self.register_buffer("values", Tensor())
+
+NotAModule().values  # E: Object of class `NotAModule` has no attribute `values`
+"#,
+);


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3988

Recognizes `self.register_buffer(...)` and `self.register_parameter(...)` in `__init__/__post_init__`, synthesizes correctly typed instance attributes for `torch.nn.Module` subclasses.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test