### PR TITLE
Refresh LSP import paths after .pth changes

### DIFF
--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -1194,6 +1194,12 @@ impl ConfigFile {
                         format!("**/*.{suffix}"),
                     ));
                 });
+            config.site_package_path().for_each(|site_packages| {
+                result.insert(WatchPattern::root(
+                    InternedPath::from_path(site_packages),
+                    "*.pth".to_owned(),
+                ));
+            });
         }
 
         for source_db in source_dbs {
@@ -2671,6 +2677,34 @@ output-format = "omit-errors"
 
         // test replace_imports_with_any special case None path
         assert!(config.replace_imports_with_any(None, ModuleName::from_str("root")));
+    }
+
+    #[test]
+    fn test_site_package_pth_files_are_watched() {
+        let tempdir = TempDir::new().unwrap();
+        let site_packages = tempdir.path().join("site-packages");
+        std::fs::create_dir(&site_packages).unwrap();
+        let mut config = ConfigFile {
+            interpreters: Interpreters {
+                skip_interpreter_query: true,
+                ..Default::default()
+            },
+            python_environment: PythonEnvironment {
+                site_package_path: Some(vec![site_packages.clone()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        config.configure();
+        let mut configs = SmallSet::new();
+        configs.insert(ArcId::new(config));
+
+        assert!(
+            ConfigFile::get_paths_to_watch(&configs).contains(&WatchPattern::root(
+                InternedPath::from_path(&site_packages),
+                "*.pth".to_owned(),
+            ))
+        );
     }
 
     #[test]

--- a/crates/pyrefly_config/src/environment/environment.rs
+++ b/crates/pyrefly_config/src/environment/environment.rs
@@ -75,6 +75,11 @@ pub struct PythonEnvironment {
 }
 
 impl PythonEnvironment {
+    /// Clear cached interpreter queries after environment metadata changes.
+    pub fn clear_interpreter_cache() {
+        INTERPRETER_ENV_REGISTRY.lock().clear();
+    }
+
     fn pyrefly_default() -> Self {
         let mut env = Self::default();
         env.set_empty_to_default();

--- a/pyrefly/lib/lsp/non_wasm/queue.rs
+++ b/pyrefly/lib/lsp/non_wasm/queue.rs
@@ -44,6 +44,8 @@ pub enum LspEvent {
     /// based on the latest `State`. The included config files are configs whose find
     /// caches should be invalidated. on the next run.
     RecheckFinished,
+    /// Re-register filesystem watchers after a config reload changes import paths.
+    RefreshFileWatchers,
     /// Inform the server that a request is cancelled.
     /// Server should know about this ASAP to avoid wasting time on cancelled requests.
     CancelRequest(RequestId),
@@ -71,6 +73,7 @@ impl LspEvent {
     pub fn describe(&self) -> String {
         match self {
             Self::RecheckFinished => "RecheckFinished".to_owned(),
+            Self::RefreshFileWatchers => "RefreshFileWatchers".to_owned(),
             Self::CancelRequest(_) => "CancelRequest".to_owned(),
             Self::InvalidateConfigFind => "InvalidateConfigFind".to_owned(),
             Self::DidOpenTextDocument(_) => "DidOpenTextDocument".to_owned(),
@@ -114,7 +117,9 @@ impl LspEvent {
 
     fn kind(&self) -> LspEventKind {
         match self {
-            Self::RecheckFinished | Self::CancelRequest(_) => LspEventKind::Priority,
+            Self::RecheckFinished | Self::RefreshFileWatchers | Self::CancelRequest(_) => {
+                LspEventKind::Priority
+            }
             Self::DidOpenTextDocument(_)
             | Self::DidChangeTextDocument(_)
             | Self::DidCloseTextDocument(_)

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -1855,6 +1855,9 @@ impl Server {
                 // But in practice though the operations are usually cheap so it's OK.
                 self.publish_workspace_diagnostics_if_enabled();
             }
+            LspEvent::RefreshFileWatchers => {
+                self.setup_file_watcher_if_necessary(Some(telemetry_event));
+            }
             LspEvent::CancelRequest(id) => {
                 telemetry_event.request_id = Some(id.to_string());
                 info!("We should cancel request {id:?}");
@@ -3277,6 +3280,7 @@ impl Server {
         self.invalidate(
             TelemetryEventKind::InvalidateFind,
             Some(TelemetryInvalidateFindReason::SourceDbConfigChanged),
+            false,
             |t| t.invalidate_find_for_configs(invalidated_configs),
         );
     }
@@ -3372,6 +3376,7 @@ impl Server {
         &self,
         kind: TelemetryEventKind,
         invalidate_find_reason: Option<TelemetryInvalidateFindReason>,
+        refresh_file_watchers: bool,
         f: impl FnOnce(&mut Transaction) + Send + Sync + 'static,
     ) {
         let open_handles = self.get_open_file_handles();
@@ -3445,6 +3450,9 @@ impl Server {
                 );
                 *server.currently_streaming_diagnostics_for_handles.write() = None;
 
+                if refresh_file_watchers {
+                    let _ = server.lsp_queue.send(LspEvent::RefreshFileWatchers);
+                }
                 // After we finished a recheck asynchronously, we immediately send `RecheckFinished` to
                 // the main event loop of the server. As a result, the server can do a revalidation of
                 // all the in-memory files based on the fresh main State as soon as possible.
@@ -3679,7 +3687,7 @@ impl Server {
 
     fn did_save(&self, url: Url) {
         if let Some(path) = self.path_for_uri(&url) {
-            self.invalidate(TelemetryEventKind::InvalidateDisk, None, move |t| {
+            self.invalidate(TelemetryEventKind::InvalidateDisk, None, false, move |t| {
                 t.invalidate_disk(&[path])
             })
         }
@@ -4020,6 +4028,11 @@ impl Server {
         });
 
         let should_requery_build_system = should_requery_build_system(&events);
+        let interpreter_environment_changed = events.iter().any(|path| {
+            path.extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("pth"))
+        });
 
         // Rewatch files if necessary (config changed, files added/removed, etc.)
         if Self::should_rewatch(&events) {
@@ -4036,6 +4049,7 @@ impl Server {
         self.invalidate(
             TelemetryEventKind::InvalidateFind,
             Some(TelemetryInvalidateFindReason::WatcherEvents),
+            interpreter_environment_changed,
             move |t| {
                 let events = std::mem::take(&mut *pending.lock());
                 if !events.is_empty() {

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -104,6 +104,7 @@ use crate::binding::metadata::BindingsMetadata;
 use crate::binding::scope::builtin_module_for_name;
 use crate::binding::table::TableKeyed;
 use crate::config::config::ConfigFile;
+use crate::config::environment::environment::PythonEnvironment;
 use crate::config::error_kind::ErrorKind;
 use crate::config::finder::ConfigError;
 use crate::config::finder::ConfigFinder;
@@ -2279,6 +2280,15 @@ impl<'a> Transaction<'a> {
 
     /// Invalidate based on what a watcher told you.
     pub fn invalidate_events(&mut self, events: &CategorizedEvents) {
+        let interpreter_environment_changed = events.iter().any(|path| {
+            path.extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("pth"))
+        });
+        if interpreter_environment_changed {
+            PythonEnvironment::clear_interpreter_cache();
+        }
+
         // If any files were added or removed, we need to invalidate the find step.
         if !events.created.is_empty() || !events.removed.is_empty() || !events.unknown.is_empty() {
             self.invalidate_find();
@@ -2289,11 +2299,13 @@ impl<'a> Transaction<'a> {
         self.invalidate_disk(&files);
 
         // If any config files changed, we need to invalidate the config step.
-        if events.iter().any(|x| {
-            x.file_name()
-                .and_then(|x| x.to_str())
-                .is_some_and(|x| ConfigFile::CONFIG_FILE_NAMES.contains(&x))
-        }) {
+        if interpreter_environment_changed
+            || events.iter().any(|x| {
+                x.file_name()
+                    .and_then(|x| x.to_str())
+                    .is_some_and(|x| ConfigFile::CONFIG_FILE_NAMES.contains(&x))
+            })
+        {
             self.invalidate_config();
         }
     }

--- a/pyrefly/lib/test/lsp/lsp_interaction/file_watcher.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/file_watcher.rs
@@ -6,6 +6,10 @@
  */
 
 use std::collections::HashSet;
+#[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 use lsp_types::RegistrationParams;
 use lsp_types::Url;
@@ -177,6 +181,113 @@ fn test_consecutive_file_watcher_events() {
         .client
         .expect_publish_diagnostics_eventual_error_count(c_path.clone(), 1)
         .expect("Failed to receive diagnostics after file watcher events");
+
+    interaction.shutdown().unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn test_pth_change_refreshes_interpreter_paths() {
+    let root = get_test_files_root();
+    let project_root = root.path().join("pth_refresh");
+    let source_root = project_root.join("src");
+    let bin_root = project_root.join("bin");
+    let site_packages = bin_root.join("site-packages");
+    let workspace_package = project_root.join("workspace-package");
+    fs::create_dir_all(&source_root).unwrap();
+    fs::create_dir_all(&site_packages).unwrap();
+    fs::create_dir_all(&workspace_package).unwrap();
+    fs::write(
+        source_root.join("main.py"),
+        "from dynamic_module import value\nprint(value)\n",
+    )
+    .unwrap();
+    fs::write(
+        workspace_package.join("dynamic_module.py"),
+        "value: int = 1\n",
+    )
+    .unwrap();
+    fs::write(
+        source_root.join("pyrefly.toml"),
+        "python-interpreter-path = \"../bin/python\"\n",
+    )
+    .unwrap();
+
+    let pth_path = site_packages.join("workspace.pth");
+    let environment_without_pth = json!({
+        "python_platform": "linux",
+        "python_version": "3.12.0",
+        "site_package_path": [site_packages],
+    });
+    let environment_with_pth = json!({
+        "python_platform": "linux",
+        "python_version": "3.12.0",
+        "site_package_path": [site_packages, workspace_package],
+    });
+    let interpreter_script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "-c" ]; then
+    if [ -f "{pth_path}" ]; then
+        cat <<'EOF'
+{environment_with_pth}
+EOF
+    else
+        cat <<'EOF'
+{environment_without_pth}
+EOF
+    fi
+else
+    exit 1
+fi
+"#,
+        pth_path = pth_path.display(),
+    );
+    let interpreter = bin_root.join("python");
+    fs::write(&interpreter, interpreter_script).unwrap();
+    let mut permissions = fs::metadata(&interpreter).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&interpreter, permissions).unwrap();
+
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            workspace_folders: Some(vec![(
+                "test".to_owned(),
+                Url::from_file_path(root.path()).unwrap(),
+            )]),
+            file_watch: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open("pth_refresh/src/main.py");
+    interaction
+        .client
+        .expect_publish_diagnostics_eventual_error_count(source_root.join("main.py"), 1)
+        .unwrap();
+    let watched_patterns = expect_watched_files(&interaction).unwrap();
+    assert!(
+        watched_patterns
+            .iter()
+            .any(|pattern| pattern.ends_with("*.pth"))
+    );
+
+    fs::write(&pth_path, format!("{}\n", workspace_package.display())).unwrap();
+    interaction
+        .client
+        .file_created("pth_refresh/bin/site-packages/workspace.pth");
+    interaction
+        .client
+        .expect_publish_diagnostics_eventual_error_count(source_root.join("main.py"), 0)
+        .unwrap();
+    let refreshed_patterns = expect_watched_files(&interaction).unwrap();
+    assert!(refreshed_patterns.iter().any(|pattern| {
+        pattern.contains(workspace_package.to_str().unwrap()) && pattern.ends_with("**/*.py")
+    }));
 
     interaction.shutdown().unwrap();
 }


### PR DESCRIPTION
## Summary

- watch `.pth` files directly under configured site-package directories
- clear cached interpreter metadata and reload configuration when a `.pth` file changes
- re-register LSP file watchers after refreshed interpreter paths are available
- add an end-to-end LSP regression covering a newly created editable-install path

## Root cause

The LSP watched Python modules inside site-packages but not `.pth` metadata. Even if a `.pth` event was delivered, it did not invalidate configuration, and interpreter queries were cached by executable path. As a result, environment synchronization could add import paths without the running LSP observing them.

## User impact

After commands such as `uv sync` update editable-install metadata, open files are rechecked with the new import paths without restarting the language server.

## Testing

- `cargo test test_site_package_pth_files_are_watched`
- `cargo test test::lsp::lsp_interaction::file_watcher` (4 tests)
- formatter and Clippy through `test.py`

Fixes #3553
