### PR TITLE
Relative binary fix

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -144,7 +144,7 @@
                 "pyrefly.lspPath": {
                     "type": "string",
                     "default": "",
-                    "description": "The path to the binary used for the lsp",
+                    "description": "The path to the binary (or the binary available in your $PATH) used as the language server. This is useful to guarantee version parity between your IDE and CLI, but means extension updates won't update which Pyrefly version you'll be using.",
                     "scope": "machine-overridable"
                 },
                 "pyrefly.lspArguments": {

--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -115,7 +115,7 @@ export async function activate(context: ExtensionContext) {
   }
 
   // There may be more than one URI due to multi-root workspaces, so just take the primary root.
-  let globalCwd: vscode.Uri | undefined = vscode.workspace.workspaceFolders?.[0].uri;
+  let globalCwd: vscode.Uri | undefined = vscode.workspace.workspaceFolders?.[0]?.uri;
 
   const lspPath: string = resolveLspPath(requireSetting('pyrefly.lspPath'), globalCwd);
   // `pyrefly.lspArguments` resolves to an empty array in some environments

--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -88,6 +88,14 @@ async function overridePythonPath(
   return newResult;
 }
 
+function resolveLspPath(lspPath: string, cwd: vscode.Uri | undefined) {
+  let lspPathIsRelative = lspPath.startsWith("./") || lspPath.startsWith("../");
+  if (cwd != null && lspPathIsRelative) {
+    return vscode.Uri.joinPath(cwd, lspPath).fsPath;
+  }
+  return lspPath;
+}
+
 export async function activate(context: ExtensionContext) {
   // Initialize the output channel if it doesn't exist
   if (!outputChannel) {
@@ -106,7 +114,10 @@ export async function activate(context: ExtensionContext) {
     inferOutputChannel = vscode.window.createOutputChannel('Pyrefly infer');
   }
 
-  const lspPath: string = requireSetting('pyrefly.lspPath');
+  // There may be more than one URI due to multi-root workspaces, so just take the primary root.
+  let globalCwd: vscode.Uri | undefined = vscode.workspace.workspaceFolders?.[0].uri;
+
+  const lspPath: string = resolveLspPath(requireSetting('pyrefly.lspPath'), globalCwd);
   // `pyrefly.lspArguments` resolves to an empty array in some environments
   // (notably dev containers / remote, where the `machine-overridable` default
   // of `["lsp"]` is not applied). Spawning the binary with no subcommand makes

--- a/lsp/src/status-bar.ts
+++ b/lsp/src/status-bar.ts
@@ -37,6 +37,9 @@ type TypeErrorDisplayStatusV2 = {
   // Markdown — fed straight into MarkdownString.
   tooltip: string;
   docsUrl: string;
+  // Version string of the language server binary, or null when the
+  // server doesn't know it.
+  pyreflyVersion: string | null;
 };
 
 /// Update the status bar based on current configuration
@@ -154,25 +157,38 @@ No errors will be shown even if there is a [\`pyrefly.toml\`](https://pyrefly.or
 function renderV2(status: TypeErrorDisplayStatusV2) {
   statusBarItem.text =
     status.label == null ? 'Pyrefly' : `Pyrefly (${status.label})`;
+  // Sections are joined with a blank line because markdown treats a
+  // single newline as a space, which would run them together on one
+  // line. The docs link is tied to the tooltip: a configured project
+  // gets an empty tooltip, and a bare "Docs" link with no explanation
+  // above it is noise. The version is independent — it is the one thing
+  // worth surfacing even when the server has nothing else to say.
+  const sections: string[] = [];
   if (status.tooltip) {
-    const md = new vscode.MarkdownString(status.tooltip);
-    // The kill-switch and IDE-override tooltips embed
-    // `command:workbench.action.openSettings?["<setting-id>"]` links so
-    // clicking the setting name jumps the user straight into the
-    // Settings UI. `MarkdownString` rejects `command:` URIs unless
-    // `isTrusted` allow-lists them — narrow the allow-list to just the
-    // one command we use rather than blanket-trusting everything.
-    md.isTrusted = {enabledCommands: ['workbench.action.openSettings']};
+    sections.push(status.tooltip);
     if (status.docsUrl) {
       // Render as `Docs: <url>` where <url> is the visible text and
       // also the link target — keeps the URL readable in the hover
       // (and copyable) while still clickable.
-      md.appendMarkdown(`\n\nDocs: [${status.docsUrl}](${status.docsUrl})`);
+      sections.push(`Docs: [${status.docsUrl}](${status.docsUrl})`);
     }
-    statusBarItem.tooltip = md;
-  } else {
-    statusBarItem.tooltip = undefined;
   }
+  if (status.pyreflyVersion) {
+    sections.push(`Pyrefly version: ${status.pyreflyVersion}`);
+  }
+  if (sections.length === 0) {
+    statusBarItem.tooltip = undefined;
+    return;
+  }
+  const md = new vscode.MarkdownString(sections.join('\n\n'));
+  // The kill-switch and IDE-override tooltips embed
+  // `command:workbench.action.openSettings?["<setting-id>"]` links so
+  // clicking the setting name jumps the user straight into the
+  // Settings UI. `MarkdownString` rejects `command:` URIs unless
+  // `isTrusted` allow-lists them — narrow the allow-list to just the
+  // one command we use rather than blanket-trusting everything.
+  md.isTrusted = {enabledCommands: ['workbench.action.openSettings']};
+  statusBarItem.tooltip = md;
 }
 
 export function getStatusBarItem(): vscode.StatusBarItem {

--- a/pyrefly/lib/commands/all.rs
+++ b/pyrefly/lib/commands/all.rs
@@ -103,7 +103,12 @@ impl Command {
                 None,
             )),
             Command::Tsp(args) => Ok((
-                args.run(telemetry, config_configurer_wrapper, thread_count)?,
+                args.run(
+                    telemetry,
+                    config_configurer_wrapper,
+                    thread_count,
+                    Some(version.to_owned()),
+                )?,
                 None,
             )),
             Command::Init(args) => Ok((

--- a/pyrefly/lib/commands/lsp.rs
+++ b/pyrefly/lib/commands/lsp.rs
@@ -136,6 +136,7 @@ pub fn run_lsp(
     thread_count: ThreadCount,
 ) -> anyhow::Result<()> {
     let lsp_start_time = Instant::now();
+    let server_version = server_info.as_ref().and_then(|i| i.version.clone());
     if let Some(initialize_info) =
         initialize_connection(&connection, &mut reader, args.indexing_mode, server_info)?
     {
@@ -153,6 +154,7 @@ pub fn run_lsp(
             wrapper,
             thread_count,
             lsp_start_time,
+            server_version,
         )?;
     }
     Ok(())

--- a/pyrefly/lib/commands/tsp.rs
+++ b/pyrefly/lib/commands/tsp.rs
@@ -52,6 +52,7 @@ pub fn run_tsp(
     telemetry: &impl Telemetry,
     wrapper: Option<ConfigConfigurerWrapper>,
     thread_count: ThreadCount,
+    server_version: Option<String>,
 ) -> anyhow::Result<()> {
     if let Some(initialize_info) =
         initialize_tsp_connection(&connection, &mut reader, args.indexing_mode)?
@@ -79,6 +80,7 @@ pub fn run_tsp(
             wrapper,
             thread_count,
             Instant::now(),
+            server_version,
         );
 
         // Reuse the existing lsp_loop but with TSP initialization
@@ -109,13 +111,22 @@ impl TspArgs {
         telemetry: &impl Telemetry,
         wrapper: Option<ConfigConfigurerWrapper>,
         thread_count: ThreadCount,
+        server_version: Option<String>,
     ) -> anyhow::Result<CommandExitStatus> {
         // Note that we must have our logging only write out to stderr.
         eprintln!("starting TSP server");
 
         let (connection, reader, io_threads) = Connection::from_transport(&self.transport)?;
 
-        run_tsp(connection, reader, self, telemetry, wrapper, thread_count)?;
+        run_tsp(
+            connection,
+            reader,
+            self,
+            telemetry,
+            wrapper,
+            thread_count,
+            server_version,
+        )?;
         io_threads.join()?;
         // We have shut down gracefully.
         // Use writeln! instead of eprintln! to avoid panicking if stderr is closed.

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -985,6 +985,8 @@ pub struct Server {
     external_references: Arc<dyn ExternalProvider>,
     /// The time at which the server was started, for telemetry.
     server_start_time: Instant,
+    /// The version of Pyrefly that's currently running.
+    server_version: Option<String>,
 }
 
 pub fn shutdown_finish(sender: &Sender<Message>, reader: &mut MessageReader, id: RequestId) {
@@ -1501,6 +1503,7 @@ pub fn lsp_loop(
     wrapper: Option<ConfigConfigurerWrapper>,
     thread_count: ThreadCount,
     lsp_start_time: Instant,
+    server_version: Option<String>,
 ) -> anyhow::Result<()> {
     info!("Reading messages");
     let lsp_queue = LspQueue::new();
@@ -1525,6 +1528,7 @@ pub fn lsp_loop(
         wrapper,
         thread_count,
         lsp_start_time,
+        server_version,
     );
     std::thread::scope(|scope| {
         // Spawn the event processing loop on a thread with a large stack
@@ -2652,7 +2656,9 @@ impl Server {
                                 )
                             }
                             TypeErrorDisplayStatusVersion::V2 => {
-                                TypeErrorDisplayStatusResponse::V2(default_v2_response())
+                                TypeErrorDisplayStatusResponse::V2(default_v2_response(
+                                    self.server_version.clone(),
+                                ))
                             }
                         }
                     };
@@ -2700,6 +2706,7 @@ impl Server {
         wrapper: Option<ConfigConfigurerWrapper>,
         thread_count: ThreadCount,
         lsp_start_time: Instant,
+        server_version: Option<String>,
     ) -> Self {
         let folders = if let Some(capability) = &initialize_params.capabilities.workspace
             && let Some(true) = capability.workspace_folders
@@ -2784,6 +2791,7 @@ impl Server {
             pending_invalidation_events: Arc::new(Mutex::new(CategorizedEvents::default())),
             external_references,
             server_start_time: lsp_start_time,
+            server_version,
         };
 
         if let Some(init_options) = &s.initialize_params.initialization_options {
@@ -3082,6 +3090,7 @@ impl Server {
             config.disable_type_errors_in_ide(path),
             workspace_disable_type_errors,
             workspace_type_checking_mode,
+            self.server_version.clone(),
         )
     }
 

--- a/pyrefly/lib/lsp/non_wasm/type_error_display_status.rs
+++ b/pyrefly/lib/lsp/non_wasm/type_error_display_status.rs
@@ -343,6 +343,7 @@ mod tests {
                 false,
                 false,
                 Some(TypeCheckingMode::Strict),
+                None,
             );
             assert_eq!(r.label, None);
             assert!(r.tooltip.contains("typeCheckingMode"));
@@ -365,6 +366,7 @@ mod tests {
                 false,
                 false,
                 None,
+                None,
             );
             assert_eq!(r.label.as_deref(), Some("Legacy"));
             assert!(r.tooltip.contains("your `mypy.ini`"));
@@ -380,6 +382,7 @@ mod tests {
                 &ConfigSource::Synthetic(None),
                 false,
                 false,
+                None,
                 None,
             );
             assert_eq!(r.label.as_deref(), Some("Legacy"));
@@ -397,6 +400,7 @@ mod tests {
                 false,
                 false,
                 None,
+                None,
             );
             assert_eq!(r.label.as_deref(), Some("Default"));
             assert!(r.tooltip.contains("your `pyrightconfig.json`"));
@@ -411,6 +415,7 @@ mod tests {
                 &ConfigSource::Synthetic(None),
                 false,
                 false,
+                None,
                 None,
             );
             assert_eq!(r.label.as_deref(), Some("Default"));
@@ -429,6 +434,7 @@ mod tests {
                 false,
                 false,
                 None,
+                None,
             );
             assert_eq!(r.label.as_deref(), Some("Basic"));
             assert!(r.tooltip.contains("basic"));
@@ -446,6 +452,7 @@ mod tests {
                 false,
                 false,
                 None,
+                None,
             );
             assert_eq!(r.label, None);
             assert!(r.tooltip.is_empty());
@@ -462,6 +469,7 @@ mod tests {
                 &ConfigSource::File(PathBuf::from("/proj/pyrefly.toml")),
                 true,
                 false,
+                None,
                 None,
             );
             assert_eq!(r.label.as_deref(), Some("Errors Off"));
@@ -485,6 +493,7 @@ mod tests {
                 true,
                 false,
                 None,
+                None,
             );
             assert_eq!(r.label.as_deref(), Some("Errors Off"));
             assert!(r.tooltip.contains("disable-type-errors-in-ide"));
@@ -502,7 +511,14 @@ mod tests {
         /// know which knob to flip.
         #[test]
         fn workspace_kill_switch_yields_errors_off_label() {
-            let r = derive_v2_response(None, &ConfigSource::Synthetic(None), false, true, None);
+            let r = derive_v2_response(
+                None,
+                &ConfigSource::Synthetic(None),
+                false,
+                true,
+                None,
+                None,
+            );
             assert_eq!(r.label.as_deref(), Some("Errors Off"));
             assert!(r.tooltip.contains("python.pyrefly.disableTypeErrors"));
         }
@@ -519,6 +535,7 @@ mod tests {
                 false,
                 true,
                 None,
+                None,
             );
             assert_eq!(r.label.as_deref(), Some("Errors Off"));
             assert!(r.tooltip.contains("python.pyrefly.disableTypeErrors"));
@@ -531,6 +548,7 @@ mod tests {
                 &ConfigSource::File(PathBuf::from("/proj/pyrefly.toml")),
                 true,
                 true,
+                None,
                 None,
             );
             assert_eq!(r.label.as_deref(), Some("Errors Off"));

--- a/pyrefly/lib/lsp/non_wasm/type_error_display_status.rs
+++ b/pyrefly/lib/lsp/non_wasm/type_error_display_status.rs
@@ -115,6 +115,8 @@ pub struct TypeErrorDisplayStatusV2 {
     /// URL referenced from the tooltip — the IDE typically renders this
     /// as the trailing "Docs" link in the hover.
     pub docs_url: String,
+    /// The version of Pyrefly that's currently running.
+    pub pyrefly_version: Option<String>,
 }
 
 /// Internal sum type covering both wire shapes. `#[serde(untagged)]`
@@ -154,12 +156,13 @@ const STATUS_BAR_DOCS_URL: &str = "https://pyrefly.org/en/docs/IDE/";
 /// The onboarding nudge for genuine no-config states lives in the
 /// `Some(SynthesizedPresetReason::NoNearbyConfig)` branch of
 /// `derive_v2_response` (with `Basic` label + `pyrefly init` tooltip).
-pub fn default_v2_response() -> TypeErrorDisplayStatusV2 {
+pub fn default_v2_response(pyrefly_version: Option<String>) -> TypeErrorDisplayStatusV2 {
     TypeErrorDisplayStatusV2 {
         version: "v2".to_owned(),
         label: None,
         tooltip: String::new(),
         docs_url: STATUS_BAR_DOCS_URL.to_owned(),
+        pyrefly_version,
     }
 }
 
@@ -178,6 +181,7 @@ pub fn derive_v2_response(
     disable_type_errors_in_ide: bool,
     workspace_disable_type_errors: bool,
     workspace_type_checking_mode: Option<TypeCheckingMode>,
+    pyrefly_version: Option<String>,
 ) -> TypeErrorDisplayStatusV2 {
     if workspace_disable_type_errors {
         return TypeErrorDisplayStatusV2 {
@@ -187,6 +191,7 @@ pub fn derive_v2_response(
                 "Pyrefly diagnostics are suppressed by [`python.pyrefly.disableTypeErrors`](command:workbench.action.openSettings?[\"python.pyrefly.disableTypeErrors\"]).\n\nUnset this setting to re-enable diagnostics."
                     .to_owned(),
             docs_url: STATUS_BAR_DOCS_URL.to_owned(),
+            pyrefly_version,
         };
     }
     match reason {
@@ -205,6 +210,7 @@ pub fn derive_v2_response(
                     "Pyrefly is using the [`python.pyrefly.typeCheckingMode`](command:workbench.action.openSettings?[\"python.pyrefly.typeCheckingMode\"]) setting (currently: `{value}`) because no `pyrefly.toml` was found.\n\nRun `pyrefly init` to continue setting up Pyrefly.",
                 ),
                 docs_url: STATUS_BAR_DOCS_URL.to_owned(),
+                pyrefly_version,
             }
         }
         Some(SynthesizedPresetReason::Migrated(kind)) => {
@@ -233,6 +239,7 @@ pub fn derive_v2_response(
                     "Pyrefly is using settings imported from {location} (preset: {preset}).\n\nRun `pyrefly init` to continue setting up Pyrefly.",
                 ),
                 docs_url: STATUS_BAR_DOCS_URL.to_owned(),
+                pyrefly_version,
             }
         }
         Some(SynthesizedPresetReason::NoNearbyConfig) => TypeErrorDisplayStatusV2 {
@@ -242,6 +249,7 @@ pub fn derive_v2_response(
                 "Pyrefly is running with the `basic` preset because no `pyrefly.toml` was found.\n\nRun `pyrefly init` to continue setting up Pyrefly."
                     .to_owned(),
             docs_url: STATUS_BAR_DOCS_URL.to_owned(),
+            pyrefly_version,
         },
         None => match source {
             ConfigSource::File(path) if disable_type_errors_in_ide => {
@@ -265,6 +273,7 @@ pub fn derive_v2_response(
                         "Pyrefly diagnostics are suppressed by `disable-type-errors-in-ide` in {location}.\n\nRemove this config to re-enable diagnostics.",
                     ),
                     docs_url: STATUS_BAR_DOCS_URL.to_owned(),
+                    pyrefly_version,
                 }
             }
             ConfigSource::File(_) => TypeErrorDisplayStatusV2 {
@@ -272,8 +281,9 @@ pub fn derive_v2_response(
                 label: None,
                 tooltip: String::new(),
                 docs_url: STATUS_BAR_DOCS_URL.to_owned(),
+                pyrefly_version,
             },
-            _ => default_v2_response(),
+            _ => default_v2_response(pyrefly_version),
         },
     }
 }

--- a/pyrefly/lib/test/tsp/tsp_interaction/object_model.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/object_model.rs
@@ -586,6 +586,7 @@ impl TspInteraction {
                 &NoTelemetry,
                 None,
                 TEST_THREAD_COUNT,
+                None,
             )
             .map(|_| ())
             .map_err(|e| std::io::Error::other(e.to_string()))


### PR DESCRIPTION
When Pyrefly would execute binaries passed in from VSCode through the `pyrefy.lspPath` setting, it would run the command without any modifications, even for relative paths. This means any relative binary definitions (or wrapper scripts) would be run from whatever the cwd of the VSCode extension would be, typically resulting in an ENOENT (or occasionally an EINVAL).

Instead, we should do at least a basic check to see if the path is relative, and prepend the workspace path onto it. Since VSCode allows multi-workspace roots, this means taking the first (a.k.a. the primary) workspace root, and using that as our cwd.

This should fix the main problem with #4306, but there will be other changes I'd like to make here to make Pyrefly binary selection match user expectations a bit more.