### PR TITLE
[pyrefly] Diagnose duplicate dataclass KW_ONLY markers

### DIFF
--- a/pyrefly/lib/alt/class/dataclass.rs
+++ b/pyrefly/lib/alt/class/dataclass.rs
@@ -143,6 +143,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // Compute kw_only fields once for all methods that need it
         let kw_only_by_class = self.compute_kw_only_fields_by_class(cls);
 
+        self.check_duplicate_kw_only_markers(cls, errors);
         self.check_dataclass_non_data_descriptors(cls, dataclass, errors);
         self.check_dataclass_data_descriptor_defaults(cls, dataclass, errors);
         self.check_attrs_default_decorator_return_types(cls, dataclass, errors);
@@ -328,6 +329,30 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             self.get_dataclass_replace(cls, dataclass, &kw_only_by_class, errors),
         );
         Some(ClassSynthesizedFields::new(fields))
+    }
+
+    fn check_duplicate_kw_only_markers(&self, cls: &Class, errors: &ErrorCollector) {
+        let Some(class_fields) = self.get_class_fields(cls) else {
+            return;
+        };
+        let mut seen_marker = false;
+        for name in class_fields.names() {
+            if class_fields.is_field_annotated(name)
+                && matches!(
+                    self.get_dataclass_member(cls, name),
+                    DataclassMember::KwOnlyMarker
+                )
+                && std::mem::replace(&mut seen_marker, true)
+                && let Some(range) = class_fields.field_decl_range(name)
+            {
+                self.error(
+                    errors,
+                    range,
+                    ErrorKind::BadClassDefinition,
+                    format!("`{name}` is KW_ONLY, but KW_ONLY has already been specified"),
+                );
+            }
+        }
     }
 
     /// Check for non-data descriptors in dataclass fields and emit errors.

--- a/pyrefly/lib/test/dataclasses.rs
+++ b/pyrefly/lib/test/dataclasses.rs
@@ -1254,6 +1254,21 @@ assert_type(C.__match_args__, tuple[Literal["x"]])
 );
 
 testcase!(
+    test_duplicate_kw_only_sentinel,
+    r#"
+from dataclasses import dataclass, KW_ONLY
+
+@dataclass
+class C:
+    x: int
+    first: KW_ONLY
+    y: str
+    second: KW_ONLY  # E: `second` is KW_ONLY, but KW_ONLY has already been specified
+    z: bytes
+    "#,
+);
+
+testcase!(
     test_order,
     r#"
 from dataclasses import dataclass


### PR DESCRIPTION
# Summary

Report a bad-class-definition error on the second and subsequent dataclasses.KW_ONLY markers in a single dataclass. The diagnostic is attached to the duplicate declaration and matches the runtime rule enforced by dataclasses.

This keeps valid inheritance behavior unchanged because markers are counted independently in each class body.

Fixes #3737

# Test Plan

- CARGO_TARGET_DIR=/tmp/pyrefly-target cargo test test_duplicate_kw_only_sentinel
- CARGO_TARGET_DIR=/tmp/pyrefly-target cargo test test::dataclasses:: (148 passed)
- CARGO_TARGET_DIR=/tmp/pyrefly-target python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema
- git diff --check

AI disclosure: This change was prepared with an AI coding agent and manually validated against the repository tests and contribution guidance.