### PR TITLE
fix args maybe add a * #4378

### DIFF
--- a/pyrefly/lib/lsp/wasm/inlay_hints.rs
+++ b/pyrefly/lib/lsp/wasm/inlay_hints.rs
@@ -187,14 +187,24 @@ pub struct ParameterAnnotation {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ParamNameMatch<'param> {
     pub name: &'param Name,
+    pub is_vararg: bool,
     pub is_vararg_repeat: bool,
 }
 
 impl<'param> ParamNameMatch<'param> {
-    fn new(name: &'param Name, is_vararg_repeat: bool) -> Self {
+    fn new(name: &'param Name, is_vararg: bool, is_vararg_repeat: bool) -> Self {
         Self {
             name,
+            is_vararg,
             is_vararg_repeat,
+        }
+    }
+
+    fn display_name(&self) -> String {
+        if self.is_vararg {
+            format!("*{}", self.name.as_str())
+        } else {
+            self.name.as_str().to_owned()
         }
     }
 }
@@ -596,7 +606,7 @@ impl<'a> Transaction<'a> {
                             {
                                 param_hints.push((
                                     arg.range().start(),
-                                    format!("{}= ", param_match.name.as_str()),
+                                    format!("{}= ", param_match.display_name()),
                                 ));
                             }
                         }
@@ -619,21 +629,29 @@ impl<'a> Transaction<'a> {
                 Param::PosOnly(name, ..) => {
                     if positional_params_seen == positional_arg_index {
                         return name.as_ref().map(|name| {
-                            ParamNameMatch::new(name, /* is_vararg_repeat */ false)
+                            ParamNameMatch::new(
+                                name, /* is_vararg */ false, /* is_vararg_repeat */ false,
+                            )
                         });
                     }
                     positional_params_seen += 1;
                 }
                 Param::Pos(name, ..) => {
                     if positional_params_seen == positional_arg_index {
-                        return Some(ParamNameMatch::new(name, false));
+                        return Some(ParamNameMatch::new(
+                            name, /* is_vararg */ false, /* is_vararg_repeat */ false,
+                        ));
                     }
                     positional_params_seen += 1;
                 }
                 Param::Varargs(name, ..) => {
                     if positional_arg_index >= positional_params_seen {
                         return name.as_ref().map(|name| {
-                            ParamNameMatch::new(name, positional_arg_index > positional_params_seen)
+                            ParamNameMatch::new(
+                                name,
+                                /* is_vararg */ true,
+                                positional_arg_index > positional_params_seen,
+                            )
                         });
                     }
                     break;

--- a/pyrefly/lib/test/lsp/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/inlay_hint.rs
@@ -541,7 +541,7 @@ foo("hello", 1, 2, 3, 5, a=1, b=2, t=4)
         ^ inlay-hint: `s= `
 
 5 | foo("hello", 1, 2, 3, 5, a=1, b=2, t=4)
-                 ^ inlay-hint: `args= `
+                 ^ inlay-hint: `*args= `
 "#
         .trim(),
         generate_inlay_hint_report(
@@ -570,7 +570,7 @@ mark("database", "cache")
         r#"
 # main.py
 7 | mark("database", "cache")
-         ^ inlay-hint: `fixtures= `
+         ^ inlay-hint: `*fixtures= `
 "#
         .trim(),
         generate_inlay_hint_report(


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4378

Variadic positional parameter hints now preserve the marker, so `args=`  becomes `*args=`

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

update test