### PR TITLE
fix __call__ don't have parameter name #4377

### DIFF
--- a/pyrefly/lib/lsp/wasm/inlay_hints.rs
+++ b/pyrefly/lib/lsp/wasm/inlay_hints.rs
@@ -419,8 +419,9 @@ impl<'a> Transaction<'a> {
                         answers.get_type_trace(call.func.range())
                     };
 
-                    if let Some(params) =
-                        callee_type.and_then(normalize_singleton_function_type_into_params)
+                    if let Some(params) = callee_type
+                        .map(|ty| self.coerce_type_to_callable(handle, ty))
+                        .and_then(normalize_singleton_function_type_into_params)
                     {
                         for (arg_idx, arg) in call.arguments.args.iter().enumerate() {
                             // Skip keyword arguments - they already show their parameter name

--- a/pyrefly/lib/test/lsp/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/inlay_hint.rs
@@ -512,6 +512,35 @@ foo("hello", 1, 2, 3, 5, a=1, b=2, t=4)
     );
 }
 
+#[test]
+fn test_parameter_name_hints_for_callable_object() {
+    let code = r#"
+class MarkDecorator:
+    def __call__(self, *fixtures: str) -> None:
+        pass
+
+mark = MarkDecorator()
+mark("database", "cache")
+"#;
+    assert_eq!(
+        r#"
+# main.py
+7 | mark("database", "cache")
+         ^ inlay-hint: `fixtures= `
+"#
+        .trim(),
+        generate_inlay_hint_report(
+            code,
+            InlayHintConfig {
+                call_argument_names: AllOffPartial::All,
+                variable_types: false,
+                ..Default::default()
+            }
+        )
+        .trim()
+    );
+}
+
 /// todo(jvansch): Update test once parameter hints have locations.
 #[test]
 fn test_parameter_hints_do_not_have_locations() {


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4377

Callable instances are now coerced to their bound `__call__` signature before generating parameter-name hints

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test