### PR TITLE
[pyrefly] Recognize inherited comparisons for total_ordering

### DIFF
--- a/pyrefly/lib/alt/class/total_ordering.rs
+++ b/pyrefly/lib/alt/class/total_ordering.rs
@@ -13,7 +13,6 @@ use crate::alt::answers::LookupAnswer;
 use crate::alt::answers_solver::AnswersSolver;
 use crate::alt::types::class_metadata::ClassSynthesizedField;
 use crate::alt::types::class_metadata::ClassSynthesizedFields;
-use crate::binding::binding::KeyClassField;
 use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
 use crate::types::class::Class;
@@ -39,14 +38,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             unreachable!("Unexpected rich comparison method: {}", cmp);
         };
         // The first field in the conversion order is the one that we will use to synthesize the method.
-        let class_fields = self.get_class_fields(cls);
         for other_cmp in conversion_order {
-            let has_field = class_fields.is_some_and(|f| f.contains(other_cmp));
-            if has_field
-                && let Some(other_cmp_field) =
-                    self.get_from_class(cls, &KeyClassField(cls.index(), other_cmp.clone()))
+            if let Some(other_cmp_field) = self
+                .get_non_synthesized_class_member_and_defining_class(cls, other_cmp)
+                .filter(|field| !field.defining_class.is_builtin("object"))
             {
-                let ty = other_cmp_field.as_named_tuple_type();
+                let ty = other_cmp_field.value.as_named_tuple_type();
                 return ClassSynthesizedField::new(ty);
             }
         }
@@ -62,12 +59,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if !metadata.is_total_ordering() {
             return None;
         }
-        let class_fields = self.get_class_fields(cls);
         // The class must have one of the rich comparison dunder methods defined
-        if !class_fields.is_some_and(|f| {
-            f.names().any(|f| {
-                *f == dunder::LT || *f == dunder::LE || *f == dunder::GT || *f == dunder::GE
-            })
+        if !dunder::RICH_CMPS_TOTAL_ORDERING.iter().any(|cmp| {
+            self.get_non_synthesized_class_member_and_defining_class(cls, cmp)
+                .is_some_and(|field| !field.defining_class.is_builtin("object"))
         }) {
             let total_ordering_metadata = metadata.total_ordering_metadata().unwrap();
             self.error(
@@ -83,7 +78,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
         let rich_cmps_to_synthesize: Vec<_> = dunder::RICH_CMPS_TOTAL_ORDERING
             .iter()
-            .filter(|cmp| !class_fields.is_some_and(|f| f.contains(cmp)))
+            .filter(|cmp| {
+                self.get_non_synthesized_class_member_and_defining_class(cls, cmp)
+                    .is_none_or(|field| field.defining_class.is_builtin("object"))
+            })
             .collect();
         let mut fields = SmallMap::with_capacity(rich_cmps_to_synthesize.len());
         for cmp in rich_cmps_to_synthesize {

--- a/pyrefly/lib/test/decorators.rs
+++ b/pyrefly/lib/test/decorators.rs
@@ -529,6 +529,23 @@ class A:
 );
 
 testcase!(
+    test_total_ordering_inherited_rich_cmp,
+    r#"
+from functools import total_ordering
+from typing import reveal_type
+
+class Base:
+    def __lt__(self, other: "Base") -> bool: ...
+
+@total_ordering
+class Child(Base):
+    pass
+
+reveal_type(Child.__gt__)  # E: revealed type: (self: Child, other: Base) -> bool
+    "#,
+);
+
+testcase!(
     test_total_ordering_dataclass,
     r#"
 from dataclasses import dataclass


### PR DESCRIPTION
Fixes #4379

`@total_ordering` now recognizes non-synthesized rich comparison methods inherited through the class MRO and uses them when synthesizing missing comparisons. Direct methods, builtin `object` behavior, and existing diagnostics remain unchanged.

Validation:
- `cargo test -p pyrefly test_total_ordering`
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`

The local `.scratch` planning files are intentionally not part of this PR.
