### PR TITLE
fix Django: Instance vs Class access of attributes should return different types #4080

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -252,6 +252,9 @@ pub struct Descriptor {
     setter: bool,
     /// Does `__delete__` exist on the descriptor?
     deleter: bool,
+    /// A framework-provided instance access type that overrides the descriptor's `__get__`.
+    /// Class access still calls `__get__` so it can return the descriptor object.
+    instance_getter_type: Option<Type>,
     /// How the descriptor field was initialized. Used to distinguish class-body
     /// descriptors (which have an actual object on the class) from annotation-only
     /// descriptors (which rely on metaclass or other runtime machinery).
@@ -353,6 +356,8 @@ enum ClassFieldInner {
         ty: Type,
         annotation: Option<Annotation>,
         descriptor: Descriptor,
+        is_foreign_key: bool,
+        has_choices: bool,
     },
     /// Methods (including abstract methods, functions without return annotations). We always
     /// treat them as read only.
@@ -623,16 +628,23 @@ impl ClassField {
                 ty,
                 annotation,
                 descriptor,
+                is_foreign_key,
+                has_choices,
             } => {
                 let mut ty = ty.clone();
                 f(&mut ty);
                 let mut descriptor = descriptor.clone();
                 descriptor.cls.visit_mut(f);
+                if let Some(instance_getter_type) = &mut descriptor.instance_getter_type {
+                    f(instance_getter_type);
+                }
                 Self(
                     ClassFieldInner::Descriptor {
                         ty,
                         annotation: annotation.clone(),
                         descriptor,
+                        is_foreign_key: *is_foreign_key,
+                        has_choices: *has_choices,
                     },
                     self.1.clone(),
                 )
@@ -915,7 +927,7 @@ impl ClassField {
     pub fn is_foreign_key(&self) -> bool {
         match &self.0 {
             ClassFieldInner::Property { .. } => false,
-            ClassFieldInner::Descriptor { .. } => false,
+            ClassFieldInner::Descriptor { is_foreign_key, .. } => *is_foreign_key,
             ClassFieldInner::Method { .. } => false,
             ClassFieldInner::ProxyMethod { .. } => false,
             ClassFieldInner::NestedClass { .. } => false,
@@ -927,7 +939,7 @@ impl ClassField {
     pub fn has_choices(&self) -> bool {
         match &self.0 {
             ClassFieldInner::Property { .. } => false,
-            ClassFieldInner::Descriptor { .. } => false,
+            ClassFieldInner::Descriptor { has_choices, .. } => *has_choices,
             ClassFieldInner::Method { .. } => false,
             ClassFieldInner::ProxyMethod { .. } => false,
             ClassFieldInner::NestedClass { .. } => false,
@@ -2059,7 +2071,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
         // Identify whether this is a descriptor. Construct the stored descriptor only after
         // forcing the field type so its class cannot retain solver variables.
-        let mut descriptor_methods = None;
+        let mut descriptor_info = None;
         let mut descriptor_range = None;
         let is_annotation_initialized_in_method = match field_definition {
             ClassFieldDefinition::DeclaredByAnnotation {
@@ -2091,7 +2103,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         || has_deleter
                         || has_getter && !is_annotation_initialized_in_method
                     {
-                        descriptor_methods = Some((has_getter, has_setter, has_deleter));
+                        descriptor_info =
+                            Some(((has_getter, has_setter, has_deleter), ty.clone()));
                     }
                 }
                 // Only members with `__get__` participate in descriptor reads. A member with only
@@ -2124,6 +2137,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             false
         };
 
+        let mut is_django_descriptor = false;
         let ty = if let Some(special_ty) = self.get_special_class_field_type(
             class,
             name,
@@ -2131,16 +2145,33 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             &ty,
             unpromoted_ty.as_ref(),
             field_definition,
-            descriptor_methods.is_some() || descriptor_range.is_some(),
+            descriptor_info.is_some() || descriptor_range.is_some(),
             range,
             errors,
         ) {
             // Don't use the descriptor, since we've set a custom type instead.
-            descriptor_methods = None;
+            descriptor_info = None;
             descriptor_range = None;
             special_ty
         } else {
-            ty
+            let initial_value_expr = match field_definition {
+                ClassFieldDefinition::AssignedInBody { value, .. } => {
+                    if let ExprOrBinding::Expr(expr) = value.as_ref() {
+                        Some(expr)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+            if let Some(django_ty) =
+                self.get_django_field_type(&ty, class, Some(name), initial_value_expr)
+            {
+                is_django_descriptor = descriptor_info.is_some();
+                django_ty
+            } else {
+                ty
+            }
         };
 
         // Pin any vars in the type: leaking a var in a class field is particularly
@@ -2149,18 +2180,28 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // TODO(stroxler): Ideally we would implement some simple heuristics, similar to
         // first-use based inference we use with assignments, to get more useful types here.
         let ty = self.solver().force(ty);
-        let descriptor = match (descriptor_methods, &ty) {
-            (Some((getter, setter, deleter)), Type::ClassType(cls)) => Some(Descriptor {
+        let descriptor = descriptor_info.map(|((getter, setter, deleter), descriptor_type)| {
+            let Type::ClassType(mut cls) = self.solver().force(descriptor_type) else {
+                unreachable!("a detected descriptor must have a class type")
+            };
+            let instance_getter_type = is_django_descriptor.then(|| ty.clone());
+            if let Some(get_type) = &instance_getter_type
+                && let Some(field_type) =
+                    self.specialize_django_field_descriptor(cls.class_object(), get_type.clone())
+            {
+                cls = field_type;
+            }
+            Descriptor {
                 range,
-                cls: cls.clone(),
+                cls,
                 getter,
                 setter,
                 deleter,
+                instance_getter_type,
                 initialization: initialization.clone(),
                 is_override: descriptor_is_override,
-            }),
-            _ => None,
-        };
+            }
+        });
 
         let direct_annotation_idx = match field_definition {
             ClassFieldDefinition::DeclaredByAnnotation { annotation, .. } => Some(*annotation),
@@ -2293,6 +2334,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     ty,
                     annotation,
                     descriptor,
+                    is_foreign_key,
+                    has_choices,
                 },
                 is_inherited,
             )
@@ -2520,19 +2563,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         )
         .or_else(|| self.get_property_class_field_type(class, name, field_definition))
         .or_else(|| self.get_pydantic_root_model_class_field_type(class, name))
-        .or_else(|| {
-            let initial_value_expr = match field_definition {
-                ClassFieldDefinition::AssignedInBody { value, .. } => {
-                    if let ExprOrBinding::Expr(expr) = value.as_ref() {
-                        Some(expr)
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            };
-            self.get_django_field_type(ty, class, Some(name), initial_value_expr)
-        })
     }
 
     /// Recognize `x = property(fget, fset, fdel)` and return the corresponding
@@ -5747,6 +5777,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 Ok(self.call_property_getter(getter, range, errors, context))
             }
             ClassAttribute::Descriptor(x, base) => {
+                if matches!(
+                    &base,
+                    DescriptorBase::Instance(_) | DescriptorBase::SelfInstance(_)
+                ) && let Some(instance_getter_type) = x.instance_getter_type.clone()
+                {
+                    return Ok(instance_getter_type);
+                }
                 if let Some(getter) = self.resolve_descriptor_getter(attr_name, &x, errors) {
                     // Reading a descriptor with a getter resolves to a method call
                     //

--- a/pyrefly/lib/alt/class/django.rs
+++ b/pyrefly/lib/alt/class/django.rs
@@ -12,6 +12,7 @@ use pyrefly_python::module_name::is_python_identifier;
 use pyrefly_types::callable::Callable;
 use pyrefly_types::callable::ParamList;
 use pyrefly_types::class::Class;
+use pyrefly_types::class::ClassType;
 use pyrefly_types::function::FuncMetadata;
 use pyrefly_types::function::Function;
 use pyrefly_types::function::PropertyMetadata;
@@ -43,6 +44,7 @@ use crate::types::simplify::unions;
 
 /// Django stubs use this attribute to specify the Python type that a field should infer to
 const DJANGO_PRIVATE_GET_TYPE: Name = Name::new_static("_pyi_private_get_type");
+const DJANGO_PRIVATE_SET_TYPE: Name = Name::new_static("_pyi_private_set_type");
 
 pub fn is_django_choices_subclass(bases_with_metadata: &[(Class, Arc<ClassMetadata>)]) -> bool {
     bases_with_metadata.iter().any(|(base, base_meta)| {
@@ -116,6 +118,35 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             ModuleName::django_models_fields_related().as_str(),
             ONE_TO_ONE_FIELD.as_str(),
         )
+    }
+
+    /// Specialize the set/get parameters used by Django's generic field descriptors.
+    pub fn specialize_django_field_descriptor(
+        &self,
+        field: &Class,
+        get_type: Type,
+    ) -> Option<ClassType> {
+        let tparams = self.get_class_tparams(field);
+        let mut tparams = tparams.iter();
+        if !matches!(
+            (tparams.next(), tparams.next(), tparams.next()),
+            (Some(set), Some(get), None)
+                if set.name().as_str() == "_ST" && get.name().as_str() == "_GT"
+        ) {
+            return None;
+        }
+        let mut set_type = self.get_class_member(field, &DJANGO_PRIVATE_SET_TYPE)?.ty();
+        if get_type.is_none()
+            || matches!(&get_type, Type::Union(union) if union.members.iter().any(Type::is_none))
+        {
+            set_type = self.union(set_type, self.heap.mk_none());
+        }
+        Some(self.specialize_nontypeddict_to_classtype(
+            field,
+            vec![set_type, get_type],
+            TextRange::default(),
+            &self.error_swallower(),
+        ))
     }
 
     pub fn get_django_field_type(

--- a/pyrefly/lib/test/django/fields.rs
+++ b/pyrefly/lib/test/django/fields.rs
@@ -8,6 +8,28 @@
 use crate::django_testcase;
 
 django_testcase!(
+    test_field_access_on_class_and_instance,
+    r#"
+from typing import assert_type
+
+from django.db import models
+from django.db.models.expressions import Combinable
+from django.db.models.fields import _FieldDescriptor
+
+class Contact(models.Model):
+    address = models.CharField(max_length=200)
+
+contact = Contact(address="123 Fake St")
+assert_type(contact.address, str)
+assert_type(
+    Contact.address,
+    _FieldDescriptor[models.CharField[str | int | Combinable, str]],
+)
+assert_type(Contact.address.field.max_length, int | None)
+"#,
+);
+
+django_testcase!(
     test_textfield_nullable,
     r#"
 from django.db import models


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4080

Django fields now preserve descriptor semantics for class access while retaining inferred instance types, `_ST`/`_GT` parameters are specialized from Django stubs.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test
