### PR TITLE
[pyrefly] Rename legacy type parameter constructor names

### DIFF
--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -69,6 +69,7 @@ use crate::alt::answers::Index;
 use crate::alt::answers_solver::AnswersSolver;
 use crate::alt::attr::AttrDefinition;
 use crate::alt::attr::AttrInfo;
+use crate::binding::binding::Binding;
 use crate::binding::binding::Key;
 use crate::config::error_kind::ErrorKind;
 use crate::error::suppress::detect_line_ending;
@@ -3833,6 +3834,37 @@ impl<'a> Transaction<'a> {
             definition_name,
         ) {
             references.extend(pytest_references);
+        }
+        if let Some(bindings) = self.get_bindings(handle) {
+            let key = Key::Definition(ShortIdentifier::from_text_range(definition_range));
+            if bindings.is_valid_key(&key) {
+                let binding = bindings.get(bindings.key_to_idx(&key));
+                let call = match binding {
+                    Binding::TypeVar(binding) => Some(&binding.2),
+                    Binding::ParamSpec(binding) => Some(&binding.2),
+                    _ => None,
+                };
+                if let Some(call) = call {
+                    let name_expr = call.arguments.args.first().or_else(|| {
+                        call.arguments
+                            .keywords
+                            .iter()
+                            .find(|keyword| {
+                                keyword
+                                    .arg
+                                    .as_ref()
+                                    .is_some_and(|arg| arg.id.as_str() == "name")
+                            })
+                            .map(|keyword| &keyword.value)
+                    });
+                    if let Some(Expr::StringLiteral(literal)) = name_expr
+                        && let Some(literal) = literal.as_single_part_string()
+                        && literal.value.as_ref() == definition_name.as_str()
+                    {
+                        references.push(literal.content_range());
+                    }
+                }
+            }
         }
         if include_declaration {
             references.push(definition_range);

--- a/pyrefly/lib/test/lsp/rename.rs
+++ b/pyrefly/lib/test/lsp/rename.rs
@@ -140,3 +140,36 @@ Rename locations:
         report.trim(),
     );
 }
+
+#[test]
+fn test_rename_legacy_type_parameters_updates_constructor_names() {
+    let code = r#"
+from typing import Callable, ParamSpec, TypeVar
+
+T = TypeVar("T")
+P = ParamSpec(name="P")
+unrelated = "T"
+unrelated_param = "P"
+
+def f(value: T) -> T:
+#             ^
+    return value
+
+def g(func: Callable[P, None]) -> None:
+#                     ^
+    pass
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], |state, handle, position| {
+        let transaction = state.transaction();
+        let module_info = transaction.get_module_info(handle).unwrap();
+        let source = module_info.contents();
+        let labels = transaction
+            .find_local_references(handle, position, true)
+            .into_iter()
+            .map(|range| source[range.start().to_usize()..range.end().to_usize()].to_owned())
+            .join(",");
+        format!("Rename locations:\n{labels}")
+    });
+    assert!(report.contains("Rename locations:\nT,T,T,T"), "{report}");
+    assert!(report.contains("Rename locations:\nP,P,P"), "{report}");
+}


### PR DESCRIPTION
Fixes #4348

LSP rename now includes the string name argument in legacy TypeVar and ParamSpec constructor calls. Other strings and constructor calls are unchanged.

Validation:
- cargo test -p pyrefly test::lsp::rename
- python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema

The local `.scratch` planning files are intentionally not part of this PR.