### PR TITLE
Fix bounded `type[T]` calls with custom metaclass returns

### DIFF
--- a/pyrefly/lib/alt/call.rs
+++ b/pyrefly/lib/alt/call.rs
@@ -1710,6 +1710,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     }
                 };
                 self.check_unnecessary_type_conversion(&cls, args, arguments_range, errors);
+                let class_object = cls.class_object().clone();
                 let constructed_type = self.construct_class(
                     cls,
                     constructor_kind,
@@ -1725,7 +1726,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // this class is being called via a quantified type with a class
                 // bound, to allow calls on TypeVars with class bounds to work
                 // as expected.
-                if let Some(quantified) = as_quantified_bound {
+                if let Some(quantified) = as_quantified_bound
+                    && self.is_compatible_constructor_return(&constructed_type, &class_object)
+                {
                     Type::Quantified(Box::new(quantified))
                 } else {
                     constructed_type

--- a/pyrefly/lib/test/constructors.rs
+++ b/pyrefly/lib/test/constructors.rs
@@ -193,6 +193,36 @@ assert_type(x, int)
 );
 
 testcase!(
+    test_bounded_type_with_metaclass_call_returns_something_else,
+    r#"
+from typing import assert_type
+
+class Meta(type):
+    def __call__(cls, x: int) -> str: ...
+
+class BoundClass(metaclass=Meta):
+    pass
+
+class C[T: BoundClass]:
+    x: type[T]
+    y: type[BoundClass]
+
+    def check(self) -> None:
+        assert_type(self.x(10), str)
+        assert_type(self.y(10), str)
+
+assert_type(BoundClass(10), str)
+
+class OrdinaryBase: ...
+
+def ordinary[T: OrdinaryBase](cls: type[T]) -> T:
+    return cls()
+
+assert_type(ordinary(OrdinaryBase), OrdinaryBase)
+    "#,
+);
+
+testcase!(
     test_metaclass_invalid_generic,
     r#"
 from typing import Any, assert_type


### PR DESCRIPTION
• # Summary

  Fix bounded `type[T]` calls with custom metaclass constructor returns.

  Pyrefly now only substitutes a bounded constructor result with `T` when the inferred constructor return is compatible with the
  bounded class. This preserves unrelated custom metaclass `__call__` return types, such as `str`, while keeping ordinary bounded
  `type[T]` construction behavior intact.

  Added a regression test covering direct construction, `type[T]`, `type[BoundClass]`, and ordinary bounded `type[T]` behavior.

  Fixes #4626

  # Test Plan

  - `cargo test constructors`
  - `CCACHE_DISABLE=1 python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`