### PR TITLE
Hold LSP requests until the initial `workspace/configuration` response

### DIFF
--- a/crates/pyrefly_lsp_test/src/object_model.rs
+++ b/crates/pyrefly_lsp_test/src/object_model.rs
@@ -247,6 +247,18 @@ impl<'a, R: lsp_types::request::Request> ServerRequestHandle<'a, R> {
             error: None,
         }));
     }
+
+    pub fn send_response_error(self, code: i32, message: &str) {
+        self.client.send_message(Message::Response(Response {
+            id: self.id,
+            result: None,
+            error: Some(ResponseError {
+                code,
+                message: message.to_owned(),
+                data: None,
+            }),
+        }));
+    }
 }
 
 impl<'a> ServerRequestHandle<'a, WorkspaceConfiguration> {

--- a/crates/pyrefly_lsp_test/src/object_model.rs
+++ b/crates/pyrefly_lsp_test/src/object_model.rs
@@ -239,6 +239,18 @@ impl<'a, R: lsp_types::request::Request> ServerRequestHandle<'a, R> {
     pub fn send_response(self, result: Value) {
         self.client.send_response::<R>(self.id, result)
     }
+
+    pub fn send_response_error(self, code: i32, message: &str) {
+        self.client.send_message(Message::Response(Response {
+            id: self.id,
+            result: None,
+            error: Some(ResponseError {
+                code,
+                message: message.to_owned(),
+                data: None,
+            }),
+        }));
+    }
 }
 
 impl<'a> ServerRequestHandle<'a, WorkspaceConfiguration> {

--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -58,6 +58,10 @@ function requireSetting<T>(path: string): T {
  * - VSCode returns a configuration of {setting: 'value'} from settings.json
  * - This function will add pythonPath: '/usr/bin/python3' from the Python extension to the configuration
  * - {setting: 'value', pythonPath: '/usr/bin/python3'} is returned
+ *
+ * Only added if the Python extension has already activated: blocking on it would delay the whole
+ * response past the requests the server handles at startup (#4332). An absent pythonPath leaves
+ * the server's value untouched; `activate` re-pulls it later.
  */
 async function overridePythonPath(
   pythonEnv: PythonEnvironment,
@@ -73,7 +77,7 @@ async function overridePythonPath(
         return item;
       }
       const scopeUri = configurationItems[index].scopeUri;
-      const pythonPath = await pythonEnv.getInterpreterPath(
+      const pythonPath = await pythonEnv.getInterpreterPathIfResolved(
         scopeUri === undefined ? undefined : vscode.Uri.parse(scopeUri),
       );
       if (pythonPath === undefined) {
@@ -274,6 +278,18 @@ export async function activate(context: ExtensionContext) {
 
   // Start the client. This will also launch the server
   await client.start();
+
+  // The middleware responds before the interpreter resolves, so re-pull once it does;
+  // `onDidChangeInterpreter` can't cover this, as it only fires on a later change.
+  pythonEnv
+    .getInterpreterPath()
+    .then(() => {
+      client.sendNotification(DidChangeConfigurationNotification.type, {
+        settings: {},
+      });
+    })
+    // Best effort: the client may have stopped by now.
+    .catch(() => {});
 
   await updateStatusBar(client);
   const statusBarItem = getStatusBarItem();

--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -61,6 +61,10 @@ function requireSetting<T>(path: string): T {
  * - VSCode returns a configuration of {setting: 'value'} from settings.json
  * - This function will add pythonPath: '/usr/bin/python3' from the Python extension to the configuration
  * - {setting: 'value', pythonPath: '/usr/bin/python3'} is returned
+ *
+ * Only added if the Python extension has already activated: blocking on it would delay the whole
+ * response past the requests the server handles at startup (#4332). An absent pythonPath leaves
+ * the server's value untouched; `activate` re-pulls it later.
  */
 async function overridePythonPath(
   pythonEnv: PythonEnvironment,
@@ -76,7 +80,7 @@ async function overridePythonPath(
         return item;
       }
       const scopeUri = configurationItems[index].scopeUri;
-      const pythonPath = await pythonEnv.getInterpreterPath(
+      const pythonPath = await pythonEnv.getInterpreterPathIfResolved(
         scopeUri === undefined ? undefined : vscode.Uri.parse(scopeUri),
       );
       if (pythonPath === undefined) {
@@ -347,6 +351,18 @@ export async function activate(context: ExtensionContext) {
 
   // Start the client. This will also launch the server
   await client.start();
+
+  // The middleware responds before the interpreter resolves, so re-pull once it does;
+  // `onDidChangeInterpreter` can't cover this, as it only fires on a later change.
+  pythonEnv
+    .getInterpreterPath()
+    .then(() => {
+      client.sendNotification(DidChangeConfigurationNotification.type, {
+        settings: {},
+      });
+    })
+    // Best effort: the client may have stopped by now.
+    .catch(() => {});
 
   await updateStatusBar(client);
   const statusBarItem = getStatusBarItem();

--- a/lsp/src/python-environment.ts
+++ b/lsp/src/python-environment.ts
@@ -20,6 +20,8 @@ interface InterpreterProvider {
 
 export class PythonEnvironment {
   private provider: Promise<InterpreterProvider | undefined>;
+  /** `provider` once settled; undefined while resolving, and when none was found. */
+  private resolvedProvider: InterpreterProvider | undefined;
   private listeners: (() => void)[] = [];
   private listenerDisposables: vscode.Disposable[] = [];
   private context: vscode.ExtensionContext;
@@ -30,6 +32,7 @@ export class PythonEnvironment {
       if (!provider) {
         this.showInstallWarning();
       }
+      this.resolvedProvider = provider;
       return provider;
     });
     this.watchExtensionChanges();
@@ -121,6 +124,7 @@ export class PythonEnvironment {
             this.listenerDisposables = [];
 
             this.provider = Promise.resolve(provider);
+            this.resolvedProvider = provider;
 
             if (provider) {
               for (const listener of this.listeners) {
@@ -134,6 +138,11 @@ export class PythonEnvironment {
           .catch(() => {});
       }),
     );
+  }
+
+  /** Like `getInterpreterPath`, but yields `undefined` rather than waiting for activation. */
+  async getInterpreterPathIfResolved(uri?: vscode.Uri): Promise<string | undefined> {
+    return this.resolvedProvider?.getPath(uri);
   }
 
   async getInterpreterPath(uri?: vscode.Uri): Promise<string | undefined> {

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -973,6 +973,9 @@ pub struct Server {
     /// When true, background indexing (populate_project/workspace_files) is deferred
     /// until we receive the config response, avoiding double-indexing at startup.
     awaiting_initial_workspace_config: AtomicBool,
+    /// Requests we received while waiting for the initial workspace/configuration response. These
+    /// are re-enqueued once we receive it, so we never respond based on the default workspace.
+    requests_awaiting_initial_config: Mutex<Vec<Request>>,
     /// Optional callback for remapping paths before converting to URIs.
     path_remapper: Option<PathRemapper>,
     thrift_remapper: Option<ThriftRemapper>,
@@ -2027,6 +2030,11 @@ impl Server {
                             }
                         }
                     }
+                    // Outside the branch above, so a response that fails to parse also stops us
+                    // waiting, and after it, since that branch clears the flag itself.
+                    if request.method == WorkspaceConfiguration::METHOD {
+                        self.release_requests_awaiting_initial_config();
+                    }
                 } else {
                     info!("Response for unknown request: {x:?}");
                 }
@@ -2084,6 +2092,21 @@ impl Server {
                         ErrorCode::RequestCanceled as i32,
                         message,
                     ));
+                    return Ok(ProcessEvent::Continue);
+                }
+
+                // The default workspace has language services enabled and no interpreter, and
+                // clients cache what we send (VSCode caches document symbols per version), so hold
+                // the request until the real settings arrive (#4332).
+                if self
+                    .awaiting_initial_workspace_config
+                    .load(Ordering::Relaxed)
+                {
+                    info!(
+                        "Holding request {} ({}) until the config response arrives",
+                        x.method, &x.id
+                    );
+                    self.requests_awaiting_initial_config.lock().push(x);
                     return Ok(ProcessEvent::Continue);
                 }
 
@@ -2768,6 +2791,7 @@ impl Server {
             do_not_commit_recheck: AtomicBool::new(false),
             // Will be set to true if we send a workspace/configuration request
             awaiting_initial_workspace_config: AtomicBool::new(should_request_workspace_settings),
+            requests_awaiting_initial_config: Mutex::new(Vec::new()),
             path_remapper,
             thrift_remapper,
             pending_watched_file_changes: Mutex::new(Vec::new()),
@@ -4188,6 +4212,17 @@ impl Server {
 
         if modified {
             self.invalidate_config_and_validate_in_memory();
+        }
+    }
+
+    /// Clear `awaiting_initial_workspace_config` and re-enqueue every held request. Re-enqueued
+    /// rather than handled here, so they run only after the caller has applied the settings.
+    fn release_requests_awaiting_initial_config(&self) {
+        self.awaiting_initial_workspace_config
+            .store(false, Ordering::Relaxed);
+        for request in self.requests_awaiting_initial_config.lock().drain(..) {
+            // Only fails once the connection is closed, when no response is needed.
+            let _ = self.lsp_queue.send(LspEvent::LspRequest(request));
         }
     }
 

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -972,6 +972,9 @@ pub struct Server {
     /// When true, background indexing (populate_project/workspace_files) is deferred
     /// until we receive the config response, avoiding double-indexing at startup.
     awaiting_initial_workspace_config: AtomicBool,
+    /// Requests we received while waiting for the initial workspace/configuration response. These
+    /// are re-enqueued once we receive it, so we never respond based on the default workspace.
+    requests_awaiting_initial_config: Mutex<Vec<Request>>,
     /// Optional callback for remapping paths before converting to URIs.
     path_remapper: Option<PathRemapper>,
     thrift_remapper: Option<ThriftRemapper>,
@@ -2010,6 +2013,11 @@ impl Server {
                     {
                         self.workspace_configuration_response(&request, &response, telemetry_event);
                     }
+                    // Outside the branch above, so a response that fails to parse also stops us
+                    // waiting, and after it, since that branch clears the flag itself.
+                    if request.method == WorkspaceConfiguration::METHOD {
+                        self.release_requests_awaiting_initial_config();
+                    }
                 } else {
                     info!("Response for unknown request: {x:?}");
                 }
@@ -2067,6 +2075,21 @@ impl Server {
                         ErrorCode::RequestCanceled as i32,
                         message,
                     ));
+                    return Ok(ProcessEvent::Continue);
+                }
+
+                // The default workspace has language services enabled and no interpreter, and
+                // clients cache what we send (VSCode caches document symbols per version), so hold
+                // the request until the real settings arrive (#4332).
+                if self
+                    .awaiting_initial_workspace_config
+                    .load(Ordering::Relaxed)
+                {
+                    info!(
+                        "Holding request {} ({}) until the config response arrives",
+                        x.method, &x.id
+                    );
+                    self.requests_awaiting_initial_config.lock().push(x);
                     return Ok(ProcessEvent::Continue);
                 }
 
@@ -2751,6 +2774,7 @@ impl Server {
             do_not_commit_recheck: AtomicBool::new(false),
             // Will be set to true if we send a workspace/configuration request
             awaiting_initial_workspace_config: AtomicBool::new(should_request_workspace_settings),
+            requests_awaiting_initial_config: Mutex::new(Vec::new()),
             path_remapper,
             thrift_remapper,
             pending_watched_file_changes: Mutex::new(Vec::new()),
@@ -4171,6 +4195,17 @@ impl Server {
 
         if modified {
             self.invalidate_config_and_validate_in_memory();
+        }
+    }
+
+    /// Clear `awaiting_initial_workspace_config` and re-enqueue every held request. Re-enqueued
+    /// rather than handled here, so they run only after the caller has applied the settings.
+    fn release_requests_awaiting_initial_config(&self) {
+        self.awaiting_initial_workspace_config
+            .store(false, Ordering::Relaxed);
+        for request in self.requests_awaiting_initial_config.lock().drain(..) {
+            // Only fails once the connection is closed, when no response is needed.
+            let _ = self.lsp_queue.send(LspEvent::LspRequest(request));
         }
     }
 

--- a/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
@@ -14,12 +14,14 @@ use std::path::Path;
 #[cfg(unix)]
 use std::path::PathBuf;
 
+use lsp_server::ErrorCode;
 use lsp_types::Url;
 use lsp_types::notification::DidChangeWorkspaceFolders;
 use lsp_types::request::WorkspaceConfiguration;
 use pyrefly_lsp_test::object_model::InitializeSettings;
 use pyrefly_lsp_test::object_model::LspInteraction;
 use pyrefly_util::fs_anyhow::write;
+use serde_json::Value;
 use serde_json::json;
 
 use crate::test::lsp::lsp_interaction::util::get_test_files_root;
@@ -508,6 +510,78 @@ fn test_disable_language_services_default_workspace() {
         .expect("Failed to receive expected response");
 
     interaction.shutdown().expect("Failed to shutdown");
+}
+
+enum HeldDefinition {
+    Target,
+    Suppressed,
+}
+
+/// Manual handshake: `initialize` answers the configuration request, which these tests must defer.
+fn assert_definition_held_until_configuration(
+    configuration_response: Result<Value, &str>,
+    expected: HeldDefinition,
+) {
+    let test_files_root = get_test_files_root();
+    let root_path = test_files_root.path().join("basic");
+    let scope_uri = Url::from_file_path(&root_path).unwrap();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root_path.clone());
+
+    let client = &interaction.client;
+    client.send_initialize(client.get_initialize_params(&InitializeSettings {
+        workspace_folders: Some(vec![("test".to_owned(), scope_uri.clone())]),
+        // Advertises the `workspace/configuration` capability, without which nothing is held.
+        configuration: Some(None),
+        ..Default::default()
+    }));
+    client.expect_any_message().expect("Failed to initialize");
+    client.send_initialized();
+    let configuration_request = client
+        .expect_configuration_request(Some(vec![&scope_uri]))
+        .expect("Failed to receive configuration request");
+
+    client.did_open("foo.py");
+    let definition = client.definition("foo.py", 6, 16);
+    match configuration_response {
+        Ok(settings) => configuration_request.send_configuration_response(settings),
+        Err(message) => {
+            configuration_request.send_response_error(ErrorCode::InternalError as i32, message)
+        }
+    }
+
+    let expected = match expected {
+        HeldDefinition::Target => json!({
+            "uri": Url::from_file_path(root_path.join("bar.py")).unwrap().to_string(),
+            "range": {
+                "start": {"line": 6, "character": 6},
+                "end": {"line": 6, "character": 9}
+            }
+        }),
+        HeldDefinition::Suppressed => json!(null),
+    };
+    definition
+        .expect_response(expected)
+        .expect("Held request must resolve from the client's settings, not the defaults");
+
+    interaction.shutdown().expect("Failed to shutdown");
+}
+
+#[test]
+fn test_request_before_initial_configuration_honors_disable_language_services() {
+    assert_definition_held_until_configuration(
+        Ok(json!([{"pyrefly": {"disableLanguageServices": true}}])),
+        HeldDefinition::Suppressed,
+    );
+}
+
+/// Reachable: the VS Code middleware forwards a `ResponseError` from the underlying handler.
+#[test]
+fn test_failed_initial_configuration_still_responds_to_held_requests() {
+    assert_definition_held_until_configuration(
+        Err("configuration handler failed"),
+        HeldDefinition::Target,
+    );
 }
 
 #[test]

--- a/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
@@ -14,12 +14,14 @@ use std::path::Path;
 #[cfg(unix)]
 use std::path::PathBuf;
 
+use lsp_server::ErrorCode;
 use lsp_types::Url;
 use lsp_types::notification::DidChangeWorkspaceFolders;
 use lsp_types::request::WorkspaceConfiguration;
 use pyrefly_lsp_test::object_model::InitializeSettings;
 use pyrefly_lsp_test::object_model::LspInteraction;
 use pyrefly_util::fs_anyhow::write;
+use serde_json::Value;
 use serde_json::json;
 
 use crate::test::lsp::lsp_interaction::util::get_test_files_root;
@@ -537,6 +539,78 @@ fn test_disable_language_services_default_workspace() {
         .expect("Failed to receive expected response");
 
     interaction.shutdown().expect("Failed to shutdown");
+}
+
+enum HeldDefinition {
+    Target,
+    Suppressed,
+}
+
+/// Manual handshake: `initialize` answers the configuration request, which these tests must defer.
+fn assert_definition_held_until_configuration(
+    configuration_response: Result<Value, &str>,
+    expected: HeldDefinition,
+) {
+    let test_files_root = get_test_files_root();
+    let root_path = test_files_root.path().join("basic");
+    let scope_uri = Url::from_file_path(&root_path).unwrap();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root_path.clone());
+
+    let client = &interaction.client;
+    client.send_initialize(client.get_initialize_params(&InitializeSettings {
+        workspace_folders: Some(vec![("test".to_owned(), scope_uri.clone())]),
+        // Advertises the `workspace/configuration` capability, without which nothing is held.
+        configuration: Some(None),
+        ..Default::default()
+    }));
+    client.expect_any_message().expect("Failed to initialize");
+    client.send_initialized();
+    let configuration_request = client
+        .expect_configuration_request(Some(vec![&scope_uri]))
+        .expect("Failed to receive configuration request");
+
+    client.did_open("foo.py");
+    let definition = client.definition("foo.py", 6, 16);
+    match configuration_response {
+        Ok(settings) => configuration_request.send_configuration_response(settings),
+        Err(message) => {
+            configuration_request.send_response_error(ErrorCode::InternalError as i32, message)
+        }
+    }
+
+    let expected = match expected {
+        HeldDefinition::Target => json!({
+            "uri": Url::from_file_path(root_path.join("bar.py")).unwrap().to_string(),
+            "range": {
+                "start": {"line": 6, "character": 6},
+                "end": {"line": 6, "character": 9}
+            }
+        }),
+        HeldDefinition::Suppressed => json!(null),
+    };
+    definition
+        .expect_response(expected)
+        .expect("Held request must resolve from the client's settings, not the defaults");
+
+    interaction.shutdown().expect("Failed to shutdown");
+}
+
+#[test]
+fn test_request_before_initial_configuration_honors_disable_language_services() {
+    assert_definition_held_until_configuration(
+        Ok(json!([{"pyrefly": {"disableLanguageServices": true}}])),
+        HeldDefinition::Suppressed,
+    );
+}
+
+/// Reachable: the VS Code middleware forwards a `ResponseError` from the underlying handler.
+#[test]
+fn test_failed_initial_configuration_still_responds_to_held_requests() {
+    assert_definition_held_until_configuration(
+        Err("configuration handler failed"),
+        HeldDefinition::Target,
+    );
 }
 
 #[test]


### PR DESCRIPTION
# Summary

Requests received while `awaiting_initial_workspace_config` is set are now held and re-enqueued once the response lands. Checking that flag in `make_handle_if_enabled` instead, as the issue suggests, would return empty responses during startup for everyone, not just those who disabled language services. Releasing is keyed on the request method rather than on a successful parse, so a client that *fails* the configuration request stops us waiting too.

The middleware no longer waits for the Python extension. It uses a new non-blocking `getInterpreterPathIfResolved`, and `activate` re-pulls the configuration once the interpreter resolves, since `onDidChangeInterpreter` only fires on a later change.

Fixes #4332

# Test Plan

Regression tests added, for both a successful and a failed configuration response.