### PR TITLE
fix: preserve known exports in unresolvable `__all__`

### DIFF
--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -806,19 +806,15 @@ impl DefinitionsBuilder {
                                 self.inner.dunder_all.entries.extend(entries);
                             }
                             None => {
-                                self.inner.dunder_all = DunderAll {
-                                    kind: DunderAllKind::Unresolvable(arguments.args[0].range()),
-                                    entries: Vec::new(),
-                                };
+                                self.inner.dunder_all.kind =
+                                    DunderAllKind::Unresolvable(arguments.args[0].range());
                             }
                         },
                         "append" => match DunderAllEntry::as_item(&arguments.args[0]) {
                             Some(entry) => self.inner.dunder_all.entries.push(entry),
                             None => {
-                                self.inner.dunder_all = DunderAll {
-                                    kind: DunderAllKind::Unresolvable(arguments.args[0].range()),
-                                    entries: Vec::new(),
-                                };
+                                self.inner.dunder_all.kind =
+                                    DunderAllKind::Unresolvable(arguments.args[0].range());
                             }
                         },
                         "remove" => {

--- a/pyrefly/lib/export/exports.rs
+++ b/pyrefly/lib/export/exports.rs
@@ -110,6 +110,8 @@ pub struct Exports {
     /// but they take up very little space, so not worth the hassle to detect when
     /// calculation completes.
     definitions: Definitions,
+    /// Names statically known to be in a partially resolvable explicit `__all__`.
+    partially_known_dunder_all: SmallSet<Name>,
     /// Names that are available via `from <this_module> import *`
     wildcard: Calculation<Arc<SmallSet<Name>>>,
     /// Names that are available via `from <this_module> import <name>` along with their locations
@@ -143,6 +145,7 @@ impl Exports {
             sys_info,
         );
         definitions.inject_implicit_globals();
+        let partially_known_dunder_all = Self::get_partially_known_dunder_all(&definitions);
         definitions.ensure_dunder_all(module_info.path().style());
         if module_info.name() == ModuleName::builtins() {
             // The `builtins` module is a bit weird. It has no `__all__` in TypeShed,
@@ -161,6 +164,7 @@ impl Exports {
             module_name: module_info.name(),
             is_init: module_info.path().is_init(),
             definitions,
+            partially_known_dunder_all,
             wildcard: Calculation::new(),
             exports: Calculation::new(),
             docstring_range: Docstring::range_from_stmts(x),
@@ -245,6 +249,8 @@ impl Exports {
                         || self_defs.special_exports.get(name)
                             != other_defs.special_exports.get(name)
                         || self_def.main_guard_only != other_def.main_guard_only
+                        || self.partially_known_dunder_all.contains(name)
+                            != other.partially_known_dunder_all.contains(name)
                     {
                         changed.0.names.entry(name.clone()).or_default().metadata = true;
                     }
@@ -314,6 +320,29 @@ impl Exports {
             ),
             _ => None,
         }
+    }
+
+    // Returns statically known entries in an unresolvable `__all__`.
+    pub fn get_partially_known_dunder_all(definitions: &Definitions) -> SmallSet<Name> {
+        let mut names = SmallSet::new();
+
+        if !matches!(definitions.dunder_all.kind, DunderAllKind::Unresolvable(_)) {
+            return names;
+        }
+
+        for entry in &definitions.dunder_all.entries {
+            match entry {
+                DunderAllEntry::Name(_, name) => {
+                    names.insert(name.clone());
+                }
+                DunderAllEntry::Remove(_, name) => {
+                    names.shift_remove(name);
+                }
+                DunderAllEntry::Module(..) => {}
+            }
+        }
+
+        names
     }
 
     /// Returns entries in `__all__` that don't exist in the module's definitions.
@@ -458,6 +487,9 @@ impl Exports {
     /// Names defined locally, redundantly aliased (`as` same-name), or introduced
     /// via a wildcard import are not implicit re-exports.
     pub fn is_implicit_reexport(&self, name: &Name) -> bool {
+        if self.partially_known_dunder_all.contains(name) {
+            return false;
+        }
         if let Some(mut all) = self.get_explicit_dunder_all_names_iter()
             && all.any(|n| n == name)
         {

--- a/pyrefly/lib/test/imports.rs
+++ b/pyrefly/lib/test/imports.rs
@@ -2344,3 +2344,47 @@ testcase!(
 from bar import a
 "#,
 );
+
+fn env_implicit_reexport_unresolvable_all() -> TestEnv {
+    let mut t = TestEnv::new();
+    t.add(
+        "foo",
+        r#"
+a: int = 1
+b: int = 2
+c: int = 3
+d: int = 4
+e: int = 5
+"#,
+    );
+    t.add(
+        "bar",
+        r#"
+from foo import a
+from foo import b as b
+from foo import c
+from foo import d
+from foo import e
+f: int = 4
+__all__ = ["c", "e"]
+__all__.append("d")
+__all__.remove("e")
+for name in ["f"]:
+    __all__.append(name)  # E: `__all__` could not be statically analyzed
+"#,
+    );
+    t
+}
+
+testcase!(
+    test_implicit_reexport_unresolvable_all,
+    env_implicit_reexport_unresolvable_all().enable_implicit_reexport_error(),
+    r#"
+from bar import a  # E: `a` is not exported from module `bar`
+from bar import b
+from bar import c
+from bar import d
+from bar import e  # E: `e` is not exported from module `bar`
+from bar import f
+"#,
+);


### PR DESCRIPTION
# Summary

Preserve statically known `__all__` names when a later dynamic append or extend cannot be resolved. This prevents explicit re-exports such as `torch.Tensor` from being reported as implicit while keeping the conservative fallback for the unresolved portion of `__all__`.

Taken from #4479, just modified to split the logic for computing partially known `__all__` entries and to make a separate test for this case.

Fixes #4424

---

There are still a bug with `implicit-reexport` that I decided not to tackle in this PR. `DunderAllKind::Specified` does not account for `DunderAllEntry::Remove`, so an `__all__` that calls `.remove()` will not be correctly identified as an implicit reexport. This is a really minor issue due to the unlikeliness of `__all__.remove`. For example:
```
# foo.py
c: int = 3

# bar.py
from foo import c
__all__ = ["c"]
__all__.remove("c")

# baz.py
from bar import c  # No error here.
``` 

I think fixing this and simplifying the code could involve modifying `get_explicit_dunder_all_names_iter` to accept `DunderAllKind::Specified | DunderAllKind::Unresolved` and provide the same entry logic + handle `DunderAllEntry::Remove`. This would remove the need for the `partially_known_dunder_all` member variable. But `get_explicit_dunder_all_names_iter` is used elsewhere and modifying this might have an unexpected blast radius. So I kept the safer, minimally local approach. Another option is to avoid using `get_explicit_dunder_all_names_iter` in the implicit reexport check and implement that same replay logic described above, only for use in that check only. I didn't feel comfortable implementing either solution and understanding its effects.

---

There was one other quirk. `DunderAllKind::Unresolvable` is not "Sticky". The following causes `__all__` to be `DunderAllKind::Specified`:
```
__all__ = []
for name in ["a"]:
    __all__.append(name)
__all__.remove("a")
```

Whereas the following causes `__all__` to be `DunderAllKind::Unresolvable`
```
__all__ = []
__all__.remove("a")
for name in ["a"]:
    __all__.append(name)
```

But this didn't bring out any bugs or unexpected behavior I could find.

# Test Plan

- `python3 test.py`
- Built Pyrefly `maturin build --release -m pyrefly/Cargo.toml` and checked `from torch import Tensor` against `torch==2.12.0` with `pyrefly check --preset all example.py`. No significant runtime increase and 0 errors now.