### PR TITLE
Skip missing-super-call check in stub files

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -3764,6 +3764,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         {
             return;
         }
+        // Stubs describe signatures, not implementations: a method body in a `.pyi`
+        // is always elided, so it can never call the parent method and the check
+        // would fire on every override.
+        if cls.module_path().is_interface() {
+            return;
+        }
         // If any base derives from `Any`, we can't reliably tell whether the method
         // overrides a concrete parent method, so suppress the check. Gather this
         // across all bases first so the decision is independent of base order.

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -1927,3 +1927,22 @@ class B(A):
         pass
  "#,
 );
+
+testcase!(
+    test_missing_super_call_in_stub,
+    TestEnv::one_with_path(
+        "stub",
+        "stub.pyi",
+        r#"
+class C:
+    def __init__(self) -> None: ...
+
+class D(C):
+    def __init__(self) -> None: ...
+"#,
+    )
+    .enable_missing_super_call_error(),
+    r#"
+from stub import C, D
+    "#,
+);


### PR DESCRIPTION
# Summary

`missing-super-call` fires on every method override in a `.pyi`. Stub bodies are always elided, so an override there can never call the parent method — the check has no way to pass.

`check_missing_super_call_for_field` now returns early when the class is defined in an interface file, matching how the rest of the checker guards stub-only behaviour (`cls.module_path().is_interface()` is used in ~14 other places).

Fixes #4443

# Test Plan

Added `test_missing_super_call_in_stub` to `pyrefly/lib/test/class_overrides.rs`, using the repro from the issue. Stashing the `class_field.rs` change makes it fail with the reported error and pass again with the fix restored:

```
test test::class_overrides::test_missing_super_call_in_stub ... FAILED
Error: Expectations failed for in-memory stub.pyi: expected 0 errors, but got 1
```

`cargo test -p pyrefly --lib` — 7786 passed, 0 failed.

---

Disclosure per CONTRIBUTING.md: this PR was written with AI assistance. The fix and its regression test were reviewed and verified locally against the repo's own test suite before submitting.
