### PR TITLE
Fix typeHierarchy/subtypes missing subtypes declared in other modules

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -6320,7 +6320,8 @@ impl Server {
                 let Some(class_def_index) = bindings.class_def_index(class_def) else {
                     continue;
                 };
-                if class_def_index == target.def_index && module_info.path() == &target.module_path
+                if class_def_index == target.def_index
+                    && module_info.path().as_path() == target.module_path.as_path()
                 {
                     continue;
                 }
@@ -6330,8 +6331,13 @@ impl Server {
                     let mro = solutions.get(&KeyClassMro(class_def_index));
                     mro.ancestors_no_object().iter().any(|ancestor| {
                         let ancestor_class = ancestor.class_object();
+                        // Compare the underlying file, not the `ModulePath`. An open file is held
+                        // as `ModulePathDetails::Memory` while a module that merely imports it
+                        // resolves the ancestor to `FileSystem`, so `==` on `ModulePath` is false
+                        // for the same file and every cross-module subtype is silently dropped.
                         ancestor_class.index() == target.def_index
-                            && ancestor_class.module_path() == &target.module_path
+                            && ancestor_class.module_path().as_path()
+                                == target.module_path.as_path()
                     })
                 };
                 if !is_subtype {

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/type_hierarchy_test/derived.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/type_hierarchy_test/derived.py
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from classes import B
+
+
+class D(B):
+    pass

--- a/pyrefly/lib/test/lsp/lsp_interaction/type_hierarchy.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/type_hierarchy.rs
@@ -12,10 +12,13 @@ use lsp_types::request::Request as _;
 use lsp_types::request::TypeHierarchyPrepare;
 use lsp_types::request::TypeHierarchySubtypes;
 use lsp_types::request::TypeHierarchySupertypes;
+use pyrefly_lsp_test::IndexingMode;
+use pyrefly_lsp_test::LspArgs;
 use pyrefly_lsp_test::Message;
 use pyrefly_lsp_test::Request;
 use pyrefly_lsp_test::object_model::InitializeSettings;
 use pyrefly_lsp_test::object_model::LspInteraction;
+use pyrefly_lsp_test::object_model::LspInteractionArgs;
 use serde_json::json;
 
 use crate::test::lsp::lsp_interaction::util::get_test_files_root;
@@ -100,6 +103,69 @@ fn test_type_hierarchy_basic() {
                 return false;
             };
             items.iter().any(|item| item.name == "C")
+        })
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+/// Regression test: a subtype declared in a *different* module must be reported.
+///
+/// The class being queried is necessarily open (LSP cannot serve a position request on a
+/// document it does not have), so its module is held as `ModulePathDetails::Memory`, while a
+/// module that merely imports it resolves the ancestor to `ModulePathDetails::FileSystem`.
+/// Comparing `ModulePath` directly is therefore false for the same file, and every cross-module
+/// subtype was silently dropped. `test_type_hierarchy_basic` keeps A, B and C in one file, so it
+/// cannot catch this.
+#[test]
+fn test_type_hierarchy_subtypes_in_another_module() {
+    let root = get_test_files_root();
+    let root_path = root.path().join("type_hierarchy_test");
+    let scope_uri = Url::from_file_path(&root_path).unwrap();
+    let mut interaction = LspInteraction::new_with_args(LspInteractionArgs {
+        args: LspArgs {
+            indexing_mode: IndexingMode::LazyBlocking,
+            ..LspInteractionArgs::default().args
+        },
+        ..Default::default()
+    });
+    interaction.set_root(root_path.clone());
+    interaction
+        .initialize(InitializeSettings {
+            workspace_folders: Some(vec![("test".to_owned(), scope_uri)]),
+            configuration: Some(None),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open("classes.py");
+    let uri = Url::from_file_path(root_path.join("classes.py")).unwrap();
+
+    let class_b_item = json!({
+        "name": "B",
+        "kind": SymbolKind::CLASS,
+        "uri": uri.to_string(),
+        "range": {
+            "start": {"line": 10, "character": 0},
+            "end": {"line": 11, "character": 8}
+        },
+        "selectionRange": {
+            "start": {"line": 10, "character": 6},
+            "end": {"line": 10, "character": 7}
+        }
+    });
+
+    interaction
+        .client
+        .send_request::<TypeHierarchySubtypes>(json!({
+            "item": class_b_item
+        }))
+        .expect_response_with(|result| {
+            let Some(items) = result else {
+                return false;
+            };
+            // C is in the opened file and was always found; D is the one this guards.
+            items.iter().any(|item| item.name == "C") && items.iter().any(|item| item.name == "D")
         })
         .unwrap();
 


### PR DESCRIPTION
Fixes #4644.

## The bug

`typeHierarchy/subtypes` only reports subtypes declared in the same file as the class being
queried. A subclass in any other module is dropped from the response, with no error.

```python
# classes.py
class A: pass
class B(A): pass
class C(B): pass
```
```python
# derived.py
from classes import B
class D(B): pass
```

Open `classes.py`, `typeHierarchy/prepare` on `B`, then `typeHierarchy/subtypes`:

| | |
| --- | --- |
| expected | `C` and `D` |
| actual | `C` only |

## Cause

`type_hierarchy_subtype_items` decides whether a candidate is a subtype by walking its MRO and
requiring both halves to match:

```rust
ancestor_class.index() == target.def_index
    && ancestor_class.module_path() == &target.module_path
```

`target.module_path` comes from the definition's module. The queried file is necessarily open —
LSP cannot serve a position request on a document the client has not sent — so that module is
held as `ModulePathDetails::Memory`. A module that merely *imports* it resolves the ancestor to
`ModulePathDetails::FileSystem`. Two different variants of the same enum, naming the same file,
so `==` on `ModulePath` is `false` and the candidate is silently rejected.

`C` matches only because it lives inside the open file and resolves its ancestor within the same
in-memory module.

Two consequences worth stating, because both cost me time:

- **Opening the other file does not help.** That module's own path becomes in-memory, but its
  *ancestor* still resolves to the filesystem path, so the comparison fails either way.
- **There is no configuration where this works.** With nothing open, `prepare` returns `None`.
  The file has to be open, and being open is exactly what breaks the comparison.

## Ruling out the obvious suspect

The function skips any candidate whose AST, solutions or bindings are missing:

```rust
let Some(ast) = transaction.as_ref().get_ast(&candidate) else { continue; };
```

which looks like the `Require::Indexing` / `get_ast` problem from #3636. It is not. Instrumenting
the walk on the fixture above shows the candidate module **is** in
`type_hierarchy_candidate_handles`' output, its AST, solutions and bindings **all** resolve, and
the ancestor reports the expected class index — only the path half of the comparison fails.
Forcing every candidate to `Require::Everything` does not fix it.

## Fix

Compare the underlying file with `ModulePath::as_path()` rather than the `ModulePath` wrapper.
This is the normalisation `patch_definition_for_handle_impl` already applies to reconcile
`Memory` against `FileSystem` on the references path. The same comparison is used a few lines
above to exclude the target class itself, and is fixed too.

## Tests

Adds `test_type_hierarchy_subtypes_in_another_module` with a cross-module fixture.

| | new test | `test_type_hierarchy_basic` |
| --- | --- | --- |
| without the fix | **FAILED** | ok |
| with the fix | ok | ok |

`test_type_hierarchy_basic` keeps its classes in a single opened file, so it passes either way —
which is why existing coverage could not catch this.

Full suite on this branch: **8,094 passed / 0 failed / 4 ignored** in the `pyrefly` crate,
8,829 passed and 0 failed across all 13 test binaries. The 4 ignored are pre-existing.
