### PR TITLE
fix Overriding a mutable instance attribute with a same-typed read/write @property (getter + setter) in a subclass is flagged as an inconsistent override #4676

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -1470,14 +1470,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     ) -> Result<(), Box<AttrSubsetError>> {
         match got {
             Attribute::ClassAttribute(got_class_attr) => {
-                self.is_class_attribute_subset(got_class_attr, want, is_subset)
+                self.is_class_attribute_subset(got_class_attr, want, false, is_subset)
             }
             Attribute::Simple(got_ty) => {
                 // Treat Simple attributes (which come up for cases like attribute access
                 // on modules, Any, and Never) as if they were read-write class attributes
                 // for the purpose of protocol subtyping.
                 let synthetic_got = ClassAttribute::read_write(got_ty.clone());
-                self.is_class_attribute_subset(&synthetic_got, want, is_subset)
+                self.is_class_attribute_subset(&synthetic_got, want, false, is_subset)
             }
             Attribute::GetAttr(not_found, got_attr, name) => {
                 let NotFoundOn::ClassInstance(cls, _) = not_found else {
@@ -1502,7 +1502,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 } else {
                     ClassAttribute::read_only(got_ty, ReadOnlyReason::Getattr)
                 };
-                self.is_class_attribute_subset(&synthetic_got, want, is_subset)
+                self.is_class_attribute_subset(&synthetic_got, want, false, is_subset)
             }
             Attribute::ModuleFallback(..) => Err(Box::new(AttrSubsetError::ModuleFallback)),
         }

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -4281,10 +4281,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     )
                 })
             };
-            let attr_check =
-                self.is_class_attribute_subset(got_attribute, &want_attribute, &mut |got, want| {
-                    self.is_subset_eq_with_reason(got, want)
-                });
+            let attr_check = self.is_class_attribute_subset(
+                got_attribute,
+                &want_attribute,
+                true,
+                &mut |got, want| self.is_subset_eq_with_reason(got, want),
+            );
             let error = match attr_check {
                 Err(ref e)
                     if let (Some((child, parent)), Some(got), Some(want)) = (
@@ -5565,6 +5567,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         &self,
         got: &ClassAttribute,
         want: &ClassAttribute,
+        allow_property_override: bool,
         is_subset: &mut dyn FnMut(&Type, &Type) -> Result<(), SubsetError>,
     ) -> Result<(), Box<AttrSubsetError>> {
         // Both ClassVar and ClassObjectInitializedOnBody represent class-level read-only
@@ -5595,11 +5598,53 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             }
             (ClassAttribute::DescriptorRead { .. }, _) => {
                 let got = (*got).clone().into_declared();
-                self.is_class_attribute_subset(&got, want, is_subset)
+                self.is_class_attribute_subset(&got, want, allow_property_override, is_subset)
             }
             (_, ClassAttribute::DescriptorRead { .. }) => {
                 let want = (*want).clone().into_declared();
-                self.is_class_attribute_subset(got, &want, is_subset)
+                self.is_class_attribute_subset(got, &want, allow_property_override, is_subset)
+            }
+            (
+                ClassAttribute::Property(got_getter, Some(got_setter), _),
+                ClassAttribute::ReadWrite(want),
+            ) if allow_property_override => {
+                is_subset(
+                    got_getter,
+                    // Synthesize the getter for a plain attribute.
+                    &self.heap.mk_callable_ellipsis(want.clone()),
+                )
+                .map_err(|subset_error| {
+                    Box::new(AttrSubsetError::Covariant {
+                        got: got_getter.clone(),
+                        want: want.clone(),
+                        got_is_property: true,
+                        want_is_property: false,
+                        subset_error,
+                    })
+                })?;
+                let setter_sigs = got_setter.callable_signatures();
+                let Some(setter_value_type) = setter_sigs
+                    .first()
+                    .and_then(|setter| setter.strip_first_param())
+                    .and_then(|setter| setter.get_first_param().cloned())
+                else {
+                    return Err(Box::new(AttrSubsetError::Contravariant {
+                        got: got_setter.clone(),
+                        want: want.clone(),
+                        got_is_property: true,
+                        want_is_property: false,
+                        subset_error: SubsetError::Other,
+                    }));
+                };
+                is_subset(want, &setter_value_type).map_err(|subset_error| {
+                    Box::new(AttrSubsetError::Contravariant {
+                        got: got_setter.clone(),
+                        want: want.clone(),
+                        got_is_property: true,
+                        want_is_property: false,
+                        subset_error,
+                    })
+                })
             }
             (
                 ClassAttribute::Property(_, _, _),

--- a/pyrefly/lib/test/class_overrides.rs
+++ b/pyrefly/lib/test/class_overrides.rs
@@ -1995,6 +1995,72 @@ class B(A):
 );
 
 testcase!(
+    test_override_mutable_attribute_with_property,
+    r#"
+class ExprNode: ...
+
+class Expr:
+    def __init__(self, *nodes: ExprNode) -> None:
+        self._nodes = nodes
+
+class Then(Expr):
+    _cached_nodes: tuple[ExprNode, ...] | None = None
+
+    @property
+    def _nodes(self) -> tuple[ExprNode, ...]:
+        return self._cached_nodes or ()
+
+    @_nodes.setter
+    def _nodes(self, nodes: tuple[ExprNode, ...]) -> None:
+        self._cached_nodes = nodes
+
+class Value:
+    value: int
+
+class WideGetter(Value):
+    @property
+    def value(self) -> object:  # E: Class member `WideGetter.value` overrides parent class `Value` in an inconsistent manner
+        return 0
+
+    @value.setter
+    def value(self, value: int) -> None:
+        pass
+
+class NarrowSetter(Value):
+    @property
+    def value(self) -> int:  # E: Class member `NarrowSetter.value` overrides parent class `Value` in an inconsistent manner
+        return 0
+
+    @value.setter
+    def value(self, value: bool) -> None:
+        pass
+
+class Compatible(Value):
+    @property
+    def value(self) -> bool:
+        return True
+
+    @value.setter
+    def value(self, value: object) -> None:
+        pass
+
+class ReadOnly(Value):
+    @property
+    def value(self) -> int:  # E: Class member `ReadOnly.value` overrides parent class `Value` in an inconsistent manner
+        return 0
+
+class MissingSetterValue(Value):
+    @property
+    def value(self) -> int:  # E: Class member `MissingSetterValue.value` overrides parent class `Value` in an inconsistent manner
+        return 0
+
+    @value.setter
+    def value(self) -> None:
+        pass
+ "#,
+);
+
+testcase!(
     test_override_mutable_attribute_suppressed_by_parent_kind,
     r#"
 class A:


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4676

Writable properties can now override mutable attributes when getter and setter types are compatible.

Unsafe getter/setter types and read-only or malformed properties remain errors.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test