### PR TITLE
Detect cyclic type aliases that are reachable but not self-referential

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -1545,8 +1545,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     /// user-defined `class C[T]: x: T | None` makes `type A = C[A]`
     /// inhabitable (e.g. `C(x=C(x=None))`), so we can't assume all generic
     /// containers require their type parameter.
+    /// `names` holds the alias being resolved plus any alias left as a
+    /// recursive reference while expanding its body, so a cycle that is merely
+    /// reachable is caught as well as one the alias belongs to.
     /// Returns `true` if a cyclic self-reference was found.
-    fn type_alias_has_cyclic_reference(&self, name: &Name, ta: &TypeAlias) -> bool {
+    fn type_alias_has_cyclic_reference(&self, names: &SmallSet<Name>, ta: &TypeAlias) -> bool {
         // Unwrap the type[body] wrapper. We operate on the inner body because
         // map_over_union wraps inner union members in type[...] when traversing
         // inside Type::Type, which would prevent matching UntypedAlias nodes.
@@ -1557,7 +1560,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::Type(inner) => inner.as_ref(),
             _ => return false,
         };
-        let is_self_ref = |ty: &Type| matches!(ty, Type::UntypedAlias(ta) if ta.name() == name);
+        let is_self_ref =
+            |ty: &Type| matches!(ty, Type::UntypedAlias(ta) if names.contains(ta.name()));
 
         fn collect_tuple_members(tuple: &Tuple) -> Vec<&Type> {
             match tuple {
@@ -1644,15 +1648,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // inlining the referenced alias's body. Only runs for binding-time
         // aliases (current_index is Some); implicit legacy aliases detected
         // at solve time skip expansion.
+        let mut cyclic_names = SmallSet::new();
+        cyclic_names.insert(name.clone());
         if let Some(index) = current_index {
-            self.expand_type_alias_refs(ta.as_type_mut(), index);
+            cyclic_names.extend(self.expand_type_alias_refs(ta.as_type_mut(), index));
         }
 
         // Step 2: Check for cyclic self-references after expansion.
         // If a cycle is found, replace the body with an error type to prevent
         // infinite recursion when downstream operations (e.g. attribute lookup,
         // subset checks) try to resolve the alias.
-        if self.type_alias_has_cyclic_reference(name, &ta) {
+        if self.type_alias_has_cyclic_reference(&cyclic_names, &ta) {
             return self.error(
                 errors,
                 range,
@@ -1811,10 +1817,20 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     /// Recursive references (detected via a visiting set) are left in place.
     /// `current_index` is the alias being defined — pre-seeded in the
     /// visiting set so self-references are immediately recognized as recursive.
-    fn expand_type_alias_refs(&self, ty: &mut Type, current_index: TypeAliasIndex) {
+    /// Returns the names of aliases left in place as recursive references.
+    /// A cycle can be reachable from the alias being resolved without that
+    /// alias taking part in it (`type T1 = T2` where `type T2 = T2`), so those
+    /// names also count as self-references for `type_alias_has_cyclic_reference`.
+    fn expand_type_alias_refs(
+        &self,
+        ty: &mut Type,
+        current_index: TypeAliasIndex,
+    ) -> SmallSet<Name> {
         let mut visiting = SmallSet::new();
         visiting.insert((self.module().name(), current_index));
-        self.expand_type_alias_refs_inner(ty, &mut visiting);
+        let mut recursive_refs = SmallSet::new();
+        self.expand_type_alias_refs_inner(ty, &mut visiting, &mut recursive_refs);
+        recursive_refs
     }
 
     /// Inner recursive walker for `expand_type_alias_refs`. Matches
@@ -1825,6 +1841,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         &self,
         ty: &mut Type,
         visiting: &mut SmallSet<(ModuleName, TypeAliasIndex)>,
+        recursive_refs: &mut SmallSet<Name>,
     ) {
         match ty {
             Type::UntypedAlias(f)
@@ -1833,7 +1850,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             {
                 let key = (r.module_name, r.index);
                 if visiting.contains(&key) {
-                    // Recursive reference — leave as Ref for cycle detection
+                    // Recursive reference — leave as Ref for cycle detection,
+                    // and record the name so the caller treats it as a
+                    // self-reference even when the cycle does not include the
+                    // alias currently being resolved.
+                    recursive_refs.insert(r.name.clone());
                     return;
                 }
                 let key_type_alias = KeyTypeAlias(r.index);
@@ -1857,7 +1878,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // Recursively expand any Refs in the inlined body, so that all nested
                 // alias bodies are inlined before we apply the outer substitution.
                 visiting.insert(key);
-                self.expand_type_alias_refs_inner(&mut body, visiting);
+                self.expand_type_alias_refs_inner(&mut body, visiting, recursive_refs);
                 visiting.shift_remove(&key);
                 // Apply type arguments if the reference was parameterized.
                 // For generic aliases used without explicit args, promote_forall
@@ -1868,7 +1889,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 *ty = body;
             }
             _ => ty.recurse_mut(&mut |child: &mut Type| {
-                self.expand_type_alias_refs_inner(child, visiting);
+                self.expand_type_alias_refs_inner(child, visiting, recursive_refs);
             }),
         }
     }

--- a/pyrefly/lib/test/recursive_alias.rs
+++ b/pyrefly/lib/test/recursive_alias.rs
@@ -409,3 +409,51 @@ IncEx: TypeAlias = Mapping[int, int] | Mapping[str, "IncEx | list[A]"]
 ok: IncEx = {"a": {"__all__": [B()]}}
     "#,
 );
+
+// Regression test for https://github.com/facebook/pyrefly/issues/4324: a
+// self-referential alias reached *through* another alias used to leave a live
+// reference into the cycle, so attribute lookup recursed until the stack
+// overflowed. Contrast with `type T2 = T2` alone, which was already detected.
+testcase!(
+    test_cyclic_indirect_self_reference,
+    r#"
+type T1 = T2  # E: cyclic self-reference in `T1`
+type T2 = T2  # E: cyclic self-reference in `T2`
+
+x: T1 = 1
+x.__str__
+    "#,
+);
+
+// Indirection depth is irrelevant: the cycle is reachable from `T1` without
+// `T1` participating in it.
+testcase!(
+    test_cyclic_indirect_self_reference_multi_hop,
+    r#"
+type T1 = T2  # E: cyclic self-reference in `T1`
+type T2 = T3  # E: cyclic self-reference in `T2`
+type T3 = T3  # E: cyclic self-reference in `T3`
+
+x: T1 = 1
+x.foo
+    "#,
+);
+
+// Guard for the fix above: recording the names of recursive references must not
+// flag an alias that merely *points at* a well-founded recursive alias, nor one
+// whose cycle runs through a user-defined generic that can be inhabited.
+testcase!(
+    test_alias_referencing_valid_recursive_alias_is_not_cyclic,
+    r#"
+type Inner = int | list[Inner]
+type Outer = Inner
+
+class C[T]:
+    x: T | None = None
+type A = C[A]
+type B = A
+
+v: Outer = 1
+w: B = C()
+    "#,
+);


### PR DESCRIPTION
Fixes #4324

Checking this aborted with a stack overflow:

```python
type T1 = T2
type T2 = T2
x.__str__
x: T1
```

### What the shape of the bug is

`__str__` is not special and the ordering does not matter. What matters is the alias topology, and both the annotation and an attribute access are needed:

| Source | Before | After |
|---|---|---|
| `type T2 = T2`, use `T2` | ok | ok |
| `type T1 = T1`, use `T1` | ok | ok |
| `type T1 = T2` / `type T2 = T1` (mutual) | ok | ok |
| `type T1 = T2` / `type T2 = T2`, use `T1` | **stack overflow** | diagnosed |
| `type T1 = T2` / `type T2 = T3` / `type T3 = T3`, use `T1` | **stack overflow** | diagnosed |

So a self-referential alias reached through one or more hops crashed, while a direct self-loop or a pure mutual cycle was already handled.

### Root cause

Step 2 of `wrap_type_alias` already replaces a cyclic alias body with an error type, and its comment says this exists "to prevent infinite recursion when downstream operations (e.g. attribute lookup, subset checks) try to resolve the alias". The detection was incomplete rather than missing.

`type_alias_has_cyclic_reference` decided self-reference by name:

```rust
let is_self_ref = |ty: &Type| matches!(ty, Type::UntypedAlias(ta) if ta.name() == name);
```

That catches a cycle the alias *belongs to*, mutual cycles included, because `expand_type_alias_refs` inlines the referenced body first and so reintroduces the alias's own name. It does not catch a cycle that is merely *reachable*. Resolving `T1` only ever sees the name `T2`, never `T1`, so `T1` was not flagged and kept a live `UntypedAlias(Ref(T2))` edge into `T2`'s self-loop. Attribute lookup then followed it without bound:

```rust
Type::TypeAlias(ta) => {
    self.as_attribute_base1(self.get_type_alias(&ta).as_value(self.stdlib), acc)
}
```

`lldb` puts frame #0 at `AnswersSolver::get_idx::<KeyTypeAlias>`, and the three-hop row above confirms indirection depth is irrelevant.

### The fix

Expansion already knows where the cycles are, because it leaves a reference in place exactly when it would otherwise revisit an alias. It now returns the names it left behind, and those count as self-references for the cyclic check alongside the alias being resolved. `T1` is therefore diagnosed and reduced to an error type just as `T2` is.

I went this way rather than adding a visited set at the crash site because the same unguarded `get_type_alias` recursion also exists in `solver/subset.rs` and `alt/call.rs`. Removing the unbounded reference at the source covers those without a guard in each one.

The base-case analysis is untouched, so an alias that merely points at a well-founded recursive alias is unaffected: the recorded name only widens what counts as a self-reference, and a union or container with a non-self-referential member is still accepted. There is a test pinning that, including the user-defined-generic case the existing doc comment warns about (`class C[T]: x: T | None` makes `type A = C[A]` inhabitable).

### Testing

`cargo test -p pyrefly` is 7133 passed, 0 failed. `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema` exits 0. The one clippy warning it prints is pre-existing in `pyrefly_config`, in code this PR does not touch.

Three tests added to `recursive_alias.rs`, following the guidance to start from a failing test:

- `test_cyclic_indirect_self_reference`: the issue, reduced
- `test_cyclic_indirect_self_reference_multi_hop`: pins that depth does not matter
- `test_alias_referencing_valid_recursive_alias_is_not_cyclic`: guards against over-flagging

Before the change both of the first two abort the test binary with SIGABRT; after it they pass, and all pre-existing cyclic-alias tests keep passing unchanged.

I also confirmed the original repro from the issue against a release build: it now reports `cyclic self-reference in T1` and `in T2` plus the legitimate uninitialized-name error, with no crash.

### One thing worth splitting off

The default `basic` preset does not enable `invalid-type-alias`, so `type W = W` reports zero errors from the CLI even though the test suite asserts a diagnostic for it. That is unrelated to this crash and I have not touched it, but it does mean the existing cyclic-alias diagnostics are invisible to most CLI users. Happy to file a separate issue if you think it is worth changing.

---

Submitted by an AI agent (Claude), as asked for in CONTRIBUTING.md. Reviewed by the PR owner before submission.
