### PR TITLE
fix djangorestframework-stubs: ModelSerializer.Meta class pattern causes false positive bad-override errors #4595

### DIFF
--- a/crates/pyrefly_python/src/module_name.rs
+++ b/crates/pyrefly_python/src/module_name.rs
@@ -309,6 +309,10 @@ impl ModuleName {
         Self::from_str("marshmallow.schema")
     }
 
+    pub fn rest_framework_serializers() -> Self {
+        Self::from_str("rest_framework.serializers")
+    }
+
     pub fn pydantic_types() -> Self {
         Self::from_str("pydantic.types")
     }

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -3831,13 +3831,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             return false;
         }
 
-        // Django models, marshmallow schemas, and factory-boy factories: skip override
-        // check for `Meta` class. These frameworks use a nested `Meta` class for
-        // configuration, and child classes define their own `Meta` without inheriting
-        // from the parent's `Meta`.
+        // These frameworks use a nested `Meta` class for configuration, and child classes
+        // define their own `Meta` without inheriting from the parent's `Meta`.
         if (class_metadata.is_django_model()
             || class_metadata.is_marshmallow_schema()
-            || class_metadata.is_factory_boy_factory())
+            || class_metadata.is_factory_boy_factory()
+            || class_metadata.is_django_rest_framework_model_serializer())
             && field_name.as_str() == "Meta"
         {
             return false;

--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -326,6 +326,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         || metadata.is_factory_boy_factory()
                 });
 
+        let is_django_rest_framework_model_serializer =
+            bases_with_metadata
+                .iter()
+                .any(|(base_class_object, metadata)| {
+                    base_class_object.has_toplevel_qname(
+                        ModuleName::rest_framework_serializers().as_str(),
+                        "ModelSerializer",
+                    ) || metadata.is_django_rest_framework_model_serializer()
+                });
+
         let is_metaclass = bases_with_metadata
             .iter()
             .any(|(base_class_object, metadata)| {
@@ -566,6 +576,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             django_model_metadata,
             is_marshmallow_schema,
             is_factory_boy_factory,
+            is_django_rest_framework_model_serializer,
             is_metaclass,
             explicit_slots,
             capture_init.map(|names| names.to_vec()),

--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -113,6 +113,7 @@ pub struct ClassMetadata {
     django_model_metadata: Option<DjangoModelMetadata>,
     is_marshmallow_schema: bool,
     is_factory_boy_factory: bool,
+    is_django_rest_framework_model_serializer: bool,
     /// Whether this class is a metaclass (i.e., a subclass of `type`).
     is_metaclass: bool,
     explicit_slots: ExplicitSlots,
@@ -209,6 +210,7 @@ impl ClassMetadata {
         django_model_metadata: Option<DjangoModelMetadata>,
         is_marshmallow_schema: bool,
         is_factory_boy_factory: bool,
+        is_django_rest_framework_model_serializer: bool,
         is_metaclass: bool,
         explicit_slots: ExplicitSlots,
         capture_init: Option<Vec<Name>>,
@@ -238,6 +240,7 @@ impl ClassMetadata {
             django_model_metadata,
             is_marshmallow_schema,
             is_factory_boy_factory,
+            is_django_rest_framework_model_serializer,
             is_metaclass,
             explicit_slots,
             capture_init,
@@ -270,6 +273,7 @@ impl ClassMetadata {
             django_model_metadata: None,
             is_marshmallow_schema: false,
             is_factory_boy_factory: false,
+            is_django_rest_framework_model_serializer: false,
             is_metaclass: false,
             explicit_slots: ExplicitSlots::Absent,
             capture_init: None,
@@ -312,6 +316,10 @@ impl ClassMetadata {
 
     pub fn is_factory_boy_factory(&self) -> bool {
         self.is_factory_boy_factory
+    }
+
+    pub fn is_django_rest_framework_model_serializer(&self) -> bool {
+        self.is_django_rest_framework_model_serializer
     }
 
     /// Whether this class is a metaclass (i.e., a subclass of `type`).

--- a/pyrefly/lib/test/django.rs
+++ b/pyrefly/lib/test/django.rs
@@ -14,6 +14,7 @@ mod fields;
 mod foreign_key;
 mod many_to_many;
 mod model;
+mod model_serializer;
 mod reverse_relations;
 mod util;
 mod view;

--- a/pyrefly/lib/test/django/model_serializer.rs
+++ b/pyrefly/lib/test/django/model_serializer.rs
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::django_testcase;
+
+django_testcase!(
+    test_meta_override_without_inheritance,
+    r#"
+from django.db import models
+from rest_framework import serializers
+
+class MyModel(models.Model):
+    name = models.CharField(max_length=100)
+
+class MySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = MyModel
+        fields = ["name"]
+
+class GenericSerializer(serializers.ModelSerializer[MyModel]):
+    class Meta:
+        model = MyModel
+        fields = ["name"]
+"#,
+);

--- a/pyrefly/lib/test/django/third-party/rest_framework-stubs/__init__.pyi
+++ b/pyrefly/lib/test/django/third-party/rest_framework-stubs/__init__.pyi
@@ -1,0 +1,1 @@
+from rest_framework import serializers as serializers

--- a/pyrefly/lib/test/django/third-party/rest_framework-stubs/serializers.pyi
+++ b/pyrefly/lib/test/django/third-party/rest_framework-stubs/serializers.pyi
@@ -1,0 +1,13 @@
+from collections.abc import Sequence
+from typing import ClassVar, Generic, Literal, TypeVar
+
+from django.db.models import Model
+
+_MT = TypeVar("_MT", bound=Model)
+
+class Serializer(Generic[_MT]): ...
+
+class ModelSerializer(Serializer[_MT]):
+    class Meta:
+        model: ClassVar[type[_MT]]
+        fields: ClassVar[Sequence[str] | Literal["__all__"]]


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4595

Detects descendants of rest_framework.serializers.ModelSerializer and suppresses bad-override only for their nested Meta class.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test