### PR TITLE
fix enum.Flag unions incorrectly do not match typing.self in (class)methods. #4657

### DIFF
--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -2539,7 +2539,7 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
                 self.is_subset_eq(&got, want)
             }
             (Type::ClassType(got), Type::SelfType(want))
-                if got == want && self.type_order.is_final(got.class_object()) =>
+                if got == want && !self.type_order.is_subclassable(got.class_object()) =>
             {
                 Ok(())
             }

--- a/pyrefly/lib/solver/type_order.rs
+++ b/pyrefly/lib/solver/type_order.rs
@@ -94,8 +94,8 @@ impl<'solver, Ans: LookupAnswer> TypeOrder<'solver, Ans> {
         cls.is_protocol()
     }
 
-    pub fn is_final(self, cls: &Class) -> bool {
-        self.0.get_metadata_for_class(cls).is_final()
+    pub fn is_subclassable(self, cls: &Class) -> bool {
+        self.0.is_subclassable(cls)
     }
 
     pub fn is_new_type(self, cls: &Class) -> bool {

--- a/pyrefly/lib/test/enums.rs
+++ b/pyrefly/lib/test/enums.rs
@@ -394,6 +394,26 @@ def foo(f: MyFlag) -> None:
 "#,
 );
 
+// Regression test for https://github.com/facebook/pyrefly/issues/4657
+testcase!(
+    test_flag_union_return_self,
+    r#"
+import enum
+from typing import Self
+
+class MyFlag(enum.Flag):
+    a = enum.auto()
+    b = enum.auto()
+
+    @classmethod
+    def all_flags(cls) -> Self:
+        return cls.a | cls.b
+
+    def foo(self) -> Self:
+        return self.a | self.b
+"#,
+);
+
 testcase!(
     test_recursive_enum_class,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4657

fixes enum.Flag unions being incorrectly rejected as typing.Self return values, recognizes member-bearing enums as non-subclassable.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test