### PR TITLE
fix False alarm: Unnecessary comparison between an instance of Hashable and class int is always False #4334

### DIFF
--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -942,8 +942,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
     /// Checks for unnecessary identity comparisons.
     ///
-    /// Only emits warnings for identity comparisons (`is` or `is not`) between literals
-    /// whose comparison result is statically known.
+    /// Only emits warnings for identity comparisons (`is` or `is not`) whose result is
+    /// statically known.
     /// Returns early without warnings for other comparison operators.
     fn check_unnecessary_comparison(
         &self,
@@ -1026,20 +1026,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 );
             }
 
-            // ClassDef vs ClassType - disjoint unless ClassType is `type`, `object`,
-            // or another metaclass (subclass of type)
-            (Type::ClassDef(cdef), ctype @ Type::ClassType(cls))
-            | (ctype @ Type::ClassType(cls), Type::ClassDef(cdef)) => {
-                // A class object is an instance of `type` (or a metaclass), so it's only
-                // compatible with ClassType if that ClassType is `type`, `object`, or a metaclass
-                let is_metaclass_or_object = cls.is_builtin("object")
-                    || self.has_superclass(
-                        cls.class_object(),
-                        self.stdlib.builtins_type().class_object(),
-                    );
-                if !is_metaclass_or_object {
-                    emit_instance_is_class_warning(&ctype.to_string(), cdef.name().as_str(), is_op);
-                }
+            // ClassDef vs ClassType - disjoint unless the class object is assignable to ClassType.
+            (Type::ClassDef(cdef), ctype @ Type::ClassType(_))
+            | (ctype @ Type::ClassType(_), Type::ClassDef(cdef))
+                if !self.is_subset_eq(&Type::ClassDef(cdef.clone()), ctype) =>
+            {
+                emit_instance_is_class_warning(&ctype.to_string(), cdef.name().as_str(), is_op);
             }
 
             // All other combinations: no warning

--- a/pyrefly/lib/test/unnecessary_comparison.rs
+++ b/pyrefly/lib/test/unnecessary_comparison.rs
@@ -107,3 +107,14 @@ def f(x: object):
         pass
 "#,
 );
+
+testcase!(
+    test_classdef_vs_protocol_ok,
+    r#"
+from collections.abc import Hashable
+
+def f(x: Hashable):
+    if x is int:  # OK - class objects may satisfy protocols
+        pass
+"#,
+);


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4334

Replaced the hard-coded class-object overlap logic with Pyrefly's assignability check, correctly handling structural protocols such as Hashable

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test