### PR TITLE
feat: support `baseline-error-level` config option, emit baseline provenance in `pyrefly check` output

### DIFF
--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -594,8 +594,12 @@ pub struct ConfigFile {
     pub typeshed_path: Option<PathBuf>,
 
     /// Path to baseline file for comparing type errors.
-    /// Errors matching the baseline are suppressed.
+    /// Errors matching the baseline are suppressed by default.
     pub baseline: Option<PathBuf>,
+
+    /// Severity assigned to errors that match the baseline.
+    /// Defaults to `ignore`.
+    pub baseline_error_level: Option<Severity>,
 
     /// Default error output format for CLI checks when `--output-format` is not set.
     pub output_format: Option<OutputFormat>,
@@ -710,6 +714,7 @@ impl Default for ConfigFile {
             use_ignore_files: true,
             typeshed_path: None,
             baseline: None,
+            baseline_error_level: None,
             min_severity: None,
             output_format: None,
             skip_lsp_config_indexing: false,
@@ -2047,6 +2052,7 @@ mod tests {
                 },
                 typeshed_path: None,
                 baseline: None,
+                baseline_error_level: None,
                 min_severity: None,
                 skip_lsp_config_indexing: false,
                 extra_file_extensions: Vec::new(),
@@ -2371,6 +2377,7 @@ mod tests {
             },
             typeshed_path: Some(PathBuf::from(typeshed)),
             baseline: Some(PathBuf::from("baseline.json")),
+            baseline_error_level: None,
             min_severity: None,
             skip_lsp_config_indexing: false,
             extra_file_extensions: Vec::new(),
@@ -2442,6 +2449,7 @@ mod tests {
             },
             typeshed_path: Some(expected_typeshed),
             baseline: Some(test_path.join("baseline.json")),
+            baseline_error_level: None,
             min_severity: None,
             skip_lsp_config_indexing: false,
             extra_file_extensions: Vec::new(),
@@ -2528,9 +2536,11 @@ mod tests {
     fn test_baseline_config_parsing() {
         let config_str = r#"
 baseline = "baseline.json"
+baseline-error-level = "warn"
 "#;
         let config = ConfigFile::parse_config(config_str).unwrap();
         assert_eq!(config.baseline, Some(PathBuf::from("baseline.json")));
+        assert_eq!(config.baseline_error_level, Some(Severity::Warn));
     }
 
     #[test]

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -1603,7 +1603,7 @@ impl CheckArgs {
                 .iter()
                 .filter(|e| only.contains(&e.error_kind()))
                 .map(|e| {
-                    e.with_severity(baseline_error_level)
+                    e.with_severity(e.severity().min(baseline_error_level))
                         .with_baseline_status(BaselineStatus::Matched)
                 })
                 .collect()
@@ -1612,7 +1612,7 @@ impl CheckArgs {
                 .baseline
                 .iter()
                 .map(|e| {
-                    e.with_severity(baseline_error_level)
+                    e.with_severity(e.severity().min(baseline_error_level))
                         .with_baseline_status(BaselineStatus::Matched)
                 })
                 .collect()

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -78,6 +78,7 @@ use crate::commands::util::CommandExitStatus;
 use crate::config::error_kind::Severity;
 use crate::config::finder::ConfigFinder;
 use crate::error::code_climate::CodeClimateIssues;
+use crate::error::error::BaselineStatus;
 use crate::error::error::Error;
 use crate::error::error::ErrorRenderer;
 use crate::error::error::print_error_counts;
@@ -380,6 +381,10 @@ struct OutputArgs {
     #[arg(long, value_name = "BASELINE_FILE")]
     baseline: Option<PathBuf>,
 
+    /// Severity assigned to errors that match the baseline. Defaults to "ignore".
+    #[arg(long, value_enum)]
+    baseline_error_level: Option<Severity>,
+
     /// When specified, emit a sorted/formatted JSON of the errors to the baseline file
     #[arg(long, group = "baseline_action")]
     update_baseline: bool,
@@ -476,6 +481,9 @@ impl OutputArgs {
         if self.baseline.is_none() {
             self.baseline = config.baseline.clone();
         }
+        if self.baseline_error_level.is_none() {
+            self.baseline_error_level = config.baseline_error_level;
+        }
         if self.output_format.is_none() {
             self.output_format = config.output_format;
         }
@@ -486,6 +494,10 @@ impl OutputArgs {
 
     fn output_format(&self) -> OutputFormat {
         self.output_format.unwrap_or_default()
+    }
+
+    fn baseline_error_level(&self) -> Severity {
+        self.baseline_error_level.unwrap_or(Severity::Ignore)
     }
 
     /// Resolve the effective progress bar style, taking deprecated flags into account.
@@ -872,6 +884,11 @@ fn github_actions_command(error: &Error) -> Option<String> {
     let command = severity_to_github_command(error.severity())?;
     let range = error.display_range();
     let file = path_to_unix_string(error.path().as_path());
+    let baseline_marker = if error.baseline_status() == BaselineStatus::Matched {
+        " [baselined]"
+    } else {
+        ""
+    };
     let params = format!(
         "file={},line={},col={},endLine={},endColumn={},title={}",
         escape_workflow_property(&file),
@@ -879,7 +896,10 @@ fn github_actions_command(error: &Error) -> Option<String> {
         range.start.column().get(),
         range.end.line_within_file().get(),
         range.end.column().get(),
-        escape_workflow_property(&format!("Pyrefly {}", error.error_kind().to_name())),
+        escape_workflow_property(&format!(
+            "Pyrefly {}{baseline_marker}",
+            error.error_kind().to_name()
+        )),
     );
     let message = escape_workflow_data(&error.msg());
     Some(format!("::{command} {params}::{message}"))
@@ -1200,6 +1220,7 @@ impl CheckArgs {
 
         // Project-level output settings can come from config when CLI flags are absent.
         if (self.output.baseline.is_none()
+            || self.output.baseline_error_level.is_none()
             || self.output.output_format.is_none()
             || self.output.min_severity.is_none())
             && let Some(handle) = loaded_handles.first()
@@ -1251,6 +1272,7 @@ impl CheckArgs {
 
         // Project-level output settings can come from config when CLI flags are absent.
         if self.output.baseline.is_none()
+            || self.output.baseline_error_level.is_none()
             || self.output.output_format.is_none()
             || self.output.min_severity.is_none()
         {
@@ -1304,6 +1326,7 @@ impl CheckArgs {
 
         // Track which output settings were explicitly set on the CLI.
         let cli_provided_baseline = self.output.baseline.is_some();
+        let cli_provided_baseline_error_level = self.output.baseline_error_level.is_some();
         let cli_provided_min_severity = self.output.min_severity.is_some();
         let cli_provided_output_format = self.output.output_format.is_some();
 
@@ -1316,7 +1339,10 @@ impl CheckArgs {
             // Inherit project-level output settings from config on every iteration
             // to pick up config file changes when the CLI did not override them.
             // Reset non-CLI-provided fields first so updated config values are applied.
-            if (!cli_provided_baseline || !cli_provided_output_format || !cli_provided_min_severity)
+            if (!cli_provided_baseline
+                || !cli_provided_baseline_error_level
+                || !cli_provided_output_format
+                || !cli_provided_min_severity)
                 && let Some(handle) = loaded_handles.first()
             {
                 if !cli_provided_baseline {
@@ -1324,6 +1350,9 @@ impl CheckArgs {
                 }
                 if !cli_provided_output_format {
                     self.output.output_format = None;
+                }
+                if !cli_provided_baseline_error_level {
+                    self.output.baseline_error_level = None;
                 }
                 if !cli_provided_min_severity {
                     self.output.min_severity = None;
@@ -1501,12 +1530,13 @@ impl CheckArgs {
         // Pass pre-collected errors to avoid redundant error collection.
         let unused_ignore_errors = loads.collect_unused_ignore_errors_for_display(&collected);
         collected.ordinary.extend(unused_ignore_errors.ordinary);
-        let (unused_baseline_entries, retained_baseline_entries) = match loads.apply_baseline(
-            &mut collected,
-            self.output.baseline.as_deref(),
-            relative_to.as_path(),
-            self.output.prune_baseline || self.output.error_stale_baseline,
-        ) {
+        let (unused_baseline_entries, retained_baseline_entries, baseline_loaded) = match loads
+            .apply_baseline(
+                &mut collected,
+                self.output.baseline.as_deref(),
+                relative_to.as_path(),
+                self.output.prune_baseline || self.output.error_stale_baseline,
+            ) {
             Ok(result) => result,
             // `--update-baseline` regenerates the baseline from the current run, so
             // a missing or unreadable existing baseline is not fatal. Log the
@@ -1517,27 +1547,75 @@ impl CheckArgs {
                 debug!(
                     "ignoring unreadable baseline while regenerating it with `--update-baseline`: {e:#}"
                 );
-                (0, Vec::new())
+                (0, Vec::new(), false)
             }
             Err(e) => return Err(e),
         };
         let errors = collected;
-        let (directives, ordinary_errors) = if let Some(only) = &self.output.only {
-            let only = only.iter().collect::<SmallSet<_>>();
-            (
-                errors
-                    .directives
-                    .into_iter()
-                    .filter(|e| only.contains(&e.error_kind()))
-                    .collect(),
-                errors
-                    .ordinary
-                    .into_iter()
-                    .filter(|e| only.contains(&e.error_kind()))
-                    .collect(),
-            )
+        let baseline_status = if self.output.baseline.is_none() {
+            BaselineStatus::NotConfigured
+        } else if baseline_loaded {
+            BaselineStatus::Unmatched
         } else {
-            (errors.directives, errors.ordinary)
+            BaselineStatus::NotCompared
+        };
+        let (directives, ordinary_errors): (Vec<Error>, Vec<Error>) =
+            if let Some(only) = &self.output.only {
+                let only = only.iter().collect::<SmallSet<_>>();
+                (
+                    errors
+                        .directives
+                        .into_iter()
+                        .filter(|e| only.contains(&e.error_kind()))
+                        .map(|e| e.with_baseline_status(baseline_status))
+                        .collect(),
+                    errors
+                        .ordinary
+                        .into_iter()
+                        .filter(|e| only.contains(&e.error_kind()))
+                        .map(|e| e.with_baseline_status(baseline_status))
+                        .collect(),
+                )
+            } else {
+                (
+                    errors
+                        .directives
+                        .into_iter()
+                        .map(|e| e.with_baseline_status(baseline_status))
+                        .collect(),
+                    errors
+                        .ordinary
+                        .into_iter()
+                        .map(|e| e.with_baseline_status(baseline_status))
+                        .collect(),
+                )
+            };
+
+        // Baseline matches are cloned for display. Baseline maintenance uses the
+        // original severity and baseline representation.
+        let baseline_error_level = self.output.baseline_error_level();
+        let displayed_baseline_errors = if baseline_error_level == Severity::Ignore {
+            Vec::new()
+        } else if let Some(only) = &self.output.only {
+            let only = only.iter().collect::<SmallSet<_>>();
+            errors
+                .baseline
+                .iter()
+                .filter(|e| only.contains(&e.error_kind()))
+                .map(|e| {
+                    e.with_severity(baseline_error_level)
+                        .with_baseline_status(BaselineStatus::Matched)
+                })
+                .collect()
+        } else {
+            errors
+                .baseline
+                .iter()
+                .map(|e| {
+                    e.with_severity(baseline_error_level)
+                        .with_baseline_status(BaselineStatus::Matched)
+                })
+                .collect()
         };
 
         // Filter by minimum severity. Directives are not subject to this
@@ -1547,9 +1625,13 @@ impl CheckArgs {
         // via `--min-severity` should not get a suppression comment written
         // into source.
         let min_severity = self.output.min_severity.unwrap_or(Severity::Error);
-        let (ordinary_errors, hidden_errors): (Vec<_>, Vec<_>) = ordinary_errors
+        let (ordinary_errors, mut hidden_errors): (Vec<_>, Vec<_>) = ordinary_errors
             .into_iter()
             .partition(|e| e.severity() >= min_severity);
+        let (baseline_errors, hidden_baseline_errors): (Vec<_>, Vec<_>) = displayed_baseline_errors
+            .into_iter()
+            .partition(|e| e.severity() >= min_severity);
+        hidden_errors.extend(hidden_baseline_errors);
 
         // Suppress operates on ordinary diagnostics only — directives are
         // structurally excluded since they live in `directives`, not `ordinary_errors`.
@@ -1627,8 +1709,10 @@ impl CheckArgs {
 
         // Directives always display, but only affect the exit code when they
         // meet the user's severity threshold.
+        let baselined_diagnostics_count = baseline_errors.len();
         let diagnostics_count = config_errors_count
             + ordinary_errors.len()
+            + baseline_errors.len()
             + directives
                 .iter()
                 .filter(|e| e.severity() >= min_severity)
@@ -1638,6 +1722,7 @@ impl CheckArgs {
         // name, path, and source range so output preserves file/line
         // interleaving across modules.
         let mut output_errors = ordinary_errors;
+        output_errors.extend(baseline_errors);
         output_errors.extend(directives);
         output_errors.sort_by_cached_key(|e| {
             (
@@ -1694,6 +1779,19 @@ impl CheckArgs {
             let mut parts = vec![count(diagnostics_count, label)];
             if suppress_count > 0 {
                 parts.push(format!("{} suppressed", number_thousands(suppress_count)));
+            }
+            let reports_omit_errors = if self.output.output.is_empty() {
+                output_format == OutputFormat::OmitErrors
+            } else {
+                self.output.output.iter().any(|output| {
+                    output.format.unwrap_or(output_format) == OutputFormat::OmitErrors
+                })
+            };
+            if reports_omit_errors && baselined_diagnostics_count > 0 {
+                parts.push(format!(
+                    "{} baselined",
+                    number_thousands(baselined_diagnostics_count)
+                ));
             }
             if !hidden_errors.is_empty() {
                 let mut hidden_warnings = 0;
@@ -1888,6 +1986,19 @@ mod tests {
     }
 
     #[test]
+    fn github_actions_command_marks_baselined_errors() {
+        let error = sample_error("bad".into())
+            .with_severity(Severity::Warn)
+            .with_baseline_status(BaselineStatus::Matched);
+        let command = github_actions_command(&error).unwrap();
+        assert!(command.starts_with("::warning "), "{command}");
+        assert!(
+            command.contains("title=Pyrefly bad-assignment [baselined]"),
+            "{command}"
+        );
+    }
+
+    #[test]
     fn escape_helpers_follow_workflow_spec() {
         assert_eq!(
             escape_workflow_data("line1\nline2\r% done"),
@@ -1908,13 +2019,13 @@ mod tests {
 
     #[test]
     fn full_text_with_github_output_format_writes_both() {
-        let errors = vec![sample_error("bad".into())];
+        let errors = vec![sample_error("bad".into()).with_baseline_status(BaselineStatus::Matched)];
         let mut buf = Vec::new();
         write_error_full_text_with_github(&mut buf, ColorChoice::Never, Path::new("/"), &errors)
             .unwrap();
         let output = String::from_utf8(buf).unwrap();
-        assert!(output.contains("ERROR bad [bad-assignment]"));
-        assert!(output.contains("::error file=/repo/foo.py"));
+        assert!(output.contains("ERROR bad [bad-assignment] [baselined]"));
+        assert!(output.contains("title=Pyrefly bad-assignment [baselined]"));
         assert!(output.ends_with("::bad\n"));
     }
 
@@ -2107,6 +2218,33 @@ mod tests {
         output.inherit_defaults_from_config(&config);
 
         assert_eq!(output.output_format(), OutputFormat::MinText);
+    }
+
+    #[test]
+    fn baseline_error_level_cli_and_config_precedence() {
+        let mut inherited = OutputArgs::parse_from(["pyrefly-check"]);
+        assert_eq!(inherited.baseline_error_level(), Severity::Ignore);
+        inherited.inherit_defaults_from_config(&ConfigFile {
+            baseline_error_level: Some(Severity::Warn),
+            ..Default::default()
+        });
+        assert_eq!(inherited.baseline_error_level(), Severity::Warn);
+
+        // Watch mode clears inherited values before reloading project configuration.
+        inherited.baseline_error_level = None;
+        inherited.inherit_defaults_from_config(&ConfigFile {
+            baseline_error_level: Some(Severity::Info),
+            ..Default::default()
+        });
+        assert_eq!(inherited.baseline_error_level(), Severity::Info);
+
+        let mut overridden =
+            OutputArgs::parse_from(["pyrefly-check", "--baseline-error-level=error"]);
+        overridden.inherit_defaults_from_config(&ConfigFile {
+            baseline_error_level: Some(Severity::Warn),
+            ..Default::default()
+        });
+        assert_eq!(overridden.baseline_error_level(), Severity::Error);
     }
 
     #[test]

--- a/pyrefly/lib/commands/check/sarif.rs
+++ b/pyrefly/lib/commands/check/sarif.rs
@@ -29,6 +29,7 @@ use pyrefly_util::absolutize::Absolutize;
 use pyrefly_util::lined_buffer::DisplayRange;
 use serde::Serialize;
 
+use crate::error::error::BaselineStatus;
 use crate::error::error::Error;
 
 const SCHEMA_URL: &str = "https://json.schemastore.org/sarif-2.1.0.json";
@@ -92,6 +93,8 @@ struct SarifResult {
     locations: Vec<Location>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     related_locations: Vec<Location>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    baseline_state: Option<SarifBaselineState>,
 }
 
 #[derive(Serialize)]
@@ -135,6 +138,13 @@ enum Level {
     Note,
     Warning,
     Error,
+}
+
+#[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+enum SarifBaselineState {
+    New,
+    Unchanged,
 }
 
 /// `Ignore` maps to `none`, which in a rule's `defaultConfiguration` means the rule
@@ -315,6 +325,11 @@ fn errors_to_sarif(version: &str, relative_to: &Path, errors: &[Error]) -> anyho
                         )
                     })
                     .collect(),
+                baseline_state: match error.baseline_status() {
+                    BaselineStatus::Unmatched => Some(SarifBaselineState::New),
+                    BaselineStatus::Matched => Some(SarifBaselineState::Unchanged),
+                    BaselineStatus::NotConfigured | BaselineStatus::NotCompared => None,
+                },
             }
         })
         .collect();
@@ -509,6 +524,46 @@ mod tests {
         assert!(sarif.runs[0].results.is_empty());
         // A dropped diagnostic must not leave its rule behind either.
         assert!(sarif.runs[0].tool.driver.rules.is_empty());
+    }
+
+    #[test]
+    fn conversion_maps_baseline_provenance() {
+        let errors = vec![
+            sample_error(
+                PathBuf::from("/repo/matched.py"),
+                "x\n",
+                0,
+                1,
+                "matched",
+                ErrorKind::BadAssignment,
+            )
+            .with_baseline_status(BaselineStatus::Matched),
+            sample_error(
+                PathBuf::from("/repo/new.py"),
+                "x\n",
+                0,
+                1,
+                "new",
+                ErrorKind::BadAssignment,
+            )
+            .with_baseline_status(BaselineStatus::Unmatched),
+        ];
+
+        let json = to_json(Path::new("/repo"), &errors);
+        assert_eq!(json["runs"][0]["results"][0]["baselineState"], "unchanged");
+        assert_eq!(json["runs"][0]["results"][1]["baselineState"], "new");
+
+        let not_compared = sample_error(
+            PathBuf::from("/repo/uncompared.py"),
+            "x\n",
+            0,
+            1,
+            "uncompared",
+            ErrorKind::BadAssignment,
+        )
+        .with_baseline_status(BaselineStatus::NotCompared);
+        let json = to_json(Path::new("/repo"), &[not_compared]);
+        assert!(json["runs"][0]["results"][0].get("baselineState").is_none());
     }
 
     #[test]

--- a/pyrefly/lib/error/error.rs
+++ b/pyrefly/lib/error/error.rs
@@ -49,6 +49,19 @@ pub enum ErrorQuickFix {
     ReplaceWithEnumMember { replacement: String },
 }
 
+/// Whether an error was compared with the configured baseline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BaselineStatus {
+    /// No baseline was configured for this check.
+    NotConfigured,
+    /// A baseline was configured but was not loaded for comparison.
+    NotCompared,
+    /// The error did not match the loaded baseline.
+    Unmatched,
+    /// The error matched the loaded baseline.
+    Matched,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Error {
     module: Module,
@@ -56,6 +69,7 @@ pub struct Error {
     display_range: DisplayRange,
     error_kind: ErrorKind,
     severity: Severity,
+    baseline_status: BaselineStatus,
     /// First line of the error message
     msg_header: Box<str>,
     /// The rest of the error message after the first line.
@@ -138,18 +152,29 @@ impl<W: Write> ErrorRenderer<W> {
         match self.mode {
             ErrorRenderMode::Plain => writeln!(
                 self.writer,
-                "{} {} [{}]",
+                "{} {} [{}]{}",
                 error.severity.label(),
                 error.msg_header,
                 error.error_kind.to_name(),
+                if error.baseline_status == BaselineStatus::Matched {
+                    " [baselined]"
+                } else {
+                    ""
+                },
             ),
-            ErrorRenderMode::Color => writeln!(
-                self.writer,
-                "{} {} {}",
-                error.severity.painted(),
-                Paint::new(&*error.msg_header),
-                Paint::dim(format!("[{}]", error.error_kind().to_name()).as_str()),
-            ),
+            ErrorRenderMode::Color => {
+                write!(
+                    self.writer,
+                    "{} {} {}",
+                    error.severity.painted(),
+                    Paint::new(&*error.msg_header),
+                    Paint::dim(format!("[{}]", error.error_kind().to_name()).as_str()),
+                )?;
+                if error.baseline_status == BaselineStatus::Matched {
+                    write!(self.writer, " {}", Paint::dim("[baselined]"))?;
+                }
+                writeln!(self.writer)
+            }
         }
     }
 
@@ -158,22 +183,33 @@ impl<W: Write> ErrorRenderer<W> {
         match self.mode {
             ErrorRenderMode::Plain => writeln!(
                 self.writer,
-                "{} {}:{}: {} [{}]",
+                "{} {}:{}: {} [{}]{}",
                 error.severity.label(),
                 origin,
                 error.display_range,
                 header,
                 error.error_kind.to_name(),
+                if error.baseline_status == BaselineStatus::Matched {
+                    " [baselined]"
+                } else {
+                    ""
+                },
             ),
-            ErrorRenderMode::Color => writeln!(
-                self.writer,
-                "{} {}:{}: {} {}",
-                error.severity.painted(),
-                Paint::blue(origin),
-                Paint::dim(error.display_range()),
-                Paint::new(&header),
-                Paint::dim(format!("[{}]", error.error_kind().to_name()).as_str()),
-            ),
+            ErrorRenderMode::Color => {
+                write!(
+                    self.writer,
+                    "{} {}:{}: {} {}",
+                    error.severity.painted(),
+                    Paint::blue(origin),
+                    Paint::dim(error.display_range()),
+                    Paint::new(&header),
+                    Paint::dim(format!("[{}]", error.error_kind().to_name()).as_str()),
+                )?;
+                if error.baseline_status == BaselineStatus::Matched {
+                    write!(self.writer, " {}", Paint::dim("[baselined]"))?;
+                }
+                writeln!(self.writer)
+            }
         }
     }
 
@@ -317,6 +353,15 @@ impl Error {
         self.severity
     }
 
+    pub fn with_baseline_status(mut self, baseline_status: BaselineStatus) -> Self {
+        self.baseline_status = baseline_status;
+        self
+    }
+
+    pub fn baseline_status(&self) -> BaselineStatus {
+        self.baseline_status
+    }
+
     /// Create a diagnostic suitable for use in LSP.
     pub fn to_diagnostic(&self) -> Diagnostic {
         let code = self.error_kind().to_name().to_owned();
@@ -424,6 +469,7 @@ impl Error {
             display_range,
             error_kind,
             severity: error_kind.default_severity(),
+            baseline_status: BaselineStatus::NotConfigured,
             msg_header,
             msg_details,
             secondary_annotations: Vec::new(),
@@ -574,6 +620,32 @@ mod tests {
   |     ^^^^^^^^
   |
 "#,
+        );
+    }
+
+    #[test]
+    fn test_baselined_error_render() {
+        let module_info = Module::new(
+            ModuleName::from_str("test"),
+            ModulePath::filesystem(PathBuf::from("test.py")),
+            Arc::new("x: str = 1".to_owned()),
+        );
+        let error = Error::new(
+            module_info,
+            TextRange::new(TextSize::new(9), TextSize::new(10)),
+            "bad assignment".to_owned(),
+            Vec::new(),
+            ErrorKind::BadAssignment,
+        )
+        .with_baseline_status(BaselineStatus::Matched);
+
+        assert_eq!(
+            render_error(&error, Path::new(""), false),
+            "ERROR test.py:1:10-11: bad assignment [bad-assignment] [baselined]\n"
+        );
+        assert!(
+            render_error(&error, Path::new(""), true)
+                .starts_with("ERROR bad assignment [bad-assignment] [baselined]\n")
         );
     }
 

--- a/pyrefly/lib/error/legacy.rs
+++ b/pyrefly/lib/error/legacy.rs
@@ -13,6 +13,7 @@ use pyrefly_util::prelude::SliceExt;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::error::error::BaselineStatus;
 use crate::error::error::Error;
 
 pub(crate) fn severity_to_str(severity: Severity) -> String {
@@ -48,6 +49,9 @@ pub struct LegacyError {
     /// This field is not part of Pyre1 error format. But it's useful for Pyrefly clients
     #[serde(default = "default_severity")]
     severity: String,
+    /// Whether the error matched a configured baseline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    baselined: Option<bool>,
     /// Optional notebook cell number for errors in notebook files
     #[serde(skip_serializing_if = "Option::is_none")]
     cell: Option<usize>,
@@ -73,6 +77,11 @@ impl LegacyError {
             description: error.msg(),
             concise_description: error.msg_header().to_owned(),
             severity: severity_to_str(error.severity()),
+            baselined: match error.baseline_status() {
+                BaselineStatus::NotConfigured => None,
+                BaselineStatus::NotCompared | BaselineStatus::Unmatched => Some(false),
+                BaselineStatus::Matched => Some(true),
+            },
         }
     }
 }
@@ -165,5 +174,38 @@ mod tests {
         );
         let legacy = LegacyError::from_error(Path::new("/repo/src"), &error);
         assert_eq!(legacy.path, "../libs/foo.py");
+    }
+
+    #[test]
+    fn test_baseline_provenance_is_optional() {
+        let module = Module::new(
+            ModuleName::from_str("foo"),
+            ModulePath::filesystem(PathBuf::from("/repo/foo.py")),
+            Arc::new("x = 1\n".to_owned()),
+        );
+        let error = Error::new(
+            module,
+            TextRange::new(TextSize::new(0), TextSize::new(1)),
+            "err".to_owned(),
+            Vec::new(),
+            ErrorKind::BadAssignment,
+        );
+
+        let without_baseline =
+            serde_json::to_value(LegacyError::from_error(Path::new("/repo"), &error)).unwrap();
+        assert!(without_baseline.get("baselined").is_none());
+
+        let matched = error.clone().with_baseline_status(BaselineStatus::Matched);
+        assert_eq!(
+            serde_json::to_value(LegacyError::from_error(Path::new("/repo"), &matched)).unwrap()["baselined"],
+            true
+        );
+
+        let not_compared = error.with_baseline_status(BaselineStatus::NotCompared);
+        assert_eq!(
+            serde_json::to_value(LegacyError::from_error(Path::new("/repo"), &not_compared))
+                .unwrap()["baselined"],
+            false
+        );
     }
 }

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -317,6 +317,7 @@ impl Errors {
     /// When `classify_stale_entries` is true, returns the number of baseline entries
     /// that are definitely unused together with all entries that should be retained.
     /// Ordinary checks skip that filesystem work and return empty maintenance data.
+    /// The final return value records whether a baseline was loaded for comparison.
     ///
     /// A baseline path that exists but cannot be read or parsed is a hard error
     /// rather than being silently ignored, so a corrupt baseline surfaces instead
@@ -328,9 +329,10 @@ impl Errors {
         baseline_path: Option<&Path>,
         relative_to: &Path,
         classify_stale_entries: bool,
-    ) -> anyhow::Result<(usize, Vec<BaselineError>)> {
+    ) -> anyhow::Result<(usize, Vec<BaselineError>, bool)> {
         let mut unused_baseline_entries = 0;
         let mut retained_baseline_entries = Vec::new();
+        let mut baseline_loaded = false;
         if let Some(baseline_path) = baseline_path
             && baseline_path.exists()
         {
@@ -351,15 +353,21 @@ impl Errors {
                 let result = processor.into_pruning_result(&checked_paths);
                 unused_baseline_entries = result.unused_entry_count;
                 retained_baseline_entries = result.retained_entries;
+                baseline_loaded = true;
             } else {
                 let processor = BaselineProcessor::from_file(baseline_path, relative_to)
                     .with_context(|| {
                         format!("failed to read baseline file `{}`", baseline_path.display())
                     })?;
                 processor.process_errors(&mut errors.ordinary, &mut errors.baseline);
+                baseline_loaded = true;
             }
         }
-        Ok((unused_baseline_entries, retained_baseline_entries))
+        Ok((
+            unused_baseline_entries,
+            retained_baseline_entries,
+            baseline_loaded,
+        ))
     }
 
     /// Collect display errors for the language server, partitioned by whether or not they

--- a/schemas/pyrefly.json
+++ b/schemas/pyrefly.json
@@ -209,6 +209,12 @@
           "description": "Path to a baseline file for suppressing existing errors.",
           "type": "string"
         },
+        "baseline-error-level": {
+          "description": "Severity assigned to errors that match the baseline.",
+          "type": "string",
+          "enum": ["ignore", "info", "warn", "error"],
+          "default": "ignore"
+        },
         "build-system": {
           "description": "Pyrefly supports integrating into build systems to discover targets to type check and their dependencies. Currently supports Buck2 and custom queries.",
           "type": "object",

--- a/schemas/test-pyproject.toml
+++ b/schemas/test-pyproject.toml
@@ -46,6 +46,7 @@ skip-lsp-config-indexing = false
 
 # Baseline
 baseline = "baseline.json"
+baseline-error-level = "warn"
 
 # Error configuration
 [tool.pyrefly.errors]

--- a/schemas/test-pyrefly.toml
+++ b/schemas/test-pyrefly.toml
@@ -45,6 +45,7 @@ skip-lsp-config-indexing = false
 
 # Baseline
 baseline = "baseline.json"
+baseline-error-level = "warn"
 
 # Error configuration
 [errors]

--- a/test/baseline.md
+++ b/test/baseline.md
@@ -343,6 +343,26 @@ ERROR new.py:2:12-13: * [bad-return] (glob)
 [1]
 ```
 
+## Baseline error levels do not increase a finding's severity
+
+```scrut {output_stream: stdout}
+$ mkdir -p $TMPDIR/baseline_warning && \
+> printf 'x: str = 1\n' > $TMPDIR/baseline_warning/warning.py && \
+> printf 'baseline = "baseline.json"\n[errors]\nbad-assignment = "warn"\n' > $TMPDIR/baseline_warning/pyrefly.toml && \
+> cd $TMPDIR/baseline_warning && \
+> $PYREFLY check --update-baseline --min-severity=warn --summary=none --output-format=omit-errors >/dev/null 2>/dev/null; \
+> $JQ -r '.errors[0].severity' baseline.json
+warn
+[0]
+```
+
+```scrut {output_stream: stdout}
+$ cd $TMPDIR/baseline_warning && \
+> $PYREFLY check warning.py --baseline-error-level=error --min-severity=warn --summary=none --output-format=min-text
+ WARN warning.py:1:10-11: * [bad-assignment] [baselined] (glob)
+[1]
+```
+
 ## `--only` filters baselined and new findings
 
 ```scrut {output_stream: stdout}

--- a/test/baseline.md
+++ b/test/baseline.md
@@ -288,3 +288,173 @@ Usage: pyrefly check --prune-baseline [FILES]...
 For more information, try '--help'.
 [2]
 ```
+
+## Baselined findings can be emitted at a configured severity
+
+```scrut
+$ mkdir -p $TMPDIR/baseline_levels && \
+> printf 'x: str = 1\n' > $TMPDIR/baseline_levels/matched.py && \
+> printf 'def f() -> str:\n    return 1\n' > $TMPDIR/baseline_levels/new.py && \
+> echo '{"errors":[{"column":10,"path":"matched.py","name":"bad-assignment","concise_description":"test","severity":"error"}]}' > $TMPDIR/baseline_levels/baseline.json && \
+> printf 'baseline = "baseline.json"\nbaseline-error-level = "warn"\n' > $TMPDIR/baseline_levels/pyrefly.toml
+[0]
+```
+
+The configured warning is hidden by the default error threshold.
+
+```scrut {output_stream: stdout}
+$ cd $TMPDIR/baseline_levels && \
+> $PYREFLY check matched.py --summary=none --output-format=min-text
+[0]
+```
+
+At a matching threshold it is reported, marked as baselined, and affects the
+exit status normally.
+
+```scrut {output_stream: stdout}
+$ cd $TMPDIR/baseline_levels && \
+> $PYREFLY check matched.py --min-severity=warn --summary=none --output-format=min-text
+ WARN matched.py:1:10-11: * [bad-assignment] [baselined] (glob)
+[1]
+```
+
+The CLI level overrides configuration. `info` is likewise hidden until the
+minimum severity includes it.
+
+```scrut {output_stream: stdout}
+$ cd $TMPDIR/baseline_levels && \
+> $PYREFLY check matched.py --baseline-error-level=info --summary=none --output-format=min-text
+[0]
+```
+
+```scrut {output_stream: stdout}
+$ cd $TMPDIR/baseline_levels && \
+> $PYREFLY check matched.py --baseline-error-level=info --min-severity=info --summary=none --output-format=min-text
+ INFO matched.py:1:10-11: * [bad-assignment] [baselined] (glob)
+[1]
+```
+
+Explicit `ignore` hides matching findings while new errors are reported.
+
+```scrut {output_stream: stdout}
+$ cd $TMPDIR/baseline_levels && \
+> $PYREFLY check --baseline-error-level=ignore --summary=none --output-format=min-text
+ERROR new.py:2:12-13: * [bad-return] (glob)
+[1]
+```
+
+## `--only` filters baselined and new findings
+
+```scrut {output_stream: stdout}
+$ cd $TMPDIR/baseline_levels && \
+> $PYREFLY check --baseline-error-level=error --only=bad-assignment --summary=none --output-format=min-text
+ERROR matched.py:1:10-11: * [bad-assignment] [baselined] (glob)
+[1]
+```
+
+```scrut {output_stream: stdout}
+$ cd $TMPDIR/baseline_levels && \
+> $PYREFLY check --baseline-error-level=error --only=bad-return --summary=none --output-format=min-text
+ERROR new.py:2:12-13: * [bad-return] (glob)
+[1]
+```
+
+## JSON records baseline provenance only when a baseline is configured
+
+```scrut {output_stream: stdout}
+$ cd $TMPDIR/no_baseline && \
+> $PYREFLY check --summary=none --output=json:diagnostics.json --output=sarif:diagnostics.sarif >/dev/null 2>/dev/null; \
+> $JQ -c '[.errors[] | has("baselined")]' diagnostics.json && \
+> $JQ -c '[.runs[0].results[] | has("baselineState")]' diagnostics.sarif
+[false]
+[false]
+[0]
+```
+
+With a loaded baseline, matched and new findings are both identified. Using
+the `error` level reports both at full severity.
+
+```scrut {output_stream: stdout}
+$ cd $TMPDIR/baseline_levels && \
+> $PYREFLY check --baseline-error-level=error --summary=none --output=json:diagnostics.json >/dev/null 2>/dev/null; \
+> $JQ -c '[.errors[] | {path, severity, baselined}]' diagnostics.json
+[{"path":"matched.py","severity":"error","baselined":true},{"path":"new.py","severity":"error","baselined":false}]
+[0]
+```
+
+## SARIF records matching findings as unchanged and other findings as new
+
+```scrut {output_stream: stdout}
+$ cd $TMPDIR/baseline_levels && \
+> $PYREFLY check --baseline-error-level=error --summary=none --output=sarif:diagnostics.sarif >/dev/null 2>/dev/null; \
+> $JQ -c '[.runs[0].results[] | {path: .locations[0].physicalLocation.artifactLocation.uri, baselineState}]' diagnostics.sarif
+[{"path":"matched.py","baselineState":"unchanged"},{"path":"new.py","baselineState":"new"}]
+[0]
+```
+
+## Baseline regeneration reports configured but uncompared provenance
+
+```scrut {output_stream: stdout}
+$ mkdir -p $TMPDIR/baseline_regeneration && \
+> printf 'x: str = 1\n' > $TMPDIR/baseline_regeneration/bad.py && \
+> touch $TMPDIR/baseline_regeneration/pyrefly.toml && \
+> cd $TMPDIR/baseline_regeneration && \
+> $PYREFLY check --baseline=baseline.json --update-baseline --summary=none --output=json:diagnostics.json --output=sarif:diagnostics.sarif >/dev/null 2>/dev/null; \
+> $JQ -c '[.errors[] | .baselined]' diagnostics.json && \
+> $JQ -c '[.runs[0].results[] | has("baselineState")]' diagnostics.sarif
+[false]
+[false]
+[0]
+```
+
+## GitHub Actions annotations mark baselined findings in their title
+
+```scrut {output_stream: stdout}
+$ cd $TMPDIR/baseline_levels && \
+> $PYREFLY check --baseline-error-level=warn --min-severity=warn --summary=none --output-format=github
+::warning file=*/matched.py,line=1,col=10,endLine=1,endColumn=11,title=Pyrefly bad-assignment [baselined]::* (glob)
+::error file=*/new.py,line=2,col=12,endLine=2,endColumn=13,title=Pyrefly bad-return::* (glob)
+[1]
+```
+
+## Omitted-error output reports the number of baselined diagnostics
+
+```scrut {output_stream: stderr}
+$ cd $TMPDIR/baseline_levels && \
+> $PYREFLY check matched.py --baseline-error-level=warn --min-severity=warn --output-format=omit-errors --progress-bar=no
+ INFO 1 diagnostic (1 baselined)
+[1]
+```
+
+## Display metadata is not written into an updated baseline
+
+```scrut {output_stream: stdout}
+$ cd $TMPDIR/baseline_levels && \
+> $PYREFLY check --update-baseline --min-severity=warn --summary=none --output-format=omit-errors >/dev/null 2>/dev/null; \
+> $JQ -c '[.errors[] | {severity, baselined: has("baselined")}]' baseline.json
+[{"severity":"error","baselined":false},{"severity":"error","baselined":false}]
+[0]
+```
+
+## Pruning writes stored baseline severity and omits provenance
+
+```scrut {output_stream: stdout}
+$ mkdir -p $TMPDIR/baseline_prune_provenance && \
+> printf 'x: str = 1\n' > $TMPDIR/baseline_prune_provenance/matched.py && \
+> echo '{"errors":[{"column":10,"path":"matched.py","name":"bad-assignment","concise_description":"test","severity":"info"},{"column":1,"path":"gone.py","name":"bad-return","concise_description":"stale","severity":"error"}]}' > $TMPDIR/baseline_prune_provenance/baseline.json && \
+> touch $TMPDIR/baseline_prune_provenance/pyrefly.toml && \
+> cd $TMPDIR/baseline_prune_provenance && \
+> $PYREFLY check matched.py --baseline=baseline.json --baseline-error-level=warn --prune-baseline --summary=none --output-format=omit-errors >/dev/null 2>/dev/null; \
+> $JQ -c '[.errors[] | {severity, baselined: has("baselined")}]' baseline.json
+[{"severity":"info","baselined":false}]
+[0]
+```
+
+## Baselined display findings are not converted into inline suppressions
+
+```scrut
+$ cd $TMPDIR/baseline_levels && \
+> $PYREFLY check matched.py --baseline-error-level=error --only=bad-assignment --suppress-errors --summary=none >/dev/null 2>/dev/null; \
+> ! grep -q pyrefly matched.py
+[0]
+```

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -499,6 +499,28 @@ more details on how baseline files work.
     - Errors suppressed by the baseline file are still shown in the IDE.
     - Errors are matched with the baseline by file, error code, and column number.
 
+### `baseline-error-level`
+
+The severity assigned to diagnostics that match the baseline. The default value,
+`"ignore"`, suppresses them from CLI output. Set this to `"info"`, `"warn"`, or
+`"error"` to report matched diagnostics at that severity. Reported matches follow
+the normal [`min-severity`](#min-severity) filtering and exit-status behaviour.
+
+```toml
+baseline = "baseline.json"
+baseline-error-level = "warn"
+```
+
+- Type: `"ignore"` | `"info"` | `"warn"` | `"error"`
+- Default: `"ignore"`
+- Flag equivalent: `--baseline-error-level`
+- Notes:
+    - `baseline-error-level` is a **project-level setting** and cannot be overridden
+      in [`sub-config`](#sub-configs) sections.
+    - A CLI flag takes precedence over the configuration value.
+    - This setting affects `pyrefly check` output only. The IDE displays baselined
+      diagnostics as hints.
+
 ### `min-severity`
 
 The minimum severity level for diagnostics to be displayed by `pyrefly check`. Diagnostics

--- a/website/docs/error-suppressions.mdx
+++ b/website/docs/error-suppressions.mdx
@@ -133,6 +133,25 @@ Note that `baseline` is a **project-level setting** and cannot be overridden in 
 Errors are matched with the baseline by looking at file, error code, and column number.
 Note that errors suppressed by the baseline file are still shown in the IDE.
 
+`--baseline-error-level=<ignore|info|warn|error>` and the project-level
+`baseline-error-level` setting control how matching errors are reported. The
+default is `ignore`, which omits them from CLI output; the other levels emit them
+at a reduced or unchanged severity:
+
+```toml
+baseline = "baseline.json"
+baseline-error-level = "warn"
+```
+
+Emitted matches follow the normal `--min-severity` filtering and exit-status rules.
+Pyrefly records baseline provenance differently depending on the output format:
+
+- `full-text` and `min-text`: matched findings include `[baselined]` after the error-kind marker.
+- `github`: matched findings include `[baselined]` in the annotation title.
+- `json`: when a baseline is configured, each result has `baselined` set to `true` for a match and `false` otherwise.
+- `sarif`: when a baseline is configured, each result has `baselineState` set to `unchanged` for a match and `new` otherwise.
+- `omit-errors`: the summary includes the number of emitted baselined diagnostics.
+
 If a baseline file is configured but cannot be read or parsed, the run fails with an error rather than proceeding as if no baseline were set. The exception is `--update-baseline`, which regenerates the file from scratch and so tolerates a missing or unparseable baseline.
 
 As you fix errors, the entries that suppressed them become stale. Two flags help keep the baseline current:


### PR DESCRIPTION
Resolves #4543.

With the `baseline-error-level` option, baselined errors can be shown in Pyrefly's output at a possibly reduced severity. 

When this setting causes baselined results to be present in the output, most output formats (excluding `code-climate` and `junit-xml`) include a marker with each result which matches the baseline.

Default `pyrefly check` behaviour remains unchanged. Also, this setting does not affect the Pyrefly LSP (yet).