### PR TITLE
fix Django REST Framework: false positives on serializer declared fields (named like Field attrs) and inner Meta #3933

### DIFF
--- a/crates/pyrefly_python/src/module_name.rs
+++ b/crates/pyrefly_python/src/module_name.rs
@@ -309,6 +309,10 @@ impl ModuleName {
         Self::from_str("marshmallow.schema")
     }
 
+    pub fn rest_framework_fields() -> Self {
+        Self::from_str("rest_framework.fields")
+    }
+
     pub fn rest_framework_serializers() -> Self {
         Self::from_str("rest_framework.serializers")
     }

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -2969,6 +2969,38 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         } else {
             None
         };
+        if !inferred_from_method
+            && direct_annotation.is_none()
+            && self
+                .get_metadata_for_class(class)
+                .is_django_rest_framework_serializer()
+            && let ExprOrBinding::Expr(e) = value
+        {
+            let inferred_ty = self.attribute_expr_infer(e, None, name, &self.error_swallower());
+            let is_declared_field = match &inferred_ty {
+                Type::ClassType(field) => iter::once(field)
+                    .chain(
+                        self.get_mro_for_class(field.class_object())
+                            .ancestors_no_object(),
+                    )
+                    .any(|field| {
+                        field.class_object().has_toplevel_qname(
+                            ModuleName::rest_framework_fields().as_str(),
+                            "Field",
+                        )
+                    }),
+                _ => false,
+            };
+            if is_declared_field {
+                // SerializerMetaclass removes declared fields from the class namespace, so an
+                // inherited Field attribute with the same name is not being reassigned.
+                return (
+                    self.attribute_expr_infer(e, None, name, errors),
+                    None,
+                    IsInherited::No,
+                );
+            }
+        }
         // Otherwise, analyze the value to determine the type
         let (inherited_ty, inherited_annotation) =
             self.get_inherited_type_and_annotation(class, name);

--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -53,6 +53,7 @@ use crate::alt::types::class_metadata::ClassMro;
 use crate::alt::types::class_metadata::DataclassKind;
 use crate::alt::types::class_metadata::DataclassMetadata;
 use crate::alt::types::class_metadata::DjangoModelMetadata;
+use crate::alt::types::class_metadata::DjangoRestFrameworkSerializerKind;
 use crate::alt::types::class_metadata::EnumMetadata;
 use crate::alt::types::class_metadata::ExplicitSlots;
 use crate::alt::types::class_metadata::InitDefaults;
@@ -307,6 +308,27 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             None
         };
 
+        let mut django_rest_framework_serializer_kind = None;
+        for (base_class_object, metadata) in &bases_with_metadata {
+            if base_class_object.has_toplevel_qname(
+                ModuleName::rest_framework_serializers().as_str(),
+                "ModelSerializer",
+            ) || metadata.is_django_rest_framework_model_serializer()
+            {
+                django_rest_framework_serializer_kind =
+                    Some(DjangoRestFrameworkSerializerKind::ModelSerializer);
+                break;
+            }
+            if base_class_object.has_toplevel_qname(
+                ModuleName::rest_framework_serializers().as_str(),
+                "Serializer",
+            ) || metadata.is_django_rest_framework_serializer()
+            {
+                django_rest_framework_serializer_kind =
+                    Some(DjangoRestFrameworkSerializerKind::Serializer);
+            }
+        }
+
         // Check if this class inherits from marshmallow.Schema
         let is_marshmallow_schema =
             bases_with_metadata
@@ -324,16 +346,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     base_class_object
                         .has_toplevel_qname(ModuleName::factory_base().as_str(), "Factory")
                         || metadata.is_factory_boy_factory()
-                });
-
-        let is_django_rest_framework_model_serializer =
-            bases_with_metadata
-                .iter()
-                .any(|(base_class_object, metadata)| {
-                    base_class_object.has_toplevel_qname(
-                        ModuleName::rest_framework_serializers().as_str(),
-                        "ModelSerializer",
-                    ) || metadata.is_django_rest_framework_model_serializer()
                 });
 
         let is_metaclass = bases_with_metadata
@@ -574,9 +586,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             pydantic_model_kind,
             is_attrs_class,
             django_model_metadata,
+            django_rest_framework_serializer_kind,
             is_marshmallow_schema,
             is_factory_boy_factory,
-            is_django_rest_framework_model_serializer,
             is_metaclass,
             explicit_slots,
             capture_init.map(|names| names.to_vec()),

--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -67,6 +67,12 @@ pub enum ExplicitSlots {
     Known(SlotsInfo),
 }
 
+#[derive(Clone, Copy, Debug, TypeEq, PartialEq, Eq)]
+pub enum DjangoRestFrameworkSerializerKind {
+    Serializer,
+    ModelSerializer,
+}
+
 impl ExplicitSlots {
     pub fn has_explicit_slots(&self) -> bool {
         !matches!(self, Self::Absent)
@@ -111,9 +117,9 @@ pub struct ClassMetadata {
     pydantic_model_kind: Option<PydanticModelKind>,
     is_attrs_class: bool,
     django_model_metadata: Option<DjangoModelMetadata>,
+    django_rest_framework_serializer_kind: Option<DjangoRestFrameworkSerializerKind>,
     is_marshmallow_schema: bool,
     is_factory_boy_factory: bool,
-    is_django_rest_framework_model_serializer: bool,
     /// Whether this class is a metaclass (i.e., a subclass of `type`).
     is_metaclass: bool,
     explicit_slots: ExplicitSlots,
@@ -208,9 +214,9 @@ impl ClassMetadata {
         pydantic_model_kind: Option<PydanticModelKind>,
         is_attrs_class: bool,
         django_model_metadata: Option<DjangoModelMetadata>,
+        django_rest_framework_serializer_kind: Option<DjangoRestFrameworkSerializerKind>,
         is_marshmallow_schema: bool,
         is_factory_boy_factory: bool,
-        is_django_rest_framework_model_serializer: bool,
         is_metaclass: bool,
         explicit_slots: ExplicitSlots,
         capture_init: Option<Vec<Name>>,
@@ -238,9 +244,9 @@ impl ClassMetadata {
             pydantic_model_kind,
             is_attrs_class,
             django_model_metadata,
+            django_rest_framework_serializer_kind,
             is_marshmallow_schema,
             is_factory_boy_factory,
-            is_django_rest_framework_model_serializer,
             is_metaclass,
             explicit_slots,
             capture_init,
@@ -271,9 +277,9 @@ impl ClassMetadata {
             pydantic_model_kind: None,
             is_attrs_class: false,
             django_model_metadata: None,
+            django_rest_framework_serializer_kind: None,
             is_marshmallow_schema: false,
             is_factory_boy_factory: false,
-            is_django_rest_framework_model_serializer: false,
             is_metaclass: false,
             explicit_slots: ExplicitSlots::Absent,
             capture_init: None,
@@ -310,6 +316,10 @@ impl ClassMetadata {
         self.django_model_metadata.is_some()
     }
 
+    pub fn is_django_rest_framework_serializer(&self) -> bool {
+        self.django_rest_framework_serializer_kind.is_some()
+    }
+
     pub fn is_marshmallow_schema(&self) -> bool {
         self.is_marshmallow_schema
     }
@@ -319,7 +329,8 @@ impl ClassMetadata {
     }
 
     pub fn is_django_rest_framework_model_serializer(&self) -> bool {
-        self.is_django_rest_framework_model_serializer
+        self.django_rest_framework_serializer_kind
+            == Some(DjangoRestFrameworkSerializerKind::ModelSerializer)
     }
 
     /// Whether this class is a metaclass (i.e., a subclass of `type`).

--- a/pyrefly/lib/test/django/model_serializer.rs
+++ b/pyrefly/lib/test/django/model_serializer.rs
@@ -25,5 +25,45 @@ class GenericSerializer(serializers.ModelSerializer[MyModel]):
     class Meta:
         model = MyModel
         fields = ["name"]
+
+class ChildSerializer(MySerializer):
+    class Meta:
+        fields = "__all__"
+"#,
+);
+
+django_testcase!(
+    test_declared_fields,
+    r#"
+from rest_framework import serializers
+
+class FieldNameSerializer(serializers.Serializer):
+    label = serializers.CharField()
+    source = serializers.CharField()
+    context = serializers.CharField()
+    data = serializers.CharField()
+
+class NestedSerializer(serializers.Serializer):
+    child = FieldNameSerializer()
+"#,
+);
+
+django_testcase!(
+    test_declared_field_suppression_is_scoped,
+    r#"
+from rest_framework import serializers
+
+class BadSerializer(serializers.Serializer):
+    label = 42  # E: `Literal[42]` is not assignable to attribute `label`
+
+class NotSerializer(serializers.CharField):
+    label = serializers.CharField()  # E: `CharField` is not assignable to attribute `label`
+
+class ParentSerializer(serializers.Serializer):
+    class Meta: ...
+
+class ChildSerializer(ParentSerializer):
+    class Meta:  # E: overrides parent class `ParentSerializer` in an inconsistent manner
+        ...
 "#,
 );

--- a/pyrefly/lib/test/django/third-party/rest_framework-stubs/fields.pyi
+++ b/pyrefly/lib/test/django/third-party/rest_framework-stubs/fields.pyi
@@ -1,0 +1,7 @@
+class Field:
+    label: str | None
+    source: str | None
+    context: dict[str, object]
+    data: object
+
+class CharField(Field): ...

--- a/pyrefly/lib/test/django/third-party/rest_framework-stubs/serializers.pyi
+++ b/pyrefly/lib/test/django/third-party/rest_framework-stubs/serializers.pyi
@@ -2,10 +2,11 @@ from collections.abc import Sequence
 from typing import ClassVar, Generic, Literal, TypeVar
 
 from django.db.models import Model
+from rest_framework.fields import CharField as CharField, Field as Field
 
 _MT = TypeVar("_MT", bound=Model)
 
-class Serializer(Generic[_MT]): ...
+class Serializer(Field, Generic[_MT]): ...
 
 class ModelSerializer(Serializer[_MT]):
     class Meta:


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3933

DRF Serializer subclasses now recognize metaclass-consumed Field declarations, avoiding inherited-attribute false positives.

Nested Meta classes on serializers no longer trigger bad-override.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test