### PR TITLE
fix warn when default=mutable in sqlalchemy #1610

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1470,14 +1470,18 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         range: TextRange,
         errors: &ErrorCollector,
     ) {
-        let has_default = call.arguments.find_keyword("default").is_some();
+        let default = call.arguments.find_keyword("default");
+        let has_default = default.is_some();
         let has_default_factory = call.arguments.find_keyword("default_factory").is_some();
         let has_factory = call.arguments.find_keyword("factory").is_some();
         let has_keyword_conflict = has_default && (has_default_factory || has_factory)
             || has_default_factory && has_factory;
         let may_have_positional_default =
             !call.arguments.args.is_empty() && (has_default_factory || has_factory);
-        if !has_keyword_conflict && !may_have_positional_default {
+        let mutable_default = default.filter(|default| {
+            matches!(&default.value, Expr::Dict(_) | Expr::List(_) | Expr::Set(_))
+        });
+        if !has_keyword_conflict && !may_have_positional_default && mutable_default.is_none() {
             return;
         }
 
@@ -1502,6 +1506,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 || id.has_toplevel_qname("pydantic.fields", "PrivateAttr")
                 || id.has_toplevel_qname("pydantic._internal._model_construction", "NoInitField")
         }) {
+            return;
+        }
+
+        // SQLAlchemy passes mapped dataclass fields to stdlib dataclasses, which reject mutable
+        // container defaults.
+        if !has_keyword_conflict
+            && let Some(default) = mutable_default
+            && function_id.is_some_and(|id| {
+                id.has_toplevel_qname("sqlalchemy.orm", "mapped_column")
+                    || id.has_toplevel_qname("sqlalchemy.orm._orm_constructors", "mapped_column")
+            })
+        {
+            self.error(
+                errors,
+                default.value.range(),
+                ErrorKind::BadClassDefinition,
+                format!("Mutable default for field `{name}` is not allowed; use `default_factory`"),
+            );
             return;
         }
 

--- a/pyrefly/lib/test/descriptors.rs
+++ b/pyrefly/lib/test/descriptors.rs
@@ -898,6 +898,14 @@ assert_type(A().a, MyDescriptor)
 fn sqlalchemy_mapped_env() -> TestEnv {
     let mut env = TestEnv::new();
     env.add(
+        "sqlalchemy.orm._orm_constructors",
+        r#"
+from typing import Any
+
+def mapped_column(*args: Any, **kw: Any) -> Any: ...
+    "#,
+    );
+    env.add(
         "sqlalchemy.orm.base",
         r#"
 class Mapped[T]:
@@ -923,7 +931,18 @@ class Update:
     env.add_with_path(
         "sqlalchemy.orm.decl_api",
         "sqlalchemy/orm/decl_api.py",
-        "class DeclarativeBase: ...",
+        r#"
+from typing import dataclass_transform
+
+from ._orm_constructors import mapped_column
+
+class DeclarativeBase: ...
+
+@dataclass_transform(field_specifiers=(mapped_column,))
+class DCTransformDeclarative(type): ...
+
+class MappedAsDataclass(metaclass=DCTransformDeclarative): ...
+        "#,
     );
     env.add_with_path(
         "sqlalchemy.orm",
@@ -931,6 +950,8 @@ class Update:
         r#"
 from .base import Mapped as Mapped
 from .decl_api import DeclarativeBase as DeclarativeBase
+from .decl_api import MappedAsDataclass as MappedAsDataclass
+from ._orm_constructors import mapped_column as mapped_column
     "#,
     );
     env.add_with_path(
@@ -983,6 +1004,22 @@ class User(Base):
     name: Mapped[str]
     def __init__(self, name: str):
         self.name = name
+    "#,
+);
+
+// Regression test for https://github.com/facebook/pyrefly/issues/1610
+testcase!(
+    test_sqlalchemy_mapped_dataclass_mutable_default,
+    sqlalchemy_mapped_env(),
+    r#"
+from sqlalchemy.orm import DeclarativeBase, Mapped, MappedAsDataclass, mapped_column
+
+class Base(MappedAsDataclass, DeclarativeBase):
+    pass
+
+class Model(Base):
+    client_params: Mapped[dict] = mapped_column(default={})  # E: Mutable default for field `client_params` is not allowed; use `default_factory`
+    labels: Mapped[list[str]] = mapped_column(default_factory=list)
     "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1610

SQLAlchemy dataclass fields now reject mutable dict, list, and set literals passed via mapped_column(default=...).

Diagnostic recommends default_factory.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test