### PR TITLE
Don't report pytest **tracebackhide** as unused

### DIFF
--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -1995,7 +1995,8 @@ impl Scopes {
         variables
             .into_iter()
             .filter_map(|(name, usage)| {
-                if usage.used {
+                // Pytest reads this local implicitly when formatting tracebacks.
+                if usage.used || name.as_str() == "__tracebackhide__" {
                     None
                 } else {
                     Some(UnusedVariable {

--- a/pyrefly/lib/test/lsp/diagnostic.rs
+++ b/pyrefly/lib/test/lsp/diagnostic.rs
@@ -299,6 +299,19 @@ def main():
 }
 
 #[test]
+fn test_pytest_tracebackhide_not_reported_as_unused() {
+    let code = r#"
+def helper() -> None:
+    __tracebackhide__ = True
+    unused_var = True
+"#;
+    let (handles, state) = mk_multi_file_state(&[("main", code)], Require::Exports, true);
+    let handle = handles.get("main").unwrap();
+    let report = get_unused_variable_diagnostics(&state, handle);
+    assert_eq!(report, "Variable `unused_var` is unused");
+}
+
+#[test]
 fn test_unused_variable_in_override() {
     let code = r#"
 from typing_extensions import override


### PR DESCRIPTION
Pytest reads `__tracebackhide__` implicitly when formatting tracebacks, so reporting it as an unused local is a false positive.

Skip `__tracebackhide__` in unused-variable diagnostics and add a regression test that still reports a normal unused local in the same function.

Fixes #4484