### PR TITLE
Add regression tests for instance-method inlay hint alignment

### DIFF
--- a/pyrefly/lib/test/lsp/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/inlay_hint.rs
@@ -504,6 +504,88 @@ fn parameter_name_hint_labels(code: &str, assert_zero_errors: bool) -> Vec<Strin
         .collect()
 }
 
+// Regression coverage for #4611: instance-method parameter-name hints must
+// align one-to-one with positional arguments (`self` never consumes a slot).
+#[test]
+fn test_issue_4611_instance_method_hint_alignment() {
+    // Inferred receiver.
+    let code = r#"
+class _Mini:
+    def method(self, a: int, b: str, c: float) -> None:
+        pass
+
+m = _Mini()
+m.method(1, "x", 2.0)
+"#;
+    assert_eq!(
+        parameter_name_hint_labels(code, true),
+        vec!["a= ", "b= ", "c= "]
+    );
+
+    // Annotated receiver.
+    let code = r#"
+class _Mini:
+    def method(self, a: int, b: str, c: float) -> None:
+        pass
+
+m2: _Mini = _Mini()
+m2.method(1, "x", 2.0)
+"#;
+    assert_eq!(
+        parameter_name_hint_labels(code, true),
+        vec!["a= ", "b= ", "c= "]
+    );
+
+    // Plain-function control (unchanged behavior).
+    let code = r#"
+def _func(a: int, b: str, c: float) -> None:
+    pass
+
+_func(1, "x", 2.0)
+"#;
+    assert_eq!(
+        parameter_name_hint_labels(code, true),
+        vec!["a= ", "b= ", "c= "]
+    );
+}
+
+#[test]
+fn test_issue_4611_hint_alignment_other_receivers() {
+    // self.method(...) inside another method.
+    let code = r#"
+class _Outer:
+    def helper(self, a: int, b: str) -> None:
+        pass
+
+    def caller(self) -> None:
+        self.helper(1, "x")
+"#;
+    assert_eq!(parameter_name_hint_labels(code, true), vec!["a= ", "b= "]);
+
+    // Classmethod dispatch through cls.
+    let code = r#"
+class _Factory:
+    @classmethod
+    def make(cls, a: int, b: str) -> None:
+        pass
+
+_Factory.make(1, "x")
+"#;
+    assert_eq!(parameter_name_hint_labels(code, true), vec!["a= ", "b= "]);
+
+    // Bound method stored in a variable keeps alignment.
+    let code = r#"
+class _Mini:
+    def method(self, a: int, b: str) -> None:
+        pass
+
+m = _Mini()
+f = m.method
+f(1, "x")
+"#;
+    assert_eq!(parameter_name_hint_labels(code, true), vec!["a= ", "b= "]);
+}
+
 #[test]
 fn test_parameter_name_hint_after_keyword_argument() {
     let code = r#"

--- a/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/inlay_hint.rs
@@ -958,3 +958,62 @@ fn test_inlay_hint_unpack_has_location() {
 
     interaction.shutdown().unwrap();
 }
+
+// Regression coverage for #4611: instance-method parameter-name hints must
+// align one-to-one with positional arguments (`self` never consumes a slot)
+// through the full LSP handler path.
+#[test]
+fn test_inlay_hint_issue_4611_instance_method_alignment() {
+    let root = get_test_files_root();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(json!([{
+                "pyrefly": {"analysis": {"inlayHints": {
+                    "callArgumentNames": "all",
+                    "functionReturnTypes": false,
+                    "pytestParameters": false,
+                    "variableTypes": false,
+                }}},
+            }]))),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open("issue_4611_inlay_hint_test.py");
+
+    interaction
+        .client
+        .inlay_hint("issue_4611_inlay_hint_test.py", 0, 0, 100, 0)
+        .expect_response_with(|result| {
+            let hints = match result {
+                Some(hints) => hints,
+                None => return false,
+            };
+            if hints.len() != 3 {
+                return false;
+            }
+            // All three hints sit on the `m.method(1, "x", 2.0)` call line,
+            // ordered by column; labels align with the positional args.
+            let mut sorted = hints.clone();
+            sorted.sort_by_key(|hint| hint.position.character);
+            let expected_columns = [9, 12, 17];
+            let expected_labels = ["a= ", "b= ", "c= "];
+            for (hint, (column, label)) in sorted
+                .iter()
+                .zip(expected_columns.iter().zip(expected_labels.iter()))
+            {
+                if hint.position.line != 12 || hint.position.character != *column {
+                    return false;
+                }
+                if !check_inlay_hint_label_values(hint, &[(*label, false)]) {
+                    return false;
+                }
+            }
+            true
+        })
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/issue_4611_inlay_hint_test.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/issue_4611_inlay_hint_test.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+class Mini:
+    def method(self, a: int, b: str, c: float) -> None:
+        pass
+
+
+m = Mini()
+m.method(1, "x", 2.0)


### PR DESCRIPTION
## Summary

Issue #4611 reports parameter-name inlay hints shifted by one position for instance-method calls (e.g. `m.method(1, "x", 2.0)` over `def method(self, a: int, b: str, c: float)` showing `b=`/`c=` instead of `a=`/`b=`/`c=`) on pyrefly `1.3.0-dev.2`.

We verified that the exact repro produces **correct** hints (`a= b= c=`) on current `main` through both harnesses:

- the core inlay-hint computation (`Transaction::inlay_hints`), with inferred and annotated receivers, and additionally for `self.method(...)` calls inside other methods, classmethods (`cls`), bound methods stored in variables, and plain functions as a control;
- the full LSP path (`textDocument/inlayHint`, the layer editors like PyCharm exercise).

Since main does not reproduce the shift (the regression window is between Aug 4 and Aug 18, tag `1.3.0-dev.2`; suspects are #4399/#4539-era changes or a stale build on the reporter side), this PR locks the correct behavior in with permanent regression tests at both levels rather than speculative refactors.

Fixes #4611 — we'd ask the reporter to retest against a current build; if the shift still reproduces there, a fresh trace from that build would pinpoint the delta.

AI-generated: this PR was prepared by an AI agent (with human review before submission), per the repository's AI contribution guidelines.
