### PR TITLE
Respect skip-interpreter-query for client-provided pythonPath in the LSP

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/workspace.rs
+++ b/pyrefly/lib/lsp/non_wasm/workspace.rs
@@ -42,26 +42,16 @@ use crate::state::lsp::ImportFormat;
 use crate::state::lsp::InlayHintConfig;
 use crate::state::lsp::TypeCheckingMode;
 
-/// Information about the Python environment provided by this workspace.
+/// A Python interpreter path provided by the client (e.g. via `pythonPath`).
 #[derive(Debug, Clone)]
 pub struct PythonInfo {
-    /// The path to the interpreter used to query this `PythonInfo`'s [`PythonEnvironment`].
+    /// The path to the Python interpreter.
     interpreter: PathBuf,
-    /// The [`PythonEnvironment`] values all [`ConfigFile`]s in a given workspace should
-    /// use if no explicit [`ConfigFile::python_interpreter`] is provided, or any
-    /// `PythonEnvironment` values in that `ConfigFile` are unfiled. If the `interpreter
-    /// provided fails to execute or is invalid, this `PythonEnvironment` might instead
-    /// be a system interpreter or [`PythonEnvironment::pyrefly_default()`].
-    env: PythonEnvironment,
 }
 
 impl PythonInfo {
     pub fn new(interpreter: PathBuf) -> Self {
-        let (env, query_error) = PythonEnvironment::get_interpreter_env(&interpreter);
-        if let Some(error) = query_error {
-            error!("{error}");
-        }
-        Self { interpreter, env }
+        Self { interpreter }
     }
 }
 
@@ -172,12 +162,19 @@ impl ConfigConfigurer for WorkspaceConfigConfigurer {
                     config.fallback_search_path =
                         FallbackSearchPath::Explicit(Arc::new(new_fallback_search_path));
                 }
-                if let Some(PythonInfo {
-                    interpreter,
-                    mut env,
-                }) = w.python_info.clone()
+                // Use the client-provided interpreter (e.g. `pythonPath`) only when the
+                // config doesn't already specify an interpreter and hasn't opted out of
+                // interpreter queries entirely (`skip-interpreter-query`). The query is
+                // deferred until here so an opt-out config never pays for it.
+                if let Some(PythonInfo { interpreter }) = w.python_info.clone()
                     && config.interpreters.is_empty()
+                    && !config.interpreters.skip_interpreter_query
                 {
+                    let (mut env, query_error) =
+                        PythonEnvironment::get_interpreter_env(&interpreter);
+                    if let Some(error) = query_error {
+                        error!("{error}");
+                    }
                     let site_package_path: Option<Vec<PathBuf>> =
                         config.python_environment.site_package_path.take();
                     env.site_package_path = site_package_path;
@@ -1527,5 +1524,41 @@ mod tests {
             );
             assert!(!modified);
         }
+    }
+
+    /// A client-supplied `pythonPath` must not be applied to a config that opted
+    /// out of interpreter queries (`skip-interpreter-query = true`), and it must
+    /// only be applied to a config that hasn't already picked an interpreter. This
+    /// pins the workspace side of the `skip-interpreter-query` contract: a config
+    /// that opts out should never pay for — or even perform — an interpreter query.
+    /// Regression test for facebook/pyrefly#4445.
+    #[test]
+    fn test_skip_interpreter_query_blocks_client_pythonpath() {
+        let workspaces = Workspaces::new(Workspace::new(), &[]);
+        workspaces
+            .default
+            .write()
+            .python_info = Some(PythonInfo::new(PathBuf::from("/fake/python")));
+        let configurer = WorkspaceConfigConfigurer(Arc::new(workspaces));
+
+        // A config with `skip-interpreter-query = true`: the client interpreter is
+        // ignored entirely (neither queried nor applied as an interpreter path).
+        let mut skip_config = ConfigFile::parse_config("skip-interpreter-query = true").unwrap();
+        // Mark it as file-loaded so the unconfigured resolver (which would otherwise
+        // rebuild the config) doesn't drop the opt-out flag.
+        skip_config.source = ConfigSource::File(PathBuf::from("/fake/root/pyrefly.toml"));
+        let (applied, _) = configurer.configure(Some(Path::new("/fake/root")), skip_config, vec![]);
+        assert!(
+            applied.interpreters.is_empty(),
+            "client pythonPath must be ignored when skip-interpreter-query is set"
+        );
+
+        // A config that is silent about interpreters: the client interpreter is applied.
+        let (applied, _) =
+            configurer.configure(Some(Path::new("/fake/root")), ConfigFile::default(), vec![]);
+        assert!(
+            !applied.interpreters.is_empty(),
+            "client pythonPath is applied when the config is silent about interpreters"
+        );
     }
 }

--- a/pyrefly/lib/lsp/non_wasm/workspace.rs
+++ b/pyrefly/lib/lsp/non_wasm/workspace.rs
@@ -42,23 +42,13 @@ use crate::state::lsp::ImportFormat;
 use crate::state::lsp::InlayHintConfig;
 use crate::state::lsp::TypeCheckingMode;
 
-/// A Python interpreter path provided by the client (e.g. via `pythonPath`).
-#[derive(Debug, Clone)]
-pub struct PythonInfo {
-    /// The path to the Python interpreter.
-    interpreter: PathBuf,
-}
-
-impl PythonInfo {
-    pub fn new(interpreter: PathBuf) -> Self {
-        Self { interpreter }
-    }
-}
-
 /// LSP workspace settings: this is all that is necessary to run an LSP at a given root.
 #[derive(Debug, Clone, Default)]
 pub struct Workspace {
-    python_info: Option<PythonInfo>,
+    /// A Python interpreter path provided by the client (e.g. via `pythonPath`).
+    /// Only applied to configs that don't pick their own interpreter and haven't
+    /// opted out of interpreter queries (`skip-interpreter-query`).
+    client_interpreter: Option<PathBuf>,
     search_path: Option<Vec<PathBuf>>,
     /// Extra `project_excludes` globs contributed by the client, already
     /// rewritten relative to this workspace's root. Appended to (never
@@ -166,7 +156,7 @@ impl ConfigConfigurer for WorkspaceConfigConfigurer {
                 // config doesn't already specify an interpreter and hasn't opted out of
                 // interpreter queries entirely (`skip-interpreter-query`). The query is
                 // deferred until here so an opt-out config never pays for it.
-                if let Some(PythonInfo { interpreter }) = w.python_info.clone()
+                if let Some(interpreter) = w.client_interpreter.clone()
                     && config.interpreters.is_empty()
                     && !config.interpreters.skip_interpreter_query
                 {
@@ -822,19 +812,18 @@ impl Workspaces {
     fn update_pythonpath(&self, modified: &mut bool, scope_uri: &Option<Url>, python_path: &str) {
         let mut workspaces = self.workspaces.write();
         let interpreter = PathBuf::from(python_path);
-        let python_info = Some(PythonInfo::new(interpreter));
         match scope_uri {
             Some(scope_uri) => {
                 if let Ok(workspace_path) = scope_uri.to_file_path()
                     && let Some(workspace) = workspaces.get_mut(&workspace_path)
                 {
                     *modified = true;
-                    workspace.python_info = python_info;
+                    workspace.client_interpreter = Some(interpreter);
                 }
             }
             None => {
                 *modified = true;
-                self.default.write().python_info = python_info;
+                self.default.write().client_interpreter = Some(interpreter);
             }
         }
     }
@@ -1535,10 +1524,7 @@ mod tests {
     #[test]
     fn test_skip_interpreter_query_blocks_client_pythonpath() {
         let workspaces = Workspaces::new(Workspace::new(), &[]);
-        workspaces
-            .default
-            .write()
-            .python_info = Some(PythonInfo::new(PathBuf::from("/fake/python")));
+        workspaces.default.write().client_interpreter = Some(PathBuf::from("/fake/python"));
         let configurer = WorkspaceConfigConfigurer(Arc::new(workspaces));
 
         // A config with `skip-interpreter-query = true`: the client interpreter is

--- a/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
@@ -360,6 +360,67 @@ fn test_workspace_pythonpath_ignored_when_set_in_config_file() {
     interaction.shutdown().expect("Failed to shutdown");
 }
 
+// A config with `skip-interpreter-query = true` opts out of interpreter queries
+// entirely: a client-provided `pythonPath` must not be applied, even though it
+// would resolve the import. Regression test for the LSP eagerly querying (and
+// applying) the client interpreter despite the opt-out.
+// Only run this test on unix since windows has no way to mock a .exe without compiling something
+// (we call python with python.exe)
+#[cfg(unix)]
+#[test]
+fn test_skip_interpreter_query_ignores_lsp_pythonpath() {
+    let test_files_root = get_test_files_root();
+    // This interpreter *would* resolve `custom_module` if it were applied, so the
+    // test distinguishes "pythonPath applied" (0 errors) from "pythonPath ignored
+    // because of `skip-interpreter-query`" (1 error).
+    let good_interpreter_path =
+        setup_dummy_interpreter(&test_files_root.path().join("custom_interpreter"));
+
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(test_files_root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open("skip_interpreter_config/src/foo.py");
+    // `skip-interpreter-query = true` with no `site-package-path` in the config means
+    // the import cannot be resolved.
+    interaction
+        .client
+        .expect_publish_diagnostics_eventual_error_count(
+            test_files_root.path().join("skip_interpreter_config/src/foo.py"),
+            1,
+        )
+        .unwrap();
+
+    // Even though this interpreter would resolve the import, the config opted out of
+    // interpreter queries, so the import error must persist.
+    interaction.client.did_change_configuration();
+    interaction
+        .client
+        .expect_request::<WorkspaceConfiguration>(json!({"items":[{"section":"python"}]}))
+        .unwrap()
+        .send_configuration_response(json!([
+            {
+                "pythonPath": good_interpreter_path.to_str().unwrap()
+            }
+        ]));
+    interaction
+        .client
+        .expect_publish_diagnostics_eventual_error_count(
+            test_files_root.path().join("skip_interpreter_config/src/foo.py"),
+            1,
+        )
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
 // Only run this test on unix since windows has no way to mock a .exe without compiling something
 // (we call python with python.exe)
 #[cfg(unix)]

--- a/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/configuration.rs
@@ -387,13 +387,17 @@ fn test_skip_interpreter_query_ignores_lsp_pythonpath() {
         })
         .unwrap();
 
-    interaction.client.did_open("skip_interpreter_config/src/foo.py");
+    interaction
+        .client
+        .did_open("skip_interpreter_config/src/foo.py");
     // `skip-interpreter-query = true` with no `site-package-path` in the config means
     // the import cannot be resolved.
     interaction
         .client
         .expect_publish_diagnostics_eventual_error_count(
-            test_files_root.path().join("skip_interpreter_config/src/foo.py"),
+            test_files_root
+                .path()
+                .join("skip_interpreter_config/src/foo.py"),
             1,
         )
         .unwrap();
@@ -413,7 +417,9 @@ fn test_skip_interpreter_query_ignores_lsp_pythonpath() {
     interaction
         .client
         .expect_publish_diagnostics_eventual_error_count(
-            test_files_root.path().join("skip_interpreter_config/src/foo.py"),
+            test_files_root
+                .path()
+                .join("skip_interpreter_config/src/foo.py"),
             1,
         )
         .unwrap();

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/skip_interpreter_config/src/foo.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/skip_interpreter_config/src/foo.py
@@ -1,0 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from custom_module import CustomClass
+
+print(CustomClass.custom_attr)

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/skip_interpreter_config/src/pyrefly.toml
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/skip_interpreter_config/src/pyrefly.toml
@@ -1,0 +1,1 @@
+skip-interpreter-query = true


### PR DESCRIPTION
## Summary

Fixes #4445: with `skip-interpreter-query = true` in `pyrefly.toml`, the LSP still queried the interpreter the client supplied via `pythonPath` — logging e.g. `ERROR Failed to query interpreter at <deleted venv>...` and then applying that interpreter on top of the config, defeating the opt-out.

## Root cause

`PythonInfo::new` queried the interpreter eagerly in `update_pythonpath`, i.e. as soon as the client sent `pythonPath`, before any config file had been resolved. The `skip-interpreter-query` flag only lives on the `ConfigFile`, so it was never consulted. The configurer then applied the pre-queried environment unconditionally (when the config hadn't picked an interpreter).

## Fix

- `PythonInfo` now stores only the interpreter path; the query is deferred to the point where the workspace config is applied (`WorkspaceConfigConfigurer::configure`).
- The client interpreter is applied only when the resolved config has no interpreter selection **and** has not opted out of queries (`skip-interpreter-query`).
- A config with `skip-interpreter-query = true` now never performs (or pays for) an interpreter query, and the client `pythonPath` is ignored in favor of the config's own environment settings.

## Tests

- `test_skip_interpreter_query_ignores_lsp_pythonpath` (unix-gated LSP interaction test): opens a project whose config sets `skip-interpreter-query = true`, verifies an unresolved import stays an error even after the client sends a `pythonPath` that *would* resolve it.
- `test_skip_interpreter_query_blocks_client_pythonpath` (cross-platform unit test in `workspace.rs`): pins that a `skip-interpreter-query` config ignores a client interpreter while a config silent about interpreters still applies it.

Verified with `cargo +1.96.1 test`: all LSP interaction tests (1081) and the `workspace`/`configuration` modules pass.