### PR TITLE
Centralize sanitization of out-of-scope typevars in typevar defaults (#4483)

### DIFF
--- a/crates/pyrefly_types/src/types.rs
+++ b/crates/pyrefly_types/src/types.rs
@@ -284,6 +284,11 @@ impl TArgs {
         &mut Arc::make_mut(&mut self.0).1
     }
 
+    pub fn split_mut(&mut self) -> (&TParams, &mut [Type]) {
+        let inner = Arc::make_mut(&mut self.0);
+        (&inner.0, &mut inner.1)
+    }
+
     pub fn is_empty(&self) -> bool {
         self.0.1.is_empty()
     }
@@ -354,6 +359,13 @@ impl TArgs {
 pub struct Substitution<'a>(SmallMap<&'a Quantified, &'a Type>);
 
 impl<'a> Substitution<'a> {
+    /// Builds a substitution for a prefix of `tparams` by pairing `args` with the first
+    /// `args.len()` parameters.
+    pub fn for_prefix(tparams: &'a TParams, args: &'a [Type]) -> Self {
+        assert!(args.len() <= tparams.len());
+        Self(tparams.iter().zip(args).collect())
+    }
+
     pub fn substitute_into_mut(&self, ty: &mut Type) {
         ty.subst_mut(&self.0)
     }

--- a/pyrefly/lib/alt/class/targs.rs
+++ b/pyrefly/lib/alt/class/targs.rs
@@ -17,7 +17,6 @@ use pyrefly_util::display::count;
 use pyrefly_util::prelude::SliceExt;
 use ruff_python_ast::name::Name;
 use ruff_text_size::TextRange;
-use starlark_map::small_map::SmallMap;
 
 use crate::alt::answers::LookupAnswer;
 use crate::alt::answers_solver::AnswersSolver;
@@ -45,6 +44,7 @@ use crate::types::type_var::Restriction;
 use crate::types::typed_dict::TypedDict;
 use crate::types::types::Forall;
 use crate::types::types::Forallable;
+use crate::types::types::Substitution;
 use crate::types::types::TArgs;
 use crate::types::types::TParams;
 use crate::types::types::Type;
@@ -440,7 +440,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let nparams = tparams.len();
         let mut targs_cursor = TArgsCursor::new(targs);
         let mut checked_targs = Vec::new();
-        let mut name_to_idx = SmallMap::new();
         for (param_idx, param) in tparams.iter().enumerate() {
             if let Some(arg) = targs_cursor.peek() {
                 // Get next type argument
@@ -493,13 +492,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     param_idx,
                     &mut checked_targs,
                     targs_cursor.nargs(),
-                    &mut name_to_idx,
                     range,
                     errors,
                 );
                 break;
             }
-            name_to_idx.insert(param.name(), param_idx);
         }
         if targs_cursor.nargs_unconsumed(targs_cursor.nargs()) > 0 {
             self.error(
@@ -514,7 +511,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 ),
             );
         }
-        drop(name_to_idx);
         TArgs::new(tparams, checked_targs)
     }
 
@@ -743,44 +739,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
-    fn get_tparam_default(
-        &self,
-        param: &Quantified,
-        checked_targs: &[Type],
-        name_to_idx: &SmallMap<&Name, usize>,
-    ) -> Type {
-        if let Some(default) = param.default() {
-            default.clone().transform(&mut |default| {
-                let (typevar_name, typevar_kind) = match default {
-                    Type::TypeVar(t) => (t.qname().id(), QuantifiedKind::TypeVar),
-                    Type::TypeVarTuple(t) => (t.qname().id(), QuantifiedKind::TypeVarTuple),
-                    Type::ParamSpec(p) => (p.qname().id(), QuantifiedKind::ParamSpec),
-                    Type::Quantified(q) => (q.name(), q.kind()),
-                    _ => return,
-                };
-                *default = if let Some(i) = name_to_idx.get(typevar_name) {
-                    // The default of this TypeVar contains the value of a previous TypeVar.
-                    checked_targs[*i].clone()
-                } else {
-                    // The default refers to the value of a TypeVar that isn't in scope. We've
-                    // already logged an error in TParams::new(); return a sensible default.
-                    Quantified::as_gradual_type_helper(typevar_kind, None)
-                }
-            })
-        } else {
-            param.as_gradual_type()
-        }
-    }
-
     /// Consume all remaining type parameters after we've run out of arguments.
-    fn consume_remaining_tparams<'b>(
+    fn consume_remaining_tparams(
         &self,
         name: &Name,
-        tparams: &'b TParams,
+        tparams: &TParams,
         param_idx: usize,
         checked_targs: &mut Vec<Type>,
         nargs: usize,
-        name_to_idx: &mut SmallMap<&'b Name, usize>,
         range: TextRange,
         errors: &ErrorCollector,
     ) {
@@ -808,11 +774,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             // to avoid cascading errors.
             let targ = if all_remaining_params_can_be_empty && x.is_type_var_tuple() {
                 self.heap.mk_concrete_tuple(Vec::new())
+            } else if let Some(default) = x.default() {
+                // A default may refer to the parameters declared before it.
+                Substitution::for_prefix(tparams, checked_targs).substitute_into(default.clone())
             } else {
-                self.get_tparam_default(x, checked_targs, name_to_idx)
+                x.as_gradual_type()
             };
             checked_targs.push(targ);
-            name_to_idx.insert(x.name(), checked_targs.len() - 1);
         }
     }
 }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -2202,18 +2202,20 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
-    fn validate_type_params(
+    /// Validates `tparams` and returns a validated `TParams`.
+    /// References to out-of-scope legacy type variables are replaced with gradual fallbacks.
+    pub fn validated_tparams(
         &self,
         range: TextRange,
-        tparams: &[Quantified],
+        mut tparams: Vec<Quantified>,
         source: TParamsSource,
         errors: &ErrorCollector,
-    ) {
+    ) -> Arc<TParams> {
         let mut last_tparam: Option<&Quantified> = None;
-        let mut seen = SmallSet::new();
+        let mut seen: SmallMap<&Name, &Quantified> = SmallMap::new();
         let mut typevartuple = None;
         let mut typevartuple_count = 0;
-        for tparam in tparams {
+        for tparam in tparams.iter_mut() {
             if let Some(p) = last_tparam
                 && p.default().is_some()
             {
@@ -2231,10 +2233,25 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     );
                 }
             }
-            if let Some(default) = tparam.default() {
+            if let Some(default) = &mut tparam.default {
                 let mut out_of_scope_names = Vec::new();
-                default.collect_raw_legacy_type_variables(&mut out_of_scope_names);
-                out_of_scope_names.retain(|name| !seen.contains(name));
+                default.transform_raw_legacy_type_variables(&mut |ty| {
+                    let (name, kind) = match &*ty {
+                        Type::TypeVar(t) => (t.qname().id(), QuantifiedKind::TypeVar),
+                        Type::TypeVarTuple(t) => (t.qname().id(), QuantifiedKind::TypeVarTuple),
+                        Type::ParamSpec(p) => (p.qname().id(), QuantifiedKind::ParamSpec),
+                        _ => unreachable!(
+                            "transform_raw_legacy_type_variables only visits legacy type variables"
+                        ),
+                    };
+                    *ty = match seen.get(name) {
+                        Some(q) => (**q).clone().to_type(self.heap),
+                        None => {
+                            out_of_scope_names.push(name.clone());
+                            Quantified::as_gradual_type_helper(kind, None)
+                        }
+                    };
+                });
                 if !out_of_scope_names.is_empty() {
                     self.error(
                         errors,
@@ -2263,7 +2280,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     );
                 }
             }
-            seen.insert(tparam.name().clone());
+            seen.insert(tparam.name(), tparam);
             if tparam.is_type_var_tuple() {
                 typevartuple = Some(tparam.name().clone());
                 typevartuple_count += 1;
@@ -2281,16 +2298,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     .to_owned(),
             );
         }
-    }
-
-    pub fn validated_tparams(
-        &self,
-        range: TextRange,
-        tparams: Vec<Quantified>,
-        source: TParamsSource,
-        errors: &ErrorCollector,
-    ) -> Arc<TParams> {
-        self.validate_type_params(range, &tparams, source, errors);
+        drop(seen);
         Arc::new(TParams::new(tparams))
     }
 

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -73,6 +73,7 @@ use crate::types::simplify::simplify_tuples;
 use crate::types::simplify::unions;
 use crate::types::simplify::unions_with_literals;
 use crate::types::typed_dict::TypedDict;
+use crate::types::types::Substitution;
 use crate::types::types::TParams;
 use crate::types::types::Type;
 use crate::types::types::Var;
@@ -2913,62 +2914,26 @@ impl Solver {
     /// will resolve to their default, if one exists. Otherwise, create a "partial" var and
     /// try to find an instantiation at the first use, like finish_quantified.
     pub fn finish_class_targs(&self, targs: &mut TArgs, uniques: &UniqueFactory) {
-        // The default can refer to a tparam from earlier in the list, so we maintain a
-        // small scope data structure during the traversal.
-        let mut seen_params = SmallMap::new();
-        let mut new_targs: Vec<Option<Type>> = Vec::with_capacity(targs.len());
-        targs.iter_paired().enumerate().for_each(|(i, (param, t))| {
-            let new_targ = if let Type::Quantified(q) = t
-                && **q == *param
-            {
-                if let Some(default) = param.default() {
-                    // Note that TypeVars are stored in Type::TypeVar form, and have not yet been
-                    // converted to Quantified form, so we do that now.
-                    // TODO: deal with code duplication in get_tparam_default
-                    let mut t = default.clone();
-                    t.transform_mut(&mut |t| {
-                        let name = match t {
-                            Type::TypeVar(t) => Some(t.qname().id()),
-                            Type::TypeVarTuple(t) => Some(t.qname().id()),
-                            Type::ParamSpec(p) => Some(p.qname().id()),
-                            Type::Quantified(q) => Some(q.name()),
-                            _ => None,
-                        };
-                        if let Some(name) = name {
-                            *t = if let Some(i) = seen_params.get(name) {
-                                let new_targ: &Option<Type> = &new_targs[*i];
-                                new_targ
-                                    .as_ref()
-                                    .unwrap_or_else(|| &targs.as_slice()[*i])
-                                    .clone()
-                            } else {
-                                param.as_gradual_type()
-                            }
-                        }
-                    });
-                    Some(t)
-                } else if self.infer_with_first_use {
-                    let v = Var::new(uniques);
-                    self.variables.lock().insert_fresh(v, Variable::finished(q));
-                    Some(v.to_type(&self.heap))
-                } else {
-                    Some(q.as_gradual_type())
-                }
-            } else {
-                None
+        let (tparams, args) = targs.split_mut();
+        for (i, param) in tparams.iter().enumerate() {
+            let Type::Quantified(q) = &args[i] else {
+                continue;
             };
-            seen_params.insert(param.name(), i);
-            new_targs.push(new_targ);
-        });
-        drop(seen_params);
-        new_targs
-            .into_iter()
-            .zip(targs.as_mut().iter_mut())
-            .for_each(|(new_targ, targ)| {
-                if let Some(new_targ) = new_targ {
-                    *targ = new_targ;
-                }
-            })
+            if **q != *param {
+                continue;
+            }
+            let new_targ = if let Some(default) = param.default() {
+                // The default can refer to a tparam from earlier in the list.
+                Substitution::for_prefix(tparams, &args[..i]).substitute_into(default.clone())
+            } else if self.infer_with_first_use {
+                let v = Var::new(uniques);
+                self.variables.lock().insert_fresh(v, Variable::finished(q));
+                v.to_type(&self.heap)
+            } else {
+                q.as_gradual_type()
+            };
+            args[i] = new_targ;
+        }
     }
 
     /// Generate a fresh variable used to tie recursive bindings.


### PR DESCRIPTION
Summary:

Pyrefly had almost-duplicate code in `AnswersSolver::get_tparam_default` and `Solver::finish_class_targs` that did two things:

1. Replace out-of-scope legacy type variables in typevar defaults with gradual fallbacks
1. Substitute quantifieds in typevar defaults with the appropriate values.

This diff moves (1) to `validated_tparams`, so tparams are sanitized exactly once, before being stored. (2) still happens in the same places as before, but the code is much simpler now that it doesn't need to do two things at once.

Fixes https://github.com/facebook/pyrefly/issues/4298.

Reviewed By: grievejia

Differential Revision: D115350225


