### PR TITLE
Improve SQLModel constructor hover and completion

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1124,6 +1124,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // Tracks whether we've already recorded a trace for IDE features.
         // Priority: metaclass __call__ > overridden __new__ > __init__.
         let mut recorded_trace = false;
+        let prefer_init_trace = self.constructor_prefers_init_over_inherited_new(&cls);
         let errors = self.error_collector();
         if let Some(ret) = self.call_metaclass(
             &cls,
@@ -1220,7 +1221,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         AttributeReferenceKind::ConstructorCall,
                     );
                 }
-                if !recorded_trace {
+                if !recorded_trace && !prefer_init_trace {
                     self.record_resolved_trace(arguments_range, &new_method);
                     recorded_trace = true;
                 }
@@ -2268,6 +2269,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         } else {
             (default_constructor(), false)
         };
+        if overrides_init && self.constructor_prefers_init_over_inherited_new(cls) {
+            // An inherited catch-all `__new__` should not obscure a more useful `__init__`
+            // signature. Direct construction still checks both methods independently.
+            return init_attr_ty;
+        }
         if !overrides_new && overrides_init {
             // If `__init__` is overridden and `__new__` is inherited from object, use `__init__`
             init_attr_ty

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -5095,6 +5095,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
     }
 
+    /// Whether an inherited permissive `__new__` should yield to an overridden `__init__`
+    /// when presenting the class as a callable.
+    pub(crate) fn constructor_prefers_init_over_inherited_new(&self, cls: &ClassType) -> bool {
+        let Some(new_member) =
+            self.get_class_member_with_defining_class(cls.class_object(), &dunder::NEW)
+        else {
+            return false;
+        };
+        self.get_dunder_init(cls, false).is_some()
+            && new_member.defining_class != *cls.class_object()
+            && new_member.value.is_function_without_return_annotation()
+            && new_member
+                .value
+                .ty()
+                .visit_toplevel_func_metadata::<bool>(&|meta| {
+                    meta.flags.has_gradual_variadic_params
+                })
+    }
     fn get_dunder_init_helper(&self, instance: &Instance, get_object_init: bool) -> Option<Type> {
         let init_method =
             self.get_class_member_with_defining_class(instance.class, &dunder::INIT)?;

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -1667,6 +1667,44 @@ Completion Results:
 }
 
 #[test]
+fn kwargs_completion_pydantic_constructor_ignores_inherited_unannotated_new() {
+    let sqlmodel = r#"
+from typing import Any
+from pydantic import BaseModel
+
+class SQLModel(BaseModel):
+    def __new__(cls, *args: Any, **kwargs: Any):
+        return object.__new__(cls)
+
+    def __init__(self, **data: Any) -> None: ...
+"#;
+    let main = r#"
+from sqlmodel import SQLModel
+
+class A(SQLModel):
+    a: int
+    b: str
+
+A(
+# ^
+"#;
+    let pydantic_path =
+        std::env::var("PYDANTIC_TEST_PATH").expect("PYDANTIC_TEST_PATH must be set");
+    let mut test_env = TestEnv::new_with_site_package_paths(&[&pydantic_path]);
+    test_env.add("sqlmodel", sqlmodel);
+    test_env.add("main", main);
+    let (state, handle) = test_env
+        .with_default_require_level(Require::Exports)
+        .to_state();
+    let report =
+        get_default_test_report()(&state, &handle("main"), extract_cursors_for_test(main)[0]);
+    assert!(report.contains("- (Variable) a=:"), "{report}");
+    assert!(report.contains("- (Variable) b=:"), "{report}");
+    assert!(!report.contains("args="), "{report}");
+    assert!(!report.contains("kwargs="), "{report}");
+}
+
+#[test]
 fn kwargs_completion_dunder_call_metaclass_constructor() {
     let code = r#"
 class Meta(type):

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -2169,6 +2169,51 @@ Person("Alice", 25)
 }
 
 #[test]
+fn hover_on_pydantic_constructor_ignores_inherited_unannotated_new() {
+    let sqlmodel = r#"
+from typing import Any
+from pydantic import BaseModel
+
+class SQLModel(BaseModel):
+    def __new__(cls, *args: Any, **kwargs: Any):
+        return object.__new__(cls)
+
+    def __init__(self, **data: Any) -> None: ...
+"#;
+    let main = r#"
+from sqlmodel import SQLModel
+
+class A(SQLModel):
+    a: int
+    b: str
+
+value = A
+#       ^
+A(a=1, b="")
+#^
+"#;
+    let pydantic_path =
+        std::env::var("PYDANTIC_TEST_PATH").expect("PYDANTIC_TEST_PATH must be set");
+    let mut test_env = TestEnv::new_with_site_package_paths(&[&pydantic_path]);
+    test_env.add("sqlmodel", sqlmodel);
+    test_env.add("main", main);
+    let (state, handle) = test_env
+        .with_default_require_level(Require::Exports)
+        .to_state();
+    for position in extract_cursors_for_test(main) {
+        let report = get_test_report(&state, &handle("main"), position);
+        assert!(
+            report.contains("a:") && report.contains("b:"),
+            "Expected Pydantic constructor hover to show synthesized fields, got: {report}"
+        );
+        assert!(
+            !report.contains("*args: Any") && !report.contains("**kwargs: Any"),
+            "Expected Pydantic constructor hover to hide inherited broad __new__, got: {report}"
+        );
+    }
+}
+
+#[test]
 fn hover_on_namedtuple_constructor_shows_field_signature() {
     let code = r#"
 from typing import NamedTuple

--- a/pyrefly/test_laziness/test_attribute_inherited.md
+++ b/pyrefly/test_laziness/test_attribute_inherited.md
@@ -50,7 +50,7 @@ a: Solutions
 b: Answers
 c: Answers
 
-(64 builtin demands hidden)
+(66 builtin demands hidden)
 a -> b::Exports(is_special_export)
 a -> b::Load(module_exists)
 a -> b::Exports(export_exists)

--- a/pyrefly/test_laziness/test_attribute_on_class_itself.md
+++ b/pyrefly/test_laziness/test_attribute_on_class_itself.md
@@ -52,7 +52,7 @@ a: Solutions
 b: Answers
 c: Answers
 
-(80 builtin demands hidden)
+(82 builtin demands hidden)
 a -> b::Exports(is_special_export)
 a -> b::Load(module_exists)
 a -> b::Exports(export_exists)

--- a/pyrefly/test_laziness/test_import_class_instantiated.md
+++ b/pyrefly/test_laziness/test_import_class_instantiated.md
@@ -34,7 +34,7 @@ class Foo:
 a: Solutions
 b: Answers
 
-(34 builtin demands hidden)
+(36 builtin demands hidden)
 a -> b::Exports(is_special_export)
 a -> b::Load(module_exists)
 a -> b::Exports(export_exists)


### PR DESCRIPTION
## Summary

- prefer an overridden `__init__` signature when a class inherits an unannotated catch-all `__new__`
- use the same preference for constructor call traces so hover and signature surfaces agree
- add SQLModel-shaped Pydantic regressions for hover and keyword completion

## Root cause

SQLModel defines `__new__(cls, *args: Any, **kwargs: Any)` without a return annotation. For subclasses, Pyrefly combined that inherited catch-all with the synthesized Pydantic `__init__`; the broader signature then obscured the model fields in IDE surfaces even though constructor diagnostics still checked those fields correctly.

The new preference is intentionally narrow: `__new__` must be inherited, unannotated, and gradual, while `__init__` must be overridden. Direct construction continues to check both methods.

## User impact

SQLModel subclasses now expose their synthesized Pydantic fields in hover and keyword completion instead of only `args` and `kwargs`.

## Test plan

- `cargo test -p pyrefly test::lsp::hover::`
- `cargo test -p pyrefly test::lsp::completion::`
- `cargo test -p pyrefly constructor`
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`

Fixes #4530
