### PR TITLE
Allow language server features for non-Jupyter notebooks

### DIFF
--- a/crates/pyrefly_lsp_test/src/object_model.rs
+++ b/crates/pyrefly_lsp_test/src/object_model.rs
@@ -1535,7 +1535,17 @@ impl LspInteraction {
         let root = self.client.get_root_or_panic();
         let notebook_path = root.join(file_name);
         let notebook_uri = Url::from_file_path(&notebook_path).unwrap().to_string();
+        self.open_notebook_with_uri(&notebook_uri, "jupyter-notebook", file_name, cells_spec);
+    }
 
+    /// Opens a notebook document under an explicit notebook URI and notebook type.
+    pub fn open_notebook_with_uri(
+        &self,
+        notebook_uri: &str,
+        notebook_type: &str,
+        file_name: &str,
+        cells_spec: Vec<(CellKind, &str)>,
+    ) {
         let mut cells = Vec::new();
         let mut cell_text_documents = Vec::new();
         for (i, (kind, text)) in cells_spec.iter().enumerate() {
@@ -1548,7 +1558,7 @@ impl LspInteraction {
             .send_notification::<DidOpenNotebookDocument>(json!({
                 "notebookDocument": {
                     "uri": notebook_uri,
-                    "notebookType": "jupyter-notebook",
+                    "notebookType": notebook_type,
                     "version": 1,
                     "metadata": {
                         "language_info": {

--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -184,12 +184,12 @@ export async function activate(context: ExtensionContext) {
       // Support for in-memory documents like the Positron Console
       {scheme: 'inmemory', language: 'python'},
     ],
-    // Support for notebooks
+    // Support for any notebook type
     // @ts-ignore
     notebookDocumentSync: {
       notebookSelector: [
         {
-          notebook: {notebookType: 'jupyter-notebook'},
+          notebook: '*',
           cells: [{language: 'python'}],
         },
       ],

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -1888,23 +1888,10 @@ impl Server {
                     let ruff_notebook =
                         params.notebook_document.to_ruff_notebook(&cell_contents)?;
                     let lsp_notebook = LspNotebook::new(ruff_notebook, notebook_document);
-                    let notebook_path = url
-                        .to_file_path()
-                        .or_else(|_| {
-                            if url.scheme() == "untitled" || url.scheme() == "inmemory" {
-                                Ok(self
-                                    .unsaved_file_tracker
-                                    .ensure_path_for_open(&url, "jupyter"))
-                            } else {
-                                Err(())
-                            }
-                        })
-                        .map_err(|_| {
-                            anyhow::anyhow!(
-                                "Could not convert uri to filepath: {}, expected a notebook",
-                                url
-                            )
-                        })?;
+                    let notebook_path = url.to_file_path().unwrap_or_else(|_| {
+                        self.unsaved_file_tracker
+                            .ensure_path_for_open(&url, "jupyter")
+                    });
                     for cell_url in lsp_notebook.code_cell_urls() {
                         self.open_notebook_cells
                             .write()
@@ -2926,7 +2913,11 @@ impl Server {
             // resolver at config synthesis time, not per-diagnostic.
 
             if let Some(lsp_file) = open_files.get(&path)
-                && config.project_includes.covers(&path)
+                && (config.project_includes.covers(&path)
+                    || (matches!(&**lsp_file, LspFile::Notebook(_))
+                        && config
+                            .project_includes
+                            .covers(&path.with_extension("ipynb"))))
                 && !config.project_excludes.covers(&path)
                 && type_error_status.is_enabled()
             {
@@ -3659,13 +3650,14 @@ impl Server {
         version: i32,
         contents: Arc<LspFile>,
     ) -> anyhow::Result<()> {
+        let is_notebook = matches!(&*contents, LspFile::Notebook(_));
         let path = url
             .to_file_path()
             .or_else(|_| {
-                if url.scheme() == "untitled" || url.scheme() == "inmemory" {
+                if is_notebook || url.scheme() == "untitled" || url.scheme() == "inmemory" {
                     Ok(self
                         .unsaved_file_tracker
-                        .ensure_path_for_open(&url, "python"))
+                        .ensure_path_for_open(&url, if is_notebook { "jupyter" } else { "python" }))
                 } else {
                     Err(())
                 }

--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_sync.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_sync.rs
@@ -5,11 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::path::Path;
+
+use lsp_types::PublishDiagnosticsParams;
 use lsp_types::Url;
 use lsp_types::notification::DidOpenNotebookDocument;
+use lsp_types::notification::DidOpenTextDocument;
+use lsp_types::notification::Notification as _;
+use lsp_types::notification::PublishDiagnostics;
+use pyrefly_lsp_test::Message;
 use pyrefly_lsp_test::object_model::CellKind;
 use pyrefly_lsp_test::object_model::InitializeSettings;
 use pyrefly_lsp_test::object_model::LspInteraction;
+use pyrefly_lsp_test::object_model::LspMessageError;
 use serde_json::json;
 
 use crate::test::lsp::lsp_interaction::util::get_test_files_root;
@@ -613,6 +621,531 @@ fn test_unsaved_notebook_did_open() {
     interaction
         .client
         .expect_publish_diagnostics_uri(&cell2_url, 1)
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+/// Builds the URI a client uses for a notebook that projects the code chunks of
+/// a source document: a custom scheme, no authority, and the source document's
+/// path preserved.
+fn projected_notebook_uri(root: &Path, file_name: &str) -> String {
+    let file_uri = Url::from_file_path(root.join(file_name)).unwrap();
+    format!("quarto-cells:{}", file_uri.path())
+}
+
+#[test]
+fn test_notebook_with_custom_scheme_publishes_cell_diagnostics() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let file_name = "notebook_custom_scheme/analysis.qmd";
+    let notebook_uri = projected_notebook_uri(root.path(), file_name);
+    interaction.open_notebook_with_uri(
+        &notebook_uri,
+        "quarto-cells",
+        file_name,
+        vec![(CellKind::Code, "z: str = ''\nz = 1")],
+    );
+
+    let cell_uri = interaction.cell_uri(file_name, "cell1");
+    interaction
+        .client
+        .expect_publish_diagnostics_uri(&cell_uri, 1)
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_notebook_with_non_python_extension_publishes_cell_diagnostics() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let file_name = "notebook_custom_scheme/analysis.qmd";
+    interaction.open_notebook(file_name, vec!["z: str = \'\'\nz = 1"]);
+
+    let cell_uri = interaction.cell_uri(file_name, "cell1");
+    interaction
+        .client
+        .expect_publish_diagnostics_uri(&cell_uri, 1)
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_notebook_with_custom_scheme_and_ipynb_path_publishes_cell_diagnostics() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let file_name = "notebook_custom_scheme/analysis.ipynb";
+    let notebook_uri = projected_notebook_uri(root.path(), file_name);
+    interaction.open_notebook_with_uri(
+        &notebook_uri,
+        "quarto-cells",
+        file_name,
+        vec![(CellKind::Code, "z: str = \'\'\nz = 1")],
+    );
+
+    let cell_uri = interaction.cell_uri(file_name, "cell1");
+    interaction
+        .client
+        .expect_publish_diagnostics_uri(&cell_uri, 1)
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_notebook_with_non_python_path_resolves_names_across_cells() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let file_name = "notebook_custom_scheme/analysis.qmd";
+    interaction.open_notebook(file_name, vec!["shared: int = 1", "shared = 'text'"]);
+
+    interaction
+        .diagnostic_for_cell(file_name, "cell2")
+        .expect_response(json!({
+            "items": [{
+                "code": "bad-assignment",
+                "codeDescription": {
+                    "href": "https://pyrefly.org/en/docs/error-kinds/#bad-assignment"
+                },
+                "message": "`Literal['text']` is not assignable to variable `shared` with type `int`",
+                "range": {
+                    "start": {"line": 0, "character": 9},
+                    "end": {"line": 0, "character": 15}
+                },
+                "severity": 1,
+                "source": "Pyrefly"
+            }],
+            "kind": "full"
+        }))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_notebook_with_custom_scheme_resolves_sibling_module() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let file_name = "notebook_custom_scheme/analysis.qmd";
+    let notebook_uri = projected_notebook_uri(root.path(), file_name);
+    interaction.open_notebook_with_uri(
+        &notebook_uri,
+        "quarto-cells",
+        file_name,
+        vec![(CellKind::Code, "from helpers import scale\n\nscale('one')")],
+    );
+
+    interaction
+        .diagnostic_for_cell(file_name, "cell1")
+        .expect_response(json!({
+            "items": [{
+                "code": "bad-argument-type",
+                "codeDescription": {
+                    "href": "https://pyrefly.org/en/docs/error-kinds/#bad-argument-type"
+                },
+                "message": "Argument `Literal['one']` is not assignable to parameter `value` with type `int` in function `helpers.scale`",
+                "range": {
+                    "start": {"line": 2, "character": 6},
+                    "end": {"line": 2, "character": 11}
+                },
+                "severity": 1,
+                "source": "Pyrefly"
+            }],
+            "kind": "full"
+        }))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_notebook_with_non_python_path_republishes_on_change_and_close() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let file_name = "notebook_custom_scheme/analysis.qmd";
+    interaction.open_notebook(file_name, vec!["z: str = ''\nz = 1"]);
+    let cell_uri = interaction.cell_uri(file_name, "cell1");
+    interaction
+        .client
+        .expect_publish_diagnostics_uri(&cell_uri, 1)
+        .unwrap();
+
+    interaction.change_notebook(
+        file_name,
+        2,
+        json!({
+            "cells": {
+                "textContent": [{
+                    "document": { "uri": cell_uri, "version": 2 },
+                    "changes": [{ "text": "z: str = ''\nz = 'fixed'" }]
+                }]
+            }
+        }),
+    );
+    interaction
+        .client
+        .expect_publish_diagnostics_uri(&cell_uri, 0)
+        .unwrap();
+
+    interaction.close_notebook(file_name);
+    interaction
+        .client
+        .expect_publish_diagnostics_uri(&cell_uri, 0)
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_notebook_with_python_path_publishes_cell_diagnostics() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    // A Marimo notebook is a `.py` file on disk, synced under its own notebook type.
+    let file_name = "notebook_custom_scheme/marimo_nb.py";
+    let notebook_uri = Url::from_file_path(root.path().join(file_name))
+        .unwrap()
+        .to_string();
+    interaction.open_notebook_with_uri(
+        &notebook_uri,
+        "marimo-notebook",
+        file_name,
+        vec![(CellKind::Code, "z: str = ''\nz = 1")],
+    );
+
+    let cell_uri = interaction.cell_uri(file_name, "cell1");
+    interaction
+        .client
+        .expect_publish_diagnostics_uri(&cell_uri, 1)
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_notebook_outside_project_includes_publishes_no_diagnostics() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.open_notebook(
+        "notebook_not_in_includes/outside.ipynb",
+        vec!["z: str = ''\nz = 1"],
+    );
+    interaction
+        .diagnostic_for_cell("notebook_not_in_includes/outside.ipynb", "cell1")
+        .expect_response(json!({ "items": [], "kind": "full" }))
+        .unwrap();
+
+    let file_name = "notebook_not_in_includes/outside.qmd";
+    let notebook_uri = projected_notebook_uri(root.path(), file_name);
+    interaction.open_notebook_with_uri(
+        &notebook_uri,
+        "quarto-cells",
+        file_name,
+        vec![(CellKind::Code, "z: str = ''\nz = 1")],
+    );
+    interaction
+        .diagnostic_for_cell(file_name, "cell1")
+        .expect_response(json!({ "items": [], "kind": "full" }))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_notebook_inside_project_includes_publishes_cell_diagnostics() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let file_name = "notebook_not_in_includes/included/inside.qmd";
+    let notebook_uri = projected_notebook_uri(root.path(), file_name);
+    interaction.open_notebook_with_uri(
+        &notebook_uri,
+        "quarto-cells",
+        file_name,
+        vec![(CellKind::Code, "z: str = ''\nz = 1")],
+    );
+
+    let cell_uri = interaction.cell_uri(file_name, "cell1");
+    interaction
+        .client
+        .expect_publish_diagnostics_uri(&cell_uri, 1)
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_notebook_under_excluded_path_publishes_no_diagnostics() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let file_name = "notebook_excluded/excluded.qmd";
+    let notebook_uri = projected_notebook_uri(root.path(), file_name);
+    interaction.open_notebook_with_uri(
+        &notebook_uri,
+        "quarto-cells",
+        file_name,
+        vec![(CellKind::Code, "z: str = ''\nz = 1")],
+    );
+
+    interaction
+        .diagnostic_for_cell(file_name, "cell1")
+        .expect_response(json!({ "items": [], "kind": "full" }))
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_notebook_diagnostics_are_published_on_cell_uris_only() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let file_name = "notebook_custom_scheme/analysis.qmd";
+    let notebook_uri = projected_notebook_uri(root.path(), file_name);
+    interaction.open_notebook_with_uri(
+        &notebook_uri,
+        "quarto-cells",
+        file_name,
+        vec![(CellKind::Code, "z: str = ''\nz = 1")],
+    );
+
+    interaction
+        .client
+        .expect_message("first publishDiagnostics notification", |msg| {
+            if let Message::Notification(x) = msg
+                && x.method == PublishDiagnostics::METHOD
+            {
+                let params: PublishDiagnosticsParams = serde_json::from_value(x.params).unwrap();
+                if params.uri.scheme() == "vscode-notebook-cell" {
+                    Some(Ok(()))
+                } else {
+                    Some(Err(LspMessageError::Custom {
+                        description: format!(
+                            "diagnostics published on {} instead of a cell URI",
+                            params.uri
+                        ),
+                    }))
+                }
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_projected_unsaved_notebook_did_open() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let notebook_uri = "quarto-cells:Untitled-1.qmd";
+    let cell1_uri_str = "vscode-notebook-cell://Untitled-1.qmd#cell1";
+    let cell2_uri_str = "vscode-notebook-cell://Untitled-1.qmd#cell2";
+    let cell1_url = Url::parse(cell1_uri_str).unwrap();
+    let cell2_url = Url::parse(cell2_uri_str).unwrap();
+
+    interaction
+        .client
+        .send_notification::<DidOpenNotebookDocument>(json!({
+            "notebookDocument": {
+                "uri": notebook_uri,
+                "notebookType": "quarto-cells",
+                "version": 1,
+                "metadata": {
+                    "language_info": { "name": "python" }
+                },
+                "cells": [
+                    { "kind": 2, "document": cell1_uri_str },
+                    { "kind": 2, "document": cell2_uri_str },
+                ]
+            },
+            "cellTextDocuments": [
+                { "uri": cell1_uri_str, "languageId": "python", "version": 1, "text": "x: int = 1" },
+                { "uri": cell2_uri_str, "languageId": "python", "version": 1, "text": "y: str = 1" },
+            ]
+        }));
+
+    interaction
+        .client
+        .expect_publish_diagnostics_uri(&cell1_url, 0)
+        .unwrap();
+    interaction
+        .client
+        .expect_publish_diagnostics_uri(&cell2_url, 1)
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_text_document_under_unknown_scheme_is_not_opened() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(
+                json!([{"pyrefly": {"displayTypeErrors": "force-on"}}]),
+            )),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction
+        .client
+        .send_notification::<DidOpenTextDocument>(json!({
+            "textDocument": {
+                "uri": "quarto-cells:Untitled-1.qmd",
+                "languageId": "python",
+                "version": 1,
+                "text": "y: str = 1"
+            }
+        }));
+
+    let file_name = "notebook_custom_scheme/analysis.qmd";
+    interaction.open_notebook(file_name, vec!["z: str = \'\'\nz = 1"]);
+
+    interaction
+        .client
+        .expect_message("first publishDiagnostics notification", |msg| {
+            if let Message::Notification(x) = msg
+                && x.method == PublishDiagnostics::METHOD
+            {
+                let params: PublishDiagnosticsParams = serde_json::from_value(x.params).unwrap();
+                if params.uri.scheme() == "vscode-notebook-cell" {
+                    Some(Ok(()))
+                } else {
+                    Some(Err(LspMessageError::Custom {
+                        description: format!(
+                            "text document under an unhandled scheme was opened: {}",
+                            params.uri
+                        ),
+                    }))
+                }
+            } else {
+                None
+            }
+        })
         .unwrap();
 
     interaction.shutdown().unwrap();

--- a/pyrefly/lib/test/lsp/lsp_interaction/notebook_tokens.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/notebook_tokens.rs
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use lsp_types::Url;
+use pyrefly_lsp_test::object_model::CellKind;
 use pyrefly_lsp_test::object_model::InitializeSettings;
 use pyrefly_lsp_test::object_model::LspInteraction;
 use serde_json::json;
@@ -47,6 +49,35 @@ fn test_semantic_tokens_full() {
 
     interaction
         .semantic_tokens_cell("notebook.ipynb", "cell2")
+        .expect_response(json!({"data":[0,0,2,8,0]}))
+        .unwrap();
+    interaction.shutdown().unwrap();
+}
+
+#[test]
+fn test_semantic_tokens_full_custom_scheme() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction.initialize(initialize_settings()).unwrap();
+
+    let file_name = "notebook_custom_scheme/analysis.qmd";
+    let file_uri = Url::from_file_path(root.path().join(file_name)).unwrap();
+    let notebook_uri = format!("quarto-cells:{}", file_uri.path());
+    interaction.open_notebook_with_uri(
+        &notebook_uri,
+        "quarto-cells",
+        file_name,
+        vec![(CellKind::Code, "x = 1"), (CellKind::Code, "x2 = 1")],
+    );
+
+    interaction
+        .semantic_tokens_cell(file_name, "cell1")
+        .expect_response(json!({"data":[0,0,1,8,0]}))
+        .unwrap();
+
+    interaction
+        .semantic_tokens_cell(file_name, "cell2")
         .expect_response(json!({"data":[0,0,2,8,0]}))
         .unwrap();
     interaction.shutdown().unwrap();

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/notebook_custom_scheme/analysis.qmd
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/notebook_custom_scheme/analysis.qmd
@@ -1,0 +1,8 @@
+---
+title: "Projected source document"
+---
+
+```{python}
+z: str = ''
+z = 1
+```

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/notebook_custom_scheme/helpers.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/notebook_custom_scheme/helpers.py
@@ -1,0 +1,2 @@
+def scale(value: int) -> int:
+    return value * 2

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/notebook_excluded/excluded.qmd
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/notebook_excluded/excluded.qmd
@@ -1,0 +1,3 @@
+---
+title: "Excluded from the project"
+---

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/notebook_excluded/pyrefly.toml
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/notebook_excluded/pyrefly.toml
@@ -1,0 +1,1 @@
+project-excludes = ["excluded.qmd"]

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/notebook_not_in_includes/pyrefly.toml
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/notebook_not_in_includes/pyrefly.toml
@@ -1,0 +1,1 @@
+project-includes = ["included/**"]


### PR DESCRIPTION
# Summary

Fixes #4642. This PR allows notebooks that aren't `.ipynb` files on disk to get language server features too. The three main changes are:

1. The client's `notebookSelector` matches any notebook type, so the cell language stays the only filter.
2. A notebook URI that doesn't convert to a path gets a synthesized path, the same way an unsaved text document does.
3. The `project_includes` check matches a synced notebook as if it were an `.ipynb` file at the same path, so the globs narrow by location but not extension.

`project_excludes` still apply, and a notebook outside a narrowed `project_includes` gets no diagnostics, the same as an open text document. Text documents keep the narrower list of schemes, so a document under a scheme that Pyrefly shouldn't analyze is still turned away.

# Test Plan

The new tests are in the notebook sync and notebook token suites. Each of these fails without the change:

- a notebook with a `.qmd` (Quarto markdown) path publishes its cell diagnostics
- the same notebook under a custom scheme
- a notebook projected from an unsaved document, which has no path at all
- a name from the first cell resolves in the second cell
- a module beside the source document resolves
- a cell edit republishes, and a close clears
- semantic tokens come back for the cells of a custom-scheme notebook

These pin the limits of the change:

- a notebook under an excluded path publishes nothing
- a notebook outside a narrowed `project_includes` publishes nothing, and one inside it still publishes
- a Marimo-style notebook, a `.py` file on disk, keeps working
- a text document under an unhandled scheme is still turned away
- every diagnostic arrives on a cell URI
- a custom-scheme notebook with an `.ipynb` path keeps working

I also tested this by hand against the first case it's meant to serve: in Positron, the code chunks of an open `.qmd` are modeled as a hidden notebook under the `quarto-cells` scheme. With this branch, Pyrefly serves those chunks over the notebook channel, and I read the LSP traffic directly to confirm it's working.