### PR TITLE
Dedup tparam-default substitution between alt and solver layers

### DIFF
--- a/crates/pyrefly_types/src/quantified.rs
+++ b/crates/pyrefly_types/src/quantified.rs
@@ -443,3 +443,30 @@ impl Quantified {
         Self::as_gradual_type_helper(self.kind(), self.default())
     }
 }
+
+/// Substitute references to earlier type parameters inside a tparam default.
+///
+/// The `default` is a tparam's default type, whose leaves may reference earlier
+/// tparams (matched here as `TypeVar`/`TypeVarTuple`/`ParamSpec`/`Quantified`).
+/// `lookup` resolves an earlier tparam's name to its already-computed targ;
+/// when a name is out of scope (no entry), `fallback` is used. Both are passed
+/// by the caller because the two call paths (call/specialization vs class-level
+/// finalization) intentionally differ in lookup source and fallback value.
+pub fn substitute_tparam_defaults(
+    default: Type,
+    lookup: &dyn Fn(&Name) -> Option<Type>,
+    fallback: Type,
+) -> Type {
+    default.transform(&mut |default| {
+        let name = match default {
+            Type::TypeVar(t) => Some(t.qname().id()),
+            Type::TypeVarTuple(t) => Some(t.qname().id()),
+            Type::ParamSpec(p) => Some(p.qname().id()),
+            Type::Quantified(q) => Some(q.name()),
+            _ => None,
+        };
+        if let Some(name) = name {
+            *default = lookup(name).unwrap_or_else(|| fallback.clone());
+        }
+    })
+}

--- a/pyrefly/lib/alt/class/targs.rs
+++ b/pyrefly/lib/alt/class/targs.rs
@@ -39,6 +39,7 @@ use crate::types::quantified::Quantified;
 use crate::types::quantified::QuantifiedIdentity;
 use crate::types::quantified::QuantifiedKind;
 use crate::types::quantified::QuantifiedOrigin;
+use crate::types::quantified::substitute_tparam_defaults;
 use crate::types::tuple::Tuple;
 use crate::types::type_var::PreInferenceVariance;
 use crate::types::type_var::Restriction;
@@ -750,25 +751,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         name_to_idx: &SmallMap<&Name, usize>,
     ) -> Type {
         if let Some(default) = param.default() {
-            default.clone().transform(&mut |default| {
-                let typevar_name = match default {
-                    Type::TypeVar(t) => Some(t.qname().id()),
-                    Type::TypeVarTuple(t) => Some(t.qname().id()),
-                    Type::ParamSpec(p) => Some(p.qname().id()),
-                    Type::Quantified(q) => Some(q.name()),
-                    _ => None,
-                };
-                if let Some(typevar_name) = typevar_name {
-                    *default = if let Some(i) = name_to_idx.get(typevar_name) {
+            substitute_tparam_defaults(
+                default.clone(),
+                &|name| {
+                    name_to_idx.get(name).map(|i| {
                         // The default of this TypeVar contains the value of a previous TypeVar.
                         checked_targs[*i].clone()
-                    } else {
-                        // The default refers to the value of a TypeVar that isn't in scope. We've
-                        // already logged an error in TParams::new(); return a sensible default.
-                        self.heap.mk_any_implicit()
-                    }
-                }
-            })
+                    })
+                },
+                // The default may refer to the value of a TypeVar that isn't in scope. We've
+                // already logged an error in TParams::new(); return a sensible default.
+                self.heap.mk_any_implicit(),
+            )
         } else {
             param.as_gradual_type()
         }

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -31,6 +31,7 @@ use pyrefly_types::dimension::is_gradual_size;
 use pyrefly_types::heap::TypeHeap;
 use pyrefly_types::quantified::Quantified;
 use pyrefly_types::quantified::QuantifiedKind;
+use pyrefly_types::quantified::substitute_tparam_defaults;
 use pyrefly_types::simplify::intersect;
 use pyrefly_types::special_form::SpecialForm;
 use pyrefly_types::tuple::Tuple;
@@ -2921,28 +2922,19 @@ impl Solver {
                 if let Some(default) = param.default() {
                     // Note that TypeVars are stored in Type::TypeVar form, and have not yet been
                     // converted to Quantified form, so we do that now.
-                    // TODO: deal with code duplication in get_tparam_default
-                    let mut t = default.clone();
-                    t.transform_mut(&mut |t| {
-                        let name = match t {
-                            Type::TypeVar(t) => Some(t.qname().id()),
-                            Type::TypeVarTuple(t) => Some(t.qname().id()),
-                            Type::ParamSpec(p) => Some(p.qname().id()),
-                            Type::Quantified(q) => Some(q.name()),
-                            _ => None,
-                        };
-                        if let Some(name) = name {
-                            *t = if let Some(i) = seen_params.get(name) {
+                    let t = substitute_tparam_defaults(
+                        default.clone(),
+                        &|name| {
+                            seen_params.get(name).map(|i| {
                                 let new_targ: &Option<Type> = &new_targs[*i];
                                 new_targ
                                     .as_ref()
                                     .unwrap_or_else(|| &targs.as_slice()[*i])
                                     .clone()
-                            } else {
-                                param.as_gradual_type()
-                            }
-                        }
-                    });
+                            })
+                        },
+                        param.as_gradual_type(),
+                    );
                     Some(t)
                 } else if self.infer_with_first_use {
                     let v = Var::new(uniques);


### PR DESCRIPTION
## Summary

The logic for substituting references to earlier type parameters inside a tparam's `default` was duplicated in two places:

- `get_tparam_default` in `pyrefly/lib/alt/class/targs.rs` (used during call/specialization)
- an inlined copy in `finish_class_targs` in `pyrefly/lib/solver/solver.rs` (used during class-level finalization), flagged by a `// TODO: deal with code duplication in get_tparam_default` marker.

The two copies differed only in their lookup source and their fallback value for out-of-scope references — differences that are intentional, since one path runs where an out-of-scope reference is an already-reported error (returns `Any(Implicit)`) and the other runs during finalization with no such error (returns the param's gradual type).

This PR extracts a shared `substitute_tparam_defaults` helper into `pyrefly_types::quantified` (next to the existing `as_gradual_type_helper`, which already uses the same `TypeVar`/`TypeVarTuple`/`ParamSpec`/`Quantified` match idiom). The helper takes the default by value, a `&dyn Fn(&Name) -> Option<Type>` lookup closure, and a caller-chosen fallback `Type`, so each call site keeps its own lookup source and fallback semantics. Both callers are rewritten to delegate to it, and the `// TODO` marker is removed.

## Behavior

This is a behavior-preserving refactor. Each call site passes the same lookup and fallback it used inline, so the produced types are identical for every input:

- `get_tparam_default` passes `name_to_idx` -> `checked_targs` lookup with `self.heap.mk_any_implicit()` fallback (unchanged).
- `finish_class_targs` passes `seen_params` -> `new_targs`-then-`targs` lookup with `param.as_gradual_type()` fallback (unchanged).

The two fallbacks are deliberately **not** collapsed — they intentionally differ (error path vs finalization path).

## Test plan

- `cargo build -p pyrefly_types` — clean
- `cargo build -p pyrefly` — clean
- `cargo test -p pyrefly --lib` — **7675 passed, 0 failed, 3 ignored** (the full typechecker regression suite; zero behavior diff)
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema` — clean for the touched files

Fixes #4298