### PR TITLE
Support test imports in inferred src layouts

### DIFF
--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -752,6 +752,13 @@ impl ConfigFile {
             result.fallback_search_path = FallbackSearchPath::Explicit(Arc::new(vec![import_root]));
         } else {
             result.import_root = Some(import_root);
+            if matches!(layout, ProjectLayout::Src) {
+                // Pytest projects commonly keep importable test modules beside `src/`.
+                // Keep the project root lower precedence so modules under `src/` retain their
+                // canonical names.
+                result.fallback_search_path =
+                    FallbackSearchPath::Explicit(Arc::new(vec![root.to_path_buf()]));
+            }
         }
         // ignore failures rewriting path to config, since we're trying to construct
         // an ephemeral config for the user, and it's not fatal (but things might be

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -3265,6 +3265,36 @@ output-format = "omit-errors"
     }
 
     #[test]
+    fn test_src_layout_module_names_use_primary_and_fallback_roots() {
+        let tempdir = TempDir::new().unwrap();
+        fs::create_dir_all(tempdir.path().join("src/example")).unwrap();
+        fs::create_dir_all(tempdir.path().join("tests")).unwrap();
+        let mut config = ConfigFile::init_at_root(tempdir.path(), &ProjectLayout::Src, false);
+        config.interpreters.skip_interpreter_query = true;
+        config.configure();
+        assert_eq!(
+            config.search_path().cloned().collect::<Vec<_>>(),
+            vec![tempdir.path().join("src")]
+        );
+        assert_eq!(
+            config.fallback_search_path,
+            FallbackSearchPath::Explicit(Arc::new(vec![tempdir.path().to_path_buf()])),
+        );
+
+        let source = config.handle_from_module_path(ModulePath::filesystem(
+            tempdir.path().join("src/example/core.py"),
+        ));
+        assert_eq!(source.module(), ModuleName::from_str("example.core"));
+        assert!(!source.is_fallback());
+
+        let test = config.handle_from_module_path(ModulePath::filesystem(
+            tempdir.path().join("tests/helpers.py"),
+        ));
+        assert_eq!(test.module(), ModuleName::from_str("tests.helpers"));
+        assert!(test.is_fallback());
+    }
+
+    #[test]
     fn test_pyproject_toml_search_path() {
         let root = TempDir::new().unwrap();
         let path = root.path().join(ConfigFile::PYPROJECT_FILE_NAME);
@@ -3340,6 +3370,10 @@ output-format = "omit-errors"
             config.search_path().cloned().collect::<Vec<_>>(),
             vec![src_dir]
         );
+        assert_eq!(
+            config.fallback_search_path,
+            FallbackSearchPath::Explicit(Arc::new(vec![root.path().to_path_buf()])),
+        );
     }
 
     #[test]
@@ -3362,6 +3396,7 @@ output-format = "omit-errors"
             config.search_path().cloned().collect::<Vec<_>>(),
             vec![src_dir]
         );
+        assert_eq!(config.fallback_search_path, FallbackSearchPath::Empty);
     }
 
     #[test]

--- a/test/find.md
+++ b/test/find.md
@@ -91,6 +91,29 @@ Docs: * (glob)
 [0]
 ```
 
+## Src layout with pytest tests
+
+A synthesized config should use `src/` as the primary import root while
+allowing tests to import sibling test helpers from the project root.
+
+```scrut {output_stream: stderr}
+$ mkdir -p $TMPDIR/pytest_project/src/example $TMPDIR/pytest_project/tests && \
+> printf '[tool.pytest.ini_options]\ntestpaths = ["tests"]\n' \
+>     > $TMPDIR/pytest_project/pyproject.toml && \
+> echo "VALUE: int = 1" > $TMPDIR/pytest_project/src/example/__init__.py && \
+> touch $TMPDIR/pytest_project/tests/__init__.py && \
+> echo "HELPER: int = 2" > $TMPDIR/pytest_project/tests/helpers.py && \
+> printf 'from example import VALUE\nfrom tests.helpers import HELPER\nresult: int = VALUE + HELPER\n' \
+>     > $TMPDIR/pytest_project/tests/test_core.py && \
+> cd $TMPDIR/pytest_project && $PYREFLY check
+ INFO Found `*/pyproject.toml` marking project root, checking root directory with auto configuration (glob)
+ INFO 0 errors
+No `pyrefly.toml` found — using preset `basic`.
+Run `pyrefly init` to continue setting up Pyrefly.
+Docs: * (glob)
+[0]
+```
+
 ## Relative --project-excludes
 
 ```scrut {output_stream: stderr}

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -291,7 +291,7 @@ the most common ways of setting up and configuring your project, on top of any
 [`search-path`](#search-path) entries you may pass in through the CLI or
 set in your config.
 
-The two heuristics that are currently supported are:
+The three heuristics that are currently supported are:
 
 1. Adding your import root to the end of your search path. Your import root is
    a `src/` directory in the same directory as a config file, the parent directory
@@ -300,8 +300,12 @@ The two heuristics that are currently supported are:
    or files can be found.
    See [Configuration Finding](#configuration-finding) for more information on
    what we'll find as a config file.
-2. If no config can be found, each directory from the given file to `/` will be
-   added as a fallback search path.
+2. If no Pyrefly config is present and a `src/` layout is inferred, adding the
+   project root as a lower-precedence fallback path. This lets modules under a
+   sibling `tests/` directory import each other without changing the canonical
+   names of modules under `src/`.
+3. If no project root can be inferred, each directory from the given file to `/`
+   will be added as a fallback search path.
 
 See more on [how Pyrefly does import resolution](import-resolution.mdx).
 

--- a/website/docs/import-resolution.mdx
+++ b/website/docs/import-resolution.mdx
@@ -69,15 +69,18 @@ The import root is:
 
 ### Fallback Search Path
 
-The fallback search path is a heuristic automatically constructed by Pyrefly to attempt to
-find project files when there's no config file marking the project root, and Pyrefly
-is unable to determine from other heuristics where an import root might be.
+The fallback search path is a lower-precedence heuristic automatically constructed by
+Pyrefly when no Pyrefly config defines the project's import roots. For an inferred
+`src/` layout, it includes the project root so sibling directories such as `tests/`
+are importable without changing the primary `src/` import root. When Pyrefly cannot
+infer a project root, it instead searches the importing file's ancestors.
 It is only constructed when
 [`disable-search-path-heuristics`](configuration.mdx#disable-search-path-heuristics)
 is not set.
 
-The fallback search path consists of each directory from the directory containing
-a given file to the root of your filesystem. For example, if you have the following setup:
+For an unknown project root, the fallback search path consists of each directory from
+the directory containing a given file to the root of your filesystem. For example, if
+you have the following setup:
 
 ```
 /


### PR DESCRIPTION
# Summary

When Pyrefly infers a `src/` layout without an explicit config, keep `src/` as the primary import root and add the project root as a lower-precedence fallback search path. This allows sibling test packages such as `tests.helpers` to resolve while preserving canonical source names such as `example.core`.

Explicitly configured projects retain their current search-path behavior. This also adds unit and end-to-end regression coverage and documents the fallback heuristic.

Fixes #1486

# Test Plan

- `cargo test -p pyrefly_config`
- `cargo test`
- `scrut test test/find.md`
- `scrut test test` - 184/184 cases passed
- `python3 conformance/conformance_output.py conformance/third_party --executable target/debug/pyrefly`
- `python3 schemas/validate_schemas.py` - 56/56 passed
- `python3 test/sarif/validate_sarif.py` - 3/3 passed
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`

