### PR TITLE
Significantly optimise checking of repeatedly-instantiated `TypedDict` objects

### DIFF
--- a/crates/pyrefly_types/src/typed_dict.rs
+++ b/crates/pyrefly_types/src/typed_dict.rs
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::sync::LazyLock;
-
 use pyrefly_derive::TypeEq;
 use pyrefly_derive::Visit;
 use pyrefly_derive::VisitMut;
@@ -107,10 +105,9 @@ pub enum TypedDict {
     Anonymous(Box<AnonymousTypedDictInner>),
 }
 
-// When we get the name of a class-based typed dict we borrow the class's name, so we need
-// a name that we can borrow for anonymous typed dicts
-// This is a lazily initialized value, Name::new normally can't be used as the RHS of a static
-pub static ANONYMOUS_TYPED_DICT: LazyLock<Name> = LazyLock::new(|| Name::new("<anonymous>"));
+// When we get the name of a class-based typed dict we borrow the class's name,
+// so we need a name that we can borrow for anonymous typed dicts.
+pub static ANONYMOUS_TYPED_DICT: Name = Name::new_static("<anonymous>");
 
 impl TypedDict {
     pub fn new(class: Class, args: TArgs) -> Self {
@@ -123,6 +120,15 @@ impl TypedDict {
 
     pub fn is_anonymous(&self) -> bool {
         matches!(self, Self::Anonymous(_))
+    }
+
+    /// Whether anything derived from this TypedDict may be memoised across calls. Generic fields
+    /// depend on the context supplying the type arguments; anonymous ones have no stable key.
+    pub fn is_context_independent(&self) -> bool {
+        match self {
+            Self::TypedDict(inner) => inner.targs().is_empty(),
+            Self::Anonymous(_) => false,
+        }
     }
 
     /// Display label for error messages: `"dict"` for anonymous TypedDicts,

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -907,8 +907,8 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         // We want to work mostly with references, but some things are taken from elsewhere,
         // so have some owners to capture them.
         let param_list_owner = Owner::new();
-        let name_owner = Owner::new();
         let type_owner = Owner::new();
+        let fields_owner = Owner::new();
 
         let error = |errors, range, kind, msg: String| {
             self.error_with_context(
@@ -965,9 +965,9 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 }
                 TypeOrExpr::Type(ty, _) => match ty {
                     Type::TypedDict(typed_dict) | Type::PartialTypedDict(typed_dict) => {
-                        for (name, field) in self.typed_dict_fields(typed_dict) {
+                        for (name, field) in self.typed_dict_fields(typed_dict).iter() {
                             if field.required {
-                                keyword_arg_names.insert(name);
+                                keyword_arg_names.insert(name.clone());
                             }
                         }
                     }
@@ -1450,22 +1450,22 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     kwparams.insert(name, (ty, NameOrigin::Param, required));
                 }
                 Param::Kwargs(name, ty) if let Some(typed_dict) = ty.unpacked_typed_dict() => {
-                    self.typed_dict_fields(typed_dict).into_iter().for_each(
-                        |(field_name, field)| {
-                            kwparams.insert(
-                                name_owner.push(field_name),
-                                (
-                                    type_owner.push(field.ty),
-                                    NameOrigin::UnpackedKwargs(name.as_ref()),
-                                    if field.required {
-                                        &Required::Required
-                                    } else {
-                                        &Required::Optional(None)
-                                    },
-                                ),
-                            );
-                        },
-                    );
+                    for (field_name, field) in
+                        fields_owner.push(self.typed_dict_fields(typed_dict)).iter()
+                    {
+                        kwparams.insert(
+                            field_name,
+                            (
+                                &field.ty,
+                                NameOrigin::UnpackedKwargs(name.as_ref()),
+                                if field.required {
+                                    &Required::Required
+                                } else {
+                                    &Required::Optional(None)
+                                },
+                            ),
+                        );
+                    }
                     if let ExtraItems::Extra(extra) = self.typed_dict_extra_items(typed_dict) {
                         kwargs = Some((name.as_ref(), Some(type_owner.push(extra.ty))))
                     } else {
@@ -1523,8 +1523,10 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                                 ),
                             );
                         }
-                        for (name, field) in self.typed_dict_fields(&typed_dict).into_iter() {
-                            let name = name_owner.push(name);
+                        for (name, field) in fields_owner
+                            .push(self.typed_dict_fields(&typed_dict))
+                            .iter()
+                        {
                             let mut hint = kwargs.as_ref().and_then(|(_, ty)| *ty);
                             if let Some((ty, _, definitely_seen)) = seen_names.get(name) {
                                 // For Required fields, the conflict is guaranteed, so report

--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -150,8 +150,8 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     ) {
         let ty = self.expr_infer(&keyword.value, errors);
         if let Type::TypedDict(typed_dict) = ty {
-            for (name, field) in self.typed_dict_fields(&typed_dict) {
-                keywords.push((name, Annotation::new_type(field.ty)));
+            for (name, field) in self.typed_dict_fields(&typed_dict).iter() {
+                keywords.push((name.clone(), Annotation::new_type(field.ty.clone())));
             }
         } else if let Some((key, _)) = self.unwrap_mapping(&ty) {
             if !self.is_subset_eq(&key, &self.heap.mk_class_type(self.stdlib.str().clone())) {

--- a/pyrefly/lib/alt/class/typed_dict.rs
+++ b/pyrefly/lib/alt/class/typed_dict.rs
@@ -62,6 +62,16 @@ use crate::types::types::OverloadType;
 use crate::types::types::TParams;
 use crate::types::types::Type;
 
+/// Why a single TypedDict field did or did not materialize. The failure modes differ
+/// only in whether `typed_dict_fields` is allowed to cache the map it built.
+enum FieldOutcome {
+    Field(TypedDictField),
+    /// The member cannot be a field (property, descriptor, no annotation).
+    PermanentlyAbsent,
+    /// Failed for a reason a later call may not hit, such as a stale class mid-update.
+    TransientFailure,
+}
+
 const CLEAR_METHOD: Name = Name::new_static("clear");
 const GET_METHOD: Name = Name::new_static("get");
 const POP_METHOD: Name = Name::new_static("pop");
@@ -210,7 +220,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         });
         // You can update a TypedDict with a subset of its items. Otherwise, all required fields must be present.
         if !has_expansion && !is_update {
-            for (key, field) in &fields {
+            for (key, field) in fields.iter() {
                 if field.required && !keys.contains(key) {
                     self.error(
                         check_errors,
@@ -245,54 +255,96 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         }
     }
 
-    fn instantiate_typed_dict_field(
+    /// Instantiates one field, classifying failure so the caller knows whether a map
+    /// missing this field is still cacheable.
+    fn try_instantiate_typed_dict_field(
         &self,
         typed_dict: &TypedDictInner,
         name: &Name,
         is_total: bool,
-    ) -> Option<TypedDictField> {
-        let member = self.get_non_synthesized_class_member(typed_dict.class_object(), name)?;
-        let instantiated_ty =
-            self.instantiate_typed_dict_field_type(typed_dict, name, member.as_ref())?;
-        let mut typed_dict_field = member.as_typed_dict_field_info(is_total)?;
-        typed_dict_field.ty = instantiated_ty;
-        Some(typed_dict_field)
+    ) -> FieldOutcome {
+        let Some(member) = self.get_non_synthesized_class_member(typed_dict.class_object(), name)
+        else {
+            // Absent member and stale class both arrive as `None`, so assume the transient
+            // case: under-caching is cheap, whereas over-caching loses a real field.
+            return FieldOutcome::TransientFailure;
+        };
+
+        // Permanent: resolves to a `NoAccess`, `Property` or `Descriptor` attribute.
+        let Some(instantiated_ty) =
+            self.instantiate_typed_dict_field_type(typed_dict, name, member.as_ref())
+        else {
+            return FieldOutcome::PermanentlyAbsent;
+        };
+
+        // Also permanent: unannotated fields/classmethods/staticmethods have no field info.
+        match member.as_typed_dict_field_info(is_total) {
+            Some(mut field) => {
+                field.ty = instantiated_ty;
+                FieldOutcome::Field(field)
+            }
+            None => FieldOutcome::PermanentlyAbsent,
+        }
     }
 
-    pub fn typed_dict_fields(&self, typed_dict: &TypedDict) -> SmallMap<Name, TypedDictField> {
-        match typed_dict {
-            TypedDict::TypedDict(inner) => {
-                let class = inner.class_object();
-                let metadata = self.get_metadata_for_class(class);
-                match metadata.typed_dict_metadata() {
-                    None => {
-                        // This may happen during incremental update where `class` is stale/outdated
-                        SmallMap::new()
-                    }
-                    Some(typed_dict_metadata) => typed_dict_metadata
-                        .fields
-                        .iter()
-                        .filter_map(|(name, is_total)| {
-                            self.instantiate_typed_dict_field(inner, name, *is_total)
-                                .map(|field| (name.clone(), field))
-                        })
-                        .collect(),
-                }
+    /// Instantiated fields for `typed_dict`, shared via `Arc` so repeat calls do not re-clone
+    /// every field type. Caching an incomplete map would make a transient failure permanent.
+    pub fn typed_dict_fields(&self, typed_dict: &TypedDict) -> Arc<SmallMap<Name, TypedDictField>> {
+        // Anonymous TypedDicts have all fields in hand, and nothing to key a cache on.
+        let inner = match typed_dict {
+            TypedDict::TypedDict(inner) => inner,
+            TypedDict::Anonymous(inner) => {
+                return Arc::new(inner.fields.iter().cloned().collect());
             }
-            TypedDict::Anonymous(inner) => inner.fields.iter().cloned().collect(),
+        };
+        let cacheable = typed_dict.is_context_independent();
+        if cacheable && let Some(hit) = self.solver().check_typed_dict_fields_cache(typed_dict) {
+            return hit;
         }
+        let metadata = self.get_metadata_for_class(inner.class_object());
+        // Absent during an incremental update where the class is stale.
+        let Some(typed_dict_metadata) = metadata.typed_dict_metadata() else {
+            return Arc::new(SmallMap::new());
+        };
+        let mut map = SmallMap::new();
+        let mut complete = true;
+        for (name, is_total) in &typed_dict_metadata.fields {
+            match self.try_instantiate_typed_dict_field(inner, name, *is_total) {
+                FieldOutcome::Field(field) => {
+                    map.insert(name.clone(), field);
+                }
+                FieldOutcome::PermanentlyAbsent => {}
+                FieldOutcome::TransientFailure => complete = false,
+            }
+        }
+        let fields = Arc::new(map);
+        if cacheable && complete {
+            self.solver()
+                .store_typed_dict_fields_cache(typed_dict, &fields, self.type_order());
+        }
+        fields
     }
 
     pub fn typed_dict_field(&self, typed_dict: &TypedDict, name: &Name) -> Option<TypedDictField> {
         match typed_dict {
             TypedDict::TypedDict(inner) => {
-                let class = inner.class_object();
-                let metadata = self.get_metadata_for_class(class);
+                // A cached map is complete, so an absent name is genuinely not a field. Never
+                // build one here: that costs more than the single lookup it would answer.
+                if typed_dict.is_context_independent()
+                    && let Some(fields) = self.solver().check_typed_dict_fields_cache(typed_dict)
+                {
+                    return fields.get(name).cloned();
+                }
+                let metadata = self.get_metadata_for_class(inner.class_object());
                 metadata
                     .typed_dict_metadata()
                     .and_then(|typed_dict_metadata| {
                         typed_dict_metadata.fields.get(name).and_then(|is_total| {
-                            self.instantiate_typed_dict_field(inner, name, *is_total)
+                            match self.try_instantiate_typed_dict_field(inner, name, *is_total) {
+                                FieldOutcome::Field(field) => Some(field),
+                                FieldOutcome::PermanentlyAbsent
+                                | FieldOutcome::TransientFailure => None,
+                            }
                         })
                     })
             }
@@ -311,9 +363,11 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         cls: &'b Class,
         fields: &'b SmallMap<Name, bool>,
     ) -> impl Iterator<Item = (&'b Name, TypedDictField)> + 'b {
+        // Unlike `typed_dict_fields`, this does not substitute type arguments: callers synthesize
+        // methods on the class itself, where there is no `TypedDictInner` to instantiate against.
         // TODO(stroxler): Look into whether we can re-wire the code so that it is not possible to
         // have the typed dict think a field exists that cannot be converted to a `TypedDictField`
-        // (this can happen for any unannotated field - e.g. a classmethod or staticmethod).
+        // (see `FieldOutcome::PermanentlyAbsent`).
         fields.iter().filter_map(|(name, is_total)| {
             self.get_non_synthesized_class_member(cls, name)
                 .and_then(|member| {
@@ -1001,14 +1055,14 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             );
         }
 
-        let annotation = match annotation {
+        let mut annotation = match annotation {
             None => {
                 return ClassField::invalid_typed_dict_field(self.heap);
             }
             Some(idx) => self.get_idx(*idx).annotation.clone(),
         };
 
-        for q in &[Qualifier::Final, Qualifier::ClassVar] {
+        for q in &[Qualifier::Final, Qualifier::ClassVar, Qualifier::InitVar] {
             if annotation.has_qualifier(q) {
                 self.error(
                     errors,
@@ -1018,6 +1072,9 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 );
             }
         }
+        // Unlike the other rejected qualifiers, `InitVar` also hides the member from the MRO walk
+        // (see `ClassField::is_init_var`), so strip it to keep the field from vanishing.
+        annotation.qualifiers.retain(|q| q != &Qualifier::InitVar);
         if annotation
             .ty
             .as_ref()

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -1435,12 +1435,12 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             if let Type::Unpack(unpack) = &ty
                 && let Type::TypedDict(typed_dict) = &**unpack
             {
-                for (name, _) in self.typed_dict_fields(typed_dict) {
+                for name in self.typed_dict_fields(typed_dict).keys() {
                     if params.iter().any(|param| {
                         matches!(
                             param,
                             Param::Pos(param_name, ..) | Param::KwOnly(param_name, ..)
-                                if param_name == &name
+                                if param_name == name
                         )
                     }) {
                         self.error(

--- a/pyrefly/lib/alt/functools.rs
+++ b/pyrefly/lib/alt/functools.rs
@@ -431,11 +431,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     let Type::TypedDict(td) = ty else {
                         return None;
                     };
-                    names.extend(
-                        self.typed_dict_fields(&td)
-                            .into_iter()
-                            .map(|(name, _)| name),
-                    );
+                    names.extend(self.typed_dict_fields(&td).keys().cloned());
                 }
             }
         }

--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -406,10 +406,11 @@ impl Transaction<'_> {
                                         "completion_typed_dict_kwargs",
                                         |solver| solver.type_order().typed_dict_fields(typed_dict),
                                     )
+                                    .as_deref()
                                     .into_iter()
                                     .flatten()
                                 {
-                                    push_kwarg_completion(&name, &field.ty, &mut seen, completions);
+                                    push_kwarg_completion(name, &field.ty, &mut seen, completions);
                                 }
                             }
                             Param::Varargs(None, _)

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -80,6 +80,7 @@ use crate::types::simplify::simplify_tuples_and_distribute_unpacking;
 use crate::types::simplify::unions;
 use crate::types::simplify::unions_with_literals;
 use crate::types::typed_dict::TypedDict;
+use crate::types::typed_dict::TypedDictField;
 use crate::types::types::Substitution;
 use crate::types::types::TParams;
 use crate::types::types::Type;
@@ -509,8 +510,11 @@ pub struct Solver {
     /// soundness across different subset contexts.
     protocol_cache: Mutex<HashMap<(Type, Type), Result<(), SubsetError>>>,
     /// Cross-call cache for TypedDict subset results.
-    /// Like protocol_cache, only caches Var-free types.
+    /// Like `protocol_cache`, but only caches Var-free types.
     typed_dict_cache: Mutex<HashMap<(TypedDict, TypedDict), Result<(), SubsetError>>>,
+    /// Cross-call cache for instantiated TypedDict field maps.
+    /// Like `protocol_cache`, but only caches Var-free TypedDicts.
+    typed_dict_fields_cache: Mutex<HashMap<TypedDict, Arc<SmallMap<Name, TypedDictField>>>>,
     pub infer_with_first_use: bool,
     pub check_all_matches: bool,
     pub heap: TypeHeap,
@@ -585,6 +589,7 @@ impl Solver {
             instantiation_errors: Default::default(),
             protocol_cache: Default::default(),
             typed_dict_cache: Default::default(),
+            typed_dict_fields_cache: Default::default(),
             infer_with_first_use,
             check_all_matches,
             heap: TypeHeap::new(),
@@ -598,6 +603,12 @@ impl Solver {
 
     pub fn recurse<'a>(&self, var: Var, recurser: &'a VarRecurser) -> Option<Guard<'a, Var>> {
         self.variables.lock().recurse(var, recurser)
+    }
+
+    /// Whether a result computed now may be stored in one of the caches above. SCC-local answers
+    /// are provisional until the SCC converges: they may *use* cached results, but not store them.
+    fn can_cache<Ans: LookupAnswer>(type_order: TypeOrder<'_, Ans>) -> bool {
+        !type_order.has_active_scc()
     }
 
     /// Look up a cached protocol conformance result.
@@ -616,14 +627,11 @@ impl Solver {
         result: &Result<(), SubsetError>,
         type_order: TypeOrder<'_, Ans>,
     ) {
-        // SCC-local answers are provisional until the SCC converges. They may use
-        // stable cached results, but must not publish results to a persistent cache.
-        if type_order.has_active_scc() {
-            return;
+        if Self::can_cache(type_order) {
+            self.protocol_cache
+                .lock()
+                .insert((got.clone(), want.clone()), result.clone());
         }
-        self.protocol_cache
-            .lock()
-            .insert((got.clone(), want.clone()), result.clone());
     }
 
     pub fn check_typed_dict_cache(
@@ -644,14 +652,41 @@ impl Solver {
         result: &Result<(), SubsetError>,
         type_order: TypeOrder<'_, Ans>,
     ) {
-        // SCC-local answers are provisional until the SCC converges. They may use
-        // stable cached results, but must not publish results to a persistent cache.
-        if type_order.has_active_scc() {
-            return;
+        if Self::can_cache(type_order) {
+            self.typed_dict_cache
+                .lock()
+                .insert((got.clone(), want.clone()), result.clone());
         }
-        self.typed_dict_cache
-            .lock()
-            .insert((got.clone(), want.clone()), result.clone());
+    }
+
+    pub fn check_typed_dict_fields_cache(
+        &self,
+        td: &TypedDict,
+    ) -> Option<Arc<SmallMap<Name, TypedDictField>>> {
+        self.typed_dict_fields_cache.lock().get(td).cloned()
+    }
+
+    pub fn store_typed_dict_fields_cache<Ans: LookupAnswer>(
+        &self,
+        td: &TypedDict,
+        fields: &Arc<SmallMap<Name, TypedDictField>>,
+        type_order: TypeOrder<'_, Ans>,
+    ) {
+        if Self::can_cache(type_order) {
+            debug_assert!(
+                td.is_context_independent(),
+                "store_typed_dict_fields_cache called with generic or anonymous TypedDict"
+            );
+            debug_assert!(
+                !fields
+                    .values()
+                    .any(|field| field.ty.any(|ty| matches!(ty, Type::Var(_)))),
+                "cached TypedDict field map contains a Var, so it is not context-independent"
+            );
+            self.typed_dict_fields_cache
+                .lock()
+                .insert(td.clone(), fields.clone());
+        }
     }
 
     /// Force all non-recursive Vars in `vars`.

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -76,6 +76,9 @@ use crate::types::types::Forallable;
 use crate::types::types::TArgs;
 use crate::types::types::Type;
 
+/// Stands in for a TypedDict's `extra_items` in field-mismatch errors, which name a field.
+const EXTRA_ITEMS_FIELD: Name = Name::new_static("<extra_items>");
+
 /// Extract a `TypeAliasData` reference from a `Type` that wraps one,
 /// either directly as `Type::TypeAlias` or inside `Type::Forall`.
 fn as_type_alias(ty: &Type) -> Option<&TypeAliasData> {
@@ -89,21 +92,6 @@ fn as_type_alias(ty: &Type) -> Option<&TypeAliasData> {
             }
         }
         _ => None,
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-enum TypedDictFieldId {
-    Name(Name),
-    ExtraItems,
-}
-
-impl TypedDictFieldId {
-    fn display_name(&self) -> Name {
-        match self {
-            TypedDictFieldId::Name(name) => name.clone(),
-            TypedDictFieldId::ExtraItems => Name::from("<extra_items>"),
-        }
     }
 }
 
@@ -1189,14 +1177,6 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
         }
     }
 
-    fn get_typed_dict_fields(&self, td: &TypedDict) -> SmallMap<TypedDictFieldId, TypedDictField> {
-        self.type_order
-            .typed_dict_fields(td)
-            .into_iter()
-            .map(|(name, field)| (TypedDictFieldId::Name(name), field))
-            .collect()
-    }
-
     fn is_subset_typed_dict_field(
         &mut self,
         got: (&Name, &TypedDictField),
@@ -1269,7 +1249,7 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
         got: &TypedDict,
         want: &TypedDict,
     ) -> Result<(), SubsetError> {
-        let cacheable = Self::typed_dict_is_cacheable(got) && Self::typed_dict_is_cacheable(want);
+        let cacheable = got.is_context_independent() && want.is_context_independent();
         if cacheable && let Some(result) = self.solver.check_typed_dict_cache(got, want) {
             return result;
         }
@@ -1293,15 +1273,6 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
         res
     }
 
-    /// Only cache non-generic class-based TypedDicts. Generic TypedDicts could
-    /// contain Vars whose meaning depends on the subset context.
-    fn typed_dict_is_cacheable(td: &TypedDict) -> bool {
-        match td {
-            TypedDict::TypedDict(inner) => inner.targs().is_empty(),
-            TypedDict::Anonymous(_) => false,
-        }
-    }
-
     fn is_subset_typed_dict_inner(
         &mut self,
         got: &TypedDict,
@@ -1309,66 +1280,55 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
     ) -> Result<(), SubsetError> {
         let got_name = got.name();
         let want_name = want.name();
-        let (got_fields, want_fields) = {
-            let mut got_fields = self.get_typed_dict_fields(got);
-            let mut want_fields = self.get_typed_dict_fields(want);
-            let got_extra_items = self.type_order.typed_dict_extra_items(got);
-            let want_extra_items = self.type_order.typed_dict_extra_items(want);
-            if [&got_extra_items, &want_extra_items]
-                .iter()
-                .any(|extra| !matches!(extra, ExtraItems::Default))
-            {
-                // If either TypedDict has extra_items restrictions, add extra_items as a
-                // non-required pseudo-field.
-                got_fields.insert(
-                    TypedDictFieldId::ExtraItems,
-                    self.typed_dict_extra_items_field(got_extra_items),
-                );
-                want_fields.insert(
-                    TypedDictFieldId::ExtraItems,
-                    self.typed_dict_extra_items_field(want_extra_items),
-                );
-            }
-            (got_fields, want_fields)
-        };
+        let got_fields = self.type_order.typed_dict_fields(got);
+        let want_fields = self.type_order.typed_dict_fields(want);
+        let got_extra_items = self.type_order.typed_dict_extra_items(got);
+        let want_extra_items = self.type_order.typed_dict_extra_items(want);
+
+        // If either side restricts extra items, both get an `extra_items` pseudo-field. It rides
+        // beside the field maps rather than inside them, so those maps stay shared with the cache.
+        let restricts_extra_items = !matches!(got_extra_items, ExtraItems::Default)
+            || !matches!(want_extra_items, ExtraItems::Default);
+        let extra = restricts_extra_items.then(|| {
+            (
+                self.typed_dict_extra_items_field(got_extra_items),
+                self.typed_dict_extra_items_field(want_extra_items),
+            )
+        });
         all(want_fields.iter(), |(k, want_v)| {
-            let field_name = k.display_name();
             got_fields
                 .get(k)
-                .or_else(|| got_fields.get(&TypedDictFieldId::ExtraItems))
+                .or(extra.as_ref().map(|(got_v, _)| got_v))
                 .map_or(
                     Err(SubsetError::TypedDict(Box::new(
                         TypedDictSubsetError::MissingField {
                             got: got_name.clone(),
                             want: want_name.clone(),
-                            field: field_name.clone(),
+                            field: k.clone(),
                         },
                     ))),
                     |got_v| {
-                        self.is_subset_typed_dict_field(
-                            (got_name, got_v),
-                            (want_name, want_v),
-                            &field_name,
-                        )
+                        self.is_subset_typed_dict_field((got_name, got_v), (want_name, want_v), k)
                     },
                 )
         })?;
-        want_fields
-            .get(&TypedDictFieldId::ExtraItems)
-            .map_or(Ok(()), |want_v| {
-                // Make sure all fields in `got` that aren't on `want` match the latter's `extra_items` type.
-                all(got_fields.iter(), |(k, got_v)| {
-                    if want_fields.contains_key(k) {
-                        Ok(())
-                    } else {
-                        self.is_subset_typed_dict_field(
-                            (got_name, got_v),
-                            (want_name, want_v),
-                            &k.display_name(),
-                        )
-                    }
-                })
-            })
+        if let Some((got_v, want_v)) = &extra {
+            // `extra_items` is not a member of `got_fields`, so it needs its own comparison.
+            self.is_subset_typed_dict_field(
+                (got_name, got_v),
+                (want_name, want_v),
+                &EXTRA_ITEMS_FIELD,
+            )?;
+            // Every field in `got` that `want` does not name must match want's extra_items type.
+            all(got_fields.iter(), |(k, got_v)| {
+                if want_fields.contains_key(k) {
+                    Ok(())
+                } else {
+                    self.is_subset_typed_dict_field((got_name, got_v), (want_name, want_v), k)
+                }
+            })?;
+        }
+        Ok(())
     }
 
     fn is_subset_partial_typed_dict_field(

--- a/pyrefly/lib/solver/type_order.rs
+++ b/pyrefly/lib/solver/type_order.rs
@@ -6,6 +6,7 @@
  */
 
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use dupe::Clone_;
 use dupe::Copy_;
@@ -150,7 +151,7 @@ impl<'solver, Ans: LookupAnswer> TypeOrder<'solver, Ans> {
         self.0.promote_silently(cls)
     }
 
-    pub fn typed_dict_fields(self, typed_dict: &TypedDict) -> SmallMap<Name, TypedDictField> {
+    pub fn typed_dict_fields(self, typed_dict: &TypedDict) -> Arc<SmallMap<Name, TypedDictField>> {
         self.0.typed_dict_fields(typed_dict)
     }
 

--- a/pyrefly/lib/state/lsp/dict_completions.rs
+++ b/pyrefly/lib/state/lsp/dict_completions.rs
@@ -171,8 +171,8 @@ impl<'a> Transaction<'a> {
                 let fields = solver
                     .type_order()
                     .typed_dict_fields(typed_dict)
-                    .into_iter()
-                    .map(|(name, field)| (name.to_string(), field.ty))
+                    .iter()
+                    .map(|(name, field)| (name.to_string(), field.ty.clone()))
                     .collect();
                 Some((member, fields))
             })
@@ -600,7 +600,7 @@ impl<'a> Transaction<'a> {
                     Type::TypedDict(td) | Type::PartialTypedDict(td) => td,
                     _ => continue,
                 };
-                for (name, field) in solver.type_order().typed_dict_fields(&typed_dict) {
+                for (name, field) in solver.type_order().typed_dict_fields(&typed_dict).iter() {
                     map.entry(name.to_string())
                         .or_insert_with(|| field.ty.clone());
                 }

--- a/pyrefly/lib/test/incremental.rs
+++ b/pyrefly/lib/test/incremental.rs
@@ -2823,3 +2823,46 @@ def first(shapes: IntTuple) -> IntTuple:
     changed.check_recompute(&["consumer", "helpers", "main"]);
     changed.check_errors();
 }
+
+// The cached field map is keyed without a version, so editing a field's type must invalidate it.
+#[test]
+fn test_typed_dict_field_type_edit_invalidates() {
+    let mut i = Incremental::new();
+    i.set(
+        "foo",
+        r#"
+from typing import TypedDict
+class Coord(TypedDict):
+    x: int
+"#,
+    );
+    i.set(
+        "main",
+        r#"
+from foo import Coord
+def f() -> int:
+    c: Coord = {"x": 1}
+    return c["x"]
+"#,
+    );
+    i.check(&["main"], &["foo", "main"]);
+
+    i.set(
+        "foo",
+        r#"
+from typing import TypedDict
+class Coord(TypedDict):
+    x: str
+"#,
+    );
+    i.set(
+        "main",
+        r#"
+from foo import Coord
+def f() -> int:
+    c: Coord = {"x": "hello"}
+    return c["x"]  # E: Returned type `str` is not assignable to declared return type `int`
+"#,
+    );
+    i.check(&["main"], &["foo", "main"]);
+}

--- a/pyrefly/lib/test/typed_dict.rs
+++ b/pyrefly/lib/test/typed_dict.rs
@@ -2909,3 +2909,64 @@ def test(x: T) -> object:
     return x.get("name")
     "#,
 );
+
+testcase!(
+    test_recursive_typed_dict_fields_resolve_repeatedly,
+    r#"
+from typing import TypedDict, assert_type
+
+class Node(TypedDict):
+    value: int
+    child: "Node | None"
+
+def f() -> None:
+    n1: Node = {"value": 1, "child": None}
+    n2: Node = {"value": 2, "child": None}
+    assert_type(n1["value"], int)
+    assert_type(n2["child"], Node | None)
+"#,
+);
+
+testcase!(
+    test_typed_dict_field_shadowed_by_property_is_cacheable,
+    r#"
+from typing import TypedDict, assert_type
+
+class Base(TypedDict):
+    x: int
+    y: str
+
+class Mixin:
+    @property
+    def x(self) -> int: ...
+
+class Derived(Mixin, Base):  # E: `Mixin` is not a typed dictionary
+    pass
+
+def f() -> None:
+    d1: Derived = {"x": 1, "y": "a"}  # E: Key `x` is not defined in TypedDict `Derived`
+    d2: Derived = {"x": 2, "y": "b"}  # E: Key `x` is not defined in TypedDict `Derived`
+    assert_type(d1["y"], str)
+    assert_type(d2["y"], str)
+"#,
+);
+
+// `InitVar` is stripped as well as rejected, so `x` is still a field. Left in place it would
+// vanish from the field map, and the map would stay uncacheable for the `Solver`'s lifetime.
+testcase!(
+    test_typed_dict_init_var_member_rejected,
+    r#"
+from typing import TypedDict, assert_type
+from dataclasses import InitVar
+
+class TD(TypedDict):
+    x: InitVar[int]  # E: `InitVar` may not be used for TypedDict members
+    y: str
+
+def f(a: TD, b: TD) -> None:
+    assert_type(a["x"], int)
+    assert_type(a["y"], str)
+    assert_type(b["x"], int)
+    assert_type(b["y"], str)
+"#,
+);


### PR DESCRIPTION
# Summary

Identified a somewhat niche hotspot relating to `TypedDict`; with this PR in place, type-checking `pydantic` gets **~2x faster** (measured ~60% less CPU time), and two other packages get a ~6-10% improvement. Pretty much a no-op otherwise.

### Problem

Instantiating `TypedDict` fields rebuilt a full `SmallMap` of field types on every call, with each rebuild deep-copying every field type; callers that only iterate paid that cost repeatedly.

### Solution

* Cache the instantiated field map per `Solver`, in such a way that repeat calls share one allocation (instead of re-cloning each field's type tree).
* Only cache what is context-independent (mirrors the existing `protocol_cache` rule of caching only Var-free types).
* Never cache an _incomplete_ map (field lookup failures are now classified: see `FieldOutcome`).
* Fixed `InitVar` on a `TypedDict` member (it's not valid and blocked caching).
* Don't clone `ClassField` just to read it.

# Test Plan

All existing unit tests pass without modification.
Several new unit tests added.

# Benchmarks[^1]

**Huge** positive impact on `pydantic` (the `pydantic_core.core_schema` module is an absolute _wall_ of `TypedDict`) 🚀 

The speedup tracks with repeated instantiation of the same `TypedDict`, not the overall `TypedDict` count, and it seems that's not a common pattern; only a couple of packages show much benefit (aside from `pydantic` the only other solid gains I spotted are for `numpy` and `narwhals`, which both get a bit faster).

### CPU time (user+sys)

My machine was a bit contended, so I recorded CPU-time instead of wall-clock as it was much more stable (measurements are standard multithreaded runs):

| project | before | after | Δ |
|:---|---:|---:|---:|
| pydantic |  3.71s | 1.53s | **−58.7%** |
| numpy | 12.01s | 11.08s | **−6.9%** |
| narwhals[^2] | 2.36s | 2.18s | **−7.9%** |

[^1]: Test machine: Apple Silicon M3 Max (16 cores).
[^2]: @MarcoGorelli, "you're welcome" 🤣 