### PR TITLE
fix behavior of init=False for pydantic.BaseModel

### DIFF
--- a/pyrefly/lib/alt/class/dataclass.rs
+++ b/pyrefly/lib/alt/class/dataclass.rs
@@ -1232,11 +1232,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         } else {
             self.class_self_param(cls, false)
         };
+        // Pydantic models (BaseModel/RootModel/BaseSettings) do not honor `Field(init=False)`:
+        // the field still appears in the validator-driven `__init__`.
+        // Pydantic dataclasses and stdlib/attrs dataclasses follow the behavior of built-in dataclasses.
+        let init_arg_should_be_ignored = matches!(
+            self.get_metadata_for_class(cls).pydantic_model_kind(),
+            Some(
+                PydanticModelKind::BaseModel
+                    | PydanticModelKind::RootModel
+                    | PydanticModelKind::BaseSettings
+            )
+        );
         let mut params = vec![self_param];
         let mut has_seen_default = false;
         for (name, field, field_flags) in self.iter_fields(cls, dataclass, true, kw_only_by_class) {
             let strict = field_flags.strict.unwrap_or(strict_default);
-            if field_flags.init {
+            if field_flags.init || init_arg_should_be_ignored {
                 let has_default = force_optional
                     || field_flags.default.is_some()
                     || (field_flags.init_by_name && field_flags.init_by_alias.is_some());

--- a/pyrefly/lib/alt/class/pydantic.rs
+++ b/pyrefly/lib/alt/class/pydantic.rs
@@ -275,10 +275,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     .has_toplevel_qname(ModuleName::pydantic_settings().as_str(), "BaseSettings")
             });
 
+        // Note: `metadata.is_pydantic_model()` is also true for `DataClass`-kind bases,
+        // but we need to differentiate between pydantic dataclass and BaseModel
         let is_pydantic_model = has_pydantic_base_model_base_class
-            || bases_with_metadata
-                .iter()
-                .any(|(_, metadata)| metadata.is_pydantic_model());
+            || bases_with_metadata.iter().any(|(_, metadata)| {
+                matches!(
+                    metadata.pydantic_model_kind(),
+                    Some(
+                        PydanticModelKind::BaseModel
+                            | PydanticModelKind::RootModel
+                            | PydanticModelKind::BaseSettings
+                    )
+                )
+            });
 
         // If not a pydantic model, check if it's a pydantic dataclass
         if !is_pydantic_model {

--- a/pyrefly/lib/test/pydantic/field.rs
+++ b/pyrefly/lib/test/pydantic/field.rs
@@ -511,6 +511,7 @@ pydantic_testcase!(
     test_pydantic_model_field_init_false_ignored,
     r#"
 from pydantic import BaseModel, Field
+from typing import reveal_type
 
 class Model(BaseModel):
     x: int = Field(init=False, default=0)

--- a/pyrefly/lib/test/pydantic/field.rs
+++ b/pyrefly/lib/test/pydantic/field.rs
@@ -502,3 +502,19 @@ m = Model(self="test")
 assert_type(m.self, str)
 "#,
 );
+
+// pydantic `BaseModel` does not honor `Field(init=False)`,
+// unlike stdlib/attrs dataclasses and unlike pydantic.dataclass
+// The field stays a real keyword parameter of the synthesized `__init__`,
+// and it is type-checked.
+pydantic_testcase!(
+    test_pydantic_model_field_init_false_ignored,
+    r#"
+from pydantic import BaseModel, Field
+
+class Model(BaseModel):
+    x: int = Field(init=False, default=0)
+
+reveal_type(Model.__init__)  # E: revealed type: (self: Model, *, x: LaxInt = ..., **Unknown) -> None
+"#,
+);


### PR DESCRIPTION
# Summary

`Field(init=False)` is ignored for `pydantic.BaseModel`, see this discussion: https://github.com/pydantic/pydantic/discussions/9341#discussioncomment-17052595

Currently pyrefly assumes the field is not part of `__init__` signature. That's a subtle thing but I hit this a lot in my codebase.

Found no relevant issue in github tracker.

# Test Plan

This PR adds a test case. Compiled locally, tested on a small test file to confirm behavior was fixed.