### PR TITLE
feat(lsp): quick-fix code action for removing unused ignores

### DIFF
--- a/crates/pyrefly_python/src/ignore.rs
+++ b/crates/pyrefly_python/src/ignore.rs
@@ -32,6 +32,9 @@ use clap::ValueEnum;
 use dupe::Dupe;
 use enum_iterator::Sequence;
 use pyrefly_util::lined_buffer::LineNumber;
+use pyrefly_util::lined_buffer::LinedBuffer;
+use ruff_text_size::TextRange;
+use ruff_text_size::TextSize;
 use serde::Deserialize;
 use serde::Serialize;
 use starlark_map::small_map::SmallMap;
@@ -252,16 +255,38 @@ pub struct Suppression {
     comment_line: LineNumber,
     /// Byte offset within `comment_line` of the `#` that starts the comment.
     comment_offset: usize,
+    /// Byte offset within `comment_line` immediately after this suppression comment.
+    /// This is either the next `#` on the line or the end of the line.
+    comment_end_offset: usize,
+}
+
+/// A source edit that removes all or part of a suppression comment.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SuppressionEdit {
+    /// The type checker targeted by the suppression.
+    pub tool: Tool,
+    /// The exact source range occupied by the suppression comment.
+    pub range: TextRange,
+    /// The source text expected in `range`, used to reject stale edits.
+    pub expected: String,
+    /// Replacement text for `range`; empty text removes the entire suppression.
+    pub replacement: String,
 }
 
 impl Suppression {
     /// A blanket suppression for `tool` that matches every error code.
-    fn blanket(tool: Tool, comment_line: LineNumber, comment_offset: usize) -> Self {
+    fn blanket(
+        tool: Tool,
+        comment_line: LineNumber,
+        comment_offset: usize,
+        comment_end_offset: usize,
+    ) -> Self {
         Self {
             tool,
             kind: Vec::new(),
             comment_line,
             comment_offset,
+            comment_end_offset,
         }
     }
 
@@ -275,6 +300,11 @@ impl Suppression {
         self.comment_offset
     }
 
+    /// Returns the byte offset immediately after this suppression comment.
+    pub fn comment_end_offset(&self) -> usize {
+        self.comment_end_offset
+    }
+
     /// Returns the error codes that this suppression applies to.
     /// An empty slice means the suppression applies to all error codes.
     pub fn error_codes(&self) -> &[String] {
@@ -284,6 +314,58 @@ impl Suppression {
     /// Returns the tool that this suppression is for.
     pub fn tool(&self) -> Tool {
         self.tool
+    }
+
+    /// Build an edit that removes this suppression, or only `codes_to_remove` when present.
+    pub fn removal_edit(
+        &self,
+        buffer: &LinedBuffer,
+        codes_to_remove: Option<&SmallSet<String>>,
+    ) -> SuppressionEdit {
+        let line = buffer.content_in_line_range(self.comment_line, self.comment_line);
+        let comment = line
+            .get(self.comment_offset..self.comment_end_offset)
+            .expect("suppression offsets must be within its source line");
+        let replacement = codes_to_remove.map_or_else(String::new, |codes_to_remove| {
+            let codes_start = comment
+                .find('[')
+                .expect("a code-specific suppression must contain an opening bracket")
+                + 1;
+            let codes_end = comment[codes_start..]
+                .find(']')
+                .map_or(comment.len(), |offset| codes_start + offset);
+            let codes = &comment[codes_start..codes_end];
+            let separator = if codes.contains(", ") { ", " } else { "," };
+            let kept = codes
+                .split(',')
+                .map(str::trim)
+                .filter(|code| !code.is_empty() && !codes_to_remove.contains(*code))
+                .collect::<Vec<_>>();
+            assert!(
+                !kept.is_empty(),
+                "a partial suppression edit must retain at least one code"
+            );
+            format!(
+                "{}{kept}{}",
+                &comment[..codes_start],
+                &comment[codes_end..],
+                kept = kept.join(separator),
+            )
+        });
+        let line_start = buffer.line_start(self.comment_line);
+        SuppressionEdit {
+            tool: self.tool,
+            range: TextRange::new(
+                line_start
+                    + TextSize::try_from(self.comment_offset)
+                        .expect("suppression offset must fit in u32"),
+                line_start
+                    + TextSize::try_from(self.comment_end_offset)
+                        .expect("suppression offset must fit in u32"),
+            ),
+            expected: comment.to_owned(),
+            replacement,
+        }
     }
 }
 
@@ -321,9 +403,20 @@ impl Ignore {
             let Some(comment_start) = comment_start else {
                 continue;
             };
-            // We know `#` is at `comment_start`, so the first split is an empty string
-            for x in line_str[comment_start..].split('#').skip(1) {
-                if let Some(supp) = Self::parse_ignore_comment(x, line, comment_start) {
+            let comment = &line_str[comment_start..];
+            let mut comment_starts = comment
+                .match_indices('#')
+                .map(|(offset, _)| offset)
+                .peekable();
+            while let Some(suppression_start) = comment_starts.next() {
+                let suppression_end = comment_starts.peek().copied().unwrap_or(comment.len());
+                let body = &comment[suppression_start + 1..suppression_end];
+                if let Some(supp) = Self::parse_ignore_comment(
+                    body,
+                    line,
+                    comment_start + suppression_start,
+                    comment_start + suppression_end,
+                ) {
                     if is_comment_only_line {
                         pending.push(supp);
                     } else {
@@ -342,11 +435,12 @@ impl Ignore {
     }
 
     /// Given the content of a comment, parse it as a suppression.
-    /// `comment_line` and `comment_offset` locate the `#` starting the comment.
+    /// `comment_line`, `comment_offset`, and `comment_end_offset` locate the comment.
     fn parse_ignore_comment(
         l: &str,
         comment_line: LineNumber,
         comment_offset: usize,
+        comment_end_offset: usize,
     ) -> Option<Suppression> {
         let mut lex = Lexer(l);
         lex.trim_start();
@@ -372,9 +466,15 @@ impl Ignore {
                 kind: parse_error_codes(inside),
                 comment_line,
                 comment_offset,
+                comment_end_offset,
             });
         } else if gap || lex.word_boundary() {
-            return Some(Suppression::blanket(tool, comment_line, comment_offset));
+            return Some(Suppression::blanket(
+                tool,
+                comment_line,
+                comment_offset,
+                comment_end_offset,
+            ));
         }
         None
     }
@@ -520,10 +620,15 @@ pub fn parse_ignore_all(
             break;
         }
 
-        if let Some((tool, prev_line, prev_offset)) = prev_ignore {
+        if let Some((tool, prev_line, prev_offset, prev_end_offset)) = prev_ignore {
             // The previous `# type: ignore` was followed by another comment or
             // blank line, so it is a whole-file suppression.
-            res.push(Suppression::blanket(tool, prev_line, prev_offset));
+            res.push(Suppression::blanket(
+                tool,
+                prev_line,
+                prev_offset,
+                prev_end_offset,
+            ));
             prev_ignore = None;
         }
 
@@ -535,7 +640,12 @@ pub fn parse_ignore_all(
         let comment_offset = raw_line.len() - raw_line.trim_start().len();
         lex.trim_start();
         if lex.starts_with("pyre-ignore-all-errors") {
-            res.push(Suppression::blanket(Tool::Pyre, line, comment_offset));
+            res.push(Suppression::blanket(
+                Tool::Pyre,
+                line,
+                comment_offset,
+                raw_line.len(),
+            ));
         } else if let Some(tool) = lex.starts_with_tool() {
             lex.trim_start();
             if lex.0.starts_with("ignore-errors") {
@@ -551,12 +661,13 @@ pub fn parse_ignore_all(
                         kind,
                         comment_line: line,
                         comment_offset,
+                        comment_end_offset: raw_line.len(),
                     });
                 }
             } else if !seen_docstring && lex.starts_with("ignore") && lex.blank() {
                 // After a docstring, bare `# type: ignore` is not recognized
                 // as an ignore-all directive.
-                prev_ignore = Some((tool, line, comment_offset));
+                prev_ignore = Some((tool, line, comment_offset, raw_line.len()));
             }
         }
     }
@@ -743,24 +854,31 @@ x = """
 
     #[test]
     fn test_suppression_comment_offset() {
-        fn f(x: &str, expect: &[(u32, usize)]) {
+        fn f(x: &str, expect: &[(u32, usize, usize)]) {
             assert_eq!(
                 &Ignore::parse_ignores(x)
                     .into_iter()
-                    .flat_map(|(_, xs)| xs.map(|x| (x.comment_line.get(), x.comment_offset)))
+                    .flat_map(|(_, xs)| {
+                        xs.map(|x| (x.comment_line.get(), x.comment_offset, x.comment_end_offset))
+                    })
                     .collect::<Vec<_>>(),
                 expect,
                 "{x:?}"
             );
         }
 
-        f("x = 1  # type: ignore", &[(1, 7)]);
+        f("x = 1  # type: ignore", &[(1, 7, 21)]);
         // Not the `#` inside the string literal
-        f(r##"x: str = "#hash"  # type: ignore"##, &[(1, 18)]);
+        f(r##"x: str = "#hash"  # type: ignore"##, &[(1, 18, 32)]);
         // Line starts inside a triple-quoted string that closes mid-line
-        f("x = \"\"\"\n#fake\"\"\" # type: ignore", &[(2, 9)]);
+        f("x = \"\"\"\n#fake\"\"\" # type: ignore", &[(2, 9, 23)]);
         // A comment above code keeps its own line and offset
-        f("  # type: ignore\nx = 1", &[(1, 2)]);
+        f("  # type: ignore\nx = 1", &[(1, 2, 16)]);
+        // Co-located suppressions retain distinct, non-overlapping spans.
+        f(
+            "x = 1  # pyrefly: ignore  # type: ignore",
+            &[(1, 7, 26), (1, 26, 40)],
+        );
     }
 
     #[test]
@@ -768,12 +886,13 @@ x = """
         fn f(x: &str, tool: Option<Tool>, kind: &[&str]) {
             let dummy_line = LineNumber::default();
             assert_eq!(
-                Ignore::parse_ignore_comment(x, dummy_line, 0),
+                Ignore::parse_ignore_comment(x, dummy_line, 0, x.len() + 1),
                 tool.map(|tool| Suppression {
                     tool,
                     kind: kind.map(|x| (*x).to_owned()),
                     comment_line: dummy_line,
                     comment_offset: 0,
+                    comment_end_offset: x.len() + 1,
                 }),
                 "{x:?}"
             );
@@ -859,15 +978,13 @@ x = """
     fn test_parse_ignore_all() {
         fn f(x: &str, ignores: &[(Tool, u32, &[&str])]) {
             assert_eq!(
-                parse_ignore_all(x, &[]),
+                parse_ignore_all(x, &[])
+                    .into_iter()
+                    .map(|x| (x.tool, x.comment_line.get(), x.kind))
+                    .collect::<Vec<_>>(),
                 ignores
                     .iter()
-                    .map(|x| Suppression {
-                        tool: x.0,
-                        kind: x.2.iter().map(|x| (*x).to_owned()).collect(),
-                        comment_line: LineNumber::new(x.1).unwrap(),
-                        comment_offset: 0,
-                    })
+                    .map(|x| (x.0, x.1, x.2.iter().map(|x| (*x).to_owned()).collect()))
                     .collect::<Vec<_>>(),
                 "{x:?}"
             );
@@ -947,15 +1064,13 @@ x = """
     fn test_parse_ignore_all_with_docstring() {
         fn f(x: &str, ranges: &[(LineNumber, LineNumber)], ignores: &[(Tool, u32, &[&str])]) {
             assert_eq!(
-                parse_ignore_all(x, ranges),
+                parse_ignore_all(x, ranges)
+                    .into_iter()
+                    .map(|x| (x.tool, x.comment_line.get(), x.kind))
+                    .collect::<Vec<_>>(),
                 ignores
                     .iter()
-                    .map(|x| Suppression {
-                        tool: x.0,
-                        kind: x.2.iter().map(|x| (*x).to_owned()).collect(),
-                        comment_line: LineNumber::new(x.1).unwrap(),
-                        comment_offset: 0,
-                    })
+                    .map(|x| (x.0, x.1, x.2.iter().map(|x| (*x).to_owned()).collect()))
                     .collect::<Vec<_>>(),
                 "{x:?}"
             );

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -1405,7 +1405,7 @@ impl CheckArgs {
             // TODO: Deprecate this in favor of `pyrefly suppress`
             let collected = loads.collect_errors();
             let unused_errors = loads.collect_unused_ignore_errors(&collected);
-            suppress::remove_unused_ignores(unused_errors, kind);
+            suppress::remove_unused_ignores(unused_errors, kind)?;
         }
 
         // We update the baseline file if requested, after reporting any new

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -2015,7 +2015,7 @@ impl CheckArgs {
             // TODO: Deprecate this in favor of `pyrefly suppress`
             let collected = loads.collect_errors();
             let unused_errors = loads.collect_unused_ignore_errors(&collected);
-            suppress::remove_unused_ignores(unused_errors, kind);
+            suppress::remove_unused_ignores(unused_errors, kind)?;
         }
 
         // We update the baseline file if requested, after reporting any new

--- a/pyrefly/lib/commands/suppress.rs
+++ b/pyrefly/lib/commands/suppress.rs
@@ -33,6 +33,7 @@ pub struct SuppressArgs {
 
     /// Path to a JSON file containing errors to suppress.
     /// The JSON should be an array of objects with "path", "line", "name", and "message" fields.
+    /// Unused suppression diagnostics must also include a structured "suppression_edit".
     #[arg(long)]
     json: Option<PathBuf>,
 
@@ -106,7 +107,7 @@ impl SuppressArgs {
             };
 
             // Remove unused ignores (JSON path only)
-            suppress::remove_unused_ignores_from_serialized(unused_errors, kind);
+            suppress::remove_unused_ignores_from_serialized(unused_errors, kind)?;
         } else {
             // Add suppressions mode (existing behavior)
             let serialized_errors: Vec<SerializedError> = if let Some(json_path) = &self.json {

--- a/pyrefly/lib/commands/suppress.rs
+++ b/pyrefly/lib/commands/suppress.rs
@@ -32,8 +32,10 @@ pub struct SuppressArgs {
     config_override: ConfigOverrideArgs,
 
     /// Path to a JSON file containing errors to suppress.
-    /// The JSON should be an array of objects with "path", "line", "name", and "message" fields.
-    /// Unused suppression diagnostics must also include a structured "suppression_edit".
+    /// The JSON should be an array of objects with "path", "line", and "name" fields.
+    /// When combined with `--remove-unused`, unused suppression diagnostics must also include a
+    /// structured "suppression_edit" field with "tool", "start", "end", "expected", and
+    /// "replacement" sub-fields.
     #[arg(long)]
     json: Option<PathBuf>,
 

--- a/pyrefly/lib/commands/suppress.rs
+++ b/pyrefly/lib/commands/suppress.rs
@@ -33,6 +33,7 @@ pub struct SuppressArgs {
 
     /// Path to a JSON file containing errors to suppress.
     /// The JSON should be an array of objects with "path", "line", "name", and "message" fields.
+    /// Unused suppression diagnostics must also include a structured "suppression_edit".
     #[arg(long)]
     json: Option<PathBuf>,
 
@@ -99,7 +100,7 @@ impl SuppressArgs {
             };
 
             // Remove unused ignores (JSON path only)
-            suppress::remove_unused_ignores_from_serialized(unused_errors, kind);
+            suppress::remove_unused_ignores_from_serialized(unused_errors, kind)?;
         } else {
             // Add suppressions mode (existing behavior)
             let serialized_errors: Vec<SerializedError> = if let Some(json_path) = &self.json {

--- a/pyrefly/lib/error/error.rs
+++ b/pyrefly/lib/error/error.rs
@@ -16,6 +16,7 @@ use lsp_types::CodeDescription;
 use lsp_types::Diagnostic;
 use lsp_types::DiagnosticTag;
 use lsp_types::Url;
+use pyrefly_python::ignore::SuppressionEdit;
 use pyrefly_python::ignore::Tool;
 use pyrefly_python::module::Module;
 use pyrefly_python::module_path::ModulePath;
@@ -47,6 +48,13 @@ pub struct SecondaryAnnotation {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ErrorQuickFix {
     ReplaceWithEnumMember { replacement: String },
+    RemoveUnusedSuppression(SuppressionEdit),
+}
+
+impl From<SuppressionEdit> for ErrorQuickFix {
+    fn from(edit: SuppressionEdit) -> Self {
+        Self::RemoveUnusedSuppression(edit)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -63,7 +71,7 @@ pub struct Error {
     msg_details: Option<Box<str>>,
     /// Additional labeled spans in the same file for richer diagnostics.
     secondary_annotations: Vec<SecondaryAnnotation>,
-    /// Structured fixes that can be exposed by editor integrations.
+    /// Structured fixes used by editor and command integrations.
     quick_fixes: Vec<ErrorQuickFix>,
 }
 

--- a/pyrefly/lib/error/error.rs
+++ b/pyrefly/lib/error/error.rs
@@ -16,6 +16,7 @@ use lsp_types::CodeDescription;
 use lsp_types::Diagnostic;
 use lsp_types::DiagnosticTag;
 use lsp_types::Url;
+use pyrefly_python::ignore::SuppressionEdit;
 use pyrefly_python::ignore::Tool;
 use pyrefly_python::module::Module;
 use pyrefly_python::module_path::ModulePath;
@@ -53,6 +54,13 @@ pub struct SecondaryAnnotation {
 pub enum ErrorQuickFix {
     ReplaceWithEnumMember { replacement: String },
     AssertNotNone,
+    RemoveUnusedSuppression(SuppressionEdit),
+}
+
+impl From<SuppressionEdit> for ErrorQuickFix {
+    fn from(edit: SuppressionEdit) -> Self {
+        Self::RemoveUnusedSuppression(edit)
+    }
 }
 
 /// Whether an error was compared with the configured baseline.
@@ -103,7 +111,7 @@ pub struct Error {
     msg_details: Option<Box<str>>,
     /// Additional labeled spans in the same file for richer diagnostics.
     secondary_annotations: Vec<SecondaryAnnotation>,
-    /// Structured fixes that can be exposed by editor integrations.
+    /// Structured fixes used by editor and command integrations.
     quick_fixes: Vec<ErrorQuickFix>,
     /// Whether to mark `range` with the LSP `DEPRECATED` tag, which editors render as a
     /// strikethrough. This is only correct when `range` is the reference to the deprecated

--- a/pyrefly/lib/error/suppress.rs
+++ b/pyrefly/lib/error/suppress.rs
@@ -83,8 +83,6 @@ pub struct SerializedError {
     pub line: usize,
     /// The kebab-case name of the error kind (e.g., "bad-assignment").
     pub name: String,
-    /// The human-readable error message.
-    pub message: String,
     /// An exact machine-applicable edit when this diagnostic reports an unused suppression.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub suppression_edit: Option<SerializedSuppressionEdit>,
@@ -126,7 +124,6 @@ impl SerializedError {
                 path: (**path).clone(),
                 line: line.to_zero_indexed() as usize,
                 name: error.error_kind().to_name().to_owned(),
-                message: error.msg().to_owned(),
                 suppression_edit,
             })
         } else {
@@ -395,7 +392,6 @@ fn add_suppressions(
                     path: e.path.clone(),
                     line: new_line.to_zero_indexed() as usize,
                     name: e.name.clone(),
-                    message: e.message.clone(),
                     suppression_edit: e.suppression_edit.clone(),
                 }
             })
@@ -908,14 +904,12 @@ def foo() -> None:
                 path: path.clone(),
                 line: 2, // x = 1 (0-indexed)
                 name: "new-error".to_owned(),
-                message: String::new(),
                 suppression_edit: None,
             },
             SerializedError {
                 path: path.clone(),
                 line: 4, // y = 2 (0-indexed)
                 name: "new-error".to_owned(),
-                message: String::new(),
                 suppression_edit: None,
             },
         ];
@@ -1460,7 +1454,6 @@ def f() -> int:
         path: PathBuf,
         line: usize,
         name: &str,
-        message: &str,
         tool: Tool,
         start: usize,
         end: usize,
@@ -1471,7 +1464,6 @@ def f() -> int:
             path,
             line,
             name: name.to_owned(),
-            message: message.to_owned(),
             suppression_edit: Some(SerializedSuppressionEdit {
                 tool,
                 start,
@@ -1541,6 +1533,21 @@ def f() -> int:
     }
 
     #[test]
+    fn test_serialized_error_accepts_obsolete_message_field() {
+        let error: SerializedError = serde_json::from_str(
+            r#"{"path":"test.py","line":0,"name":"bad-assignment","message":"ignored"}"#,
+        )
+        .unwrap();
+        assert_eq!(error.path, PathBuf::from("test.py"));
+        assert_eq!(error.line, 0);
+        assert_eq!(error.name, "bad-assignment");
+        assert!(error.suppression_edit.is_none());
+
+        let serialized = serde_json::to_value(error).unwrap();
+        assert!(serialized.get("message").is_none());
+    }
+
+    #[test]
     fn test_unused_ignore_without_structured_edit_is_rejected() {
         let tdir = tempfile::tempdir().unwrap();
         let path = get_path(&tdir);
@@ -1550,7 +1557,6 @@ def f() -> int:
             path: path.clone(),
             line: 0,
             name: "unused-ignore".to_owned(),
-            message: "Unused `# pyrefly: ignore` comment".to_owned(),
             suppression_edit: None,
         };
 
@@ -1573,7 +1579,6 @@ def f() -> int:
             PathBuf::from("test.py"),
             0,
             "unused-ignore",
-            "The diagnostic wording is irrelevant",
             Tool::Pyrefly,
             7,
             26,
@@ -1599,7 +1604,6 @@ def f() -> int:
             PathBuf::from("test.py"),
             0,
             "unused-type-ignore",
-            "The diagnostic wording is irrelevant",
             Tool::Type,
             7,
             23,
@@ -1627,7 +1631,6 @@ def f() -> int:
                     PathBuf::from("test.py"),
                     0,
                     "unused-ignore",
-                    "unused",
                     Tool::Pyrefly,
                     7,
                     26,
@@ -1638,7 +1641,6 @@ def f() -> int:
                     PathBuf::from("test.py"),
                     0,
                     "unused-type-ignore",
-                    "unused",
                     Tool::Type,
                     26,
                     40,
@@ -1662,7 +1664,6 @@ def f() -> int:
                     PathBuf::from("test.py"),
                     0,
                     "unused-ignore",
-                    "unused",
                     Tool::Pyrefly,
                     pyrefly_start,
                     pyrefly_end,
@@ -1673,7 +1674,6 @@ def f() -> int:
                     PathBuf::from("test.py"),
                     0,
                     "unused-type-ignore",
-                    "unused",
                     Tool::Type,
                     type_start,
                     type_end,
@@ -1703,7 +1703,6 @@ def f() -> int:
             PathBuf::from("test.py"),
             1,
             "unused-ignore",
-            "unused",
             Tool::Pyrefly,
             19,
             36,
@@ -1727,7 +1726,6 @@ a: int = ""
             PathBuf::from("test.py"),
             1,
             "unused-ignore",
-            "This message contains no error codes",
             Tool::Pyrefly,
             0,
             "# pyrefly: ignore[bad-assignment,bad-override]".len(),
@@ -1753,7 +1751,6 @@ def foo() -> str:
             PathBuf::from("test.py"),
             2,
             "unused-ignore",
-            "unused",
             Tool::Pyrefly,
             4,
             "    # pyrefly: ignore [bad-return, unsupported-operation, bad-assignment]".len(),
@@ -1778,7 +1775,6 @@ def g() -> str:
             PathBuf::from("test.py"),
             2,
             "unused-ignore",
-            "unused",
             Tool::Pyrefly,
             source_line.find('#').unwrap(),
             source_line.len(),
@@ -1805,7 +1801,6 @@ def g() -> str:
                 path1.clone(),
                 0,
                 "unused-ignore",
-                "unused",
                 Tool::Pyrefly,
                 7,
                 content1.trim_end().len(),
@@ -1816,7 +1811,6 @@ def g() -> str:
                 path2.clone(),
                 0,
                 "unused-ignore",
-                "unused",
                 Tool::Pyrefly,
                 7,
                 content2.trim_end().len(),
@@ -1852,7 +1846,6 @@ def g() -> str:
             PathBuf::from("test.py"),
             1,
             "unused-ignore",
-            "unused",
             Tool::Pyrefly,
             source_line.find('#').unwrap(),
             source_line.len(),
@@ -1890,7 +1883,6 @@ y = 1 + 1
             PathBuf::from("test.py"),
             0,
             "unused-ignore",
-            "unused",
             Tool::Pyrefly,
             source_line.rfind('#').unwrap(),
             source_line.len(),
@@ -2272,7 +2264,6 @@ build_query(
             PathBuf::from("test.py"),
             0,
             "unused-ignore",
-            "unused",
             Tool::Pyre,
             7,
             input.trim_end().len(),
@@ -2290,7 +2281,6 @@ build_query(
             PathBuf::from("test.py"),
             0,
             "unused-ignore",
-            "unused",
             Tool::Pyre,
             7,
             input.trim_end().len(),
@@ -2309,7 +2299,6 @@ build_query(
             PathBuf::from("test.py"),
             0,
             "unused-ignore",
-            "unused",
             Tool::Pyre,
             0,
             source_line.len(),
@@ -2327,7 +2316,6 @@ build_query(
             PathBuf::from("test.py"),
             0,
             "unused-ignore",
-            "unused",
             Tool::Pyre,
             7,
             input.trim_end().len(),
@@ -2345,7 +2333,6 @@ build_query(
             PathBuf::from("test.py"),
             0,
             "unused-ignore",
-            "unused",
             Tool::Pyre,
             7,
             input.trim_end().len(),
@@ -2364,7 +2351,6 @@ build_query(
             PathBuf::from("test.py"),
             0,
             "unused-ignore",
-            "unused",
             Tool::Pyre,
             7,
             source_line.rfind('#').unwrap(),
@@ -2386,7 +2372,6 @@ build_query(
             path.clone(),
             1,
             "unused-ignore",
-            "unused",
             Tool::Pyre,
             source_line.rfind('#').unwrap(),
             source_line.len(),

--- a/pyrefly/lib/error/suppress.rs
+++ b/pyrefly/lib/error/suppress.rs
@@ -5,17 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::borrow::Cow;
 use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::LazyLock;
 
 use anyhow::anyhow;
 use clap::ValueEnum;
 use pyrefly_config::error_kind::ErrorKind;
 use pyrefly_python::ast::Ast;
+use pyrefly_python::ignore::Tool;
 use pyrefly_python::ignore::find_comment_start_in_line;
 use pyrefly_python::module::GENERATED_TOKEN;
 use pyrefly_python::module::Module;
@@ -34,25 +33,11 @@ use starlark_map::small_set::SmallSet;
 use tracing::info;
 
 use crate::error::error::Error;
+use crate::error::error::ErrorQuickFix;
 use crate::state::errors::find_containing_range;
 use crate::state::errors::sorted_backslash_continuation_ranges;
 use crate::state::errors::sorted_bracketed_continuation_ranges;
 use crate::state::errors::sorted_multi_line_string_ranges;
-
-/// Regexes to match ignore comments with optional error codes and trailing text.
-/// Each consumes all non-`#` characters after its ignore pattern, so removing one
-/// suppression preserves any other pragma later on the same line.
-static PYREFLY_IGNORE_COMMENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"#\s*pyrefly:\s*ignore\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*").unwrap()
-});
-static TYPE_IGNORE_COMMENT_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"#\s*type:\s*ignore\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*").unwrap());
-static PYRE_IGNORE_COMMENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r"#\s*pyre-(?:fixme|ignore)\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*|#\s*pyre:\s*ignore\s*(\[[^\]]*\])?\s*(?:;\s*)?[^#]*",
-    )
-    .unwrap()
-});
 
 /// Where to place suppression comments relative to the error line.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
@@ -90,7 +75,7 @@ impl UnusedIgnoreKind {
 
 /// A serializable representation of an error for JSON input/output.
 /// This struct holds the fields needed to add or remove a suppression comment.
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SerializedError {
     /// The file path where the error occurs.
     pub path: PathBuf,
@@ -98,8 +83,26 @@ pub struct SerializedError {
     pub line: usize,
     /// The kebab-case name of the error kind (e.g., "bad-assignment").
     pub name: String,
-    /// The error message. Used for UnusedIgnore errors to determine what to remove.
+    /// The human-readable error message.
     pub message: String,
+    /// An exact machine-applicable edit when this diagnostic reports an unused suppression.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suppression_edit: Option<SerializedSuppressionEdit>,
+}
+
+/// A line-relative source edit for an unused suppression comment.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SerializedSuppressionEdit {
+    /// The suppression syntax being edited.
+    pub tool: Tool,
+    /// Byte offset within the diagnostic line where the edit starts.
+    pub start: usize,
+    /// Byte offset within the diagnostic line where the edit ends.
+    pub end: usize,
+    /// Source text expected in the range, used to reject stale edits.
+    pub expected: String,
+    /// Replacement text for the range. Empty text removes the entire suppression.
+    pub replacement: String,
 }
 
 impl SerializedError {
@@ -107,15 +110,24 @@ impl SerializedError {
     /// Returns None if the error is not from a filesystem path.
     pub fn from_error(error: &Error) -> Option<Self> {
         if let ModulePathDetails::FileSystem(path) = error.path().details() {
+            let line = error.display_range().start.line_within_file();
+            let line_start = error.lined_buffer().line_start(line);
+            let suppression_edit = error.quick_fixes().iter().find_map(|fix| match fix {
+                ErrorQuickFix::RemoveUnusedSuppression(edit) => Some(SerializedSuppressionEdit {
+                    tool: edit.tool,
+                    start: (edit.range.start() - line_start).to_usize(),
+                    end: (edit.range.end() - line_start).to_usize(),
+                    expected: edit.expected.clone(),
+                    replacement: edit.replacement.clone(),
+                }),
+                ErrorQuickFix::ReplaceWithEnumMember { .. } => None,
+            });
             Some(Self {
                 path: (**path).clone(),
-                line: error
-                    .display_range()
-                    .start
-                    .line_within_file()
-                    .to_zero_indexed() as usize,
+                line: line.to_zero_indexed() as usize,
                 name: error.error_kind().to_name().to_owned(),
                 message: error.msg().to_owned(),
+                suppression_edit,
             })
         } else {
             None
@@ -384,6 +396,7 @@ fn add_suppressions(
                     line: new_line.to_zero_indexed() as usize,
                     name: e.name.clone(),
                     message: e.message.clone(),
+                    suppression_edit: e.suppression_edit.clone(),
                 }
             })
             .collect();
@@ -533,64 +546,13 @@ pub fn suppress_errors(errors: Vec<SerializedError>, comment_location: CommentLo
     }
 }
 
-/// Given a line with a pyrefly ignore comment and sets of used/unused error codes,
-/// returns the updated line. If all codes are unused, removes the entire comment.
-/// If some codes are used, keeps only the used codes in the comment.
-/// Uses string-aware parsing to only modify the comment portion of the line.
-fn update_ignore_comment_with_used_codes(
-    line: &str,
-    used_codes: &SmallSet<String>,
-    unused_codes: &SmallSet<String>,
-) -> Option<String> {
-    // If there are no unused codes, keep the line as-is
-    if unused_codes.is_empty() {
-        return None;
-    }
-
-    let comment_start = find_comment_start_in_line(line)?;
-    let code_part = &line[..comment_start];
-    let comment_part = &line[comment_start..];
-
-    // If there are no used codes, remove the entire comment
-    if used_codes.is_empty() {
-        if PYREFLY_IGNORE_COMMENT_REGEX.is_match(comment_part) {
-            let new_comment = PYREFLY_IGNORE_COMMENT_REGEX.replace(comment_part, "");
-            let result = format!("{}{}", code_part, new_comment);
-            return Some(result.trim_end().to_owned());
-        }
-        return None;
-    }
-
-    // Drop only the unused codes; preserve the user's original whitespace and comma style.
-    let regex = Regex::new(r"#\s*pyrefly:\s*ignore\s*\[([^\]]*)\]").unwrap();
-    let codes = regex.captures(comment_part)?.get(1).unwrap();
-    let separator = if codes.as_str().contains(", ") {
-        ", "
-    } else {
-        ","
-    };
-    let kept = codes
-        .as_str()
-        .split(',')
-        .map(str::trim)
-        .filter(|c| !c.is_empty() && used_codes.contains(*c))
-        .collect::<Vec<_>>()
-        .join(separator);
-    Some(format!(
-        "{code_part}{}{kept}{}",
-        &comment_part[..codes.start()],
-        &comment_part[codes.end()..],
-    ))
-}
-
 /// Removes unused ignore comments from source files.
-/// Takes a list of UnusedIgnore errors (from collect_unused_ignore_errors) and uses
-/// the error location and message to determine what to remove:
-/// - "Unused `# pyrefly: ignore` comment" -> remove entire comment
-/// - "Unused `# type: ignore` comment" -> remove entire comment when opted in
-/// - "Unused `# pyrefly: ignore` comment for code(s): X, Y" -> remove entire comment
-/// - "Unused error code(s) in `# pyrefly: ignore`: X, Y" -> remove only those codes
-pub fn remove_unused_ignores(unused_ignore_errors: Vec<Error>, kind: UnusedIgnoreKind) -> usize {
+/// Takes UnusedIgnore errors from `collect_unused_ignore_errors` and applies their
+/// structured suppression edits.
+pub fn remove_unused_ignores(
+    unused_ignore_errors: Vec<Error>,
+    kind: UnusedIgnoreKind,
+) -> anyhow::Result<usize> {
     let serialized: Vec<SerializedError> = unused_ignore_errors
         .iter()
         .filter_map(SerializedError::from_error)
@@ -604,23 +566,31 @@ pub fn remove_unused_ignores(unused_ignore_errors: Vec<Error>, kind: UnusedIgnor
 pub fn remove_unused_ignores_from_serialized(
     unused_ignore_errors: Vec<SerializedError>,
     kind: UnusedIgnoreKind,
-) -> usize {
+) -> anyhow::Result<usize> {
     if unused_ignore_errors.is_empty() {
-        return 0;
+        return Ok(0);
     }
 
     // Group errors by file path
-    let mut errors_by_path: SmallMap<PathBuf, Vec<&SerializedError>> = SmallMap::new();
+    let mut errors_by_path: SmallMap<PathBuf, Vec<(&SerializedError, &SerializedSuppressionEdit)>> =
+        SmallMap::new();
     for error in &unused_ignore_errors {
         if !((kind.includes_pyrefly_or_pyre() && error.is_unused_ignore())
             || (kind.includes_type() && error.is_unused_type_ignore()))
         {
             continue;
         }
+        let edit = error.suppression_edit.as_ref().ok_or_else(|| {
+            anyhow!(
+                "Unused suppression diagnostic for {}:{} has no structured suppression edit",
+                error.path.display(),
+                error.line + 1,
+            )
+        })?;
         errors_by_path
             .entry(error.path.clone())
             .or_default()
-            .push(error);
+            .push((error, edit));
     }
 
     let mut removed_ignores: SmallMap<PathBuf, usize> = SmallMap::new();
@@ -628,9 +598,9 @@ pub fn remove_unused_ignores_from_serialized(
     for (path, path_errors) in &errors_by_path {
         // Build a map from line number to its errors. Multiple unused suppressions
         // may appear on the same line and must each be handled independently.
-        let mut line_errors: SmallMap<usize, Vec<&SerializedError>> = SmallMap::new();
-        for error in path_errors {
-            line_errors.entry(error.line).or_default().push(*error);
+        let mut line_edits: SmallMap<usize, Vec<&SerializedSuppressionEdit>> = SmallMap::new();
+        for (error, edit) in path_errors {
+            line_edits.entry(error.line).or_default().push(*edit);
         }
 
         if let Ok((file, _ast)) = read_and_validate_file(path) {
@@ -640,73 +610,49 @@ pub fn remove_unused_ignores_from_serialized(
             let mut unused_count = 0;
 
             for (idx, line) in lines.iter().enumerate() {
-                if let Some(errors) = line_errors.get(&idx) {
-                    let mut updated_line = Cow::Borrowed(*line);
+                if let Some(edits) = line_edits.get(&idx) {
+                    let mut updated_line = (*line).to_owned();
+                    let mut edits = edits.clone();
+                    edits.sort_by_key(|edit| std::cmp::Reverse(edit.start));
+                    edits.dedup_by(|a, b| {
+                        a.start == b.start
+                            && a.end == b.end
+                            && a.expected == b.expected
+                            && a.replacement == b.replacement
+                            && a.tool == b.tool
+                    });
 
-                    for error in errors {
-                        let msg = &error.message;
-
-                        if msg.starts_with("Unused error code(s)") {
-                            // Partially unused - extract codes from message and remove only those.
-                            // Message format: "Unused error code(s) in `# pyrefly: ignore`: code1, code2"
-                            if let Some(codes_part) = msg.split(": ").last() {
-                                let unused_codes: SmallSet<String> = codes_part
-                                    .split(", ")
-                                    .map(|s| s.trim().to_owned())
-                                    .collect();
-
-                                if let Some(existing_codes) = parse_ignore_comment(&updated_line) {
-                                    let used_codes: SmallSet<String> = existing_codes
-                                        .into_iter()
-                                        .filter(|c| !unused_codes.contains(c))
-                                        .collect();
-
-                                    if let Some(updated) = update_ignore_comment_with_used_codes(
-                                        &updated_line,
-                                        &used_codes,
-                                        &unused_codes,
-                                    ) {
-                                        updated_line = Cow::Owned(updated);
-                                        unused_count += 1;
-                                    }
-                                }
-                            }
-                            continue;
+                    for edit in edits {
+                        if edit.start > edit.end
+                            || edit.end > updated_line.len()
+                            || !updated_line.is_char_boundary(edit.start)
+                            || !updated_line.is_char_boundary(edit.end)
+                        {
+                            return Err(anyhow!(
+                                "Invalid suppression edit range {}..{} for {}:{}",
+                                edit.start,
+                                edit.end,
+                                path.display(),
+                                idx + 1,
+                            ));
                         }
-
-                        let ignore_regex = if error.is_unused_type_ignore() {
-                            &*TYPE_IGNORE_COMMENT_REGEX
-                        } else if msg.starts_with("Unused `# pyrefly: ignore` comment") {
-                            &*PYREFLY_IGNORE_COMMENT_REGEX
-                        } else if msg.starts_with("Unused pyre-fixme comment") {
-                            &*PYRE_IGNORE_COMMENT_REGEX
-                        } else {
-                            continue;
-                        };
-
-                        // Use string-aware comment detection instead of raw regex.
-                        let Some(comment_start) = find_comment_start_in_line(&updated_line) else {
-                            continue;
-                        };
-                        let comment_part = &updated_line[comment_start..];
-                        if let Cow::Owned(new_comment) = ignore_regex.replace(comment_part, "") {
-                            let code_part = &updated_line[..comment_start];
-                            updated_line = Cow::Owned(
-                                format!("{}{}", code_part, new_comment)
-                                    .trim_end()
-                                    .to_owned(),
-                            );
-                            unused_count += 1;
+                        if updated_line.get(edit.start..edit.end) != Some(&edit.expected) {
+                            return Err(anyhow!(
+                                "Suppression edit no longer matches {}:{}",
+                                path.display(),
+                                idx + 1,
+                            ));
                         }
+                        updated_line.replace_range(edit.start..edit.end, &edit.replacement);
+                        unused_count += 1;
                     }
 
-                    if let Cow::Owned(updated_line) = updated_line {
-                        if !updated_line.trim().is_empty() {
-                            buf.push_str(&updated_line);
-                            buf.push_str(line_ending);
-                        }
-                        continue;
+                    updated_line.truncate(updated_line.trim_end().len());
+                    if !updated_line.trim().is_empty() {
+                        buf.push_str(&updated_line);
+                        buf.push_str(line_ending);
                     }
+                    continue;
                 }
                 buf.push_str(line);
                 buf.push_str(line_ending);
@@ -725,7 +671,7 @@ pub fn remove_unused_ignores_from_serialized(
         removals,
         removed_ignores.len(),
     );
-    removals
+    Ok(removals)
 }
 
 #[cfg(test)]
@@ -788,7 +734,8 @@ mod tests {
         let (errors, tdir) = get_errors(before);
         let collected = errors.collect_errors();
         let unused_errors = errors.collect_unused_ignore_errors(&collected);
-        let removals = suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::Pyrefly);
+        let removals =
+            suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::Pyrefly).unwrap();
         let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
         assert_eq!(after, got_file);
         assert_eq!(removals, expected_removals);
@@ -805,7 +752,8 @@ mod tests {
         let (errors, tdir) = get_errors(before);
         let collected = errors.collect_errors();
         let unused_errors = errors.collect_unused_ignore_errors(&collected);
-        let removals = suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::Pyrefly);
+        let removals =
+            suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::Pyrefly).unwrap();
         let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
         assert_eq!(after, got_file);
         assert_eq!(removals, expected_removals);
@@ -961,12 +909,14 @@ def foo() -> None:
                 line: 2, // x = 1 (0-indexed)
                 name: "new-error".to_owned(),
                 message: String::new(),
+                suppression_edit: None,
             },
             SerializedError {
                 path: path.clone(),
                 line: 4, // y = 2 (0-indexed)
                 name: "new-error".to_owned(),
                 message: String::new(),
+                suppression_edit: None,
             },
         ];
 
@@ -1202,7 +1152,8 @@ def f() -> int:
         let collected = errors.collect_errors();
         let unused_errors = errors.collect_unused_ignore_errors(&collected);
 
-        let removals = suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::All);
+        let removals =
+            suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::All).unwrap();
 
         let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
         assert_eq!(want, got_file);
@@ -1504,6 +1455,33 @@ def f() -> int:
     }
 
     // Helper function to test remove_unused_ignores_from_serialized
+    fn serialized_unused_suppression(
+        source: &str,
+        path: PathBuf,
+        line: usize,
+        name: &str,
+        message: &str,
+        tool: Tool,
+        start: usize,
+        end: usize,
+        replacement: &str,
+    ) -> SerializedError {
+        let source_line = source.lines().nth(line).unwrap();
+        SerializedError {
+            path,
+            line,
+            name: name.to_owned(),
+            message: message.to_owned(),
+            suppression_edit: Some(SerializedSuppressionEdit {
+                tool,
+                start,
+                end,
+                expected: source_line[start..end].to_owned(),
+                replacement: replacement.to_owned(),
+            }),
+        }
+    }
+
     fn assert_remove_ignores_from_serialized(
         file_content: &str,
         serialized_errors: Vec<SerializedError>,
@@ -1535,11 +1513,53 @@ def f() -> int:
             error.path = path.clone();
         }
 
-        let removals = suppress::remove_unused_ignores_from_serialized(serialized_errors, kind);
+        let removals =
+            suppress::remove_unused_ignores_from_serialized(serialized_errors, kind).unwrap();
 
         let got_file = fs_anyhow::read_to_string(&path).unwrap();
         assert_eq!(expected_content, got_file);
         assert_eq!(removals, expected_removals);
+    }
+
+    #[test]
+    fn test_unused_ignore_serializes_structured_edit() {
+        let input = "# pyrefly: ignore [bad-assignment, bad-return]\nx: str = 1\n";
+        let (errors, _tdir) = get_errors(input);
+        let collected = errors.collect_errors();
+        let unused_errors = errors.collect_unused_ignore_errors(&collected);
+        let serialized = SerializedError::from_error(&unused_errors[0]).unwrap();
+
+        let edit = serialized.suppression_edit.unwrap();
+        assert_eq!(edit.tool, Tool::Pyrefly);
+        assert_eq!(edit.start, 0);
+        assert_eq!(edit.end, input.lines().next().unwrap().len());
+        assert_eq!(
+            edit.expected,
+            "# pyrefly: ignore [bad-assignment, bad-return]"
+        );
+        assert_eq!(edit.replacement, "# pyrefly: ignore [bad-assignment]");
+    }
+
+    #[test]
+    fn test_unused_ignore_without_structured_edit_is_rejected() {
+        let tdir = tempfile::tempdir().unwrap();
+        let path = get_path(&tdir);
+        let input = "x = 1  # pyrefly: ignore\n";
+        fs_anyhow::write(&path, input).unwrap();
+        let error = SerializedError {
+            path: path.clone(),
+            line: 0,
+            name: "unused-ignore".to_owned(),
+            message: "Unused `# pyrefly: ignore` comment".to_owned(),
+            suppression_edit: None,
+        };
+
+        let error =
+            suppress::remove_unused_ignores_from_serialized(vec![error], UnusedIgnoreKind::Pyrefly)
+                .unwrap_err()
+                .to_string();
+        assert!(error.contains("has no structured suppression edit"));
+        assert_eq!(fs_anyhow::read_to_string(&path).unwrap(), input);
     }
 
     #[test]
@@ -1548,12 +1568,17 @@ def f() -> int:
         // from the same line when type-ignore removal was not requested.
         let input = "x = 1  # pyrefly: ignore  # type: ignore\n";
         let want = "x = 1  # type: ignore\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused `# pyrefly: ignore` comment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "The diagnostic wording is irrelevant",
+            Tool::Pyrefly,
+            7,
+            26,
+            "",
+        )];
         assert_remove_ignores_from_serialized_with_kind(
             input,
             errors,
@@ -1569,12 +1594,17 @@ def f() -> int:
         // from the same line when type-ignore removal was requested.
         let input = "x = 1  # type: ignore  # pyrefly: ignore\n";
         let want = "x = 1  # pyrefly: ignore\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-type-ignore".to_owned(),
-            message: "Unused `# type: ignore` comment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-type-ignore",
+            "The diagnostic wording is irrelevant",
+            Tool::Type,
+            7,
+            23,
+            "",
+        )];
         assert_remove_ignores_from_serialized_with_kind(
             input,
             errors,
@@ -1592,18 +1622,28 @@ def f() -> int:
             (UnusedIgnoreKind::Type, "x = 1  # pyrefly: ignore\n"),
         ] {
             let errors = vec![
-                SerializedError {
-                    path: PathBuf::from("test.py"),
-                    line: 0,
-                    name: "unused-ignore".to_owned(),
-                    message: "Unused `# pyrefly: ignore` comment".to_owned(),
-                },
-                SerializedError {
-                    path: PathBuf::from("test.py"),
-                    line: 0,
-                    name: "unused-type-ignore".to_owned(),
-                    message: "Unused `# type: ignore` comment".to_owned(),
-                },
+                serialized_unused_suppression(
+                    input,
+                    PathBuf::from("test.py"),
+                    0,
+                    "unused-ignore",
+                    "unused",
+                    Tool::Pyrefly,
+                    7,
+                    26,
+                    "",
+                ),
+                serialized_unused_suppression(
+                    input,
+                    PathBuf::from("test.py"),
+                    0,
+                    "unused-type-ignore",
+                    "unused",
+                    Tool::Type,
+                    26,
+                    40,
+                    "",
+                ),
             ];
             assert_remove_ignores_from_serialized_with_kind(input, errors, want, 1, kind);
         }
@@ -1612,23 +1652,33 @@ def f() -> int:
     #[test]
     fn test_remove_multiple_unused_suppressions_from_same_line() {
         let want = "x = 1\n";
-        for input in [
-            "x = 1  # pyrefly: ignore  # type: ignore\n",
-            "x = 1  # type: ignore  # pyrefly: ignore\n",
+        for (input, pyrefly_start, pyrefly_end, type_start, type_end) in [
+            ("x = 1  # pyrefly: ignore  # type: ignore\n", 7, 26, 26, 40),
+            ("x = 1  # type: ignore  # pyrefly: ignore\n", 23, 40, 7, 23),
         ] {
             let errors = vec![
-                SerializedError {
-                    path: PathBuf::from("test.py"),
-                    line: 0,
-                    name: "unused-ignore".to_owned(),
-                    message: "Unused `# pyrefly: ignore` comment".to_owned(),
-                },
-                SerializedError {
-                    path: PathBuf::from("test.py"),
-                    line: 0,
-                    name: "unused-type-ignore".to_owned(),
-                    message: "Unused `# type: ignore` comment".to_owned(),
-                },
+                serialized_unused_suppression(
+                    input,
+                    PathBuf::from("test.py"),
+                    0,
+                    "unused-ignore",
+                    "unused",
+                    Tool::Pyrefly,
+                    pyrefly_start,
+                    pyrefly_end,
+                    "",
+                ),
+                serialized_unused_suppression(
+                    input,
+                    PathBuf::from("test.py"),
+                    0,
+                    "unused-type-ignore",
+                    "unused",
+                    Tool::Type,
+                    type_start,
+                    type_end,
+                    "",
+                ),
             ];
             assert_remove_ignores_from_serialized_with_kind(
                 input,
@@ -1648,12 +1698,17 @@ def f() -> int:
         let want = r#"def g() -> str:
     return "hello"
 "#;
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 1,
-            name: "unused-ignore".to_owned(),
-            message: "Unused `# pyrefly: ignore` comment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            1,
+            "unused-ignore",
+            "unused",
+            Tool::Pyrefly,
+            19,
+            36,
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -1667,12 +1722,17 @@ a: int = ""
 # pyrefly: ignore[bad-assignment]
 a: int = ""
 "#;
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 1,
-            name: "unused-ignore".to_owned(),
-            message: "Unused error code(s) in `# pyrefly: ignore`: bad-override".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            before,
+            PathBuf::from("test.py"),
+            1,
+            "unused-ignore",
+            "This message contains no error codes",
+            Tool::Pyrefly,
+            0,
+            "# pyrefly: ignore[bad-assignment,bad-override]".len(),
+            "# pyrefly: ignore[bad-assignment]",
+        )];
         assert_remove_ignores_from_serialized(before, errors, after, 1);
     }
 
@@ -1688,12 +1748,17 @@ def foo() -> str:
     # pyrefly: ignore [bad-return, unsupported-operation]
     return 1 + []
 "#;
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 2,
-            name: "unused-ignore".to_owned(),
-            message: "Unused error code(s) in `# pyrefly: ignore`: bad-assignment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            before,
+            PathBuf::from("test.py"),
+            2,
+            "unused-ignore",
+            "unused",
+            Tool::Pyrefly,
+            4,
+            "    # pyrefly: ignore [bad-return, unsupported-operation, bad-assignment]".len(),
+            "# pyrefly: ignore [bad-return, unsupported-operation]",
+        )];
         assert_remove_ignores_from_serialized(before, errors, after, 1);
     }
 
@@ -1707,12 +1772,18 @@ def g() -> str:
 def g() -> str:
     return "hello"
 "#;
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 2,
-            name: "unused-ignore".to_owned(),
-            message: "Unused `# pyrefly: ignore` comment for code(s): bad-return".to_owned(),
-        }];
+        let source_line = input.lines().nth(2).unwrap();
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            2,
+            "unused-ignore",
+            "unused",
+            Tool::Pyrefly,
+            source_line.find('#').unwrap(),
+            source_line.len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -1729,22 +1800,33 @@ def g() -> str:
         fs_anyhow::write(&path2, content2).unwrap();
 
         let errors = vec![
-            SerializedError {
-                path: path1.clone(),
-                line: 0,
-                name: "unused-ignore".to_owned(),
-                message: "Unused `# pyrefly: ignore` comment".to_owned(),
-            },
-            SerializedError {
-                path: path2.clone(),
-                line: 0,
-                name: "unused-ignore".to_owned(),
-                message: "Unused `# pyrefly: ignore` comment".to_owned(),
-            },
+            serialized_unused_suppression(
+                content1,
+                path1.clone(),
+                0,
+                "unused-ignore",
+                "unused",
+                Tool::Pyrefly,
+                7,
+                content1.trim_end().len(),
+                "",
+            ),
+            serialized_unused_suppression(
+                content2,
+                path2.clone(),
+                0,
+                "unused-ignore",
+                "unused",
+                Tool::Pyrefly,
+                7,
+                content2.trim_end().len(),
+                "",
+            ),
         ];
 
         let removals =
-            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly);
+            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly)
+                .unwrap();
 
         assert_eq!(fs_anyhow::read_to_string(&path1).unwrap(), "x = 1\n");
         assert_eq!(fs_anyhow::read_to_string(&path2).unwrap(), "y = 2\n");
@@ -1755,7 +1837,8 @@ def g() -> str:
     fn test_remove_unused_ignores_from_serialized_empty_list() {
         let errors: Vec<SerializedError> = vec![];
         let removals =
-            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly);
+            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly)
+                .unwrap();
         assert_eq!(removals, 0);
     }
 
@@ -1763,12 +1846,18 @@ def g() -> str:
     fn test_remove_unused_ignores_from_serialized_preserves_crlf() {
         let input = "def g() -> str:\r\n    return \"hello\" # pyrefly: ignore [bad-return]\r\n";
         let want = "def g() -> str:\r\n    return \"hello\"\r\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 1,
-            name: "unused-ignore".to_owned(),
-            message: "Unused `# pyrefly: ignore` comment".to_owned(),
-        }];
+        let source_line = input.lines().nth(1).unwrap();
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            1,
+            "unused-ignore",
+            "unused",
+            Tool::Pyrefly,
+            source_line.find('#').unwrap(),
+            source_line.len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -1795,12 +1884,18 @@ y = 1 + 1
 "##;
         let want = r##"x = "# pyrefly: ignore [bad-override]"
 "##;
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused `# pyrefly: ignore` comment".to_owned(),
-        }];
+        let source_line = input.lines().next().unwrap();
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "unused",
+            Tool::Pyrefly,
+            source_line.rfind('#').unwrap(),
+            source_line.len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -2172,12 +2267,17 @@ build_query(
     fn test_remove_unused_pyre_fixme_inline() {
         let input = "x = 1  # pyre-fixme\n";
         let want = "x = 1\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused pyre-fixme comment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "unused",
+            Tool::Pyre,
+            7,
+            input.trim_end().len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -2185,12 +2285,17 @@ build_query(
     fn test_remove_unused_pyre_ignore_inline() {
         let input = "x = 1  # pyre-ignore\n";
         let want = "x = 1\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused pyre-fixme comment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "unused",
+            Tool::Pyre,
+            7,
+            input.trim_end().len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -2198,12 +2303,18 @@ build_query(
     fn test_remove_unused_pyre_fixme_above() {
         let input = "# pyre-fixme[7]\nx = 1\n";
         let want = "x = 1\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused pyre-fixme comment".to_owned(),
-        }];
+        let source_line = input.lines().next().unwrap();
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "unused",
+            Tool::Pyre,
+            0,
+            source_line.len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -2211,12 +2322,17 @@ build_query(
     fn test_remove_unused_pyre_fixme_with_description() {
         let input = "x = 1  # pyre-fixme[7]: Expected `int` but got `str`\n";
         let want = "x = 1\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused pyre-fixme comment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "unused",
+            Tool::Pyre,
+            7,
+            input.trim_end().len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -2224,12 +2340,17 @@ build_query(
     fn test_remove_unused_pyre_colon_ignore() {
         let input = "x = 1  # pyre: ignore\n";
         let want = "x = 1\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused pyre-fixme comment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "unused",
+            Tool::Pyre,
+            7,
+            input.trim_end().len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -2237,12 +2358,18 @@ build_query(
     fn test_remove_unused_pyre_fixme_preserves_other_comments() {
         let input = "x = 1  # pyre-fixme # important note\n";
         let want = "x = 1  # important note\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused pyre-fixme comment".to_owned(),
-        }];
+        let source_line = input.trim_end();
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "unused",
+            Tool::Pyre,
+            7,
+            source_line.rfind('#').unwrap(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -2253,14 +2380,21 @@ build_query(
         let input = "x = \"# pyre-fixme\"\ny = 1  # pyre-fixme\n";
         let want = "x = \"# pyre-fixme\"\ny = 1\n";
         fs_anyhow::write(&path, input).unwrap();
-        let errors = vec![SerializedError {
-            path: path.clone(),
-            line: 1,
-            name: "unused-ignore".to_owned(),
-            message: "Unused pyre-fixme comment".to_owned(),
-        }];
+        let source_line = input.lines().nth(1).unwrap();
+        let errors = vec![serialized_unused_suppression(
+            input,
+            path.clone(),
+            1,
+            "unused-ignore",
+            "unused",
+            Tool::Pyre,
+            source_line.rfind('#').unwrap(),
+            source_line.len(),
+            "",
+        )];
         let removals =
-            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly);
+            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly)
+                .unwrap();
         let got = fs_anyhow::read_to_string(&path).unwrap();
         assert_eq!(want, got);
         assert_eq!(removals, 1);

--- a/pyrefly/lib/error/suppress.rs
+++ b/pyrefly/lib/error/suppress.rs
@@ -5,17 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::borrow::Cow;
 use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::LazyLock;
 
 use anyhow::anyhow;
 use clap::ValueEnum;
 use pyrefly_config::error_kind::ErrorKind;
 use pyrefly_python::ast::Ast;
+use pyrefly_python::ignore::Tool;
 use pyrefly_python::ignore::find_comment_start_in_line;
 use pyrefly_python::module::GENERATED_TOKEN;
 use pyrefly_python::module::Module;
@@ -34,24 +33,11 @@ use starlark_map::small_set::SmallSet;
 use tracing::info;
 
 use crate::error::error::Error;
+use crate::error::error::ErrorQuickFix;
 use crate::state::errors::find_containing_range;
 use crate::state::errors::sorted_backslash_continuation_ranges;
 use crate::state::errors::sorted_bracketed_continuation_ranges;
 use crate::state::errors::sorted_multi_line_string_ranges;
-
-/// Regexes to match ignore comments with optional error codes and trailing text.
-/// Each consumes all non-`#` characters after its ignore pattern, so removing one
-/// suppression preserves any other pragma later on the same line.
-static PYREFLY_IGNORE_COMMENT_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"#\s*pyrefly:\s*ignore\s*(\[[^\]]*\])?[^#]*").unwrap());
-static TYPE_IGNORE_COMMENT_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"#\s*type:\s*ignore\s*(\[[^\]]*\])?[^#]*").unwrap());
-static PYRE_IGNORE_COMMENT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r"#\s*pyre-(?:fixme|ignore)\s*(\[[^\]]*\])?[^#]*|#\s*pyre:\s*ignore\s*(\[[^\]]*\])?[^#]*",
-    )
-    .unwrap()
-});
 
 /// Where to place suppression comments relative to the error line.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
@@ -89,7 +75,7 @@ impl UnusedIgnoreKind {
 
 /// A serializable representation of an error for JSON input/output.
 /// This struct holds the fields needed to add or remove a suppression comment.
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SerializedError {
     /// The file path where the error occurs.
     pub path: PathBuf,
@@ -97,8 +83,26 @@ pub struct SerializedError {
     pub line: usize,
     /// The kebab-case name of the error kind (e.g., "bad-assignment").
     pub name: String,
-    /// The error message. Used for UnusedIgnore errors to determine what to remove.
+    /// The human-readable error message.
     pub message: String,
+    /// An exact machine-applicable edit when this diagnostic reports an unused suppression.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suppression_edit: Option<SerializedSuppressionEdit>,
+}
+
+/// A line-relative source edit for an unused suppression comment.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SerializedSuppressionEdit {
+    /// The suppression syntax being edited.
+    pub tool: Tool,
+    /// Byte offset within the diagnostic line where the edit starts.
+    pub start: usize,
+    /// Byte offset within the diagnostic line where the edit ends.
+    pub end: usize,
+    /// Source text expected in the range, used to reject stale edits.
+    pub expected: String,
+    /// Replacement text for the range. Empty text removes the entire suppression.
+    pub replacement: String,
 }
 
 impl SerializedError {
@@ -106,15 +110,24 @@ impl SerializedError {
     /// Returns None if the error is not from a filesystem path.
     pub fn from_error(error: &Error) -> Option<Self> {
         if let ModulePathDetails::FileSystem(path) = error.path().details() {
+            let line = error.display_range().start.line_within_file();
+            let line_start = error.lined_buffer().line_start(line);
+            let suppression_edit = error.quick_fixes().iter().find_map(|fix| match fix {
+                ErrorQuickFix::RemoveUnusedSuppression(edit) => Some(SerializedSuppressionEdit {
+                    tool: edit.tool,
+                    start: (edit.range.start() - line_start).to_usize(),
+                    end: (edit.range.end() - line_start).to_usize(),
+                    expected: edit.expected.clone(),
+                    replacement: edit.replacement.clone(),
+                }),
+                ErrorQuickFix::ReplaceWithEnumMember { .. } | ErrorQuickFix::AssertNotNone => None,
+            });
             Some(Self {
                 path: (**path).clone(),
-                line: error
-                    .display_range()
-                    .start
-                    .line_within_file()
-                    .to_zero_indexed() as usize,
+                line: line.to_zero_indexed() as usize,
                 name: error.error_kind().to_name().to_owned(),
                 message: error.msg().to_owned(),
+                suppression_edit,
             })
         } else {
             None
@@ -383,6 +396,7 @@ fn add_suppressions(
                     line: new_line.to_zero_indexed() as usize,
                     name: e.name.clone(),
                     message: e.message.clone(),
+                    suppression_edit: e.suppression_edit.clone(),
                 }
             })
             .collect();
@@ -532,64 +546,13 @@ pub fn suppress_errors(errors: Vec<SerializedError>, comment_location: CommentLo
     }
 }
 
-/// Given a line with a pyrefly ignore comment and sets of used/unused error codes,
-/// returns the updated line. If all codes are unused, removes the entire comment.
-/// If some codes are used, keeps only the used codes in the comment.
-/// Uses string-aware parsing to only modify the comment portion of the line.
-fn update_ignore_comment_with_used_codes(
-    line: &str,
-    used_codes: &SmallSet<String>,
-    unused_codes: &SmallSet<String>,
-) -> Option<String> {
-    // If there are no unused codes, keep the line as-is
-    if unused_codes.is_empty() {
-        return None;
-    }
-
-    let comment_start = find_comment_start_in_line(line)?;
-    let code_part = &line[..comment_start];
-    let comment_part = &line[comment_start..];
-
-    // If there are no used codes, remove the entire comment
-    if used_codes.is_empty() {
-        if PYREFLY_IGNORE_COMMENT_REGEX.is_match(comment_part) {
-            let new_comment = PYREFLY_IGNORE_COMMENT_REGEX.replace(comment_part, "");
-            let result = format!("{}{}", code_part, new_comment);
-            return Some(result.trim_end().to_owned());
-        }
-        return None;
-    }
-
-    // Drop only the unused codes; preserve the user's original whitespace and comma style.
-    let regex = Regex::new(r"#\s*pyrefly:\s*ignore\s*\[([^\]]*)\]").unwrap();
-    let codes = regex.captures(comment_part)?.get(1).unwrap();
-    let separator = if codes.as_str().contains(", ") {
-        ", "
-    } else {
-        ","
-    };
-    let kept = codes
-        .as_str()
-        .split(',')
-        .map(str::trim)
-        .filter(|c| !c.is_empty() && used_codes.contains(*c))
-        .collect::<Vec<_>>()
-        .join(separator);
-    Some(format!(
-        "{code_part}{}{kept}{}",
-        &comment_part[..codes.start()],
-        &comment_part[codes.end()..],
-    ))
-}
-
 /// Removes unused ignore comments from source files.
-/// Takes a list of UnusedIgnore errors (from collect_unused_ignore_errors) and uses
-/// the error location and message to determine what to remove:
-/// - "Unused `# pyrefly: ignore` comment" -> remove entire comment
-/// - "Unused `# type: ignore` comment" -> remove entire comment when opted in
-/// - "Unused `# pyrefly: ignore` comment for code(s): X, Y" -> remove entire comment
-/// - "Unused error code(s) in `# pyrefly: ignore`: X, Y" -> remove only those codes
-pub fn remove_unused_ignores(unused_ignore_errors: Vec<Error>, kind: UnusedIgnoreKind) -> usize {
+/// Takes UnusedIgnore errors from `collect_unused_ignore_errors` and applies their
+/// structured suppression edits.
+pub fn remove_unused_ignores(
+    unused_ignore_errors: Vec<Error>,
+    kind: UnusedIgnoreKind,
+) -> anyhow::Result<usize> {
     let serialized: Vec<SerializedError> = unused_ignore_errors
         .iter()
         .filter_map(SerializedError::from_error)
@@ -603,23 +566,31 @@ pub fn remove_unused_ignores(unused_ignore_errors: Vec<Error>, kind: UnusedIgnor
 pub fn remove_unused_ignores_from_serialized(
     unused_ignore_errors: Vec<SerializedError>,
     kind: UnusedIgnoreKind,
-) -> usize {
+) -> anyhow::Result<usize> {
     if unused_ignore_errors.is_empty() {
-        return 0;
+        return Ok(0);
     }
 
     // Group errors by file path
-    let mut errors_by_path: SmallMap<PathBuf, Vec<&SerializedError>> = SmallMap::new();
+    let mut errors_by_path: SmallMap<PathBuf, Vec<(&SerializedError, &SerializedSuppressionEdit)>> =
+        SmallMap::new();
     for error in &unused_ignore_errors {
         if !((kind.includes_pyrefly_or_pyre() && error.is_unused_ignore())
             || (kind.includes_type() && error.is_unused_type_ignore()))
         {
             continue;
         }
+        let edit = error.suppression_edit.as_ref().ok_or_else(|| {
+            anyhow!(
+                "Unused suppression diagnostic for {}:{} has no structured suppression edit",
+                error.path.display(),
+                error.line + 1,
+            )
+        })?;
         errors_by_path
             .entry(error.path.clone())
             .or_default()
-            .push(error);
+            .push((error, edit));
     }
 
     let mut removed_ignores: SmallMap<PathBuf, usize> = SmallMap::new();
@@ -627,9 +598,9 @@ pub fn remove_unused_ignores_from_serialized(
     for (path, path_errors) in &errors_by_path {
         // Build a map from line number to its errors. Multiple unused suppressions
         // may appear on the same line and must each be handled independently.
-        let mut line_errors: SmallMap<usize, Vec<&SerializedError>> = SmallMap::new();
-        for error in path_errors {
-            line_errors.entry(error.line).or_default().push(*error);
+        let mut line_edits: SmallMap<usize, Vec<&SerializedSuppressionEdit>> = SmallMap::new();
+        for (error, edit) in path_errors {
+            line_edits.entry(error.line).or_default().push(*edit);
         }
 
         if let Ok((file, _ast)) = read_and_validate_file(path) {
@@ -639,73 +610,49 @@ pub fn remove_unused_ignores_from_serialized(
             let mut unused_count = 0;
 
             for (idx, line) in lines.iter().enumerate() {
-                if let Some(errors) = line_errors.get(&idx) {
-                    let mut updated_line = Cow::Borrowed(*line);
+                if let Some(edits) = line_edits.get(&idx) {
+                    let mut updated_line = (*line).to_owned();
+                    let mut edits = edits.clone();
+                    edits.sort_by_key(|edit| std::cmp::Reverse(edit.start));
+                    edits.dedup_by(|a, b| {
+                        a.start == b.start
+                            && a.end == b.end
+                            && a.expected == b.expected
+                            && a.replacement == b.replacement
+                            && a.tool == b.tool
+                    });
 
-                    for error in errors {
-                        let msg = &error.message;
-
-                        if msg.starts_with("Unused error code(s)") {
-                            // Partially unused - extract codes from message and remove only those.
-                            // Message format: "Unused error code(s) in `# pyrefly: ignore`: code1, code2"
-                            if let Some(codes_part) = msg.split(": ").last() {
-                                let unused_codes: SmallSet<String> = codes_part
-                                    .split(", ")
-                                    .map(|s| s.trim().to_owned())
-                                    .collect();
-
-                                if let Some(existing_codes) = parse_ignore_comment(&updated_line) {
-                                    let used_codes: SmallSet<String> = existing_codes
-                                        .into_iter()
-                                        .filter(|c| !unused_codes.contains(c))
-                                        .collect();
-
-                                    if let Some(updated) = update_ignore_comment_with_used_codes(
-                                        &updated_line,
-                                        &used_codes,
-                                        &unused_codes,
-                                    ) {
-                                        updated_line = Cow::Owned(updated);
-                                        unused_count += 1;
-                                    }
-                                }
-                            }
-                            continue;
+                    for edit in edits {
+                        if edit.start > edit.end
+                            || edit.end > updated_line.len()
+                            || !updated_line.is_char_boundary(edit.start)
+                            || !updated_line.is_char_boundary(edit.end)
+                        {
+                            return Err(anyhow!(
+                                "Invalid suppression edit range {}..{} for {}:{}",
+                                edit.start,
+                                edit.end,
+                                path.display(),
+                                idx + 1,
+                            ));
                         }
-
-                        let ignore_regex = if error.is_unused_type_ignore() {
-                            &*TYPE_IGNORE_COMMENT_REGEX
-                        } else if msg.starts_with("Unused `# pyrefly: ignore` comment") {
-                            &*PYREFLY_IGNORE_COMMENT_REGEX
-                        } else if msg.starts_with("Unused pyre-fixme comment") {
-                            &*PYRE_IGNORE_COMMENT_REGEX
-                        } else {
-                            continue;
-                        };
-
-                        // Use string-aware comment detection instead of raw regex.
-                        let Some(comment_start) = find_comment_start_in_line(&updated_line) else {
-                            continue;
-                        };
-                        let comment_part = &updated_line[comment_start..];
-                        if let Cow::Owned(new_comment) = ignore_regex.replace(comment_part, "") {
-                            let code_part = &updated_line[..comment_start];
-                            updated_line = Cow::Owned(
-                                format!("{}{}", code_part, new_comment)
-                                    .trim_end()
-                                    .to_owned(),
-                            );
-                            unused_count += 1;
+                        if updated_line.get(edit.start..edit.end) != Some(&edit.expected) {
+                            return Err(anyhow!(
+                                "Suppression edit no longer matches {}:{}",
+                                path.display(),
+                                idx + 1,
+                            ));
                         }
+                        updated_line.replace_range(edit.start..edit.end, &edit.replacement);
+                        unused_count += 1;
                     }
 
-                    if let Cow::Owned(updated_line) = updated_line {
-                        if !updated_line.trim().is_empty() {
-                            buf.push_str(&updated_line);
-                            buf.push_str(line_ending);
-                        }
-                        continue;
+                    updated_line.truncate(updated_line.trim_end().len());
+                    if !updated_line.trim().is_empty() {
+                        buf.push_str(&updated_line);
+                        buf.push_str(line_ending);
                     }
+                    continue;
                 }
                 buf.push_str(line);
                 buf.push_str(line_ending);
@@ -724,7 +671,7 @@ pub fn remove_unused_ignores_from_serialized(
         removals,
         removed_ignores.len(),
     );
-    removals
+    Ok(removals)
 }
 
 #[cfg(test)]
@@ -787,7 +734,8 @@ mod tests {
         let (errors, tdir) = get_errors(before);
         let collected = errors.collect_errors();
         let unused_errors = errors.collect_unused_ignore_errors(&collected);
-        let removals = suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::Pyrefly);
+        let removals =
+            suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::Pyrefly).unwrap();
         let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
         assert_eq!(after, got_file);
         assert_eq!(removals, expected_removals);
@@ -804,7 +752,8 @@ mod tests {
         let (errors, tdir) = get_errors(before);
         let collected = errors.collect_errors();
         let unused_errors = errors.collect_unused_ignore_errors(&collected);
-        let removals = suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::Pyrefly);
+        let removals =
+            suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::Pyrefly).unwrap();
         let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
         assert_eq!(after, got_file);
         assert_eq!(removals, expected_removals);
@@ -960,12 +909,14 @@ def foo() -> None:
                 line: 2, // x = 1 (0-indexed)
                 name: "new-error".to_owned(),
                 message: String::new(),
+                suppression_edit: None,
             },
             SerializedError {
                 path: path.clone(),
                 line: 4, // y = 2 (0-indexed)
                 name: "new-error".to_owned(),
                 message: String::new(),
+                suppression_edit: None,
             },
         ];
 
@@ -1201,7 +1152,8 @@ def f() -> int:
         let collected = errors.collect_errors();
         let unused_errors = errors.collect_unused_ignore_errors(&collected);
 
-        let removals = suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::All);
+        let removals =
+            suppress::remove_unused_ignores(unused_errors, UnusedIgnoreKind::All).unwrap();
 
         let got_file = fs_anyhow::read_to_string(&get_path(&tdir)).unwrap();
         assert_eq!(want, got_file);
@@ -1503,6 +1455,33 @@ def f() -> int:
     }
 
     // Helper function to test remove_unused_ignores_from_serialized
+    fn serialized_unused_suppression(
+        source: &str,
+        path: PathBuf,
+        line: usize,
+        name: &str,
+        message: &str,
+        tool: Tool,
+        start: usize,
+        end: usize,
+        replacement: &str,
+    ) -> SerializedError {
+        let source_line = source.lines().nth(line).unwrap();
+        SerializedError {
+            path,
+            line,
+            name: name.to_owned(),
+            message: message.to_owned(),
+            suppression_edit: Some(SerializedSuppressionEdit {
+                tool,
+                start,
+                end,
+                expected: source_line[start..end].to_owned(),
+                replacement: replacement.to_owned(),
+            }),
+        }
+    }
+
     fn assert_remove_ignores_from_serialized(
         file_content: &str,
         serialized_errors: Vec<SerializedError>,
@@ -1534,11 +1513,53 @@ def f() -> int:
             error.path = path.clone();
         }
 
-        let removals = suppress::remove_unused_ignores_from_serialized(serialized_errors, kind);
+        let removals =
+            suppress::remove_unused_ignores_from_serialized(serialized_errors, kind).unwrap();
 
         let got_file = fs_anyhow::read_to_string(&path).unwrap();
         assert_eq!(expected_content, got_file);
         assert_eq!(removals, expected_removals);
+    }
+
+    #[test]
+    fn test_unused_ignore_serializes_structured_edit() {
+        let input = "# pyrefly: ignore [bad-assignment, bad-return]\nx: str = 1\n";
+        let (errors, _tdir) = get_errors(input);
+        let collected = errors.collect_errors();
+        let unused_errors = errors.collect_unused_ignore_errors(&collected);
+        let serialized = SerializedError::from_error(&unused_errors[0]).unwrap();
+
+        let edit = serialized.suppression_edit.unwrap();
+        assert_eq!(edit.tool, Tool::Pyrefly);
+        assert_eq!(edit.start, 0);
+        assert_eq!(edit.end, input.lines().next().unwrap().len());
+        assert_eq!(
+            edit.expected,
+            "# pyrefly: ignore [bad-assignment, bad-return]"
+        );
+        assert_eq!(edit.replacement, "# pyrefly: ignore [bad-assignment]");
+    }
+
+    #[test]
+    fn test_unused_ignore_without_structured_edit_is_rejected() {
+        let tdir = tempfile::tempdir().unwrap();
+        let path = get_path(&tdir);
+        let input = "x = 1  # pyrefly: ignore\n";
+        fs_anyhow::write(&path, input).unwrap();
+        let error = SerializedError {
+            path: path.clone(),
+            line: 0,
+            name: "unused-ignore".to_owned(),
+            message: "Unused `# pyrefly: ignore` comment".to_owned(),
+            suppression_edit: None,
+        };
+
+        let error =
+            suppress::remove_unused_ignores_from_serialized(vec![error], UnusedIgnoreKind::Pyrefly)
+                .unwrap_err()
+                .to_string();
+        assert!(error.contains("has no structured suppression edit"));
+        assert_eq!(fs_anyhow::read_to_string(&path).unwrap(), input);
     }
 
     #[test]
@@ -1547,12 +1568,17 @@ def f() -> int:
         // from the same line when type-ignore removal was not requested.
         let input = "x = 1  # pyrefly: ignore  # type: ignore\n";
         let want = "x = 1  # type: ignore\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused `# pyrefly: ignore` comment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "The diagnostic wording is irrelevant",
+            Tool::Pyrefly,
+            7,
+            26,
+            "",
+        )];
         assert_remove_ignores_from_serialized_with_kind(
             input,
             errors,
@@ -1568,12 +1594,17 @@ def f() -> int:
         // from the same line when type-ignore removal was requested.
         let input = "x = 1  # type: ignore  # pyrefly: ignore\n";
         let want = "x = 1  # pyrefly: ignore\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-type-ignore".to_owned(),
-            message: "Unused `# type: ignore` comment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-type-ignore",
+            "The diagnostic wording is irrelevant",
+            Tool::Type,
+            7,
+            23,
+            "",
+        )];
         assert_remove_ignores_from_serialized_with_kind(
             input,
             errors,
@@ -1591,18 +1622,28 @@ def f() -> int:
             (UnusedIgnoreKind::Type, "x = 1  # pyrefly: ignore\n"),
         ] {
             let errors = vec![
-                SerializedError {
-                    path: PathBuf::from("test.py"),
-                    line: 0,
-                    name: "unused-ignore".to_owned(),
-                    message: "Unused `# pyrefly: ignore` comment".to_owned(),
-                },
-                SerializedError {
-                    path: PathBuf::from("test.py"),
-                    line: 0,
-                    name: "unused-type-ignore".to_owned(),
-                    message: "Unused `# type: ignore` comment".to_owned(),
-                },
+                serialized_unused_suppression(
+                    input,
+                    PathBuf::from("test.py"),
+                    0,
+                    "unused-ignore",
+                    "unused",
+                    Tool::Pyrefly,
+                    7,
+                    26,
+                    "",
+                ),
+                serialized_unused_suppression(
+                    input,
+                    PathBuf::from("test.py"),
+                    0,
+                    "unused-type-ignore",
+                    "unused",
+                    Tool::Type,
+                    26,
+                    40,
+                    "",
+                ),
             ];
             assert_remove_ignores_from_serialized_with_kind(input, errors, want, 1, kind);
         }
@@ -1611,23 +1652,33 @@ def f() -> int:
     #[test]
     fn test_remove_multiple_unused_suppressions_from_same_line() {
         let want = "x = 1\n";
-        for input in [
-            "x = 1  # pyrefly: ignore  # type: ignore\n",
-            "x = 1  # type: ignore  # pyrefly: ignore\n",
+        for (input, pyrefly_start, pyrefly_end, type_start, type_end) in [
+            ("x = 1  # pyrefly: ignore  # type: ignore\n", 7, 26, 26, 40),
+            ("x = 1  # type: ignore  # pyrefly: ignore\n", 23, 40, 7, 23),
         ] {
             let errors = vec![
-                SerializedError {
-                    path: PathBuf::from("test.py"),
-                    line: 0,
-                    name: "unused-ignore".to_owned(),
-                    message: "Unused `# pyrefly: ignore` comment".to_owned(),
-                },
-                SerializedError {
-                    path: PathBuf::from("test.py"),
-                    line: 0,
-                    name: "unused-type-ignore".to_owned(),
-                    message: "Unused `# type: ignore` comment".to_owned(),
-                },
+                serialized_unused_suppression(
+                    input,
+                    PathBuf::from("test.py"),
+                    0,
+                    "unused-ignore",
+                    "unused",
+                    Tool::Pyrefly,
+                    pyrefly_start,
+                    pyrefly_end,
+                    "",
+                ),
+                serialized_unused_suppression(
+                    input,
+                    PathBuf::from("test.py"),
+                    0,
+                    "unused-type-ignore",
+                    "unused",
+                    Tool::Type,
+                    type_start,
+                    type_end,
+                    "",
+                ),
             ];
             assert_remove_ignores_from_serialized_with_kind(
                 input,
@@ -1647,12 +1698,17 @@ def f() -> int:
         let want = r#"def g() -> str:
     return "hello"
 "#;
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 1,
-            name: "unused-ignore".to_owned(),
-            message: "Unused `# pyrefly: ignore` comment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            1,
+            "unused-ignore",
+            "unused",
+            Tool::Pyrefly,
+            19,
+            36,
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -1666,12 +1722,17 @@ a: int = ""
 # pyrefly: ignore[bad-assignment]
 a: int = ""
 "#;
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 1,
-            name: "unused-ignore".to_owned(),
-            message: "Unused error code(s) in `# pyrefly: ignore`: bad-override".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            before,
+            PathBuf::from("test.py"),
+            1,
+            "unused-ignore",
+            "This message contains no error codes",
+            Tool::Pyrefly,
+            0,
+            "# pyrefly: ignore[bad-assignment,bad-override]".len(),
+            "# pyrefly: ignore[bad-assignment]",
+        )];
         assert_remove_ignores_from_serialized(before, errors, after, 1);
     }
 
@@ -1687,12 +1748,17 @@ def foo() -> str:
     # pyrefly: ignore [bad-return, unsupported-operation]
     return 1 + []
 "#;
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 2,
-            name: "unused-ignore".to_owned(),
-            message: "Unused error code(s) in `# pyrefly: ignore`: bad-assignment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            before,
+            PathBuf::from("test.py"),
+            2,
+            "unused-ignore",
+            "unused",
+            Tool::Pyrefly,
+            4,
+            "    # pyrefly: ignore [bad-return, unsupported-operation, bad-assignment]".len(),
+            "# pyrefly: ignore [bad-return, unsupported-operation]",
+        )];
         assert_remove_ignores_from_serialized(before, errors, after, 1);
     }
 
@@ -1706,12 +1772,18 @@ def g() -> str:
 def g() -> str:
     return "hello"
 "#;
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 2,
-            name: "unused-ignore".to_owned(),
-            message: "Unused `# pyrefly: ignore` comment for code(s): bad-return".to_owned(),
-        }];
+        let source_line = input.lines().nth(2).unwrap();
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            2,
+            "unused-ignore",
+            "unused",
+            Tool::Pyrefly,
+            source_line.find('#').unwrap(),
+            source_line.len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -1728,22 +1800,33 @@ def g() -> str:
         fs_anyhow::write(&path2, content2).unwrap();
 
         let errors = vec![
-            SerializedError {
-                path: path1.clone(),
-                line: 0,
-                name: "unused-ignore".to_owned(),
-                message: "Unused `# pyrefly: ignore` comment".to_owned(),
-            },
-            SerializedError {
-                path: path2.clone(),
-                line: 0,
-                name: "unused-ignore".to_owned(),
-                message: "Unused `# pyrefly: ignore` comment".to_owned(),
-            },
+            serialized_unused_suppression(
+                content1,
+                path1.clone(),
+                0,
+                "unused-ignore",
+                "unused",
+                Tool::Pyrefly,
+                7,
+                content1.trim_end().len(),
+                "",
+            ),
+            serialized_unused_suppression(
+                content2,
+                path2.clone(),
+                0,
+                "unused-ignore",
+                "unused",
+                Tool::Pyrefly,
+                7,
+                content2.trim_end().len(),
+                "",
+            ),
         ];
 
         let removals =
-            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly);
+            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly)
+                .unwrap();
 
         assert_eq!(fs_anyhow::read_to_string(&path1).unwrap(), "x = 1\n");
         assert_eq!(fs_anyhow::read_to_string(&path2).unwrap(), "y = 2\n");
@@ -1754,7 +1837,8 @@ def g() -> str:
     fn test_remove_unused_ignores_from_serialized_empty_list() {
         let errors: Vec<SerializedError> = vec![];
         let removals =
-            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly);
+            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly)
+                .unwrap();
         assert_eq!(removals, 0);
     }
 
@@ -1762,12 +1846,18 @@ def g() -> str:
     fn test_remove_unused_ignores_from_serialized_preserves_crlf() {
         let input = "def g() -> str:\r\n    return \"hello\" # pyrefly: ignore [bad-return]\r\n";
         let want = "def g() -> str:\r\n    return \"hello\"\r\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 1,
-            name: "unused-ignore".to_owned(),
-            message: "Unused `# pyrefly: ignore` comment".to_owned(),
-        }];
+        let source_line = input.lines().nth(1).unwrap();
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            1,
+            "unused-ignore",
+            "unused",
+            Tool::Pyrefly,
+            source_line.find('#').unwrap(),
+            source_line.len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -1794,12 +1884,18 @@ y = 1 + 1
 "##;
         let want = r##"x = "# pyrefly: ignore [bad-override]"
 "##;
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused `# pyrefly: ignore` comment".to_owned(),
-        }];
+        let source_line = input.lines().next().unwrap();
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "unused",
+            Tool::Pyrefly,
+            source_line.rfind('#').unwrap(),
+            source_line.len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -2171,12 +2267,17 @@ build_query(
     fn test_remove_unused_pyre_fixme_inline() {
         let input = "x = 1  # pyre-fixme\n";
         let want = "x = 1\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused pyre-fixme comment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "unused",
+            Tool::Pyre,
+            7,
+            input.trim_end().len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -2184,12 +2285,17 @@ build_query(
     fn test_remove_unused_pyre_ignore_inline() {
         let input = "x = 1  # pyre-ignore\n";
         let want = "x = 1\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused pyre-fixme comment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "unused",
+            Tool::Pyre,
+            7,
+            input.trim_end().len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -2197,12 +2303,18 @@ build_query(
     fn test_remove_unused_pyre_fixme_above() {
         let input = "# pyre-fixme[7]\nx = 1\n";
         let want = "x = 1\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused pyre-fixme comment".to_owned(),
-        }];
+        let source_line = input.lines().next().unwrap();
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "unused",
+            Tool::Pyre,
+            0,
+            source_line.len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -2210,12 +2322,17 @@ build_query(
     fn test_remove_unused_pyre_fixme_with_description() {
         let input = "x = 1  # pyre-fixme[7]: Expected `int` but got `str`\n";
         let want = "x = 1\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused pyre-fixme comment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "unused",
+            Tool::Pyre,
+            7,
+            input.trim_end().len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -2223,12 +2340,17 @@ build_query(
     fn test_remove_unused_pyre_colon_ignore() {
         let input = "x = 1  # pyre: ignore\n";
         let want = "x = 1\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused pyre-fixme comment".to_owned(),
-        }];
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "unused",
+            Tool::Pyre,
+            7,
+            input.trim_end().len(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -2236,12 +2358,18 @@ build_query(
     fn test_remove_unused_pyre_fixme_preserves_other_comments() {
         let input = "x = 1  # pyre-fixme # important note\n";
         let want = "x = 1  # important note\n";
-        let errors = vec![SerializedError {
-            path: PathBuf::from("test.py"),
-            line: 0,
-            name: "unused-ignore".to_owned(),
-            message: "Unused pyre-fixme comment".to_owned(),
-        }];
+        let source_line = input.trim_end();
+        let errors = vec![serialized_unused_suppression(
+            input,
+            PathBuf::from("test.py"),
+            0,
+            "unused-ignore",
+            "unused",
+            Tool::Pyre,
+            7,
+            source_line.rfind('#').unwrap(),
+            "",
+        )];
         assert_remove_ignores_from_serialized(input, errors, want, 1);
     }
 
@@ -2252,14 +2380,21 @@ build_query(
         let input = "x = \"# pyre-fixme\"\ny = 1  # pyre-fixme\n";
         let want = "x = \"# pyre-fixme\"\ny = 1\n";
         fs_anyhow::write(&path, input).unwrap();
-        let errors = vec![SerializedError {
-            path: path.clone(),
-            line: 1,
-            name: "unused-ignore".to_owned(),
-            message: "Unused pyre-fixme comment".to_owned(),
-        }];
+        let source_line = input.lines().nth(1).unwrap();
+        let errors = vec![serialized_unused_suppression(
+            input,
+            path.clone(),
+            1,
+            "unused-ignore",
+            "unused",
+            Tool::Pyre,
+            source_line.rfind('#').unwrap(),
+            source_line.len(),
+            "",
+        )];
         let removals =
-            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly);
+            suppress::remove_unused_ignores_from_serialized(errors, UnusedIgnoreKind::Pyrefly)
+                .unwrap();
         let got = fs_anyhow::read_to_string(&path).unwrap();
         assert_eq!(want, got);
         assert_eq!(removals, 1);

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -539,13 +539,16 @@ impl Errors {
                         let comment_line = supp.comment_line();
                         let line_start = module.lined_buffer().line_start(comment_line);
                         let range = TextRange::new(line_start, line_start + TextSize::new(1));
-                        unused_errors.push(Error::new(
-                            module.dupe(),
-                            range,
-                            "Unused pyre-fixme comment".to_owned(),
-                            Vec::new(),
-                            ErrorKind::UnusedIgnore,
-                        ));
+                        unused_errors.push(
+                            Error::new(
+                                module.dupe(),
+                                range,
+                                "Unused pyre-fixme comment".to_owned(),
+                                Vec::new(),
+                                ErrorKind::UnusedIgnore,
+                            )
+                            .with_quick_fix(supp.removal_edit(module.lined_buffer(), None).into()),
+                        );
                         continue;
                     }
 
@@ -557,13 +560,16 @@ impl Errors {
                         let comment_line = supp.comment_line();
                         let line_start = module.lined_buffer().line_start(comment_line);
                         let range = TextRange::new(line_start, line_start + TextSize::new(1));
-                        unused_errors.push(Error::new(
-                            module.dupe(),
-                            range,
-                            "Unused `# type: ignore` comment".to_owned(),
-                            Vec::new(),
-                            ErrorKind::UnusedTypeIgnore,
-                        ));
+                        unused_errors.push(
+                            Error::new(
+                                module.dupe(),
+                                range,
+                                "Unused `# type: ignore` comment".to_owned(),
+                                Vec::new(),
+                                ErrorKind::UnusedTypeIgnore,
+                            )
+                            .with_quick_fix(supp.removal_edit(module.lined_buffer(), None).into()),
+                        );
                         continue;
                     }
 
@@ -611,13 +617,24 @@ impl Errors {
                         )
                     };
 
-                    unused_errors.push(Error::new(
-                        module.dupe(),
-                        range,
-                        msg,
-                        Vec::new(),
-                        ErrorKind::UnusedIgnore,
-                    ));
+                    let partially_unused =
+                        !declared_codes.is_empty() && unused_codes.len() != declared_codes.len();
+                    unused_errors.push(
+                        Error::new(
+                            module.dupe(),
+                            range,
+                            msg,
+                            Vec::new(),
+                            ErrorKind::UnusedIgnore,
+                        )
+                        .with_quick_fix(
+                            supp.removal_edit(
+                                module.lined_buffer(),
+                                partially_unused.then_some(&unused_codes),
+                            )
+                            .into(),
+                        ),
+                    );
                 }
             }
         }

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -27,8 +27,6 @@ use ruff_python_ast::ModModule;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::visitor::walk_expr;
 use ruff_text_size::Ranged;
-use ruff_text_size::TextRange;
-use ruff_text_size::TextSize;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 
@@ -536,18 +534,16 @@ impl Errors {
                         if !used_codes.is_empty() {
                             continue; // Pyre suppression is used
                         }
-                        let comment_line = supp.comment_line();
-                        let line_start = module.lined_buffer().line_start(comment_line);
-                        let range = TextRange::new(line_start, line_start + TextSize::new(1));
+                        let edit = supp.removal_edit(module.lined_buffer(), None);
                         unused_errors.push(
                             Error::new(
                                 module.dupe(),
-                                range,
+                                edit.range,
                                 "Unused pyre-fixme comment".to_owned(),
                                 Vec::new(),
                                 ErrorKind::UnusedIgnore,
                             )
-                            .with_quick_fix(supp.removal_edit(module.lined_buffer(), None).into()),
+                            .with_quick_fix(edit.into()),
                         );
                         continue;
                     }
@@ -557,18 +553,16 @@ impl Errors {
                         if !used_codes.is_empty() {
                             continue; // type: ignore is used
                         }
-                        let comment_line = supp.comment_line();
-                        let line_start = module.lined_buffer().line_start(comment_line);
-                        let range = TextRange::new(line_start, line_start + TextSize::new(1));
+                        let edit = supp.removal_edit(module.lined_buffer(), None);
                         unused_errors.push(
                             Error::new(
                                 module.dupe(),
-                                range,
+                                edit.range,
                                 "Unused `# type: ignore` comment".to_owned(),
                                 Vec::new(),
                                 ErrorKind::UnusedTypeIgnore,
                             )
-                            .with_quick_fix(supp.removal_edit(module.lined_buffer(), None).into()),
+                            .with_quick_fix(edit.into()),
                         );
                         continue;
                     }
@@ -598,11 +592,6 @@ impl Errors {
                         unused
                     };
 
-                    // Create an error for the unused suppression
-                    let comment_line = supp.comment_line();
-                    let line_start = module.lined_buffer().line_start(comment_line);
-                    let range = TextRange::new(line_start, line_start + TextSize::new(1));
-
                     let msg = if declared_codes.is_empty() {
                         "Unused `# pyrefly: ignore` comment".to_owned()
                     } else if unused_codes.len() == declared_codes.len() {
@@ -619,21 +608,19 @@ impl Errors {
 
                     let partially_unused =
                         !declared_codes.is_empty() && unused_codes.len() != declared_codes.len();
+                    let edit = supp.removal_edit(
+                        module.lined_buffer(),
+                        partially_unused.then_some(&unused_codes),
+                    );
                     unused_errors.push(
                         Error::new(
                             module.dupe(),
-                            range,
+                            edit.range,
                             msg,
                             Vec::new(),
                             ErrorKind::UnusedIgnore,
                         )
-                        .with_quick_fix(
-                            supp.removal_edit(
-                                module.lined_buffer(),
-                                partially_unused.then_some(&unused_codes),
-                            )
-                            .into(),
-                        ),
+                        .with_quick_fix(edit.into()),
                     );
                 }
             }
@@ -715,6 +702,7 @@ mod tests {
     use pyrefly_util::fs_anyhow;
     use pyrefly_util::thread_pool::TEST_THREAD_COUNT;
     use regex::Regex;
+    use ruff_text_size::Ranged;
     use tempfile::TempDir;
 
     use crate::config::config::ConfigFile;
@@ -865,6 +853,32 @@ def g() -> str:
         let collected = errors.collect_errors();
         let unused = errors.collect_unused_ignore_errors(&collected);
         assert_eq!(unused.len(), 2);
+    }
+
+    #[test]
+    fn test_unused_ignore_ranges_cover_suppression_comments() {
+        let contents = "\
+# type: ignore
+x = 1
+y: int = \"bad\"  # pyrefly: ignore [bad-assignment, unknown-name]
+z = 2  # pyrefly: ignore
+";
+        let (errors, _tdir) = get_errors(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        let mut ranges = unused
+            .iter()
+            .map(|error| error.module().code_at(error.range()))
+            .collect::<Vec<_>>();
+        ranges.sort_unstable();
+        assert_eq!(
+            ranges,
+            vec![
+                "# pyrefly: ignore",
+                "# pyrefly: ignore [bad-assignment, unknown-name]",
+                "# type: ignore",
+            ]
+        );
     }
 
     #[test]

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -662,13 +662,16 @@ impl Errors {
                         if !used_codes.is_empty() {
                             continue; // Pyre suppression is used
                         }
-                        unused_errors.push(Error::new(
-                            module.dupe(),
-                            comment_range,
-                            "Unused pyre-fixme comment".to_owned(),
-                            Vec::new(),
-                            ErrorKind::UnusedIgnore,
-                        ));
+                        unused_errors.push(
+                            Error::new(
+                                module.dupe(),
+                                comment_range,
+                                "Unused pyre-fixme comment".to_owned(),
+                                Vec::new(),
+                                ErrorKind::UnusedIgnore,
+                            )
+                            .with_quick_fix(supp.removal_edit(module.lined_buffer(), None).into()),
+                        );
                         continue;
                     }
 
@@ -677,13 +680,16 @@ impl Errors {
                         if !used_codes.is_empty() {
                             continue; // type: ignore is used
                         }
-                        unused_errors.push(Error::new(
-                            module.dupe(),
-                            comment_range,
-                            "Unused `# type: ignore` comment".to_owned(),
-                            Vec::new(),
-                            ErrorKind::UnusedTypeIgnore,
-                        ));
+                        unused_errors.push(
+                            Error::new(
+                                module.dupe(),
+                                comment_range,
+                                "Unused `# type: ignore` comment".to_owned(),
+                                Vec::new(),
+                                ErrorKind::UnusedTypeIgnore,
+                            )
+                            .with_quick_fix(supp.removal_edit(module.lined_buffer(), None).into()),
+                        );
                         continue;
                     }
 
@@ -727,13 +733,24 @@ impl Errors {
                         )
                     };
 
-                    unused_errors.push(Error::new(
-                        module.dupe(),
-                        comment_range,
-                        msg,
-                        Vec::new(),
-                        ErrorKind::UnusedIgnore,
-                    ));
+                    let partially_unused =
+                        !declared_codes.is_empty() && unused_codes.len() != declared_codes.len();
+                    unused_errors.push(
+                        Error::new(
+                            module.dupe(),
+                            comment_range,
+                            msg,
+                            Vec::new(),
+                            ErrorKind::UnusedIgnore,
+                        )
+                        .with_quick_fix(
+                            supp.removal_edit(
+                                module.lined_buffer(),
+                                partially_unused.then_some(&unused_codes),
+                            )
+                            .into(),
+                        ),
+                    );
                 }
             }
         }

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -32,8 +32,6 @@ use ruff_python_ast::ModModule;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::visitor::walk_expr;
 use ruff_text_size::Ranged;
-use ruff_text_size::TextRange;
-use ruff_text_size::TextSize;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 
@@ -648,12 +646,6 @@ impl Errors {
                         .and_then(|m| m.get(applies_to_line))
                         .cloned()
                         .unwrap_or_default();
-                    let comment_start = module.lined_buffer().line_start(supp.comment_line())
-                        + TextSize::try_from(supp.comment_offset())
-                            .expect("Python source offsets fit in TextSize");
-                    let comment_range =
-                        TextRange::new(comment_start, comment_start + TextSize::new(1));
-
                     // For Tool::Pyre, error code filtering is not enforced
                     // (any Pyre suppression suppresses all errors on the line),
                     // so we only report it as unused when no errors at all were
@@ -662,15 +654,16 @@ impl Errors {
                         if !used_codes.is_empty() {
                             continue; // Pyre suppression is used
                         }
+                        let edit = supp.removal_edit(module.lined_buffer(), None);
                         unused_errors.push(
                             Error::new(
                                 module.dupe(),
-                                comment_range,
+                                edit.range,
                                 "Unused pyre-fixme comment".to_owned(),
                                 Vec::new(),
                                 ErrorKind::UnusedIgnore,
                             )
-                            .with_quick_fix(supp.removal_edit(module.lined_buffer(), None).into()),
+                            .with_quick_fix(edit.into()),
                         );
                         continue;
                     }
@@ -680,15 +673,16 @@ impl Errors {
                         if !used_codes.is_empty() {
                             continue; // type: ignore is used
                         }
+                        let edit = supp.removal_edit(module.lined_buffer(), None);
                         unused_errors.push(
                             Error::new(
                                 module.dupe(),
-                                comment_range,
+                                edit.range,
                                 "Unused `# type: ignore` comment".to_owned(),
                                 Vec::new(),
                                 ErrorKind::UnusedTypeIgnore,
                             )
-                            .with_quick_fix(supp.removal_edit(module.lined_buffer(), None).into()),
+                            .with_quick_fix(edit.into()),
                         );
                         continue;
                     }
@@ -718,7 +712,6 @@ impl Errors {
                         unused
                     };
 
-                    // Create an error for the unused suppression
                     let msg = if declared_codes.is_empty() {
                         "Unused `# pyrefly: ignore` comment".to_owned()
                     } else if unused_codes.len() == declared_codes.len() {
@@ -735,21 +728,19 @@ impl Errors {
 
                     let partially_unused =
                         !declared_codes.is_empty() && unused_codes.len() != declared_codes.len();
+                    let edit = supp.removal_edit(
+                        module.lined_buffer(),
+                        partially_unused.then_some(&unused_codes),
+                    );
                     unused_errors.push(
                         Error::new(
                             module.dupe(),
-                            comment_range,
+                            edit.range,
                             msg,
                             Vec::new(),
                             ErrorKind::UnusedIgnore,
                         )
-                        .with_quick_fix(
-                            supp.removal_edit(
-                                module.lined_buffer(),
-                                partially_unused.then_some(&unused_codes),
-                            )
-                            .into(),
-                        ),
+                        .with_quick_fix(edit.into()),
                     );
                 }
             }
@@ -1007,6 +998,32 @@ def g() -> str:
     }
 
     #[test]
+    fn test_unused_ignore_ranges_cover_suppression_comments() {
+        let contents = "\
+# type: ignore
+x = 1
+y: int = \"bad\"  # pyrefly: ignore [bad-assignment, unknown-name]
+z = 2  # pyrefly: ignore
+";
+        let (errors, _tdir) = get_errors(contents);
+        let collected = errors.collect_errors();
+        let unused = errors.collect_unused_ignore_errors(&collected);
+        let mut ranges = unused
+            .iter()
+            .map(|error| error.module().code_at(error.range()))
+            .collect::<Vec<_>>();
+        ranges.sort_unstable();
+        assert_eq!(
+            ranges,
+            vec![
+                "# pyrefly: ignore",
+                "# pyrefly: ignore [bad-assignment, unknown-name]",
+                "# type: ignore",
+            ]
+        );
+    }
+
+    #[test]
     fn test_unused_type_ignore_no_error() {
         let contents = r#"
 def f() -> int:
@@ -1052,7 +1069,10 @@ def f() -> int:
         let collected = errors.collect_errors();
         let unused = errors.collect_unused_ignore_errors(&collected);
         assert_eq!(unused.len(), 1);
-        assert_eq!(unused[0].lined_buffer().code_at(unused[0].range()), "#");
+        assert_eq!(
+            unused[0].lined_buffer().code_at(unused[0].range()),
+            "# type: ignore"
+        );
 
         let mut renderer = ErrorRenderer::plain(Vec::new());
         renderer.write(&unused[0], Path::new(""), true).unwrap();

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3002,7 +3002,10 @@ impl<'a> Transaction<'a> {
     ) -> Option<Vec<(String, Vec<(Module, TextRange, String)>)>> {
         let module_info = self.get_module_info(handle)?;
         let ast = self.get_ast(handle)?;
-        let errors = self.get_errors(vec![handle]).collect_errors().ordinary;
+        let error_collection = self.get_errors(vec![handle]);
+        let collected = error_collection.collect_errors();
+        let unused = error_collection.collect_unused_ignore_errors_for_display(&collected);
+        let errors = collected.ordinary.into_iter().chain(unused.ordinary);
         let mut import_actions = Vec::new();
         let mut generate_actions = Vec::new();
         let mut other_actions = Vec::new();
@@ -3036,6 +3039,20 @@ impl<'a> Transaction<'a> {
                 }
             }
             match error.error_kind() {
+                ErrorKind::UnusedIgnore | ErrorKind::UnusedTypeIgnore => {
+                    if let Some(action) =
+                        quick_fixes::unused_ignore::remove_unused_ignore_code_action(
+                            &module_info,
+                            &error,
+                        )
+                        && (error_range.contains_range(range) || action.2.contains_range(range))
+                    {
+                        let key = (action.0.clone(), action.2, action.3.clone());
+                        if other_action_keys.insert(key) {
+                            other_actions.push(action);
+                        }
+                    }
+                }
                 ErrorKind::UnknownName | ErrorKind::UnimportedDirective
                     if error_range.contains_range(range) =>
                 {

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3306,7 +3306,10 @@ impl<'a> Transaction<'a> {
     ) -> Option<Vec<(String, Vec<(Module, TextRange, String)>)>> {
         let module_info = self.get_module_info(handle)?;
         let ast = self.get_ast(handle)?;
-        let errors = self.get_errors(vec![handle]).collect_errors().ordinary;
+        let error_collection = self.get_errors(vec![handle]);
+        let collected = error_collection.collect_errors();
+        let unused = error_collection.collect_unused_ignore_errors_for_display(&collected);
+        let errors = collected.ordinary.into_iter().chain(unused.ordinary);
         let mut import_actions = Vec::new();
         let mut generate_actions = Vec::new();
         let mut other_actions = Vec::new();
@@ -3377,6 +3380,20 @@ impl<'a> Transaction<'a> {
                 }
             }
             match error.error_kind() {
+                ErrorKind::UnusedIgnore | ErrorKind::UnusedTypeIgnore => {
+                    if let Some(action) =
+                        quick_fixes::unused_ignore::remove_unused_ignore_code_action(
+                            &module_info,
+                            &error,
+                        )
+                        && (error_range.contains_range(range) || action.2.contains_range(range))
+                    {
+                        let key = (action.0.clone(), action.2, action.3.clone());
+                        if other_action_keys.insert(key) {
+                            other_actions.push(action);
+                        }
+                    }
+                }
                 ErrorKind::UnknownName | ErrorKind::UnimportedDirective
                     if error_range.contains_range(range) =>
                 {

--- a/pyrefly/lib/state/lsp/quick_fixes.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes.rs
@@ -28,3 +28,4 @@ pub(crate) mod redundant_cast;
 pub(crate) mod safe_delete;
 pub(crate) mod types;
 pub(crate) mod unnecessary_type_conversion;
+pub(crate) mod unused_ignore;

--- a/pyrefly/lib/state/lsp/quick_fixes.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes.rs
@@ -30,4 +30,5 @@ pub(crate) mod redundant_cast;
 pub(crate) mod safe_delete;
 pub(crate) mod types;
 pub(crate) mod unnecessary_type_conversion;
+pub(crate) mod unused_ignore;
 pub(crate) mod unused_import;

--- a/pyrefly/lib/state/lsp/quick_fixes/enum_member.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/enum_member.rs
@@ -33,7 +33,9 @@ pub(crate) fn replace_with_enum_member_code_action(
 }
 
 fn enum_member_replacement(error: &Error) -> Option<&str> {
-    let ErrorQuickFix::ReplaceWithEnumMember { replacement } = error.quick_fixes().first()?;
+    let ErrorQuickFix::ReplaceWithEnumMember { replacement } = error.quick_fixes().first()? else {
+        return None;
+    };
     Some(replacement.as_str())
 }
 

--- a/pyrefly/lib/state/lsp/quick_fixes/enum_member.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/enum_member.rs
@@ -35,7 +35,7 @@ pub(crate) fn replace_with_enum_member_code_action(
 fn enum_member_replacement(error: &Error) -> Option<&str> {
     error.quick_fixes().iter().find_map(|fix| match fix {
         ErrorQuickFix::ReplaceWithEnumMember { replacement } => Some(replacement.as_str()),
-        ErrorQuickFix::AssertNotNone => None,
+        ErrorQuickFix::AssertNotNone | ErrorQuickFix::RemoveUnusedSuppression(_) => None,
     })
 }
 

--- a/pyrefly/lib/state/lsp/quick_fixes/pyrefly_ignore.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/pyrefly_ignore.rs
@@ -64,7 +64,10 @@ pub(crate) fn add_pyrefly_ignore_code_action(
 fn should_offer_pyrefly_ignore(module_info: &ModuleInfo, error: &Error) -> bool {
     !module_info.is_notebook()
         && !module_info.is_generated()
-        && error.error_kind() != ErrorKind::UnusedIgnore
+        && !matches!(
+            error.error_kind(),
+            ErrorKind::UnusedIgnore | ErrorKind::UnusedTypeIgnore
+        )
 }
 
 fn get_line_text_and_range(

--- a/pyrefly/lib/state/lsp/quick_fixes/unused_ignore.rs
+++ b/pyrefly/lib/state/lsp/quick_fixes/unused_ignore.rs
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use dupe::Dupe;
+use pyrefly_python::ignore::Tool;
+use pyrefly_python::module::Module;
+use ruff_text_size::TextRange;
+use ruff_text_size::TextSize;
+
+use crate::ModuleInfo;
+use crate::error::error::Error;
+use crate::error::error::ErrorQuickFix;
+
+pub(crate) fn remove_unused_ignore_code_action(
+    module_info: &ModuleInfo,
+    error: &Error,
+) -> Option<(String, Module, TextRange, String)> {
+    let ErrorQuickFix::RemoveUnusedSuppression(edit) = error.quick_fixes().first()? else {
+        return None;
+    };
+    if module_info.code_at(edit.range) != edit.expected {
+        return None;
+    }
+
+    let title = if edit.replacement.is_empty() {
+        match edit.tool {
+            Tool::Type => "Remove unused `# type: ignore` comment",
+            Tool::Pyrefly => "Remove unused `# pyrefly: ignore` comment",
+            Tool::Pyre => "Remove unused Pyre suppression",
+            Tool::Pyright | Tool::Mypy | Tool::Ty | Tool::Zuban => {
+                unreachable!(
+                    "unused-ignore diagnostics are not emitted for {:?}",
+                    edit.tool
+                )
+            }
+        }
+    } else {
+        "Remove unused suppression codes"
+    };
+
+    let mut edit_range = edit.range;
+    if edit.replacement.is_empty() {
+        let line = error.display_range().start.line_within_file();
+        let line_start = module_info.lined_buffer().line_start(line);
+        let line_text_full = module_info.lined_buffer().content_in_line_range(line, line);
+        let line_text = line_text_full
+            .strip_suffix("\r\n")
+            .or_else(|| line_text_full.strip_suffix('\n'))
+            .unwrap_or(line_text_full);
+        let line_end = line_start
+            + TextSize::try_from(line_text.len()).expect("source line length must fit in u32");
+        let prefix = module_info.code_at(TextRange::new(line_start, edit.range.start()));
+        let suffix = module_info.code_at(TextRange::new(edit.range.end(), line_end));
+
+        if prefix.trim().is_empty() && suffix.trim().is_empty() {
+            // Avoid leaving a blank line when the suppression is the only comment.
+            edit_range = TextRange::new(
+                line_start,
+                line_start
+                    + TextSize::try_from(line_text_full.len())
+                        .expect("source line length must fit in u32"),
+            );
+        } else if suffix.is_empty() {
+            // Avoid leaving trailing whitespace after an inline suppression.
+            edit_range = TextRange::new(
+                line_start
+                    + TextSize::try_from(prefix.trim_end().len())
+                        .expect("source line length must fit in u32"),
+                edit.range.end(),
+            );
+        }
+    }
+
+    Some((
+        title.to_owned(),
+        module_info.dupe(),
+        edit_range,
+        edit.replacement.clone(),
+    ))
+}

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -1121,6 +1121,55 @@ Code Actions Results:
     );
 }
 
+fn remove_unused_ignore_quickfix(code: &str, suppression: &str) -> (String, String) {
+    let mut env = TestEnv::new();
+    env.add("main", code);
+    let (state, handle_for_module) = env.enable_unused_ignore_errors().to_state();
+    let handle = handle_for_module("main");
+    let transaction = state.transaction();
+    let module_info = transaction.get_module_info(&handle).unwrap();
+    let position = TextSize::try_from(code.find(suppression).unwrap()).unwrap();
+    let (title, edits) = transaction
+        .local_quickfix_code_actions_sorted(
+            &handle,
+            TextRange::new(position, position),
+            ImportFormat::Absolute,
+            None,
+        )
+        .unwrap_or_default()
+        .into_iter()
+        .find(|(title, _)| title.starts_with("Remove unused"))
+        .expect("expected remove-unused-ignore quick fix");
+    (title, apply_refactor_edits_for_module(&module_info, &edits))
+}
+
+#[test]
+fn quickfix_remove_unused_type_ignore_line() {
+    let code = "# type: ignore\nx = 1\n";
+    let (title, after) = remove_unused_ignore_quickfix(code, "# type: ignore");
+    assert_eq!(title, "Remove unused `# type: ignore` comment");
+    assert_eq!(after, "x = 1\n");
+}
+
+#[test]
+fn quickfix_remove_unused_inline_pyrefly_ignore() {
+    let code = "x = 1  # pyrefly: ignore\n";
+    let (title, after) = remove_unused_ignore_quickfix(code, "# pyrefly: ignore");
+    assert_eq!(title, "Remove unused `# pyrefly: ignore` comment");
+    assert_eq!(after, "x = 1\n");
+}
+
+#[test]
+fn quickfix_remove_partially_unused_pyrefly_ignore_codes() {
+    let code = "x: int = \"bad\"  # pyrefly: ignore [bad-assignment, unknown-name]\n";
+    let (title, after) = remove_unused_ignore_quickfix(code, "# pyrefly: ignore");
+    assert_eq!(title, "Remove unused suppression codes");
+    assert_eq!(
+        after,
+        "x: int = \"bad\"  # pyrefly: ignore [bad-assignment]\n"
+    );
+}
+
 #[test]
 fn insertion_test_existing_imports() {
     let report = get_batched_lsp_operations_report_allow_error(

--- a/pyrefly/lib/test/lsp/code_actions.rs
+++ b/pyrefly/lib/test/lsp/code_actions.rs
@@ -1313,6 +1313,55 @@ Code Actions Results:
     );
 }
 
+fn remove_unused_ignore_quickfix(code: &str, suppression: &str) -> (String, String) {
+    let mut env = TestEnv::new();
+    env.add("main", code);
+    let (state, handle_for_module) = env.enable_unused_ignore_errors().to_state();
+    let handle = handle_for_module("main");
+    let transaction = state.transaction();
+    let module_info = transaction.get_module_info(&handle).unwrap();
+    let position = TextSize::try_from(code.find(suppression).unwrap()).unwrap();
+    let (title, edits) = transaction
+        .local_quickfix_code_actions_sorted(
+            &handle,
+            TextRange::new(position, position),
+            ImportFormat::Absolute,
+            None,
+        )
+        .unwrap_or_default()
+        .into_iter()
+        .find(|(title, _)| title.starts_with("Remove unused"))
+        .expect("expected remove-unused-ignore quick fix");
+    (title, apply_refactor_edits_for_module(&module_info, &edits))
+}
+
+#[test]
+fn quickfix_remove_unused_type_ignore_line() {
+    let code = "# type: ignore\nx = 1\n";
+    let (title, after) = remove_unused_ignore_quickfix(code, "# type: ignore");
+    assert_eq!(title, "Remove unused `# type: ignore` comment");
+    assert_eq!(after, "x = 1\n");
+}
+
+#[test]
+fn quickfix_remove_unused_inline_pyrefly_ignore() {
+    let code = "x = 1  # pyrefly: ignore\n";
+    let (title, after) = remove_unused_ignore_quickfix(code, "# pyrefly: ignore");
+    assert_eq!(title, "Remove unused `# pyrefly: ignore` comment");
+    assert_eq!(after, "x = 1\n");
+}
+
+#[test]
+fn quickfix_remove_partially_unused_pyrefly_ignore_codes() {
+    let code = "x: int = \"bad\"  # pyrefly: ignore [bad-assignment, unknown-name]\n";
+    let (title, after) = remove_unused_ignore_quickfix(code, "# pyrefly: ignore");
+    assert_eq!(title, "Remove unused suppression codes");
+    assert_eq!(
+        after,
+        "x: int = \"bad\"  # pyrefly: ignore [bad-assignment]\n"
+    );
+}
+
 #[test]
 fn insertion_test_existing_imports() {
     let report = get_batched_lsp_operations_report_allow_error(

--- a/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
@@ -1918,7 +1918,7 @@ fn test_unused_ignore_diagnostic() {
                     "message": "Unused `# pyrefly: ignore` comment",
                     "range": {
                         "start": {"line": 5, "character": 0},
-                        "end": {"line": 5, "character": 1}
+                        "end": {"line": 5, "character": 17}
                     },
                     "severity": 1,
                     "source": "Pyrefly"
@@ -1989,7 +1989,7 @@ fn test_unused_type_ignore_diagnostic() {
                     "message": "Unused `# type: ignore` comment",
                     "range": {
                         "start": {"line": 5, "character": 0},
-                        "end": {"line": 5, "character": 1}
+                        "end": {"line": 5, "character": 14}
                     },
                     "severity": 1,
                     "source": "Pyrefly"

--- a/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
@@ -2000,7 +2000,7 @@ fn test_unused_ignore_diagnostic() {
                     "message": "Unused `# pyrefly: ignore` comment",
                     "range": {
                         "start": {"line": 5, "character": 0},
-                        "end": {"line": 5, "character": 1}
+                        "end": {"line": 5, "character": 17}
                     },
                     "severity": 1,
                     "source": "Pyrefly"
@@ -2071,7 +2071,7 @@ fn test_unused_type_ignore_diagnostic() {
                     "message": "Unused `# type: ignore` comment",
                     "range": {
                         "start": {"line": 5, "character": 0},
-                        "end": {"line": 5, "character": 1}
+                        "end": {"line": 5, "character": 14}
                     },
                     "severity": 1,
                     "source": "Pyrefly"

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -118,6 +118,7 @@ pub struct TestEnv {
     open_unpacking_error: bool,
     missing_override_decorator_error: bool,
     missing_super_call_error: bool,
+    unused_ignore_errors: bool,
     not_required_key_access_error: bool,
     pytorch_efficiency_lint_error: bool,
     incompatible_comparison_error: bool,
@@ -169,6 +170,7 @@ impl TestEnv {
             open_unpacking_error: false,
             missing_override_decorator_error: false,
             missing_super_call_error: false,
+            unused_ignore_errors: false,
             not_required_key_access_error: false,
             pytorch_efficiency_lint_error: false,
             incompatible_comparison_error: false,
@@ -338,6 +340,11 @@ impl TestEnv {
 
     pub fn enable_missing_super_call_error(mut self) -> Self {
         self.missing_super_call_error = true;
+        self
+    }
+
+    pub fn enable_unused_ignore_errors(mut self) -> Self {
+        self.unused_ignore_errors = true;
         self
     }
 
@@ -571,6 +578,10 @@ impl TestEnv {
         }
         if self.missing_super_call_error {
             errors.set_error_severity(ErrorKind::MissingSuperCall, Severity::Error);
+        }
+        if self.unused_ignore_errors {
+            errors.set_error_severity(ErrorKind::UnusedIgnore, Severity::Error);
+            errors.set_error_severity(ErrorKind::UnusedTypeIgnore, Severity::Error);
         }
         if self.not_required_key_access_error {
             errors.set_error_severity(ErrorKind::NotRequiredKeyAccess, Severity::Error);

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -160,6 +160,7 @@ pub struct TestEnv {
     open_unpacking_error: bool,
     missing_override_decorator_error: bool,
     missing_super_call_error: bool,
+    unused_ignore_errors: bool,
     not_required_key_access_error: bool,
     pytorch_efficiency_lint_error: bool,
     incompatible_comparison_error: bool,
@@ -216,6 +217,7 @@ impl TestEnv {
             open_unpacking_error: false,
             missing_override_decorator_error: false,
             missing_super_call_error: false,
+            unused_ignore_errors: false,
             not_required_key_access_error: false,
             pytorch_efficiency_lint_error: false,
             incompatible_comparison_error: false,
@@ -393,6 +395,11 @@ impl TestEnv {
 
     pub fn enable_missing_super_call_error(mut self) -> Self {
         self.missing_super_call_error = true;
+        self
+    }
+
+    pub fn enable_unused_ignore_errors(mut self) -> Self {
+        self.unused_ignore_errors = true;
         self
     }
 
@@ -650,6 +657,10 @@ impl TestEnv {
         }
         if self.missing_super_call_error {
             errors.set_error_severity(ErrorKind::MissingSuperCall, Severity::Error);
+        }
+        if self.unused_ignore_errors {
+            errors.set_error_severity(ErrorKind::UnusedIgnore, Severity::Error);
+            errors.set_error_severity(ErrorKind::UnusedTypeIgnore, Severity::Error);
         }
         if self.not_required_key_access_error {
             errors.set_error_severity(ErrorKind::NotRequiredKeyAccess, Severity::Error);


### PR DESCRIPTION
# Summary
Follow-up to #4200.

- Adds an editor quick-fix code action to remove an unused `# pyrefly: ignore` / `# type: ignore` comment (mentioned in #2207).
- Changes the highlighted diagnostic range for unused-ignore / unused-type-ignore errors to cover the full suppression comment, not just the start of the line where the comment appears. This ensures the underline in the IDE is in the correct place.
- Refactors the implementation of `pyrefly suppress --remove-unused` to be simpler and rely on richer information coming from check diagnostics. This was discussed in https://github.com/facebook/pyrefly/pull/4200#discussion_r3607881358.

# Test Plan
- [x] Verified code action appears and works in LSP with VSCode and Cursor

https://github.com/user-attachments/assets/a2c56965-1493-4820-89d3-e21f8de57fef



