### PR TITLE
Fix broken website link.

### DIFF
--- a/website/docs/pants.mdx
+++ b/website/docs/pants.mdx
@@ -265,7 +265,7 @@ partly bridge the gap. For those packages, either suppress the errors, fold them
 into a baseline, or keep mypy enabled for just those packages during the
 transition.
 
-[Migrating from Mypy](./migrating-from-mypy.mdx) covers the checker-level
+[Migrating from Mypy](./migrate/mypy/index.mdx) covers the checker-level
 differences — command-line equivalents, suppression syntax, and behavioral
 divergences — independently of Pants.
 


### PR DESCRIPTION
# Summary

Our website build was broken due to a race condition between a change that added a link to the mypy migration docs and a change that moved them to a new location. This fixes the now-stale link.

# Test Plan

Website build is green on this branch.