### PR TITLE
Fix positional inlay hints after keyword arguments

### DIFF
--- a/pyrefly/lib/lsp/wasm/inlay_hints.rs
+++ b/pyrefly/lib/lsp/wasm/inlay_hints.rs
@@ -423,7 +423,16 @@ impl<'a> Transaction<'a> {
                         callee_type.and_then(normalize_singleton_function_type_into_params)
                     {
                         for (arg_idx, arg) in call.arguments.args.iter().enumerate() {
-                            // Skip keyword arguments - they already show their parameter name
+                            // Account for keyword arguments omitted from `args`, including
+                            // malformed calls while an inlay edit is being applied.
+                            let positional_arg_idx = arg_idx
+                                + call
+                                    .arguments
+                                    .keywords
+                                    .iter()
+                                    .filter(|kw| kw.range().start() < arg.range().start())
+                                    .count();
+                            // Skip keyword arguments - they already show their parameter name.
                             let is_keyword_arg = call
                                 .arguments
                                 .keywords
@@ -431,8 +440,10 @@ impl<'a> Transaction<'a> {
                                 .any(|kw| kw.value.range() == arg.range());
 
                             if !is_keyword_arg
-                                && let Some(param_match) =
-                                    Self::param_name_for_positional_argument(&params, arg_idx)
+                                && let Some(param_match) = Self::param_name_for_positional_argument(
+                                    &params,
+                                    positional_arg_idx,
+                                )
                                 && !param_match.is_vararg_repeat
                                 && param_match.name.as_str() != "self"
                                 && param_match.name.as_str() != "cls"

--- a/pyrefly/lib/test/lsp/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/inlay_hint.rs
@@ -482,6 +482,49 @@ obj.method(5, "world")
     );
 }
 
+fn parameter_name_hint_labels(code: &str, assert_zero_errors: bool) -> Vec<String> {
+    let files = [("main", code)];
+    let (handles, state) = mk_multi_file_state(&files, Require::Exports, assert_zero_errors);
+    let handle = handles.get("main").unwrap();
+    state
+        .transaction()
+        .inlay_hints(
+            handle,
+            InlayHintConfig {
+                call_argument_names: AllOffPartial::All,
+                variable_types: false,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .into_iter()
+        .flat_map(|hint| hint.label_parts.into_iter().map(|(text, _)| text))
+        .filter(|text| text.ends_with("= "))
+        .collect()
+}
+
+#[test]
+fn test_parameter_name_hint_after_keyword_argument() {
+    let code = r#"
+def test(a: str, b: str) -> None:
+    pass
+
+test(a="a", "b")
+"#;
+    assert_eq!(parameter_name_hint_labels(code, false), vec!["b= "]);
+}
+
+#[test]
+fn test_parameter_name_hints_for_multiple_positional_arguments() {
+    let code = r#"
+def test(a: str, b: str) -> None:
+    pass
+
+test("a", "b")
+"#;
+    assert_eq!(parameter_name_hint_labels(code, true), vec!["a= ", "b= "]);
+}
+
 #[test]
 fn test_parameter_name_hints_with_varargs() {
     let code = r#"


### PR DESCRIPTION
## Description

Fixes incorrect positional-argument inlay hints after inserting an inlay hint into a call containing keyword arguments.

Added regression tests for:
- a remaining positional argument after a keyword argument
- multiple positional arguments.

Closes: https://github.com/facebook/pyrefly/issues/4387