### PR TITLE
Preserve narrowing across neutral boolean operands

### DIFF
--- a/pyrefly/lib/binding/narrow.rs
+++ b/pyrefly/lib/binding/narrow.rs
@@ -19,6 +19,7 @@ use ruff_python_ast::BoolOp;
 use ruff_python_ast::CmpOp;
 use ruff_python_ast::Expr;
 use ruff_python_ast::ExprBoolOp;
+use ruff_python_ast::ExprBooleanLiteral;
 use ruff_python_ast::ExprCall;
 use ruff_python_ast::ExprCompare;
 use ruff_python_ast::ExprNamed;
@@ -1034,7 +1035,18 @@ impl NarrowOps {
                     BoolOp::And => NarrowOps::and_all,
                     BoolOp::Or => NarrowOps::or_all,
                 };
-                let mut exprs = values.iter();
+                let mut exprs = values.iter().filter(|expr| {
+                    !matches!(
+                        (op, expr),
+                        (
+                            BoolOp::And,
+                            Expr::BooleanLiteral(ExprBooleanLiteral { value: true, .. })
+                        ) | (
+                            BoolOp::Or,
+                            Expr::BooleanLiteral(ExprBooleanLiteral { value: false, .. })
+                        )
+                    )
+                });
                 let mut narrow_ops = Self::from_expr_helper(builder, exprs.next(), seen.clone());
                 for next_val in exprs {
                     extend(

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -709,6 +709,20 @@ def f(x: str | None, y: int):
 );
 
 testcase!(
+    test_ternary_isinstance_with_neutral_boolean,
+    r#"
+from typing import reveal_type
+
+def f(value: type[int] | str):
+    reveal_type(None if isinstance(value, type) else value)  # E: revealed type: str | None
+    reveal_type(None if isinstance(value, type) and True else value)  # E: revealed type: str | None
+    reveal_type(None if True and isinstance(value, type) else value)  # E: revealed type: str | None
+    reveal_type(None if isinstance(value, type) or False else value)  # E: revealed type: str | None
+    reveal_type(None if False or isinstance(value, type) else value)  # E: revealed type: str | None
+    "#,
+);
+
+testcase!(
     test_is_supertype,
     r#"
 from typing import Literal, assert_type


### PR DESCRIPTION
Boolean literals that are neutral to an expression should not introduce placeholder narrowing operations. 

Skip `True` in `and` expressions and `False` in `or` expressions so positive and negative narrowing remain equivalent to the original condition.

# Summary

<!-- Describe the change in this PR -->

Fixes #4317

# Test Plan
  Added a regression test covering:

  - `A and True`
  - `True and A`
  - `A or False`
  - `False or A`

  Ran:

  ```sh
  cargo test -p pyrefly --lib test_ternary_isinstance_with_neutral_boolean
```

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->
