### PR TITLE
Fix hover range for not expressions

### DIFF
--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -44,6 +44,7 @@ use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::Identifier;
 use ruff_python_ast::ModModule;
 use ruff_python_ast::Stmt;
+use ruff_python_ast::UnaryOp;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
@@ -935,7 +936,7 @@ pub fn get_hover_with_verbosity(
     let type_ = resolve_hovered_type(transaction, handle, ast.as_deref(), position)?;
 
     // `a and b and c` is a single flat BoolOp, so hovering any operator in the
-    // chain highlights the whole expression.
+    // chain highlights the whole expression. `not` highlights its unary expression.
     let range = ast
         .as_deref()
         .zip(module_info.as_ref())
@@ -946,6 +947,9 @@ pub fn get_hover_with_verbosity(
                 .and_then(|node| match node {
                     AnyNodeRef::ExprBoolOp(bool_op) => {
                         Some(module_info.to_lsp_range(bool_op.range()))
+                    }
+                    AnyNodeRef::ExprUnaryOp(unary_op) if unary_op.op == UnaryOp::Not => {
+                        Some(module_info.to_lsp_range(unary_op.range()))
                     }
                     _ => None,
                 })

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -1938,6 +1938,32 @@ y = 1 or 2
 }
 
 #[test]
+fn hover_over_not_operator_highlights_unary_expression() {
+    let code = r#"
+x = not value
+#   ^
+"#;
+    let mut test_env = TestEnv::new();
+    test_env.add("main", code);
+    let (state, handle) = test_env
+        .with_default_require_level(Require::Exports)
+        .to_state();
+    let handle = handle("main");
+    let position = extract_cursors_for_test(code)[0];
+    let range = match get_hover(&state.transaction(), &handle, position, false) {
+        Some(hover) => hover.range,
+        None => panic!("Expected hover result for not operator"),
+    };
+    assert_eq!(
+        range,
+        Some(Range {
+            start: Position::new(1, 4),
+            end: Position::new(1, 13),
+        })
+    );
+}
+
+#[test]
 fn hover_over_bool_operator_chain_highlights_whole_chain() {
     // `a and b and c` is a single flat BoolOp, so hovering any operator in the
     // chain highlights the entire boolean expression, not just the adjacent


### PR DESCRIPTION
## Summary

- Return the full unary expression range when hovering over `not`
- Add language-server regression coverage for the highlighted range

## Test plan

- `CARGO_BUILD_JOBS=1 cargo +1.95.0 test -p pyrefly test::lsp::hover`
- `RUSTUP_TOOLCHAIN=1.95.0 CARGO_BUILD_JOBS=1 python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`

Fixes #4523

## AI usage

I used Codex to inspect the existing hover implementation, add the regression test, and validate the change. I reviewed the diff and test results.