### PR TITLE
fix  What's up with django-models-utils #2328

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -2970,8 +2970,17 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             None
         };
         // Otherwise, analyze the value to determine the type
-        let (inherited_ty, inherited_annotation) =
+        let (inherited_ty, mut inherited_annotation) =
             self.get_inherited_type_and_annotation(class, name);
+        // `Model.objects` is a fallback for models without an explicit manager. An assignment
+        // installs that manager at runtime, so preserve its concrete type and custom methods.
+        let is_django_manager_assignment = direct_annotation.is_none()
+            && matches!(value, ExprOrBinding::Expr(_))
+            && self.get_metadata_for_class(class).is_django_model()
+            && name.as_str() == "objects";
+        if is_django_manager_assignment {
+            inherited_annotation = None;
+        }
         let mut is_inherited = if inherited_ty.is_none() {
             IsInherited::No
         } else {
@@ -3011,7 +3020,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     {
                         // If there are no explicit annotations, use the inherited type as a contextual hint.
                         let errors2 = self.error_collector();
-                        self.attribute_expr_infer(
+                        let hinted_ty = self.attribute_expr_infer(
                             e,
                             Some(&Annotation::new_type(inherited_ty.clone())),
                             name,
@@ -3022,7 +3031,11 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             // inferred type to preserve type precision. Skip the override check
                             // since we've already validated compatibility above.
                             is_inherited = IsInherited::No;
-                            self.attribute_expr_infer(e, None, name, errors)
+                            if is_django_manager_assignment {
+                                hinted_ty
+                            } else {
+                                self.attribute_expr_infer(e, None, name, errors)
+                            }
                         } else {
                             // The hint was no good; infer the type without it.
                             self.attribute_expr_infer(e, None, name, errors)

--- a/pyrefly/lib/test/django/model.rs
+++ b/pyrefly/lib/test/django/model.rs
@@ -6,6 +6,46 @@
  */
 
 use crate::django_testcase;
+use crate::test::django::util::django_env;
+use crate::test::util::TestEnv;
+use crate::testcase;
+
+fn django_model_utils_env() -> TestEnv {
+    let mut env = django_env();
+    env.add(
+        "model_utils.managers",
+        r#"
+from typing import Generic, TypeVar
+
+from django.db import models
+
+ModelT = TypeVar("ModelT", bound=models.Model, covariant=True)
+
+class InheritanceQuerySet(models.QuerySet[ModelT]): ...
+
+class InheritanceManager(models.Manager[ModelT]):
+    def select_subclasses(self) -> InheritanceQuerySet[ModelT]: ...
+"#,
+    );
+    env
+}
+
+testcase!(
+    test_django_model_utils_custom_manager,
+    django_model_utils_env(),
+    r#"
+from typing import assert_type
+
+from django.db import models
+from model_utils.managers import InheritanceManager, InheritanceQuerySet
+
+class Place(models.Model):
+    objects = InheritanceManager()
+
+assert_type(Place.objects, InheritanceManager[Place])
+assert_type(Place.objects.select_subclasses(), InheritanceQuerySet[Place])
+"#,
+);
 
 django_testcase!(
     test_model,


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #2328

now preserves explicitly assigned Django manager types, so django-model-utils APIs such as `InheritanceManager.select_subclasses()` remain available and correctly specialize to the model type.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test