### PR TITLE
sandbox: noindex the crash fallback and stop it hijacking the page title

### DIFF
--- a/website/src/pages/sandbox.tsx
+++ b/website/src/pages/sandbox.tsx
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 import BrowserOnly from '@docusaurus/BrowserOnly';
+import Head from '@docusaurus/Head';
 import Layout from '@theme/Layout';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import * as stylex from '@stylexjs/stylex';
@@ -100,7 +101,12 @@ function SandboxCrashFallback({
 }): React.JSX.Element {
     return (
         <div role="alert" {...stylex.props(styles.crashContainer)}>
-            <h1 {...stylex.props(styles.crashTitle)}>The sandbox crashed.</h1>
+            <Head>
+                <meta name="robots" content="noindex" />
+            </Head>
+            <p role="heading" aria-level={1} {...stylex.props(styles.crashTitle)}>
+                The sandbox crashed.
+            </p>
             <p {...stylex.props(styles.crashText)}>
                 Try again keeps your files and reruns the sandbox. Reset clears
                 your saved sandbox files and starts from the default sandbox.


### PR DESCRIPTION
Googlebot renders `/sandbox`, and on a startup crash the React error boundary shows a fallback whose `<h1>` (`The sandbox crashed.`) got indexed as the page title. Mark the fallback `noindex` and demote its heading so crawlers keep the real page title. Does not change behavior for normal users.

Verification:
- Forced the sandbox component to throw during a production build.
- Confirmed the rendered title remains `Try Pyrefly: the Pyrefly Sandbox | Pyrefly`.
- Confirmed the crash fallback adds `robots: noindex` and renders the alert.
- Removed the temporary throw and rebuilt successfully.
- Ran `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`.