### PR TITLE
Use Iterator rather than Iterable as return type for NamedTuple.__iter__

### DIFF
--- a/crates/pyrefly_types/src/stdlib.rs
+++ b/crates/pyrefly_types/src/stdlib.rs
@@ -82,6 +82,7 @@ pub struct Stdlib {
     tuple: StdlibResult<(Class, Arc<TParams>)>,
     enumerate: StdlibResult<(Class, Arc<TParams>)>,
     iterable: StdlibResult<(Class, Arc<TParams>)>,
+    iterator: StdlibResult<(Class, Arc<TParams>)>,
     async_iterable: StdlibResult<(Class, Arc<TParams>)>,
     async_iterator: StdlibResult<(Class, Arc<TParams>)>,
     mutable_sequence: StdlibResult<(Class, Arc<TParams>)>,
@@ -251,6 +252,7 @@ impl Stdlib {
                 .then(|| lookup_concrete(types, "EllipsisType")),
             none_type: lookup_concrete(none_location, "NoneType"),
             iterable: lookup_generic(typing, "Iterable", 1),
+            iterator: lookup_generic(typing, "Iterator", 1),
             async_iterable: lookup_generic(typing, "AsyncIterable", 1),
             async_iterator: lookup_generic(typing, "AsyncIterator", 1),
             mutable_sequence: lookup_generic(typing, "MutableSequence", 1),
@@ -530,6 +532,10 @@ impl Stdlib {
 
     pub fn iterable(&self, x: Type) -> ClassType {
         Self::apply(&self.iterable, vec![x])
+    }
+
+    pub fn iterator(&self, x: Type) -> ClassType {
+        Self::apply(&self.iterator, vec![x])
     }
 
     pub fn async_iterable(&self, x: Type) -> ClassType {

--- a/pyrefly/lib/alt/class/named_tuple.rs
+++ b/pyrefly/lib/alt/class/named_tuple.rs
@@ -222,7 +222,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             dunder::ITER,
             params,
             self.heap
-                .mk_class_type(self.stdlib.iterable(self.unions(element_types))),
+                .mk_class_type(self.stdlib.iterator(self.unions(element_types))),
         );
         ClassSynthesizedField::new(ty)
     }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -957,7 +957,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             )
         };
         match iterable {
-            Type::ClassType(cls) if self.has_named_tuple_iter_override(cls) => {
+            Type::ClassType(cls) | Type::SelfType(cls)
+                if self.has_named_tuple_iter_override(cls) =>
+            {
                 let ty = self
                     .call_magic_dunder_method(
                         iterable,
@@ -974,7 +976,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     });
                 vec![Iterable::OfType(ty)]
             }
-            Type::ClassType(cls) if let Some(Tuple::Concrete(elts)) = self.as_tuple(cls) => {
+            Type::ClassType(cls) | Type::SelfType(cls)
+                if let Some(Tuple::Concrete(elts)) = self.as_tuple(cls) =>
+            {
                 vec![Iterable::FixedLen(elts.clone())]
             }
             Type::IntTuple(int_tuple) => self.iterate_int_tuple(int_tuple),

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -346,8 +346,8 @@ class Pair2[T](NamedTuple):
     y: T
 
 def test(p: Pair, p2: Pair2[bytes]):
-    reveal_type(p.__iter__)  # E: (self: Pair) -> Iterable[int | str]
-    reveal_type(p2.__iter__)  # E: (self: Pair2[bytes]) -> Iterable[bytes | int]
+    reveal_type(p.__iter__)  # E: (self: Pair) -> Iterator[int | str]
+    reveal_type(p2.__iter__)  # E: (self: Pair2[bytes]) -> Iterator[bytes | int]
     "#,
 );
 

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -470,15 +470,21 @@ Tup = namedtuple("Tup", ["a", "b"], defaults=(1, 2, 3))  # E: Too many defaults:
 testcase!(
     test_named_tuple_dunder_unpack,
     r#"
-from typing import NamedTuple
+from typing import NamedTuple, assert_type
+
 class A(NamedTuple):
     a: int
     b: str
-    def __repr__(self) -> str:
-        return "A"
 
-def test(x: A) -> None:
+    def test_unpack_self(self) -> None:
+        a, b = self
+        assert_type(a, int)
+        assert_type(b, str)
+
+def test_unpack(x: A) -> None:
     a, b = x
+    assert_type(a, int)
+    assert_type(b, str)
 "#,
 );
 

--- a/pyrefly/lib/test/pysa/functions.rs
+++ b/pyrefly/lib/test/pysa/functions.rs
@@ -1638,9 +1638,9 @@ MyTuple = collections.namedtuple("MyTuple", "x y")
                         required: true,
                     }],
                     PysaType::new(
-                        "typing.Iterable[Unknown]".to_owned(),
+                        "typing.Iterator[Unknown]".to_owned(),
                         ClassNamesFromType::from_classes(
-                            vec![get_class_ref("typing", "Iterable", context)],
+                            vec![get_class_ref("typing", "Iterator", context)],
                             true,
                         ),
                     ),


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4417

- added `iterator` analog to `iterable` in stdlib.rs
- updated namedtuple synthesized `__iter__` method to return `Iterator` rather than `Iterable`

# Test Plan

<!-- Describe how you tested this PR -->

Updated existing test.

<!-- Run test.py and commit any changes to generated files -->
