### PR TITLE
fix show warning when function returning Not[Never] contains a Never loop #1132

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -220,6 +220,8 @@ pub enum ErrorKind {
     /// An inconsistency between a function parameter's type in an overload signature and its
     /// default value in the implementation.
     InconsistentOverloadDefault,
+    /// A function declares a non-None, non-Never return type but can only loop forever.
+    InfiniteLoop,
     /// Internal Pyrefly error.
     InternalError,
     /// An `@abstractmethod` is defined in a class that is not abstract.
@@ -545,6 +547,7 @@ impl ErrorKind {
             ErrorKind::ImplicitReexport => Severity::Ignore,
             ErrorKind::ImplicitlyDefinedAttribute => Severity::Ignore,
             ErrorKind::IncompatibleComparison => Severity::Ignore,
+            ErrorKind::InfiniteLoop => Severity::Warn,
             ErrorKind::InvalidAbstractMethod => Severity::Ignore,
             ErrorKind::InvalidCast => Severity::Ignore,
             ErrorKind::InvalidDecorator => Severity::Warn,

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -2591,6 +2591,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 is_async,
                 is_generator,
                 has_explicit_return,
+                has_infinite_loop,
             } => {
                 let annotation = self.get_idx(*annotation).annotation.get_type().clone();
                 let implicit_return = self.get_idx(*implicit_return);
@@ -2600,6 +2601,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     *is_async,
                     *is_generator,
                     *has_explicit_return,
+                    *has_infinite_loop,
                     range,
                     errors,
                 );
@@ -5627,9 +5629,27 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         is_async: bool,
         is_generator: bool,
         has_explicit_returns: bool,
+        has_infinite_loop: bool,
         range: TextRange,
         errors: &ErrorCollector,
     ) {
+        if has_infinite_loop
+            && !has_explicit_returns
+            && !is_generator
+            && !annotation.is_never()
+            && !annotation.is_none()
+            && implicit_return.ty().is_never()
+        {
+            self.error(
+                errors,
+                range,
+                ErrorKind::InfiniteLoop,
+                format!(
+                    "Function declared to return `{}` but can never return",
+                    self.for_display(annotation.clone())
+                ),
+            );
+        }
         if is_async && is_generator {
             let hints = self.decompose_hint(HintRef::soft(annotation), |hint| {
                 self.decompose_async_generator(hint)

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -1166,6 +1166,7 @@ pub enum BindingExpect {
         is_async: bool,
         is_generator: bool,
         has_explicit_return: bool,
+        has_infinite_loop: bool,
     },
     /// Expression used in a boolean context (`bool()`, `if`, or `while`)
     Bool(Expr),

--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -483,8 +483,9 @@ impl<'a> BindingsBuilder<'a> {
     /// This function must not be called unless the function body statements will be bound;
     /// it relies on that binding to ensure we don't have a dangling `Idx<Key>` (which could lead
     /// to a panic).
-    fn implicit_return(&mut self, body: &[Stmt], func_name: &Identifier) -> Idx<Key> {
-        let last_exprs = function_last_expressions(body, self.sys_info).map(|x| {
+    fn implicit_return(&mut self, body: &[Stmt], func_name: &Identifier) -> (Idx<Key>, bool) {
+        let (last_exprs, has_infinite_loop) = function_last_expressions(body, self.sys_info);
+        let last_exprs = last_exprs.map(|x| {
             x.into_map(|(last, x)| {
                 (
                     last.clone(),
@@ -493,9 +494,12 @@ impl<'a> BindingsBuilder<'a> {
             })
             .into_boxed_slice()
         });
-        self.insert_binding(
-            Key::ReturnImplicit(ShortIdentifier::new(func_name)),
-            Binding::ReturnImplicit(ReturnImplicit { last_exprs }),
+        (
+            self.insert_binding(
+                Key::ReturnImplicit(ShortIdentifier::new(func_name)),
+                Binding::ReturnImplicit(ReturnImplicit { last_exprs }),
+            ),
+            has_infinite_loop,
         )
     }
 
@@ -507,7 +511,7 @@ impl<'a> BindingsBuilder<'a> {
         is_async: bool,
         yields_and_returns: YieldsAndReturns,
         return_ann_with_range: Option<(TextRange, Idx<KeyAnnotation>)>,
-        implicit_return: Option<Idx<Key>>,
+        implicit_return: Option<(Idx<Key>, bool)>,
         should_infer_return_type: bool,
         is_stub: bool,
     ) {
@@ -519,6 +523,10 @@ impl<'a> BindingsBuilder<'a> {
             } else {
                 None
             };
+        let has_reachable_return = yields_and_returns
+            .returns
+            .iter()
+            .any(|(_, _, is_unreachable)| !is_unreachable);
 
         // Collect the keys of explicit returns.
         let return_keys = yields_and_returns
@@ -568,7 +576,11 @@ impl<'a> BindingsBuilder<'a> {
 
         let return_type_binding = {
             let kind = match (return_ann_with_range, implicit_return, is_stub) {
-                (Some((range, annotation)), Some(implicit_return), false) => {
+                (
+                    Some((range, annotation)),
+                    Some((implicit_return, has_infinite_loop)),
+                    false,
+                ) => {
                     self.insert_binding(
                         KeyExpect::ValidateImplicitReturn(range),
                         BindingExpect::ValidateImplicitReturn {
@@ -576,7 +588,8 @@ impl<'a> BindingsBuilder<'a> {
                             implicit_return,
                             is_async,
                             is_generator,
-                            has_explicit_return: !return_keys.is_empty(),
+                            has_explicit_return: has_reachable_return,
+                            has_infinite_loop,
                         },
                     );
                     ReturnTypeKind::ShouldTrustAnnotation {
@@ -595,7 +608,7 @@ impl<'a> BindingsBuilder<'a> {
                         is_generator,
                     }
                 }
-                (None, Some(implicit_return), _) if should_infer_return_type => {
+                (None, Some((implicit_return, _)), _) if should_infer_return_type => {
                     // We don't have an explicit return annotation, but we want to infer it.
                     ReturnTypeKind::ShouldInferType {
                         returns: return_keys,
@@ -1063,11 +1076,18 @@ impl<'a> BindingsBuilder<'a> {
 /// * Return None to say there are branches that fall off the end always.
 /// * Return Some([]) to say that we can never reach the end (e.g. always return, raise)
 /// * Return Some(xs) to say this set might be the last expression.
+///
+/// The boolean records whether an unconditional loop is one of the terminal paths.
 fn function_last_expressions<'a>(
     x: &'a [Stmt],
     sys_info: SysInfo,
-) -> Option<Vec<(LastStmt, &'a Expr)>> {
-    fn f<'a>(sys_info: SysInfo, x: &'a [Stmt], res: &mut Vec<(LastStmt, &'a Expr)>) -> Option<()> {
+) -> (Option<Vec<(LastStmt, &'a Expr)>>, bool) {
+    fn f<'a>(
+        sys_info: SysInfo,
+        x: &'a [Stmt],
+        res: &mut Vec<(LastStmt, &'a Expr)>,
+        has_infinite_loop: &mut bool,
+    ) -> Option<()> {
         fn loop_body_has_break_statement(statement: &Stmt, has_break: &mut bool) {
             match statement {
                 Stmt::Break(_) => {
@@ -1088,7 +1108,7 @@ fn function_last_expressions<'a>(
                 for y in &x.items {
                     res.push((LastStmt::With(kind), &y.context_expr));
                 }
-                f(sys_info, &x.body, res)?;
+                f(sys_info, &x.body, res, has_infinite_loop)?;
             }
             Stmt::While(x) => {
                 let test_value = sys_info.evaluate_bool(&x.test);
@@ -1100,10 +1120,11 @@ fn function_last_expressions<'a>(
                 }
                 if test_value == Some(true) && !has_break {
                     // Infinite loop with no break never falls through.
+                    *has_infinite_loop = true;
                 } else if has_break || x.orelse.is_empty() {
                     return None;
                 } else {
-                    f(sys_info, &x.orelse, res)?;
+                    f(sys_info, &x.orelse, res, has_infinite_loop)?;
                 }
             }
             Stmt::For(x) => {
@@ -1113,7 +1134,7 @@ fn function_last_expressions<'a>(
                 if has_break || x.orelse.is_empty() {
                     return None;
                 }
-                f(sys_info, &x.orelse, res)?;
+                f(sys_info, &x.orelse, res, has_infinite_loop)?;
             }
             Stmt::If(x) => {
                 let mut last_test = None;
@@ -1121,7 +1142,7 @@ fn function_last_expressions<'a>(
                 for (test, body) in sys_info.pruned_if_branches(x) {
                     any_branch_processed = true;
                     last_test = test;
-                    f(sys_info, body, res)?;
+                    f(sys_info, body, res, has_infinite_loop)?;
                 }
                 if !any_branch_processed {
                     // All branches were pruned, so the code falls through
@@ -1146,16 +1167,18 @@ fn function_last_expressions<'a>(
                         .iter()
                         .any(|stmt| matches!(stmt, Stmt::Return(_)))
                 {
-                    f(sys_info, &x.finalbody, res)?;
+                    f(sys_info, &x.finalbody, res, has_infinite_loop)?;
                 } else {
                     if x.orelse.is_empty() {
-                        f(sys_info, &x.body, res)?;
+                        f(sys_info, &x.body, res, has_infinite_loop)?;
                     } else {
-                        f(sys_info, &x.orelse, res)?;
+                        f(sys_info, &x.orelse, res, has_infinite_loop)?;
                     }
                     for handler in &x.handlers {
                         match handler {
-                            ExceptHandler::ExceptHandler(x) => f(sys_info, &x.body, res)?,
+                            ExceptHandler::ExceptHandler(x) => {
+                                f(sys_info, &x.body, res, has_infinite_loop)?
+                            }
                         }
                     }
                     // If we don't have a matching handler, we raise an exception, which is fine.
@@ -1164,7 +1187,7 @@ fn function_last_expressions<'a>(
             Stmt::Match(x) => {
                 let mut syntactically_exhaustive = false;
                 for case in x.cases.iter() {
-                    f(sys_info, &case.body, res)?;
+                    f(sys_info, &case.body, res, has_infinite_loop)?;
                     // Must match the binding step's exhaustiveness judgment in
                     // `stmt_match`; otherwise the `Key::Exhaustive(Match, ...)` promised
                     // below is never inserted and solve time panics.
@@ -1190,8 +1213,9 @@ fn function_last_expressions<'a>(
     }
 
     let mut res = Vec::new();
-    f(sys_info, x, &mut res)?;
-    Some(res)
+    let mut has_infinite_loop = false;
+    let last_exprs = f(sys_info, x, &mut res, &mut has_infinite_loop).map(|()| res);
+    (last_exprs, has_infinite_loop)
 }
 
 fn is_docstring(x: &Stmt) -> bool {

--- a/pyrefly/lib/test/returns.rs
+++ b/pyrefly/lib/test/returns.rs
@@ -282,6 +282,42 @@ def f() -> int:
 "#,
 );
 
+// Regression test for https://github.com/facebook/pyrefly/issues/1132
+testcase!(
+    test_return_infinite_loop_without_return,
+    r#"
+from typing import Never, TypeAlias
+
+NeverAlias: TypeAlias = Never
+
+def f() -> int:  # E: Function declared to return `int` but can never return
+    while True:
+        pass
+
+def returns_never() -> Never:
+    while True:
+        pass
+
+def returns_never_alias() -> NeverAlias:
+    while True:
+        pass
+
+def event_loop() -> None:
+    while True:
+        pass
+
+def unreachable_return() -> int:  # E: Function declared to return `int` but can never return
+    while True:
+        continue
+        return 1  # E: This `return` statement is unreachable
+
+def falls_through(b: bool) -> int:  # E: Function declared to return `int` but is missing an explicit `return`
+    if b:
+        while True:
+            pass
+"#,
+);
+
 testcase!(
     test_return_while_false_break_else,
     r#"

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -834,6 +834,20 @@ def f(x: bool = False) -> int | None:
     return 0 if x else None
 ```
 
+## infinite-loop
+
+Default severity: `warn`
+
+This warning is emitted when a function declares a return type other than
+`None`, `Never`, or `NoReturn`, but its body has no reachable return and ends
+in an unconditional loop.
+
+```python
+def f() -> int:  # Function declared to return `int` but can never return [infinite-loop]
+    while True:
+        pass
+```
+
 ## internal-error
 
 Ideally you'll never see this one. If you do, please consider [filing a bug](https://github.com/facebook/pyrefly/issues).


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1132

Added an infinite-loop warning for non-Never functions that cannot return, exempted generators, Never/NoReturn aliases, reachable returns, and ordinary fallthrough paths.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test