### PR TITLE
Fix first-use inference for tuple-unpacked names

### DIFF
--- a/pyrefly/lib/alt/answers_solver.rs
+++ b/pyrefly/lib/alt/answers_solver.rs
@@ -1985,6 +1985,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let binding = self.bindings().get(target);
         match binding {
             Binding::NameAssign(na) if na.def_idx.is_some() => Some(target),
+            Binding::UnpackedName(_) => Some(target),
             _ => None,
         }
     }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -5967,7 +5967,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     errors,
                 ),
             Binding::UnpackedName(unpacked) => self.binding_to_type_unpacked_value(
-                unpacked.annotation,
+                None,
                 unpacked.source,
                 unpacked.range,
                 &unpacked.position,

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -2324,21 +2324,20 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if let Binding::PromoteForward(fwd) = binding {
             return Arc::new(self.resolve_promote_forward(*fwd));
         }
-        // Inline first-use pinning for NameAssign.
-        let mut type_info = if let Binding::NameAssign(na) = binding
-            && self.solver().infer_with_first_use
-            && na.def_idx.is_some()
-            && na.annotation.is_none()
-            && let FirstUse::UsedBy(first_use_idx) = &na.first_use
-        {
-            self.solve_binding_with_first_use_pinning(
-                binding,
-                na.def_idx.unwrap(),
-                *first_use_idx,
-                errors,
-            )
-        } else {
-            self.binding_to_type_info(binding, errors)
+        let first_use = match binding {
+            Binding::NameAssign(na) if na.def_idx.is_some() && na.annotation.is_none() => {
+                Some((&na.first_use, na.def_idx.unwrap()))
+            }
+            Binding::UnpackedName(unpacked) => Some((&unpacked.first_use, unpacked.def_idx)),
+            _ => None,
+        };
+        let mut type_info = match first_use {
+            Some((FirstUse::UsedBy(first_use_idx), def_idx))
+                if self.solver().infer_with_first_use =>
+            {
+                self.solve_binding_with_first_use_pinning(binding, def_idx, *first_use_idx, errors)
+            }
+            _ => self.binding_to_type_info(binding, errors),
         };
         type_info.visit_mut(&mut |ty| {
             self.pin_all_placeholder_types(ty, true, range, errors);
@@ -4408,9 +4407,29 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         range: TextRange,
         pos: &UnpackedPosition,
         receiver: Option<&MultiTargetReceiver>,
+        raw_source: bool,
         errors: &ErrorCollector,
     ) -> Type {
-        let iterables = self.iterate(self.get_idx(to_unpack).ty(), range, errors, None);
+        let unpacked =
+            if raw_source && let Binding::UnpackSource(source) = self.bindings().get(to_unpack) {
+                match source.as_ref() {
+                    Binding::UnpackedValue(ann, source, range, pos, receiver) => {
+                        TypeInfo::of_ty(self.binding_to_type_unpacked_value(
+                            *ann,
+                            *source,
+                            *range,
+                            pos,
+                            receiver.as_deref(),
+                            true,
+                            errors,
+                        ))
+                    }
+                    source => self.binding_to_type_info(source, errors),
+                }
+            } else {
+                self.get_idx(to_unpack).arc_clone()
+            };
+        let iterables = self.iterate(unpacked.ty(), range, errors, None);
         let mut values = Vec::new();
         for iterable in iterables {
             values.push(match iterable {
@@ -5338,6 +5357,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     fn binding_to_type_info(&self, binding: &Binding, errors: &ErrorCollector) -> TypeInfo {
         match binding {
             Binding::Forward(k) | Binding::PatternCapture(k) => self.get_idx(*k).arc_clone(),
+            Binding::UnpackSource(source) => self.binding_to_type_info(source, errors),
             Binding::PromoteForward(k) => self.resolve_promote_forward(*k),
             Binding::ForwardToFirstUse(k) => {
                 if let Some(def_idx) = self.def_idx_for_forward_to_first_use(*k)
@@ -5784,6 +5804,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     fn binding_to_type(&self, binding: &Binding, errors: &ErrorCollector) -> Type {
         match binding {
             Binding::Forward(..)
+            | Binding::UnpackSource(..)
             | Binding::PatternCapture(..)
             | Binding::PromoteForward(..)
             | Binding::ForwardToFirstUse(..)
@@ -5942,8 +5963,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     *range,
                     pos,
                     receiver.as_deref(),
+                    false,
                     errors,
                 ),
+            Binding::UnpackedName(unpacked) => self.binding_to_type_unpacked_value(
+                unpacked.annotation,
+                unpacked.source,
+                unpacked.range,
+                &unpacked.position,
+                None,
+                true,
+                errors,
+            ),
             &Binding::Function {
                 decorated_idx,
                 mut pred_idx,

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -2221,6 +2221,18 @@ pub struct MultiTargetReceiver {
     pub idx: Idx<Key>,
 }
 
+/// A name target whose value is selected from an unpacking assignment.
+#[derive(Clone, Debug)]
+pub struct UnpackedName {
+    pub annotation: Option<Idx<KeyAnnotation>>,
+    pub source: Idx<Key>,
+    pub range: TextRange,
+    pub position: UnpackedPosition,
+    pub first_use: FirstUse,
+    /// The definition idx used for partial-answer lookup during first-use pinning.
+    pub def_idx: Idx<Key>,
+}
+
 /// Data for a type alias binding.
 #[derive(Clone, Debug)]
 pub struct TypeAliasBinding {
@@ -2354,6 +2366,9 @@ pub enum Binding {
     /// An expression, optionally with a Key saying what the type must be.
     /// The Key must be a type of types, e.g. `Type::Type`.
     Expr(Option<Idx<KeyAnnotation>>, Box<Expr>),
+    /// The shared source of an unpacking assignment. Placeholder types stay unpinned
+    /// until each name target is solved through its first semantic use.
+    UnpackSource(Box<Binding>),
     // This binding is created specifically for stand-alone `Stmt::Expr` statements.
     // Unlike the general `Expr` binding above, this separate binding allows us to
     // perform additional checks that are only relevant for expressions in `Stmt::Expr`,
@@ -2410,6 +2425,8 @@ pub enum Binding {
         UnpackedPosition,
         Option<Box<MultiTargetReceiver>>,
     ),
+    /// An unannotated name target participating in first-use inference.
+    UnpackedName(Box<UnpackedName>),
     /// A type where we have an annotation, but also a type we computed.
     /// If the annotation has a type inside it (e.g. `int` then use the annotation).
     /// If the annotation doesn't (e.g. it's `Final`), then use the binding.
@@ -2549,6 +2566,7 @@ impl DisplayWith<Bindings> for Binding {
         };
         match self {
             Self::Expr(a, x) => write!(f, "Expr({}, {})", ann(a), m.display(x)),
+            Self::UnpackSource(x) => write!(f, "UnpackSource({})", x.display_with(ctx)),
             Self::StmtExpr(x, _) => write!(f, "StmtExpr({})", m.display(x)),
             Self::MultiTargetAssign(a, idx, range, receiver) => {
                 write!(
@@ -2568,6 +2586,13 @@ impl DisplayWith<Bindings> for Binding {
                 }
                 write!(f, ")")
             }
+            Self::UnpackedName(x) => write!(
+                f,
+                "UnpackedName({}, {}, {:?})",
+                ann(&x.annotation),
+                ctx.display(x.source),
+                x.position
+            ),
             Self::TypeVar(x) => {
                 let (a, name, call, kind) = x.as_ref();
                 write!(f, "{kind}({}, {name}, {})", ann(a), m.display(call))
@@ -2933,9 +2958,11 @@ impl Binding {
             // class-shaped — match the `NameAssign` path above.
             Binding::MultiTargetAssign(_, _, _, Some(_))
             | Binding::UnpackedValue(_, _, _, _, Some(_)) => Some(SymbolKind::Class),
+            Binding::UnpackedName(_) => Some(SymbolKind::Variable),
             Binding::UnpackedValue(_, _, _, _, None) => Some(SymbolKind::Variable),
             Binding::AugAssign(_, _) => Some(SymbolKind::Variable),
             Binding::Expr(_, _)
+            | Binding::UnpackSource(_)
             | Binding::StmtExpr(_, _)
             | Binding::MultiTargetAssign(_, _, _, None)
             | Binding::ReturnExplicit(_)

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -2224,7 +2224,6 @@ pub struct MultiTargetReceiver {
 /// A name target whose value is selected from an unpacking assignment.
 #[derive(Clone, Debug)]
 pub struct UnpackedName {
-    pub annotation: Option<Idx<KeyAnnotation>>,
     pub source: Idx<Key>,
     pub range: TextRange,
     pub position: UnpackedPosition,
@@ -2588,8 +2587,7 @@ impl DisplayWith<Bindings> for Binding {
             }
             Self::UnpackedName(x) => write!(
                 f,
-                "UnpackedName({}, {}, {:?})",
-                ann(&x.annotation),
+                "UnpackedName({}, {:?})",
                 ctx.display(x.source),
                 x.position
             ),

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -1792,7 +1792,7 @@ impl<'a> BindingsBuilder<'a> {
         }
     }
 
-    /// Follow Forward chains to find a NameAssign with partial type support.
+    /// Follow Forward chains to find a binding with partial type support.
     ///
     /// Returns (default_idx, Some((def_idx, first_use))) if a NameAssign with
     /// `def_idx.is_some()` is found, or (default_idx, None) otherwise.
@@ -1819,6 +1819,9 @@ impl<'a> BindingsBuilder<'a> {
                 }
                 Some(Binding::NameAssign(na)) if na.def_idx.is_some() => {
                     return (current, Some((current, na.first_use.clone())));
+                }
+                Some(Binding::UnpackedName(unpacked)) => {
+                    return (current, Some((current, unpacked.first_use.clone())));
                 }
                 _ => {
                     return (current, None);
@@ -1850,10 +1853,14 @@ impl<'a> BindingsBuilder<'a> {
         }
     }
 
-    /// Mark a NameAssign as used by a specific binding for first-use pinning.
+    /// Mark a partial type binding as used by a specific binding for first-use pinning.
     fn mark_first_use(&mut self, def_idx: Idx<Key>, user_idx: Idx<Key>) {
-        if let Some(Binding::NameAssign(na)) = self.idx_to_binding_mut(def_idx) {
-            na.first_use = FirstUse::UsedBy(user_idx);
+        match self.idx_to_binding_mut(def_idx) {
+            Some(Binding::NameAssign(na)) => na.first_use = FirstUse::UsedBy(user_idx),
+            Some(Binding::UnpackedName(unpacked)) => {
+                unpacked.first_use = FirstUse::UsedBy(user_idx);
+            }
+            _ => unreachable!("partial type binding must support first-use tracking"),
         }
     }
 
@@ -1862,10 +1869,16 @@ impl<'a> BindingsBuilder<'a> {
     /// This is used when looking up names in static type contexts or for narrowing,
     /// where we don't want to pin partial types. Should be called after `lookup_name`.
     pub fn mark_does_not_pin_if_first_use(&mut self, def_idx: Idx<Key>) {
-        if let Some(Binding::NameAssign(na)) = self.idx_to_binding_mut(def_idx)
-            && matches!(na.first_use, FirstUse::Undetermined)
-        {
-            na.first_use = FirstUse::DoesNotPin;
+        match self.idx_to_binding_mut(def_idx) {
+            Some(Binding::NameAssign(na)) if matches!(na.first_use, FirstUse::Undetermined) => {
+                na.first_use = FirstUse::DoesNotPin;
+            }
+            Some(Binding::UnpackedName(unpacked))
+                if matches!(unpacked.first_use, FirstUse::Undetermined) =>
+            {
+                unpacked.first_use = FirstUse::DoesNotPin;
+            }
+            _ => {}
         }
     }
 
@@ -2033,6 +2046,7 @@ impl<'a> BindingsBuilder<'a> {
                 Binding::NameAssign(..)
                     | Binding::MultiTargetAssign(..)
                     | Binding::UnpackedValue(..)
+                    | Binding::UnpackedName(..)
                     | Binding::AugAssign(..)
                     | Binding::AnnotatedType(..)
                     | Binding::IterableValueLoop(..)

--- a/pyrefly/lib/binding/target.rs
+++ b/pyrefly/lib/binding/target.rs
@@ -37,6 +37,7 @@ use crate::binding::binding::NameAssign;
 use crate::binding::binding::SizeExpectation;
 use crate::binding::binding::TypeAliasBinding;
 use crate::binding::binding::TypeAliasParams;
+use crate::binding::binding::UnpackedName;
 use crate::binding::binding::UnpackedPosition;
 use crate::binding::bindings::BindingsBuilder;
 use crate::binding::bindings::LegacyTParamCollector;
@@ -88,8 +89,10 @@ impl<'a> BindingsBuilder<'a> {
         if ensure_assigned && let Some(assigned) = &mut assigned {
             self.ensure_expr(assigned, unpacked.usage())
         }
-        let unpack_idx =
-            self.insert_binding_current(unpacked, make_binding(assigned.as_deref(), None));
+        let unpack_idx = self.insert_binding_current(
+            unpacked,
+            Binding::UnpackSource(Box::new(make_binding(assigned.as_deref(), None))),
+        );
 
         // An unpacking has zero or one splats (starred expressions). Without a splat the
         // source length is pinned exactly; with one it is only a lower bound.
@@ -575,6 +578,18 @@ impl<'a> BindingsBuilder<'a> {
         }
         let binding = make_binding(assigned.as_deref(), ann);
         let binding = match (receiver_idx, binding) {
+            (None, Binding::UnpackedValue(None, source, range, position, None))
+                if self.infer_with_first_use() =>
+            {
+                Binding::UnpackedName(Box::new(UnpackedName {
+                    annotation: None,
+                    source,
+                    range,
+                    position,
+                    first_use: FirstUse::Undetermined,
+                    def_idx: user.idx(),
+                }))
+            }
             (Some(idx), Binding::MultiTargetAssign(a, rhs, range, _)) => {
                 let receiver = Box::new(MultiTargetReceiver {
                     name: name.id.clone(),

--- a/pyrefly/lib/binding/target.rs
+++ b/pyrefly/lib/binding/target.rs
@@ -582,7 +582,6 @@ impl<'a> BindingsBuilder<'a> {
                 if self.infer_with_first_use() =>
             {
                 Binding::UnpackedName(Box::new(UnpackedName {
-                    annotation: None,
                     source,
                     range,
                     position,

--- a/pyrefly/lib/lsp/wasm/inlay_hints.rs
+++ b/pyrefly/lib/lsp/wasm/inlay_hints.rs
@@ -508,7 +508,10 @@ impl<'a> Transaction<'a> {
         pos: UnpackedPosition,
     ) -> Option<&'b Expr> {
         // Get the binding for the unpacked source
-        let source_binding = bindings.get(unpack_idx);
+        let source_binding = match bindings.get(unpack_idx) {
+            Binding::UnpackSource(source) => source.as_ref(),
+            source => source,
+        };
         // For top-level unpacking, the source is Binding::Expr containing the RHS.
         // For nested unpacking, it's Binding::UnpackedValue - we return None in that case.
         let source_expr = match source_binding {

--- a/pyrefly/lib/lsp/wasm/inlay_hints.rs
+++ b/pyrefly/lib/lsp/wasm/inlay_hints.rs
@@ -384,6 +384,14 @@ impl<'a> Transaction<'a> {
                                 Self::get_unpacked_element_expr(&bindings, *unpack_idx, *pos);
                             (element_expr, true)
                         }
+                        Binding::UnpackedName(unpacked) => {
+                            let element_expr = Self::get_unpacked_element_expr(
+                                &bindings,
+                                unpacked.source,
+                                unpacked.position,
+                            );
+                            (element_expr, true)
+                        }
                         _ => (None, false),
                     };
                     // If the inferred type is a class type w/ no type arguments and the

--- a/pyrefly/lib/test/delayed_inference.rs
+++ b/pyrefly/lib/test/delayed_inference.rs
@@ -71,6 +71,32 @@ assert_type(x, list[int])
 );
 
 testcase!(
+    tuple_unpack_preserves_independent_first_use_inference,
+    r#"
+from typing import assert_type
+xs, ys = [], []
+xs.append(1)
+ys.append("value")
+assert_type(xs, list[int])
+assert_type(ys, list[str])
+"#,
+);
+
+testcase!(
+    nested_tuple_unpack_preserves_first_use_inference,
+    r#"
+from typing import assert_type
+head, (left, right) = [], ([], [])
+head.append(1)
+left.append("value")
+right.append(b"value")
+assert_type(head, list[int])
+assert_type(left, list[str])
+assert_type(right, list[bytes])
+"#,
+);
+
+testcase!(
     test_empty_list_check,
     r#"
 from typing import Literal, assert_type

--- a/pyrefly/lib/test/delayed_inference.rs
+++ b/pyrefly/lib/test/delayed_inference.rs
@@ -357,7 +357,7 @@ fn env_inconsistent_pins_for_non_name_assign_placeholder() -> TestEnv {
         r#"
 x, _ = [], 5
 y = x.append(1)
-z = x.append("1")
+z = x.append("1") # E: `Literal['1']` is not assignable to parameter `object` with type `int`
 "#,
     )
 }
@@ -366,11 +366,11 @@ testcase!(
     inconsistent_pins_for_non_name_assign_placeholder_a,
     env_inconsistent_pins_for_non_name_assign_placeholder(),
     r#"
-from typing import assert_type, Any
+from typing import assert_type
 from inconsistent_pins_for_non_name_assign_placeholder import y
 assert_type(y, None)
 from inconsistent_pins_for_non_name_assign_placeholder import x
-assert_type(x, list[Any])
+assert_type(x, list[int])
 "#,
 );
 
@@ -378,10 +378,21 @@ testcase!(
     inconsistent_pins_for_non_name_assign_placeholder_b,
     env_inconsistent_pins_for_non_name_assign_placeholder(),
     r#"
-from typing import assert_type, Any
+from typing import assert_type
 from inconsistent_pins_for_non_name_assign_placeholder import z
 assert_type(z, None)
 from inconsistent_pins_for_non_name_assign_placeholder import x
+assert_type(x, list[int])
+"#,
+);
+
+testcase!(
+    tuple_unpack_respects_disabled_first_use_inference,
+    TestEnv::new_with_infer_with_first_use(false),
+    r#"
+from typing import Any, assert_type
+x, _ = [], 5
+x.append(1)
 assert_type(x, list[Any])
 "#,
 );


### PR DESCRIPTION
# Summary

Fixes #4522

Tuple-unpacked name targets now retain their own first-use inference state. Empty containers remain unpinned while the shared right-hand side is unpacked, so each target can be inferred from its first semantic use. Nested unpacking follows the same path; annotated, attribute, subscript, and receiver-constrained targets keep their existing behavior.

This change was implemented with AI assistance. The commands below were run on the submitted commits.

# Test Plan

- `cargo check -p pyrefly --lib`
- `cargo test tuple_unpack_`
- `cargo test test::delayed_inference::`
- `cargo test test::lsp::inlay_hint::`
- `cargo fmt --all --check`
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`
