### PR TITLE
Guard against recursive protocol member checking in __getattr__ self validation

### DIFF
--- a/pyrefly/lib/alt/answers_solver.rs
+++ b/pyrefly/lib/alt/answers_solver.rs
@@ -32,6 +32,7 @@ use pyrefly_graph::calculation::ProposalResult;
 use pyrefly_graph::index::Idx;
 use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::module_path::ModulePath;
+use pyrefly_types::class::ClassType;
 use pyrefly_types::heap::TypeHeap;
 use pyrefly_types::quantified::AnchorIndex;
 use pyrefly_types::quantified::Quantified;
@@ -1769,6 +1770,13 @@ pub struct ThreadState {
     /// check is currently in progress, used as a coinductive guard against
     /// self-referential protocols. See `filter_overloads_by_self_type`.
     overload_self_filter_stack: RefCell<FxHashSet<(Type, Type)>>,
+    /// `(got_type, protocol_class_type, attr_name)` tuples whose protocol-member check is
+    /// currently in progress, used as a coinductive guard against recursive protocol checks
+    /// (e.g. `__getattr__` annotated with a protocol).
+    protocol_member_guard_stack: RefCell<FxHashSet<(Type, ClassType, Name)>>,
+    /// Tracks whether any coinductive assumption was used during solving
+    /// (e.g. recursive protocol member resolution via dynamic fallback).
+    coinductive_assumptions_used: Cell<bool>,
 }
 
 impl ThreadState {
@@ -1782,6 +1790,8 @@ impl ThreadState {
             trace_sink: RefCell::new(None),
             trace_sink_stack: RefCell::new(Vec::new()),
             overload_self_filter_stack: RefCell::new(FxHashSet::default()),
+            protocol_member_guard_stack: RefCell::new(FxHashSet::default()),
+            coinductive_assumptions_used: Cell::new(false),
         }
     }
 
@@ -2228,6 +2238,35 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .overload_self_filter_stack
             .borrow_mut()
             .remove(key);
+    }
+
+    /// Mark a protocol member check `(got, protocol_class_type, attr_name)` as in progress.
+    /// Returns `true` if it was already active, signaling a coinductive cycle.
+    pub(crate) fn enter_protocol_member_check(&self, key: (Type, ClassType, Name)) -> bool {
+        let is_cycle = !self
+            .thread_state
+            .protocol_member_guard_stack
+            .borrow_mut()
+            .insert(key);
+        if is_cycle {
+            self.thread_state.coinductive_assumptions_used.set(true);
+        }
+        is_cycle
+    }
+
+    pub(crate) fn exit_protocol_member_check(&self, key: &(Type, ClassType, Name)) {
+        self.thread_state
+            .protocol_member_guard_stack
+            .borrow_mut()
+            .remove(key);
+    }
+
+    pub(crate) fn coinductive_assumptions_used(&self) -> bool {
+        self.thread_state.coinductive_assumptions_used.get()
+    }
+
+    pub(crate) fn set_coinductive_assumptions_used(&self, value: bool) {
+        self.thread_state.coinductive_assumptions_used.set(value);
     }
 
     /// Given the target idx of a ForwardToFirstUse binding, find the NameAssign's

--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -1430,14 +1430,22 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             attr_name.clone(),
                         ));
                     }
-                    // Filter overloaded got-side methods by self-type so the subset
-                    // solver doesn't match an overload whose `self:` is incompatible
-                    // with the receiver.
-                    let filtered = self.filter_got_overloads_for_protocol(got_attr);
-                    let got_attr = filtered.as_ref().unwrap_or(got_attr);
-                    self.is_attribute_subset(got_attr, &want, &mut |got, want| {
-                        is_subset(got, want)
-                    })
+                    if matches!(got_attr, Attribute::GetAttr(..)) {
+                        let guard_key = (got.clone(), protocol.clone(), attr_name.clone());
+                        if self.enter_protocol_member_check(guard_key.clone()) {
+                            continue;
+                        }
+                        let res = self.is_attribute_subset(got_attr, &want, is_subset);
+                        self.exit_protocol_member_check(&guard_key);
+                        res
+                    } else {
+                        // Filter overloaded got-side methods by self-type so the subset
+                        // solver doesn't match an overload whose `self:` is incompatible
+                        // with the receiver.
+                        let filtered = self.filter_got_overloads_for_protocol(got_attr);
+                        let got_attr = filtered.as_ref().unwrap_or(got_attr);
+                        self.is_attribute_subset(got_attr, &want, is_subset)
+                    }
                     .map_err(|err| {
                         SubsetError::IncompatibleAttribute(Box::new((
                             protocol.name().clone(),

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -677,8 +677,10 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
 
         // Save coinductive state so we can detect if any coinductive assumptions
         // were used during this protocol check.
-        let prev_coinductive = self.coinductive_assumptions_used;
+        let prev_coinductive =
+            self.coinductive_assumptions_used || self.type_order.coinductive_assumptions_used();
         self.coinductive_assumptions_used = false;
+        self.type_order.set_coinductive_assumptions_used(false);
 
         // For class-level coinductive reasoning: if the `got` type's type arguments
         // contain Vars, we're likely in a recursive pattern (e.g., checking method return
@@ -713,7 +715,8 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
         // 2. No coinductive assumptions were used during this check
         //    (otherwise the result may be contingent on an assumption
         //    that could be invalidated by rollback)
-        let used_coinductive = self.coinductive_assumptions_used;
+        let used_coinductive =
+            self.coinductive_assumptions_used || self.type_order.coinductive_assumptions_used();
         if has_no_vars && !used_coinductive {
             self.solver
                 .store_protocol_cache(&got, &want, &res, self.type_order);
@@ -721,6 +724,8 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
 
         // Restore: propagate any coinductive usage upward
         self.coinductive_assumptions_used = prev_coinductive || used_coinductive;
+        self.type_order
+            .set_coinductive_assumptions_used(prev_coinductive || used_coinductive);
 
         res
     }
@@ -1254,15 +1259,20 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
         // Save coinductive state so we can detect if any coinductive assumptions
         // were used during field comparisons (e.g., a field with a protocol type
         // that recursively references this TypedDict).
-        let prev_coinductive = self.coinductive_assumptions_used;
+        let prev_coinductive =
+            self.coinductive_assumptions_used || self.type_order.coinductive_assumptions_used();
         self.coinductive_assumptions_used = false;
+        self.type_order.set_coinductive_assumptions_used(false);
         let res = self.is_subset_typed_dict_inner(got, want);
-        let used_coinductive = self.coinductive_assumptions_used;
+        let used_coinductive =
+            self.coinductive_assumptions_used || self.type_order.coinductive_assumptions_used();
         if cacheable && !used_coinductive {
             self.solver
                 .store_typed_dict_cache(got, want, &res, self.type_order);
         }
         self.coinductive_assumptions_used = prev_coinductive || used_coinductive;
+        self.type_order
+            .set_coinductive_assumptions_used(prev_coinductive || used_coinductive);
         res
     }
 

--- a/pyrefly/lib/solver/type_order.rs
+++ b/pyrefly/lib/solver/type_order.rs
@@ -130,6 +130,14 @@ impl<'solver, Ans: LookupAnswer> TypeOrder<'solver, Ans> {
             .is_protocol_subset_at_attr(got, protocol, name, is_subset)
     }
 
+    pub fn coinductive_assumptions_used(self) -> bool {
+        self.0.coinductive_assumptions_used()
+    }
+
+    pub fn set_coinductive_assumptions_used(self, value: bool) {
+        self.0.set_coinductive_assumptions_used(value)
+    }
+
     pub fn as_tuple_type(self, cls: &ClassType) -> Option<Type> {
         self.0.as_tuple(cls).map(Type::Tuple)
     }

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -3148,3 +3148,39 @@ del f.real_method.test  # E: has no attribute `test`
 name: str = f.real_method.__name__
 "#,
 );
+
+testcase!(
+    test_getattr_self_awaitable_recursion,
+    r#"
+from collections.abc import Awaitable
+
+class C:
+    def __getattr__(self: Awaitable, name: str):
+        pass
+
+C().a  # E: Argument `C` is not assignable to parameter `self` with type `Awaitable[Unknown]` in function `C.__getattr__`
+"#,
+);
+
+testcase!(
+    test_getattr_self_protocol_generic_cache_order,
+    r#"
+from typing import Protocol, TypeVar
+
+T = TypeVar("T", covariant=True)
+
+class P(Protocol[T]):
+    @property
+    def x(self) -> T: ...
+
+class C:
+    def __getattr__(self: "P[str]", name: str) -> int:
+        return 0
+
+def f_int(x: P[int]) -> None: ...
+def f_str(x: P[str]) -> None: ...
+
+f_int(C())
+f_str(C())  # E: Argument `C` is not assignable to parameter `x` with type `P[str]` in function `f_str`
+"#,
+);


### PR DESCRIPTION
## Summary

Fixes #4632

### Why
When accessing an attribute on a class instance where the attribute does not exist statically, Pyrefly invokes `__getattr__` / `__getattribute__` fallback resolution. When `__getattr__` has a protocol-annotated `self` parameter (e.g. `def __getattr__(self: Awaitable): ...`), Pyrefly validates receiver compatibility via structural protocol subtyping (`C <: Awaitable`).

During structural protocol subtyping, Pyrefly checks whether `C` provides each member of `Awaitable` (such as `__await__`). Because `C` does not statically define `__await__`, looking up `__await__` on `C` invokes `C.__getattr__` again, triggering another receiver self validation against `Awaitable`.

Because each fallback invocation initiates a new subset query across query boundaries, local cycle detection in `Subset` alone does not observe the outer in-progress protocol-member check. This leads to unbounded recursion and a stack overflow abort.

### What
- Added `protocol_member_guard_stack: RefCell<FxHashSet<(Type, Class, Name)>>` to `ThreadState` in `answers_solver.rs`, following the existing coinductive pattern used by `overload_self_filter_stack`.
- Added `enter_protocol_member_check` and `exit_protocol_member_check` helpers to `AnswersSolver`.
- Wrapped `is_protocol_subset_at_attr` in `attr.rs` with the coinductive guard keyed by `(got_type, protocol_class, attr_name)`.
- Added a regression test `test_getattr_self_awaitable_recursion` in `attributes.rs`.

### Why it works
The guard tracks active `(got_type, protocol_class, member_name)` checks across nested subset queries on the current thread. When the exact same check is re-entered during nested attribute resolution, Pyrefly recognizes the cycle and terminates the check coinductively (`Ok(())`), preventing unbounded recursion while preserving standard protocol and receiver validation semantics on all non-cyclic paths.

## Test Plan
- `cargo test test_getattr_self_awaitable_recursion` passes (reproducer no longer overflows the stack and reports the expected diagnostics).
- `cargo test attributes` (242 tests) passes.
- `cargo test protocol` (172 tests) passes.
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema` passes formatting and linting.
- `git diff --check` passes.
