### PR TITLE
fix datetimes and dates are not substitutable #4342

### DIFF
--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -828,6 +828,26 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                                 current_right_range,
                             )
                         };
+                        // `datetime` inherits from `date`, but their runtime ordering methods
+                        // reject the other type instead of honoring that nominal relationship.
+                        if matches!(op, CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE)
+                            && matches!(
+                                (left, right),
+                                (Type::ClassType(left), Type::ClassType(right))
+                                    if (left == self.stdlib.datetime()
+                                        && right == self.stdlib.date())
+                                        || (left == self.stdlib.date()
+                                            && right == self.stdlib.datetime())
+                            )
+                        {
+                            self.error(
+                                errors,
+                                x.range,
+                                ErrorKind::UnsupportedOperation,
+                                context().format(),
+                            );
+                            return self.heap.mk_class_type(self.stdlib.bool().clone());
+                        }
                         match op {
                             CmpOp::Is | CmpOp::IsNot => {
                                 // These comparisons never error.

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -969,6 +969,31 @@ def test(a: A, b: B, c: C) -> None:
     "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/4342
+testcase!(
+    test_date_datetime_comparison,
+    r#"
+from datetime import date, datetime
+
+d = date.today()
+dt = datetime.now()
+
+dt < d  # E: `<` is not supported between `datetime` and `date`
+dt <= d  # E: `<=` is not supported between `datetime` and `date`
+dt > d  # E: `>` is not supported between `datetime` and `date`
+dt >= d  # E: `>=` is not supported between `datetime` and `date`
+d < dt  # E: `<` is not supported between `date` and `datetime`
+d <= dt  # E: `<=` is not supported between `date` and `datetime`
+d > dt  # E: `>` is not supported between `date` and `datetime`
+d >= dt  # E: `>=` is not supported between `date` and `datetime`
+
+dt == d
+dt != d
+d < date.today()
+dt < datetime.now()
+"#,
+);
+
 testcase!(
     test_bitor_unknown_operands,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4342

Ordered date/datetime comparisons now report unsupported-operation in either operand order.
Equality and same-type ordering remain valid.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test