### PR TITLE
fix Protocol is not understood as ABCMeta/_ProtocolMeta #1130

### DIFF
--- a/crates/pyrefly_types/src/stdlib.rs
+++ b/crates/pyrefly_types/src/stdlib.rs
@@ -120,6 +120,7 @@ pub struct Stdlib {
     method_type: StdlibResult<ClassType>,
     module_type: StdlibResult<ClassType>,
     enum_meta: StdlibResult<ClassType>,
+    protocol_meta: StdlibResult<ClassType>,
     enum_flag: StdlibResult<ClassType>,
     enum_class: StdlibResult<ClassType>,
     /// A fallback class that contains attributes that all NamedTuple subclasses share. Note that
@@ -275,6 +276,7 @@ impl Stdlib {
             module_type: lookup_concrete(types, "ModuleType"),
             mapping: lookup_generic(typing, "Mapping", 2),
             enum_meta: lookup_concrete(enum_, "EnumMeta"),
+            protocol_meta: lookup_concrete(typing, "_ProtocolMeta"),
             enum_flag: lookup_concrete(enum_, "Flag"),
             enum_class: lookup_concrete(enum_, "Enum"),
             named_tuple_fallback: lookup_concrete(type_checker_internals, "NamedTupleFallback"),
@@ -338,6 +340,10 @@ impl Stdlib {
 
     pub fn enum_meta(&self) -> &ClassType {
         Self::primitive(&self.enum_meta)
+    }
+
+    pub fn protocol_meta(&self) -> &ClassType {
+        Self::primitive(&self.protocol_meta)
     }
 
     pub fn enum_flag(&self) -> &ClassType {

--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -196,10 +196,23 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             });
         let keyword_annotations = keyword_annotations.into_map(|(name, annot)| (name.id, annot));
 
-        let base_metaclasses = bases_with_metadata
+        let protocol_base_name = Name::new_static("Protocol");
+        let mut base_metaclasses = bases_with_metadata
             .iter()
             .filter_map(|(b, metadata)| metadata.custom_metaclass().map(|m| (b.name(), m)))
             .collect::<Vec<_>>();
+        // Typeshed uses protocols to model several special stdlib classes that are not
+        // runtime Protocol classes.
+        let module_name = cls.qname().module_name();
+        let module = module_name.as_str();
+        if protocol_metadata.is_some()
+            && !matches!(
+                module,
+                "builtins" | "_typeshed" | "typing" | "typing_extensions"
+            )
+        {
+            base_metaclasses.push((&protocol_base_name, self.stdlib.protocol_meta()));
+        }
         let mut calculated_metaclass = self.calculate_metaclass(
             cls,
             metaclasses.into_iter().next(),
@@ -1869,7 +1882,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let metaclass_type = self.heap.mk_class_type(metaclass.clone());
         for (base_name, m) in base_metaclasses {
             let base_metaclass_type = self.heap.mk_class_type((*m).clone());
-            if !self.is_subset_eq(&metaclass_type, &base_metaclass_type) {
+            let protocol_base_selects_more_specific_metaclass = m.class_object()
+                == self.stdlib.protocol_meta().class_object()
+                && self.is_subset_eq(&base_metaclass_type, &metaclass_type);
+            if !self.is_subset_eq(&metaclass_type, &base_metaclass_type)
+                && !protocol_base_selects_more_specific_metaclass
+            {
                 self.error(errors,
                     cls.range(),
                     ErrorKind::InvalidInheritance,

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -2427,6 +2427,18 @@ impl<'a, Ans: LookupAnswer> Subset<'a, Ans> {
                 ok_or(self.type_order.has_metaclass(got, want), SubsetError::Other)
             }
             (Type::Type(inner), Type::ClassType(want))
+                if matches!(&**inner, Type::SpecialForm(SpecialForm::Protocol)) =>
+            {
+                let want = self.solver.heap.mk_class_type(want.clone());
+                self.is_subset_eq(
+                    &self
+                        .solver
+                        .heap
+                        .mk_class_type(self.type_order.stdlib().protocol_meta().clone()),
+                    &want,
+                )
+            }
+            (Type::Type(inner), Type::ClassType(want))
                 if let Type::ClassType(got_cls) = &**inner =>
             {
                 ok_or(

--- a/pyrefly/lib/test/protocol.rs
+++ b/pyrefly/lib/test/protocol.rs
@@ -48,6 +48,27 @@ def g(p: P, c1: C1, c2: C2, c3: C3, c4: C4, c5: C5) -> None:
 );
 
 testcase!(
+    test_protocol_metaclass,
+    r#"
+from abc import ABCMeta
+from enum import Enum
+from typing import Protocol, _ProtocolMeta
+
+abc_meta: ABCMeta = Protocol
+protocol_meta: _ProtocolMeta = Protocol
+
+class P(Protocol): ...
+
+class M(type): ...
+
+class BadMeta(P, metaclass=M): ...  # E: Class `BadMeta` has metaclass `M` which is not a subclass of metaclass `_ProtocolMeta` from base class `P`
+
+class BadEnum(Enum, P):  # E: Class `BadEnum` has metaclass `EnumMeta` which is not a subclass of metaclass `_ProtocolMeta` from base class `P`
+    X = 1
+"#,
+);
+
+testcase!(
     test_proxy_method_direct_call_and_attribute_access,
     proxy_method_env(),
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1130

Models Protocol using typeshed's `_ProtocolMeta`, making it assignable to ABCMeta.

Detects incompatible custom and enum metaclasses for protocol-derived classes.

Preserves typeshed's special stdlib protocol models.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test