### PR TITLE
fix assert callable narrows too much #911

### DIFF
--- a/crates/pyrefly_types/src/function.rs
+++ b/crates/pyrefly_types/src/function.rs
@@ -415,6 +415,7 @@ impl FuncSymbol {
 pub enum FunctionKind {
     IsInstance,
     IsSubclass,
+    Callable,
     /// The builtin `len`. Special-cased so that when the argument's `__len__`
     /// returns a subtype of `int` (e.g. a shaped array's `Int[N]`), `len(x)`
     /// yields that type instead of typeshed's plain `int`.
@@ -509,6 +510,7 @@ impl FunctionKind {
         match (qname.module_name().as_str(), qname.id().as_str()) {
             ("builtins", "isinstance") => Self::IsInstance,
             ("builtins", "issubclass") => Self::IsSubclass,
+            ("builtins", "callable") => Self::Callable,
             ("builtins", "len") => Self::Len,
             ("builtins", "classmethod") => Self::ClassMethod,
             ("dataclasses", "dataclass") => Self::Dataclass,
@@ -545,6 +547,7 @@ impl FunctionKind {
         match self {
             Self::IsInstance => ModuleName::builtins(),
             Self::IsSubclass => ModuleName::builtins(),
+            Self::Callable => ModuleName::builtins(),
             Self::Len => ModuleName::builtins(),
             Self::ClassMethod => ModuleName::builtins(),
             Self::Dataclass => ModuleName::dataclasses(),
@@ -585,6 +588,7 @@ impl FunctionKind {
         match self {
             Self::IsInstance => Cow::Owned(Name::new_static("isinstance")),
             Self::IsSubclass => Cow::Owned(Name::new_static("issubclass")),
+            Self::Callable => Cow::Owned(Name::new_static("callable")),
             Self::Len => Cow::Owned(Name::new_static("len")),
             Self::ClassMethod => Cow::Owned(Name::new_static("classmethod")),
             Self::Dataclass => Cow::Owned(Name::new_static("dataclass")),
@@ -625,6 +629,7 @@ impl FunctionKind {
         match self {
             Self::IsInstance => None,
             Self::IsSubclass => None,
+            Self::Callable => None,
             Self::Len => None,
             Self::ClassMethod => None,
             Self::Dataclass => None,

--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -1702,6 +1702,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             AtomicNarrowOp::NotTypeGuard(_, _) => ty.clone(),
             AtomicNarrowOp::TypeIs(t, arguments) => {
+                let is_builtin_callable =
+                    t.callee_kind() == Some(CalleeKind::Function(FunctionKind::Callable));
                 if let CallTargetLookup::Ok(call_target) = self.as_call_target(t.clone()) {
                     let args = arguments.args.map(CallArg::expr_maybe_starred);
                     let kws = arguments.keywords.map(CallKeyword::new);
@@ -1718,7 +1720,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                         None,
                     );
                     if let Type::TypeIs(t) = ret {
-                        return self.narrow_typeis(ty, &t, range, errors);
+                        let target = if is_builtin_callable {
+                            // `callable` proves callability but reveals nothing about the return type.
+                            self.heap.mk_callable_ellipsis(self.heap.mk_any_implicit())
+                        } else {
+                            *t
+                        };
+                        return self.narrow_typeis(ty, &target, range, errors);
                     }
                 }
                 ty.clone()

--- a/pyrefly/lib/test/callable.rs
+++ b/pyrefly/lib/test/callable.rs
@@ -1518,6 +1518,29 @@ def f(
 );
 
 testcase!(
+    test_builtins_callable_narrow_unknown,
+    r#"
+from typing import Any, Callable, TypeIs, assert_type
+
+def f(x):
+    assert callable(x)
+    assert_type(x, Callable[..., Any])
+    assert_type(x(), Any)
+
+def g(x: object):
+    assert callable(x)
+    assert_type(x, Callable[..., Any])
+
+def is_object_callable(x: object) -> TypeIs[Callable[..., object]]:
+    return callable(x)
+
+def h(x):
+    assert is_object_callable(x)
+    assert_type(x(), object)
+    "#,
+);
+
+testcase!(
     test_narrow_union,
     r#"
 from typing import Any, Callable, assert_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #911

callable(x) now narrows unknown values to `Callable[..., Any]`, while preserving known signatures.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test