### PR TITLE
Publish diagnostics for open extension-less scripts

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -2926,8 +2926,13 @@ impl Server {
             // the `typeCheckingMode` IDE setting reaches us through the
             // resolver at config synthesis time, not per-diagnostic.
 
+            // A file the editor explicitly opened as Python is in scope for
+            // diagnostics even though its name lacks a python extension —
+            // default includes are an extension heuristic, not a scope
+            // decision; only excludes scope open files down (pyright/ty
+            // parity, #4397).
             if let Some(lsp_file) = open_files.get(&path)
-                && config.project_includes.covers(&path)
+                && (config.project_includes.covers(&path) || path.extension().is_none())
                 && !config.project_excludes.covers(&path)
                 && type_error_status.is_enabled()
             {

--- a/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/diagnostic.rs
@@ -6,6 +6,7 @@
  */
 
 use lsp_server::RequestId;
+use lsp_types::DocumentDiagnosticReport;
 use lsp_types::DocumentDiagnosticReportResult;
 use lsp_types::PublishDiagnosticsParams;
 use lsp_types::Url;
@@ -2040,6 +2041,121 @@ fn test_unused_type_ignore_diagnostic() {
         .unwrap();
 
     interaction.shutdown().unwrap();
+}
+
+// An open file with no file extension (e.g. a shebang script the editor
+// opened as Python) gets diagnostics even though default `project-includes`
+// only covers extension-bearing names (#4397).
+#[test]
+fn test_diagnostics_for_extensionless_script() {
+    let test_files_root = get_test_files_root();
+    // The harness copies a fixed fixture tree, so the extension-less script is
+    // written at runtime to keep its name free of any extension.
+    std::fs::write(
+        test_files_root.path().join("myscript"),
+        "#!/usr/bin/env python3\n\nx: int = \"hello\"\n",
+    )
+    .unwrap();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(test_files_root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(json!([{
+                "pyrefly": {"displayTypeErrors": "force-on"}
+            }]))),
+            ..Default::default()
+        })
+        .expect("Failed to initialize");
+
+    let script_path = test_files_root.path().join("myscript");
+
+    interaction.client.did_open("myscript");
+
+    // Push mode: publishDiagnostics carries the type error.
+    interaction
+        .client
+        .expect_publish_diagnostics_eventual_message_contains(
+            script_path,
+            "not assignable to `int`",
+        )
+        .expect("Failed to receive published diagnostics");
+
+    // Pull mode: textDocument/diagnostic returns the item.
+    interaction
+        .client
+        .diagnostic("myscript")
+        .expect_response_with(|response| {
+            let DocumentDiagnosticReportResult::Report(report) = response else {
+                return false;
+            };
+            let DocumentDiagnosticReport::Full(full) = report else {
+                return false;
+            };
+            full.full_document_diagnostic_report
+                .items
+                .iter()
+                .any(|item| {
+                    item.code
+                        == Some(lsp_types::NumberOrString::String(
+                            "bad-assignment".to_owned(),
+                        ))
+                })
+        })
+        .expect("Failed to receive expected response");
+
+    interaction.shutdown().expect("Failed to shutdown");
+}
+
+// Explicit `project-excludes` still suppress an open extension-less script —
+// excludes scope open files down even when the includes bypass applies.
+#[test]
+fn test_diagnostics_extensionless_in_excludes_still_suppressed() {
+    let test_files_root = get_test_files_root();
+    // The harness copies a fixed fixture tree, so the excluded subdirectory is
+    // written at runtime.
+    let dir = test_files_root.path().join("extensionless_excluded");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("pyrefly.toml"),
+        "project-excludes = [\"myscript\"]\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("myscript"),
+        "#!/usr/bin/env python3\n\nx: int = \"hello\"\n",
+    )
+    .unwrap();
+    let mut interaction = LspInteraction::new();
+    interaction.set_root(test_files_root.path().to_path_buf());
+    interaction
+        .initialize(InitializeSettings {
+            configuration: Some(Some(json!([{
+                "pyrefly": {"displayTypeErrors": "force-on"}
+            }]))),
+            ..Default::default()
+        })
+        .expect("Failed to initialize");
+
+    let script_path = dir.join("myscript");
+
+    interaction
+        .client
+        .did_open("extensionless_excluded/myscript");
+
+    // Push mode: nothing published for the excluded script.
+    interaction
+        .client
+        .expect_publish_diagnostics_eventual_error_count(script_path, 0)
+        .expect("Failed to receive empty diagnostics");
+
+    // Pull mode: no items for the excluded script.
+    interaction
+        .client
+        .diagnostic("extensionless_excluded/myscript")
+        .expect_response(json!({"items": [], "kind": "full"}))
+        .expect("Failed to receive expected response");
+
+    interaction.shutdown().expect("Failed to shutdown");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Extension-less Python scripts (e.g. a shebang script named `script` rather than `script.py`) received no LSP diagnostics: the display-time filter in `get_diag_if_shown` required open files to be covered by `project_includes`, whose default globs (`**/*.py*`, `**/*.ipynb`) can never match an extension-less path — so the checker computed the errors but they were dropped before publishing. Pyright and ty both provide diagnostics for such files.

The fix accepts an open file with no file extension even when the includes glob misses it (`project_includes.covers(path) || path.extension().is_none()`). Files with extensions keep exactly the previous gating — including customized `project_includes` scope — and `project_excludes` still suppress extension-less files. Both push (`publishDiagnostics`) and pull (`textDocument/diagnostic`) paths are fixed since both funnel through `get_diag_if_shown`.

Fixes #4397

## Test Plan

- New LSP interaction test `test_diagnostics_for_extensionless_script`: opens a shebang script without extension containing a type error and asserts the diagnostic arrives (push and pull).
- New test `test_diagnostics_extensionless_in_excludes_still_suppressed`: an extension-less script matched by `project-excludes` stays silent.
- Existing gating tests (`test_diagnostics_file_not_in_includes`, `test_diagnostics_file_in_excludes`) pass unchanged, proving custom project scoping is untouched.

AI-generated: this PR was prepared by an AI agent (with human review before submission), per the repository's AI contribution guidelines.
