### PR TITLE
fix Stack overflow with recursive TypedDict definition #4597

### DIFF
--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -2170,6 +2170,22 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
                     )),
                 )
             }
+            (Type::TypedDict(TypedDict::TypedDict(_)), Type::ClassType(want))
+                if !self.type_order.is_protocol(want.class_object())
+                    && !self.type_order.has_superclass(
+                        self.type_order.stdlib().mapping_object(),
+                        want.class_object(),
+                    )
+                    && !self.type_order.has_superclass(
+                        self.type_order.stdlib().dict_object(),
+                        want.class_object(),
+                    ) =>
+            {
+                // A declared TypedDict's nominal carrier is either Mapping or dict. Reject
+                // classes unrelated to both before calculating its value type, which may
+                // require solving recursive fields of the TypedDict currently being defined.
+                Err(SubsetError::Other)
+            }
             (Type::TypedDict(td @ TypedDict::TypedDict(_)), _) => {
                 let stdlib = self.type_order.stdlib();
                 if let Some(value_type) = self

--- a/pyrefly/lib/test/typed_dict.rs
+++ b/pyrefly/lib/test/typed_dict.rs
@@ -1552,6 +1552,19 @@ class BadChild2(Parent):
 );
 
 testcase!(
+    test_recursive_field_with_extra_items,
+    r#"
+from typing import NotRequired, TypedDict
+
+class C(TypedDict, extra_items=bool):
+    pass
+
+class D(C):
+    a: NotRequired[D]  # E: `D` is not consistent with `extra_items` type `bool` of TypedDict `C`  # E: `D` is uninitialized
+"#,
+);
+
+testcase!(
     test_extra_items_assignability,
     r#"
 from typing import ReadOnly, TypedDict


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4597

Added an early nominal subtype check preventing recursive TypedDict field expansion for unrelated classes

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test