### PR TITLE
Remove float for unnecessary-type-conversion warning to account for int

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1496,7 +1496,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         range: TextRange,
         errors: &ErrorCollector,
     ) {
-        let builtin_names = ["str", "int", "float", "bool", "bytes"];
+        let builtin_names = ["str", "int", "bool", "bytes"];
         if !builtin_names
             .iter()
             .any(|name| cls.has_qname("builtins", name))

--- a/pyrefly/lib/test/unnecessary_type_conversion.rs
+++ b/pyrefly/lib/test/unnecessary_type_conversion.rs
@@ -24,10 +24,10 @@ def f(x: int) -> None:
 );
 
 testcase!(
-    test_float_to_float,
+    test_float_to_float_ok,
     r#"
 def f(x: float) -> None:
-    y = float(x)  # E: Unnecessary `float()` call; argument is already of type `float`
+    y = float(x)  # OK - `x` may be an int due to numeric tower compatibility.
 "#,
 );
 


### PR DESCRIPTION
# Summary

As @pdhall99 found, pyrefly reports a 'unnecessary-type-conversion' warning for running a float() conversion, even though an int can be passed without runtime conversion which makes float() valid under python's numeric tower rule. 

Fixes #4524

# Test Plan
$ cargo test
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

$ cargo test test_float_to_float_ok
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 32 filtered out; finished in 0.00s

$ python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema
passed with 1 warning unrelated to this change

