### PR TITLE
fix panic: Key Anon already exists with value ClassDef w/ NamedTuple and match #4459

### DIFF
--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -941,6 +941,8 @@ pub enum Key {
     ContextExpr(TextRange),
     /// I am the context manager value for a `with` item without an assignment target.
     ContextValue(TextRange),
+    /// I am the subject value of a `match` statement.
+    MatchSubject(TextRange),
     /// I am the result of joining several branches.
     Phi(Box<(Name, TextRange)>),
     /// I am the result of narrowing a type. The two ranges are the range at which the operation is
@@ -1002,6 +1004,7 @@ impl Ranged for Key {
             Self::StmtExpr(r) => *r,
             Self::ContextExpr(r) => *r,
             Self::ContextValue(r) => *r,
+            Self::MatchSubject(r) => *r,
             Self::Phi(x) => x.1,
             Self::Narrow(x) => x.1,
             Self::Anywhere(x) => x.1,
@@ -1034,6 +1037,7 @@ impl DisplayWith<ModuleInfo> for Key {
             Self::StmtExpr(r) => write!(f, "Key::StmtExpr({})", ctx.display(r)),
             Self::ContextExpr(r) => write!(f, "Key::ContextExpr({})", ctx.display(r)),
             Self::ContextValue(r) => write!(f, "Key::ContextValue({})", ctx.display(r)),
+            Self::MatchSubject(r) => write!(f, "Key::MatchSubject({})", ctx.display(r)),
             Self::Phi(x) => write!(f, "Key::Phi({} {})", x.0, ctx.display(&x.1)),
             Self::Narrow(x) => {
                 write!(

--- a/pyrefly/lib/binding/pattern.rs
+++ b/pyrefly/lib/binding/pattern.rs
@@ -846,7 +846,7 @@ impl<'a> BindingsBuilder<'a> {
     }
 
     pub fn stmt_match(&mut self, mut x: StmtMatch, parent: &NestingContext) {
-        let mut subject = self.declare_current_idx(Key::Anon(x.subject.range()));
+        let mut subject = self.declare_current_idx(Key::MatchSubject(x.subject.range()));
         self.ensure_expr(&mut x.subject, subject.usage());
         let subject_expr = x.subject.clone();
         let subject_idx =

--- a/pyrefly/lib/test/named_tuple.rs
+++ b/pyrefly/lib/test/named_tuple.rs
@@ -769,6 +769,18 @@ fn test_named_tuple_in_assert() {
     );
 }
 
+// Regression test for https://github.com/facebook/pyrefly/issues/4459
+#[test]
+fn test_named_tuple_in_match_subject() {
+    // Keep the malformed source exact: adding inline expectations changes the unterminated string.
+    let _ = testcase_for_macro(
+        TestEnv::new(),
+        "from typing import NamedTuple\n\nmatch NamedTuple('\n",
+        file!(),
+        line!(),
+    );
+}
+
 testcase!(
     test_named_tuple_dynamic_fields,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4459

Added a dedicated MatchSubject binding key, preventing collisions with inline NamedTuple class bindings.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test