### PR TITLE
fix: don't panic on a non-generic classproperty in get_attributes

### DIFF
--- a/pyrefly/lib/query.rs
+++ b/pyrefly/lib/query.rs
@@ -1142,9 +1142,9 @@ impl Query {
                     (Some(String::from("property")), ty)
                 }
                 Type::ClassType(c)
-                    if c.name() == "classproperty" || c.name() == "cached_classproperty" =>
+                    if (c.name() == "classproperty" || c.name() == "cached_classproperty")
+                        && let Some(result_ty) = c.targs().as_slice().first() =>
                 {
-                    let result_ty = c.targs().as_slice().first().unwrap();
                     (Some(String::from("property")), result_ty)
                 }
                 _ => (None, ty),

--- a/pyrefly/lib/test/query.rs
+++ b/pyrefly/lib/test/query.rs
@@ -424,3 +424,38 @@ class C:
         "Expected two constructor callees for C(), got: {callees:?}"
     );
 }
+
+#[test]
+fn test_get_attributes_non_generic_classproperty() {
+    let tdir = TempDir::new().unwrap();
+    let file_path = tdir.path().join("main.py");
+    // A non-generic class named `classproperty` has no type arguments, so the
+    // `classproperty` match arm must not assume one is present.
+    let code = r#"class classproperty:
+    def __init__(self, f):
+        self.f = f
+    def __get__(self, obj, owner):
+        return self.f(owner)
+
+class Config:
+    @classproperty
+    def name(cls) -> str:
+        return "cfg"
+"#;
+    fs_anyhow::write(&file_path, code).unwrap();
+
+    let query = create_query();
+    let module_name = ModuleName::from_str("main");
+    let path = ModulePath::filesystem(file_path.clone());
+    let errors = query.add_files(vec![(module_name, path.clone())]);
+    assert!(errors.is_empty(), "Unexpected errors: {:?}", errors);
+
+    let attributes = query
+        .get_attributes(module_name, path, "Config")
+        .expect("expected attributes for Config");
+    assert!(
+        attributes.iter().any(|a| a.name == "name"),
+        "expected an attribute named `name`"
+    );
+}
+


### PR DESCRIPTION
Fixes #4453.

`get_kind_and_field_type` matched `classproperty` / `cached_classproperty` on the class *name* alone, then unwrapped the first type argument:

```rust
Type::ClassType(c)
    if c.name() == "classproperty" || c.name() == "cached_classproperty" =>
{
    let result_ty = c.targs().as_slice().first().unwrap();
```

A class with that name but **no type arguments** reaches this arm with empty `targs`, so `get_attributes` panics.

### Change

Per @yangdanny97's suggestion in the issue, the no-type-arguments case now behaves as `(None, ty)`. Rather than adding a nested match, the check moves into the match guard, so such a class simply doesn't match this arm and falls through to the existing `_ => (None, ty)`:

```rust
Type::ClassType(c)
    if (c.name() == "classproperty" || c.name() == "cached_classproperty")
        && let Some(result_ty) = c.targs().as_slice().first() =>
{
    (Some(String::from("property")), result_ty)
}
```

### Testing

Adds `test_get_attributes_non_generic_classproperty`, following the existing `TempDir` + `create_query()` pattern in `test/query.rs`. It checks out a module defining a plain `class classproperty:` used as a decorator, and asserts `get_attributes` returns the attribute rather than panicking.

- The test **fails without** the fix (`panicked at pyrefly/lib/query.rs:1147:66: called Option::unwrap() on a None value`) and passes with it.
- `cargo test -p pyrefly --lib test::query` — 7 passed, 0 failed.
- `cargo fmt --check` clean.
