### PR TITLE
Scope the Require::Everything escalation to the requests that read ASTs, and add the #3636 regression test

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/call_hierarchy.rs
+++ b/pyrefly/lib/lsp/non_wasm/call_hierarchy.rs
@@ -436,13 +436,7 @@ impl CancellableTransaction<'_> {
             let mut callers_in_file = Vec::new();
 
             ast.visit(&mut |expr| {
-                collect_calls_from_expr(
-                    expr,
-                    &ref_set,
-                    handle.module(),
-                    &ast,
-                    &mut callers_in_file,
-                )
+                collect_calls_from_expr(expr, &ref_set, handle.module(), &ast, &mut callers_in_file)
             });
 
             if !callers_in_file.is_empty() {

--- a/pyrefly/lib/lsp/non_wasm/call_hierarchy.rs
+++ b/pyrefly/lib/lsp/non_wasm/call_hierarchy.rs
@@ -40,6 +40,7 @@ use crate::lsp::non_wasm::module_helpers::module_info_to_uri;
 use crate::state::lsp::DefinitionMetadata;
 use crate::state::lsp::FindPreference;
 use crate::state::lsp::ReferenceOptions;
+use crate::state::require::Require;
 use crate::state::state::CancellableTransaction;
 
 pub struct CallerInfo {
@@ -353,14 +354,13 @@ impl CancellableTransaction<'_> {
         definition_kind: DefinitionMetadata,
         target_definition: &TextRangeWithModule,
     ) -> Result<Vec<(Module, Vec<CallerInfo>)>, Cancelled> {
-        // Use process_rdeps_with_definition to find references and filter to call sites in a single pass
-        let results = self.process_rdeps_with_definition(
+        // Pass 1: work out which files reference the target at all. This is answered from
+        // the index, which every rdep carries at `Require::Indexing`, so a file that never
+        // mentions the target costs nothing beyond the lookup.
+        let files_with_refs = self.process_rdeps_with_definition(
             sys_info,
             target_definition,
             |transaction, handle, patched_definition| {
-                let module_info = transaction.as_ref().get_module_info(handle)?;
-                let ast = transaction.as_ref().get_ast(handle)?;
-
                 let references = transaction
                     .as_ref()
                     .local_references_from_definition(
@@ -373,62 +373,82 @@ impl CancellableTransaction<'_> {
                     .unwrap_or_default();
 
                 if references.is_empty() {
-                    return None;
-                }
-
-                let ref_set: std::collections::HashSet<TextRange> =
-                    references.into_iter().collect();
-
-                let mut callers_in_file = Vec::new();
-
-                fn collect_calls_from_expr(
-                    expr: &Expr,
-                    ref_set: &std::collections::HashSet<TextRange>,
-                    module_name: ModuleName,
-                    ast: &ModModule,
-                    callers: &mut Vec<CallerInfo>,
-                ) {
-                    if let Expr::Call(call) = expr
-                        && ref_set
-                            .iter()
-                            .any(|ref_range| call.func.range().contains(ref_range.start()))
-                    {
-                        let (name, full_range, name_range, kind) =
-                            find_containing_function_for_call(
-                                module_name,
-                                ast,
-                                call.range().start(),
-                            );
-                        callers.push(CallerInfo {
-                            call_range: call.range(),
-                            name,
-                            full_range,
-                            name_range,
-                            kind,
-                        });
-                    }
-                    expr.recurse(&mut |child| {
-                        collect_calls_from_expr(child, ref_set, module_name, ast, callers)
-                    });
-                }
-
-                ast.visit(&mut |expr| {
-                    collect_calls_from_expr(
-                        expr,
-                        &ref_set,
-                        handle.module(),
-                        &ast,
-                        &mut callers_in_file,
-                    )
-                });
-
-                if callers_in_file.is_empty() {
                     None
                 } else {
-                    Some((module_info, callers_in_file))
+                    Some((handle.dupe(), references))
                 }
             },
         )?;
+
+        // Attributing a call site to its enclosing function needs the AST, and the AST is
+        // only retained at `Require::Everything`. A file the client never opened is held at
+        // `Require::Indexing`, so its AST is absent and its call sites were previously
+        // dropped without a trace. Pull up exactly the files that do reference the target,
+        // and do it in one run: escalating them individually from inside the walk above
+        // leaves every file after the first still missing its AST.
+        let handles_needing_ast = files_with_refs
+            .iter()
+            .filter(|(handle, _)| self.as_ref().get_ast(handle).is_none())
+            .map(|(handle, _)| handle.dupe())
+            .collect::<Vec<_>>();
+        if !handles_needing_ast.is_empty() {
+            self.run(&handles_needing_ast, Require::Everything, None)?;
+        }
+
+        fn collect_calls_from_expr(
+            expr: &Expr,
+            ref_set: &std::collections::HashSet<TextRange>,
+            module_name: ModuleName,
+            ast: &ModModule,
+            callers: &mut Vec<CallerInfo>,
+        ) {
+            if let Expr::Call(call) = expr
+                && ref_set
+                    .iter()
+                    .any(|ref_range| call.func.range().contains(ref_range.start()))
+            {
+                let (name, full_range, name_range, kind) =
+                    find_containing_function_for_call(module_name, ast, call.range().start());
+                callers.push(CallerInfo {
+                    call_range: call.range(),
+                    name,
+                    full_range,
+                    name_range,
+                    kind,
+                });
+            }
+            expr.recurse(&mut |child| {
+                collect_calls_from_expr(child, ref_set, module_name, ast, callers)
+            });
+        }
+
+        // Pass 2: attribute each call site to the function that contains it.
+        let mut results = Vec::new();
+        for (handle, references) in files_with_refs {
+            let (Some(module_info), Some(ast)) = (
+                self.as_ref().get_module_info(&handle),
+                self.as_ref().get_ast(&handle),
+            ) else {
+                continue;
+            };
+
+            let ref_set: std::collections::HashSet<TextRange> = references.into_iter().collect();
+            let mut callers_in_file = Vec::new();
+
+            ast.visit(&mut |expr| {
+                collect_calls_from_expr(
+                    expr,
+                    &ref_set,
+                    handle.module(),
+                    &ast,
+                    &mut callers_in_file,
+                )
+            });
+
+            if !callers_in_file.is_empty() {
+                results.push((module_info, callers_in_file));
+            }
+        }
 
         Ok(results)
     }

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -6280,6 +6280,15 @@ impl Server {
                 handles.push(candidate);
             }
         }
+        // `type_hierarchy_subtype_items` reads each candidate's AST, solutions and bindings and
+        // silently `continue`s past any candidate missing them, so it needs `Require::Everything`.
+        // Escalate here rather than in `compute_transitive_rdeps_for_definition_impl`: this keeps
+        // type hierarchy's behaviour exactly as it is today while letting `textDocument/references`
+        // and `find_global_implementations_from_definition`, both answered entirely from the index,
+        // stop paying for ASTs they never read.
+        if !handles.is_empty() {
+            transaction.run(&handles, Require::Everything, None)?;
+        }
         Ok(handles)
     }
 

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -5007,7 +5007,9 @@ fn compute_transitive_rdeps_for_definition_impl<T: RdepTransaction>(
                 definition.module.path().dupe(),
                 sys_info,
             );
-            transaction.transitive_rdeps(definition_handle.dupe())
+            let rdeps = transaction.transitive_rdeps(definition_handle.dupe());
+            transaction.run_for_handles(&[definition_handle], Require::Everything)?;
+            rdeps
         }
     };
     for fs_counterpart_of_in_memory_handles in transitive_rdeps
@@ -5028,8 +5030,6 @@ fn compute_transitive_rdeps_for_definition_impl<T: RdepTransaction>(
         .into_iter()
         .sorted_by_key(|h| h.path().dupe())
         .collect();
-
-    transaction.run_for_handles(&candidate_handles, Require::Everything)?;
 
     Ok(candidate_handles)
 }

--- a/pyrefly/lib/test/lsp/lsp_interaction/call_hierarchy.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/call_hierarchy.rs
@@ -12,10 +12,13 @@ use lsp_types::notification::DidOpenTextDocument;
 use lsp_types::request::CallHierarchyIncomingCalls;
 use lsp_types::request::CallHierarchyOutgoingCalls;
 use lsp_types::request::CallHierarchyPrepare;
+use pyrefly_lsp_test::IndexingMode;
+use pyrefly_lsp_test::LspArgs;
 use pyrefly_lsp_test::Message;
 use pyrefly_lsp_test::Request;
 use pyrefly_lsp_test::object_model::InitializeSettings;
 use pyrefly_lsp_test::object_model::LspInteraction;
+use pyrefly_lsp_test::object_model::LspInteractionArgs;
 use serde_json::json;
 
 use crate::test::lsp::lsp_interaction::util::get_test_files_root;
@@ -240,6 +243,80 @@ fn test_incoming_call_hierarchy_basic() {
             } else {
                 panic!("Expected Some(incoming_calls), got None");
             }
+        })
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+/// Regression test for #3636: incoming calls must be found in files the client never
+/// opened. `test_incoming_call_hierarchy_basic` opens both files, so it cannot catch
+/// this — only `callee.py` is opened here, and `caller.py` is reached through the index.
+#[test]
+fn test_incoming_call_hierarchy_unopened_caller_file() {
+    let root = get_test_files_root();
+    let root_path = root.path().join("call_hierarchy_test");
+    let scope_uri = Url::from_file_path(&root_path).unwrap();
+    let mut interaction = LspInteraction::new_with_args(LspInteractionArgs {
+        args: LspArgs {
+            indexing_mode: IndexingMode::LazyBlocking,
+            ..LspInteractionArgs::default().args
+        },
+        ..Default::default()
+    });
+    interaction.set_root(root_path.clone());
+    interaction
+        .initialize(InitializeSettings {
+            workspace_folders: Some(vec![("test".to_owned(), scope_uri)]),
+            configuration: Some(None),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let callee_file = root_path.join("callee.py");
+
+    // Deliberately open ONLY the callee. caller.py stays closed, so it is held at
+    // `Require::Indexing` and has no AST until the call hierarchy asks for one.
+    interaction.client.did_open("callee.py");
+
+    let callee_uri = Url::from_file_path(&callee_file).unwrap();
+    let call_hierarchy_item = json!({
+        "name": "my_function",
+        "kind": SymbolKind::FUNCTION,
+        "uri": callee_uri.to_string(),
+        "range": {
+            "start": {"line": 6, "character": 0},
+            "end": {"line": 8, "character": 13}
+        },
+        "selectionRange": {
+            "start": {"line": 6, "character": 4},
+            "end": {"line": 6, "character": 15}
+        }
+    });
+
+    interaction
+        .client
+        .send_request::<CallHierarchyIncomingCalls>(json!({
+            "item": call_hierarchy_item
+        }))
+        .expect_response_with(|result| {
+            let incoming_calls =
+                result.expect("Expected Some(incoming_calls) for an unopened caller file");
+            let caller_names: Vec<String> = incoming_calls
+                .iter()
+                .map(|call| call.from.name.clone())
+                .collect();
+
+            for expected in ["caller_one", "caller_two", "method_caller"] {
+                assert!(
+                    caller_names.contains(&expected.to_owned()),
+                    "Expected to find {} in an unopened file, got: {:?}",
+                    expected,
+                    caller_names
+                );
+            }
+
+            true
         })
         .unwrap();
 


### PR DESCRIPTION
Follow-up to #3637 (landed as `3c288a2`), measured against `origin/main` @ `8ec5070d2`.

Two things: the regression test #3636 still lacks, and a narrowing of where the
`Require::Everything` escalation is paid.

## 1. The regression test

`3c288a2` is correct — I verified `test_incoming_call_hierarchy_unopened_caller_file` passes
against unmodified `main`. But it landed as 4 additions / 3 deletions in one file with no test,
so nothing holds the behaviour. `test_incoming_call_hierarchy_basic` opens *both* files, so it
cannot catch #3636.

The new test opens only `callee.py` and runs with `IndexingMode::LazyBlocking`, so `caller.py`
is reached through the index. Verified to fail against the code as it stood before `3c288a2`.

@d34db3ff — this is the test we discussed on #3637; the PR merged before I could add it there.

## 2. Who pays for the escalation

`3c288a2` moved the escalation into `compute_transitive_rdeps_for_definition_impl`, which is
shared by four features. Only two of them ever read an AST:

| consumer | reads an AST? |
| --- | --- |
| `callHierarchy/incomingCalls` | **yes** — `get_ast`, to attribute a call site to its enclosing function |
| `typeHierarchy` subtypes | **yes** — `get_ast` + `get_solutions` + `get_bindings` |
| `textDocument/references` | no — `local_references_from_definition` and `find_child_implementations_impl` are both index-backed |
| `find_global_implementations_from_definition` | no — `solutions_index` only |

So `references`, much the hottest of the four, now runs a full check over every transitive rdep
of the definition's module and retains their ASTs for data it never reads.

This PR moves the escalation to the two consumers that need it:

- **call hierarchy** asks the index which rdeps actually reference the target, then escalates
  only those. A file that never mentions the target costs nothing beyond the lookup. Ordering
  matters: the pre-`3c288a2` code fetched the AST *before* checking for references. The
  escalation is batched into one `run` — doing it per file from inside the walk leaves every
  file after the first still without an AST.
- **type hierarchy** escalates its own deduped candidates, so its behaviour is exactly what
  `main` does today.

`references` and `implementations` stop paying entirely.

## Measurements

This answers the perf question @yangdanny97 raised on #3637 in June.

Release builds, a 209-file Python project (the same one I profiled on #3637, since grown from
189), LSP driven programmatically opening only the file it queries. **A fresh server per cold rep**, median of 3; the timed request is the first one that
server receives. RSS delta is sampled immediately before and after that single request, so it is
what the request itself retained. Result counts in parentheses are ground truth and were
identical on both builds. The three positions are the same ones I profiled on #3637.

| | refs (82) | refs (36) | `incomingCalls` (32) |
| --- | --- | --- | --- |
| `main` @ `8ec5070d2` — cold | 65.4 ms | 31.5 ms | 31.6 ms |
| this PR — cold | **3.4 ms** | **1.9 ms** | **26.8 ms** |
| `main` — RSS retained by the one request | 81 MB | 15 MB | 16 MB |
| this PR — RSS retained | **2 MB** | **1 MB** | **7 MB** |
| `main` — server peak RSS | 396 MB | 329 MB | 316 MB |
| this PR — server peak RSS | **281 MB** | **281 MB** | **291 MB** |

The whole table was run twice on a quiet machine; every figure reproduced within 1%
(e.g. refs (82) cold 65.4 / 65.5 ms on `main`, 3.4 / 3.4 ms here).

A note on methodology, because it changes the answer: the profile I posted on #3637 used a
**median of 5 warm reps**. Escalation to `Require::Everything` is a one-time state transition
that the transaction retains, so reps 2..5 measure the already-escalated steady state and a warm
median structurally hides the cost being argued about. That profile was not evidence that the
escalation is cheap. Hence the fresh-server-per-rep harness here.

## Test suite

`cargo test --lib --no-fail-fast` on this branch: **8,093 passed / 0 failed / 4 ignored** in the
`pyrefly` crate, 8,828 passed and 0 failed across all 13 test binaries. The 4 ignored are
pre-existing. Result counts from the probes above were identical to `main` on every case
(82 / 36 / 32), so this is a cost change, not a behaviour change.

## What this does not do

Nothing tests the *cost* property. If the escalation is re-broadened later, the tests stay green
and only the numbers change. I did not find a good way to assert it at this layer; suggestions
welcome.
