### PR TITLE
docs: correct site package autoconfiguration

### DIFF
--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -1181,7 +1181,9 @@ The config options we query the interpreter for are:
 
 - `python-platform`: `sys.platform`
 - `python-version`: `sys.version_info[:3]`
-- `site-package-path`: `site.getsitepackages() + [site.getusersitepackages()]`
+- `site-package-path`: entries from `sys.path`, excluding the empty entry, `.zip`
+  archives, the standard library path reported by `sysconfig.get_path("stdlib")`, and
+  paths ending in `/lib-dynload`
 
 :::info
 You can run `pyrefly dump-config` and pass in your file or configuration like you would


### PR DESCRIPTION
# Summary

Document the current site-package-path autoconfiguration: Pyrefly derives it from filtered sys.path entries rather than site.getsitepackages().

Fixes #4222

# Test Plan

- yarn build (passed; only existing broken-anchor warnings were reported)
- Changed MDX block verified against Prettier output
- env PATH=/Users/shensheng/.cargo/bin:$PATH python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema (passed)

# AI Usage

This documentation correction was prepared with an AI coding agent and reviewed against the current interpreter-query implementation.