### PR TITLE
Fix apply baselines to unused-ignore diagnostics

### DIFF
--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -1339,9 +1339,10 @@ impl CheckArgs {
         );
         let output_format = self.output.output_format();
 
-        let collected = loads.collect_errors();
+        let mut collected = loads.collect_errors();
         // Pass pre-collected errors to avoid redundant error collection.
         let unused_ignore_errors = loads.collect_unused_ignore_errors_for_display(&collected);
+        collected.ordinary.extend(unused_ignore_errors.ordinary);
         let errors = loads.apply_baseline(
             collected,
             self.output.baseline.as_deref(),
@@ -1363,20 +1364,6 @@ impl CheckArgs {
             )
         } else {
             (errors.directives, errors.ordinary)
-        };
-        let ordinary_errors: Vec<_> = if let Some(only) = &self.output.only {
-            let only = only.iter().collect::<SmallSet<_>>();
-            let filtered: Vec<_> = unused_ignore_errors
-                .ordinary
-                .into_iter()
-                .filter(|e| only.contains(&e.error_kind()))
-                .collect();
-            ordinary_errors.into_iter().chain(filtered).collect()
-        } else {
-            ordinary_errors
-                .into_iter()
-                .chain(unused_ignore_errors.ordinary)
-                .collect()
         };
 
         // Filter by minimum severity. Directives are not subject to this

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -328,8 +328,9 @@ impl Errors {
     /// Each baseline is loaded once (cached per config) and resolved relative to its
     /// config's source root, falling back to the baseline file's own directory.
     pub fn collect_lsp_errors_with_baselines(&self) -> (Vec<Error>, Vec<Error>) {
-        let collected = self.collect_errors();
+        let mut collected = self.collect_errors();
         let unused = self.collect_unused_ignore_errors_for_display(&collected);
+        collected.ordinary.extend(unused.ordinary);
         let config_by_path: SmallMap<&ModulePath, &ArcId<ConfigFile>> = self
             .loads
             .iter()
@@ -366,7 +367,6 @@ impl Errors {
             }
         }
 
-        ordinary.extend(unused.ordinary);
         (
             Self::merge_display_errors(ordinary, errors.directives),
             Self::merge_display_errors(errors.baseline, Vec::new()),

--- a/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
@@ -221,6 +221,44 @@ fn test_baseline_diagnostic_is_hint() {
     interaction.shutdown().unwrap();
 }
 
+#[test]
+fn test_baselined_unused_type_ignore_is_hint() {
+    let test_files_root = get_test_files_root();
+    let root_path = test_files_root.path().join("baseline_unused_type_ignore");
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root_path);
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(None),
+            ..Default::default()
+        })
+        .expect("Failed to initialize");
+
+    interaction.client.did_open("bad.py");
+
+    interaction
+        .client
+        .diagnostic("bad.py")
+        .expect_response_with(|response| {
+            let DocumentDiagnosticReportResult::Report(report) = response else {
+                return false;
+            };
+            let lsp_types::DocumentDiagnosticReport::Full(full) = report else {
+                return false;
+            };
+            let items = &full.full_document_diagnostic_report.items;
+            items.len() == 1
+                && items[0].code
+                    == Some(lsp_types::NumberOrString::String(
+                        "unused-type-ignore".to_owned(),
+                    ))
+                && items[0].severity == Some(lsp_types::DiagnosticSeverity::HINT)
+        })
+        .expect("Failed to receive baselined unused-type-ignore diagnostic");
+
+    interaction.shutdown().unwrap();
+}
+
 /// Push diagnostics (`publishDiagnostics`) is the primary user-facing path and
 /// has the same HINT-downgrade logic as the pull path exercised above, so assert
 /// the published notification downgrades only the baselined error.

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/baseline_unused_type_ignore/bad.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/baseline_unused_type_ignore/bad.py
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+x = 1  # type: ignore

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/baseline_unused_type_ignore/baseline.json
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/baseline_unused_type_ignore/baseline.json
@@ -1,0 +1,15 @@
+{
+  "errors": [
+    {
+      "line": 6,
+      "column": 1,
+      "stop_line": 6,
+      "stop_column": 2,
+      "path": "bad.py",
+      "code": -2,
+      "name": "unused-type-ignore",
+      "description": "test",
+      "concise_description": "test"
+    }
+  ]
+}

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/baseline_unused_type_ignore/pyrefly.toml
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/baseline_unused_type_ignore/pyrefly.toml
@@ -1,0 +1,4 @@
+baseline = "baseline.json"
+
+[errors]
+unused-type-ignore = "error"

--- a/test/baseline.md
+++ b/test/baseline.md
@@ -49,3 +49,33 @@ $ mkdir -p $TMPDIR/baseline_relative/subdir && \
  INFO 0 errors
 [0]
 ```
+
+## Updating a baseline records unused `# type: ignore` errors
+
+```scrut {output_stream: stdout}
+$ mkdir -p $TMPDIR/baseline_unused_type_ignore_update && \
+> echo "# type: ignore" > $TMPDIR/baseline_unused_type_ignore_update/bad.py && \
+> touch $TMPDIR/baseline_unused_type_ignore_update/pyrefly.toml && \
+> cd $TMPDIR/baseline_unused_type_ignore_update && \
+> $PYREFLY check --error=unused-type-ignore --baseline=baseline.json --update-baseline --output-format=min-text
+ERROR *bad.py* ?unused-type-ignore? (glob)
+[1]
+```
+
+```scrut {output_stream: stdout}
+$ grep '"name": "unused-type-ignore"' $TMPDIR/baseline_unused_type_ignore_update/baseline.json
+      "name": "unused-type-ignore",
+[0]
+```
+
+## A baselined unused `# type: ignore` error is suppressed
+
+```scrut {output_stream: stdout}
+$ mkdir -p $TMPDIR/baseline_unused_type_ignore_check && \
+> echo "# type: ignore" > $TMPDIR/baseline_unused_type_ignore_check/bad.py && \
+> echo '{"errors": [{"line": 1, "column": 1, "stop_line": 1, "stop_column": 2, "path": "bad.py", "code": -2, "name": "unused-type-ignore", "description": "test", "concise_description": "test"}]}' > $TMPDIR/baseline_unused_type_ignore_check/baseline.json && \
+> touch $TMPDIR/baseline_unused_type_ignore_check/pyrefly.toml && \
+> cd $TMPDIR/baseline_unused_type_ignore_check && \
+> $PYREFLY check --error=unused-type-ignore --baseline=baseline.json --output-format=min-text
+[0]
+```


### PR DESCRIPTION
# Summary

Fixes #4307 

The root cause was that unused-ignore diagnostics were derived after ordinary errors had already passed through baseline filtering. Although `--update-baseline` recorded these diagnostics, subsequent checks appended them after baseline matching, so they continued to be reported.

This change merges unused-ignore diagnostics into ordinary diagnostics before baseline processing in both the CLI and LSP paths. Matching diagnostics are now suppressed by CLI checks and reported as hints by the LSP.

Because unused-ignore collection covers both `unused-type-ignore` and `unused-ignore`, all enabled unused-ignore diagnostics now receive the same baseline behavior. 

Fixes #4307

# Test Plan

- `Updating a baseline records unused # type: ignore errors`
- `A baselined unused # type: ignore error is suppressed`
- `test_baselined_unused_type_ignore_is_hint`