### PR TITLE
Add instance-var-assign diagnostic for assigning to instance variables via the class

### DIFF
--- a/crates/pyrefly_config/src/base.rs
+++ b/crates/pyrefly_config/src/base.rs
@@ -179,6 +179,7 @@ impl Preset {
                 let errors = HashMap::from([
                     (ErrorKind::DirectAbstractBaseInstantiation, Severity::Error),
                     (ErrorKind::ImplicitAny, Severity::Error),
+                    (ErrorKind::InstanceVarAssign, Severity::Error),
                     (ErrorKind::MissingOverrideDecorator, Severity::Error),
                     (ErrorKind::OpenUnpacking, Severity::Error),
                     (ErrorKind::PotentialBadKeywordArgument, Severity::Error),

--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -228,6 +228,8 @@ pub enum ErrorKind {
     /// An inconsistency between a function parameter's type in an overload signature and its
     /// default value in the implementation.
     InconsistentOverloadDefault,
+    /// Cannot assign to a class-body-declared instance variable via the class (e.g. `C.instance_var = ...`).
+    InstanceVarAssign,
     /// Internal Pyrefly error.
     InternalError,
     /// An `@abstractmethod` is defined in a class that is not abstract.
@@ -563,6 +565,7 @@ impl ErrorKind {
             ErrorKind::ImplicitReexport => Severity::Ignore,
             ErrorKind::ImplicitlyDefinedAttribute => Severity::Ignore,
             ErrorKind::IncompatibleComparison => Severity::Ignore,
+            ErrorKind::InstanceVarAssign => Severity::Ignore,
             ErrorKind::InvalidAbstractMethod => Severity::Ignore,
             ErrorKind::InvalidCast => Severity::Ignore,
             ErrorKind::InvalidDecorator => Severity::Warn,

--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -1350,7 +1350,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             return None;
         };
         let ty = match class_attr {
-            ClassAttribute::ReadWrite(ty) | ClassAttribute::ReadOnly(ty, _) => ty,
+            ClassAttribute::ReadWrite(ty, _) | ClassAttribute::ReadOnly(ty, _) => ty,
             _ => return None,
         };
         let Type::BoundMethod(bound_method) = ty else {
@@ -1373,7 +1373,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         new_bound_method.func = BoundMethodType::Overload(filtered_overload);
         let new_method = self.heap.mk_bound_method(new_bound_method);
         Some(Attribute::ClassAttribute(match class_attr {
-            ClassAttribute::ReadWrite(_) => ClassAttribute::ReadWrite(new_method),
+            ClassAttribute::ReadWrite(_, is_instance_var) => {
+                ClassAttribute::ReadWrite(new_method, *is_instance_var)
+            }
             ClassAttribute::ReadOnly(_, reason) => {
                 ClassAttribute::ReadOnly(new_method, reason.clone())
             }
@@ -3122,7 +3124,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     .into_iter()
                     .filter_map(|(attr, _)| {
                         match &attr {
-                            Attribute::ClassAttribute(ClassAttribute::ReadWrite(ty))
+                            Attribute::ClassAttribute(ClassAttribute::ReadWrite(ty, _))
                             | Attribute::ClassAttribute(ClassAttribute::ReadOnly(ty, _))
                             | Attribute::Simple(ty)
                             | Attribute::ClassAttribute(ClassAttribute::Property(ty, _, _))

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -118,7 +118,9 @@ use crate::types::types::Union;
 #[derive(Debug, Clone)]
 pub enum ClassAttribute {
     /// A read-write attribute with a closed form type for both get and set actions.
-    ReadWrite(Type),
+    /// The flag is `true` when the attribute is a class-body-declared instance
+    /// variable (annotated, not `ClassVar`), used to flag writes via the class.
+    ReadWrite(Type, bool),
     /// A read-only attribute with a closed form type for get actions.
     ReadOnly(Type, ReadOnlyReason),
     /// A `NoAccess` attribute indicates that the attribute is well-defined, but does
@@ -143,7 +145,13 @@ pub enum ClassAttribute {
 
 impl ClassAttribute {
     pub fn read_write(ty: Type) -> Self {
-        Self::ReadWrite(ty)
+        Self::ReadWrite(ty, false)
+    }
+
+    /// Like [`read_write`](Self::read_write) but marks the attribute as a
+    /// class-body-declared instance variable (annotated, not `ClassVar`).
+    pub fn read_write_instance_var(ty: Type) -> Self {
+        Self::ReadWrite(ty, true)
     }
 
     pub fn read_only(ty: Type, reason: ReadOnlyReason) -> Self {
@@ -183,7 +191,7 @@ impl ClassAttribute {
 
     pub fn read_only_equivalent(self, reason: ReadOnlyReason) -> Self {
         match self {
-            Self::ReadWrite(ty) => Self::ReadOnly(ty, reason),
+            Self::ReadWrite(ty, _) => Self::ReadOnly(ty, reason),
             Self::Property(getter, _, cls) => Self::Property(getter, None, cls),
             Self::Descriptor(descriptor, base) => Self::Descriptor(
                 Descriptor {
@@ -215,7 +223,7 @@ impl ClassAttribute {
         match self {
             // TODO(stroxler): ReadWrite attributes are not actually methods but limiting access to
             // ReadOnly breaks unit tests; we should investigate callsites to understand this better.
-            ClassAttribute::ReadWrite(ty) | ClassAttribute::ReadOnly(ty, _) => Some(ty),
+            ClassAttribute::ReadWrite(ty, _) | ClassAttribute::ReadOnly(ty, _) => Some(ty),
             ClassAttribute::NoAccess(..)
             | ClassAttribute::Property(..)
             | ClassAttribute::Descriptor(..)
@@ -1289,10 +1297,13 @@ fn bind_class_attribute(
     cls: &ClassBase,
     attr: Type,
     read_only_reason: Option<ReadOnlyReason>,
+    is_instance_var: bool,
 ) -> ClassAttribute {
     let ty = make_bound_classmethod(heap, cls, attr).into_inner();
     if let Some(reason) = read_only_reason {
         ClassAttribute::read_only(ty, reason)
+    } else if is_instance_var {
+        ClassAttribute::read_write_instance_var(ty)
     } else {
         ClassAttribute::read_write(ty)
     }
@@ -3569,12 +3580,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             ClassFieldInner::ClassAttribute {
                 mut ty,
+                annotation,
                 is_classvar,
                 read_only_reason,
                 descriptor_range,
                 ..
             } => {
                 ty = self.normalize_attr_ty(ty);
+                // A class-body-declared instance variable (annotated, not `ClassVar`);
+                // writing it via the class object is flagged at the set chokepoint.
+                let is_instance_var = annotation.is_some() && !is_classvar;
                 let read_only_reason = if is_classvar {
                     Some(ReadOnlyReason::ClassVar)
                 } else {
@@ -3599,6 +3614,8 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     (_, ty) => {
                         if let Some(reason) = read_only_reason {
                             ClassAttribute::read_only(ty, reason)
+                        } else if is_instance_var {
+                            ClassAttribute::read_write_instance_var(ty)
                         } else {
                             ClassAttribute::read_write(ty)
                         }
@@ -3654,7 +3671,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             ClassFieldInner::Property { mut ty, .. } => {
                 // When accessing a property on a class (not instance), you get the property object itself
                 ty = self.normalize_attr_ty(ty);
-                bind_class_attribute(self.heap, cls, ty, None)
+                bind_class_attribute(self.heap, cls, ty, None, false)
             }
             ClassFieldInner::Descriptor { descriptor, .. } => {
                 ClassAttribute::descriptor(descriptor, DescriptorBase::ClassDef(cls.clone()))
@@ -3676,7 +3693,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 if let Some(quantified) = self_quantified {
                     ty = self.wrap_with_quantified(ty, quantified);
                 }
-                bind_class_attribute(self.heap, cls, ty, None)
+                bind_class_attribute(self.heap, cls, ty, None, false)
             }
             ClassFieldInner::ProxyMethod { .. } => ClassAttribute::no_access(
                 NoAccessReason::ProxyMethodClassAccess(cls.class_object().dupe()),
@@ -3689,6 +3706,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     cls,
                     ty,
                     Some(ReadOnlyReason::ClassObjectInitializedOnBody),
+                    false,
                 )
             }
             ClassFieldInner::ClassAttribute {
@@ -3699,11 +3717,16 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             )),
             ClassFieldInner::ClassAttribute {
                 mut ty,
+                annotation,
+                is_classvar,
                 read_only_reason,
                 descriptor_range,
                 ..
             } => {
                 ty = self.normalize_attr_ty(ty);
+                // A class-body-declared instance variable (annotated, not `ClassVar`);
+                // writing it via the class object is flagged at the set chokepoint.
+                let is_instance_var = annotation.is_some() && !is_classvar;
                 if ambiguous && !matches!(cls, ClassBase::SelfType(_)) {
                     ClassAttribute::no_access(NoAccessReason::ClassAttributeIsGeneric(
                         cls.class_object().dupe(),
@@ -3718,7 +3741,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             base: DescriptorBase::ClassDef(cls.clone()),
                             read_only_reason,
                         },
-                        (_, ty) => bind_class_attribute(self.heap, cls, ty, read_only_reason),
+                        (_, ty) => bind_class_attribute(
+                            self.heap,
+                            cls,
+                            ty,
+                            read_only_reason,
+                            is_instance_var,
+                        ),
                     }
                 }
             }
@@ -4242,7 +4271,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     });
                 };
                 match &mut attr {
-                    ClassAttribute::ReadOnly(ty, _) | ClassAttribute::ReadWrite(ty)
+                    ClassAttribute::ReadOnly(ty, _) | ClassAttribute::ReadWrite(ty, _)
                         if ty.has_toplevel_func_metadata() =>
                     {
                         relax_ty(ty);
@@ -5338,7 +5367,26 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     *should_narrow = false;
                 }
             }
-            ClassAttribute::ReadWrite(attr_ty) => {
+            ClassAttribute::ReadWrite(attr_ty, is_instance_var) => {
+                // Writing a class-body-declared instance variable via the class object
+                // misuses it (it should be assigned on instances). Emitted before the
+                // type-compat check below so this kind and bad-assignment fire on
+                // separate paths, and before the narrowing decision so the check is
+                // purely additive.
+                if is_instance_var && instance_class.is_none() && class_base.is_some() {
+                    errors
+                        .error_builder(
+                            range,
+                            ErrorKind::InstanceVarAssign,
+                            format!("Cannot set instance variable `{attr_name}` from the class"),
+                        )
+                        .with_detail(
+                            "instance variables declared in a class body (without ClassVar) should be assigned on instances"
+                                .to_owned(),
+                        )
+                        .emit();
+                    *should_narrow = false;
+                }
                 // If the attribute has a converter, then `want` should be the type expected by the converter.
                 let attr_ty = match instance_class {
                     Some(cls) => match self.get_dataclass_member(cls.class_object(), attr_name) {
@@ -5553,7 +5601,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
         };
         match attr {
-            ClassAttribute::ReadWrite(ty) => Some(ClassAttribute::ReadWrite(filter_type(ty)?)),
+            ClassAttribute::ReadWrite(ty, is_instance_var) => {
+                Some(ClassAttribute::ReadWrite(filter_type(ty)?, is_instance_var))
+            }
             ClassAttribute::ReadOnly(ty, reason) => {
                 Some(ClassAttribute::ReadOnly(filter_type(ty)?, reason))
             }
@@ -5607,13 +5657,13 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             ) => Err(Box::new(AttrSubsetError::Property)),
             (
                 ClassAttribute::ReadOnly(..),
-                ClassAttribute::Property(_, Some(_), _) | ClassAttribute::ReadWrite(_),
+                ClassAttribute::Property(_, Some(_), _) | ClassAttribute::ReadWrite(..),
             ) => Err(Box::new(AttrSubsetError::ReadOnly)),
             (
                 // TODO(stroxler): Investigate this case more: methods should be ReadOnly, but
                 // in some cases for unknown reasons they wind up being ReadWrite.
-                ClassAttribute::ReadWrite(got),
-                ClassAttribute::ReadWrite(want),
+                ClassAttribute::ReadWrite(got, _),
+                ClassAttribute::ReadWrite(want, _),
             ) if got.has_toplevel_func_metadata() && want.has_toplevel_func_metadata() => {
                 is_subset(got, want).map_err(|subset_error| {
                     Box::new(AttrSubsetError::Covariant {
@@ -5625,7 +5675,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     })
                 })
             }
-            (ClassAttribute::ReadWrite(got), ClassAttribute::ReadWrite(want)) => {
+            (ClassAttribute::ReadWrite(got, _), ClassAttribute::ReadWrite(want, _)) => {
                 let subset_error = is_subset(got, want)
                     .map_or_else(Some, |_| is_subset(want, got).map_or_else(Some, |_| None));
                 if let Some(subset_error) = subset_error {
@@ -5639,7 +5689,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 }
             }
             (
-                ClassAttribute::ReadWrite(got) | ClassAttribute::ReadOnly(got, ..),
+                ClassAttribute::ReadWrite(got, _) | ClassAttribute::ReadOnly(got, ..),
                 ClassAttribute::ReadOnly(want, _),
             ) => is_subset(got, want).map_err(|subset_error| {
                 Box::new(AttrSubsetError::Covariant {
@@ -5666,7 +5716,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     })
                 })
             }
-            (ClassAttribute::ReadWrite(got), ClassAttribute::Property(want, want_setter, _)) => {
+            (ClassAttribute::ReadWrite(got, _), ClassAttribute::Property(want, want_setter, _)) => {
                 is_subset(
                     // Synthesize a getter method
                     &self.heap.mk_callable_ellipsis(got.clone()),
@@ -5767,7 +5817,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Result<Type, NoAccessReason> {
         match class_attr {
             ClassAttribute::NoAccess(reason) => Err(reason),
-            ClassAttribute::ReadWrite(ty) | ClassAttribute::ReadOnly(ty, _) => Ok(ty),
+            ClassAttribute::ReadWrite(ty, _) | ClassAttribute::ReadOnly(ty, _) => Ok(ty),
             ClassAttribute::Property(getter, ..) => {
                 self.record_property_getter(range, &getter);
                 Ok(self.call_property_getter(getter, range, errors, context))

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -3148,3 +3148,105 @@ del f.real_method.test  # E: has no attribute `test`
 name: str = f.real_method.__name__
 "#,
 );
+
+// `instance-var-assign` (issue #3750): assigning to a class-body-declared
+// instance variable (annotated, not `ClassVar`) via the class object is flagged
+// when the kind is enabled. Inherited fields and fields annotated with a default
+// are still instance variables, so they are flagged too. The existing
+// bad-assignment check still runs (both fire on separate paths).
+testcase!(
+    test_instance_var_assign_diagnostic,
+    TestEnv::new().enable_instance_var_assign_error(),
+    r#"
+from typing import ClassVar
+
+class C:
+    instance_var: int
+C.instance_var = 3  # E: Cannot set instance variable `instance_var` from the class
+
+# Annotated with a default: still an instance variable per the typing spec.
+class WithDefault:
+    x: int = 3
+WithDefault.x = 4  # E: Cannot set instance variable `x` from the class
+
+# Inherited fields keep their provenance through the MRO lookup.
+class Sub(C):
+    pass
+Sub.instance_var = 5  # E: Cannot set instance variable `instance_var` from the class
+
+# A type-incompatible value yields BOTH instance-var-assign and bad-assignment.
+C.instance_var = "oops"  # E: Cannot set instance variable `instance_var` from the class  # E: `Literal['oops']` is not assignable to attribute `instance_var` with type `int`
+
+# Suppressible via the standard directive.
+C.instance_var = 7  # pyrefly: ignore[instance-var-assign]
+    "#,
+);
+
+// Non-instance-variable fields must NOT trigger the new kind even when it is
+// enabled: unannotated assignments and ClassVars are class variables,
+// staticmethods become unannotated ClassAttributes, instance-only attributes
+// keep their existing no-access error, and instance writes are unaffected.
+testcase!(
+    test_instance_var_assign_non_instance_fields_not_flagged,
+    TestEnv::new().enable_instance_var_assign_error(),
+    r#"
+from typing import ClassVar, Generic, TypeVar
+
+class C:
+    unannotated = 1
+    cv: ClassVar[int] = 2
+
+    @staticmethod
+    def stat() -> int:
+        return 3
+
+def f() -> int:
+    return 4
+
+T = TypeVar("T")
+
+
+class G(Generic[T]):
+    item: T
+
+
+C.unannotated = 5
+C.cv = 6
+C.stat = f
+
+# Writing a ClassVar via an instance keeps firing the pre-existing mirror rule.
+C().cv = 7  # E: Cannot set field `cv`
+
+# Generic-class attribute access already has its own error; our rule must not
+# stack another one on top.
+
+# Instance-only attributes keep their pre-existing error on class access.
+class D:
+    def __init__(self) -> None:
+        self.only = 1
+D.only = 56  # E: Instance-only attribute `only` of class `D` is not visible on the class
+D().only = 57
+
+# Generic fields are unreachable via the class object (pre-existing no-access).
+G.item = 6  # E: Generic attribute `item` of class `G` is not visible on the class
+
+# Reads are never flagged, and writes via an INSTANCE are unaffected even when
+# the kind is enabled (the flag is set but emission requires a class base).
+class E:
+    read_only_use: int = 1
+print(E.read_only_use)
+print(E().read_only_use)
+E().read_only_use = 2
+    "#,
+);
+
+// `instance-var-assign` is off by default: assignments that WOULD be flagged in
+// strict mode emit nothing under the default configuration.
+testcase!(
+    test_instance_var_assign_off_by_default,
+    r#"
+class C:
+    instance_var: int
+C.instance_var = 3
+    "#,
+);

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -140,6 +140,7 @@ pub struct TestEnv {
     implicit_any_lambda_error: bool,
     invalid_abstract_method_error: bool,
     empty_body_error: bool,
+    instance_var_assign_error: bool,
     unknown_argument_type_error: bool,
     unknown_variable_type_error: bool,
     implicit_reexport_error: bool,
@@ -196,6 +197,7 @@ impl TestEnv {
             implicit_any_lambda_error: false,
             invalid_abstract_method_error: false,
             empty_body_error: false,
+            instance_var_assign_error: false,
             unknown_argument_type_error: false,
             unknown_variable_type_error: false,
             implicit_reexport_error: false,
@@ -461,6 +463,11 @@ impl TestEnv {
         self
     }
 
+    pub fn enable_instance_var_assign_error(mut self) -> Self {
+        self.instance_var_assign_error = true;
+        self
+    }
+
     pub fn enable_unknown_argument_type_error(mut self) -> Self {
         self.unknown_argument_type_error = true;
         self
@@ -662,6 +669,9 @@ impl TestEnv {
         }
         if self.empty_body_error {
             errors.set_error_severity(ErrorKind::EmptyBody, Severity::Error);
+        }
+        if self.instance_var_assign_error {
+            errors.set_error_severity(ErrorKind::InstanceVarAssign, Severity::Error);
         }
         if self.unknown_variable_type_error {
             errors.set_error_severity(ErrorKind::UnknownVariableType, Severity::Error);

--- a/scripts/error_presets.json
+++ b/scripts/error_presets.json
@@ -56,6 +56,7 @@
     "inconsistent-inheritance": ["legacy", "default", "strict", "all"],
     "inconsistent-overload": ["legacy", "default", "strict", "all"],
     "inconsistent-overload-default": ["legacy", "default", "strict", "all"],
+    "instance-var-assign": ["strict", "all"],
     "internal-error": ["legacy", "default", "strict", "all"],
     "invalid-abstract-method": ["all"],
     "invalid-annotation": ["basic", "legacy", "default", "strict", "all"],

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -665,7 +665,7 @@ The default Pyrefly configuration. Equivalent to having no preset at all.
 Enables additional error codes on top of the default for stricter checking.
 
 - Sets [`strict-callable-subtyping`](#strict-callable-subtyping) `= true`
-- Enables (as errors): [`direct-abstract-base-instantiation`](./error-kinds.mdx#direct-abstract-base-instantiation), [`implicit-any`](./error-kinds.mdx#implicit-any) (covers every implicit-`Any` sub-kind), [`missing-override-decorator`](./error-kinds.mdx#missing-override-decorator), [`open-unpacking`](./error-kinds.mdx#open-unpacking), [`potential-bad-keyword-argument`](./error-kinds.mdx#potential-bad-keyword-argument), [`unused-ignore`](./error-kinds.mdx#unused-ignore)
+- Enables (as errors): [`direct-abstract-base-instantiation`](./error-kinds.mdx#direct-abstract-base-instantiation), [`implicit-any`](./error-kinds.mdx#implicit-any) (covers every implicit-`Any` sub-kind), [`instance-var-assign`](./error-kinds.mdx#instance-var-assign), [`missing-override-decorator`](./error-kinds.mdx#missing-override-decorator), [`open-unpacking`](./error-kinds.mdx#open-unpacking), [`potential-bad-keyword-argument`](./error-kinds.mdx#potential-bad-keyword-argument), [`unused-ignore`](./error-kinds.mdx#unused-ignore)
 
 #### Preset: `all`
 

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -901,6 +901,26 @@ def f(x: bool = False) -> int | None:
     return 0 if x else None
 ```
 
+## instance-var-assign
+
+Default severity: `ignore`
+
+Assigning to an instance variable via the class object — e.g. `C.instance_var = ...`
+where the class body declares `instance_var: int` without `ClassVar` — misuses the
+declaration: instance variables should be assigned on instances. Pyrefly flags such
+assignments when this kind is enabled (it is on in strict mode).
+
+```python
+class C:
+    instance_var: int
+C.instance_var = 3  # Cannot set instance variable `instance_var` from the class [instance-var-assign]
+```
+
+Only class-body-declared, annotated, non-`ClassVar` attributes are flagged.
+Unannotated assignments and `ClassVar` declarations are class variables and may be
+assigned via the class; inherited fields are also covered. Assignments via `setattr`
+and `del` are out of scope.
+
 ## internal-error
 
 Ideally you'll never see this one. If you do, please consider [filing a bug](https://github.com/facebook/pyrefly/issues).


### PR DESCRIPTION
## Summary

`C.instance_var = 3`, where `instance_var` is a class-body-declared, annotated, non-`ClassVar` field, was silently allowed. The mirror direction (assigning to a `ClassVar` through an instance) already errors, and the issue asks for a rule covering this direction too.

This adds a new `instance-var-assign` diagnostic, **off by default** (`Severity::Ignore`) and enabled in the `strict` preset, following the same shape as `method-assign`: detection keys off the authoritative `ClassFieldInner::ClassAttribute` origin (annotated and not `ClassVar`), threaded as a provenance flag on `ClassAttribute::ReadWrite` to the attribute-write chokepoint `check_class_attr_set_and_infer_narrow`, which emits only for class-object writes (`instance_class.is_none() && class_base.is_some()`). The existing type-compatibility check still runs, so an incompatible value reports both this and `bad-assignment`.

Off by default matches ty's current documented semantics (body-declared instance variables *may* be assigned via the class there; only instance-only variables error) — see the discussion linked in the issue. If maintainers prefer on-by-default symmetry with the ClassVar mirror rule, that is a one-line severity change and this PR can carry it.

Fixes #3750

## Test Plan

- Positive tests with the rule enabled: issue repro, inherited field via subclass, annotated-with-default field, generic class field — each reports `instance-var-assign`.
- Negative tests under default config: same code stays silent; unannotated `x = 3` via class, `ClassVar` via class, instance writes, `@staticmethod` assignment, and reads are unaffected; `# pyrefly: ignore[instance-var-assign]` suppresses.
- Website `error-kinds` documentation added; full `test.py` fmt+lint+tests green.

AI-generated: this PR was prepared by an AI agent (with human review before submission), per the repository's AI contribution guidelines.
