### PR TITLE
Run hinted call pass to recover shared union-branch type variables

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1801,11 +1801,25 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             None,
             ctor_targs_no_hint.as_mut(),
         );
-        // If the call succeeds, attempt contextual typing with the hint.
+        // Attempt contextual typing with the hint. When the no-hint pass already succeeds we
+        // always try the hint (this is ordinary contextual typing). When the no-hint pass
+        // produced hard errors, the hint can still steer type variable solving toward a valid
+        // solution the no-hint pass missed (e.g. when a parameter is a union in which the same
+        // type variable appears in multiple branches). But a speculative hinted pass mutates
+        // shared solver vars, so on that recovery path we only take the risk when the hint is
+        // "ground" — it has no free placeholder vars belonging to an enclosing call that the
+        // pass could pollute. The hinted result is only adopted when it is at least as good as
+        // the no-hint result (see below).
+        let run_hinted = hint.is_some_and(|h| {
+            !call_errors_no_hint.has_hard()
+                || h.types()
+                    .iter()
+                    .all(|t| t.collect_maybe_placeholder_vars().is_empty())
+        });
+        // `retry_input` is `Some` exactly when `hint` is, and `run_hinted` implies `hint.is_some()`,
+        // so this destructuring never fails — it only recovers the clones made above.
         let (chosen_ctor_targs, chosen_call_errors, chosen_arg_errors, chosen_res) =
-            if !call_errors_no_hint.has_hard()
-                && let Some((callable, self_obj)) = retry_input
-            {
+            if run_hinted && let Some((callable, self_obj)) = retry_input {
                 let mut ctor_targs_with_hint = ctor_targs.as_ref().map(|x| (**x).clone());
                 let arg_errors_with_hint = self.error_collector();
                 let call_errors_with_hint = self.error_collector();

--- a/pyrefly/lib/test/generic_basic.rs
+++ b/pyrefly/lib/test/generic_basic.rs
@@ -866,3 +866,34 @@ def test2(cls: T2) -> str:
     return cls.name  # E:
     "#,
 );
+
+// A function type variable appearing in multiple branches of a union parameter must
+// solve to the branch matched by the argument, not collapse to the widest branch. Here
+// the return hint `T` (from `fn2`) steers the call so `T` in `fn` binds to `fn2`'s `T`.
+testcase!(
+    test_typevar_in_multiple_union_branches_with_hint,
+    r#"
+class Foo[T, U]:
+    def t(self) -> T: ...
+    def u(self) -> U: ...
+def fn[T](foo: Foo[T, object] | Foo[object, T], value: list[T]) -> T: ...
+def fn2[T](value: list[T]) -> T:
+    return fn(Foo[T, object](), value)
+    "#,
+);
+
+// Without a return hint the greedy union-branch matching commits `T` to the widest
+// branch (`object`) instead of the branch matched by the argument.
+testcase!(
+    bug = "T should reveal as T, not object (greedy union-branch matching)",
+    test_typevar_in_multiple_union_branches_no_hint,
+    r#"
+from typing import reveal_type
+class Foo[T, U]:
+    def t(self) -> T: ...
+    def u(self) -> U: ...
+def fn[T](foo: Foo[T, object] | Foo[object, T], value: T) -> T: ...
+def fn2[T](value: T) -> None:
+    reveal_type(fn(Foo[T, object](), value))  # E: revealed type: object
+    "#,
+);


### PR DESCRIPTION
When a generic function's parameter is a union in which the same function type variable appears in multiple branches (Foo[T, object] | Foo[object, T]), the call should bind T to the branch matched by the argument. Pyrefly instead collapsed T to the widest branch (object), producing spurious errors even when a return hint was available to steer solving to the correct branch.

`call_infer_inner` only ran its contextual (hinted) inference pass when the no-hint pass already succeeded. But when the parameter union shares a type variable across branches, the no-hint pass hits hard errors — greedy union-branch matching collapses the variable to the widest branch — so the return hint was never tried. 

Run the hinted pass on that recovery path too, but only when the hint is "ground": it carries no free placeholder vars from an enclosing call. A speculative hinted pass mutates shared solver vars, so gating on a ground hint keeps recovery from polluting an enclosing call's
variables through the hint. The existing selection guard still adopts the hinted result only when it is at least as good as the no-hint result.

# Summary

<!-- Describe the change in this PR -->

Fixes #3583

# Test Plan

Added ```test_typevar_in_multiple_union_branches_with_hint``` (the fix — now reports
no errors) and ```test_typevar_in_multiple_union_branches_no_hint``` (bug-marked,
documenting the remaining no-hint case) in pyrefly/lib/test/generic_basic.rs.

Verified the new test fails on main with the two spurious errors and passes
with the fix. test_complicated_paramspec_forwarding (which an earlier
broader relaxation regressed) stays green, confirming the ground-hint gate.

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
