### PR TITLE
Fix --update-baseline with baseline from configuration

### DIFF
--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -361,7 +361,7 @@ struct OutputArgs {
     baseline: Option<PathBuf>,
 
     /// When specified, emit a sorted/formatted JSON of the errors to the baseline file
-    #[arg(long, requires("baseline"))]
+    #[arg(long)]
     update_baseline: bool,
 
     /// Minimum severity level for errors to be displayed.
@@ -1275,6 +1275,13 @@ impl CheckArgs {
         require: Require,
         upsell: UpsellDecision,
     ) -> anyhow::Result<(CommandExitStatus, Vec<Error>)> {
+        let baseline_path = if self.output.update_baseline {
+            Some(self.output.baseline.as_ref().context(
+                "`--update-baseline` requires a baseline file set by `--baseline` or configuration",
+            )?)
+        } else {
+            None
+        };
         let mut memory_trace = MemoryUsageTrace::start(Duration::from_secs_f32(0.1));
 
         if let Some(pysa_directory) = &self.output.report_pysa {
@@ -1399,9 +1406,7 @@ impl CheckArgs {
         // errors using the old baseline. Directives are structurally excluded
         // — they live in `directives`, not `ordinary_errors`. The baseline only
         // tracks errors that meet the min-severity threshold.
-        if self.output.update_baseline
-            && let Some(baseline_path) = &self.output.baseline
-        {
+        if let Some(baseline_path) = baseline_path {
             let mut new_baseline = ordinary_errors.clone();
             new_baseline.extend(
                 errors

--- a/test/baseline.md
+++ b/test/baseline.md
@@ -50,6 +50,36 @@ $ mkdir -p $TMPDIR/baseline_relative/subdir && \
 [0]
 ```
 
+## Updating a baseline uses the path from pyproject.toml
+
+```scrut {output_stream: stdout}
+$ mkdir -p $TMPDIR/baseline_update_from_pyproject && \
+> echo "x: str = 1" > $TMPDIR/baseline_update_from_pyproject/bad.py && \
+> printf '[tool.pyrefly]\nbaseline = "baseline.json"\n' > $TMPDIR/baseline_update_from_pyproject/pyproject.toml && \
+> cd $TMPDIR/baseline_update_from_pyproject && \
+> $PYREFLY check --update-baseline --output-format=min-text
+ERROR *bad.py* ?bad-assignment? (glob)
+[1]
+```
+
+```scrut {output_stream: stdout}
+$ grep '"name": "bad-assignment"' $TMPDIR/baseline_update_from_pyproject/baseline.json
+      "name": "bad-assignment",
+[0]
+```
+
+## Updating a baseline requires a path from the CLI or configuration
+
+```scrut {output_stream: stderr}
+$ mkdir -p $TMPDIR/baseline_update_without_path && \
+> echo "x: str = 1" > $TMPDIR/baseline_update_without_path/bad.py && \
+> touch $TMPDIR/baseline_update_without_path/pyrefly.toml && \
+> cd $TMPDIR/baseline_update_without_path && \
+> $PYREFLY check bad.py --update-baseline --summary=none
+`--update-baseline` requires a baseline file set by `--baseline` or configuration
+[1]
+```
+
 ## Updating a baseline records unused `# type: ignore` errors
 
 ```scrut {output_stream: stdout}


### PR DESCRIPTION
# Summary

Fixes #4316.

The `--update-baseline` option used Clap's `requires("baseline")` constraint, which was evaluated before `baseline` could be inherited from configuration.

This removes the parse-time constraint and validates the effective baseline after configuration resolution. A baseline configured in `pyproject.toml` can now be updated without repeating `--baseline`, while the command still reports an error when neither the CLI nor configuration provides a path.

# Test Plan

- Added CLI regression coverage in `test/baseline.md` for a baseline configured in `pyproject.toml`.
- Added coverage preserving the error when no baseline path is available.
- `cargo +1.97.0 build -p pyrefly`
- `cargo +1.97.0 test -p pyrefly commands::check::tests`
- Formatting and Clippy via `test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema` with Python 3.12.13.
- Manually verified both CLI scenarios against the compiled binary because Scrut was not available locally.

# AI assistance

This pull request was prepared with assistance from an AI coding agent, as requested by the contributor.
