### PR TITLE
Fix collapse of multiple legacy type params hosted on the same module

### DIFF
--- a/pyrefly/lib/alt/jaxtyping.rs
+++ b/pyrefly/lib/alt/jaxtyping.rs
@@ -189,7 +189,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Binding::Import(import) => {
                 import.module.as_str() == "jaxtyping" && import.name.as_str() == "jaxtyping"
             }
-            Binding::PossibleLegacyTParam(key, _) => self.legacy_tparam_is_jaxtyping_module(*key),
+            Binding::PossibleLegacyTParam(keys, _) => keys
+                .iter()
+                .any(|key| self.legacy_tparam_is_jaxtyping_module(*key)),
             _ => false,
         }
     }
@@ -202,9 +204,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             | Binding::ForwardToFirstUse(idx) => {
                 self.binding_is_jaxtyping_wrapper_origin(self.binding_following_forwards(*idx))
             }
-            Binding::PossibleLegacyTParam(key, _) => {
-                self.legacy_tparam_is_jaxtyping_wrapper_origin(*key)
-            }
+            Binding::PossibleLegacyTParam(keys, _) => keys
+                .iter()
+                .any(|key| self.legacy_tparam_is_jaxtyping_wrapper_origin(*key)),
             _ => false,
         }
     }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -5212,45 +5212,63 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     #[inline(never)]
     fn binding_to_type_info_possible_legacy_tparam(
         &self,
-        key: Idx<KeyLegacyTypeParam>,
+        keys: &[Idx<KeyLegacyTypeParam>],
         range_if_scoped_params_exist: &Option<TextRange>,
         errors: &ErrorCollector,
     ) -> TypeInfo {
-        let ty = match &*self.get_idx(key) {
-            LegacyTypeParameterLookup::Parameter(p) => {
-                // This class or function has scoped (PEP 695) type parameters. Mixing legacy-style parameters is an error.
-                if let Some(r) = range_if_scoped_params_exist {
-                    self.error(
-                        errors,
-                        *r,
-                        ErrorKind::InvalidTypeVar,
-                        format!(
-                            "Type parameter {} is not included in the type parameter list",
-                            self.module().display(&self.bindings().idx_to_key(key).0)
-                        ),
-                    );
+        // `keys` usually holds a single element. It holds several only for a module reference
+        // (`foo`) hosting multiple legacy tparams accessed as attributes (`foo.T`, `foo.P`, ...),
+        // all of which collapsed onto this one base-name scope entry. In that case every key is
+        // `ModuleKeyed` against the same module, and we must narrow the module at *each* hosted
+        // tparam's attribute facet so a reference to any of them resolves to its Quantified.
+        let mut module_type_info: Option<TypeInfo> = None;
+        let mut param_type_info: Option<TypeInfo> = None;
+        for &key in keys {
+            let ty = match &*self.get_idx(key) {
+                LegacyTypeParameterLookup::Parameter(p) => {
+                    // This class or function has scoped (PEP 695) type parameters. Mixing legacy-style parameters is an error.
+                    if let Some(r) = range_if_scoped_params_exist {
+                        self.error(
+                            errors,
+                            *r,
+                            ErrorKind::InvalidTypeVar,
+                            format!(
+                                "Type parameter {} is not included in the type parameter list",
+                                self.module().display(&self.bindings().idx_to_key(key).0)
+                            ),
+                        );
+                    }
+                    p.clone().to_value()
                 }
-                p.clone().to_value()
-            }
-            LegacyTypeParameterLookup::NotParameter(ty) => ty.clone(),
-        };
-        match self.bindings().get(key) {
-            BindingLegacyTypeParam::ModuleKeyed(idx, attrs) => {
-                // `idx` points to a module whose attr chain may end in a legacy type
-                // variable that needs to be replaced with a QuantifiedValue. Since the
-                // binding is for the module itself, we use the mechanism for attribute
-                // ("facet") type narrowing to change the type produced when the final
-                // attr is accessed.
-                let module = (*self.get_idx(*idx)).clone();
-                if matches!(ty, Type::QuantifiedValue(_)) {
-                    let facets = attrs.mapped_ref(|a| FacetKind::Attribute(a.clone()));
-                    module.with_narrow(&facets, ty)
-                } else {
-                    module
+                LegacyTypeParameterLookup::NotParameter(ty) => ty.clone(),
+            };
+            match self.bindings().get(key) {
+                BindingLegacyTypeParam::ModuleKeyed(idx, attrs) => {
+                    // `idx` points to a module whose attr chain may end in a legacy type
+                    // variable that needs to be replaced with a QuantifiedValue. Since the
+                    // binding is for the module itself, we use the mechanism for attribute
+                    // ("facet") type narrowing to change the type produced when the final
+                    // attr is accessed. Multiple hosted tparams narrow the same module, so we
+                    // thread the accumulating `TypeInfo` through each iteration.
+                    let module = module_type_info
+                        .take()
+                        .unwrap_or_else(|| (*self.get_idx(*idx)).clone());
+                    module_type_info = Some(if matches!(ty, Type::QuantifiedValue(_)) {
+                        let facets = attrs.mapped_ref(|a| FacetKind::Attribute(a.clone()));
+                        module.with_narrow(&facets, ty)
+                    } else {
+                        module
+                    });
+                }
+                BindingLegacyTypeParam::ParamKeyed(_) => {
+                    // A bare-name tparam is never grouped with siblings, so this is the only key.
+                    param_type_info = Some(TypeInfo::of_ty(ty));
                 }
             }
-            BindingLegacyTypeParam::ParamKeyed(_) => TypeInfo::of_ty(ty),
         }
+        module_type_info
+            .or(param_type_info)
+            .unwrap_or_else(|| TypeInfo::of_ty(Type::any_implicit()))
     }
 
     /// Handle `Binding::NameAssign` in binding_to_type_info - process name assignment with dict facets.
@@ -5316,9 +5334,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Binding::AssignToSubscript(x) => {
                 self.binding_to_type_info_assign_to_subscript(&x.0, &x.1, errors)
             }
-            Binding::PossibleLegacyTParam(key, range_if_scoped_params_exist) => self
+            Binding::PossibleLegacyTParam(keys, range_if_scoped_params_exist) => self
                 .binding_to_type_info_possible_legacy_tparam(
-                    *key,
+                    keys,
                     range_if_scoped_params_exist,
                     errors,
                 ),

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -2385,7 +2385,12 @@ pub enum Binding {
     /// The TextRange is optional and controls whether to produce an error
     /// saying there are scoped type parameters for this function / class, and
     /// therefore the use of legacy type parameters is invalid.
-    PossibleLegacyTParam(Idx<KeyLegacyTypeParam>, Option<TextRange>),
+    ///
+    /// The slice usually has a single element. It holds multiple keys only for a module
+    /// reference (e.g. `foo`) that hosts several legacy type parameters accessed as
+    /// attributes (`foo.T`, `foo.P`, ...): all of them are collapsed onto the one base-name
+    /// scope entry, so we must narrow the module at every hosted tparam's attribute facet.
+    PossibleLegacyTParam(Box<[Idx<KeyLegacyTypeParam>]>, Option<TextRange>),
     /// An assignment to a name.
     NameAssign(Box<NameAssign>),
     /// A type alias (legacy, scoped, or `TypeAliasType` call).
@@ -2575,8 +2580,15 @@ impl DisplayWith<Bindings> for Binding {
             Self::TypeParameter(tp) => {
                 write!(f, "TypeParameter({}, {}, ..)", tp.identity, tp.kind)
             }
-            Self::PossibleLegacyTParam(k, _) => {
-                write!(f, "PossibleLegacyTParam({})", ctx.display(*k))
+            Self::PossibleLegacyTParam(ks, _) => {
+                write!(f, "PossibleLegacyTParam(")?;
+                for (i, k) in ks.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", ctx.display(*k))?;
+                }
+                write!(f, ")")
             }
             Self::AnnotatedType(k1, k2) => {
                 write!(

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -1810,8 +1810,9 @@ impl<'a> BindingsBuilder<'a> {
             // intercept_lookup which wraps them in PossibleLegacyTParam.
             // By finalize time we can follow through to the original
             // binding to check whether it's actually a type alias.
-            Binding::PossibleLegacyTParam(tparam_idx, _)
-                if let Some(legacy_binding) = self.idx_to_binding(*tparam_idx) =>
+            Binding::PossibleLegacyTParam(tparam_idxs, _)
+                if let Some(tparam_idx) = tparam_idxs.first()
+                    && let Some(legacy_binding) = self.idx_to_binding(*tparam_idx) =>
             {
                 self.follow_to_type_alias(legacy_binding.idx())
             }
@@ -2411,7 +2412,7 @@ impl<'a> BindingsBuilder<'a> {
         let idx = self.insert_binding(
             id.as_possible_legacy_tparam_key(),
             Binding::PossibleLegacyTParam(
-                tparam_idx,
+                Box::new([tparam_idx]),
                 if has_scoped_type_params {
                     Some(id.range())
                 } else {
@@ -2480,13 +2481,46 @@ impl<'a> BindingsBuilder<'a> {
     /// of those names point at legacy (pre-PEP-695) type variable declarations, in which
     /// case the name should be treated as a Quantified type parameter inside this scope.
     pub fn add_name_definitions(&mut self, legacy_tparams: &LegacyTParamCollector) {
+        // Several legacy type parameters can be hosted as attributes of the same module
+        // (e.g. `foo.T`, `foo.P`). They all collapse onto a single base-name scope entry
+        // (`foo`), keyed by the *last* occurrence's range. If we left each reference's binding
+        // narrowing only its own attribute, references to every tparam but the last would fall
+        // through to the raw module-level declaration. So we group by base identifier and give
+        // the surviving entry a binding that narrows the module at *all* hosted facets.
+        // For each base name we track (all hosted tparam keys, the surviving scope entry's key,
+        // the surviving occurrence's range). The surviving entry is the last one added, matching
+        // `add_possible_legacy_tparam`'s upsert.
+        let mut by_base: SmallMap<Name, (Vec<Idx<KeyLegacyTypeParam>>, Key, TextRange)> =
+            SmallMap::new();
         for entry in legacy_tparams.legacy_tparams.values() {
-            match entry {
-                TParamLookupResult::MaybeTParam(possible_tparam) => {
-                    self.scopes
-                        .add_possible_legacy_tparam(possible_tparam.id.as_identifier());
+            if let TParamLookupResult::MaybeTParam(possible_tparam) = entry {
+                self.scopes
+                    .add_possible_legacy_tparam(possible_tparam.id.as_identifier());
+                let base = possible_tparam.id.as_identifier().id.clone();
+                let key = possible_tparam.id.as_possible_legacy_tparam_key();
+                let range = possible_tparam.id.range();
+                if let Some((idxs, entry_key, entry_range)) = by_base.get_mut(&base) {
+                    idxs.push(possible_tparam.tparam_idx);
+                    *entry_key = key;
+                    *entry_range = range;
+                } else {
+                    by_base.insert(base, (vec![possible_tparam.tparam_idx], key, range));
                 }
-                _ => {}
+            }
+        }
+        for (_base, (idxs, entry_key, entry_range)) in by_base {
+            if idxs.len() > 1 {
+                // The scope entry for the base name resolves to the surviving occurrence's key;
+                // overwrite that binding so the module is narrowed at every hosted tparam's attr.
+                let scoped = if legacy_tparams.has_scoped_tparams {
+                    Some(entry_range)
+                } else {
+                    None
+                };
+                self.insert_binding_overwrite(
+                    entry_key,
+                    Binding::PossibleLegacyTParam(idxs.into_boxed_slice(), scoped),
+                );
             }
         }
     }

--- a/pyrefly/lib/state/ide.rs
+++ b/pyrefly/lib/state/ide.rs
@@ -110,7 +110,7 @@ fn find_definition_key_from<'a>(bindings: &'a Bindings, key: &'a Key) -> Option<
             Binding::Phi(_, branches) if !branches.is_empty() => {
                 current_idx = branches[0].value_key
             }
-            Binding::PossibleLegacyTParam(k, _) => {
+            Binding::PossibleLegacyTParam(ks, _) if let Some(k) = ks.first() => {
                 let binding = bindings.get(*k);
                 current_idx = binding.idx();
             }
@@ -147,7 +147,7 @@ fn create_intermediate_definition_from(
             Binding::Forward(k) | Binding::PromoteForward(k) | Binding::ForwardToFirstUse(k) => {
                 current_binding = bindings.get(*k)
             }
-            Binding::PossibleLegacyTParam(k, _) => {
+            Binding::PossibleLegacyTParam(ks, _) if let Some(k) = ks.first() => {
                 let binding = bindings.get(*k);
                 current_binding = bindings.get(binding.idx());
             }

--- a/pyrefly/lib/test/generic_legacy.rs
+++ b/pyrefly/lib/test/generic_legacy.rs
@@ -946,7 +946,6 @@ class A:
 );
 
 testcase!(
-    bug = "We currently create separate narrows for modules that may contain legacy type variables, we need to merge them",
     test_multiple_possible_legacy_tparams,
     TestEnv::one(
         "foo",
@@ -956,22 +955,60 @@ testcase!(
 from typing import Generic, assert_type
 import foo
 
-# Here, the `foo.C` possible-legacy-tparam binding is the one that winds up in scope, we
-# lose track of the `foo.T` one. It probably doesn't matter very much since we at least
-# understand the signature correctly.
+# `foo.T` and `foo.C` are both hosted on the `foo` module and collapse onto a single
+# base-name scope entry. We narrow `foo` at every hosted legacy type parameter's facet
+# (not just the last one added), so references to each resolve to the right Quantified.
 def f(x: foo.T, y: foo.C) -> foo.T:
-    z: foo.T = x  # E: Type variable `T` is not in scope  # E: `T` is not assignable to `TypeVar[T]`
-    return z  # E: Returned type `TypeVar[T]` is not assignable to declared return type `T
+    z: foo.T = x
+    return z
 assert_type(f(1, foo.C()), int)
 
-# The same thing happens here, but it's a much bigger problem because now we forget
-# about the type variable identity for the entire class body, so the signatures come out
-# wrong.
 class MyList(Generic[foo.T], list[tuple[foo.C, foo.T]]):
-    def my_append(self, c: foo.C, t: foo.T):  # E: Type variable `T` is not in scope
-        self.append((c, t))  # E: Argument `tuple[C, TypeVar[T]]` is not assignable to parameter `object` with type `tuple[C, T]` in function `list.append`
+    def my_append(self, c: foo.C, t: foo.T):
+        self.append((c, t))
 my_list: MyList[int] = MyList()
-my_list.my_append(foo.C(), 5)  # E: Argument `Literal[5]` is not assignable to parameter `t` with type `TypeVar[T]` in function `MyList.my_append`
+my_list.my_append(foo.C(), 5)
+    "#,
+);
+
+fn env_with_paramspec_host() -> TestEnv {
+    // `defs` is a source module hosting a legacy ParamSpec and TypeVar; `lib` is a stub whose
+    // generic class is parameterized by those imported legacy type variables and exposes a
+    // ParamSpec-forwarding attribute. This mirrors how modal's stubs are laid out.
+    let mut env = TestEnv::new();
+    env.add_with_path(
+        "defs",
+        "defs.py",
+        "from typing import ParamSpec, TypeVar\nP = ParamSpec('P')\nR = TypeVar('R')",
+    );
+    env.add_with_path(
+        "lib",
+        "lib.pyi",
+        "from typing import Generic, ParamSpec, Protocol, TypeVar\n\
+         import defs\n\
+         P2 = ParamSpec('P2')\n\
+         R2 = TypeVar('R2', covariant=True)\n\
+         class _Spec(Protocol[P2, R2]):\n\
+         \x20   def __call__(self, *args: P2.args, **kwargs: P2.kwargs) -> R2: ...\n\
+         class C(Generic[defs.P, defs.R]):\n\
+         \x20   call: _Spec[defs.P, defs.R]\n",
+    );
+    env
+}
+
+testcase!(
+    // Regression test: a ParamSpec hosted on a module alongside another legacy type variable
+    // used to lose its narrow (only the last-declared tparam survived), so a reference to it in
+    // a ParamSpec position produced a spurious `Unexpected ParamSpec type` error. Now both facets
+    // are narrowed, so `.call` resolves to the concrete signature and its arguments are checked.
+    test_module_hosted_paramspec_tparam,
+    env_with_paramspec_host(),
+    r#"
+from lib import C
+
+def use(x: C[[str, int], bytes]) -> None:
+    x.call("hello", 3)
+    x.call(123, "wrong")  # E: Argument `Literal[123]` is not assignable to parameter with type `str`  # E: Argument `Literal['wrong']` is not assignable to parameter with type `int`
     "#,
 );
 


### PR DESCRIPTION
## Summary

Fixes #4315.

When a generic class or function uses several legacy (pre-PEP-695) type variables imported from the same module (e.g. `foo.T` and `foo.P`), all of them collapse onto a single base-name scope entry (`foo`): `LegacyTParamId::as_identifier` returns the module base, and `add_possible_legacy_tparam` upserts by that base name, so only the last-declared tparam keeps its module-attribute narrow. References to the earlier ones fall through to the raw module-level declaration.

- For a `TypeVar` this is a silent correctness bug (a raw `TypeVar` is tolerated in a type-argument position).
- For a `ParamSpec` it surfaces as a spurious `Unexpected ParamSpec type` error, since a raw `ParamSpec` in a ParamSpec position is rejected.

This is exactly the shape of [modal](https://modal.com)'s generated stubs — `Function[P, ReturnType, OriginalReturnType]` with `P` declared first — so every `.remote()`/`.spawn()` call site gets flagged. (mypy and pyright both accept the same code.)

There is already a `bug = "…"` testcase documenting this (`test_multiple_possible_legacy_tparams`), whose comment reads *"the `foo.C` possible-legacy-tparam binding is the one that winds up in scope, we lose track of the `foo.T` one."*

## Fix

Give the surviving base-name scope entry a binding that carries **every** hosted tparam's key, and narrow the module at **all** of their attribute facets rather than only the last, so a reference to any hosted tparam resolves to its `Quantified`.

- `binding/binding.rs`: `Binding::PossibleLegacyTParam` payload `Idx<KeyLegacyTypeParam>` → `Box<[Idx<KeyLegacyTypeParam>]>`.
- `binding/bindings.rs`: `add_name_definitions` groups collected tparams by base identifier and, for a base hosting more than one, gives the surviving entry a binding with all their keys.
- `alt/solve.rs`: `binding_to_type_info_possible_legacy_tparam` iterates the keys, threading the accumulating module `TypeInfo` so it is narrowed at every hosted facet.
- Mechanical match-site updates in `alt/jaxtyping.rs` and `state/ide.rs`.

## Testing

- Updated `test_multiple_possible_legacy_tparams` to assert the corrected behavior (dropped the `bug =` annotation and the expected errors).
- Added `test_module_hosted_paramspec_tparam`, a regression test that mirrors the module-hosted-stub layout and confirms `.call(...)` arguments are still type-checked (i.e. the fix resolves the tparam rather than silencing the error).
- `cargo test --lib` is green.