### PR TITLE
Avoid exponential blowup for nested containers and constructor calls

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -983,6 +983,55 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         context: Option<&dyn Fn() -> ErrorContext>,
         hint: Option<HintRef>,
     ) -> Type {
+        // Classes that override `__new__` and also define `__init__` check/infer args
+        // twice, potentially leading to exponential check costs: `O(2^depth)`.
+        let checks_args_twice = |cls: &ClassType, preserve_self| {
+            self.get_dunder_new(cls, preserve_self).is_some()
+                && self.get_dunder_init(cls, false).is_some()
+        };
+        let is_nested_ctor = |x: &TypeOrExpr| match x {
+            TypeOrExpr::Expr(Expr::Call(c)) => {
+                matches!(self.expr_infer(&c.func, &self.error_collector()),
+                    Type::ClassDef(inner)
+                        if self.get_class_tparams(&inner).is_empty()
+                            && checks_args_twice(&self.as_class_type_unchecked(&inner), false))
+            }
+            _ => false,
+        };
+
+        // Infer nested constructors once, up front.
+        let flatten_nested = args
+            .iter()
+            .map(|a| match a {
+                CallArg::Arg(x) | CallArg::Star(x, _) => x,
+            })
+            .chain(keywords.iter().map(|k| &k.value))
+            .any(|x| matches!(x, TypeOrExpr::Expr(Expr::Call(_))))
+            && checks_args_twice(&cls, constructor_kind == ConstructorKind::TypeOfSelf);
+
+        let call = CallWithTypes::new();
+        let flattened = flatten_nested.then(|| {
+            (
+                args.map(|a| match a {
+                    CallArg::Arg(x) | CallArg::Star(x, _) if is_nested_ctor(x) => {
+                        call.call_arg(a, self, errors)
+                    }
+                    _ => a.clone(),
+                }),
+                keywords.map(|k| {
+                    if is_nested_ctor(&k.value) {
+                        call.call_keyword(k, self, errors)
+                    } else {
+                        k.clone()
+                    }
+                }),
+            )
+        });
+        let (args, keywords) = match &flattened {
+            Some((args, keywords)) => (args.as_slice(), keywords.as_slice()),
+            None => (args, keywords),
+        };
+
         self.construct_with_hint(arguments_range, errors, context, hint, |hint| {
             self.construct_class_inner(
                 cls.clone(),

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -23,6 +23,7 @@ use pyrefly_util::display::pluralize;
 use pyrefly_util::owner::Owner;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::prelude::VecExt;
+use pyrefly_util::visit::Visit;
 use pyrefly_util::visit::VisitMut;
 use ruff_python_ast::Expr;
 use ruff_python_ast::Identifier;
@@ -64,8 +65,35 @@ use crate::types::types::BoundMethodType;
 use crate::types::types::Type;
 use crate::types::types::Var;
 
+const MIN_FLATTEN_CALL_DEPTH: u32 = 2;
+
+/// The number of elements held by `x`, if it is a recognised container type.
+fn container_len(x: &Expr) -> Option<usize> {
+    match x {
+        Expr::Dict(x) => Some(x.items.len()),
+        Expr::List(x) => Some(x.elts.len()),
+        Expr::Set(x) => Some(x.elts.len()),
+        _ => None,
+    }
+}
+
+/// Does `x` nest `depth` repetitions of a call taking a *non-empty* container argument.
+fn nests_calls_to_depth(x: &Expr, depth: u32) -> bool {
+    if depth == 0 {
+        return true;
+    }
+    let mut found = matches!(x, Expr::Call(c)
+        if c.arguments.iter_source_order().any(|a|
+            container_len(a.value()).is_some_and(|n| n > 0)
+                && nests_calls_to_depth(a.value(), depth - 1)));
+    if !found {
+        x.recurse(&mut |child: &Expr| found = found || nests_calls_to_depth(child, depth));
+    }
+    found
+}
+
 /// Structure to turn TypeOrExprs into Types.
-/// This is used to avoid re-inferring types for arguments multiple types.
+/// This is used to avoid re-inferring types for arguments multiple times.
 ///
 /// Implemented by keeping an `Owner` to hand out references to `Type`.
 pub struct CallWithTypes(Owner<Type>);
@@ -82,10 +110,13 @@ impl CallWithTypes {
         errors: &ErrorCollector,
     ) -> TypeOrExpr<'a> {
         match x {
-            TypeOrExpr::Expr(e @ (Expr::Dict(_) | Expr::List(_) | Expr::Set(_))) => {
-                // Hack: don't flatten mutable builtin containers into types before calling a
-                // function, as we know these containers often need to be contextually typed using
-                // the function's parameter types.
+            TypeOrExpr::Expr(e)
+                if container_len(e).is_some()
+                    && !nests_calls_to_depth(e, MIN_FLATTEN_CALL_DEPTH) =>
+            {
+                // Hack: keep mutable builtin containers as expressions, since they often need to be
+                // contextually typed against the function's parameter types (only give that up
+                // once the nesting is deep enough to compound: see `MIN_FLATTEN_CALL_DEPTH`).
                 TypeOrExpr::Expr(e)
             }
             TypeOrExpr::Expr(e) => {

--- a/pyrefly/lib/test/calls.rs
+++ b/pyrefly/lib/test/calls.rs
@@ -834,3 +834,85 @@ def f(n: int) -> None: ...
 f(**untyped(1))  # E: The type of this argument is unknown
 "#,
 );
+
+// Nesting constructor calls inside container literals used to cost `O(overloads^depth)`
+testcase!(
+    test_nested_overloaded_call_in_list,
+    r#"
+from typing import Any, assert_type, overload
+
+class R: ...
+
+@overload
+def f(x: list[Any], /, *, a: int = 0) -> R: ...
+@overload
+def f(x: list[Any], /, *, b: int = 0) -> R: ...
+@overload
+def f(x: list[Any], /, *, c: int = 0) -> R: ...
+def f(x: list[Any], /, **kw: Any) -> R: ...
+
+y = f([f([f([f([f([f([f([f([None])])])])])])])])
+assert_type(y, R)
+"#,
+);
+
+// Flattening must not regress contextual typing of a container holding a plain call
+testcase!(
+    test_contextual_container_of_calls_still_works,
+    r#"
+class A: ...
+class B(A): ...
+
+xs: list[list[A]] = [[B()]]
+def f(x: list[A]) -> None: ...
+f([B()])
+"#,
+);
+
+// A single `call(container)` level cannot compound, so it must stay deferred.
+// Flattening it would infer the dict with no hint, breaking the test below.
+testcase!(
+    test_contextual_dict_of_call_with_container_arg,
+    r#"
+from typing import Any, Callable
+
+class Marker:
+    def __init__(self, schema: Any) -> None: ...
+class All:
+    def __init__(self, *validators: Any) -> None: ...
+
+def ensure_list(v: Any) -> list[Any]: ...
+def validator(v: Any) -> Any: ...
+def non_empty_string(value: Any) -> str: ...
+
+schema: dict[Marker | str, Callable[[Any], str] | All] = {Marker("name"): non_empty_string}
+schema.update({Marker("device_class"): All(ensure_list, [validator])})
+"#,
+);
+
+// The `{}` default below must not count as a nesting level.
+testcase!(
+    test_contextual_dict_of_call_bottoming_out_on_empty_container,
+    r#"
+from typing import Any
+
+class Marker:
+    def __init__(self, schema: Any, default: Any = None) -> None: ...
+class Optional(Marker): ...
+class Schema:
+    def __init__(self, schema: Any) -> None: ...
+class section:
+    def __init__(self, schema: Any, options: dict[str, Any] | None = None) -> None: ...
+
+user_input: dict[str, Any] = {}
+schema: dict[Marker, Any] = {}
+schema.update(
+    {
+        Optional("api"): section(
+            Schema({Optional("key", default=user_input.get("api", {}).get("key", "")): str}),
+            options={"collapsed": False},
+        ),
+    }
+)
+"#,
+);

--- a/pyrefly/lib/test/constructors.rs
+++ b/pyrefly/lib/test/constructors.rs
@@ -1320,3 +1320,64 @@ x = C([1, 2])
 assert_type(x, C[int])
     "#,
 );
+
+// A class defining both `__new__` and `__init__` has its args checked twice, so
+// nesting cost `O(2^depth)` (below test would be 2^18 checks without the fix).
+testcase!(
+    test_deeply_nested_new_and_init_ctor_calls,
+    r#"
+from typing import Self, assert_type
+class D:
+    def __new__(cls, x: "D | None" = None) -> Self: ...
+    def __init__(self, x: "D | None" = None) -> None: ...
+x = D(D(D(D(D(D(D(D(D(D(D(D(D(D(D(D(D(D(None))))))))))))))))))
+assert_type(x, D)
+    "#,
+);
+
+// The `dict` stubs declare `__new__` alongside `__init__`, so subclasses
+// inherit both https://github.com/facebook/pyrefly/issues/4276.
+testcase!(
+    test_deeply_nested_dict_subclass_ctor_calls,
+    r#"
+from typing import Any, assert_type
+class D(dict[str, Any]):
+    def __init__(self, x: "D | None" = None) -> None: ...
+x = D(D(D(D(D(D(D(D(D(D(D(D(D(D(D(D(D(D(None))))))))))))))))))
+assert_type(x, D)
+    "#,
+);
+
+// Confirm that flattening resolves by type (ensure aliases still collapse).
+testcase!(
+    test_deeply_nested_aliased_ctor_calls,
+    r#"
+from typing import Self, assert_type
+class D:
+    def __new__(cls, x: "D | None" = None) -> Self: ...
+    def __init__(self, x: "D | None" = None) -> None: ...
+E = D
+x = E(E(E(E(E(E(E(E(E(E(E(E(E(E(E(E(E(E(None))))))))))))))))))
+assert_type(x, D)
+    "#,
+);
+
+// A generic nested construction must NOT be flattened: it is inferred without the
+// parameter as a hint, which is the only thing that can pin the type argument.
+testcase!(
+    test_nested_generic_ctor_keeps_contextual_targs,
+    r#"
+from typing import Self
+class G[T]:
+    def __new__(cls, xs: list[T]) -> Self: ...
+    def __init__(self, xs: list[T]) -> None: ...
+class A: ...
+class B(A): ...
+class Outer:
+    def __new__(cls, g: "G[A]") -> Self: ...
+    def __init__(self, g: "G[A]") -> None: ...
+Outer(G([B()]))
+def takes_float(g: "G[float]") -> None: ...
+takes_float(G([1]))
+    "#,
+);

--- a/pyrefly/lib/test/dict.rs
+++ b/pyrefly/lib/test/dict.rs
@@ -275,3 +275,27 @@ d = {"photo": [images[0]], "enabled": ["yes"]}
 same(d, [dict(photo=[images[0]], enabled=["yes"], **extra)])
     "#,
 );
+
+// Nesting constructor calls inside container literals used to cost `O(overloads^depth)`
+testcase!(
+    test_nested_dict_subclass_ctor_calls,
+    r#"
+from typing import Any, assert_type
+
+class D(dict[str, Any]):
+    pass
+
+x = D({"n": D({"n": D({"n": D({"n": D({"n": D({"n": D({"n": D({"n": None})})})})})})})})
+assert_type(x, D)
+"#,
+);
+
+testcase!(
+    test_nested_dict_ctor_from_pairs,
+    r#"
+from typing import assert_type
+
+x = dict([("n", dict([("n", dict([("n", dict([("n", dict([("n", 1)]))]))]))]))])
+assert_type(x, dict[str, dict[str, dict[str, dict[str, dict[str, int]]]]])
+"#,
+);


### PR DESCRIPTION
# Summary

Fixes #4276.
Fixes #3653.

Supersedes #4280; this is a more generic fix that also handles aliases, qualified names, subclasses, and non-dict classes.

### Overview

Nested calls could become exponentially more costly, with `O(2^depth)`:

1. **Container arguments** were deferred as `Expr` for contextual typing, so a container holding a call holding a container re-inferred the same subtree _per overload_.
2. **Constructor calls** to a class defining both `__new__` and `__init__` check their arguments twice (once per dunder), with nesting compounding those checks.

### Solution

Fixed by inferring the nested expression to a `Type` once, up front, collapsing the shared subtree so repeated checks reuse the inference instead of deriving it again.

# Test Plan

All existing unit tests pass; added some new ones.
