### PR TITLE
Add configurable Python interpreter discovery command

### DIFF
--- a/crates/pyrefly_config/src/args.rs
+++ b/crates/pyrefly_config/src/args.rs
@@ -186,17 +186,20 @@ impl EnvironmentArgs {
             config.interpreters.skip_interpreter_query = true;
             config.interpreters.python_interpreter_path = None;
             config.interpreters.fallback_python_interpreter_name = None;
+            config.interpreters.python_interpreter_find_cmd = None;
             config.interpreters.conda_environment = None;
         }
         if let Some(x) = &self.python_interpreter_path {
             config.interpreters.python_interpreter_path = Some(ConfigOrigin::cli(x.clone()));
             config.interpreters.fallback_python_interpreter_name = None;
+            config.interpreters.python_interpreter_find_cmd = None;
             config.interpreters.conda_environment = None;
         }
         if let Some(x) = &self.fallback_python_interpreter_name {
             config.interpreters.fallback_python_interpreter_name =
                 Some(ConfigOrigin::cli(x.clone()));
             config.interpreters.python_interpreter_path = None;
+            config.interpreters.python_interpreter_find_cmd = None;
             config.interpreters.conda_environment = None;
         }
         if let Some(conda_environment) = &self.conda_environment {
@@ -204,6 +207,7 @@ impl EnvironmentArgs {
                 Some(ConfigOrigin::cli(conda_environment.clone()));
             config.interpreters.python_interpreter_path = None;
             config.interpreters.fallback_python_interpreter_name = None;
+            config.interpreters.python_interpreter_find_cmd = None;
         }
         if let Some(x) = &self.typeshed_path {
             config.typeshed_path = Some(x.clone());

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -75,6 +75,7 @@ use crate::finder::ConfigError;
 use crate::migration::run::MigratedFromKind;
 use crate::module_wildcard::Match;
 use crate::pyproject::PyProject;
+use crate::util::ConfigOrigin;
 
 pub static GENERATED_FILE_CONFIG_OVERRIDE: LazyLock<
     RwLock<SmallMap<InternedPath, ArcId<ConfigFile>>>,
@@ -703,6 +704,7 @@ impl Default for ConfigFile {
             interpreters: Interpreters {
                 python_interpreter_path: None,
                 fallback_python_interpreter_name: None,
+                python_interpreter_find_cmd: None,
                 conda_environment: None,
                 skip_interpreter_query: false,
             },
@@ -1346,6 +1348,19 @@ impl ConfigFile {
         // file or CLI flag). If not, we auto-discover a `typings/` directory below.
         let site_package_path_set = self.python_environment.site_package_path.is_some();
 
+        if self.interpreters.python_interpreter_find_cmd.is_some()
+            && (matches!(
+                self.interpreters.python_interpreter_path,
+                Some(ConfigOrigin::CommandLine(_) | ConfigOrigin::ConfigFile(_))
+            ) || self.interpreters.fallback_python_interpreter_name.is_some()
+                || self.interpreters.conda_environment.is_some()
+                || self.interpreters.skip_interpreter_query)
+        {
+            configure_errors.push(anyhow::anyhow!(
+                "`python-interpreter-find-cmd` cannot be combined with another interpreter selection option."
+            ));
+        }
+
         if self.interpreters.skip_interpreter_query {
             self.python_environment.set_empty_to_default();
         } else {
@@ -1608,6 +1623,7 @@ impl ConfigFile {
 
         if self.interpreters.python_interpreter_path.is_some()
             && self.interpreters.conda_environment.is_some()
+            && self.interpreters.python_interpreter_find_cmd.is_none()
         {
             configure_errors.push(anyhow::anyhow!(
                      "Cannot use both `python-interpreter-path` and `conda-environment`. Finding environment info using `python-interpreter-path`.",
@@ -2017,6 +2033,7 @@ mod tests {
                         "venv/my/python"
                     ))),
                     fallback_python_interpreter_name: None,
+                    python_interpreter_find_cmd: None,
                     conda_environment: None,
                     skip_interpreter_query: false,
                 },
@@ -2391,6 +2408,7 @@ mod tests {
                     interpreter.clone(),
                 ))),
                 fallback_python_interpreter_name: None,
+                python_interpreter_find_cmd: None,
                 conda_environment: None,
                 skip_interpreter_query: false,
             },
@@ -2452,6 +2470,7 @@ mod tests {
             interpreters: Interpreters {
                 python_interpreter_path: Some(ConfigOrigin::config(test_path.join(interpreter))),
                 fallback_python_interpreter_name: None,
+                python_interpreter_find_cmd: None,
                 conda_environment: None,
                 skip_interpreter_query: false,
             },
@@ -2605,6 +2624,23 @@ output-format = "omit-errors"
     }
 
     #[test]
+    fn test_python_interpreter_find_cmd_config_parsing() {
+        let config = ConfigFile::parse_config(
+            r#"python-interpreter-find-cmd = ["poetry", "env", "info", "-e"]"#,
+        )
+        .unwrap();
+        assert_eq!(
+            config.interpreters.python_interpreter_find_cmd,
+            Some(vec![
+                "poetry".to_owned(),
+                "env".to_owned(),
+                "info".to_owned(),
+                "-e".to_owned(),
+            ])
+        );
+    }
+
+    #[test]
     fn test_expect_all_fields_set_in_root_config() {
         let root = TempDir::new().unwrap();
         let mut config = ConfigFile::init_at_root(root.path(), &ProjectLayout::default(), false);
@@ -2619,6 +2655,7 @@ output-format = "omit-errors"
             "project-excludes",
             "python-interpreter-path",
             "fallback-python-interpreter-name",
+            "python-interpreter-find-cmd",
             // values we won't be getting
             "extras",
             // values that must be Some (if flattened, their contents will be checked)
@@ -3526,6 +3563,7 @@ output-format = "omit-errors"
             interpreters: Interpreters {
                 python_interpreter_path: Some(ConfigOrigin::config(PathBuf::new())),
                 fallback_python_interpreter_name: None,
+                python_interpreter_find_cmd: None,
                 conda_environment: Some(ConfigOrigin::config("".to_owned())),
                 skip_interpreter_query: false,
             },
@@ -3539,6 +3577,24 @@ output-format = "omit-errors"
                  e.get_message() == "Cannot use both `python-interpreter-path` and `conda-environment`. Finding environment info using `python-interpreter-path`."
              })
          );
+    }
+
+    #[test]
+    fn test_python_interpreter_find_cmd_is_mutually_exclusive() {
+        let mut config = ConfigFile {
+            interpreters: Interpreters {
+                python_interpreter_find_cmd: Some(vec!["ignored".to_owned()]),
+                skip_interpreter_query: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let validation_errors = config.configure();
+        assert!(validation_errors.iter().any(|error| {
+            error.get_message()
+                == "`python-interpreter-find-cmd` cannot be combined with another interpreter selection option."
+        }));
     }
 
     #[test]
@@ -3562,6 +3618,7 @@ output-format = "omit-errors"
             interpreters: Interpreters {
                 python_interpreter_path: Some(ConfigOrigin::config(PathBuf::from("abcd"))),
                 fallback_python_interpreter_name: None,
+                python_interpreter_find_cmd: None,
                 conda_environment: None,
                 skip_interpreter_query: false,
             },

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -1348,29 +1348,35 @@ impl ConfigFile {
         // file or CLI flag). If not, we auto-discover a `typings/` directory below.
         let site_package_path_set = self.python_environment.site_package_path.is_some();
 
-        if self.interpreters.python_interpreter_find_cmd.is_some()
-            && (matches!(
-                self.interpreters.python_interpreter_path,
-                Some(ConfigOrigin::CommandLine(_) | ConfigOrigin::ConfigFile(_))
-            ) || self.interpreters.fallback_python_interpreter_name.is_some()
-                || self.interpreters.conda_environment.is_some()
-                || self.interpreters.skip_interpreter_query)
-        {
+        let mut interpreter_selections = Vec::new();
+        if matches!(
+            self.interpreters.python_interpreter_path.as_ref(),
+            Some(ConfigOrigin::CommandLine(_) | ConfigOrigin::ConfigFile(_))
+        ) {
+            interpreter_selections.push("python-interpreter-path");
+        }
+        if self.interpreters.python_interpreter_find_cmd.is_some() {
+            interpreter_selections.push("python-interpreter-find-cmd");
+        }
+        if self.interpreters.fallback_python_interpreter_name.is_some() {
+            interpreter_selections.push("fallback-python-interpreter-name");
+        }
+        if self.interpreters.conda_environment.is_some() {
+            interpreter_selections.push("conda-environment");
+        }
+        if self.interpreters.skip_interpreter_query {
+            interpreter_selections.push("skip-interpreter-query");
+        }
+        if interpreter_selections.len() > 1 {
             configure_errors.push(anyhow::anyhow!(
-                "`python-interpreter-find-cmd` cannot be combined with another interpreter selection option."
+                "Only one interpreter selection option can be set, but found: {}.",
+                interpreter_selections.join(", ")
             ));
         }
 
         if self.interpreters.skip_interpreter_query {
             self.python_environment.set_empty_to_default();
         } else {
-            if self.interpreters.python_interpreter_path.is_some()
-                && self.interpreters.fallback_python_interpreter_name.is_some()
-            {
-                configure_errors.push(anyhow::anyhow!(
-                        "`python-interpreter-path` and `fallback-python-interpreter-name` both set, but only one can be used."
-                ));
-            }
             match self.interpreters.find_interpreter(project_root.as_deref()) {
                 Ok(interpreter) => {
                     let (env, error) = PythonEnvironment::get_interpreter_env(&interpreter);
@@ -1620,15 +1626,6 @@ impl ConfigFile {
             configure_errors.extend(validate(site_package_path.as_ref(), "site-package-path"));
         }
         configure_errors.extend(validate(&self.search_path_from_file, "search-path"));
-
-        if self.interpreters.python_interpreter_path.is_some()
-            && self.interpreters.conda_environment.is_some()
-            && self.interpreters.python_interpreter_find_cmd.is_none()
-        {
-            configure_errors.push(anyhow::anyhow!(
-                     "Cannot use both `python-interpreter-path` and `conda-environment`. Finding environment info using `python-interpreter-path`.",
-             ));
-        }
 
         if let ConfigSource::File(path) = &self.source {
             configure_errors
@@ -1950,6 +1947,7 @@ mod tests {
     use super::*;
     use crate::base::ExtraConfigs;
     use crate::base::UntypedDefBehavior;
+    use crate::environment::interpreters::InterpreterDiscoveryCommand;
     use crate::error_kind::ErrorKind;
     use crate::error_kind::Severity;
     use crate::module_wildcard::ModuleWildcard;
@@ -2629,14 +2627,19 @@ output-format = "omit-errors"
             r#"python-interpreter-find-cmd = ["poetry", "env", "info", "-e"]"#,
         )
         .unwrap();
+        let expected = ["poetry", "env", "info", "-e"].map(str::to_owned);
         assert_eq!(
-            config.interpreters.python_interpreter_find_cmd,
-            Some(vec![
-                "poetry".to_owned(),
-                "env".to_owned(),
-                "info".to_owned(),
-                "-e".to_owned(),
-            ])
+            config.interpreters.python_interpreter_find_cmd.as_deref(),
+            Some(expected.as_slice())
+        );
+        let serialized = toml::to_string(&config).unwrap();
+        assert_eq!(ConfigFile::parse_config(&serialized).unwrap(), config);
+
+        let error = ConfigFile::parse_config(r#"python-interpreter-find-cmd = []"#).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("`python-interpreter-find-cmd` must contain a program")
         );
     }
 
@@ -3558,43 +3561,61 @@ output-format = "omit-errors"
     }
 
     #[test]
-    fn test_python_interpreter_conda_environment() {
-        let mut config = ConfigFile {
-            interpreters: Interpreters {
-                python_interpreter_path: Some(ConfigOrigin::config(PathBuf::new())),
-                fallback_python_interpreter_name: None,
-                python_interpreter_find_cmd: None,
-                conda_environment: Some(ConfigOrigin::config("".to_owned())),
-                skip_interpreter_query: false,
-            },
-            ..Default::default()
-        };
+    fn test_interpreter_selection_options_are_mutually_exclusive() {
+        let selections = [
+            "python-interpreter-path",
+            "python-interpreter-find-cmd",
+            "fallback-python-interpreter-name",
+            "conda-environment",
+            "skip-interpreter-query",
+        ];
 
-        let validation_errors = config.configure();
+        for (first_index, first) in selections.iter().enumerate() {
+            for second in &selections[first_index + 1..] {
+                let mut interpreters = Interpreters::default();
+                for selection in [first, second] {
+                    match *selection {
+                        "python-interpreter-path" => {
+                            interpreters.python_interpreter_path =
+                                Some(ConfigOrigin::config(PathBuf::from("ignored")));
+                        }
+                        "python-interpreter-find-cmd" => {
+                            interpreters.python_interpreter_find_cmd = Some(
+                                InterpreterDiscoveryCommand::try_from(vec!["ignored".to_owned()])
+                                    .unwrap(),
+                            );
+                        }
+                        "fallback-python-interpreter-name" => {
+                            interpreters.fallback_python_interpreter_name =
+                                Some(ConfigOrigin::config("ignored".to_owned()));
+                        }
+                        "conda-environment" => {
+                            interpreters.conda_environment =
+                                Some(ConfigOrigin::config("ignored".to_owned()));
+                        }
+                        "skip-interpreter-query" => {
+                            interpreters.skip_interpreter_query = true;
+                        }
+                        _ => unreachable!("all interpreter selections are covered"),
+                    }
+                }
 
-        assert!(
-             validation_errors.iter().any(|e| {
-                 e.get_message() == "Cannot use both `python-interpreter-path` and `conda-environment`. Finding environment info using `python-interpreter-path`."
-             })
-         );
-    }
-
-    #[test]
-    fn test_python_interpreter_find_cmd_is_mutually_exclusive() {
-        let mut config = ConfigFile {
-            interpreters: Interpreters {
-                python_interpreter_find_cmd: Some(vec!["ignored".to_owned()]),
-                skip_interpreter_query: true,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let validation_errors = config.configure();
-        assert!(validation_errors.iter().any(|error| {
-            error.get_message()
-                == "`python-interpreter-find-cmd` cannot be combined with another interpreter selection option."
-        }));
+                let mut config = ConfigFile {
+                    interpreters,
+                    ..Default::default()
+                };
+                let expected = format!(
+                    "Only one interpreter selection option can be set, but found: {first}, {second}."
+                );
+                assert!(
+                    config
+                        .configure()
+                        .iter()
+                        .any(|error| error.get_message() == expected),
+                    "missing validation error for {first} and {second}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/pyrefly_config/src/environment/interpreters.rs
+++ b/crates/pyrefly_config/src/environment/interpreters.rs
@@ -8,8 +8,10 @@
 use std::fmt::Display;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::Command;
 use std::sync::LazyLock;
 
+use anyhow::Context;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_with::skip_serializing_none;
@@ -38,6 +40,9 @@ pub struct Interpreters {
     /// Should we turn a generic command into a `python_interpreter` path?
     pub(crate) fallback_python_interpreter_name: Option<ConfigOrigin<String>>,
 
+    /// Command whose stdout is the path to the Python interpreter.
+    pub(crate) python_interpreter_find_cmd: Option<Vec<String>>,
+
     pub(crate) conda_environment: Option<ConfigOrigin<String>>,
 
     /// Should we do any querying of an interpreter?
@@ -52,6 +57,11 @@ impl Display for Interpreters {
                 skip_interpreter_query: true,
                 ..
             } => write!(f, "<interpreter query skipped>"),
+            Self {
+                python_interpreter_path: None,
+                python_interpreter_find_cmd: Some(cmd),
+                ..
+            } => write!(f, "interpreter from command `{}`", cmd.join(" ")),
             Self {
                 python_interpreter_path: None,
                 ..
@@ -90,6 +100,7 @@ impl Interpreters {
     /// if we should respect an IDE-supplied interpreter preference.
     pub fn is_empty(&self) -> bool {
         self.python_interpreter_path.is_none()
+            && self.python_interpreter_find_cmd.is_none()
             && self.conda_environment.is_none()
             && self.fallback_python_interpreter_name.is_none()
     }
@@ -102,23 +113,21 @@ impl Interpreters {
     /// and interpreter settings.
     ///
     /// The priorities are:
-    /// 1. Check for an overridden `--python-interpreter` or `--conda-environment`
-    /// 2. Check for a configured `python-interpreter`
-    /// 3. Check for a configured `conda-environment`
-    /// 4. Check for an IDE / LSP provided `python-interpreter`.
-    /// 5. Check for an active venv or Conda environment
-    /// 6. Check for a `venv` in the current project
-    /// 7. Use an interpreter we can find on the `$PATH`
-    /// 8. Give up and return an error
+    /// 1. Check for an overridden interpreter or Conda environment from the CLI.
+    /// 2. Check for a configured interpreter path, discovery command, or Conda environment.
+    /// 3. Check for an IDE / LSP provided `python-interpreter`.
+    /// 4. Check for an active venv or Conda environment.
+    /// 5. Check for a `venv` in the current project.
+    /// 6. Use an interpreter we can find on the `$PATH`.
+    /// 7. Give up and return an error.
     pub(crate) fn find_interpreter(
         &self,
         path: Option<&Path>,
     ) -> anyhow::Result<ConfigOrigin<PathBuf>> {
-        let python_interpreter = self.interpreter_path_or_cmd()?;
+        let python_interpreter = self.interpreter_path_or_cmd(path)?;
         if let Some(interpreter @ ConfigOrigin::CommandLine(_)) = python_interpreter {
             return Ok(interpreter);
         }
-
         if let Some(conda_env @ ConfigOrigin::CommandLine(_)) = &self.conda_environment {
             return conda_env
                 .as_deref()
@@ -129,7 +138,6 @@ impl Interpreters {
         if let Some(interpreter @ ConfigOrigin::ConfigFile(_)) = python_interpreter {
             return Ok(interpreter);
         }
-
         if let Some(conda_env @ ConfigOrigin::ConfigFile(_)) = &self.conda_environment {
             return conda_env
                 .as_deref()
@@ -174,9 +182,17 @@ impl Interpreters {
         ))
     }
 
-    fn interpreter_path_or_cmd(&self) -> anyhow::Result<Option<ConfigOrigin<PathBuf>>> {
+    fn interpreter_path_or_cmd(
+        &self,
+        working_directory: Option<&Path>,
+    ) -> anyhow::Result<Option<ConfigOrigin<PathBuf>>> {
         if self.python_interpreter_path.is_some() {
             return Ok(self.python_interpreter_path.clone());
+        }
+        if self.python_interpreter_find_cmd.is_some() {
+            return self
+                .find_interpreter_from_command(working_directory)
+                .map(Some);
         }
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(cmd) = &self.fallback_python_interpreter_name {
@@ -186,6 +202,65 @@ impl Interpreters {
             return Ok(Some(cmd.as_ref().map(which_to_anyhow_err).transpose_err()?));
         }
         Ok(self.python_interpreter_path.clone())
+    }
+
+    fn find_interpreter_from_command(
+        &self,
+        working_directory: Option<&Path>,
+    ) -> anyhow::Result<ConfigOrigin<PathBuf>> {
+        let command_parts = self
+            .python_interpreter_find_cmd
+            .as_deref()
+            .context("`python-interpreter-find-cmd` is not configured")?;
+        let Some((program, args)) = command_parts.split_first() else {
+            return Err(anyhow::anyhow!(
+                "`python-interpreter-find-cmd` must contain at least one argument"
+            ));
+        };
+
+        let mut command = Command::new(program);
+        command.args(args);
+        if let Some(working_directory) = working_directory {
+            command.current_dir(working_directory);
+        }
+        let output = command.output().with_context(|| {
+            format!(
+                "Failed to run Python interpreter discovery command `{}`",
+                command_parts.join(" ")
+            )
+        })?;
+        if !output.status.success() {
+            return Err(anyhow::anyhow!(
+                "Python interpreter discovery command `{}` failed with status {}: {}",
+                command_parts.join(" "),
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
+        }
+
+        let stdout = String::from_utf8(output.stdout)
+            .context("Python interpreter discovery command output was not valid UTF-8")?;
+        let interpreter = stdout.trim();
+        if interpreter.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Python interpreter discovery command `{}` returned an empty path",
+                command_parts.join(" ")
+            ));
+        }
+        if interpreter.lines().count() != 1 {
+            return Err(anyhow::anyhow!(
+                "Python interpreter discovery command `{}` must return exactly one path",
+                command_parts.join(" ")
+            ));
+        }
+
+        let mut interpreter = PathBuf::from(interpreter);
+        if interpreter.is_relative()
+            && let Some(working_directory) = working_directory
+        {
+            interpreter = working_directory.join(interpreter);
+        }
+        Ok(ConfigOrigin::auto(interpreter))
     }
 
     /// Get the first executable interpreter available on the path.
@@ -364,5 +439,58 @@ mod test {
                     .join(test_venv_interpreter_name())
             )
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_find_interpreter_from_command() {
+        let tempdir = tempdir().unwrap();
+        let interpreters = Interpreters {
+            python_interpreter_find_cmd: Some(vec![
+                "sh".to_owned(),
+                "-c".to_owned(),
+                "printf 'venv/bin/python\\n'".to_owned(),
+            ]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            interpreters.find_interpreter(Some(tempdir.path())).unwrap(),
+            ConfigOrigin::auto(tempdir.path().join("venv/bin/python"))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_interpreter_find_command_must_return_one_path() {
+        let interpreters = Interpreters {
+            python_interpreter_find_cmd: Some(vec![
+                "sh".to_owned(),
+                "-c".to_owned(),
+                "printf 'first\\nsecond\\n'".to_owned(),
+            ]),
+            ..Default::default()
+        };
+
+        let error = interpreters.find_interpreter(None).unwrap_err();
+        assert!(error.to_string().contains("must return exactly one path"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_interpreter_find_command_reports_failure() {
+        let interpreters = Interpreters {
+            python_interpreter_find_cmd: Some(vec![
+                "sh".to_owned(),
+                "-c".to_owned(),
+                "printf 'manager failed' >&2; exit 7".to_owned(),
+            ]),
+            ..Default::default()
+        };
+
+        let error = interpreters.find_interpreter(None).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("failed with status"));
+        assert!(message.contains("manager failed"));
     }
 }

--- a/crates/pyrefly_config/src/environment/interpreters.rs
+++ b/crates/pyrefly_config/src/environment/interpreters.rs
@@ -6,23 +6,64 @@
  */
 
 use std::fmt::Display;
+use std::ops::Deref;
 use std::path::Path;
 use std::path::PathBuf;
+#[cfg(not(target_arch = "wasm32"))]
 use std::process::Command;
 use std::sync::LazyLock;
 
+#[cfg(not(target_arch = "wasm32"))]
 use anyhow::Context;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_with::skip_serializing_none;
 #[cfg(not(target_arch = "wasm32"))]
 use which::which;
+#[cfg(not(target_arch = "wasm32"))]
+use which::which_in;
 
 use crate::environment::active_environment::ActiveEnvironment;
 use crate::environment::conda;
 use crate::environment::environment::PythonEnvironment;
 use crate::environment::venv;
 use crate::util::ConfigOrigin;
+
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
+#[serde(try_from = "Vec<String>", into = "Vec<String>")]
+pub(crate) struct InterpreterDiscoveryCommand(Vec<String>);
+
+impl TryFrom<Vec<String>> for InterpreterDiscoveryCommand {
+    type Error = &'static str;
+
+    fn try_from(parts: Vec<String>) -> Result<Self, Self::Error> {
+        if parts.is_empty() {
+            Err("`python-interpreter-find-cmd` must contain a program")
+        } else {
+            Ok(Self(parts))
+        }
+    }
+}
+
+impl From<InterpreterDiscoveryCommand> for Vec<String> {
+    fn from(command: InterpreterDiscoveryCommand) -> Self {
+        command.0
+    }
+}
+
+impl Deref for InterpreterDiscoveryCommand {
+    type Target = [String];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Display for InterpreterDiscoveryCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.join(" "))
+    }
+}
 
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone, Default)]
@@ -41,7 +82,7 @@ pub struct Interpreters {
     pub(crate) fallback_python_interpreter_name: Option<ConfigOrigin<String>>,
 
     /// Command whose stdout is the path to the Python interpreter.
-    pub(crate) python_interpreter_find_cmd: Option<Vec<String>>,
+    pub(crate) python_interpreter_find_cmd: Option<InterpreterDiscoveryCommand>,
 
     pub(crate) conda_environment: Option<ConfigOrigin<String>>,
 
@@ -61,20 +102,11 @@ impl Display for Interpreters {
                 python_interpreter_path: None,
                 python_interpreter_find_cmd: Some(cmd),
                 ..
-            } => write!(f, "interpreter from command `{}`", cmd.join(" ")),
+            } => write!(f, "interpreter from command `{cmd}`"),
             Self {
                 python_interpreter_path: None,
                 ..
             } => write!(f, "<none found successfully>"),
-            Self {
-                conda_environment: Some(conda),
-                python_interpreter_path: Some(path),
-                ..
-            } => write!(
-                f,
-                "conda environment {conda} with interpreter at {}",
-                path.display()
-            ),
             Self {
                 fallback_python_interpreter_name: Some(cmd),
                 python_interpreter_path: Some(path),
@@ -83,6 +115,24 @@ impl Display for Interpreters {
                 f,
                 "interpreter at path {} (from `which {cmd}`)",
                 path.display(),
+            ),
+            Self {
+                python_interpreter_find_cmd: Some(cmd),
+                python_interpreter_path: Some(path),
+                ..
+            } => write!(
+                f,
+                "interpreter at path {} (from command `{cmd}`)",
+                path.display(),
+            ),
+            Self {
+                conda_environment: Some(conda),
+                python_interpreter_path: Some(path),
+                ..
+            } => write!(
+                f,
+                "conda environment {conda} with interpreter at {}",
+                path.display()
             ),
             Self {
                 python_interpreter_path: Some(path),
@@ -124,7 +174,7 @@ impl Interpreters {
         &self,
         path: Option<&Path>,
     ) -> anyhow::Result<ConfigOrigin<PathBuf>> {
-        let python_interpreter = self.interpreter_path_or_cmd(path)?;
+        let python_interpreter = self.interpreter_path_or_cmd()?;
         if let Some(interpreter @ ConfigOrigin::CommandLine(_)) = python_interpreter {
             return Ok(interpreter);
         }
@@ -137,6 +187,17 @@ impl Interpreters {
 
         if let Some(interpreter @ ConfigOrigin::ConfigFile(_)) = python_interpreter {
             return Ok(interpreter);
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(command) = self.python_interpreter_find_cmd.as_deref() {
+            let interpreter = Self::find_interpreter_from_command(command, path)?;
+            return Ok(ConfigOrigin::auto(interpreter));
+        }
+        #[cfg(target_arch = "wasm32")]
+        if self.python_interpreter_find_cmd.is_some() {
+            return Err(anyhow::anyhow!(
+                "`python-interpreter-find-cmd` is not supported on WebAssembly"
+            ));
         }
         if let Some(conda_env @ ConfigOrigin::ConfigFile(_)) = &self.conda_environment {
             return conda_env
@@ -182,17 +243,9 @@ impl Interpreters {
         ))
     }
 
-    fn interpreter_path_or_cmd(
-        &self,
-        working_directory: Option<&Path>,
-    ) -> anyhow::Result<Option<ConfigOrigin<PathBuf>>> {
+    fn interpreter_path_or_cmd(&self) -> anyhow::Result<Option<ConfigOrigin<PathBuf>>> {
         if self.python_interpreter_path.is_some() {
             return Ok(self.python_interpreter_path.clone());
-        }
-        if self.python_interpreter_find_cmd.is_some() {
-            return self
-                .find_interpreter_from_command(working_directory)
-                .map(Some);
         }
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(cmd) = &self.fallback_python_interpreter_name {
@@ -204,19 +257,18 @@ impl Interpreters {
         Ok(self.python_interpreter_path.clone())
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     fn find_interpreter_from_command(
-        &self,
+        command_parts: &[String],
         working_directory: Option<&Path>,
-    ) -> anyhow::Result<ConfigOrigin<PathBuf>> {
-        let command_parts = self
-            .python_interpreter_find_cmd
-            .as_deref()
-            .context("`python-interpreter-find-cmd` is not configured")?;
-        let Some((program, args)) = command_parts.split_first() else {
-            return Err(anyhow::anyhow!(
-                "`python-interpreter-find-cmd` must contain at least one argument"
-            ));
-        };
+    ) -> anyhow::Result<PathBuf> {
+        let program = &command_parts[0];
+        let args = &command_parts[1..];
+        let program = match working_directory {
+            Some(root) => which_in(program, std::env::var_os("PATH"), root),
+            None => which(program),
+        }
+        .with_context(|| "Could not resolve the Python interpreter discovery command")?;
 
         let mut command = Command::new(program);
         command.args(args);
@@ -260,7 +312,7 @@ impl Interpreters {
         {
             interpreter = working_directory.join(interpreter);
         }
-        Ok(ConfigOrigin::auto(interpreter))
+        Ok(interpreter)
     }
 
     /// Get the first executable interpreter available on the path.
@@ -287,6 +339,9 @@ impl Interpreters {
 
 #[cfg(test)]
 mod test {
+    #[cfg(windows)]
+    use std::fs;
+
     use pyrefly_util::test_path::TestPath;
     use tempfile::TempDir;
     use tempfile::tempdir;
@@ -320,6 +375,16 @@ mod test {
     /// Produces a conda environment name that should not actually be possible in conda.
     fn fake_conda_name() -> String {
         "../././".to_owned()
+    }
+
+    fn discovery_command(parts: &[&str]) -> InterpreterDiscoveryCommand {
+        InterpreterDiscoveryCommand::try_from(
+            parts
+                .iter()
+                .map(|part| (*part).to_owned())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -367,6 +432,16 @@ mod test {
             ..Default::default()
         };
 
+        assert_eq!(
+            interpreters.find_interpreter(Some(tempdir.path())).unwrap(),
+            python_interpreter
+        );
+
+        let interpreters = Interpreters {
+            python_interpreter_path: Some(python_interpreter.clone()),
+            python_interpreter_find_cmd: Some(discovery_command(&["does-not-exist"])),
+            ..Default::default()
+        };
         assert_eq!(
             interpreters.find_interpreter(Some(tempdir.path())).unwrap(),
             python_interpreter
@@ -441,22 +516,75 @@ mod test {
         );
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     #[test]
-    fn test_find_interpreter_from_command() {
+    fn test_interpreter_find_command_resolves_relative_output() {
         let tempdir = tempdir().unwrap();
+
+        #[cfg(unix)]
+        let command = discovery_command(&["sh", "-c", "printf 'venv/bin/python\\n'"]);
+        #[cfg(windows)]
+        let command = discovery_command(&["cmd", "/C", "echo venv\\Scripts\\python.exe"]);
+
         let interpreters = Interpreters {
-            python_interpreter_find_cmd: Some(vec![
-                "sh".to_owned(),
-                "-c".to_owned(),
-                "printf 'venv/bin/python\\n'".to_owned(),
-            ]),
+            python_interpreter_find_cmd: Some(command),
+            conda_environment: Some(ConfigOrigin::config(fake_conda_name())),
+            ..Default::default()
+        };
+
+        #[cfg(unix)]
+        let expected = tempdir.path().join("venv/bin/python");
+        #[cfg(windows)]
+        let expected = tempdir.path().join("venv\\Scripts\\python.exe");
+
+        assert_eq!(
+            interpreters.find_interpreter(Some(tempdir.path())).unwrap(),
+            ConfigOrigin::auto(expected)
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn test_interpreter_find_command_uses_working_directory() {
+        let tempdir = tempdir().unwrap();
+
+        #[cfg(unix)]
+        let command = discovery_command(&["sh", "-c", "pwd"]);
+        #[cfg(windows)]
+        let command = discovery_command(&["cmd", "/C", "cd"]);
+
+        let interpreters = Interpreters {
+            python_interpreter_find_cmd: Some(command),
+            ..Default::default()
+        };
+        let interpreter = interpreters.find_interpreter(Some(tempdir.path())).unwrap();
+
+        assert_eq!(
+            interpreter.as_path().canonicalize().unwrap(),
+            tempdir.path().canonicalize().unwrap(),
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_interpreter_find_command_resolves_relative_program() {
+        let tempdir = tempdir().unwrap();
+        let tools = tempdir.path().join("tools");
+        fs::create_dir(&tools).unwrap();
+        fs::copy(which("cmd").unwrap(), tools.join("find-python.exe")).unwrap();
+
+        let interpreters = Interpreters {
+            python_interpreter_find_cmd: Some(discovery_command(&[
+                "tools\\find-python.exe",
+                "/C",
+                "echo venv\\Scripts\\python.exe",
+            ])),
             ..Default::default()
         };
 
         assert_eq!(
             interpreters.find_interpreter(Some(tempdir.path())).unwrap(),
-            ConfigOrigin::auto(tempdir.path().join("venv/bin/python"))
+            ConfigOrigin::auto(tempdir.path().join("venv\\Scripts\\python.exe")),
         );
     }
 
@@ -464,11 +592,11 @@ mod test {
     #[test]
     fn test_interpreter_find_command_must_return_one_path() {
         let interpreters = Interpreters {
-            python_interpreter_find_cmd: Some(vec![
-                "sh".to_owned(),
-                "-c".to_owned(),
-                "printf 'first\\nsecond\\n'".to_owned(),
-            ]),
+            python_interpreter_find_cmd: Some(discovery_command(&[
+                "sh",
+                "-c",
+                "printf 'first\\nsecond\\n'",
+            ])),
             ..Default::default()
         };
 
@@ -480,11 +608,11 @@ mod test {
     #[test]
     fn test_interpreter_find_command_reports_failure() {
         let interpreters = Interpreters {
-            python_interpreter_find_cmd: Some(vec![
-                "sh".to_owned(),
-                "-c".to_owned(),
-                "printf 'manager failed' >&2; exit 7".to_owned(),
-            ]),
+            python_interpreter_find_cmd: Some(discovery_command(&[
+                "sh",
+                "-c",
+                "printf 'manager failed' >&2; exit 7",
+            ])),
             ..Default::default()
         };
 
@@ -492,5 +620,19 @@ mod test {
         let message = error.to_string();
         assert!(message.contains("failed with status"));
         assert!(message.contains("manager failed"));
+    }
+
+    #[test]
+    fn test_interpreter_display_includes_discovery_command() {
+        let interpreters = Interpreters {
+            python_interpreter_path: Some(ConfigOrigin::auto(PathBuf::from("/resolved/python"))),
+            python_interpreter_find_cmd: Some(discovery_command(&["poetry", "env", "info", "-e"])),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            interpreters.to_string(),
+            "interpreter at path /resolved/python (from command `poetry env info -e`)"
+        );
     }
 }

--- a/schemas/pyrefly.json
+++ b/schemas/pyrefly.json
@@ -182,6 +182,14 @@
           "description": "The Python interpreter to query when attempting to autoconfigure Python environment values (site-package-path, python-platform, python-version).",
           "type": "string"
         },
+        "python-interpreter-find-cmd": {
+          "description": "A program and its arguments that print the path of the Python interpreter to query.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
         "fallback-python-interpreter-name": {
           "description": "The Python interpreter, available on your $PATH, to use. Pyrefly will perform 'which <your command>', and automatically fill in python-interpreter-path for you with the found path.",
           "type": "string"

--- a/schemas/test-pyproject.toml
+++ b/schemas/test-pyproject.toml
@@ -20,6 +20,7 @@ python-platform = "linux"
 python-version = "3.12.0"
 skip-interpreter-query = false
 python-interpreter-path = "venv/bin/python3"
+python-interpreter-find-cmd = ["poetry", "env", "info", "-e"]
 conda-environment = "myenv"
 fallback-python-interpreter-name = "python3"
 typeshed-path = "/path/to/typeshed"

--- a/schemas/test-pyrefly.toml
+++ b/schemas/test-pyrefly.toml
@@ -19,6 +19,7 @@ python-platform = "linux"
 python-version = "3.12.0"
 skip-interpreter-query = false
 python-interpreter-path = "venv/bin/python3"
+python-interpreter-find-cmd = ["poetry", "env", "info", "-e"]
 conda-environment = "myenv"
 fallback-python-interpreter-name = "python3"
 typeshed-path = "/path/to/typeshed"

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -1216,8 +1216,8 @@ We look for an interpreter with the following logic:
 3. Use [`python-interpreter-path`](#python-interpreter-path),
    [`python-interpreter-find-cmd`](#python-interpreter-find-cmd),
    [`fallback-python-interpreter-name`](#fallback-python-interpreter-name), or
-   [`conda-environment`](#conda-environment) if either are set in a config file.
-   Both cannot be set in a config at the same time.
+   [`conda-environment`](#conda-environment) if any are set in a config file.
+   Only one of these options can be set in a configuration.
 4. Starting from the project root, look for `pyvenv.cfg` in the root itself or in a
    `.venv`, `venv`, or `env` directory. If none is found, repeat the search in each
    ancestor directory up to the filesystem root, preferring the nearest match. Pyrefly

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -390,8 +390,8 @@ We will query Conda for information about this environment, even when it's not s
 unless a Python environment (venv, Conda) is activated or `--python-interpreter-path` or
 `--conda-environment` are passed in through the CLI.
 
-**`conda-environment`, `fallback-python-interpreter-name`, `conda-environment`,
-and `skip-interpreter-query` are mutually exclusive with each other.**
+**`conda-environment`, `python-interpreter-path`, `python-interpreter-find-cmd`,
+`fallback-python-interpreter-name`, and `skip-interpreter-query` are mutually exclusive.**
 
 - Type: string of existing Conda environment name
 - Default: none
@@ -406,8 +406,8 @@ The Python interpreter to query when attempting to autoconfigure
 Python environment values (`site-package-path`, `python-platform`, `python-version`).
 See the [Environment Autoconfiguration section](#environment-autoconfiguration) for more information.
 
-**`conda-environment`, `fallback-python-interpreter-name`, `conda-environment`,
-and `skip-interpreter-query` are mutually exclusive with each other.**
+**`conda-environment`, `python-interpreter-path`, `python-interpreter-find-cmd`,
+`fallback-python-interpreter-name`, and `skip-interpreter-query` are mutually exclusive.**
 
 - Type: path to executable
 - Default: `$(which python3)`, then `$(which python)`, or none
@@ -425,6 +425,32 @@ testing specific behavior, or having trouble with [Environment Autoconfiguration
 Setting this explicitly, especially when not using a venv, will make it difficult for your configuration
 to be reused between different systems and platforms.
 
+### `python-interpreter-find-cmd`
+
+A command that prints the path of the Python interpreter Pyrefly should query. Configure it as an
+array containing the program followed by its arguments. Pyrefly runs the program directly from the
+configuration file's directory; it does not invoke a shell. The command must succeed and print exactly
+one non-empty line. A relative path is resolved from the configuration file's directory.
+
+```toml
+python-interpreter-find-cmd = ["poetry", "env", "info", "-e"]
+```
+
+For workflows that require shell features, invoke the shell explicitly, for example
+`["sh", "-c", "eval \"$(direnv export bash)\"; command -v python"]`. On Windows, use the
+equivalent `cmd /C` or PowerShell command.
+
+**`conda-environment`, `python-interpreter-path`, `python-interpreter-find-cmd`,
+`fallback-python-interpreter-name`, and `skip-interpreter-query` are mutually exclusive.**
+
+- Type: array of strings containing a program and its arguments
+- Default: none
+- Flag equivalent: none
+- Equivalent configs: none
+- Notes:
+    - This executes the configured program without checking whether it is trusted. Review project
+      configuration before running Pyrefly in an untrusted checkout.
+
 ### `fallback-python-interpreter-name`
 
 The Python interpreter, available on your `$PATH`, to use. Pyrefly will perform
@@ -435,8 +461,8 @@ path when this option and [`python-interpreter-path`](#python-interpreter-path) 
 so this should primarily be used when you have a non-standard Python executable you want to
 use.
 
-**`conda-environment`, `fallback-python-interpreter-name`, `conda-environment`,
-and `skip-interpreter-query` are mutually exclusive with each other.**
+**`conda-environment`, `python-interpreter-path`, `python-interpreter-find-cmd`,
+`fallback-python-interpreter-name`, and `skip-interpreter-query` are mutually exclusive.**
 
 - Type: string of command to use
 - Default: `python3`, then `python`, or none
@@ -458,8 +484,8 @@ and [`python-platform`](#python-platform), and will use an empty
 [`site-package-path`](#site-package-path). It's likely you'll want to override
 these to match the environment you'll be running in.
 
-**`conda-environment`, `fallback-python-interpreter-name`, `conda-environment`,
-and `skip-interpreter-query` are mutually exclusive with each other.**
+**`conda-environment`, `python-interpreter-path`, `python-interpreter-find-cmd`,
+`fallback-python-interpreter-name`, and `skip-interpreter-query` are mutually exclusive.**
 
 - Type: bool
 - Default: `false`
@@ -1188,6 +1214,7 @@ We look for an interpreter with the following logic:
 2. Determine if there's an active `venv` or `conda` environment. If both are active at
    the same time, we take `venv` over `conda`.
 3. Use [`python-interpreter-path`](#python-interpreter-path),
+   [`python-interpreter-find-cmd`](#python-interpreter-find-cmd),
    [`fallback-python-interpreter-name`](#fallback-python-interpreter-name), or
    [`conda-environment`](#conda-environment) if either are set in a config file.
    Both cannot be set in a config at the same time.
@@ -1456,6 +1483,7 @@ skip-interpreter-query = false
 # query the default Python interpreter on your system, if installed and `python_platform`,
 # `python-version`, or `site-package-path` are unset.
 # python-interpreter-path = null # this is commented out because there are no `null` values in TOML
+# python-interpreter-find-cmd = ["poetry", "env", "info", "-e"]
 
 #### configuring your type check settings
 


### PR DESCRIPTION
## Summary

- add `python-interpreter-find-cmd` as a configuration-only interpreter source
- execute the configured program directly from the config directory
- require successful UTF-8 output containing exactly one non-empty path
- resolve relative output paths from the config directory
- validate mutual exclusion with other interpreter-selection options and document explicit shell usage

## Root cause

Pyrefly only supported fixed interpreter paths, known environment types, and executable-name lookup. Environment managers that require a command to discover the active interpreter could not participate without first modifying the shell environment that launched Pyrefly.

The option is an argv array and does not invoke a shell implicitly. Workflows requiring shell features can opt in explicitly with `sh -c`, `cmd /C`, or PowerShell.

## User impact

Projects using tools such as Poetry, direnv, or Nix can provide a reproducible interpreter-discovery command in project configuration.

## Testing

- `cargo test interpreter` (config, command execution, failure handling, and LSP interpreter tests)
- formatter and Clippy through `test.py`

Fixes #1662
