### PR TITLE
[pyrefly] Keep auto-import for fuzzy local matches

### DIFF
--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -1194,6 +1194,7 @@ impl Transaction<'_> {
                     let expression_only =
                         matches!(context, IdentifierContext::Expr(_)) && !at_statement_start;
                     Self::add_keyword_completions(handle, expression_only, &mut result);
+                    let local_completion_start = result.len();
                     let has_local_completions = self.add_local_variable_completions(
                         handle,
                         Some(&identifier),
@@ -1201,7 +1202,10 @@ impl Transaction<'_> {
                         expected_type.as_ref(),
                         &mut result,
                     );
-                    if auto_import && !has_local_completions {
+                    let has_prefix_local_completion = result[local_completion_start..]
+                        .iter()
+                        .any(|completion| completion.item.label.starts_with(identifier.as_str()));
+                    if auto_import && !has_prefix_local_completion {
                         self.add_autoimport_completions(
                             handle,
                             &identifier,

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -2458,6 +2458,40 @@ Completion Results:
 }
 
 #[test]
+fn autoimport_completion_not_blocked_by_fuzzy_local_symbol() {
+    let code = r#"
+def avg_kendall_tau(): ...
+
+kendalltau
+#         ^
+"#;
+    let files = [("main", code), ("scipy.stats", "def kendalltau(): ...\n")];
+    let (handles, state) = mk_multi_file_state(&files, Require::Exports, false);
+    let handle = handles.get("main").unwrap();
+    let position = extract_cursors_for_test(code)[0];
+    let completions =
+        state
+            .transaction()
+            .completion(handle, position, ImportFormat::Absolute, true, None);
+    let autoimport = completions
+        .iter()
+        .find(|item| item.label == "kendalltau")
+        .expect("expected kendalltau auto-import completion");
+    assert!(
+        autoimport.additional_text_edits.is_some(),
+        "expected auto-import edit, got {autoimport:?}"
+    );
+    assert!(
+        autoimport
+            .detail
+            .as_ref()
+            .is_some_and(|detail| detail.contains("from scipy.stats import kendalltau")),
+        "expected scipy.stats import detail, got {:?}",
+        autoimport.detail
+    );
+}
+
+#[test]
 fn autoimport_common_alias_for_module() {
     let code = r#"
 T = spio


### PR DESCRIPTION
Fixes #4288

Allow auto-import completion when local results only match the typed name fuzzily, while preserving the existing gate for prefix-matching local results.

Validation:
- cargo test -p pyrefly autoimport_completion_not_blocked_by_fuzzy_local -- --nocapture
- cargo test -p pyrefly test::lsp::completion -- --nocapture (110 passed)
- python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema

The local `.scratch` planning files are intentionally not part of this PR.