### PR TITLE
Resolve `...` vs `EllipsisType` asymmetry

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -2498,9 +2498,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     }
 
     fn literal_equal(&self, left: &Type, right: &Type) -> bool {
+        // `...` in value position and a `types.EllipsisType` annotation denote the same
+        // singleton, so treat the two representations as one for identity comparisons.
+        let is_ellipsis = |ty: &Type| match ty {
+            Type::Ellipsis => true,
+            Type::ClassType(cls) => cls.has_qname("types", "EllipsisType"),
+            _ => false,
+        };
+        if is_ellipsis(left) && is_ellipsis(right) {
+            return true;
+        }
         match (left, right) {
             (Type::None, Type::None) => true,
-            (Type::Ellipsis, Type::Ellipsis) => true,
             (Type::Sentinel(s1), Type::Sentinel(s2)) => s1 == s2,
             (Type::Literal(left), Type::Literal(right)) => left.value == right.value,
             _ => false,

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -2699,6 +2699,14 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
                 // - probably not as a dedicated Type alternative.
                 self.is_subset_eq(&self.solver.heap.mk_class_type(ellipsis.clone()), want)
             }
+            // The value `...` is the sole inhabitant of `types.EllipsisType`, so the two
+            // representations denote the same type. Both directions must hold for them
+            // to be equivalent, which `assert_type` and narrowing rely on.
+            (_, Type::Ellipsis)
+                if let Some(ellipsis) = self.type_order.stdlib().ellipsis_type() =>
+            {
+                self.is_subset_eq(got, &self.solver.heap.mk_class_type(ellipsis.clone()))
+            }
             (Type::None, _) => self.is_subset_eq(
                 &self
                     .solver

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -204,40 +204,55 @@ def foo(bar: Bar) -> Iterable[int]:
 );
 
 testcase!(
-    bug = "Negative narrowing fails",
     test_ellipsis_is,
     r#"
-from typing import reveal_type
+from typing import assert_type
 from types import EllipsisType
 
 def f(x: int | EllipsisType):
     if x is ...:
-        reveal_type(x)  # E: Ellipsis
+        assert_type(x, EllipsisType)
     else:
-        reveal_type(x)  # E: EllipsisType | int
+        assert_type(x, int)
     if x is not ...:
-        reveal_type(x)  # E: EllipsisType | int
+        assert_type(x, int)
     else:
-        reveal_type(x)  # E: Ellipsis
+        assert_type(x, EllipsisType)
     "#,
 );
 
 testcase!(
-    bug = "Negative narrowing fails",
     test_ellipsis_eq,
     r#"
-from typing import reveal_type
+from typing import assert_type
 from types import EllipsisType
 
 def f(x: int | EllipsisType):
     if x == ...:
-        reveal_type(x)  # E: Ellipsis
+        assert_type(x, EllipsisType)
     else:
-        reveal_type(x)  # E: EllipsisType | int
+        assert_type(x, int)
     if x != ...:
-        reveal_type(x)  # E: EllipsisType | int
+        assert_type(x, int)
     else:
-        reveal_type(x)  # E: Ellipsis
+        assert_type(x, EllipsisType)
+    "#,
+);
+
+// The value `...` and a `types.EllipsisType` annotation denote the same singleton, so
+// they must match, regardless of which representation introduced the type (ref: #4426).
+testcase!(
+    test_ellipsis_value_is_ellipsis_type,
+    r#"
+from typing import assert_type
+from types import EllipsisType
+
+assert_type(..., EllipsisType)
+
+def f(x: EllipsisType):
+    assert_type(x, EllipsisType)
+    y: EllipsisType = ...
+    assert_type(y, EllipsisType)
     "#,
 );
 


### PR DESCRIPTION
# Summary

Fixes #4426.

### Overview

* Python has _one_ ellipsis object that can be written _two_ ways: as literal `...`, or `types.EllipsisType`.

* `pyrefly` represents these with two different internal types, **but** there's an asymmetry in terms of which can be assigned to which (this is the root cause).

* Specifically: the value `...` is inferred as `Type::Ellipsis`, but a `types.EllipsisType` annotation is inferred as `ClassType(EllipsisType)`, and assignability between the two holds in only _one_ direction.

### Solution

* Add the missing/reverse assignability arm.

* Ensure `literal_equal` recognises both representations.

# Test Plan

* Unit test suite was run, and a new test was added.
* Was able to remove the error markers from:
  *  `test_ellipsis_is` 
  *  `test_ellipsis_eq`
  
  Updated these tests to use `assert_type` as that validates equivalence, rather than matching substrings of the printed type (as per `reveal_type`).