### PR TITLE
Add package metadata for the NumPy and JAX stubs

### DIFF
--- a/tensor-shapes/pyrefly-jax-stubs/LICENSE
+++ b/tensor-shapes/pyrefly-jax-stubs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tensor-shapes/pyrefly-jax-stubs/README.md
+++ b/tensor-shapes/pyrefly-jax-stubs/README.md
@@ -1,5 +1,10 @@
 # Pyrefly JAX shape stubs
 
+This package is a PEP 561 stub-only distribution. It installs the `jax-stubs`
+stub package so Pyrefly can discover shape-aware stubs for the runtime `jax`
+package without replacing or shadowing JAX itself. It is versioned in lockstep
+with Pyrefly and depends on the matching `pyrefly-shape-extensions` package.
+
 Shape-typed fixture stubs for a subset of JAX. This is a starting point for
 working with the JAX core team rather than a complete model: it covers array
 creation, broadcasting arithmetic, `matmul`, `reshape`, `transpose`, the

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/py.typed
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/tensor-shapes/pyrefly-jax-stubs/pyproject.toml
+++ b/tensor-shapes/pyrefly-jax-stubs/pyproject.toml
@@ -1,0 +1,38 @@
+# Deliberately not wired into `.github/workflows/build_shape_stubs.yml`, and so
+# not published: the `pyrefly-jax-stubs` name on PyPI is already taken by
+# someone else, and that has to be resolved before this package can be
+# released. The metadata lives here so the package is ready when it is, and so
+# it stays in step with the NumPy and Torch stubs in the meantime.
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pyrefly-jax-stubs"
+description = "JAX type stubs with array-shape tracking, maintained by Pyrefly"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { file = "LICENSE" }
+version = "0.0.0"
+keywords = ["typechecker", "typechecking", "stubs", "jax"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Typing :: Stubs Only",
+]
+dependencies = [
+  "pyrefly-shape-extensions==0.0.0",
+]
+
+[project.urls]
+homepage = "https://pyrefly.org"
+documentation = "https://pyrefly.org/en/docs/"
+
+[tool.hatch.build.targets.wheel]
+only-include = ["jax-stubs"]
+
+[tool.hatch.build.targets.sdist]
+include = ["jax-stubs/", "README.md", "LICENSE"]

--- a/tensor-shapes/pyrefly-numpy-stubs/LICENSE
+++ b/tensor-shapes/pyrefly-numpy-stubs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tensor-shapes/pyrefly-numpy-stubs/README.md
+++ b/tensor-shapes/pyrefly-numpy-stubs/README.md
@@ -1,0 +1,10 @@
+# pyrefly-numpy-stubs
+
+NumPy type stubs with array shape information for Pyrefly.
+
+This package is a PEP 561 stub-only distribution. It installs the
+`numpy-stubs` stub package so Pyrefly can discover shape-aware stubs for the
+runtime `numpy` package without replacing or shadowing NumPy itself.
+
+The package is versioned in lockstep with Pyrefly and depends on the matching
+`pyrefly-shape-extensions` package.

--- a/tensor-shapes/pyrefly-numpy-stubs/numpy-stubs/py.typed
+++ b/tensor-shapes/pyrefly-numpy-stubs/numpy-stubs/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/tensor-shapes/pyrefly-numpy-stubs/pyproject.toml
+++ b/tensor-shapes/pyrefly-numpy-stubs/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pyrefly-numpy-stubs"
+description = "NumPy type stubs with array-shape tracking, maintained by Pyrefly"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { file = "LICENSE" }
+version = "0.0.0"
+keywords = ["typechecker", "typechecking", "stubs", "numpy"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Typing :: Stubs Only",
+]
+dependencies = [
+  "pyrefly-shape-extensions==0.0.0",
+]
+
+[project.urls]
+homepage = "https://pyrefly.org"
+documentation = "https://pyrefly.org/en/docs/"
+
+[tool.hatch.build.targets.wheel]
+only-include = ["numpy-stubs"]
+
+[tool.hatch.build.targets.sdist]
+include = ["numpy-stubs/", "README.md", "LICENSE"]


### PR DESCRIPTION
Summary:
Users have asked for the shape-aware NumPy stubs to be installable from PyPI, the way `pyrefly-torch-stubs` already is. Today the only way to get them is to copy the `tensor-shapes/` directory into your project.

Add the standalone `pyrefly-numpy-stubs` package metadata and PEP 561 marker so the stubs can be built as a pure-Python stub-only wheel and sdist. This mirrors `pyrefly-torch-stubs` exactly: the package installs only the `numpy-stubs` tree and depends on the matching `pyrefly-shape-extensions` version.

Because the distribution ships `numpy-stubs/` rather than `numpy/`, it is a PEP 561 stub package for the runtime `numpy` distribution and never shadows NumPy itself, so it can be co-installed with real NumPy.

The same metadata is added for `pyrefly-jax-stubs`, so the three stub packages stay in step rather than the JAX one drifting until someone needs it. It is deliberately **not** added to `build_shape_stubs.yml`, and so is not published: the `pyrefly-jax-stubs` name on PyPI is already taken by someone else, and that needs to be resolved with them before we can release under it. The build and publish workflows enumerate their packages explicitly rather than globbing, so nothing picks this up implicitly; a later diff wires it in once the name question is settled. The `pyproject.toml` says as much at the top, so the omission does not read as an oversight.

Differential Revision: D117271678


