### PR TITLE
Fix Stop stubgen retaining full analysis for the whole import closure

### DIFF
--- a/pyrefly/lib/commands/stubgen.rs
+++ b/pyrefly/lib/commands/stubgen.rs
@@ -63,8 +63,13 @@ impl StubgenArgs {
         let state = State::new(config_finder, thread_count);
         let holder = Forgetter::new(state, false);
         let handles = Handles::new(expanded_file_list);
+        // `Require::Exports` is the retention level for every module reached through an import.
+        // Stubgen reads the AST, bindings and answers only of the module it is stubbing, so
+        // imported modules need to retain no more than `check` retains for them. Passing
+        // `Require::Everything` here instead pins the AST and the answers trace table for the
+        // whole import closure, making peak memory scale with the project rather than the input.
         let mut forgetter = Forgetter::new(
-            holder.as_ref().new_transaction(Require::Everything, None),
+            holder.as_ref().new_transaction(Require::Exports, None),
             true,
         );
         let transaction = forgetter.as_mut();

--- a/pyrefly/lib/stubgen.rs
+++ b/pyrefly/lib/stubgen.rs
@@ -13,6 +13,7 @@ mod tests {
     use std::path::PathBuf;
 
     use dupe::Dupe;
+    use pyrefly_build::handle::Handle;
     use pyrefly_util::forgetter::Forgetter;
     use pyrefly_util::fs_anyhow;
     use pyrefly_util::globs::FilteredGlobs;
@@ -26,6 +27,7 @@ mod tests {
     use super::extract::extract_module_stub;
     use crate::state::require::Require;
     use crate::state::state::State;
+    use crate::state::state::Transaction;
     use crate::test::util::TestEnv;
 
     fn run_stubgen(input: &str) -> String {
@@ -109,8 +111,10 @@ class BaseModel:
         let holder = Forgetter::new(state, false);
 
         let handles_obj = crate::commands::check::Handles::new(expanded);
+        // Mirror the CLI: `Require::Exports` is the level for modules reached through
+        // imports, and each stubbed handle is raised to `Require::Everything` below.
         let mut forgetter = Forgetter::new(
-            holder.as_ref().new_transaction(Require::Everything, None),
+            holder.as_ref().new_transaction(Require::Exports, None),
             true,
         );
         let transaction = forgetter.as_mut();
@@ -124,7 +128,25 @@ class BaseModel:
                 result = emit_stub(&stub);
             }
         }
+        assert_dependency_asts_evicted(transaction, &handles);
         result
+    }
+
+    /// A module reached only through an import drops its AST as soon as its answers exist.
+    /// Holding both for the whole import closure makes stubgen's peak memory scale with the
+    /// project instead of the input, so every stubgen test checks this over what it loaded.
+    fn assert_dependency_asts_evicted(transaction: &Transaction, stubbed: &[Handle]) {
+        for handle in transaction.handles() {
+            if stubbed.contains(&handle) {
+                continue;
+            }
+            assert!(
+                transaction.get_bindings(&handle).is_none()
+                    || transaction.get_ast(&handle).is_none(),
+                "`{}` was only reached through an import, but kept its AST alongside its bindings",
+                handle.module()
+            );
+        }
     }
 
     /// Get the path to the stubgen test fixtures directory.
@@ -243,6 +265,42 @@ class BaseModel:
         assert!(
             !actual.contains("DataFrame["),
             "the schema display form must not appear in a stub, got:\n{actual}"
+        );
+    }
+
+    /// Dependencies are held at `Require::Exports`, which drops their ASTs and disables their
+    /// answer traces. Types that cross a module boundary must still resolve to the real class
+    /// rather than degrading to `Incomplete`.
+    #[test]
+    fn test_stubgen_dependency_types_survive_eviction() {
+        let config = ExtractConfig {
+            include_private: false,
+            include_docstrings: false,
+        };
+        let tdir = tempfile::tempdir().unwrap();
+
+        let dep = tdir.path().join("dep.py");
+        fs_anyhow::write(
+            &dep,
+            "class Widget:\n    pass\n\ndef make() -> Widget: ...\n",
+        )
+        .unwrap();
+
+        let input = "from dep import make\n\nwidget = make()\n";
+        let path = tdir.path().join("input.py");
+        fs_anyhow::write(&path, input).unwrap();
+
+        let mut t = TestEnv::new();
+        t.add(&path.display().to_string(), input);
+        t.add_real_path("dep", dep);
+
+        // Only stub the input file, so `dep` is reached purely as an import.
+        let includes = Globs::new(vec![path.display().to_string()]).unwrap();
+        let actual = run_stubgen_inner(&mut t, includes, &config);
+
+        assert!(
+            actual.contains("widget: Widget"),
+            "an inferred type from an imported module should name the class, got:\n{actual}"
         );
     }
 


### PR DESCRIPTION
Fixes #4650

## Problem

`pyrefly stubgen` on a single file cost memory proportional to the project's
import closure rather than to the input. The reporter saw ~14 GB peak RSS where
`pyrefly check` on the same file peaked at 81 MB, and it did not finish inside a
300 s CI budget.

## Cause

`pyrefly/lib/commands/stubgen.rs` built its transaction with
`new_transaction(Require::Everything, None)`. That first argument is
`default_require` the retention level for every module the transaction reaches
*implicitly*, i.e. the whole transitive import closure (`get_module` /
`get_imported_module` both read it).

`Require` is what gates eviction: at `Everything`, `post.evict_ast()` is skipped,
`module_parse` keeps full token data, and `enable_trace` builds the per-binding
answers trace table for every module in the closure. `check` avoids this by
using `RequireLevels { specified: Errors, default: Exports }`, and the LSP relies
on the same contract.

Stubgen never needed more. `extract_module_stub` reads `get_bindings` /
`get_answers` / `get_ast` only for the handle it is given, and that handle
already receives `Require::Everything` from the per-call
`transaction.run(&[handle], ...)`.

## Fix

Lower the transaction's `default_require` to `Require::Exports` and leave the
per-handle level untouched.

## Results

Measured on a file importing `torch`, release build, `--threads 1`:

| | wall | peak RSS |
|---|---|---|
| `stubgen` before | 33.15 s | 6.7 GB |
| `stubgen` after | 0.16 s | 91 MB |
| `check` (reference) | 0.14 s | 91 MB |

The generated `.pyi` is byte-identical between the two builds.

## Tests

- `assert_dependency_asts_evicted` is called from the shared stubgen test runner,
  so all 28 stubgen tests now assert that no module reached only through an import
  keeps its AST alongside its bindings. Reverting the level to `Require::Everything`
  fails 28/28, so the guard is not vacuous.
- `test_stubgen_dependency_types_survive_eviction` covers a type crossing a module
  boundary, pinning that it still resolves to the real class rather than degrading
  to `Incomplete`.
- No `expected.pyi` snapshot changed.

## Note on the mechanism

While implementing this I confirmed by instrumenting the compute loop that
dependencies only ever reach `Step::Answers` cross-module lookup demands
`Step::Answers`, never `Solutions`, so the `evict_answers` branch does not fire for
them at any require level. What `Exports` actually buys is AST eviction plus
disabling the answers trace table across the closure, which is exactly the profile
`check` runs at. The comments in the change describe that mechanism rather than the
`Solutions`-based one I first assumed.