### PR TITLE
fix panic: Key Anon already exists with value ClassDef w/ NamedTuple and assert #4447

### DIFF
--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -155,9 +155,7 @@ impl<'a> BindingsBuilder<'a> {
         self.ensure_expr(&mut test, &mut Usage::NonPinningValue(None));
         let narrow_ops = NarrowOps::from_expr(self, Some(&test));
         let static_test = self.sys_info.evaluate_bool(&test);
-        let test_clone = test.clone();
-        self.insert_binding(Key::Anon(test_range), Binding::Expr(None, Box::new(test)));
-        self.insert_binding(KeyExpect::Bool(test_range), BindingExpect::Bool(test_clone));
+        self.insert_binding(KeyExpect::Bool(test_range), BindingExpect::Bool(test));
         if let Some(mut msg_expr) = msg {
             let mut base = self.scopes.clone_current_flow();
             // Negate the narrowing of the test expression when typechecking

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -757,6 +757,18 @@ fn test_named_tuple_in_malformed_with_item() {
     );
 }
 
+// Regression test for https://github.com/facebook/pyrefly/issues/4447
+#[test]
+fn test_named_tuple_in_assert() {
+    // Keep the malformed source exact: adding inline expectations changes the unterminated string.
+    let _ = testcase_for_macro(
+        TestEnv::new(),
+        "from typing import NamedTuple\n\nassert NamedTuple('\n",
+        file!(),
+        line!(),
+    );
+}
+
 testcase!(
     test_named_tuple_dynamic_fields,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4447

Removed redundant anonymous binding for assert conditions, preventing collision with synthesized NamedTuple bindings.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test