### PR TITLE
fix(stubgen): preserve RHS of explicit `TypeAlias` assignments

### DIFF
--- a/pyrefly/lib/stubgen.rs
+++ b/pyrefly/lib/stubgen.rs
@@ -267,6 +267,11 @@ class BaseModel:
     }
 
     #[test]
+    fn test_stubgen_type_alias_explicit() {
+        assert_stubgen_snapshot("type_alias_explicit");
+    }
+
+    #[test]
     fn test_stubgen_generics() {
         assert_stubgen_snapshot("generics");
     }

--- a/pyrefly/lib/stubgen/extract.rs
+++ b/pyrefly/lib/stubgen/extract.rs
@@ -44,6 +44,7 @@ use starlark_map::Hashed;
 
 use crate::alt::answers::Answers;
 use crate::alt::types::decorated_function::DecoratedFunction;
+use crate::binding::binding::Binding;
 use crate::binding::binding::Key;
 use crate::binding::binding::KeyClassField;
 use crate::binding::binding::KeyClassMetadata;
@@ -935,20 +936,29 @@ fn extract_ann_assign(
     ctx: &mut ExtractionContext,
     in_class: bool,
 ) -> Option<StubVariable> {
-    let name = match ann_assign.target.as_ref() {
-        Expr::Name(n) => n.id.as_str(),
+    let name_expr = match ann_assign.target.as_ref() {
+        Expr::Name(name_expr) => name_expr,
         _ => return None,
     };
+    let name = name_expr.id.as_str();
     if !should_include_name(name, ctx.config, in_class, ctx.dunder_all) {
         return None;
     }
 
     let annotation = expr_source_text(ctx.module_info, ann_assign.annotation.range());
 
-    let value = ann_assign
-        .value
-        .as_deref()
-        .and_then(|v| simple_value_text(v, ctx.module_info));
+    let def_key = Key::Definition(ShortIdentifier::expr_name(name_expr));
+    let is_type_alias = ctx
+        .bindings
+        .key_to_idx_hashed_opt(Hashed::new(&def_key))
+        .is_some_and(|idx| matches!(ctx.bindings.get(idx), Binding::TypeAlias(_)));
+    let value = ann_assign.value.as_deref().and_then(|value| {
+        if is_type_alias {
+            Some(expr_source_text(ctx.module_info, value.range()))
+        } else {
+            simple_value_text(value, ctx.module_info)
+        }
+    });
 
     Some(StubVariable {
         name: name.to_owned(),

--- a/pyrefly/lib/test/stubgen/dunder_all/expected.pyi
+++ b/pyrefly/lib/test/stubgen/dunder_all/expected.pyi
@@ -2,7 +2,7 @@
 from typing import TypeAlias
 
 __all__ = ["public_func", "PublicClass", "PUBLIC_VAR", "Vector"]
-Vector: TypeAlias
+Vector: TypeAlias = list[float]
 
 
 def public_func(x: int) -> str: ...

--- a/pyrefly/lib/test/stubgen/mixed/expected.pyi
+++ b/pyrefly/lib/test/stubgen/mixed/expected.pyi
@@ -1,7 +1,7 @@
 # @generated
 from typing import TypeAlias
 
-Vector: TypeAlias
+Vector: TypeAlias = list[float]
 MAX: int = 42
 
 

--- a/pyrefly/lib/test/stubgen/type_alias_explicit/expected.pyi
+++ b/pyrefly/lib/test/stubgen/type_alias_explicit/expected.pyi
@@ -1,0 +1,23 @@
+# @generated
+import collections.abc
+from typing import Literal, TypeAlias, TypeVar
+
+T = TypeVar("T")
+
+TemplateId: TypeAlias = str
+TemplateKind: TypeAlias = Literal["abc", "def"]
+TemplateLookup: TypeAlias = dict[TemplateId, str]
+TemplateSequence: TypeAlias = collections.abc.Sequence[tuple[TemplateId, str]]
+GenericTemplateSequence: TypeAlias = collections.abc.Sequence[tuple[T, str]]
+
+type ModernTemplateId = str
+
+type ModernTemplateKind = Literal["abc", "def"]
+
+type ModernTemplateLookup = dict[ModernTemplateId, str]
+
+type ModernTemplateSequence = collections.abc.Sequence[tuple[ModernTemplateId, str]]
+
+type ModernGenericTemplateSequence[T] = collections.abc.Sequence[tuple[T, str]]
+
+template_names: collections.abc.Sequence[str]

--- a/pyrefly/lib/test/stubgen/type_alias_explicit/input.py
+++ b/pyrefly/lib/test/stubgen/type_alias_explicit/input.py
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import collections.abc
+from typing import Literal, TypeAlias, TypeVar
+
+T = TypeVar("T")
+
+TemplateId: TypeAlias = str
+TemplateKind: TypeAlias = Literal["abc", "def"]
+TemplateLookup: TypeAlias = dict[TemplateId, str]
+TemplateSequence: TypeAlias = collections.abc.Sequence[tuple[TemplateId, str]]
+GenericTemplateSequence: TypeAlias = collections.abc.Sequence[tuple[T, str]]
+
+type ModernTemplateId = str
+type ModernTemplateKind = Literal["abc", "def"]
+type ModernTemplateLookup = dict[ModernTemplateId, str]
+type ModernTemplateSequence = collections.abc.Sequence[tuple[ModernTemplateId, str]]
+type ModernGenericTemplateSequence[T] = collections.abc.Sequence[tuple[T, str]]
+
+# Complex runtime values on ordinary annotated variables should still be omitted.
+template_names: collections.abc.Sequence[str] = ("thumbnail", "document")


### PR DESCRIPTION
## Summary
Resolves #4319 by special-casing `TypeAlias` annotations when extracting annotated assignments.

## Testing
- Adds regression tests for both the pre-PEP 695 `TypeAlias` annotations, and the post-PEP 695 `type` statements.