### PR TITLE
Fix attribute writes after impossible narrowing

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -448,12 +448,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 let mut idx = self.bindings().key_to_idx(&key);
                 let mut gas = Gas::new(100);
                 let mut narrows = Vec::new();
+                let mut promote = false;
                 loop {
                     if gas.stop() {
                         break;
                     }
                     match self.bindings().get(idx) {
                         Binding::Forward(next) | Binding::PatternCapture(next) => idx = *next,
+                        Binding::PromoteForward(next) => {
+                            promote = true;
+                            idx = *next;
+                        }
                         Binding::Narrow(next, op, location) => {
                             narrows.push((op.as_ref(), location.range()));
                             idx = *next;
@@ -477,6 +482,10 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             type_info = narrowed;
                         }
                     }
+                }
+                if promote {
+                    type_info =
+                        type_info.map_ty(|ty| ty.promote_shallow_implicit_literals(self.stdlib));
                 }
                 type_info
             }

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -44,6 +44,7 @@ use pyrefly_types::typed_dict::ExtraItems;
 use pyrefly_types::typed_dict::TypedDict;
 use pyrefly_types::typed_dict::TypedDictField;
 use pyrefly_types::types::Forallable;
+use pyrefly_util::gas::Gas;
 use pyrefly_util::owner::Owner;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::prelude::VecExt;
@@ -116,6 +117,7 @@ use crate::types::quantified::QuantifiedKind;
 use crate::types::sentinel::Sentinel;
 use crate::types::special_form::SpecialForm;
 use crate::types::tuple::Tuple;
+use crate::types::type_info::JoinStyle;
 use crate::types::type_info::TypeInfo;
 use crate::types::type_var::PreInferenceVariance;
 use crate::types::type_var::Restriction;
@@ -420,6 +422,49 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     pub fn expr_infer(&self, x: &Expr, errors: &ErrorCollector) -> Type {
         self.expr_with_options(x, ExprOptions::infer(errors, None))
             .into_ty()
+    }
+
+    /// Infer the receiver of an attribute assignment. In an unreachable branch, narrowing a
+    /// receiver through one of its facets can reduce the receiver itself to `Never`. Attribute
+    /// writes still need to be checked against their declared type in that case.
+    pub fn expr_infer_for_attribute_assignment(&self, x: &Expr, errors: &ErrorCollector) -> Type {
+        let narrowed = self.expr_infer(x, errors);
+        if !narrowed.is_never() {
+            return narrowed;
+        }
+        self.expr_infer_without_narrowing(x, errors).into_ty()
+    }
+
+    fn expr_infer_without_narrowing(&self, x: &Expr, errors: &ErrorCollector) -> TypeInfo {
+        match x {
+            Expr::Name(name) if !Ast::is_synthesized_empty_name(name) => {
+                let key = Key::BoundName(ShortIdentifier::expr_name(name));
+                let mut idx = self.bindings().key_to_idx(&key);
+                let mut gas = Gas::new(100);
+                loop {
+                    if gas.stop() {
+                        break;
+                    }
+                    match self.bindings().get(idx) {
+                        Binding::Forward(next)
+                        | Binding::PatternCapture(next)
+                        | Binding::Narrow(next, _, _) => idx = *next,
+                        Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
+                        _ => break,
+                    }
+                }
+                TypeInfo::of_ty(self.get_idx(idx).ty().clone())
+            }
+            Expr::Attribute(attr) => {
+                let base = self.expr_infer_without_narrowing(&attr.value, errors);
+                self.attr_access_infer(attr, &base, errors)
+            }
+            Expr::Subscript(subscript) => {
+                let base = self.expr_infer_without_narrowing(&subscript.value, errors);
+                self.subscript_infer(&base, &subscript.slice, subscript.range(), errors)
+            }
+            _ => TypeInfo::of_ty(self.expr_infer(x, errors)),
+        }
     }
 
     /// Infer a type for an expression, with an optional type hint that influences the inferred type.

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -95,6 +95,7 @@ use crate::binding::binding::Key;
 use crate::binding::binding::KeyYield;
 use crate::binding::binding::KeyYieldFrom;
 use crate::binding::narrow::AtomicNarrowOp;
+use crate::binding::narrow::NarrowOp;
 use crate::binding::narrow::int_from_slice;
 use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
@@ -432,38 +433,84 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if !narrowed.is_never() {
             return narrowed;
         }
-        self.expr_infer_without_narrowing(x, errors).into_ty()
+        self.expr_infer_without_impossible_narrowing(x, errors)
+            .into_ty()
     }
 
-    fn expr_infer_without_narrowing(&self, x: &Expr, errors: &ErrorCollector) -> TypeInfo {
+    fn expr_infer_without_impossible_narrowing(
+        &self,
+        x: &Expr,
+        errors: &ErrorCollector,
+    ) -> TypeInfo {
         match x {
             Expr::Name(name) if !Ast::is_synthesized_empty_name(name) => {
                 let key = Key::BoundName(ShortIdentifier::expr_name(name));
                 let mut idx = self.bindings().key_to_idx(&key);
                 let mut gas = Gas::new(100);
+                let mut narrows = Vec::new();
                 loop {
                     if gas.stop() {
                         break;
                     }
                     match self.bindings().get(idx) {
-                        Binding::Forward(next)
-                        | Binding::PatternCapture(next)
-                        | Binding::Narrow(next, _, _) => idx = *next,
+                        Binding::Forward(next) | Binding::PatternCapture(next) => idx = *next,
+                        Binding::Narrow(next, op, location) => {
+                            narrows.push((op.as_ref(), location.range()));
+                            idx = *next;
+                        }
                         Binding::Phi(JoinStyle::NarrowOf(next), _) => idx = *next,
                         _ => break,
                     }
                 }
-                TypeInfo::of_ty(self.get_idx(idx).ty().clone())
+                let mut type_info = TypeInfo::of_ty(self.get_idx(idx).ty().clone());
+                for (op, range) in narrows.into_iter().rev() {
+                    let narrowed = self.narrow(&type_info, op, range, errors);
+                    if !narrowed.ty().is_never() {
+                        type_info = narrowed;
+                    } else if Self::is_positive_type_narrow(op) {
+                        // A positive runtime check is still useful after an earlier, contradictory
+                        // narrow made the declared type impossible.
+                        let object =
+                            TypeInfo::of_ty(self.heap.mk_class_type(self.stdlib.object().clone()));
+                        let narrowed = self.narrow(&object, op, range, errors);
+                        if !narrowed.ty().is_never() {
+                            type_info = narrowed;
+                        }
+                    }
+                }
+                type_info
             }
             Expr::Attribute(attr) => {
-                let base = self.expr_infer_without_narrowing(&attr.value, errors);
+                let base = self.expr_infer_without_impossible_narrowing(&attr.value, errors);
                 self.attr_access_infer(attr, &base, errors)
             }
             Expr::Subscript(subscript) => {
-                let base = self.expr_infer_without_narrowing(&subscript.value, errors);
-                self.subscript_infer(&base, &subscript.slice, subscript.range(), errors)
+                let base = self.expr_infer_without_impossible_narrowing(&subscript.value, errors);
+                self.subscript_infer(
+                    &base,
+                    &subscript.slice,
+                    subscript.range(),
+                    TypeFormContext::TypeExpression,
+                    errors,
+                )
             }
             _ => TypeInfo::of_ty(self.expr_infer(x, errors)),
+        }
+    }
+
+    fn is_positive_type_narrow(op: &NarrowOp) -> bool {
+        match op {
+            NarrowOp::Atomic(
+                None,
+                AtomicNarrowOp::IsInstance(..)
+                | AtomicNarrowOp::IsSubclass(..)
+                | AtomicNarrowOp::TypeEq(..)
+                | AtomicNarrowOp::TypeGuard(..)
+                | AtomicNarrowOp::TypeIs(..)
+                | AtomicNarrowOp::Call(..),
+            ) => true,
+            NarrowOp::And(ops) | NarrowOp::Or(ops) => ops.iter().any(Self::is_positive_type_narrow),
+            _ => false,
         }
     }
 

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -5130,7 +5130,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         //
         // This should be the case since contextual typing requires working out the class field
         // type information first, but is difficult to see from a skim.
-        let base = self.expr_infer(&attr.value, errors);
+        let base = self.expr_infer_for_attribute_assignment(&attr.value, errors);
         let narrowed = self.check_assign_to_attribute_and_infer_narrow(
             &base,
             &attr.attr.id,

--- a/pyrefly/lib/test/attribute_narrow.rs
+++ b/pyrefly/lib/test/attribute_narrow.rs
@@ -278,6 +278,37 @@ class Env:
 );
 
 testcase!(
+    test_attr_assignment_preserves_isinstance_narrow,
+    r#"
+class UIElement: pass
+
+class LayoutDOM(UIElement):
+    sizing_mode: str | None = None
+
+def set_sizing_mode(item: UIElement, sizing_mode: str) -> None:
+    if isinstance(item, UIElement):
+        return
+    if not isinstance(item, LayoutDOM):
+        raise ValueError
+    item.sizing_mode = sizing_mode
+"#,
+);
+
+testcase!(
+    test_attr_assignment_preserves_typeis_narrow,
+    r#"
+import inspect
+from types import FunctionType
+from typing import Any
+
+def set_annotations(function: FunctionType) -> None:
+    annotations: dict[str, Any] = {}
+    if inspect.ismethod(function):
+        function.__func__.__annotations__ = annotations
+"#,
+);
+
+testcase!(
     bug = "TODO(stroxler) We should fine-tune descriptor narrowing more; this is not high-priority",
     test_descriptor_narrowing,
     r#"

--- a/pyrefly/lib/test/attribute_narrow.rs
+++ b/pyrefly/lib/test/attribute_narrow.rs
@@ -278,6 +278,30 @@ class Env:
 );
 
 testcase!(
+    test_module_global_attr_assignment_uses_declared_type_after_impossible_narrow,
+    r#"
+from typing import assert_type
+
+class Container: pass
+
+class Env:
+    def __init__(self) -> None:
+        self.container: Container = Container()
+
+env = Env()
+
+def update() -> None:
+    if env.container is None:
+        env.container = Container()
+        assert_type(env.container, Container)
+
+def rejects_incompatible_write() -> None:
+    if env.container is None:
+        env.container = 1  # E: `Literal[1]` is not assignable to attribute `container` with type `Container`
+"#,
+);
+
+testcase!(
     test_attr_assignment_preserves_isinstance_narrow,
     r#"
 class UIElement: pass

--- a/pyrefly/lib/test/attribute_narrow.rs
+++ b/pyrefly/lib/test/attribute_narrow.rs
@@ -256,6 +256,28 @@ def test_invalidate_narrow_with_assignment(c0: C, c1: C):
 );
 
 testcase!(
+    test_attr_assignment_uses_declared_type_after_impossible_narrow,
+    r#"
+from typing import assert_type
+
+class Container: pass
+
+class Env:
+    def __init__(self) -> None:
+        self.domains: Container = Container()
+
+    def setup(self) -> None:
+        if self.domains is None:
+            self.domains = Container()
+            assert_type(self.domains, Container)
+
+    def rejects_incompatible_write(self) -> None:
+        if self.domains is None:
+            self.domains = 1  # E: `Literal[1]` is not assignable to attribute `domains` with type `Container`
+"#,
+);
+
+testcase!(
     bug = "TODO(stroxler) We should fine-tune descriptor narrowing more; this is not high-priority",
     test_descriptor_narrowing,
     r#"


### PR DESCRIPTION
# Summary

Fix attribute writes in impossible narrowing branches to fall back to the receiver's unnarrowed declared path when the flow receiver has become Never. Normal receiver narrowing is preserved, and the assignment continues to invalidate stale attribute facets.

The regression test verifies both sides: a Container write is accepted and an incompatible Literal[1] write is still rejected against the declared Container type.

Fixes #4478

# Test Plan

- cargo +stable-x86_64-pc-windows-gnu test -p pyrefly --lib test_attr_assignment_uses_declared_type_after_impossible_narrow -- --nocapture
- python test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema
- cargo fmt --all -- --check
- git diff --check