### PR TITLE
fix: annotate GenerationAnswer lifetime

### DIFF
--- a/pyrefly/lib/alt/answers_solver.rs
+++ b/pyrefly/lib/alt/answers_solver.rs
@@ -1643,7 +1643,7 @@ impl Scc {
         answer: Arc<dyn Any + Send + Sync>,
         errors: Option<Arc<ErrorCollector>>,
         traces: Option<TraceSideEffects>,
-    ) -> GenerationAnswer {
+    ) -> GenerationAnswer<'_> {
         let state = self
             .node_state
             .get_mut(current)


### PR DESCRIPTION
# Summary

Add the explicit anonymous lifetime to `GenerationAnswer` returned by `on_calculation_finished`, matching the method's borrowed receiver and removing the `mismatched_lifetime_syntaxes` warning.

Fixes #4684

AI disclosure: This focused change was implemented and validated with AI assistance under human direction.

# Test Plan

- `cargo check -p pyrefly`
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`
- `cargo test -p pyrefly answers_solver --lib` (29 passed)
