### PR TITLE
Fix select/with_columns losing schema for keyword/positional args

### DIFF
--- a/pyrefly/lib/alt/polars_specials.rs
+++ b/pyrefly/lib/alt/polars_specials.rs
@@ -2114,6 +2114,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         // same as with_columns, so a sibling's new column is not visible.
         for kw in &args.keywords {
             let name = kw.arg.as_ref()?.id.clone();
+            // A keyword value that itself resolves to multiple columns (e.g.
+            // `x=pl.col("a", "b")`) is a duplicate-column error in Polars, not a single
+            // named output — degrade the whole call, same as an opaque positional arg.
+            if !self.polars_expr_has_single_output(&kw.value) {
+                has_opaque = true;
+                continue;
+            }
             let resolved = match self.polars_column_arg(&kw.value) {
                 ColumnArg::Named(col) => resolve_column(schema, &col, kw.value.range(), errors),
                 ColumnArg::Opaque => None,
@@ -2327,10 +2334,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         match expr {
             Expr::Call(call) => {
                 if let Expr::Attribute(attr) = &*call.func {
-                    // A `when(...).then(...)` / `.otherwise(...)` chain always evaluates to
-                    // one value per row, regardless of the predicates or branch values.
+                    // A `when(...).then(...)` / `.otherwise(...)` chain evaluates to one value
+                    // per row, unless a branch value itself resolves to multiple columns (e.g.
+                    // `pl.col("a", "b")`), in which case the chain inherits that multiplicity.
                     if matches!(attr.attr.id.as_str(), "then" | "otherwise") {
-                        return true;
+                        return self.polars_when_chain_has_single_output(expr);
                     }
                     if PolarsExprMethod::parse(attr.attr.id.as_str()).is_some() {
                         return self.polars_expr_has_single_output(&attr.value);
@@ -2359,6 +2367,26 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             | Expr::BytesLiteral(_)
             | Expr::NoneLiteral(_) => true,
             _ => !self.is_polars_expr_value(expr),
+        }
+    }
+
+    /// Check that every branch value in a `when(...).then(...)[.when(...).then(...)]*
+    /// .otherwise(...)` chain is itself single-output. The chain's own `when`/`then`/
+    /// `otherwise` calls are a builder, not a data value, so only the branch *arguments*
+    /// need checking — an unrecognized receiver (e.g. the base `pl.when(...)` call) is
+    /// trivially fine since it isn't a data value either.
+    fn polars_when_chain_has_single_output(&self, expr: &Expr) -> bool {
+        let Expr::Call(call) = expr else { return true };
+        let Expr::Attribute(attr) = &*call.func else {
+            return true;
+        };
+        match attr.attr.id.as_str() {
+            "then" | "otherwise" => {
+                matches!(&call.arguments.args[..], [value] if self.polars_expr_has_single_output(value))
+                    && self.polars_when_chain_has_single_output(&attr.value)
+            }
+            "when" => self.polars_when_chain_has_single_output(&attr.value),
+            _ => true,
         }
     }
 
@@ -2437,6 +2465,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             | Expr::NoneLiteral(_) => {
                 literal_value(expr).map(|_| Name::new_static(POLARS_LITERAL_OUTPUT_NAME))
             }
+            // A bare list/tuple display passed alongside other positional arguments (not as
+            // the sole argument, which `positional_elements` already flattens into individual
+            // column specs) becomes an anonymous value column in Polars too, regardless of its
+            // element types — its dtype is left to fall back to Unknown since nested/list
+            // dtypes aren't modeled.
+            Expr::List(_) | Expr::Tuple(_) => Some(Name::new_static(POLARS_LITERAL_OUTPUT_NAME)),
             _ => None,
         }
     }
@@ -2461,11 +2495,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if schema.kind != DataFrameKind::Polars {
             return None;
         }
-        let positional = args
-            .args
-            .iter()
-            .flat_map(positional_elements)
-            .collect::<Vec<_>>();
+        // A bare list/tuple literal is only a shorthand for a sequence of expressions when
+        // it's the receiver's *sole* positional argument, matching Polars' actual behavior:
+        // `with_columns([e1, e2])` flattens, but `with_columns(e0, [e1])` does not — there,
+        // the list is one opaque value (e.g. a `List`-dtype column), not two column specs.
+        let positional: Vec<&Expr> = match &args.args[..] {
+            [arg] => positional_elements(arg).iter().collect(),
+            args => args.iter().collect(),
+        };
         // Validate names before inference so fallback does not duplicate diagnostics. A
         // positional arg with no well-defined output name is ambiguous in shape (it could
         // expand to any number of columns), so it degrades the whole call, the same as select.

--- a/pyrefly/lib/alt/polars_specials.rs
+++ b/pyrefly/lib/alt/polars_specials.rs
@@ -2039,7 +2039,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         args: &Arguments,
         errors: &ErrorCollector,
     ) -> Option<Type> {
-        let schema = column_transform_schema(base, args)?;
+        let Type::DataFrame(schema) = base else {
+            return None;
+        };
         if schema.kind != DataFrameKind::Polars {
             return None;
         }
@@ -2049,6 +2051,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .flat_map(positional_elements)
             .collect::<Vec<_>>();
         if let [arg] = &positional[..]
+            && args.keywords.is_empty()
             && let Type::Literal(lit) = &self.expr_infer(arg, &self.error_swallower())
             && let Lit::Str(value) = &lit.value
             && value.as_str() == POLARS_ALL_COLUMNS
@@ -2076,9 +2079,19 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             names.push(Some((name, is_column)));
         }
-        let mut columns = Vec::with_capacity(names.len());
+        // Keyword names are validated up front, alongside positional ones, so a name shared
+        // between a positional alias and a keyword is caught the same way as two positionals.
+        for kw in &args.keywords {
+            let Some(kw_name) = &kw.arg else {
+                return None;
+            };
+            if !output_names.insert(kw_name.id.clone()) {
+                has_repeated_name = true;
+            }
+        }
+        let mut columns = Vec::with_capacity(names.len() + args.keywords.len());
         let mut resolved_names = SmallSet::new();
-        for (output, arg) in names.iter().zip(positional) {
+        for (output, arg) in names.iter().zip(&positional) {
             let Some((name, is_column)) = output else {
                 continue;
             };
@@ -2097,11 +2110,30 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 columns.push((name.clone(), PolarsDType::Unknown));
             }
         }
+        // Polars evaluates every keyword expression against the receiver's original schema,
+        // same as with_columns, so a sibling's new column is not visible.
+        for kw in &args.keywords {
+            let name = kw.arg.as_ref()?.id.clone();
+            let resolved = match self.polars_column_arg(&kw.value) {
+                ColumnArg::Named(col) => resolve_column(schema, &col, kw.value.range(), errors),
+                ColumnArg::Opaque => None,
+                ColumnArg::Expr => self
+                    .eval_polars_expr(&kw.value, schema, errors)
+                    .map(ExprValue::dtype),
+            };
+            if resolved.is_some() && !resolved_names.insert(name.clone()) {
+                report_duplicate_column(&name, kw.value.range(), errors);
+            }
+            columns.push((name, resolved.unwrap_or(PolarsDType::Unknown)));
+        }
         if has_opaque {
             None
         } else {
             for arg in &args.args {
                 self.expr_infer(arg, errors);
+            }
+            for kw in &args.keywords {
+                self.expr_infer(&kw.value, errors);
             }
             if !has_repeated_name {
                 return Some(dataframe_type_with_columns(schema, columns));
@@ -2294,10 +2326,15 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     fn polars_expr_has_single_output(&self, expr: &Expr) -> bool {
         match expr {
             Expr::Call(call) => {
-                if let Expr::Attribute(attr) = &*call.func
-                    && PolarsExprMethod::parse(attr.attr.id.as_str()).is_some()
-                {
-                    return self.polars_expr_has_single_output(&attr.value);
+                if let Expr::Attribute(attr) = &*call.func {
+                    // A `when(...).then(...)` / `.otherwise(...)` chain always evaluates to
+                    // one value per row, regardless of the predicates or branch values.
+                    if matches!(attr.attr.id.as_str(), "then" | "otherwise") {
+                        return true;
+                    }
+                    if PolarsExprMethod::parse(attr.attr.id.as_str()).is_some() {
+                        return self.polars_expr_has_single_output(&attr.value);
+                    }
                 }
                 match self.polars_function(&call.func) {
                     Some(PolarsFunction::Len) => true,
@@ -2421,13 +2458,27 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let Type::DataFrame(schema) = base else {
             return None;
         };
-        if !args.args.is_empty() {
-            return None;
-        }
         if schema.kind != DataFrameKind::Polars {
             return None;
         }
-        // Validate names before inference so fallback does not duplicate diagnostics.
+        let positional = args
+            .args
+            .iter()
+            .flat_map(positional_elements)
+            .collect::<Vec<_>>();
+        // Validate names before inference so fallback does not duplicate diagnostics. A
+        // positional arg with no well-defined output name is ambiguous in shape (it could
+        // expand to any number of columns), so it degrades the whole call, the same as select.
+        let mut resolved_positional = Vec::with_capacity(positional.len());
+        for &arg in &positional {
+            let output = match self.polars_column_arg(arg) {
+                ColumnArg::Named(name) => Some((name, true)),
+                ColumnArg::Opaque => None,
+                ColumnArg::Expr => self.polars_expr_output_name(arg).map(|name| (name, false)),
+            };
+            output.as_ref()?;
+            resolved_positional.push(output);
+        }
         let mut named = Vec::with_capacity(args.keywords.len());
         for kw in &args.keywords {
             let Some(arg) = &kw.arg else {
@@ -2435,9 +2486,28 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             };
             named.push((arg.id.clone(), &kw.value));
         }
-        // Polars evaluates every keyword expression against the receiver's original schema in
-        // parallel, so a sibling's new column is not visible; resolve all values before applying.
+        for arg in &args.args {
+            self.expr_infer(arg, errors);
+        }
+        // Polars evaluates every positional and keyword expression against the receiver's
+        // original schema in parallel, so a sibling's new column is not visible in the same call.
         let mut columns = schema.columns.clone();
+        for (output, arg) in resolved_positional.iter().zip(&positional) {
+            let (name, is_column) = output
+                .as_ref()
+                .expect("opacity already checked before inference");
+            let dtype = if *is_column {
+                resolve_column(schema, name, arg.range(), errors)
+            } else {
+                self.eval_polars_expr(arg, schema, errors)
+                    .map(ExprValue::dtype)
+            }
+            .unwrap_or(PolarsDType::Unknown);
+            match columns.iter_mut().find(|(c, _)| c == name) {
+                Some((_, ty)) => *ty = dtype,
+                None => columns.push((name.clone(), dtype)),
+            }
+        }
         for (name, value) in named {
             self.expr_infer(value, errors);
             let dtype = match self.polars_column_arg(value) {

--- a/pyrefly/lib/test/polars/dataframe.rs
+++ b/pyrefly/lib/test/polars/dataframe.rs
@@ -171,6 +171,25 @@ def len() -> Expr: ...
 "#,
     );
     env.add_with_path(
+        "polars.expr.whenthen",
+        "polars/expr/whenthen.pyi",
+        r#"
+from polars.expr.expr import Expr
+class When:
+    def then(self, statement: object) -> "Then": ...
+class Then(Expr):
+    def otherwise(self, statement: object) -> Expr: ...
+"#,
+    );
+    env.add_with_path(
+        "polars.functions.whenthen",
+        "polars/functions/whenthen.pyi",
+        r#"
+from polars.expr.whenthen import When
+def when(*predicates: object, **constraints: object) -> When: ...
+"#,
+    );
+    env.add_with_path(
         "polars.schema",
         "polars/schema.pyi",
         r#"
@@ -187,6 +206,7 @@ from polars.functions.eager import concat as concat
 from polars.functions.col import col as col
 from polars.functions.lit import lit as lit
 from polars.functions.len import len as len
+from polars.functions.whenthen import when as when
 from polars.io.csv.functions import read_csv as read_csv, scan_csv as scan_csv
 from polars.expr.expr import Expr as Expr
 from polars.schema import Schema as Schema
@@ -2457,14 +2477,15 @@ reveal_type(df.drop("*"))  # E: revealed type: DataFrame
 "#,
 );
 
+// See https://github.com/facebook/pyrefly/issues/4565.
 testcase!(
-    test_select_method_keyword_falls_back,
+    test_select_method_keyword_tracks_schema,
     env_with_polars_stubs(),
     r#"
 import polars as pl
 from typing import reveal_type
 df = pl.DataFrame({"a": [1]})
-reveal_type(df.select(b="x"))  # E: revealed type: DataFrame
+reveal_type(df.select(b=pl.col("a")))  # E: revealed type: DataFrame[b: Int64]
 "#,
 );
 
@@ -3339,6 +3360,79 @@ import polars as pl
 from typing import reveal_type
 df = pl.DataFrame({"a": [1]})
 reveal_type(df.with_columns(pl.Series()))  # E: revealed type: DataFrame
+"#,
+);
+
+// See https://github.com/facebook/pyrefly/issues/4565.
+testcase!(
+    test_with_columns_positional_alias_tracks_schema,
+    env_with_polars_stubs(),
+    r#"
+import polars as pl
+from typing import reveal_type
+df = pl.DataFrame({"a": [1]})
+reveal_type(df.with_columns(pl.col("a").alias("c")))  # E: revealed type: DataFrame[a: Int64, c: Int64]
+"#,
+);
+
+// The exact reproduction from https://github.com/facebook/pyrefly/issues/4565: a positional
+// conditional expression. Depends on both the positional/keyword fix above and the
+// when/then/otherwise recognition in `polars_expr_has_single_output`.
+testcase!(
+    test_with_columns_positional_when_then_otherwise_tracks_schema,
+    env_with_polars_stubs(),
+    r#"
+import polars as pl
+from typing import reveal_type
+df = pl.DataFrame({"units": [12]})
+reveal_type(df.with_columns(pl.when(pl.col("units") > 10).then(pl.lit("high")).otherwise(pl.lit("low")).alias("bucket")))  # E: revealed type: DataFrame[units: Int64, bucket: Unknown]
+"#,
+);
+
+testcase!(
+    test_select_mixed_positional_and_keyword_tracks_schema,
+    env_with_polars_stubs(),
+    r#"
+import polars as pl
+from typing import reveal_type
+df = pl.DataFrame({"a": [1], "b": ["x"]})
+reveal_type(df.select(pl.col("a").alias("z"), w=pl.col("b")))  # E: revealed type: DataFrame[z: Int64, w: String]
+"#,
+);
+
+testcase!(
+    test_with_columns_mixed_positional_and_keyword_tracks_schema,
+    env_with_polars_stubs(),
+    r#"
+import polars as pl
+from typing import reveal_type
+df = pl.DataFrame({"a": [1], "b": ["x"]})
+reveal_type(df.with_columns(pl.col("a").alias("z"), w=pl.col("b")))  # E: revealed type: DataFrame[a: Int64, b: String, z: Int64, w: String]
+"#,
+);
+
+// A positional arg's new column is not visible to a sibling keyword in the same call — every
+// argument resolves against the pre-call schema, matching Polars' parallel-evaluation semantics
+// already established for keyword-only calls.
+testcase!(
+    test_with_columns_positional_new_column_not_visible_to_sibling_keyword,
+    env_with_polars_stubs(),
+    r#"
+import polars as pl
+from typing import reveal_type
+df = pl.DataFrame({"a": [1]})
+reveal_type(df.with_columns(pl.col("a").alias("b"), c=pl.col("b")))  # E: revealed type: DataFrame[a: Int64, b: Int64, c: Unknown] # E: Column `b` is not in the DataFrame schema
+"#,
+);
+
+testcase!(
+    test_with_columns_keyword_when_then_otherwise,
+    env_with_polars_stubs(),
+    r#"
+import polars as pl
+from typing import reveal_type
+df = pl.DataFrame({"units": [12]})
+reveal_type(df.with_columns(bucket=pl.when(pl.col("units") > 10).then(pl.lit("high")).otherwise(pl.lit("low"))))  # E: revealed type: DataFrame[units: Int64, bucket: Unknown]
 "#,
 );
 

--- a/pyrefly/lib/test/polars/dataframe.rs
+++ b/pyrefly/lib/test/polars/dataframe.rs
@@ -3436,6 +3436,48 @@ reveal_type(df.with_columns(bucket=pl.when(pl.col("units") > 10).then(pl.lit("hi
 "#,
 );
 
+// Review feedback on #4571: `pl.col("a", "b")` selects two columns at once, so aliasing
+// the whole when/then/otherwise chain to one name is a duplicate-column error in Polars —
+// pyrefly should fall back to plain DataFrame rather than confidently track one column.
+testcase!(
+    test_select_when_then_multi_output_falls_back,
+    env_with_polars_stubs(),
+    r#"
+import polars as pl
+from typing import reveal_type
+df = pl.DataFrame({"a": [1], "b": [2]})
+reveal_type(df.select(pl.when(pl.col("a") > 0).then(pl.col("a", "b")).otherwise(0).alias("x")))  # E: revealed type: DataFrame
+"#,
+);
+
+// Review feedback on #4571: same issue via a keyword instead of an alias.
+testcase!(
+    test_select_keyword_multi_output_falls_back,
+    env_with_polars_stubs(),
+    r#"
+import polars as pl
+from typing import reveal_type
+df = pl.DataFrame({"a": [1], "b": [2]})
+reveal_type(df.select(x=pl.col("a", "b")))  # E: revealed type: DataFrame
+"#,
+);
+
+// Review feedback on #4571: a bare list literal is only Polars' "sequence of exprs"
+// shorthand when it's the sole positional argument. Alongside another positional arg it's
+// one opaque value (a List-dtype column in real Polars); since nested dtypes aren't
+// modeled, it should track as Unknown rather than incorrectly flattening and inferring the
+// dtype of its first element.
+testcase!(
+    test_with_columns_multi_positional_list_literal_is_unknown,
+    env_with_polars_stubs(),
+    r#"
+import polars as pl
+from typing import reveal_type
+df = pl.DataFrame({"a": [1]})
+reveal_type(df.with_columns(pl.col("a").alias("x"), [1]))  # E: revealed type: DataFrame[a: Int64, x: Int64, literal: Unknown]
+"#,
+);
+
 testcase!(
     test_with_columns_spread_falls_back,
     env_with_polars_stubs(),


### PR DESCRIPTION
# Summary

`select` and `with_columns` supported opposite expression forms. `select`
preserved the schema for positional expressions but not keyword ones,
while `with_columns` did the reverse — each function's schema-tracking
logic only ever processed one argument category (`args.args` or
`args.keywords`) and fell back to bare `DataFrame` on the other, even
though real Polars accepts a mix of `*exprs` and `**named_exprs` in both.

This also affected conditional positional expressions
(`pl.when(...).then(...).otherwise(...)`), for a second, independent
reason: `polars_expr_has_single_output` had no case for `when`/`then`/
`otherwise` chains, so `.alias(...)` on top of one never resolved a name,
regardless of argument position.

Fixes #4565. Fixes both problems:
- `polars_select` now also resolves `args.keywords`, using the same
  per-argument dtype resolution `polars_with_columns` already used for
  keywords. Its existing duplicate-name detection is extended to catch a
  keyword colliding with a positional alias, since Polars raises on that
  too.
- `polars_with_columns` now also resolves `args.args`, using the same
  per-argument name resolution `polars_select` already used for
  positional expressions (including its opacity/fallback handling for
  expressions with no well-defined output name, like a bare `pl.Series()`).
- `polars_expr_has_single_output` recognizes `.then(...)`/`.otherwise(...)`
  as always single-output, since a conditional expression evaluates to
  exactly one value per row regardless of the predicates or branches
  involved.

Not in scope: `with_columns` doesn't get the same positional/keyword
collision detection `select` now has — real Polars raises on that too,
but there was no existing mechanism there to extend, and the fallback
(later argument silently wins) isn't dangerous, just less precise than
`select`. Also, `when`/`then`/`otherwise` branch values resolve to
`Unknown` dtype rather than a fully inferred type — consistent with how
other unevaluable expressions already degrade elsewhere in this file, and
not something the issue asserted an expected dtype for.