### PR TITLE
Fix missing override diagnostics for abstract contracts

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -3829,6 +3829,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
 
         let mut got_attribute = None;
         let mut parent_attr_found = false;
+        let mut parent_attr_requires_override = false;
         let mut parent_attr_is_from_object = false;
         let mut parent_has_any = false;
         let is_typed_dict_field = self.is_typed_dict_field(metadata.as_ref(), field_name);
@@ -3888,6 +3889,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 parent_attr_is_from_object = true;
             }
             let want_class_field = Arc::unwrap_or_clone(want_field.value);
+            parent_attr_requires_override = parent_attr_requires_override
+                || (!parent_metadata.is_protocol() && !want_class_field.is_abstract());
             if want_class_field.is_final() {
                 self.error(
                     errors,
@@ -4190,9 +4193,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
         // Check for missing @override decorator when overriding a parent attribute.
         // This error is emitted when a method overrides a parent but doesn't have @override.
+        // Implementing an abstract member or a directly inherited Protocol member is exempt.
+        // With multiple bases, any matching concrete non-Protocol member still makes this an
+        // override that requires the decorator.
         // Since this error has Severity::Ignore by default, it won't be shown unless enabled.
         if !(is_explicit_override
-            || !parent_attr_found
+            || !parent_attr_requires_override
             || parent_has_any
             || parent_attr_is_from_object && is_dunder(field_name.as_str()))
             && class_field.can_have_override_decorator()

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -1212,10 +1212,11 @@ testcase!(
 from typing import Protocol
 
 class Interface(Protocol):
-    def foo(self, x: int) -> None: ...
+    def foo(self, x: int) -> None:
+        return None
 
 class Implementation(Interface):
-    def foo(self, x: int) -> None: ...  # OK - implements a directly inherited protocol
+    def foo(self, x: int) -> None: ...  # OK - implements a directly inherited protocol member
     "#,
 );
 
@@ -1226,10 +1227,11 @@ testcase!(
 from typing import Protocol
 
 class Interface(Protocol):
-    def foo(self, x: int) -> None: ...
+    def foo(self, x: int) -> None:
+        return None
 
 class Base(Interface):
-    def foo(self, x: int) -> None: ...  # OK - implements a directly inherited protocol
+    pass
 
 class Derived(Base):
     def foo(self, x: int) -> None: ...  # E: Class member `Derived.foo` overrides a member in a parent class but is missing an `@override` decorator

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -889,7 +889,7 @@ class UseBase(UseDerived):
 // unusable: implementing a callable interface is not what the decorator documents, and the
 // demand lands on argparse actions, auth handlers and metaclasses throughout the ecosystem.
 testcase!(
-    test_missing_override_decorator_dunder_call,
+    test_missing_override_decorator_dunder_call_exemptions,
     TestEnv::new().enable_missing_override_decorator_error(),
     r#"
 from typing import Protocol
@@ -904,7 +904,7 @@ class P(Protocol):
     def __call__(self, x: int) -> None: ...
 
 class Impl(P):
-    def __call__(self, x: int) -> None: ...  # E: is missing an `@override` decorator
+    def __call__(self, x: int) -> None: ...
     "#,
 );
 
@@ -1187,6 +1187,70 @@ class Base:
 class Derived(Base):
     @override
     def foo(self, x: int) -> None: ...  # OK - has @override
+    "#,
+);
+
+testcase!(
+    test_missing_override_decorator_abstract_method,
+    TestEnv::new().enable_missing_override_decorator_error(),
+    r#"
+from abc import ABC, abstractmethod
+
+class Base(ABC):
+    @abstractmethod
+    def foo(self, x: int) -> None: ...
+
+class Derived(Base):
+    def foo(self, x: int) -> None: ...  # OK - implements an abstract method
+    "#,
+);
+
+testcase!(
+    test_missing_override_decorator_direct_protocol,
+    TestEnv::new().enable_missing_override_decorator_error(),
+    r#"
+from typing import Protocol
+
+class Interface(Protocol):
+    def foo(self, x: int) -> None: ...
+
+class Implementation(Interface):
+    def foo(self, x: int) -> None: ...  # OK - implements a directly inherited protocol
+    "#,
+);
+
+testcase!(
+    test_missing_override_decorator_indirect_protocol,
+    TestEnv::new().enable_missing_override_decorator_error(),
+    r#"
+from typing import Protocol
+
+class Interface(Protocol):
+    def foo(self, x: int) -> None: ...
+
+class Base(Interface):
+    def foo(self, x: int) -> None: ...  # OK - implements a directly inherited protocol
+
+class Derived(Base):
+    def foo(self, x: int) -> None: ...  # E: Class member `Derived.foo` overrides a member in a parent class but is missing an `@override` decorator
+    "#,
+);
+
+testcase!(
+    test_missing_override_decorator_mixed_abstract_and_concrete,
+    TestEnv::new().enable_missing_override_decorator_error(),
+    r#"
+from abc import ABC, abstractmethod
+
+class AbstractBase(ABC):
+    @abstractmethod
+    def foo(self, x: int) -> None: ...
+
+class ConcreteBase:
+    def foo(self, x: int) -> None: ...
+
+class Derived(AbstractBase, ConcreteBase):
+    def foo(self, x: int) -> None: ...  # E: Class member `Derived.foo` overrides a member in a parent class but is missing an `@override` decorator
     "#,
 );
 


### PR DESCRIPTION
# Summary

- Exempt concrete implementations of abstract methods and directly inherited Protocol members from missing-override-decorator diagnostics.
- Continue requiring the decorator when any matching direct base provides a concrete non-Protocol implementation.
- Cover direct Protocol, abstract ABC, indirect Protocol, multiple-inheritance, and callable Protocol cases.

Fixes #3987

# Test Plan

- `cargo test -p pyrefly test_missing_override_decorator -- --nocapture` (22 passed)
- `cargo test -p pyrefly 'test::class_overrides::' -- --nocapture` (124 passed)
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`
- `cargo test -p pyrefly --lib` (7820 passed, 3 ignored)

AI disclosure: I used OpenAI Codex to help inspect the codebase, implement the change, and run validation. I reviewed the final diff and test results.
