### PR TITLE
fix Find references on constructor #4347

### DIFF
--- a/pyrefly/lib/alt/answers.rs
+++ b/pyrefly/lib/alt/answers.rs
@@ -16,6 +16,7 @@ use dupe::Dupe;
 use pyrefly_graph::calculation::Calculation;
 use pyrefly_graph::index::Idx;
 use pyrefly_graph::index_map::IndexMap;
+use pyrefly_python::dunder;
 use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::module_path::ModulePath;
 use pyrefly_util::display::DisplayWith;
@@ -86,6 +87,8 @@ pub struct Index {
     /// A map from (attribute definition module) to a list of pairs of
     /// (range of attribute definition in the definition, range of reference in the current module).
     pub externally_defined_attribute_references: SmallMap<ModulePath, Vec<(TextRange, TextRange)>>,
+    /// A map from local constructor method definitions to references resolved through them.
+    pub locally_defined_constructor_references: SmallMap<TextRange, Vec<TextRange>>,
     /// A map from (child method range) to a list of parent method definitions (ModulePath, parent method range).
     /// This is used to find reimplementations when doing find-references on parent methods.
     pub parent_methods_map: SmallMap<TextRange, Vec<(ModulePath, TextRange)>>,
@@ -1177,7 +1180,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
-    pub fn record_external_attribute_definition_index(
+    pub fn record_attribute_definition_index(
         &self,
         base: &Type,
         attribute_name: &Name,
@@ -1198,7 +1201,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         range,
                         docstring_range: _,
                     } => {
-                        if cls.module_path() != self.bindings().module().path() {
+                        if cls.module_path() == self.bindings().module().path() {
+                            if attribute_name == &dunder::INIT
+                                || attribute_name == &dunder::NEW
+                                || attribute_name == &dunder::CALL
+                            {
+                                index
+                                    .lock()
+                                    .locally_defined_constructor_references
+                                    .entry(range)
+                                    .or_default()
+                                    .push(attribute_reference_range);
+                            }
+                        } else {
                             index
                                 .lock()
                                 .externally_defined_attribute_references

--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -999,7 +999,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if let Some(callee_range) = callee_range
                     && let Some(metaclass) = class_metadata.custom_metaclass()
                 {
-                    self.record_external_attribute_definition_index(
+                    self.record_attribute_definition_index(
                         &self.heap.mk_class_type(metaclass.clone()),
                         &dunder::CALL,
                         callee_range,
@@ -1072,7 +1072,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 let has_errors = !dunder_new_errors.is_empty();
                 errors.extend(dunder_new_errors);
                 if let Some(callee_range) = callee_range {
-                    self.record_external_attribute_definition_index(
+                    self.record_attribute_definition_index(
                         &self.heap.mk_class_type(cls.clone()),
                         &dunder::NEW,
                         callee_range,
@@ -1136,7 +1136,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 errors.extend(dunder_init_errors);
             }
             if let Some(callee_range) = callee_range {
-                self.record_external_attribute_definition_index(
+                self.record_attribute_definition_index(
                     &self.heap.mk_class_type(cls.clone()),
                     &dunder::INIT,
                     callee_range,

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -2130,7 +2130,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         base: &TypeInfo,
         errors: &ErrorCollector,
     ) -> TypeInfo {
-        self.record_external_attribute_definition_index(base.ty(), x.attr.id(), x.attr.range);
+        self.record_attribute_definition_index(base.ty(), x.attr.id(), x.attr.range);
         let attr_type = self.attr_infer(base, &x.attr.id, x.range, errors, None);
         if base.ty().is_literal_string() {
             match attr_type.ty() {

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -3834,6 +3834,16 @@ impl<'a> Transaction<'a> {
         ) {
             references.extend(pytest_references);
         }
+        if let Some(index) = self
+            .get_solutions(handle)
+            .and_then(|solutions| solutions.get_index())
+            && let Some(constructor_references) = index
+                .lock()
+                .locally_defined_constructor_references
+                .get(&definition_range)
+        {
+            references.extend(constructor_references);
+        }
         if include_declaration {
             references.push(definition_range);
         }

--- a/pyrefly/lib/test/lsp/local_find_refs.rs
+++ b/pyrefly/lib/test/lsp/local_find_refs.rs
@@ -322,7 +322,6 @@ References:
     );
 }
 
-// TODO: references on constructors
 #[test]
 fn dunder_init() {
     let code = r#"
@@ -343,6 +342,8 @@ Foo()
 References:
 3 |     def __init__(self): ...
             ^^^^^^^^
+6 | Foo()
+    ^^^
 "#
         .trim(),
         report.trim(),


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4347

Find References on `__init__` now includes same-module constructor calls such as Foo().

The solver-resolved constructor targets are indexed locally and consumed by reference lookup.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test