### PR TITLE
fix Pydantic module_construct arguments are not typechecked #4652

### DIFF
--- a/pyrefly/lib/alt/class/dataclass.rs
+++ b/pyrefly/lib/alt/class/dataclass.rs
@@ -40,6 +40,7 @@ use crate::binding::pydantic::GE;
 use crate::binding::pydantic::GT;
 use crate::binding::pydantic::LE;
 use crate::binding::pydantic::LT;
+use crate::binding::pydantic::ROOT;
 use crate::binding::pydantic::STRICT;
 use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
@@ -61,6 +62,8 @@ use crate::types::keywords::TypeMap;
 use crate::types::literal::Lit;
 use crate::types::types::Forallable;
 use crate::types::types::Type;
+
+const MODEL_CONSTRUCT: Name = Name::new_static("model_construct");
 
 /// Which constructor-copy builtin `call_dataclasses_replace` is serving. Chosen by the caller so the
 /// method itself doesn't re-derive dispatch from boolean flags.
@@ -215,6 +218,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             );
             fields.insert(Name::new_static("__attrs_init__"), init_method);
         }
+        if metadata.is_pydantic_model() {
+            fields.insert(
+                MODEL_CONSTRUCT,
+                self.get_pydantic_model_construct(cls, dataclass, &kw_only_by_class),
+            );
+        }
         let dataclass_fields_type = self.stdlib.dict(
             self.heap.mk_class_type(self.stdlib.str().clone()),
             self.heap.mk_any_implicit(),
@@ -329,6 +338,57 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             self.get_dataclass_replace(cls, dataclass, &kw_only_by_class, errors),
         );
         Some(ClassSynthesizedFields::new(fields))
+    }
+
+    /// Gets the fully typed `model_construct` classmethod for a Pydantic model.
+    fn get_pydantic_model_construct(
+        &self,
+        cls: &Class,
+        dataclass: &DataclassMetadata,
+        kw_only_by_class: &SmallMap<Class, SmallSet<Name>>,
+    ) -> ClassSynthesizedField {
+        let fields_set_type = self.heap.mk_optional(
+            self.heap.mk_class_type(
+                self.stdlib
+                    .set(self.heap.mk_class_type(self.stdlib.str().clone())),
+            ),
+        );
+        let fields_set = Param::Pos(
+            Name::new_static("_fields_set"),
+            fields_set_type,
+            Required::Optional(None),
+        );
+        let is_root_model = matches!(
+            self.get_metadata_for_class(cls).pydantic_model_kind(),
+            Some(PydanticModelKind::RootModel)
+        );
+        let mut params = Vec::new();
+        for (name, field, flags) in self.iter_fields(cls, dataclass, false, kw_only_by_class) {
+            let required = if flags.default.is_some() || is_root_model {
+                Required::Optional(None)
+            } else {
+                Required::Required
+            };
+            let param = if is_root_model && name == ROOT {
+                Param::Pos(name, field.ty(), required)
+            } else {
+                Param::KwOnly(name, field.ty(), required)
+            };
+            params.push(param);
+        }
+        if is_root_model {
+            params.push(fields_set);
+        } else {
+            params.insert(0, fields_set);
+        }
+        if dataclass.kws.extra {
+            params.push(Param::Kwargs(None, self.heap.mk_any_implicit()));
+        }
+        let ty = self.heap.mk_function(Function {
+            signature: Callable::list(ParamList::new(params), self.instantiate(cls)),
+            metadata: FuncMetadata::method(cls, MODEL_CONSTRUCT),
+        });
+        ClassSynthesizedField::new_classvar(ty)
     }
 
     fn check_duplicate_kw_only_markers(&self, cls: &Class, errors: &ErrorCollector) {

--- a/pyrefly/lib/test/pydantic/field.rs
+++ b/pyrefly/lib/test/pydantic/field.rs
@@ -185,6 +185,48 @@ Example(id="123")  # E: Missing argument `attribute_1`
 );
 
 pydantic_testcase!(
+    test_model_construct,
+    r#"
+from typing import assert_type
+
+from pydantic import BaseModel, Field
+
+class Model(BaseModel):
+    x: int
+    y: str = "default"
+    z: bool = Field(alias="aliased")
+
+model = Model.model_construct(x=1, z=True)
+assert_type(model, Model)
+Model.model_construct(x="1", z=True)  # E: Argument `Literal['1']` is not assignable to parameter `x`
+Model.model_construct(x=1, z=0)  # E: Argument `Literal[0]` is not assignable to parameter `z`
+Model.model_construct(x=1, aliased=True)  # E: Missing argument `z`
+Model.model_construct(z=True)  # E: Missing argument `x`
+Model.model_construct(x=1, z=True, _fields_set={"x"})
+Model.model_construct(x=1, z=True, _fields_set={1})  # E: `set[int]` is not assignable to parameter `_fields_set`
+
+# Normal construction performs validation and can accept coercible input.
+Model(x="1", aliased=True)
+"#,
+);
+
+pydantic_testcase!(
+    test_model_construct_generic,
+    r#"
+from typing import assert_type
+
+from pydantic import BaseModel
+
+class Model[T](BaseModel):
+    value: T
+
+model = Model[int].model_construct(value=1)
+assert_type(model, Model[int])
+Model[int].model_construct(value="1")  # E: `Literal['1']` is not assignable to parameter `value`
+"#,
+);
+
+pydantic_testcase!(
     test_frozen_field_override_covariant,
     r#"
 from pydantic import BaseModel, Field

--- a/pyrefly/lib/test/pydantic/root_model.rs
+++ b/pyrefly/lib/test/pydantic/root_model.rs
@@ -38,6 +38,24 @@ DefaultFactoryRootModel()
 );
 
 pydantic_testcase!(
+    test_root_model_construct,
+    r#"
+from typing import assert_type
+
+from pydantic import RootModel
+
+class IntRootModel(RootModel[int]):
+    pass
+
+model = IntRootModel.model_construct(1)
+assert_type(model, IntRootModel)
+IntRootModel.model_construct("1")  # E: `Literal['1']` is not assignable to parameter `root`
+IntRootModel.model_construct(1, {"root"})
+IntRootModel.model_construct(1, {1})  # E: `set[int]` is not assignable to parameter `_fields_set`
+"#,
+);
+
+pydantic_testcase!(
     test_root_model_generic,
     r#"
 from pydantic import RootModel


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4652

Synthesizes a fully typed model_construct signature matching Pydantic's plugin behavior (https://github.com/pydantic/pydantic/blob/main/pydantic/mypy.py#L903-L939).

Handles required/default fields, `_fields_set`, field names versus aliases, generics, extras, and RootModel.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test