### PR TITLE
Report redundant-condition for class instances without __bool__ or __len__

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -5100,12 +5100,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 // containers and `if obj:` is frequently a defensive pattern; the
                 // warning would create excessive noise for little benefit.
                 let is_dataclass = metadata.dataclass_metadata().is_some();
-                // Skip warning when we might have an instance of a subclass, which could define `__bool__` or `__len__`.
-                let is_subclassable = self.is_subclassable(cls);
                 if !is_abstract
                     && !is_from_stub
                     && !is_dataclass
-                    && !is_subclassable
                     && self.class_instances_always_truthy(cls)
                 {
                     Some(ConditionRedundantReason::InstanceAlwaysTruthy(

--- a/pyrefly/lib/test/flow_branching.rs
+++ b/pyrefly/lib/test/flow_branching.rs
@@ -1313,13 +1313,30 @@ def test(
 );
 
 testcase!(
-    test_redundant_condition_not_redundant_for_nonfinal_class,
+    test_redundant_condition_nonfinal_class,
     r#"
 class A:
     pass
 def f(a: A):
-    # This condition is not redundant because `a` could be a falsy instance of a subclass of `A`
-    if a:
+    if a:  # E: Instance of `A` used as condition
+        pass
+    "#,
+);
+
+testcase!(
+    test_redundant_condition_repro_issue_4665,
+    r#"
+class AlwaysTruthy:
+    pass
+
+def predicate() -> bool:
+    return True
+
+def check(value: AlwaysTruthy) -> None:
+    if value:  # E: Instance of `AlwaysTruthy` used as condition
+        pass
+
+    if predicate:  # E: Function object `predicate` used as condition
         pass
     "#,
 );


### PR DESCRIPTION
### Summary

Closes #4665.

Previously, `get_condition_redundant_reason` skipped non-final classes under the assumption that a subclass might define `__bool__` or `__len__`. However, in Python static type checking and consistent with mypy's `truthy-bool` error code, boolean condition checks evaluate the statically declared type. Because classes in Python are non-final by default, requiring `@final` prevented `redundant-condition` from emitting warnings for virtually all user-defined classes that define neither `__bool__` nor `__len__`.

This PR removes the `is_subclassable` restriction from `get_condition_redundant_reason` so that instances of classes without `__bool__` / `__len__` are reported as redundant truthy conditions, while continuing to preserve exemptions for abstract types, protocols, stub classes, and dataclasses.

### Test Plan

1. Verified against reproduction in #4665:
```python
class AlwaysTruthy:
    pass

def predicate() -> bool:
    return True

def check(value: AlwaysTruthy) -> None:
    if value:  # E: Instance of `AlwaysTruthy` used as condition. It's equivalent to `True` [redundant-condition]
        pass
    if predicate:  # E: Function object `predicate` used as condition. It's equivalent to `True` [redundant-condition]
        pass
```
2. Added unit tests in `flow_branching.rs` covering non-final classes.
3. `cargo test -p pyrefly` (8,103 passed).