### PR TITLE
fix type() of Protocol value incorrectly triggers invalid-argument when used as an isinstance argument #4686

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -6745,6 +6745,10 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     // we'll fall back to builtins.type. We can add more cases here as-needed.
     pub fn type_of(&self, ty: Type) -> Type {
         match ty {
+            // A protocol value's runtime class is an unknown concrete implementation.
+            Type::ClassType(cls) if cls.class_object().is_protocol() => {
+                self.heap.mk_type_of(Type::ClassType(cls))
+            }
             Type::ClassType(cls) => self.heap.mk_class_def(cls.class_object().clone()),
             Type::SelfType(_) => self.heap.mk_type(ty),
             Type::Literal(lit) => self.heap.mk_class_def(

--- a/pyrefly/lib/test/protocol.rs
+++ b/pyrefly/lib/test/protocol.rs
@@ -1260,6 +1260,21 @@ issubclass(ConcreteClass, RuntimeProtocol)
 );
 
 testcase!(
+    test_type_of_protocol_is_concrete_runtime_class,
+    r#"
+from typing import Protocol, assert_type
+
+class Worker(Protocol):
+    def work(self) -> None: ...
+
+def same_concrete_type(existing: Worker, candidate: Worker) -> bool:
+    candidate_type = type(candidate)
+    assert_type(candidate_type, type[Worker])
+    return isinstance(existing, candidate_type)
+"#,
+);
+
+testcase!(
     test_protocol_union_isinstance,
     r#"
 from typing import Protocol, runtime_checkable, Union


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4686

`type(protocol_value)` now produces `type[Protocol]`, representing the unknown concrete runtime implementation.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test