### PR TITLE
Fix theme-aware constant highlighting

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -132,7 +132,9 @@
             "cursorpyright.disableLanguageServices": true,
             "editor.semanticTokenColorCustomizations": {
                 "rules": {
-                    "variable.readonly:python": "#4EC9B0"
+                    "variable.readonly:python": {
+                        "bold": true
+                    }
                 }
             },
             "windsurfPyright.disableLanguageServices": true


### PR DESCRIPTION
## Summary

- remove the hard-coded Dark+ foreground color for readonly-variable semantic tokens
- retain a color-neutral bold rule so all-caps constants remain visually distinct across themes
- keep the existing `variable.other.constant.python` TextMate scope fallback

This lets the active VS Code theme choose the constant color while preserving the visual distinction added for #1780. Light Modern and Dark Modern were both verified in isolated Extension Development Host profiles; screenshots and details are included in the review thread.

Fixes #4473

## Validation

- `npm run package`
- repository formatting/lint command from `AGENTS.md`
- JSON assertion that the readonly-variable rule is color-neutral and bold
- live Light Modern and Dark Modern extension-host checks against a locally built Pyrefly LSP
- `git diff --check`

## AI disclosure

I used an AI coding assistant to help inspect the extension configuration, implement the change, and validate the result. I manually reviewed the final diff and visual evidence.
