### PR TITLE
[ez] Exclude 'epic' label from stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -38,5 +38,8 @@ jobs:
 
             Thank you for your contributions!
 
+          # Don't mark tracking tasks as stale
+          exempt-issue-labels: 'epic'
+
           # Labels to apply
           stale-pr-label: 'stale'


### PR DESCRIPTION
These are tracking tasks and can be assigned to someone long term