### PR TITLE
fix diagnostic squiggles for unsaved files (#4498)

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -1730,9 +1730,13 @@ impl Server {
             } else {
                 let path = path.absolutize();
                 let version = version_info.get(&path).copied();
-                match Url::from_file_path(&path) {
-                    Ok(uri) => self.publish_diagnostics_for_uri(uri, diags, version, source),
-                    Err(_) => eprint!("Unable to convert path to uri: {path:?}"),
+                if let Some(uri) = self.unsaved_file_tracker.uri_for_path(&path) {
+                    self.publish_diagnostics_for_uri(uri, diags, version, source)
+                } else {
+                    match Url::from_file_path(&path) {
+                        Ok(uri) => self.publish_diagnostics_for_uri(uri, diags, version, source),
+                        Err(_) => eprint!("Unable to convert path to uri: {path:?}"),
+                    }
                 }
             }
         }

--- a/pyrefly/lib/lsp/non_wasm/unsaved_file_tracker.rs
+++ b/pyrefly/lib/lsp/non_wasm/unsaved_file_tracker.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 
 use lsp_types::Url;
+use pyrefly_util::absolutize::Absolutize as _;
 use pyrefly_util::lock::RwLock;
 
 const VIRTUAL_DOCUMENT_ROOT: &str = "__pyrefly_virtual__";
@@ -81,13 +82,18 @@ impl UnsavedFileTracker {
             file_name.push_str(".ipynb");
         }
         path.push(file_name);
-
+        // Absolutize file path before storing
+        let path = path.absolutize();
         self.remember_uri_path(uri, &path);
         path
     }
 
     pub fn path_for_uri(&self, uri: &Url) -> Option<PathBuf> {
         self.uri_to_path.read().get(uri).cloned()
+    }
+
+    pub fn uri_for_path(&self, path: &Path) -> Option<Url> {
+        self.open_file_uris.read().get(path).cloned()
     }
 
     pub fn forget_uri_path(&self, uri: &Url) -> Option<PathBuf> {

--- a/pyrefly/lib/test/lsp/lsp_interaction/unsaved_file.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/unsaved_file.rs
@@ -43,6 +43,30 @@ foo()
 }
 
 #[test]
+fn test_publish_diagnostics_preserves_unsaved_file_uri() {
+    let interaction = LspInteraction::new();
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let uri = Url::parse("untitled:Untitled-Diagnostics").unwrap();
+    interaction
+        .client
+        .did_open_uri(&uri, "python", "x: str = 1\n");
+    interaction
+        .client
+        .expect_publish_diagnostics_uri(&uri, 1)
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
 fn test_completion_for_unsaved_file() {
     let interaction = LspInteraction::new();
     interaction


### PR DESCRIPTION
Summary:

fixes https://github.com/facebook/pyrefly/issues/4497

when working on an unsaved file, previously squiggles didn't show up in the file itself, only in the problems panel.

Differential Revision: D115468974


