### PR TITLE
Visit the ParamSpec tail of `Type::Concatenate`

### DIFF
--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -404,12 +404,6 @@ impl PrefixParam {
         }
     }
 
-    pub fn ty_mut(&mut self) -> &mut Type {
-        match self {
-            Self::PosOnly(_, ty, _) | Self::Pos(_, ty, _) => ty,
-        }
-    }
-
     /// Convert to a positional-only `Param`. Per the typing spec, params in
     /// `Concatenate` are positional-only at the call site. This is also appropriate
     /// for ParamSpec forwarding where prefix params must be passed positionally.

--- a/crates/pyrefly_types/src/callable.rs
+++ b/crates/pyrefly_types/src/callable.rs
@@ -406,12 +406,6 @@ impl PrefixParam {
         }
     }
 
-    pub fn ty_mut(&mut self) -> &mut Type {
-        match self {
-            Self::PosOnly(_, ty, _) | Self::Pos(_, ty, _) => ty,
-        }
-    }
-
     /// Convert to a positional-only `Param`. Per the typing spec, params in
     /// `Concatenate` are positional-only at the call site. This is also appropriate
     /// for ParamSpec forwarding where prefix params must be passed positionally.

--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -964,9 +964,6 @@ impl Visit for Type {
             Type::ParamSpec(x) => x.visit(f),
             Type::TypeVarTuple(x) => x.visit(f),
             Type::SpecialForm(x) => x.visit(f),
-            // The ParamSpec tail is a real `Type` (a `Var`, `Quantified`, `ParamSpecValue`, ...),
-            // so it must be visited. `subst`, `collect_quantifieds` and `Solver::resolve_vars` all
-            // reach it only through here; skipping it strands the tail unsubstituted.
             Type::Concatenate(prefix, pspec) => {
                 prefix.visit(f);
                 pspec.visit(f);
@@ -1030,8 +1027,6 @@ impl VisitMut for Type {
             Type::ParamSpec(x) => x.visit_mut(f),
             Type::TypeVarTuple(x) => x.visit_mut(f),
             Type::SpecialForm(x) => x.visit_mut(f),
-            // As in `Visit::recurse`, the ParamSpec tail must be visited or it never gets
-            // substituted or resolved.
             Type::Concatenate(prefix, pspec) => {
                 prefix.visit_mut(f);
                 pspec.visit_mut(f);

--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -964,7 +964,13 @@ impl Visit for Type {
             Type::ParamSpec(x) => x.visit(f),
             Type::TypeVarTuple(x) => x.visit(f),
             Type::SpecialForm(x) => x.visit(f),
-            Type::Concatenate(x, _) => x.visit(f),
+            // The ParamSpec tail is a real `Type` (a `Var`, `Quantified`, `ParamSpecValue`, ...),
+            // so it must be visited. `subst`, `collect_quantifieds` and `Solver::resolve_vars` all
+            // reach it only through here; skipping it strands the tail unsubstituted.
+            Type::Concatenate(prefix, pspec) => {
+                prefix.visit(f);
+                pspec.visit(f);
+            }
             Type::ParamSpecValue(x) => x.visit(f),
             Type::Args(x) => x.visit(f),
             Type::Kwargs(x) => x.visit(f),
@@ -1024,7 +1030,12 @@ impl VisitMut for Type {
             Type::ParamSpec(x) => x.visit_mut(f),
             Type::TypeVarTuple(x) => x.visit_mut(f),
             Type::SpecialForm(x) => x.visit_mut(f),
-            Type::Concatenate(x, _) => x.visit_mut(f),
+            // As in `Visit::recurse`, the ParamSpec tail must be visited or it never gets
+            // substituted or resolved.
+            Type::Concatenate(prefix, pspec) => {
+                prefix.visit_mut(f);
+                pspec.visit_mut(f);
+            }
             Type::ParamSpecValue(x) => x.visit_mut(f),
             Type::Args(x) => x.visit_mut(f),
             Type::Kwargs(x) => x.visit_mut(f),

--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -954,7 +954,13 @@ impl Visit for Type {
             Type::ParamSpec(x) => x.visit(f),
             Type::TypeVarTuple(x) => x.visit(f),
             Type::SpecialForm(x) => x.visit(f),
-            Type::Concatenate(x, _) => x.visit(f),
+            // The ParamSpec tail is a real `Type` (a `Var`, `Quantified`, `ParamSpecValue`, ...),
+            // so it must be visited. `subst`, `collect_quantifieds` and `Solver::resolve_vars` all
+            // reach it only through here; skipping it strands the tail unsubstituted.
+            Type::Concatenate(prefix, pspec) => {
+                prefix.visit(f);
+                pspec.visit(f);
+            }
             Type::ParamSpecValue(x) => x.visit(f),
             Type::Args(x) => x.visit(f),
             Type::Kwargs(x) => x.visit(f),
@@ -1014,7 +1020,12 @@ impl VisitMut for Type {
             Type::ParamSpec(x) => x.visit_mut(f),
             Type::TypeVarTuple(x) => x.visit_mut(f),
             Type::SpecialForm(x) => x.visit_mut(f),
-            Type::Concatenate(x, _) => x.visit_mut(f),
+            // As in `Visit::recurse`, the ParamSpec tail must be visited or it never gets
+            // substituted or resolved.
+            Type::Concatenate(prefix, pspec) => {
+                prefix.visit_mut(f);
+                pspec.visit_mut(f);
+            }
             Type::ParamSpecValue(x) => x.visit_mut(f),
             Type::Args(x) => x.visit_mut(f),
             Type::Kwargs(x) => x.visit_mut(f),

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -1372,25 +1372,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 };
                 func.signature.recurse_mut(&mut visit);
             }
-            Type::Concatenate(prefix, pspec) => {
-                for t in prefix {
+            Type::Concatenate(..) => {
+                let mut visit = |t: &mut Type| {
                     self.tvars_to_tparams_for_type_alias(
-                        t.ty_mut(),
+                        t,
                         alias_anchor,
                         seen_type_vars,
                         seen_type_var_tuples,
                         seen_param_specs,
                         tparams,
                     )
-                }
-                self.tvars_to_tparams_for_type_alias(
-                    pspec,
-                    alias_anchor,
-                    seen_type_vars,
-                    seen_type_var_tuples,
-                    seen_param_specs,
-                    tparams,
-                )
+                };
+                ty.recurse_mut(&mut visit);
             }
             Type::Tuple(tuple) => {
                 let mut visit = |t: &mut Type| {

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -1362,25 +1362,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 };
                 func.signature.recurse_mut(&mut visit);
             }
-            Type::Concatenate(prefix, pspec) => {
-                for t in prefix {
+            Type::Concatenate(..) => {
+                let mut visit = |t: &mut Type| {
                     self.tvars_to_tparams_for_type_alias(
-                        t.ty_mut(),
+                        t,
                         alias_anchor,
                         seen_type_vars,
                         seen_type_var_tuples,
                         seen_param_specs,
                         tparams,
                     )
-                }
-                self.tvars_to_tparams_for_type_alias(
-                    pspec,
-                    alias_anchor,
-                    seen_type_vars,
-                    seen_type_var_tuples,
-                    seen_param_specs,
-                    tparams,
-                )
+                };
+                ty.recurse_mut(&mut visit);
             }
             Type::Tuple(tuple) => {
                 let mut visit = |t: &mut Type| {

--- a/pyrefly/lib/test/generic_basic.rs
+++ b/pyrefly/lib/test/generic_basic.rs
@@ -276,7 +276,7 @@ class partial(Generic[_P1, _P2, _T, _R_co, *_Ts]):
     @overload
     def __new__(cls, __func: Callable[_P1, _R_co]) -> partial[_P1, _P1, Any, _R_co]: ... # E: Overload return type `partial[Ellipsis, Ellipsis, Any, object, *tuple[()]]` is not assignable to implementation return type `Self@partial`
     @overload
-    def __new__(cls, __func: Callable[Concatenate[*_Ts, _P2], _R_co], *args: *_Ts) -> partial[Concatenate[*_Ts, _P2], _P2, Any, _R_co, *_Ts]: ... # E: Overload return type `partial[Concatenate[*tuple[Unknown, ...], _P2], Ellipsis, Any, object, *tuple[Unknown, ...]]` is not assignable to implementation return type `Self@partial`
+    def __new__(cls, __func: Callable[Concatenate[*_Ts, _P2], _R_co], *args: *_Ts) -> partial[Concatenate[*_Ts, _P2], _P2, Any, _R_co, *_Ts]: ... # E: Overload return type `partial[Concatenate[*tuple[Unknown, ...], Ellipsis], Ellipsis, Any, object, *tuple[Unknown, ...]]` is not assignable to implementation return type `Self@partial`
     @overload
     def __new__(cls, __func: Callable[_P1, _R_co], *args: *_Ts, **kwargs: _T) -> partial[_P1, ..., _T, _R_co, *_Ts]: ... # E: Overload return type `partial[Ellipsis, Ellipsis, object, object, *tuple[Unknown, ...]]` is not assignable to implementation return type `Self@partial`
     def __new__(cls, __func, *args, **kwargs):

--- a/pyrefly/lib/test/paramspec.rs
+++ b/pyrefly/lib/test/paramspec.rs
@@ -923,7 +923,6 @@ service(nonexistent_param=True)  # E: Missing argument `service_name` # E: Unexp
 
 // Regression test for https://github.com/facebook/pyrefly/issues/3706
 testcase!(
-    bug = "Should reveal `A[[int, int]]`",
     test_concatenate_paramspec_tail_in_class_targ,
     r#"
 from typing import Concatenate, reveal_type
@@ -932,13 +931,12 @@ class A[**P]:
     def transform(self) -> A[Concatenate[int, P]]:
         raise NotImplementedError
 
-reveal_type(A[int]().transform())  # E: revealed type: A[Concatenate[int, P]]
+reveal_type(A[int]().transform())  # E: revealed type: A[[int, int]]
 "#,
 );
 
 // Regression test for https://github.com/facebook/pyrefly/issues/3828
 testcase!(
-    bug = "Should accept both calls and reveal `B[[]]` / `B[[str, int]]`",
     test_concatenate_paramspec_tail_in_class_param,
     r#"
 from typing import Concatenate, reveal_type
@@ -953,10 +951,88 @@ def transform[**P](arg: A[Concatenate[int, P]]) -> B[P]:
     raise NotImplementedError
 
 a1: A[[int]] = A()
-reveal_type(transform(a1))  # E: revealed type: B[@_]  # E: Argument `A[[int]]` is not assignable to parameter `arg` with type `A[Concatenate[int, P]]`
+reveal_type(transform(a1))  # E: revealed type: B[[]]
 
 a2: A[[int, str, int]] = A()
-reveal_type(transform(a2))  # E: revealed type: B[@_]  # E: Argument `A[[int, str, int]]` is not assignable to parameter `arg` with type `A[Concatenate[int, P]]`
+reveal_type(transform(a2))  # E: revealed type: B[[str, int]]
 "#,
 );
 
+// Nesting exercises the `Concatenate[..., Concatenate[...]]` collapse in the solver, which
+// could not fire while the ParamSpec tail was unreachable.
+testcase!(
+    test_concatenate_paramspec_tail_nested,
+    r#"
+from typing import Concatenate, reveal_type
+
+class A[**P]:
+    pass
+
+def add_int[**P](x: A[P]) -> A[Concatenate[int, P]]: ...
+def add_str[**P](x: A[P]) -> A[Concatenate[str, P]]: ...
+def drop_int[**P](x: A[Concatenate[int, P]]) -> A[P]: ...
+
+a: A[[bool]] = A()
+reveal_type(add_int(a))                        # E: revealed type: A[[int, bool]]
+reveal_type(add_str(add_int(a)))               # E: revealed type: A[[str, int, bool]]
+reveal_type(add_str(add_str(add_int(a))))      # E: revealed type: A[[str, str, int, bool]]
+reveal_type(drop_int(add_int(a)))              # E: revealed type: A[[bool]]
+"#,
+);
+
+// A bare `Concatenate` in a class type argument is the only thing that reaches the
+// `Type::Concatenate` arm of `tvars_to_tparams_for_type_alias`.
+testcase!(
+    test_concatenate_paramspec_tail_in_type_alias,
+    r#"
+from typing import Concatenate, ParamSpec, reveal_type
+
+class A[**P2]:
+    pass
+
+P = ParamSpec("P")
+Legacy = A[Concatenate[int, P]]
+
+type Modern[**Q] = A[Concatenate[str, Q]]
+
+def f(x: Legacy[[bool]]) -> None:
+    reveal_type(x)  # E: revealed type: A[[int, bool]]
+
+def g(x: Modern[[bool]]) -> None:
+    reveal_type(x)  # E: revealed type: A[[str, bool]]
+"#,
+);
+
+// A `ParamSpec` reachable only through a `Concatenate` tail still counts as a type variable.
+testcase!(
+    test_concatenate_paramspec_tail_is_a_type_variable,
+    r#"
+from typing import ClassVar, Concatenate
+
+class A[**P]:
+    pass
+
+class C[**P]:
+    bad: ClassVar[A[Concatenate[int, P]]]  # E: `ClassVar` arguments may not contain any type variables
+"#,
+);
+
+// `Callable[..., int]` binds `P` in `Callable[Concatenate[int, P], int]`, but the equivalent
+// user-defined generic does not; see `test_param_spec_solve` for the working `Callable` case.
+testcase!(
+    bug = "`...` should bind the tail, giving `A[Concatenate[int, ...]]` and `A[...]`",
+    test_concatenate_paramspec_tail_gradual,
+    r#"
+from typing import Concatenate, reveal_type
+
+class A[**P]:
+    pass
+
+def add_int[**P](x: A[P]) -> A[Concatenate[int, P]]: ...
+def drop_int[**P](x: A[Concatenate[int, P]]) -> A[P]: ...
+
+g: A[...] = A()
+reveal_type(add_int(g))   # E: revealed type: A[Concatenate[int, Ellipsis]]
+reveal_type(drop_int(g))  # E: revealed type: A[@_]
+"#,
+);

--- a/pyrefly/lib/test/paramspec.rs
+++ b/pyrefly/lib/test/paramspec.rs
@@ -920,3 +920,43 @@ service(service_name="nginx", running=True, _sudo=True, name="Start nginx")
 service(nonexistent_param=True)  # E: Missing argument `service_name` # E: Unexpected keyword argument `nonexistent_param`
 "#,
 );
+
+// Regression test for https://github.com/facebook/pyrefly/issues/3706
+testcase!(
+    bug = "Should reveal `A[[int, int]]`",
+    test_concatenate_paramspec_tail_in_class_targ,
+    r#"
+from typing import Concatenate, reveal_type
+
+class A[**P]:
+    def transform(self) -> A[Concatenate[int, P]]:
+        raise NotImplementedError
+
+reveal_type(A[int]().transform())  # E: revealed type: A[Concatenate[int, P]]
+"#,
+);
+
+// Regression test for https://github.com/facebook/pyrefly/issues/3828
+testcase!(
+    bug = "Should accept both calls and reveal `B[[]]` / `B[[str, int]]`",
+    test_concatenate_paramspec_tail_in_class_param,
+    r#"
+from typing import Concatenate, reveal_type
+
+class A[**P]:
+    pass
+
+class B[**P]:
+    pass
+
+def transform[**P](arg: A[Concatenate[int, P]]) -> B[P]:
+    raise NotImplementedError
+
+a1: A[[int]] = A()
+reveal_type(transform(a1))  # E: revealed type: B[@_]  # E: Argument `A[[int]]` is not assignable to parameter `arg` with type `A[Concatenate[int, P]]`
+
+a2: A[[int, str, int]] = A()
+reveal_type(transform(a2))  # E: revealed type: B[@_]  # E: Argument `A[[int, str, int]]` is not assignable to parameter `arg` with type `A[Concatenate[int, P]]`
+"#,
+);
+


### PR DESCRIPTION
# Summary

`Type::Concatenate(Box<[PrefixParam]>, Box<Type>)` stores its trailing ParamSpec as an ordinary `Type`, but the hand-written `Visit`/`VisitMut` impls for `Type` discarded that second field:

```rust
Type::Concatenate(x, _) => x.visit(f),
```

Every traversal built on those two functions — `subst`, `collect_quantifieds`, `contains_type_variable`, `transform_mut`, and the solver's `resolve_vars` — was therefore a silent no-op on the tail. The `Callable` spelling was unaffected because it is normalized at construction into `Params::ParamSpec`, whose derived visitor sees both fields; only a bare `Concatenate` in a class type argument, e.g. `A[Concatenate[int, P]]`, reached the broken path. That asymmetry is exactly what both issues report.

Visiting the tail is sufficient. Once the tail's `Var` is reachable it gets resolved, which lets the solver's existing `Concatenate[..., ParamSpecValue]` and `Concatenate[..., Concatenate]` collapses fire for the first time, and `P` is now discovered as a type variable when it occurs only inside a tail. It also subsumes the hand-rolled recursion in `tvars_to_tparams_for_type_alias`, which can now use `recurse_mut` like its neighbouring arms, leaving `PrefixParam::ty_mut` unused.

I kept the impl hand-written rather than switching to `#[derive(Visit, VisitMut)]`: `impl Visit for Type` is deliberately monomorphic (`Visit<Type> for Type`), while the derive emits `impl<To> Visit<To>` with a where-clause per field — and several of `Type`'s payload types (`TArgs`, `Union`, `Arc<TParams>`, …) only implement the monomorphic form, so it would not compile. The hand-written arms also elide no-op recursion on the checker's hottest traversal. I added a comment on both arms stating the invariant so the omission can't quietly come back.

Fixes #3706, #3828.

# Test Plan

`cargo test -p pyrefly --lib` — 7468 passed, 0 failed. Full workspace `cargo test` green. Conformance output (`conformance.exp`, `conformance.result`, `results.json`) is byte-identical to the committed versions, with all four `generics_paramspec_*` cases still passing.

First commit adds the repros as `bug`-marked tests capturing the current wrong behaviour; the second removes the markers and updates them to the correct results. Also added coverage for paths that were previously unreachable: the nested `Concatenate[..., Concatenate[...]]` collapse, a bare `Concatenate` in both legacy and PEP 695 type aliases, and a `ParamSpec` reachable only through a tail being recognised as a type variable.

Exactly one pre-existing expectation changed, in `test_functools_partial_pattern`:

- before: `partial[Concatenate[*tuple[Unknown, ...], _P2], Ellipsis, Any, object, ...]`
- after: `partial[Concatenate[*tuple[Unknown, ...], Ellipsis], Ellipsis, Any, object, ...]`

That is the fix working. The overload-consistency check instantiates the declared return type with gradual forms, and the `_P2` in the second type-argument position was already rendering as `Ellipsis` — only the one inside the `Concatenate` tail was leaking through unsubstituted. The two now agree. That test keeps its unrelated `bug` marker.

One known gap, left as a `bug`-marked test (`test_concatenate_paramspec_tail_gradual`): a gradual `A[...]` still doesn't bind the tail, so `drop_int(g)` gives `A[@_]` and `add_int(g)` gives `A[Concatenate[int, Ellipsis]]`, where the `Callable` equivalents are correct. Both issues report concrete parameter lists, which this fixes; the `...` case needs separate work.
