### PR TITLE
Allow returning Any as object

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -4110,7 +4110,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         errors: &ErrorCollector,
     ) {
         let Some(declared_ty) = hint else { return };
-        if declared_ty.is_any() {
+        let is_object = |t: &Type| matches!(t, Type::ClassType(cls) if cls.is_builtin("object"));
+        if declared_ty.is_any() || is_object(declared_ty) {
             return;
         }
         match return_ty {

--- a/pyrefly/lib/test/returns.rs
+++ b/pyrefly/lib/test/returns.rs
@@ -1014,6 +1014,34 @@ def f() -> Any:
 );
 
 testcase!(
+    test_no_any_return_explicit_no_error_when_return_type_is_object,
+    crate::test::util::TestEnv::new().enable_no_any_return_explicit_error(),
+    r#"
+from typing import Any
+
+def f(x: Any) -> object:
+    return x
+"#,
+);
+
+testcase!(
+    test_no_any_return_implicit_no_error_when_return_type_is_object,
+    crate::test::util::TestEnv::new().enable_no_any_return_implicit_error(),
+    r#"
+ObjectAlias = object
+
+def get_implicit_any(x):
+  return x
+
+def direct() -> object:
+  return get_implicit_any(3)
+
+def aliased() -> ObjectAlias:
+  return get_implicit_any(3)
+"#,
+);
+
+testcase!(
     test_no_any_return_explicit_no_error_when_no_return_annotation,
     crate::test::util::TestEnv::new().enable_no_any_return_explicit_error(),
     r#"

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -1420,7 +1420,7 @@ del Ex.meaning  # no-access
 
 Default severity: `ignore`
 
-Umbrella error code for cases where a returned expression is `Any` in a function declared to return a concrete type. Enabling this catches places where `Any` silently bypasses the function's declared return type.
+Umbrella error code for cases where a returned expression is `Any` in a function declared to return a concrete type other than `object`. Enabling this catches places where `Any` silently bypasses the function's declared return type. Returning `Any` as `object` is allowed because every runtime value is an object, so this does not weaken the return type's guarantee.
 
 Concrete diagnostics are emitted under one of the more specific sub-kinds:
 - [`no-any-return-explicit`](#no-any-return-explicit)
@@ -1430,7 +1430,7 @@ Concrete diagnostics are emitted under one of the more specific sub-kinds:
 
 Default severity: `ignore`
 
-The returned expression has type `Any`, but the function is declared to return a concrete type. The returned `Any` originates from an explicit annotation or other introduction into the type system.
+The returned expression has type `Any`, but the function is declared to return a concrete type other than `object`. The returned `Any` originates from an explicit annotation or other introduction into the type system.
 
 This is a sub-kind of [no-any-return](#no-any-return): suppressing `no-any-return` also suppresses this error.
 
@@ -1452,7 +1452,7 @@ def get_typed_port(config: dict[str, object]) -> int:
 
 Default severity: `ignore`
 
-The returned expression was inferred as `Any` (e.g., from an untyped import or missing stub), but the function's return annotation is a concrete type. This usually indicates that adding type information at an untyped boundary would restore type precision.
+The returned expression was inferred as `Any` (e.g., from an untyped import or missing stub), but the function's return annotation is a concrete type other than `object`. This usually indicates that adding type information at an untyped boundary would restore type precision.
 
 This is a sub-kind of [no-any-return](#no-any-return): suppressing `no-any-return` also suppresses this error.
 


### PR DESCRIPTION
# Summary

Allow functions that are declared to return 'object'  to return values typed as explicit or implicit 'Any', such as in json.loads(). Since python runtime values satisfy 'object', this doesn't mean it weakens the return-type checker.

Fixes #4521 

# Test Plan

cargo test test_no_any_return --no-fail-fast
Passed

python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema
Ran formatting; came across a warning unrelated to this change 