### PR TITLE
Preserve fixed tuple types for reverse slices

### DIFF
--- a/pyrefly/lib/alt/subscript.rs
+++ b/pyrefly/lib/alt/subscript.rs
@@ -86,10 +86,23 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         slice: &ExprSlice,
         slice_ty: Option<&Type>,
     ) -> Option<Type> {
+        let slice_targs = slice_ty.and_then(Self::slice_type_args);
         if slice.step.is_some() {
+            let step = self
+                .parse_slice_literal(&slice.step, slice_targs.map(|[_, _, step]| step))
+                .ok()?;
+            if step == Some(-1)
+                && slice.lower.is_none()
+                && slice.upper.is_none()
+                && let Tuple::Concrete(elts) = tuple
+            {
+                return Some(
+                    self.heap
+                        .mk_concrete_tuple(elts.iter().rev().cloned().collect()),
+                );
+            }
             return None;
         }
-        let slice_targs = slice_ty.and_then(Self::slice_type_args);
         match tuple {
             Tuple::Concrete(elts) => {
                 self.infer_concrete_slice(elts, &slice.lower, &slice.upper, slice_targs)

--- a/pyrefly/lib/test/tuple.rs
+++ b/pyrefly/lib/test/tuple.rs
@@ -623,6 +623,16 @@ def test(x: tuple[int, str, bool]) -> None:
 );
 
 testcase!(
+    test_tuple_reverse_slice,
+    r#"
+from typing import assert_type
+
+def test(x: tuple[int, str, bool]) -> None:
+    assert_type(x[::-1], tuple[bool, str, int])
+"#,
+);
+
+testcase!(
     test_slice_union_step_reported_once,
     r#"
 def test(xs: list[int] | tuple[int, ...]) -> None:


### PR DESCRIPTION
## Summary

- preserve the arity and positional element types of concrete tuples for full `[::-1]` slices
- retain the existing fallback for other stepped slices and tuples with unknown structure
- add a regression test using a heterogeneous fixed-length tuple

Fixes #4636.

## Test plan

- `cargo test test_tuple_reverse_slice`
- `cargo test test::tuple::` (81 passed)
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`
- original CLI reproduction on the patched binary (`0 errors`)

The lint command completes successfully with two pre-existing Clippy warnings in unchanged files.

## AI usage

This PR was implemented with Codex assistance. I reviewed the issue reproduction, implementation, regression test, and final diff, and ran the validation listed above.