### PR TITLE
docs(pydantic): document built-in alias generators

### DIFF
--- a/website/docs/pydantic.mdx
+++ b/website/docs/pydantic.mdx
@@ -208,15 +208,9 @@ Model(x=0)
 Model(y=0)
 ```
 
----
-
-## Features Not Yet Supported
-
-These are some Pydantic features that are **not yet supported**:
-
 ### Alias Generators
 
-Pyrefly does not yet recognize `alias_generator` (or `AliasGenerator`) configured via `ConfigDict`. Fields will be type-checked using their original names rather than the generated aliases.
+Pyrefly recognizes `to_camel`, `to_pascal`, and `to_snake` from `pydantic.alias_generators` when `alias_generator` is set on `ConfigDict`. Constructor calls accept the generated alias.
 
 ```python
 from pydantic import BaseModel, ConfigDict
@@ -226,6 +220,7 @@ class Voice(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel)
     first_name: str
 
-# Not yet supported: pyrefly reports a missing-argument error for `first_name`
 Voice(firstName="Alice")
 ```
+
+Pyrefly does not recognize a custom callable or an `AliasGenerator` instance. For those configurations, Pyrefly type-checks the original field names.


### PR DESCRIPTION
## Why

https://pyrefly.org/en/docs/pydantic/#alias-generators still tells readers that `ConfigDict(alias_generator=...)` is unsupported. Constructor synthesis has honored `to_camel`, `to_pascal`, and `to_snake` since the v1.2 work that landed in #2946. That mismatch is what #4270 asks to fix.

A prior attempt in #4295 closed without merge because the CLA could not be signed.

Fixes #4270

## Scope

`website/docs/pydantic.mdx` only.

`### Alias Generators` now sits with the other supported examples, next to alias validation. The empty `## Features Not Yet Supported` heading is gone. The `#alias-generators` heading text is unchanged so the published anchor stays valid.

The section names the three built-in generators that `PydanticAliasGenerator` recognizes. It states that a custom callable or an `AliasGenerator` instance still type-checks the original field names.

No typechecker behavior changes.

## Tradeoffs

I put the section under supported features instead of replacing `## Features Not Yet Supported` in place. Alias generators are supported, so they belong with the other examples. A leftover top-level "not yet supported" heading with nothing under it would be worse.

## Blast Radius

Readers of the Pydantic docs page. Maintainers inherit one MDX section that matches `PydanticAliasGenerator` and the existing alias tests. Type checking is unchanged.

## Verification

- `cargo test configdict_alias_generator` passed. Built-in generators accept the generated constructor keywords.
- `cargo test configdict_custom_alias_generator` passed. Custom callables still require the original field name.
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema` passed.
- `yarn tsc --noEmit` passed.
- `yarn test --runInBand` passed (49 tests). Website Jest does not cover MDX copy.
- A local Docusaurus `yarn start` was already bound to 127.0.0.1:3000 from this worktree. `curl` of `/en/docs/pydantic/` returned the client SPA shell only. Headless Chrome was not installed here, so I did not dump a rendered DOM. `yarn build` failed in this checkout because `docusaurus-plugin-internaldocs-fb` looks for `hg`.

## AI usage

This PR was mostly driven by a Cursor coding agent, as required by [CONTRIBUTING.md](https://github.com/facebook/pyrefly/blob/main/CONTRIBUTING.md#ai-usage).

I assigned #4270 and asked the agent to align the Pydantic docs with current constructor synthesis. The agent drafted the `website/docs/pydantic.mdx` change, ran the existing alias-generator tests plus lint and website Jest, and opened this PR. I reviewed the diff against `PydanticAliasGenerator` and those tests before submitting.