### PR TITLE
Load each config file and probe each candidate only once in `UpwardSearch`

### DIFF
--- a/crates/pyrefly_util/src/upward_search.rs
+++ b/crates/pyrefly_util/src/upward_search.rs
@@ -10,6 +10,7 @@ use std::fmt::Debug;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use dupe::Dupe;
 use starlark_map::small_map::Entry;
@@ -67,6 +68,9 @@ pub struct UpwardSearch<T> {
     filegroups: Vec<FileGroup<T>>,
     /// The cached state, with previously found entries.
     state: RwLock<SmallMap<PathBuf, (Option<T>, Arc<PathBuf>)>>,
+    /// Loaded files, keyed by path (a file is reachable from every directory below it *and* from
+    /// each [`FileGroup`] that lists its name; without this it would be loaded once per route).
+    loaded: RwLock<SmallMap<PathBuf, Arc<OnceLock<T>>>>,
     /// Given a config file that exists on disk, load it.
     load: Box<dyn Fn(&Path) -> T + Send + Sync>,
 }
@@ -98,6 +102,7 @@ impl<T: Dupe + Debug> UpwardSearch<T> {
         Self {
             filegroups,
             state: Default::default(),
+            loaded: Default::default(),
             load: Box::new(load),
         }
     }
@@ -105,6 +110,19 @@ impl<T: Dupe + Debug> UpwardSearch<T> {
     /// Clear all cached data.
     pub fn clear(&self) {
         self.state.write().clear();
+        self.loaded.write().clear();
+    }
+
+    /// Load `path` at most once, so that it always resolves to a single `T`.
+    fn load_once(&self, path: &Path) -> T {
+        // Note: the guard is a temporary, so the map is unlocked before the load runs.
+        let slot = self
+            .loaded
+            .write()
+            .entry(path.to_owned())
+            .or_default()
+            .dupe();
+        slot.get_or_init(|| (self.load)(path)).dupe()
     }
 
     /// Get the config file associated with a directory.
@@ -137,6 +155,9 @@ impl<T: Dupe + Debug> UpwardSearch<T> {
         }
         drop(lock);
 
+        // Prevent repeated filesystem calls for the same path in different filegroups.
+        let mut path_exists: SmallMap<PathBuf, bool> = SmallMap::new();
+
         // We didn't find a perfect hit, so now search the actual path
         'outer: for filegroup in &self.filegroups {
             let mut buffer = dir.to_owned();
@@ -144,8 +165,16 @@ impl<T: Dupe + Debug> UpwardSearch<T> {
                 for stem in &filegroup.filenames {
                     let stem_length = PathBuf::from(stem).components().count();
                     buffer.push(stem);
-                    if buffer.exists() {
-                        let c = (self.load)(&buffer);
+                    let exists = match path_exists.get(&buffer) {
+                        Some(exists) => *exists,
+                        None => {
+                            let exists = buffer.exists();
+                            path_exists.insert(buffer.clone(), exists);
+                            exists
+                        }
+                    };
+                    if exists {
+                        let c = self.load_once(&buffer);
                         if (filegroup.predicate)(&c) {
                             found_answer = Some((i + 1, Some(c), Arc::new(buffer)));
                             break 'outer;
@@ -362,6 +391,33 @@ mod tests {
             upward_search(2).directory_absolute(&root.path().join("a/b")),
             None,
         );
+    }
+
+    /// A file should only be loaded once, however many routes reach it. Here both filegroups
+    /// list `pyproject.toml`; the first rejects it, so the search finds the same file twice.
+    #[test]
+    fn test_file_is_loaded_once() {
+        let root = TempDir::new().unwrap();
+        fs::write(root.path().join("pyproject.toml"), "").unwrap();
+
+        let loads = Arc::new(Mutex::new(Vec::new()));
+        let loads2 = loads.dupe();
+        let upward_search = UpwardSearch::new_grouped(
+            vec![
+                FileGroup::new(vec![OsString::from("pyproject.toml")], |_| false),
+                FileGroup::new(vec![OsString::from("pyproject.toml")], |_| true),
+            ],
+            move |p| {
+                loads2.lock().push(p.to_path_buf());
+                Arc::new(p.to_path_buf())
+            },
+        );
+
+        assert_eq!(
+            **upward_search.directory_absolute(root.path()).unwrap(),
+            root.path().join("pyproject.toml")
+        );
+        assert_eq!(*loads.lock(), vec![root.path().join("pyproject.toml")]);
     }
 
     #[test]


### PR DESCRIPTION
# Summary

### Overview

`UpwardSearch` was doing unnecessary work; in most packages it wasn't a problem, but in some it could trigger a lot of redundant filesystem work by repeating a lot of load/stat calls on the same file(s).

### Solution

* Optimise-out redundant IO/syscalls from `UpwardSearch` (config load/probes) by using simple `SmallMap` caching, keyed by path.

* Before this PR, one config search would load the same file and stat the same candidate paths multiple times; now it only does each once. 

# Benchmarks[^1]

There's a nice positive impact (on a limited number of packages), but it can be even more significant in corporate environments running endpoint security software.

Note: I was finally able to deterministically reproduce the increased cost of syscalls/IO caused by corporate endpoint security software introspection, so I've included it in the timings below (refs: #3993, https://github.com/facebook/pyrefly/pull/4017#issuecomment-4904434219).

* The "taxed" columns show the additional overhead from endpoint security software. The real standout is `pywin32`, with a ~5-6x overhead: ~0.74s normally, ~4.29 secs with the security software tax (reduced to ~2.83 secs with this PR). 

  | Package | Speedup (s) | Δ | Taxed speedup (s) | Taxed Δ | Tax |
  | :-- | --: | --: | --: | --: | --: |
  | vision | 0.54 → 0.36 | -32.50% | 0.54 → 0.37 | -31.70% | 1.0× |
  | materialize | 1.95 → 1.48 | -23.30% | 1.97 → 1.48 | -24.80% | 1.0× |
  | kornia | 0.55 → 0.45 | -19.10% | 0.58 → 0.46 | -20.10% | 1.0× |
  | pycryptodome | 0.28 → 0.24 | -15.70% | 0.29 → 0.24 | -15.90% | 1.0× |
  | beartype | 0.45 → 0.38 | -15.60% | 0.47 → 0.39 | -14.70% | 1.0× |
  | mitmproxy | 0.57 → 0.48 | -14.90% | 0.60 → 0.52 | -13.60% | 1.1× |
  | graphql-core | 0.38 → 0.33 | -13.80% | 0.38 → 0.33 | -12.20% | 1.0× |
  | poetry | 0.91 → 0.81 | -10.90% | 1.34 → 1.06 | -21.10% | 1.5× |
  | spack | 0.55 → 0.50 | -9.30% | 0.58 → 0.53 | -8.60% | 1.1× |
  | pip | 0.66 → 0.60 | -8.90% | 0.63 → 0.59 | -5.60% | 1.0× |
  | core | 4.14 → 4.02 | -3.40% | 5.26 → 4.86 | -7.30% | 1.3× |
  | psycopg | 0.65 → 0.63 | -2.80% | 1.88 → 1.36 | -27.60% | 2.9× |
  | pylox | 0.56 → 0.55 | -2.50% | 1.77 → 1.27 | -28.10% | 3.2× |
  | archinstall | 0.76 → 0.75 | -2.40% | 1.46 → 1.43 | -3.40% | 1.9× |
  | manticore | 0.67 → 0.66 | -2.20% | 1.73 → 1.21 | -27.50% | 2.6× |
  | pywin32 | 0.74 → 0.72 | -2.00% | 4.29 → 2.83 | -33.30% | 5.8× |
  | dd-trace-py | 1.63 → 1.57 | -2.00% | 2.25 → 1.99 | -4.80% | 1.4× |
  | narwhals | 1.05 → 1.04 | -2.00% | 2.67 → 2.57 | -4.30% | 2.5× |
  | scipy | 1.08 → 1.04 | -2.00% | 1.95 → 1.81 | -3.40% | 1.8× |


* Speedups are almost entirely wall-clock, not CPU(load/stat costs are IO, not compute).

* Projects with no `.venv` benefit most, as they have to discover their own interpreter, triggering redundant config loads. The "taxed" winners are projects with a large `site-packages` tree which can trigger more syscalls. 


# Test Plan

* All existing unit tests pass, one new test added.

* Was able to trigger the endpoint security cost via symlink indirection to the test corpus (eg: on macOS `/tmp` is a symlink to `/private/tmp`, so `/tmp/primer_repos/…` crosses one symlink and `/private/tmp/primer_repos/…` crosses none; identical files/inodes/bytes, but it's the difference between a syscall costing **~0.7 µs** or **~1.28 ms** (~1000x more expensive, ouch 🚫)

[^1]: Test machine: Apple Silicon M3 Max (16 cores).
