### PR TITLE
Run conformance tests in GitHub CI (#4579)

### DIFF
--- a/.github/workflows/pyrefly.yml
+++ b/.github/workflows/pyrefly.yml
@@ -46,6 +46,11 @@ jobs:
     - run: cargo clippy --release
     - run: cargo build --release
     - run: cargo test --release
+    - name: Check conformance output is up to date
+      # The generated output is platform-independent, so one OS is enough. It must not
+      # be Windows: the check keys results by splitting paths on "/".
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: python conformance/conformance_output.py conformance/third_party --mode check --executable target/release/pyrefly
     - name: Run torch stub tests
       run: python tensor-shapes/pyrefly-torch-stubs/run_pyrefly.py --release
     - name: Run Scrut tests

--- a/conformance/conformance_output.py
+++ b/conformance/conformance_output.py
@@ -370,9 +370,10 @@ def main() -> None:
             difference = [d for d in difference if d[0] in prefixes]
             messages.append("\n".join(difference) + "\n")
         if len(messages) > 0:
+            executable = f" --executable {args.executable}" if args.executable else ""
+            regenerate = f"python3 conformance/conformance_output.py {args.directory} --mode update{executable}"
             logger.error(
-                "Conformance output is not up to date. Please cd to fbcode/pyrefly/conformance/\n"
-                + "and re-generate the output with `buck2 run :conformance_output_script -- ./third_party`.\n"
+                f"Conformance output is not up to date. Please re-generate it with `{regenerate}`.\n"
                 + "\n".join(messages)
             )
             sys.exit(1)


### PR DESCRIPTION
Summary:

The typing conformance suite only runs inside Meta, via the `conformance_output_test` Buck target. On GitHub nothing invokes it, so a PR that changes pyrefly's conformance output goes green while leaving the checked-in `conformance.exp` stale. The mismatch only surfaces later, when the change is imported internally and fails there.

Add a step to the `pyrefly` workflow that runs `conformance_output.py --mode check` against the release binary that job already built, matching what internal CI checks. The step is restricted to Linux: the generated output does not vary by platform, so one OS suffices, and the check cannot run on Windows because it keys results by splitting paths on `/`.

The check-mode failure message told the reader to re-generate the output with `buck2`, which a GitHub contributor has no way to run. It now branches on whether `--executable` was passed, since that flag is precisely the signal that the caller is outside Buck, and prints the corresponding cargo-based command.

Reviewed By: ndmitchell, rchen152

Differential Revision: D116394357


