### PR TITLE
fix attrs field order for diamond inheritance #4640

### DIFF
--- a/pyrefly/lib/alt/class/dataclass.rs
+++ b/pyrefly/lib/alt/class/dataclass.rs
@@ -79,15 +79,48 @@ impl ReplaceKind {
 }
 
 impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
-    /// Gets dataclass fields for an `@dataclass`-decorated class. attrs with
-    /// `auto_attribs=False` collects only `attr.ib()`/`field()` assignments;
-    /// every other kind is annotation-driven.
+    /// Returns the names of `cls`'s dataclass fields, ordered as they appear in the synthesized
+    /// `__init__`. The order is built by merging the fields that `cls` inherits through
+    /// `bases_with_metadata` with the fields that `cls` defines in its own body.
     pub fn get_dataclass_fields(
         &self,
         cls: &Class,
         bases_with_metadata: &[(Class, &ClassMetadata)],
         kind: &DataclassKind,
     ) -> SmallSet<Name> {
+        // attrs moves a field that a subclass redefines to the redefinition's position, whereas
+        // `@dataclass` keeps the base's position. Only fields the base declares in its own body are
+        // treated as redefined, so an inherited field keeps its place regardless of base order.
+        let relocate_redefined = matches!(kind, DataclassKind::Attrs { .. });
+        let mut all_fields = SmallSet::new();
+        for (base, metadata) in bases_with_metadata.iter().rev() {
+            if let Some(dataclass) = metadata.dataclass_metadata() {
+                let locally_declared = if relocate_redefined {
+                    self.class_body_field_names(base, &dataclass.kind)
+                } else {
+                    SmallSet::new()
+                };
+                for name in dataclass.fields.iter() {
+                    if locally_declared.contains(name) {
+                        all_fields.shift_remove(name);
+                    }
+                    all_fields.insert(name.clone());
+                }
+            }
+        }
+        for name in self.class_body_field_names(cls, kind) {
+            if relocate_redefined {
+                all_fields.shift_remove(&name);
+            }
+            all_fields.insert(name);
+        }
+        all_fields
+    }
+
+    /// Returns the names of the dataclass fields that `cls` declares in its own class body,
+    /// excluding anything inherited from a base class. Under attrs with `auto_attribs=False`, only
+    /// names assigned an `attr.ib()` or `field()` call count, not bare annotations.
+    fn class_body_field_names(&self, cls: &Class, kind: &DataclassKind) -> SmallSet<Name> {
         let attrs_initializer_only = matches!(
             kind,
             DataclassKind::Attrs {
@@ -95,38 +128,20 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 ..
             }
         );
-        // attrs relocates a redefined field to its newest declaration site (it deletes the earlier
-        // occurrence and re-appends), whereas stdlib `@dataclass` keeps the original position (it
-        // reassigns a dict entry in place). `SmallSet::insert` keeps the existing position, so for
-        // attrs we `shift_remove` first to move the name to the end.
-        let relocate_redefined = matches!(kind, DataclassKind::Attrs { .. });
-        let mut all_fields = SmallSet::new();
-        for (_, metadata) in bases_with_metadata.iter().rev() {
-            if let Some(dataclass) = metadata.dataclass_metadata() {
-                for name in dataclass.fields.iter() {
-                    if relocate_redefined {
-                        all_fields.shift_remove(name);
-                    }
-                    all_fields.insert(name.clone());
-                }
-            }
-        }
-        if let Some(class_fields) = self.get_class_fields(cls) {
-            for name in class_fields.class_body_fields() {
-                let is_field = if attrs_initializer_only {
+        let Some(class_fields) = self.get_class_fields(cls) else {
+            return SmallSet::new();
+        };
+        class_fields
+            .class_body_fields()
+            .filter(|name| {
+                if attrs_initializer_only {
                     class_fields.is_attrs_field_specifier(name)
                 } else {
                     class_fields.is_field_annotated(name)
-                };
-                if is_field {
-                    if relocate_redefined {
-                        all_fields.shift_remove(name);
-                    }
-                    all_fields.insert(name.clone());
                 }
-            }
-        }
-        all_fields
+            })
+            .cloned()
+            .collect()
     }
 
     pub fn get_dataclass_synthesized_fields(

--- a/pyrefly/lib/test/attrs/fields.rs
+++ b/pyrefly/lib/test/attrs/fields.rs
@@ -935,6 +935,102 @@ class Sub(Mixin, Base):  # E: without a default may not follow
 "#,
 );
 
+// `B` and `C` both inherit `x` from their shared base `A` without redefining it, so merging
+// `D`'s fields must not move `x`. attrs builds the same `__init__` whether `D` lists its bases
+// as `(C, B)` or `(B, C)`, so both subclasses must reveal the same signature (#4640).
+attrs_testcase!(
+    test_attrs_diamond_inheritance_shared_field_not_relocated,
+    r#"
+from typing import reveal_type
+from attrs import define, field
+
+@define
+class A:
+    x: int
+
+@define
+class B(A):
+    y: bool = field(default=True)
+
+@define(slots=False)
+class C(A):
+    z: bool = field(default=True, kw_only=True)
+
+@define
+class D(C, B):
+    pass
+
+@define
+class D2(B, C):
+    pass
+
+reveal_type(D.__init__)   # E: revealed type: (self: D, x: int, y: bool = ..., *, z: bool = ...) -> None
+reveal_type(D2.__init__)  # E: revealed type: (self: D2, x: int, y: bool = ..., *, z: bool = ...) -> None
+
+D(1)                     # OK
+D(1, y=False, z=False)   # OK
+D2(1)                    # OK
+"#,
+);
+
+// `B` redefines `x` in its own body, so attrs moves `x` to its new position after `y`.
+attrs_testcase!(
+    test_attrs_redefined_field_still_relocated,
+    r#"
+from typing import reveal_type
+from attrs import define, field
+
+@define
+class A:
+    x: int
+    y: bool = field(default=True)
+
+@define
+class B(A):
+    x: int = field(default=5)
+
+reveal_type(B.__init__)  # E: revealed type: (self: B, y: bool = ..., x: int = ...) -> None
+"#,
+);
+
+// With plain defaulted fields (no kw_only), attrs' field order depends on base-list order.
+// `D(C, B)` and `D2(B, C)` are both valid and their `__init__` signatures differ accordingly.
+attrs_testcase!(
+    test_attrs_diamond_inheritance_positional_fields_track_base_order,
+    r#"
+from typing import reveal_type
+from attrs import define
+
+@define
+class A:
+    x: int
+
+@define
+class B(A):
+    b: int = 0
+
+@define(slots=False)
+class C(A):
+    c: int = 0
+
+@define
+class D(C, B):
+    pass
+
+@define
+class D2(B, C):
+    pass
+
+reveal_type(D.__init__)   # E: revealed type: (self: D, x: int, b: int = ..., c: int = ...) -> None
+reveal_type(D2.__init__)  # E: revealed type: (self: D2, x: int, c: int = ..., b: int = ...) -> None
+
+D(1)         # OK
+D(1, 2, 3)   # OK
+D2(1)        # OK
+D2(1, 2, 3)  # OK
+"#,
+);
+
 // A conflict contained within a single base is reported once (on that base); a subclass that
 // merely inherits it does NOT re-report it.
 attrs_testcase!(


### PR DESCRIPTION
in attrs classes with diamond inheritance, `get_dataclass_fields` reordered inherited fields based on base-class order, sometimes raising a spurious "field without a default may not follow" error. It now reorders a field only when a base declares it directly, so inherited fields keep their position.

Fixes #4640 

# Test Plan

`python3 test.py`