### PR TITLE
Improve LSP path override behavior for windows, homedir paths, and relative paths not starting with `.[.]/`

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -144,7 +144,7 @@
                 "pyrefly.lspPath": {
                     "type": "string",
                     "default": "",
-                    "description": "The path to the binary (or the binary available in your $PATH) used as the language server. This is useful to guarantee version parity between your IDE and CLI, but means extension updates won't update which Pyrefly version you'll be using.",
+                    "description": "The command to run for the language server. Accepts an absolute path, a path relative to your workspace root, a path starting with ~, or a bare command name to look up on your $PATH. This is useful to guarantee version parity between your IDE and CLI, but means extension updates won't update which Pyrefly version you'll be using.",
                     "scope": "machine-overridable"
                 },
                 "pyrefly.lspArguments": {

--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -10,7 +10,8 @@
 import {ExtensionContext, workspace} from 'vscode';
 import * as vscode from 'vscode';
 import {execFile} from 'child_process';
-import {basename, dirname} from 'path';
+import {basename, dirname, join, parse, resolve} from 'path';
+import {homedir} from 'os';
 import {
   CancellationToken,
   ConfigurationItem,
@@ -88,12 +89,23 @@ async function overridePythonPath(
   return newResult;
 }
 
-function resolveLspPath(lspPath: string, cwd: vscode.Uri | undefined) {
-  let lspPathIsRelative = lspPath.startsWith("./") || lspPath.startsWith("../");
-  if (cwd != null && lspPathIsRelative) {
-    return vscode.Uri.joinPath(cwd, lspPath).fsPath;
+/**
+ * Resolve a `pyrefly.lspPath`, expanding ~ and handling relative paths.
+ *
+ * We tell a `$PATH` lookup apart from a relative or absolute by checking
+ * for a path separator.
+ */
+export function resolveLspPath(
+  lspPath: string,
+  cwd: vscode.Uri | undefined,
+): string {
+  if (lspPath.startsWith('~/') || lspPath.startsWith('~\\')) {
+    return join(homedir(), lspPath.slice(1));
   }
-  return lspPath;
+  if (cwd == null || parse(lspPath).dir === '') {
+    return lspPath;
+  }
+  return resolve(cwd.fsPath, lspPath);
 }
 
 export async function activate(context: ExtensionContext) {

--- a/lsp/src/test/extension.test.ts
+++ b/lsp/src/test/extension.test.ts
@@ -7,9 +7,10 @@
 
 import * as assert from 'assert';
 import {promises as fs} from 'fs';
-import {tmpdir} from 'os';
-import {join} from 'path';
+import {homedir, tmpdir} from 'os';
+import {dirname, join} from 'path';
 import * as vscode from 'vscode';
+import {resolveLspPath} from '../extension';
 
 suite('Extension Test Suite', () => {
 	const extension: vscode.Extension<unknown> | undefined = vscode.extensions.getExtension('meta.pyrefly');
@@ -46,5 +47,61 @@ suite('Extension Test Suite', () => {
 			await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
 			await fs.rm(directory, {recursive: true, force: true});
 		}
+	});
+});
+
+suite('resolveLspPath', () => {
+	const workspace = vscode.Uri.file(join(tmpdir(), 'pyrefly-workspace'));
+
+	test('don\'t touch default', () => {
+		assert.strictEqual(resolveLspPath('', workspace), '');
+	});
+
+	test('keep $PATH lookup untouched', () => {
+		assert.strictEqual(resolveLspPath('pyrefly', workspace), 'pyrefly');
+	});
+
+	test('leave an absolute path alone', () => {
+		const absolute = join(workspace.fsPath, 'pyrefly');
+		assert.strictEqual(resolveLspPath(absolute, workspace), absolute);
+	});
+
+	test('resolve relative paths against workspace root', () => {
+		for (const relative of ['./bin/pyrefly', 'target/debug/pyrefly']) {
+			assert.strictEqual(
+				resolveLspPath(relative, workspace),
+				join(workspace.fsPath, relative),
+			);
+		}
+	});
+
+	test('resolves parent-relative paths against workspace root', () => {
+		assert.strictEqual(
+			resolveLspPath('../target/debug/pyrefly', workspace),
+			join(dirname(workspace.fsPath), 'target', 'debug', 'pyrefly'),
+		);
+	});
+
+	test('handle windows path separators', () => {
+		const result = resolveLspPath('.\\bin\\pyrefly.exe', workspace);
+		if (process.platform === 'win32') {
+			assert.strictEqual(result, join(workspace.fsPath, 'bin', 'pyrefly.exe'));
+		} else {
+			assert.strictEqual(result, '.\\bin\\pyrefly.exe');
+		}
+	});
+
+	test('expand a ~-relative path against homedir', () => {
+		assert.strictEqual(
+			resolveLspPath('~/bin/pyrefly', workspace),
+			join(homedir(), 'bin', 'pyrefly'),
+		);
+	});
+
+	test('don\'t do anything with an unknown workspace', () => {
+		assert.strictEqual(
+			resolveLspPath('./bin/pyrefly', undefined),
+			'./bin/pyrefly',
+		);
 	});
 });


### PR DESCRIPTION
The previous logic was there just to get things working in the short term. This diff fixes that behavior to work on windows, handle `~`, and handle relative paths that don't start with a `.`. Simple tests are also added to validate behavior here.