### PR TITLE
Fix sticky unresolvable __all__ state

### DIFF
--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -798,7 +798,9 @@ impl DefinitionsBuilder {
                     && arguments.keywords.is_empty()
                     && !self.in_main_guard
                 {
-                    self.inner.dunder_all.kind = DunderAllKind::Specified;
+                    if !matches!(self.inner.dunder_all.kind, DunderAllKind::Unresolvable(_)) {
+                        self.inner.dunder_all.kind = DunderAllKind::Specified;
+                    }
                     match attr.as_str() {
                         "extend" => match DunderAllEntry::as_list(&arguments.args[0]) {
                             Some(mut entries) => {
@@ -1230,6 +1232,24 @@ __all__.remove('r')
             defs.dunder_all.entries.map(|x| x),
             vec![a, b, a, b, foo, a, b, foo, a, r]
         );
+    }
+
+    #[test]
+    fn test_all_unresolvable_is_sticky_across_mutations() {
+        let defs = calculate_unranged_definitions_with_defaults(
+            r#"
+__all__ = []
+for name in ["a"]:
+    __all__.append(name)
+__all__.append("a")
+__all__.extend(["b"])
+__all__.remove("a")
+        "#,
+        );
+        assert!(matches!(
+            defs.dunder_all.kind,
+            DunderAllKind::Unresolvable(_)
+        ));
     }
 
     #[test]

--- a/pyrefly/lib/test/imports.rs
+++ b/pyrefly/lib/test/imports.rs
@@ -1623,6 +1623,7 @@ y: str = "hello"
 _name = "x"
 __all__ = ["y"]
 __all__.append(_name)  # E: `__all__` could not be statically analyzed
+__all__.remove("y")
 "#,
     )
 }


### PR DESCRIPTION
# Summary

Fixes #4563

keep an unresolvable `__all__` state from being reset by later mutations and preserve `DunderAllKind::Unresolvable` across subsequent `append`, `extend`, and `remove` calls so star imports continue to use the fallback behavior.

# Test Plan

Added regression coverage for:

- keeping `DunderAllKind::Unresolvable` sticky across later `__all__` mutations
- preserving star-import fallback behavior after an unresolvable `append`

Ran:

```sh
cargo test test_all_unresolvable_is_sticky_across_mutations -- --nocapture
cargo test test_all_ -- --nocapture
cargo fmt --check
git diff --check
```