### PR TITLE
Run all Pytorch CodSpeed benchmarks on macro (bare-metal) runners (#4333)

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -39,10 +39,12 @@ jobs:
   # the full LSP server over all cores against the pinned PyTorch checkout, so they
   # must not run under Valgrind (which serializes threads and inflates the ~GB cold
   # start past any reasonable timeout). Walltime mode tolerates threads, I/O, and
-  # long cold starts.
+  # long cold starts. Walltime needs a bare-metal runner: on shared hosted runners
+  # (`ubuntu-latest`) CodSpeed warns that neighbor noise makes wall-clock data
+  # inconsistent. `codspeed-macro` is CodSpeed's dedicated bare-metal runner.
   walltime:
     name: PyTorch benchmarks (walltime)
-    runs-on: ubuntu-latest
+    runs-on: codspeed-macro
     steps:
     - uses: actions/checkout@v6
     # No submodule checkout: in OSS the benchmark clones the pinned PyTorch itself


### PR DESCRIPTION
Summary:

Splits the runner configuration out of the CodSpeed wiring diff (D112014630, which now keeps everything on `ubuntu-latest`) into this dedicated change: it moves `walltime` (PyTorch) — from `ubuntu-latest` to CodSpeed's dedicated `codspeed-macro` bare-metal runners.

Bare-metal is what makes CodSpeed's wall-clock measurements trustworthy: on shared hosted runners, neighbor noise makes wall-clock data inconsistent, which CodSpeed warns about. Keeping both jobs on the same runner class also keeps the workflow uniform.

Differential Revision: D113490843


