### PR TITLE
Possible fix for #3183

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -76,18 +76,10 @@
     },
     {
       "type": "shell",
-      "command": "cargo",
+      "command": "node ../lsp/build-pyrefly.js release",
       "group": "build",
       "isBackground": true,
       "label": "cargo: build pyrefly for extension",
-      "args": [
-        "build",
-        "--release",
-        "--artifact-dir",
-        "../lsp/bin",
-        "-Z",
-        "unstable-options"
-      ],
       "options": {
         "cwd": "${workspaceFolder}/pyrefly",
         "shell": {
@@ -113,7 +105,7 @@
     },
     {
       "type": "shell",
-      "command": "cargo watch -x 'build --all-features --artifact-dir ../lsp/bin -Z unstable-options'",
+      "command": "cargo watch -s \"node ../lsp/build-pyrefly.js debug\"",
       "group": "build",
       "isBackground": true,
       "label": "cargo: watch debug pyrefly for extension",

--- a/lsp/.vscodeignore
+++ b/lsp/.vscodeignore
@@ -14,6 +14,7 @@ node_modules
 out/
 src/
 esbuild.js
+build-pyrefly.js
 **/.fingerprint/
 **/build/
 **/deps/

--- a/lsp/CONTRIBUTING.md
+++ b/lsp/CONTRIBUTING.md
@@ -25,9 +25,10 @@ contributing. This file shows how to develop the extension locally.
 ## Installing
 
 - Follow steps in Pre-requisites section.
-- Build the Pyrefly binary with
-  `buck2 build pyrefly @fbcode//mode/opt --show-output` or `cargo build` and
-  either:
+- Build the Pyrefly binary and place it at `lsp/bin/pyrefly(.exe)` by running
+  `node build-pyrefly.js release` in this folder. Alternatively, build it
+  yourself with `buck2 build pyrefly @fbcode//mode/opt --show-output` or
+  `cargo build` and either:
 
 1. Place binary at `lsp/bin/pyrefly(.exe)`
 2. Add the `pyrefly.lspPath` configuration key to point at it after extension

--- a/lsp/build-pyrefly.js
+++ b/lsp/build-pyrefly.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Builds the pyrefly binary and places it in lsp/bin, where the extension looks
+// for a bundled language server. Cargo's --artifact-dir would do the placement
+// as part of the build, but it is gated behind -Z unstable-options and the
+// repository pins the toolchain to stable.
+//
+// Usage: node build-pyrefly.js [debug|release]
+
+const {spawnSync} = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const profile = process.argv[2] ?? 'release';
+if (profile !== 'debug' && profile !== 'release') {
+  throw new Error(`Expected a profile of "debug" or "release", got "${profile}"`);
+}
+
+// shell: true so that Windows resolves `cargo` to `cargo.exe` via PATHEXT.
+const cargo = (args, options) =>
+  spawnSync('cargo', args, {
+    cwd: path.join(__dirname, '..', 'pyrefly'),
+    shell: true,
+    ...options,
+  });
+
+const build = cargo(['build', profile === 'release' ? '--release' : '--all-features'], {
+  stdio: 'inherit',
+});
+if (build.status !== 0) {
+  process.exit(build.status ?? 1);
+}
+
+// Ask cargo for the target directory rather than assuming ./target, since it can
+// be redirected by CARGO_TARGET_DIR or by build.target-dir in a cargo config.
+const metadata = cargo(['metadata', '--format-version', '1', '--no-deps'], {encoding: 'utf8'});
+if (metadata.status !== 0) {
+  process.stderr.write(metadata.stderr);
+  process.exit(metadata.status ?? 1);
+}
+
+const name = process.platform === 'win32' ? 'pyrefly.exe' : 'pyrefly';
+const binDir = path.join(__dirname, 'bin');
+fs.mkdirSync(binDir, {recursive: true});
+fs.copyFileSync(
+  path.join(JSON.parse(metadata.stdout).target_directory, profile, name),
+  path.join(binDir, name),
+);

--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -248,17 +248,10 @@ export async function activate(context: ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('pyrefly.restartClient', async () => {
-      await client.stop();
       // Clear the output channel but don't dispose it
       outputChannel.clear();
       traceOutputChannel.clear();
-      client = new LanguageClient(
-        'pyrefly',
-        'Pyrefly language server',
-        serverOptions,
-        clientOptions,
-      );
-      await client.start();
+      await client.restart();
     }),
   );
 


### PR DESCRIPTION
Pyrefly restarts the client by stopping it, updating the output windows, and then recreating a client and starting it. During that time between stop and start, there's a period where VSCode can try to send file watcher update, but the client is down. We should be able to fix this by using the `client.restart()` function instead, which should do this more atomically.

I also looked into doing this by unregistering file watchers, but we don't have the ability to do that after receiving the shutdown request from VSCode. Alternatively, we may be able to forward an unregister file watcher request right before sending the shutdown from the client, but there are still possible race conditions there we could run into, so I think it's worth testing out this approach first. 

May fix https://github.com/facebook/pyrefly/issues/3183