### PR TITLE
Don't resolve implicit `__bool__` through `__getattr__`

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1974,9 +1974,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         }
         ty.as_bool().or_else(|| {
-            // If the object defines `__bool__`, we can check if it returns a statically known value
+            // If the object defines `__bool__`, we can check if it returns a statically known value.
+            // Implicit dunder lookups (like the `__bool__` used for truthiness) are resolved on the
+            // type and do not go through `__getattr__`, so we disable the `__getattr__` fallback here.
+            // Otherwise a class with a `__getattr__` returning a non-callable type would be treated as
+            // defining a non-callable `__bool__` and wrongly reported as `not-callable` (see #4467).
             if self
-                .type_of_magic_dunder_attr(ty, &dunder::BOOL, range, errors, None, "as_bool", true)?
+                .type_of_magic_dunder_attr(ty, &dunder::BOOL, range, errors, None, "as_bool", false)?
                 .is_never()
             {
                 return None;

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1975,10 +1975,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         }
         ty.as_bool().or_else(|| {
             // If the object defines `__bool__`, we can check if it returns a statically known value.
-            // Implicit dunder lookups (like the `__bool__` used for truthiness) are resolved on the
-            // type and do not go through `__getattr__`, so we disable the `__getattr__` fallback here.
-            // Otherwise a class with a `__getattr__` returning a non-callable type would be treated as
-            // defining a non-callable `__bool__` and wrongly reported as `not-callable` (see #4467).
+            // Implicit dunder lookups are resolved on the type and do not go through `__getattr__`,
+            // so disable the `__getattr__` fallback here.
             if self
                 .type_of_magic_dunder_attr(
                     ty,

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1980,7 +1980,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             // Otherwise a class with a `__getattr__` returning a non-callable type would be treated as
             // defining a non-callable `__bool__` and wrongly reported as `not-callable` (see #4467).
             if self
-                .type_of_magic_dunder_attr(ty, &dunder::BOOL, range, errors, None, "as_bool", false)?
+                .type_of_magic_dunder_attr(
+                    ty,
+                    &dunder::BOOL,
+                    range,
+                    errors,
+                    None,
+                    "as_bool",
+                    false,
+                )?
                 .is_never()
             {
                 return None;

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -961,6 +961,37 @@ def f(x: M | None) -> M:
 );
 
 testcase!(
+    test_getattribute_does_not_provide_dunder_bool,
+    r#"
+# The same rule applies to a custom `__getattribute__`: implicit `__bool__`
+# lookups go through the type, not the instance's `__getattribute__`, so a
+# `__getattribute__` returning a non-callable type must not make an instance
+# look like it has a non-callable `__bool__`.
+class Tensor: ...
+class M:
+    def __getattribute__(self, name: str) -> "Tensor | M": ...
+
+def f(x: M | None) -> M:
+    return x or M()
+    "#,
+);
+
+testcase!(
+    test_inherited_getattr_does_not_provide_dunder_bool,
+    r#"
+# The `__getattr__` fallback must be disabled for implicit `__bool__` even when
+# `__getattr__` is inherited from a base class rather than defined directly.
+class Tensor: ...
+class Base:
+    def __getattr__(self, name: str) -> "Tensor | Base": ...
+class Sub(Base): ...
+
+def f(x: Sub | None) -> Sub:
+    return x or Sub()
+    "#,
+);
+
+testcase!(
     test_object_setattr_wrong_signature,
     r#"
 from typing import assert_type

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -945,6 +945,22 @@ def test(foo: Foo) -> None:
 );
 
 testcase!(
+    test_getattr_does_not_provide_dunder_bool,
+    r#"
+# Implicit dunders like `__bool__` are looked up on the type and are not
+# resolved through `__getattr__`, so a `__getattr__` returning a non-callable
+# type must not make an instance look like it has a non-callable `__bool__`.
+# Regression test for https://github.com/facebook/pyrefly/issues/4467
+class Tensor: ...
+class M:
+    def __getattr__(self, name: str) -> "Tensor | M": ...
+
+def f(x: M | None) -> M:
+    return x or M()
+    "#,
+);
+
+testcase!(
     test_object_setattr_wrong_signature,
     r#"
 from typing import assert_type


### PR DESCRIPTION
# Summary

Fixes #4467.

Implicit dunder methods such as `__bool__` are looked up on the type and bypass `__getattr__` at runtime (CPython resolves them via `_PyObject_LookupSpecial`, which ignores both the instance dict and `__getattr__`/`__getattribute__`).

When evaluating truthiness in `as_bool`, Pyrefly looked up `__bool__` with the `__getattr__` fallback **enabled**. So a class whose `__getattr__` returns a non-callable type — e.g. `torch.nn.Module`, whose `__getattr__` is typed to return `Tensor | Module` — was treated as defining a non-callable `__bool__`, and using an instance in a boolean context was wrongly reported as `not-callable`:

```python
class Tensor: ...
class M:
    def __getattr__(self, name: str) -> "Tensor | M": ...

def f(x: M | None) -> M:
    return x or M()
    # before: ERROR Expected `__bool__` to be a callable, got `M | Tensor` [not-callable]
    # after:  0 errors
```

The fix disables the `__getattr__` fallback for the `__bool__` lookup in `as_bool` (`pyrefly/lib/alt/expr.rs`). The separate `check_dunder_bool_is_callable` path already disables the fallback; this brings the truthiness-evaluation path in line. The subsequent `__bool__` call is only reached when a real `__bool__` is found directly, so classes that genuinely define `__bool__` are unaffected.

# Test Plan

- Added `test_getattr_does_not_provide_dunder_bool` in `pyrefly/lib/test/attributes.rs`. It fails before the change (`expected 0 errors, but got 2`) and passes after.
- `cargo test -p pyrefly --lib`: all type-checking tests pass (the only failures on my machine are two pre-existing `lsp_interaction::diagnostic` timeout tests that also fail on unmodified `main`, unrelated to this change).
- `cargo clippy -p pyrefly --lib` and `cargo fmt --check` are clean for the changed files.
