### PR TITLE
Fix deprecation warnings for re-exported symbols

### DIFF
--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -2909,18 +2909,39 @@ impl<'a> LookupExport for TransactionHandle<'a> {
         )
     }
 
-    fn get_deprecated(&self, module: ModuleName, name: &Name) -> Option<Deprecation> {
-        self.with_exports(
-            module,
-            |exports, lookup| match exports.exports(lookup).get(name)? {
-                ExportLocation::ThisModule(Export {
-                    deprecation: Some(d),
-                    ..
-                }) => Some(d.clone()),
-                _ => None,
-            },
-            ModuleDep::GetDeprecated(name.clone()),
-        )?
+    fn get_deprecated(&self, mut module: ModuleName, name: &Name) -> Option<Deprecation> {
+        let mut seen = HashSet::new();
+        let mut name = name.clone();
+
+        loop {
+            if !seen.insert((module, name.clone())) {
+                return None;
+            }
+
+            let next = self.with_exports(
+                module,
+                |exports, lookup| match exports.exports(lookup).get(&name)? {
+                    ExportLocation::ThisModule(Export { deprecation, .. }) => {
+                        Some(Err(deprecation.clone()))
+                    }
+                    ExportLocation::OtherModule(other_module, original_name) => {
+                        Some(Ok((*other_module, original_name.clone())))
+                    }
+                },
+                ModuleDep::GetDeprecated(name.clone()),
+            )?;
+
+            match next {
+                None => return None,
+                Some(Err(deprecation)) => return deprecation,
+                Some(Ok((other_module, original_name))) => {
+                    if let Some(original_name) = original_name {
+                        name = original_name;
+                    }
+                    module = other_module;
+                }
+            }
+        }
     }
 
     fn reexport_source(&self, module: ModuleName, name: &Name) -> Option<ModuleName> {

--- a/pyrefly/lib/test/imports.rs
+++ b/pyrefly/lib/test/imports.rs
@@ -1019,6 +1019,85 @@ x()  # E: `foo.x` is deprecated
 "#,
 );
 
+fn env_reexport_deprecated() -> TestEnv {
+    let mut t = TestEnv::new();
+    t.add_with_path(
+        "mypkg._private",
+        "mypkg/_private.py",
+        r#"
+from warnings import deprecated
+
+@deprecated("Don't use this class")
+class MyClass: ...
+
+@deprecated("Don't use this function")
+def my_func(): ...
+
+class NonDeprecatedClass: ...
+"#,
+    );
+    t.add_with_path(
+        "mypkg",
+        "mypkg/__init__.py",
+        r#"
+from mypkg._private import MyClass, my_func, NonDeprecatedClass # E: `MyClass` is deprecated # E: `my_func` is deprecated
+"#,
+    );
+    t
+}
+
+testcase!(
+    test_import_deprecated_reexport_warn,
+    env_reexport_deprecated(),
+    r#"
+from mypkg import MyClass # E: `MyClass` is deprecated
+from mypkg import my_func # E: `my_func` is deprecated
+from mypkg import NonDeprecatedClass
+
+_ = MyClass()
+my_func()  # E: `mypkg._private.my_func` is deprecated
+"#,
+);
+
+fn env_chained_reexport_deprecated() -> TestEnv {
+    let mut t = TestEnv::new();
+    t.add_with_path(
+        "pkg.origin",
+        "pkg/origin.py",
+        r#"
+from warnings import deprecated
+
+@deprecated("Deprecation message")
+class DepClass: ...
+"#,
+    );
+    t.add_with_path(
+        "pkg.middle",
+        "pkg/middle.py",
+        r#"
+from pkg.origin import DepClass as MiddleClass # E: `DepClass` is deprecated
+"#,
+    );
+    t.add_with_path(
+        "pkg.outer",
+        "pkg/outer.py",
+        r#"
+from pkg.middle import MiddleClass # E: `MiddleClass` is deprecated
+"#,
+    );
+    t
+}
+
+testcase!(
+    test_import_deprecated_chained_reexport_warn,
+    env_chained_reexport_deprecated(),
+    r#"
+from pkg.outer import MiddleClass # E: `MiddleClass` is deprecated
+
+_ = MiddleClass()
+"#,
+);
+
 fn env_func_x_deprecated_conditionally() -> TestEnv {
     TestEnv::one(
         "foo",

--- a/test/errors.md
+++ b/test/errors.md
@@ -24,6 +24,7 @@ $ touch $TMPDIR/pyrefly.toml && \
 > echo "import shown1; y: int = shown1.x" > $TMPDIR/shown2.py && \
 > $PYREFLY check --python-version 3.13.0 $TMPDIR/shown2.py --check-all --output-format=min-text --min-severity=warn
  WARN importlib/abc.pyi:147:9-41: `ResourceReader` is deprecated [deprecated]
+ WARN importlib/machinery.pyi:14:5-51: `WindowsRegistryFinder` is deprecated [deprecated]
  WARN importlib/resources/__init__.pyi:49:9-29: `contents` is deprecated [deprecated]
  WARN importlib/resources/__init__.pyi:79:41-73: `ResourceReader` is deprecated [deprecated]
  WARN importlib/resources/_common.pyi:8:41-55: `ResourceReader` is deprecated [deprecated]


### PR DESCRIPTION
## Summary

Fix missing deprecation diagnostics when a deprecated class or function is imported through a module re-export.

## Motivation

Issue #4517 reports that a direct import from the defining module warns, while importing the same symbol from a package that re-exports it does not.

## Changes

- Preserve deprecated metadata across the relevant re-export lookup path in `LookupExport::get_deprecated`.
- Add regression coverage for the downstream re-export import, including multi-hop chained re-exports.
- Preserve existing direct-import and wildcard-import behavior.

## Validation

- `cargo fmt --all`
- `cargo test test_import_deprecated -- --nocapture`
- `cargo test test_import_deprecated_reexport_warn -- --nocapture`
- `cargo test -p pyrefly` (7912 passed, 0 failed)
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`

## AI disclosure

This pull request was prepared with assistance from an AI coding agent. The implementation, tests, diff, and validation results were reviewed before submission.

Fixes #4517
