### PR TITLE
fix Return type hint in sandbox moves to strange places if you type fast enough #756

### DIFF
--- a/website/src/__tests__/stabilizeInlayHintDecorations.test.ts
+++ b/website/src/__tests__/stabilizeInlayHintDecorations.test.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type * as monaco from 'monaco-editor';
 import stabilizeInlayHintDecorations from '../sandbox/stabilizeInlayHintDecorations';
 
 test('prevents Monaco inlay hint decorations from growing at their edges', () => {
@@ -32,7 +33,10 @@ test('prevents Monaco inlay hint decorations from growing at their edges', () =>
         }),
     };
 
-    stabilizeInlayHintDecorations(model, 1);
+    stabilizeInlayHintDecorations(
+        model as unknown as monaco.editor.ITextModel,
+        1
+    );
     decorations = [
         { id: 'inlay-hint', options: inlayHintOptions },
         { id: 'other', options: { description: 'other', stickiness: 0 } },

--- a/website/src/__tests__/stabilizeInlayHintDecorations.test.ts
+++ b/website/src/__tests__/stabilizeInlayHintDecorations.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import stabilizeInlayHintDecorations from '../sandbox/stabilizeInlayHintDecorations';
+
+test('prevents Monaco inlay hint decorations from growing at their edges', () => {
+    const changeDecorationOptions = jest.fn();
+    let decorations: Array<{
+        id: string;
+        options: { description: string; stickiness: number; after?: object };
+    }> = [];
+    let decorationsChanged = () => {};
+    const inlayHintOptions = {
+        description: 'InlayHint',
+        stickiness: 0,
+        after: { content: ' -> int' },
+    };
+    const model = {
+        changeDecorations: (
+            callback: (accessor: {
+                changeDecorationOptions: typeof changeDecorationOptions;
+            }) => void
+        ) =>
+            callback({ changeDecorationOptions }),
+        getAllDecorations: () => decorations,
+        onDidChangeDecorations: jest.fn((listener: () => void) => {
+            decorationsChanged = listener;
+        }),
+    };
+
+    stabilizeInlayHintDecorations(model, 1);
+    decorations = [
+        { id: 'inlay-hint', options: inlayHintOptions },
+        { id: 'other', options: { description: 'other', stickiness: 0 } },
+    ];
+    decorationsChanged();
+
+    expect(changeDecorationOptions).toHaveBeenCalledWith('inlay-hint', {
+        ...inlayHintOptions,
+        stickiness: 1,
+    });
+    expect(changeDecorationOptions).toHaveBeenCalledTimes(1);
+});

--- a/website/src/sandbox/configured-monaco.ts
+++ b/website/src/sandbox/configured-monaco.ts
@@ -9,6 +9,7 @@
 
 import * as monaco from 'monaco-editor';
 import { default as MonacoEditor, loader } from '@monaco-editor/react';
+import stabilizeInlayHintDecorations from './stabilizeInlayHintDecorations';
 
 type CompletionItem = monaco.languages.CompletionItem;
 type Range = monaco.IRange;
@@ -92,6 +93,10 @@ function setInlayHintFunctionForMonaco(
     model: monaco.editor.ITextModel,
     f: InlayHintFunction
 ): void {
+    stabilizeInlayHintDecorations(
+        model,
+        monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges
+    );
     inlayHintFunctionsForMonaco.set(model, f);
 }
 

--- a/website/src/sandbox/stabilizeInlayHintDecorations.ts
+++ b/website/src/sandbox/stabilizeInlayHintDecorations.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+interface DecorationOptions {
+    description?: string;
+    stickiness?: number;
+    [key: string]: unknown;
+}
+
+interface Decoration {
+    id: string;
+    options: DecorationOptions;
+}
+
+interface DecorationChangeAccessor {
+    changeDecorationOptions(id: string, options: DecorationOptions): void;
+}
+
+interface InlayHintModel {
+    changeDecorations(
+        callback: (accessor: DecorationChangeAccessor) => void
+    ): void;
+    getAllDecorations(): Decoration[];
+    onDidChangeDecorations(listener: () => void): unknown;
+}
+
+const stabilizedModels = new WeakSet<object>();
+
+/** Keep Monaco's inlay hint anchors from growing when text is inserted at an edge. */
+export default function stabilizeInlayHintDecorations(
+    model: object,
+    stableStickiness: number
+): void {
+    if (stabilizedModels.has(model)) return;
+    stabilizedModels.add(model);
+    // Monaco uses this model method internally but does not expose it in ITextModel.
+    const inlayHintModel = model as InlayHintModel;
+
+    const stabilize = () => {
+        const decorations = inlayHintModel
+            .getAllDecorations()
+            .filter(
+                (decoration) =>
+                    decoration.options.description === 'InlayHint' &&
+                    decoration.options.stickiness !== stableStickiness
+            );
+        if (decorations.length === 0) return;
+
+        inlayHintModel.changeDecorations((accessor) => {
+            decorations.forEach((decoration) =>
+                accessor.changeDecorationOptions(decoration.id, {
+                    ...decoration.options,
+                    stickiness: stableStickiness,
+                })
+            );
+        });
+    };
+
+    inlayHintModel.onDidChangeDecorations(stabilize);
+    stabilize();
+}

--- a/website/src/sandbox/stabilizeInlayHintDecorations.ts
+++ b/website/src/sandbox/stabilizeInlayHintDecorations.ts
@@ -5,34 +5,32 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-interface DecorationOptions {
-    description?: string;
-    stickiness?: number;
-    [key: string]: unknown;
-}
+import type * as monaco from 'monaco-editor';
 
-interface Decoration {
-    id: string;
-    options: DecorationOptions;
-}
+type InlayHintDecorationOptions = monaco.editor.IModelDecorationOptions & {
+    readonly description?: string;
+};
 
-interface DecorationChangeAccessor {
-    changeDecorationOptions(id: string, options: DecorationOptions): void;
-}
+type InlayHintDecoration = Pick<monaco.editor.IModelDecoration, 'id'> & {
+    readonly options: InlayHintDecorationOptions;
+};
 
-interface InlayHintModel {
+type InlayHintModel = monaco.editor.ITextModel & {
     changeDecorations(
-        callback: (accessor: DecorationChangeAccessor) => void
+        callback: (accessor: {
+            changeDecorationOptions(
+                id: string,
+                options: monaco.editor.IModelDecorationOptions
+            ): void;
+        }) => void
     ): void;
-    getAllDecorations(): Decoration[];
-    onDidChangeDecorations(listener: () => void): unknown;
-}
+};
 
-const stabilizedModels = new WeakSet<object>();
+const stabilizedModels = new WeakSet<monaco.editor.ITextModel>();
 
 /** Keep Monaco's inlay hint anchors from growing when text is inserted at an edge. */
 export default function stabilizeInlayHintDecorations(
-    model: object,
+    model: monaco.editor.ITextModel,
     stableStickiness: number
 ): void {
     if (stabilizedModels.has(model)) return;
@@ -41,13 +39,13 @@ export default function stabilizeInlayHintDecorations(
     const inlayHintModel = model as InlayHintModel;
 
     const stabilize = () => {
-        const decorations = inlayHintModel
-            .getAllDecorations()
-            .filter(
-                (decoration) =>
-                    decoration.options.description === 'InlayHint' &&
-                    decoration.options.stickiness !== stableStickiness
-            );
+        const decorations = (
+            inlayHintModel.getAllDecorations() as InlayHintDecoration[]
+        ).filter(
+            (decoration) =>
+                decoration.options.description === 'InlayHint' &&
+                decoration.options.stickiness !== stableStickiness
+        );
         if (decorations.length === 0) return;
 
         inlayHintModel.changeDecorations((accessor) => {


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #756

Monaco creates inlay hint decorations with AlwaysGrowsWhenTypingAtEdges, pressing Enter at the boundary between a function’s closing parenthesis and colon caused the return type hint to move to the next line until Monaco refreshed it.

The sandbox now changes inlay hint decorations to NeverGrowsWhenTypingAtEdges, keeping each hint anchored to the function signature without clearing or re-rendering it.

With help from gpt 5.6 sol to find the option.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test