### PR TITLE
Fix venv test fixture that broke Windows CI (#4582)

### DIFF
--- a/crates/pyrefly_config/src/environment/interpreters.rs
+++ b/crates/pyrefly_config/src/environment/interpreters.rs
@@ -343,13 +343,13 @@ mod test {
 
     use super::*;
 
-    fn test_venv_interpreter_name() -> &'static str {
-        if cfg!(windows) {
-            "python.exe"
-        } else {
-            "python3"
-        }
-    }
+    /// The interpreter location a real virtual environment provides on this platform.
+    const INTERPRETER_DIR: &str = if cfg!(windows) { "Scripts" } else { "bin" };
+    const INTERPRETER_NAME: &str = if cfg!(windows) {
+        "python.exe"
+    } else {
+        "python"
+    };
 
     fn setup_test_dir() -> TempDir {
         let tempdir = tempdir().unwrap();
@@ -359,7 +359,7 @@ mod test {
             vec![TestPath::dir(
                 "venv",
                 vec![
-                    TestPath::file(test_venv_interpreter_name()),
+                    TestPath::dir(INTERPRETER_DIR, vec![TestPath::file(INTERPRETER_NAME)]),
                     TestPath::file("pyvenv.cfg"),
                 ],
             )],
@@ -506,7 +506,8 @@ mod test {
                 tempdir
                     .path()
                     .join("venv")
-                    .join(test_venv_interpreter_name())
+                    .join(INTERPRETER_DIR)
+                    .join(INTERPRETER_NAME)
             )
         );
     }


### PR DESCRIPTION
Summary:

`test_find_interpreter_precedence_venv` fails on Windows. The fixture builds
its virtual environment out of a `python3.exe` sitting directly in the
environment root, but no virtual environment on Windows looks like that: the
interpreter is always `Scripts\python.exe`. Venv discovery therefore found
nothing and fell through to the interpreter on `$PATH`, which is what the
assertion reported.

Build the fixture the way the platform actually lays out a virtual
environment, so the test exercises a shape that discovery is meant to find.
Joining each path component separately also keeps the directory separator
native, instead of embedding a `/` inside a single component and reporting
`...\venv/python3.exe` on failure.

Reviewed By: connernilsen

Differential Revision: D116509185


