### PR TITLE
fix Show package name in hover #4358

### DIFF
--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -260,8 +260,7 @@ impl<'a> TypeDisplayContext<'a> {
         self.render_self_type_as_self = true;
     }
 
-    /// Always display the module name, except for builtins.
-    pub fn always_display_module_name_except_builtins(&mut self) {
+    fn qualify_qnames_except_builtins(&mut self) {
         let builtins_module = ModuleName::from_str("builtins");
         let fake_module = ModuleName::from_str("__pyrefly__type__display__context__");
         for c in self.qnames.values_mut() {
@@ -276,6 +275,16 @@ impl<'a> TypeDisplayContext<'a> {
                 c.info.insert(fake_module, None);
             }
         }
+    }
+
+    /// Always qualify names backed by a `QName`, except for builtins.
+    pub fn always_display_qname_module_name_except_builtins(&mut self) {
+        self.qualify_qnames_except_builtins();
+    }
+
+    /// Always display the module name, except for builtins.
+    pub fn always_display_module_name_except_builtins(&mut self) {
+        self.qualify_qnames_except_builtins();
         self.always_display_module_name = true;
     }
 

--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -260,31 +260,28 @@ impl<'a> TypeDisplayContext<'a> {
         self.render_self_type_as_self = true;
     }
 
-    fn qualify_qnames_except_builtins(&mut self) {
-        let builtins_module = ModuleName::from_str("builtins");
+    fn qualify_qnames_except(&mut self, unqualified_modules: &[ModuleName]) {
         let fake_module = ModuleName::from_str("__pyrefly__type__display__context__");
         for c in self.qnames.values_mut() {
-            if c.info.len() > 1 {
-                continue; // Multiple modules, so we need to keep the module name to disambiguate.
-            }
-            if let Some(value) = c.info.get_mut(&builtins_module) {
-                // Name is a builtin, we set it a default location so we hit the fallback branch in `QNameInfo::fmt`.
-                *value = Some(TextRange::default());
-            } else {
-                // Name is not a builtins, so we add a fake module to force the module name to be displayed.
+            if c.info.len() == 1
+                && !c
+                    .info
+                    .keys()
+                    .any(|module| unqualified_modules.contains(module))
+            {
                 c.info.insert(fake_module, None);
             }
         }
     }
 
-    /// Always qualify names backed by a `QName`, except for builtins.
-    pub fn always_display_qname_module_name_except_builtins(&mut self) {
-        self.qualify_qnames_except_builtins();
+    /// Qualify names from outside the current module, except for builtins.
+    pub fn always_display_external_qname_module_names(&mut self, current_module: ModuleName) {
+        self.qualify_qnames_except(&[ModuleName::builtins(), current_module]);
     }
 
     /// Always display the module name, except for builtins.
     pub fn always_display_module_name_except_builtins(&mut self) {
-        self.qualify_qnames_except_builtins();
+        self.qualify_qnames_except(&[ModuleName::builtins()]);
         self.always_display_module_name = true;
     }
 

--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -24,6 +24,7 @@ use pyrefly_python::ignore::Ignore;
 use pyrefly_python::ignore::Tool;
 use pyrefly_python::ignore::find_comment_start_in_line;
 use pyrefly_python::module::Module;
+use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_python::symbol_kind::SymbolKind;
 use pyrefly_types::callable::Callable;
@@ -103,17 +104,18 @@ pub struct HoverOptions {
     pub verbosity_level: usize,
 }
 
-/// Render a hover type, optionally qualifying canonical names except for builtins.
+/// Render a hover type, optionally qualifying names from external modules.
 fn display_type_for_hover(
     type_: &Type,
     fallback_name: Option<&str>,
     expand_unions: bool,
-    qualify_names: bool,
+    qualify_external_names: bool,
+    current_module: ModuleName,
 ) -> String {
     let mut context = TypeDisplayContext::new(&[type_]);
     context.set_lsp_display_mode(LspDisplayMode::Hover);
-    if qualify_names {
-        context.always_display_qname_module_name_except_builtins();
+    if qualify_external_names {
+        context.always_display_external_qname_module_names(current_module);
     }
     if expand_unions {
         context.always_display_expanded_unions();
@@ -322,6 +324,7 @@ impl HoverValue {
                 self.name.as_deref(),
                 false,
                 self.kind != Some(SymbolKind::Class) && !self.type_.is_toplevel_callable(),
+                handle.module(),
             )
         });
 
@@ -1062,14 +1065,15 @@ pub fn get_hover_with_verbosity(
                     });
                     cloned
                 };
-                let qualify_names =
+                let qualify_external_names =
                     kind != Some(SymbolKind::Class) && !display_type.is_toplevel_callable();
                 let render = |expand| {
                     display_type_for_hover(
                         &display_type,
                         name_for_display.as_deref(),
                         expand,
-                        qualify_names,
+                        qualify_external_names,
+                        handle.module(),
                     )
                 };
                 let rendered = render(unions_expanded);

--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -34,6 +34,7 @@ use pyrefly_types::callable::Required;
 use pyrefly_types::class::Class;
 use pyrefly_types::class::ClassType;
 use pyrefly_types::display::LspDisplayMode;
+use pyrefly_types::display::TypeDisplayContext;
 use pyrefly_types::type_var::Variance;
 use pyrefly_types::types::Type;
 use pyrefly_util::absolutize::Absolutize as _;
@@ -100,6 +101,33 @@ pub struct HoverResult {
 pub struct HoverOptions {
     pub show_go_to_links: bool,
     pub verbosity_level: usize,
+}
+
+/// Render a hover type, optionally qualifying canonical names except for builtins.
+fn display_type_for_hover(
+    type_: &Type,
+    fallback_name: Option<&str>,
+    expand_unions: bool,
+    qualify_names: bool,
+) -> String {
+    let mut context = TypeDisplayContext::new(&[type_]);
+    context.set_lsp_display_mode(LspDisplayMode::Hover);
+    if qualify_names {
+        context.always_display_qname_module_name_except_builtins();
+    }
+    if expand_unions {
+        context.always_display_expanded_unions();
+    }
+    let rendered = context.display(type_).to_string();
+    if let Some(name) = fallback_name
+        && type_.is_toplevel_callable()
+    {
+        let trimmed = rendered.trim_start();
+        if trimmed.starts_with('(') {
+            return format!("def {name}{trimmed}: ...");
+        }
+    }
+    rendered
 }
 
 impl HoverValue {
@@ -289,8 +317,12 @@ impl HoverValue {
             section
         };
         let type_display = self.display.clone().unwrap_or_else(|| {
-            self.type_
-                .as_lsp_string_with_fallback_name(self.name.as_deref(), LspDisplayMode::Hover)
+            display_type_for_hover(
+                &self.type_,
+                self.name.as_deref(),
+                false,
+                self.kind != Some(SymbolKind::Class) && !self.type_.is_toplevel_callable(),
+            )
         });
 
         Hover {
@@ -1030,11 +1062,14 @@ pub fn get_hover_with_verbosity(
                     });
                     cloned
                 };
+                let qualify_names =
+                    kind != Some(SymbolKind::Class) && !display_type.is_toplevel_callable();
                 let render = |expand| {
-                    display_type.as_lsp_string_with_fallback_name_and_expanded_unions(
+                    display_type_for_hover(
+                        &display_type,
                         name_for_display.as_deref(),
-                        LspDisplayMode::Hover,
                         expand,
+                        qualify_names,
                     )
                 };
                 let rendered = render(unions_expanded);

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -150,6 +150,10 @@ import numpy as np
 import torch as t
 import library as lib
 
+class Local: ...
+
+local = Local()
+#^
 tensor = t.Tensor()
 #^
 array = np.ndarray()
@@ -167,6 +171,10 @@ shape = lib.shape()
             ("main", main),
         ],
         get_test_report,
+    );
+    assert!(
+        report.contains("(variable) local: Local"),
+        "Expected hover to omit the current module, got: {report}"
     );
     assert!(
         report.contains("(variable) tensor: torch.Tensor"),
@@ -231,7 +239,7 @@ xyz = [foo.meth]
 "#;
     let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
     assert!(report.contains("(method) meth: def meth(self: Foo) -> None: ..."));
-    assert!(report.contains("(variable) xyz: list[(self: main.Foo) -> None]"));
+    assert!(report.contains("(variable) xyz: list[(self: Foo) -> None]"));
     assert!(
         report.contains("Go to [list]"),
         "Expected 'Go to [list]' link, got: {}",
@@ -552,8 +560,8 @@ def f(c: C) -> None:
 "#;
     let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
     assert!(
-        report.contains(": main.C"),
-        "Expected receiver hover to show `c`'s own qualified type, got: {report}"
+        report.contains(": C"),
+        "Expected receiver hover to show `c`'s own type `C`, got: {report}"
     );
     assert!(
         !report.contains("x: int"),
@@ -939,7 +947,7 @@ def f(x: E) -> None:
         }
     });
     assert!(
-        report.contains("Literal[main.E.y]"),
+        report.contains("Literal[E.y]"),
         "Expected hover to show remaining match type, got: {report}"
     );
 }
@@ -1384,7 +1392,7 @@ c[0]
     let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
     // Hovering the base `c` still shows the variable.
     assert!(
-        report.contains("(variable) c: main.Container"),
+        report.contains("(variable) c: Container"),
         "Expected variable hover for base `c`, got: {report}"
     );
     // Hovering inside the brackets shows the dunder method, matching `c [0]`.

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -132,6 +132,60 @@ x: int = 0
     assert!(!compact_can_increase);
 }
 
+#[test]
+fn hover_shows_qualified_type_names() {
+    let torch = "class Tensor: ...";
+    let numpy = "class ndarray: ...";
+    let library = r#"
+from numpy import ndarray
+from torch import Tensor
+
+TensorLike = Tensor | ndarray
+
+def foo(value: TensorLike) -> TensorLike: ...
+def shape() -> list[int]: ...
+"#;
+    let main = r#"
+import numpy as np
+import torch as t
+import library as lib
+
+tensor = t.Tensor()
+#^
+array = np.ndarray()
+#^
+combined = lib.foo(tensor)
+#^
+shape = lib.shape()
+#^
+"#;
+    let report = get_batched_lsp_operations_report(
+        &[
+            ("torch", torch),
+            ("numpy", numpy),
+            ("library", library),
+            ("main", main),
+        ],
+        get_test_report,
+    );
+    assert!(
+        report.contains("(variable) tensor: torch.Tensor"),
+        "Expected hover to include the canonical torch module, got: {report}"
+    );
+    assert!(
+        report.contains("(variable) array: numpy.ndarray"),
+        "Expected hover to include the canonical numpy module, got: {report}"
+    );
+    assert!(
+        report.contains("(variable) combined: torch.Tensor | numpy.ndarray"),
+        "Expected hover to qualify names in a library type alias, got: {report}"
+    );
+    assert!(
+        report.contains("(variable) shape: list[int]"),
+        "Expected hover to omit the builtins module, got: {report}"
+    );
+}
+
 fn assert_sphinx_resolved_as_link(report: &str, role: &str, target: &str) {
     let raw = format!(":{role}:`{target}`");
     assert!(
@@ -177,7 +231,7 @@ xyz = [foo.meth]
 "#;
     let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
     assert!(report.contains("(method) meth: def meth(self: Foo) -> None: ..."));
-    assert!(report.contains("(variable) xyz: list[(self: Foo) -> None]"));
+    assert!(report.contains("(variable) xyz: list[(self: main.Foo) -> None]"));
     assert!(
         report.contains("Go to [list]"),
         "Expected 'Go to [list]' link, got: {}",
@@ -498,8 +552,8 @@ def f(c: C) -> None:
 "#;
     let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
     assert!(
-        report.contains(": C"),
-        "Expected receiver hover to show `c`'s own type `C`, got: {report}"
+        report.contains(": main.C"),
+        "Expected receiver hover to show `c`'s own qualified type, got: {report}"
     );
     assert!(
         !report.contains("x: int"),
@@ -885,7 +939,7 @@ def f(x: E) -> None:
         }
     });
     assert!(
-        report.contains("Literal[E.y]"),
+        report.contains("Literal[main.E.y]"),
         "Expected hover to show remaining match type, got: {report}"
     );
 }
@@ -1330,7 +1384,7 @@ c[0]
     let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
     // Hovering the base `c` still shows the variable.
     assert!(
-        report.contains("(variable) c: Container"),
+        report.contains("(variable) c: main.Container"),
         "Expected variable hover for base `c`, got: {report}"
     );
     // Hovering inside the brackets shows the dunder method, matching `c [0]`.


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4358

Hovered values now show canonical names such as torch.Tensor and numpy.ndarray, including union aliases.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test