### PR TITLE
fix is it possible to support filter_by check in sqlalchemy #1072

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1055,7 +1055,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         self.check_pytorch_tensor_cuda_call(x, &callee_ty, errors);
         self.check_pytorch_print_tensor(x, &callee_ty, errors);
         self.check_pytorch_redundant_to_call(x, &callee_ty, errors);
-        self.check_sqlalchemy_update_values_call(x, errors);
+        self.check_sqlalchemy_keyword_call(x, errors);
         if let Some(d) = self.call_to_dict(&callee_ty, &x.arguments) {
             self.dict_infer(&d, hint, x.range, errors)
         } else if let Some(ty) = self
@@ -1387,18 +1387,24 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             .emit();
     }
 
-    /// Validate `sqlalchemy.update(Model).values(field=...)` keyword arguments against the
-    /// `Mapped[...]` fields declared on `Model`.
-    fn check_sqlalchemy_update_values_call(&self, x: &ExprCall, errors: &ErrorCollector) {
+    /// Validate SQLAlchemy keyword filters and updates against the `Mapped[...]` fields on the
+    /// model that the statement targets.
+    fn check_sqlalchemy_keyword_call(&self, x: &ExprCall, errors: &ErrorCollector) {
         let Expr::Attribute(attr_expr) = &*x.func else {
             return;
         };
-        if attr_expr.attr.id.as_str() != "values" {
-            return;
-        }
-        let Some(model) = self.sqlalchemy_update_model_from_chain(&attr_expr.value) else {
-            return;
+        let (model, statement_name) = match attr_expr.attr.id.as_str() {
+            "values" => (
+                self.sqlalchemy_update_model_from_chain(&attr_expr.value),
+                "update",
+            ),
+            "filter_by" => (
+                self.sqlalchemy_select_model_from_chain(&attr_expr.value),
+                "filter_by",
+            ),
+            _ => return,
         };
+        let Some(model) = model else { return };
         let mapped_fields = self.sqlalchemy_mapped_model_fields(&model);
         if mapped_fields.is_empty() {
             return;
@@ -1429,7 +1435,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 let mut builder = errors.error_builder(
                     field_identifier.range(),
                     ErrorKind::UnexpectedKeyword,
-                    format!("Unexpected SQLAlchemy update field `{field_name}`"),
+                    format!("Unexpected SQLAlchemy {statement_name} field `{field_name}`"),
                 );
                 if let Some(suggestion) = best_suggestion(
                     field_name,
@@ -1446,8 +1452,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         let Expr::Call(call) = expr else {
             return None;
         };
-        if self.is_sqlalchemy_update_call(call) {
-            return self.sqlalchemy_update_model_from_call(call);
+        if let Some(model) = self.sqlalchemy_model_from_call(call, "update") {
+            return Some(model);
         }
         let Expr::Attribute(attr_expr) = &*call.func else {
             return None;
@@ -1455,14 +1461,46 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         self.sqlalchemy_update_model_from_chain(&attr_expr.value)
     }
 
-    fn is_sqlalchemy_update_call(&self, call: &ExprCall) -> bool {
+    fn sqlalchemy_select_model_from_chain(&self, expr: &Expr) -> Option<Class> {
+        let Expr::Call(call) = expr else {
+            return None;
+        };
+        if let Some(model) = self.sqlalchemy_model_from_call(call, "select") {
+            return Some(model);
+        }
+        let Expr::Attribute(attr_expr) = &*call.func else {
+            return None;
+        };
+        // Joins and explicit FROM clauses can change the namespace used by `filter_by`.
+        if matches!(
+            attr_expr.attr.id.as_str(),
+            "join" | "outerjoin" | "join_from" | "outerjoin_from" | "select_from"
+        ) {
+            return None;
+        }
+        self.sqlalchemy_select_model_from_chain(&attr_expr.value)
+    }
+
+    fn sqlalchemy_model_from_call(&self, call: &ExprCall, function_name: &str) -> Option<Class> {
         let errors = self.error_swallower();
         let func_ty = self.expr_infer(&call.func, &errors);
         let Some(FunctionKind::Def(func_id)) = func_ty.to_func_kind() else {
-            return false;
+            return None;
         };
-        func_id.qname.id().as_str() == "update"
-            && Self::is_sqlalchemy_module(func_id.qname.module_name())
+        if func_id.qname.id().as_str() != function_name
+            || !Self::is_sqlalchemy_module(func_id.qname.module_name())
+        {
+            return None;
+        }
+        let model_expr = call.arguments.args.first()?;
+        match self.expr_infer(model_expr, &errors) {
+            Type::ClassDef(cls) => Some(cls),
+            Type::Type(boxed) => match *boxed {
+                Type::ClassType(cls) => Some(cls.into_class_object()),
+                _ => None,
+            },
+            _ => None,
+        }
     }
 
     fn is_sqlalchemy_module(module: ModuleName) -> bool {
@@ -1479,19 +1517,6 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             Type::Annotated(inner, _) => Self::is_sqlalchemy_owned_type(inner),
             Type::Union(union) => union.members.iter().any(Self::is_sqlalchemy_owned_type),
             _ => false,
-        }
-    }
-
-    fn sqlalchemy_update_model_from_call(&self, call: &ExprCall) -> Option<Class> {
-        let model_expr = call.arguments.args.first()?;
-        let errors = self.error_swallower();
-        match self.expr_infer(model_expr, &errors) {
-            Type::ClassDef(cls) => Some(cls),
-            Type::Type(boxed) => match *boxed {
-                Type::ClassType(cls) => Some(cls.into_class_object()),
-                _ => None,
-            },
-            _ => None,
         }
     }
 

--- a/pyrefly/lib/test/descriptors.rs
+++ b/pyrefly/lib/test/descriptors.rs
@@ -920,6 +920,15 @@ class Update:
     def values(self, **kwargs: object) -> Update: ...
     "#,
     );
+    env.add(
+        "sqlalchemy.sql.selectable",
+        r#"
+class Select:
+    def where(self, *criteria: object) -> Select: ...
+    def filter_by(self, **kwargs: object) -> Select: ...
+    def join(self, target: object) -> Select: ...
+    "#,
+    );
     env.add_with_path(
         "sqlalchemy.orm.decl_api",
         "sqlalchemy/orm/decl_api.py",
@@ -939,6 +948,8 @@ from .decl_api import DeclarativeBase as DeclarativeBase
         r#"
 from .sql.dml import Update as Update
 from .sql.elements import ColumnElement as ColumnElement
+from .sql.selectable import Select as Select
+def select(*entities: object) -> Select: ...
 def update(table: object) -> Update: ...
     "#,
     );
@@ -1015,6 +1026,47 @@ def update(table: object) -> CustomUpdate: ...
 
 # A same-named function outside SQLAlchemy must not trigger the special-case check.
 update(User).values(nam="alice")
+    "#,
+);
+
+// Regression test for https://github.com/facebook/pyrefly/issues/1072
+testcase!(
+    test_sqlalchemy_select_filter_by_checks_mapped_fields,
+    sqlalchemy_mapped_env(),
+    r#"
+import sqlalchemy as sa
+from sqlalchemy import select
+from sqlalchemy.orm import DeclarativeBase, Mapped
+
+class Base(DeclarativeBase):
+    pass
+
+class User(Base):
+    id: Mapped[int]
+    name: Mapped[str]
+
+select(User).filter_by(name="alice", id=1)
+sa.select(User).where(User.id == 1).filter_by(name=0)  # E: `Literal[0]` is not assignable to field `name` with type `str`
+select(User).filter_by(nam="alice")  # E: Unexpected SQLAlchemy filter_by field `nam`
+select(User).filter_by(id=1).filter_by(name="alice")
+
+# SQLAlchemy accepts a SQL expression wherever a column value is expected.
+def sql_expr() -> sa.ColumnElement[int]: ...
+select(User).filter_by(name=sql_expr())
+
+class Address(Base):
+    email: Mapped[str]
+
+# A join changes the namespace that filter_by uses, so defer to SQLAlchemy's typing.
+select(User).join(Address).filter_by(email="alice@example.com")
+
+class CustomSelect:
+    def filter_by(self, **kwargs: object) -> CustomSelect: ...
+
+def select_custom(entity: object) -> CustomSelect: ...
+
+# A same-named method outside SQLAlchemy must not trigger the special-case check.
+select_custom(User).filter_by(nam="alice")
     "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #1072

`select(Model).filter_by(...)` now validates mapped field names and value types.
Supports chained calls such as `.where(...).filter_by(...)`.
Preserves SQLAlchemy expression values.
Avoids unsafe checks after joins, where SQLAlchemy changes the `filter_by` namespace.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test