### PR TITLE
fix Feature: VSCode command palette that runs pyrefly infer on the current file #1069

### DIFF
--- a/lsp/README.md
+++ b/lsp/README.md
@@ -16,6 +16,8 @@ The Pyrefly extension:
 - Adds language features from Pyrefly's analysis like go-to definition, hover,
   etc. (full list [here](https://github.com/facebook/pyrefly/issues/344)) and
   disables Pylance completely (VSCode's built-in Python extension)
+- Adds a `Pyrefly: Infer Types for Current File` command that writes inferred
+  type annotations to the active Python file.
 
 ## Customization
 

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -75,6 +75,11 @@
                 "command": "pyrefly.unfoldAllDocstrings"
             },
             {
+                "title": "Infer Types for Current File",
+                "category": "pyrefly",
+                "command": "pyrefly.infer"
+            },
+            {
                 "title": "Run File",
                 "category": "pyrefly",
                 "command": "pyrefly.runMain"

--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -9,6 +9,8 @@
 
 import {ExtensionContext, workspace} from 'vscode';
 import * as vscode from 'vscode';
+import {execFile} from 'child_process';
+import {basename, dirname} from 'path';
 import {
   CancellationToken,
   ConfigurationItem,
@@ -37,6 +39,7 @@ import {
 let client: LanguageClient;
 let outputChannel: vscode.OutputChannel;
 let traceOutputChannel: vscode.OutputChannel;
+let inferOutputChannel: vscode.OutputChannel;
 
 /// Get a setting at the path, or throw an error if it's not set.
 function requireSetting<T>(path: string): T {
@@ -99,8 +102,11 @@ export async function activate(context: ExtensionContext) {
       'Pyrefly language server trace',
     );
   }
+  if (!inferOutputChannel) {
+    inferOutputChannel = vscode.window.createOutputChannel('Pyrefly infer');
+  }
 
-  const path: string = requireSetting('pyrefly.lspPath');
+  const lspPath: string = requireSetting('pyrefly.lspPath');
   const args: [string] = requireSetting('pyrefly.lspArguments');
 
   const bundledPyreflyPath = vscode.Uri.joinPath(
@@ -109,12 +115,13 @@ export async function activate(context: ExtensionContext) {
     // process.platform returns win32 on any windows CPU architecture
     process.platform === 'win32' ? 'pyrefly.exe' : 'pyrefly',
   );
+  const pyreflyPath = lspPath === '' ? bundledPyreflyPath.fsPath : lspPath;
 
   const pythonEnv = new PythonEnvironment(context);
 
   // Otherwise to spawn the server
   let serverOptions: ServerOptions = {
-    command: path === '' ? bundledPyreflyPath.fsPath : path,
+    command: pyreflyPath,
     args: args,
   };
   // `getConfiguration` returns a `WorkspaceConfiguration` proxy, not a
@@ -259,6 +266,65 @@ export async function activate(context: ExtensionContext) {
       await runDocstringFoldingCommand(client, outputChannel, 'editor.unfold');
     }),
   );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('pyrefly.infer', async () => {
+      const document = vscode.window.activeTextEditor?.document;
+      if (
+        document === undefined ||
+        document.languageId !== 'python' ||
+        document.uri.scheme !== 'file'
+      ) {
+        await vscode.window.showErrorMessage(
+          'Open a saved Python file before running Pyrefly infer.',
+        );
+        return;
+      }
+      if (!(await document.save())) {
+        await vscode.window.showErrorMessage(
+          `Pyrefly could not save ${basename(document.uri.fsPath)} before inferring types.`,
+        );
+        return;
+      }
+
+      const cwd =
+        vscode.workspace.getWorkspaceFolder(document.uri)?.uri.fsPath ??
+        dirname(document.uri.fsPath);
+      inferOutputChannel.clear();
+      try {
+        await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: `Pyrefly: Inferring types in ${basename(document.uri.fsPath)}`,
+          },
+          async () => {
+            await new Promise<void>((resolve, reject) => {
+              execFile(
+                pyreflyPath,
+                ['infer', document.uri.fsPath],
+                {cwd},
+                (error, stdout, stderr) => {
+                  inferOutputChannel.append(stdout);
+                  inferOutputChannel.append(stderr);
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve();
+                  }
+                },
+              );
+            });
+          },
+        );
+      } catch (error) {
+        inferOutputChannel.show(true);
+        const message = error instanceof Error ? error.message : String(error);
+        await vscode.window.showErrorMessage(
+          `Pyrefly could not infer types in ${basename(document.uri.fsPath)}: ${message}`,
+        );
+      }
+    }),
+  );
   registerCodeLensCommands(context, pythonEnv);
 
   // When our extension is activated, make sure ms-python knows
@@ -292,6 +358,9 @@ export function deactivate(): Thenable<void> | undefined {
   }
   if (traceOutputChannel) {
     traceOutputChannel.dispose();
+  }
+  if (inferOutputChannel) {
+    inferOutputChannel.dispose();
   }
   return client.stop();
 }

--- a/lsp/src/test/extension.test.ts
+++ b/lsp/src/test/extension.test.ts
@@ -6,6 +6,9 @@
  */
 
 import * as assert from 'assert';
+import {promises as fs} from 'fs';
+import {tmpdir} from 'os';
+import {join} from 'path';
 import * as vscode from 'vscode';
 
 suite('Extension Test Suite', () => {
@@ -16,5 +19,32 @@ suite('Extension Test Suite', () => {
 		this.timeout(10000);
 		await extension?.activate();
 		assert.ok(true);
+	});
+
+	test('Infer types in the current file', async function () {
+		this.timeout(30000);
+		assert.ok(extension);
+		await extension.activate();
+
+		const directory = await fs.mkdtemp(join(tmpdir(), 'pyrefly-infer-'));
+		const uri = vscode.Uri.file(join(directory, 'test.py'));
+		try {
+			await vscode.workspace.fs.writeFile(
+				uri,
+				Buffer.from('def foo():\n    return 1\n'),
+			);
+			const document = await vscode.workspace.openTextDocument(uri);
+			await vscode.window.showTextDocument(document);
+
+			await vscode.commands.executeCommand('pyrefly.infer');
+
+			const result = Buffer.from(
+				await vscode.workspace.fs.readFile(uri),
+			).toString();
+			assert.strictEqual(result, 'def foo() -> int:\n    return 1\n');
+		} finally {
+			await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+			await fs.rm(directory, {recursive: true, force: true});
+		}
 	});
 });


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1069

Added Pyrefly: Infer Types for Current File to the command palette.
Saves the active Python file and runs the configured/bundled pyrefly infer.
Displays progress and surfaces failures in a dedicated output channel.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test