### PR TITLE
Track splatted variadic tuple shape during call matching

### DIFF
--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -369,8 +369,27 @@ impl<'a> CallArg<'a> {
                     let tys = fixed_tys.into_map(|tys| solver.unions(tys));
                     CallArgPreEval::Fixed(tys, 0)
                 } else {
-                    let ty = solver.get_produced_type(iterables);
-                    CallArgPreEval::Star(ty, false)
+                    // A lone unpacked tuple has fixed ends at known positions, so keep
+                    // its shape. A union of iterables has no single shape to keep.
+                    let (prefix, middle, suffix) = if let [
+                        Iterable::Unpacked {
+                            prefix,
+                            middle,
+                            suffix,
+                        },
+                    ] = iterables.as_slice()
+                    {
+                        (prefix.clone(), middle.clone(), suffix.clone())
+                    } else {
+                        (Vec::new(), solver.get_produced_type(iterables), Vec::new())
+                    };
+                    CallArgPreEval::Star {
+                        prefix,
+                        middle,
+                        suffix,
+                        consumed: 0,
+                        done: false,
+                    }
                 }
             }
         }
@@ -383,20 +402,46 @@ impl<'a> CallArg<'a> {
 enum CallArgPreEval<'a> {
     Type(&'a Type, bool),
     Expr(&'a Expr, bool),
-    Star(Type, bool),
+    Star {
+        prefix: Vec<Type>,
+        middle: Type,
+        suffix: Vec<Type>,
+        consumed: usize,
+        done: bool,
+    },
     Fixed(Vec<Type>, usize),
 }
 
 impl CallArgPreEval<'_> {
     fn step(&self) -> bool {
         match self {
-            Self::Type(_, done) | Self::Expr(_, done) | Self::Star(_, done) => !*done,
+            Self::Type(_, done) | Self::Expr(_, done) | Self::Star { done, .. } => !*done,
             Self::Fixed(tys, i) => *i < tys.len(),
         }
     }
 
     fn is_star(&self) -> bool {
-        matches!(self, Self::Star(..))
+        matches!(self, Self::Star { .. })
+    }
+
+    /// The type a splat offers a parameter: an exact prefix element, or a union past
+    /// the prefix. `absorb_all` unions the whole remainder, for a variadic parameter.
+    fn star_element<Ans: LookupAnswer>(
+        solver: &AnswersSolver<Ans>,
+        prefix: &[Type],
+        middle: &Type,
+        suffix: &[Type],
+        consumed: usize,
+        absorb_all: bool,
+    ) -> Type {
+        if !absorb_all && let Some(ty) = prefix.get(consumed) {
+            return ty.clone();
+        }
+        let rest = if absorb_all { consumed } else { prefix.len() };
+        let mut tys = prefix[rest..].to_vec();
+        tys.push(middle.clone());
+        tys.extend(suffix.iter().cloned());
+        solver.unions(tys)
     }
 
     fn inferred_type<Ans: LookupAnswer>(
@@ -407,7 +452,13 @@ impl CallArgPreEval<'_> {
         match self {
             Self::Type(ty, _) => (*ty).clone(),
             Self::Expr(expr, _) => solver.expr_infer(expr, arg_errors),
-            Self::Star(ty, _) => ty.clone(),
+            Self::Star {
+                prefix,
+                middle,
+                suffix,
+                consumed,
+                ..
+            } => Self::star_element(solver, prefix, middle, suffix, *consumed, false),
             Self::Fixed(tys, idx) => tys[*idx].clone(),
         }
     }
@@ -488,15 +539,27 @@ impl CallArgPreEval<'_> {
                 solver.maybe_error_unknown_argument_type(&ty, range, arg_errors);
                 Some(ty)
             }
-            Self::Star(ty, done) => {
+            Self::Star {
+                prefix,
+                middle,
+                suffix,
+                consumed,
+                done,
+            } => {
+                let ty = Self::star_element(solver, prefix, middle, suffix, *consumed, vararg);
+                if !vararg && *consumed < prefix.len() {
+                    // A prefix element is consumed once matched; the variadic tail
+                    // is not, since it stays on offer to every later parameter.
+                    *consumed += 1;
+                }
                 *done = vararg;
                 solver.check_type_with_options(
-                    ty,
+                    &ty,
                     hint,
                     range,
                     TypeCheckOptions::new(call_errors, tcc).with_call_context(call_context),
                 );
-                Some(ty.clone())
+                Some(ty)
             }
             Self::Fixed(tys, i) => {
                 let arg_ty = tys[*i].clone();
@@ -517,7 +580,7 @@ impl CallArgPreEval<'_> {
     // Intended for arguments matched to unpack-annotated *args, which are typechecked separately later
     fn post_skip(&mut self) {
         match self {
-            Self::Type(_, done) | Self::Expr(_, done) | Self::Star(_, done) => {
+            Self::Type(_, done) | Self::Expr(_, done) | Self::Star { done, .. } => {
                 *done = true;
             }
             Self::Fixed(_, i) => {
@@ -529,7 +592,7 @@ impl CallArgPreEval<'_> {
     // Similar to post_skip but it skips to the end of any fixed length arguments.
     fn mark_done(&mut self) {
         match self {
-            Self::Type(_, done) | Self::Expr(_, done) | Self::Star(_, done) => {
+            Self::Type(_, done) | Self::Expr(_, done) | Self::Star { done, .. } => {
                 *done = true;
             }
             Self::Fixed(tys, i) => {
@@ -1028,12 +1091,25 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             suffix.push(tys[idx].clone());
                         }
                     }
-                    CallArgPreEval::Star(ty, _) => {
-                        if !middle.is_empty() {
+                    CallArgPreEval::Star {
+                        prefix: star_prefix,
+                        middle: star_middle,
+                        suffix: star_suffix,
+                        consumed,
+                        ..
+                    } => {
+                        // Only elements landing between two variadic portions lose
+                        // their position; the rest stay in the prefix or suffix.
+                        let unmatched_prefix = star_prefix.into_iter().skip(consumed);
+                        if middle.is_empty() {
+                            prefix.extend(unmatched_prefix);
+                        } else {
                             middle.extend(suffix);
                             suffix = Vec::new();
+                            middle.extend(unmatched_prefix);
                         }
-                        middle.push(ty);
+                        middle.push(star_middle);
+                        suffix.extend(star_suffix);
                     }
                 }
             }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -347,6 +347,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Tuple::Unbounded(elt) => vec![Iterable::OfType(*elt)],
             Tuple::Unpacked(unpacked) => {
                 let (prefix, middle, suffix) = *unpacked;
+                // Note: folding in the ends does not double-count them: an unpacked shape's
+                // middle is always gradual, so the union will collapse to it either way.
                 vec![Iterable::Unpacked {
                     middle: self.int_tuple_unpacked_element_type(&prefix, &middle, &suffix),
                     prefix,

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -654,6 +654,109 @@ test2(1, *(2, 3), *(4, "5"))  # E: Unpacked argument `tuple[Literal[1], Literal[
 "#,
 );
 
+// Splatting a tuple with a variadic middle preserves the positions of its fixed ends.
+// See https://github.com/facebook/pyrefly/issues/4482
+testcase!(
+    test_splat_unpacked_args_shape,
+    r#"
+class P: ...
+class V: ...
+class S: ...
+
+def f(a1: P, a2: P, /, *args: *tuple[*tuple[V, ...], S, S]) -> None: ...
+
+def test(
+    p: P,
+    v: tuple[V, ...],
+    s: S,
+    vs: tuple[*tuple[V, ...], S],
+    pv: tuple[P, *tuple[V, ...]],
+) -> None:
+    # Reassembles to exactly the `*args` type.
+    f(p, p, *vs, s)
+    # `a2` sees the prefix element `P`, not `P | V`.
+    f(p, *pv, s, s)
+    # All 45 ways to parenthesize the arguments are equivalent.
+    f(p, p, *v, s, s)
+    f(p, p, *v, *(s, s))
+    f(p, p, *(*v, s), s)
+    f(p, p, *(*v, s, s))
+    f(p, p, *(*v, *(s, s)))
+    f(p, p, *(*(*v, s), s))
+    f(p, *(p, *v), s, s)
+    f(p, *(p, *v), *(s, s))
+    f(p, *(p, *v, s), s)
+    f(p, *(p, *(*v, s)), s)
+    f(p, *(*(p, *v), s), s)
+    f(p, *(p, *v, s, s))
+    f(p, *(p, *v, *(s, s)))
+    f(p, *(p, *(*v, s), s))
+    f(p, *(p, *(*v, s, s)))
+    f(p, *(p, *(*v, *(s, s))))
+    f(p, *(p, *(*(*v, s), s)))
+    f(p, *(*(p, *v), s, s))
+    f(p, *(*(p, *v), *(s, s)))
+    f(p, *(*(p, *v, s), s))
+    f(p, *(*(p, *(*v, s)), s))
+    f(p, *(*(*(p, *v), s), s))
+    f(*(p, p), *v, s, s)
+    f(*(p, p), *v, *(s, s))
+    f(*(p, p), *(*v, s), s)
+    f(*(p, p), *(*v, s, s))
+    f(*(p, p), *(*v, *(s, s)))
+    f(*(p, p), *(*(*v, s), s))
+    f(*(p, p, *v), s, s)
+    f(*(p, *(p, *v)), s, s)
+    f(*(*(p, p), *v), s, s)
+    f(*(p, p, *v), *(s, s))
+    f(*(p, *(p, *v)), *(s, s))
+    f(*(*(p, p), *v), *(s, s))
+    f(*(p, p, *v, s), s)
+    f(*(p, p, *(*v, s)), s)
+    f(*(p, *(p, *v), s), s)
+    f(*(p, *(p, *v, s)), s)
+    f(*(p, *(p, *(*v, s))), s)
+    f(*(p, *(*(p, *v), s)), s)
+    f(*(*(p, p), *v, s), s)
+    f(*(*(p, p), *(*v, s)), s)
+    f(*(*(p, p, *v), s), s)
+    f(*(*(p, *(p, *v)), s), s)
+    f(*(*(*(p, p), *v), s), s)
+"#,
+);
+
+// Against ordinary positional parameters, only positions past the prefix widen.
+testcase!(
+    test_splat_unbounded_middle_against_positional,
+    r#"
+def f(a: int, b: str, c: bytes) -> None: ...
+
+def test(
+    prefix: tuple[int, *tuple[str, ...]],
+    suffix: tuple[*tuple[int, ...], bytes],
+) -> None:
+    # `a` gets the prefix element exactly; `b` and `c` draw from the middle.
+    f(*prefix)  # E: Argument `str` is not assignable to parameter `c` with type `bytes`
+    # No prefix, so which parameter the `bytes` reaches depends on the middle's length.
+    f(*suffix)  # E: Argument `bytes | int` is not assignable to parameter `a` with type `int` # E: Argument `bytes | int` is not assignable to parameter `b` with type `str` # E: Argument `bytes | int` is not assignable to parameter `c` with type `bytes`
+"#,
+);
+
+// Variadic parameter takes the whole remainder, so every element must be assignable to it.
+testcase!(
+    test_splat_variadic_checks_whole_remainder,
+    r#"
+def f(*args: int) -> None: ...
+
+def test(
+    mixed: tuple[int, *tuple[str, ...]],
+    none: tuple[str, *tuple[bytes, ...]],
+) -> None:
+    f(*mixed)  # E: Argument `int | str` is not assignable to parameter `*args` with type `int`
+    f(*none)  # E: Argument `bytes | str` is not assignable to parameter `*args` with type `int`
+"#,
+);
+
 testcase!(
     test_splat_union,
     r#"

--- a/pyrefly/lib/test/shape_dsl.rs
+++ b/pyrefly/lib/test/shape_dsl.rs
@@ -8,9 +8,11 @@
 use std::path::PathBuf;
 
 use pyrefly_python::symbol_kind::SymbolKind;
+use pyrefly_types::dimension::is_gradual_size;
 use pyrefly_types::function::FunctionKind;
 use pyrefly_types::quantified::Quantified;
 use pyrefly_types::quantified::QuantifiedKind;
+use pyrefly_types::tuple::Tuple;
 use pyrefly_types::type_level_dsl::TypeShapeDslDomain;
 use pyrefly_types::type_var::Restriction;
 use ruff_python_ast::name::Name;
@@ -4634,3 +4636,48 @@ def f(shapeless: Array[IntTuple, int], concrete: Array[[3], int]) -> None:
     assert_type(concrete, Array[[3], int])
 "#,
 );
+
+/// Pins the invariant `iterate_int_tuple` relies on: an unpacked shape's middle
+/// is always gradual, because a concrete one flattens into the prefix.
+#[test]
+fn test_int_tuple_unpacked_middle_is_always_gradual() {
+    let mut env = shaped_array_env();
+    env.add(
+        "main",
+        r#"
+from shape_extensions import Elements, IntTuple, shaped_array
+
+@shaped_array(shape="Shape")
+class Array[Shape: IntTuple, DType]: ...
+
+def variadic[S: IntTuple](x: Array[[2, *Elements[S], 3], int]) -> IntTuple[2, *Elements[S], 3]: ...
+def make() -> Array[[2, 4, 5, 3], int]: ...
+
+concrete = variadic(make())
+symbolic: IntTuple[2, *Elements[IntTuple], 3]
+"#,
+    );
+    let (state, handle) = env.to_state();
+    let main = handle("main");
+    let solutions = state.transaction().get_solutions(&main).unwrap();
+    for name in ["concrete", "symbolic"] {
+        let ty = &**solutions.get(&KeyExport(Name::new(name)));
+        let Type::IntTuple(shape) = ty else {
+            panic!("expected `{name}` to solve to an `IntTuple`, got `{ty}`");
+        };
+        match shape.to_tuple() {
+            // Flattened to a fixed length, so `iterate_int_tuple` never sees a middle.
+            Tuple::Concrete(_) | Tuple::Unbounded(_) => {}
+            Tuple::Unpacked(unpacked) => {
+                let (_, middle, _) = &*unpacked;
+                assert!(
+                    matches!(middle, Type::IntTuple(s) if s.is_shapeless())
+                        || matches!(middle, Type::Tuple(Tuple::Unbounded(elt))
+                            if elt.is_any() || is_gradual_size(elt)),
+                    "`{name}` has non-gradual unpacked middle `{middle}`; folding the \
+                     ends into the element type would now double-count them"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary

Fixes #4482.

### Overview

* Calls to a function annotated `*args: *tuple[*tuple[V, ...], S, S]` were rejected, even when the arguments matched.

* `pyrefly` already knows how to track positions through a splat, it just needed some additional wiring-up for `CallArgPreEval::Star`.

### Solution

Give `Star` the same treatment `Fixed` already has. So, it now carries the _shape_ (`prefix`, `middle`, `suffix`) along with `consumed`, which has much the same role as `Fixed`'s index. Note that it isn't _exactly_ the same as a parameter consumes exactly one `Fixed` element, but a variadic parameter absorbs the remainder of a splat.

# Test Plan

All existing unit tests pass, and several new unit tests were added (including the one given in the original Issue, which has been added "as-is" 👍)
