### PR TITLE
Fix wide Literal hints being discarded in generic call solving

### DIFF
--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -1724,8 +1724,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             // Optimization: no-hint and single-hint cases can return immediately.
             None => return inner(None, errors),
             Some(hint) if hint.types().len() == 1 => return inner(hint.types().first(), errors),
-            // Optimization: discard overly wide hints.
-            Some(hint) if hint.types().len() > MAX_CALL_HINT_WIDTH => return inner(None, errors),
+            // Optimization: discard overly wide hints. Scalar members (literals, `None`) are
+            // cheap to try individually and don't decompose further, so they don't count
+            // against the cap — mirrors `infer_with_decomposed_hint`'s `decomposable_width`.
+            Some(hint)
+                if hint.types().iter().filter(|t| !t.is_scalar()).count() > MAX_CALL_HINT_WIDTH =>
+            {
+                return inner(None, errors);
+            }
             Some(hint) => hint,
         };
         let mut hints = hint.types().map(Some);

--- a/pyrefly/lib/test/contextual.rs
+++ b/pyrefly/lib/test/contextual.rs
@@ -858,6 +858,36 @@ f(x=["a", "bad"])  # E: `list[str]` is not assignable to parameter `x`
     "#,
 );
 
+// Regression: a generic call's return TypeVar solved against a wide Literal hint (more
+// than MAX_CALL_HINT_WIDTH members) used to discard the hint entirely, falling back to
+// the argument's own widened type (e.g. `str` instead of the Literal) and reporting a
+// false bad-assignment/bad-argument-type/bad-return in every context that offers a hint.
+// Literal members are scalar and cheap to try individually, so — like
+// `test_list_hint_with_wide_literal_alias_union` above — they should not count against
+// the cap.
+testcase!(
+    test_call_hint_with_wide_literal_union,
+    r#"
+from typing import Literal, TypeVar
+
+T = TypeVar("T")
+
+def identity(x: T) -> T:
+    return x
+
+L5 = Literal["a", "b", "c", "d", "e"]
+v: L5 = identity("a")
+
+def takes_l5(x: L5) -> None: ...
+takes_l5(identity("a"))
+
+def returns_l5() -> L5:
+    return identity("a")
+
+bad: L5 = identity("z")  # E: `str` is not assignable to `Literal['a', 'b', 'c', 'd', 'e']`
+    "#,
+);
+
 // Regression: when a TypeVar's only constraints are upper bounds, multiple
 // such bounds where one is a subtype of the other must collapse to the
 // *narrowest* one. Previously `get_new_bound`'s absorb logic kept the wider

--- a/pyrefly/lib/test/pydantic/field.rs
+++ b/pyrefly/lib/test/pydantic/field.rs
@@ -23,6 +23,28 @@ class Model(BaseModel):
 "#,
 );
 
+// See https://github.com/facebook/pyrefly/issues/4569. Not pydantic-specific — `Field`
+// just happens to be a TypeVar-returning generic function, the shape that triggers the
+// underlying bug (see test_call_hint_with_wide_literal_union in test::contextual for the
+// general-purpose reproduction and fix).
+pydantic_testcase!(
+    test_field_default_with_wide_literal_type,
+    r#"
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+T4 = Literal["a", "b", "c", "d"]
+T5 = Literal["a", "b", "c", "d", "e"]
+
+class Works(BaseModel):
+    value: T4 = Field("a")
+
+class AlsoWorks(BaseModel):
+    value: T5 = Field("a")
+"#,
+);
+
 pydantic_testcase!(
     test_field_right_type,
     r#"


### PR DESCRIPTION
# Summary

A generic call's return `TypeVar` solved against a `Literal` hint with
more than `MAX_CALL_HINT_WIDTH` (4) members discarded the hint entirely,
falling back to the argument's own widened type instead of using the
declared type as guidance. For a bare string/int literal argument, that
widened type (`str`/`int`) is never assignable back to the declared
`Literal`, producing a false `bad-assignment`/`bad-argument-type`/
`bad-return` in every bidirectional-inference context that offers a
hint: variable assignment, argument passing, and return-type checking.

Reported via a Pydantic `Field()` default (`value: Literal[...5 items] =
Field("a")`), but the bug isn't Pydantic-specific — confirmed by
reproducing it with a plain generic function, no Pydantic involved.
`Field()` just happens to be a `TypeVar`-returning generic function, the
exact shape that triggers this.

`Literal` members are scalar (`Type::is_scalar()`) and cheap to try
individually — no per-member solving needed the way a union of
structurally distinct types would require. They shouldn't count against
the width cap that exists to guard against *that* cost. Fixes it by
filtering scalar members out of the count before comparing against
`MAX_CALL_HINT_WIDTH`, in `callable_infer_with_hint.`
(`pyrefly/lib/alt/callable.rs`).

This mirrors an identical, already-shipped fix for the same class of bug
in a sibling mechanism, `MAX_DECOMPOSE_HINT_WIDTH` (see
`test_list_hint_with_wide_literal_alias_union` in `contextual.rs`) —
same reasoning, same `is_scalar()` helper, just applied to the call-hint
path instead of the container-decomposition path.

Not in scope, noted here rather than silently left unfixed:
- `construct_with_hint` (`pyrefly/lib/alt/call.rs`), the analogous width
  check for class/`TypedDict` *constructor* calls, has the same shape of
  limitation. Not touched here since this issue's reproduction goes
  through `callable_infer_with_hint`, not the constructor path. A wide
  Literal hint reaching a constructor call specifically would need a
  separate fix.
- Didn't test a mixed hint (some scalar, some non-scalar members in the
  same union) directly — reasoned through it, but the non-scalar count
  alone still gates the cap as intended, unverified by an actual test
  case.

Fixes #4569

# Test Plan

Reproduced the exact issue first, then bisected the boundary before
touching any code:
- Boundary is a clean cutoff at 4 vs 5 members, consistent across
  `str` and `int` literals, mixed-kind literals, inline vs. aliased
  `Literal[...]`, and all three bidirectional contexts (assignment,
  argument, return type).
- Confirmed via a plain generic function (no Pydantic) that the bug is
  general, not Pydantic-specific.
- Traced the exact discard site (`callable.rs:1728`) and the constant's
  origin (`unwrap.rs:25`) before designing the fix, rather than guessing.

After the fix, rebuilt and re-ran every case above: all now resolve
correctly. Also verified a genuinely wrong value
(`identity("z")` against a `Literal` that doesn't contain `"z"`) still
correctly errors — the fix restores real checking; it doesn't suppress
it.

New tests:
- `test_call_hint_with_wide_literal_union` in `contextual.rs` — general
  reproduction covering all three contexts plus the negative case.
- `test_field_default_with_wide_literal_type` in `pydantic/field.rs` —
  matches the issue's exact reproduction.

Full suite: `cargo test -p pyrefly --lib` — 7884 passed, 0 failed, 3
ignored, both before and after the fix. Format + lint
(`test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`,
required before committing per this repo's `AGENTS.md`): clean, zero new
warnings (the one pre-existing warning present is in an untouched file).

# AI usage disclosure

Disclosure per the AI Usage section of CONTRIBUTING.md: this fix was developed with assistance from an AI agent working in my checkout. I directed the investigation and the key decisions along the way — confirming the root cause, choosing the fix approach over the alternative, and deciding what stayed in scope — and reviewed the resulting code before submitting.