### PR TITLE
Do not coalesce LSP responses as mutations

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/queue.rs
+++ b/pyrefly/lib/lsp/non_wasm/queue.rs
@@ -96,8 +96,8 @@ enum LspEventKind {
     Priority,
     /// An event that makes work triggered by preceding mutations redundant.
     Mutation,
-    /// A FIFO event that does not make preceding mutation work redundant.
-    NonMutation,
+    /// A normal-priority event that does not count as a mutation for coalescing.
+    Query,
 }
 
 impl LspEvent {
@@ -130,7 +130,7 @@ impl LspEvent {
             | Self::DidChangeNotebookDocument(_)
             | Self::InvalidateConfigFind
             | Self::Exit => LspEventKind::Mutation,
-            Self::LspResponse(_) | Self::LspRequest(_) => LspEventKind::NonMutation,
+            Self::LspResponse(_) | Self::LspRequest(_) => LspEventKind::Query,
         }
     }
 }

--- a/pyrefly/lib/lsp/non_wasm/queue.rs
+++ b/pyrefly/lib/lsp/non_wasm/queue.rs
@@ -95,7 +95,7 @@ impl LspEvent {
 enum LspEventKind {
     Priority,
     Mutation,
-    Query,
+    NonMutation,
 }
 
 impl LspEvent {
@@ -122,14 +122,16 @@ impl LspEvent {
             | Self::DrainWatchedFileChanges
             | Self::DidChangeWorkspaceFolders(_)
             | Self::DidChangeConfiguration(_)
-            | Self::LspResponse(_)
             | Self::DidOpenNotebookDocument(_)
             | Self::DidCloseNotebookDocument(_)
             | Self::DidSaveNotebookDocument(_)
             | Self::DidChangeNotebookDocument(_)
             | Self::InvalidateConfigFind
             | Self::Exit => LspEventKind::Mutation,
-            Self::LspRequest(_) => LspEventKind::Query,
+            // Responses are FIFO events, but they do not supersede preceding document
+            // mutations. In particular, a no-op configuration response will not
+            // compensate for validation skipped by a preceding didOpen.
+            Self::LspResponse(_) | Self::LspRequest(_) => LspEventKind::NonMutation,
         }
     }
 }
@@ -371,6 +373,7 @@ impl HeavyTaskQueue {
 
 #[cfg(test)]
 mod tests {
+    use lsp_types::TextDocumentItem;
     use lsp_types::Url;
     use lsp_types::VersionedTextDocumentIdentifier;
 
@@ -427,5 +430,41 @@ mod tests {
             queue.time_since_last_edit().expect("edit was enqueued") < elapsed,
             "a new edit should reset the debounce clock"
         );
+    }
+
+    #[test]
+    fn test_lsp_response_does_not_supersede_did_open() {
+        let queue = LspQueue::new();
+        queue
+            .send(LspEvent::DidOpenTextDocument(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: Url::parse("file:///test.py").unwrap(),
+                    language_id: "python".to_owned(),
+                    version: 1,
+                    text: "x: int = 'not an int'".to_owned(),
+                },
+            }))
+            .unwrap();
+        let response_id = RequestId::from(3);
+        queue
+            .send(LspEvent::LspResponse(Response::new_ok(
+                response_id.clone(),
+                serde_json::json!([{}]),
+            )))
+            .unwrap();
+
+        let (subsequent_mutation, event, _) = queue.recv().unwrap();
+        assert!(matches!(event, LspEvent::DidOpenTextDocument(_)));
+        assert!(
+            !subsequent_mutation,
+            "a client response must not suppress didOpen validation"
+        );
+
+        let (subsequent_mutation, event, _) = queue.recv().unwrap();
+        assert!(!subsequent_mutation);
+        assert!(matches!(
+            event,
+            LspEvent::LspResponse(Response { id, .. }) if id == response_id
+        ));
     }
 }

--- a/pyrefly/lib/lsp/non_wasm/queue.rs
+++ b/pyrefly/lib/lsp/non_wasm/queue.rs
@@ -94,7 +94,9 @@ impl LspEvent {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LspEventKind {
     Priority,
+    /// An event that makes work triggered by preceding mutations redundant.
     Mutation,
+    /// A FIFO event that does not make preceding mutation work redundant.
     NonMutation,
 }
 
@@ -128,9 +130,6 @@ impl LspEvent {
             | Self::DidChangeNotebookDocument(_)
             | Self::InvalidateConfigFind
             | Self::Exit => LspEventKind::Mutation,
-            // Responses are FIFO events, but they do not supersede preceding document
-            // mutations. In particular, a no-op configuration response will not
-            // compensate for validation skipped by a preceding didOpen.
             Self::LspResponse(_) | Self::LspRequest(_) => LspEventKind::NonMutation,
         }
     }
@@ -139,7 +138,8 @@ impl LspEvent {
 pub struct LspQueue {
     /// The next id to use for a new event.
     id: AtomicUsize,
-    /// The index of the last event we are aware of that is a mutation. 0 = unknown.
+    /// The index of the last queued mutation. `recv` uses this to tell handlers
+    /// whether work triggered by an earlier mutation can be deferred. 0 = unknown.
     last_mutation: AtomicUsize,
     /// When the most recent document edit was enqueued, or `None` if no edit has
     /// happened yet. Used to debounce queries (e.g. inlay hints) that shouldn't


### PR DESCRIPTION
# Summary

LSP responses are processed on the normal FIFO queue, but they were classified as state mutations. That classification also updates the queue's `last_mutation` marker, which tells earlier event handlers that a later mutation is waiting and that expensive work such as validation can be deferred.

This can lose diagnostics during startup:

1. The server receives `textDocument/didOpen`.
2. The client immediately replies to a server-initiated request such as `workspace/configuration`.
3. Because the response is marked as a mutation, dequeuing `didOpen` reports `subsequent_mutation = true`.
4. `didOpen` skips open-file validation under the assumption that the later mutation will make that work redundant.
5. A configuration response may be a no-op and does not necessarily trigger validation, so nothing compensates for the skipped work.

The server can then remain healthy and responsive while never publishing diagnostics for the opened file until some unrelated later event triggers validation.

This change classifies `LspResponse` with normal-priority query events instead. Responses still preserve FIFO ordering and are handled exactly as before, but they no longer claim that work triggered by preceding document mutations is redundant. This matches the queue's coalescing invariant: only events that can safely supersede prior mutation work should update `last_mutation`.

A deterministic regression enqueues `didOpen` followed by a configuration-shaped response and verifies that:

- `didOpen` is not reported as having a subsequent mutation, so validation is not suppressed.
- The response remains queued and is delivered in FIFO order.

# Test Plan

- `cargo test lsp::non_wasm::queue::tests --quiet`
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`