### PR TITLE
Fixes lint warning about `match { ... }` where `matches!` would do

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -624,10 +624,7 @@ impl ErrorKind {
     /// this kind. Unused-ignore diagnostics are excluded because suppressing one
     /// would only leave behind another unused ignore.
     pub fn is_suppressable(self) -> bool {
-        match self {
-            ErrorKind::UnusedIgnore | ErrorKind::UnusedTypeIgnore => false,
-            _ => true,
-        }
+        !matches!(self, ErrorKind::UnusedIgnore | ErrorKind::UnusedTypeIgnore)
     }
 
     /// A soft error is a diagnostic that should not influence overload selection


### PR DESCRIPTION
# Summary

As title, fixes lint warning

# Test Plan

Format, build, and error_kind tests are clean