### PR TITLE
Commit the solve behind a type query on an unopened file

### DIFF
--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -482,7 +482,14 @@ pub trait TspInterface: Send + Sync + 'static {
     ///
     /// Returns `None` when the URI cannot be resolved, the position is invalid,
     /// or no type information is available at that location.
-    fn type_at_position(&self, uri: &str, line: u32, character: u32) -> Option<tsp_types::Type>;
+    fn type_at_position<'a>(
+        &'a self,
+        ide_transaction_manager: &mut TransactionManager<'a>,
+        telemetry_event: &mut TelemetryEvent,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Option<tsp_types::Type>;
 
     /// Return the computed (inferred) type for a node spanning the given range,
     /// converted to the TSP wire format.
@@ -501,8 +508,10 @@ pub trait TspInterface: Send + Sync + 'static {
     /// declaration locations are resolved against the same warm transaction
     /// that produced the type, so the export lookups cannot hit a cold
     /// `get_stdlib`.
-    fn computed_type_at_range(
-        &self,
+    fn computed_type_at_range<'a>(
+        &'a self,
+        ide_transaction_manager: &mut TransactionManager<'a>,
+        telemetry_event: &mut TelemetryEvent,
         uri: &str,
         start_line: u32,
         start_character: u32,
@@ -514,8 +523,10 @@ pub trait TspInterface: Send + Sync + 'static {
     /// expected type — a call argument's parameter type, an annotated target's
     /// declared type, etc. — falling back to the computed type where no
     /// expected-type context applies.
-    fn expected_type_at_position(
-        &self,
+    fn expected_type_at_position<'a>(
+        &'a self,
+        ide_transaction_manager: &mut TransactionManager<'a>,
+        telemetry_event: &mut TelemetryEvent,
         uri: &str,
         line: u32,
         character: u32,
@@ -6479,64 +6490,81 @@ impl Server {
         )
     }
 
-    /// Build a read transaction and the handle the type checker analyzes `path`
-    /// under, so `(uri, range)` queries resolve for any analyzable file rather
-    /// than only open documents.
+    /// Run `query` in a read-only transaction where `uri` is analyzed, then
+    /// save the transaction for the next IDE request.
     ///
-    /// Open files are served from their in-memory overlay (already committed by
-    /// the recheck that ran on `didOpen`). For anything else we reuse the handle
-    /// the file was already analyzed under — an imported dependency's filesystem
-    /// handle, or a bundled stdlib stub's `BundledTypeshed` handle whose
-    /// `SysInfo` we can't reconstruct here, hence the by-path lookup — and force
-    /// a full solve (`Require::Everything` is the only level that retains
-    /// bindings/answers, which the type lookup reads) so narrowed/computed types
-    /// are available. A file that isn't analyzed yet falls back to a fresh
-    /// filesystem handle read from disk.
-    fn query_transaction_and_handle<'a>(&'a self, path: &Path) -> (Transaction<'a>, Handle) {
-        if self.open_files.read().contains_key(path) {
-            return (
-                self.state.transaction(),
-                make_open_handle(&self.state, path),
-            );
-        }
-        let mut transaction = self.state.transaction();
-        // Imported dependencies live under a filesystem handle we can rebuild
-        // directly; only scan when that misses (bundled stubs, unusual SysInfo).
-        let fs_handle =
-            handle_from_module_path(&self.state, ModulePath::filesystem(path.to_owned()));
-        let handle = if transaction.get_module_info(&fs_handle).is_some() {
-            fs_handle
-        } else {
-            transaction
-                .handles()
-                .into_iter()
-                .find(|h| !h.path().is_memory() && to_real_path(h.path()).as_deref() == Some(path))
-                .unwrap_or(fs_handle)
-        };
-        transaction.run(&[handle.dupe()], Require::Everything, None);
-        (transaction, handle)
-    }
-
-    /// Open `uri` at `(line, character)`: resolve the path, build a handle, and
-    /// start a transaction, returning it alongside the handle and the resolved
-    /// in-file position.
-    fn open_at_position<'a>(
+    /// A file the client never opened may not be retained at
+    /// `Require::Everything` yet. When it isn't we solve it in a committable
+    /// transaction and commit before answering: raising a module's `Require`
+    /// dirties it, so the solve rebuilds the module and its dependencies from
+    /// scratch, and discarding it would repeat that for every query against
+    /// the same file.
+    fn with_query_transaction<'a, T>(
         &'a self,
+        ide_transaction_manager: &mut TransactionManager<'a>,
+        telemetry_event: &mut TelemetryEvent,
         uri: &str,
-        line: u32,
-        character: u32,
-    ) -> Option<(Transaction<'a>, Handle, TextSize)> {
+        query: impl FnOnce(&Transaction<'a>, &Handle, Option<usize>) -> Option<T>,
+    ) -> Option<T> {
         let url = Url::parse(uri)
             .ok()
             .or_else(|| Url::from_file_path(uri).ok())?;
         let path = self.path_for_uri_or_notebook_cell(&url)?;
         let notebook_cell = self.maybe_get_code_cell_index(&url);
 
-        let (transaction, handle) = self.query_transaction_and_handle(&path);
-        let module_info = transaction.get_module_info(&handle)?;
-        let position =
-            module_info.from_lsp_position(lsp_types::Position { line, character }, notebook_cell);
-        Some((transaction, handle, position))
+        // The config finder picks the config, and so the `SysInfo`, from the
+        // path, so a rebuilt handle matches the one state holds. A bundled stub
+        // is the exception: state holds it under a `bundled_*` `ModulePath`, so
+        // the materialized path the client sends back rebuilds as a separate
+        // filesystem module and the stub is solved twice. Opening one in the
+        // editor already does the same through `ModulePath::memory`.
+        let handle = if self.open_files.read().contains_key(&path) {
+            make_open_handle(&self.state, &path)
+        } else {
+            handle_from_module_path(&self.state, ModulePath::filesystem(path.to_owned()))
+        };
+
+        let (mut transaction, needs_validation) =
+            match ide_transaction_manager.get_possibly_committable_transaction(&self.state) {
+                Ok(mut committable) => {
+                    // Read before validation runs: validation raises open
+                    // files to `Require::Everything`, so checking afterwards
+                    // would see the level it just created.
+                    if committable.as_ref().get_require(&handle) == Some(Require::Everything) {
+                        // Nothing to cache, so the committing lock buys us nothing.
+                        (committable.downgrade(), true)
+                    } else {
+                        let transaction = committable.as_mut();
+                        self.validate_in_memory_for_transaction(transaction, telemetry_event, None);
+                        transaction.run(&[handle.dupe()], Require::Everything, None);
+                        // `commit_transaction_downgrade` holds the state lock
+                        // across the commit, so what it hands back is the state
+                        // validated and solved just above.
+                        (
+                            self.state.commit_transaction_downgrade(
+                                committable,
+                                Some(telemetry_event),
+                                Require::Exports,
+                            ),
+                            false,
+                        )
+                    }
+                }
+                // A recheck holds the committing lock, so there is nothing to
+                // commit into and the solve happens in the read-only transaction.
+                Err(transaction) => (transaction, true),
+            };
+
+        if needs_validation {
+            // `didChange` skips validation when another mutation is already
+            // queued, so the overlay can be behind `open_files` even once the
+            // queue drains.
+            self.validate_in_memory_for_transaction(&mut transaction, telemetry_event, None);
+            transaction.run(&[handle.dupe()], Require::Everything, None);
+        }
+        let result = query(&transaction, &handle, notebook_cell);
+        ide_transaction_manager.save(transaction, telemetry_event);
+        result
     }
 
     /// Convert `ty` to the TSP wire format, resolving every declaration location
@@ -6733,69 +6761,99 @@ impl TspInterface for Server {
         Ok(paths)
     }
 
-    fn type_at_position(&self, uri: &str, line: u32, character: u32) -> Option<tsp_types::Type> {
-        let (transaction, handle, position) = self.open_at_position(uri, line, character)?;
+    fn type_at_position<'a>(
+        &'a self,
+        ide_transaction_manager: &mut TransactionManager<'a>,
+        telemetry_event: &mut TelemetryEvent,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Option<tsp_types::Type> {
         // For TSP, return the raw declared type without coercing callees in
         // call position. This keeps the function's `Declaration::Regular`
         // intact on the wire, which TSP clients need to re-resolve the
         // signature (parameters, overloads) from source.
-        let ty = transaction.get_type_at_preserving_declaration(&handle, position)?;
-        Some(self.convert_type_in_transaction(&transaction, &handle, &ty))
+        self.with_query_transaction(
+            ide_transaction_manager,
+            telemetry_event,
+            uri,
+            |transaction, handle, notebook_cell| {
+                let module_info = transaction.get_module_info(handle)?;
+                let position = module_info
+                    .from_lsp_position(lsp_types::Position { line, character }, notebook_cell);
+                let ty = transaction.get_type_at_preserving_declaration(handle, position)?;
+                Some(self.convert_type_in_transaction(transaction, handle, &ty))
+            },
+        )
     }
 
-    fn computed_type_at_range(
-        &self,
+    fn computed_type_at_range<'a>(
+        &'a self,
+        ide_transaction_manager: &mut TransactionManager<'a>,
+        telemetry_event: &mut TelemetryEvent,
         uri: &str,
         start_line: u32,
         start_character: u32,
         end_line: u32,
         end_character: u32,
     ) -> Option<tsp_types::Type> {
-        let url = Url::parse(uri)
-            .ok()
-            .or_else(|| Url::from_file_path(uri).ok())?;
-        let path = self.path_for_uri_or_notebook_cell(&url)?;
-        let notebook_cell = self.maybe_get_code_cell_index(&url);
-
-        let (transaction, handle) = self.query_transaction_and_handle(&path);
-        let module_info = transaction.get_module_info(&handle)?;
-        let start = module_info.from_lsp_position(
-            lsp_types::Position {
-                line: start_line,
-                character: start_character,
+        self.with_query_transaction(
+            ide_transaction_manager,
+            telemetry_event,
+            uri,
+            |transaction, handle, notebook_cell| {
+                let module_info = transaction.get_module_info(handle)?;
+                let start = module_info.from_lsp_position(
+                    lsp_types::Position {
+                        line: start_line,
+                        character: start_character,
+                    },
+                    notebook_cell,
+                );
+                let end = module_info.from_lsp_position(
+                    lsp_types::Position {
+                        line: end_line,
+                        character: end_character,
+                    },
+                    notebook_cell,
+                );
+                let range = TextRange::new(start, end);
+                // Range-aware lookup: a whole call-expression range resolves to the
+                // call's result type, other ranges to the declaration-preserving
+                // type. Convert against the *same* transaction that produced `ty`,
+                // so export location resolution stays warm and cannot hit a cold
+                // `get_stdlib`.
+                let ty = transaction.get_computed_type_at_range(handle, range)?;
+                Some(self.convert_type_in_transaction(transaction, handle, &ty))
             },
-            notebook_cell,
-        );
-        let end = module_info.from_lsp_position(
-            lsp_types::Position {
-                line: end_line,
-                character: end_character,
-            },
-            notebook_cell,
-        );
-        let range = TextRange::new(start, end);
-        // Range-aware lookup: a whole call-expression range resolves to the
-        // call's result type, other ranges to the declaration-preserving type.
-        // Convert against the *same* transaction that produced `ty`, so export
-        // location resolution stays warm and cannot hit a cold `get_stdlib`.
-        let ty = transaction.get_computed_type_at_range(&handle, range)?;
-        Some(self.convert_type_in_transaction(&transaction, &handle, &ty))
+        )
     }
 
-    fn expected_type_at_position(
-        &self,
+    fn expected_type_at_position<'a>(
+        &'a self,
+        ide_transaction_manager: &mut TransactionManager<'a>,
+        telemetry_event: &mut TelemetryEvent,
         uri: &str,
         line: u32,
         character: u32,
     ) -> Option<tsp_types::Type> {
-        let (transaction, handle, position) = self.open_at_position(uri, line, character)?;
         // Prefer the contextually expected type; fall back to the computed type
         // (preserving declarations) so the result is meaningful even outside an
         // expected-type context.
-        let ty = transaction
-            .get_expected_type_at(&handle, position)
-            .or_else(|| transaction.get_type_at_preserving_declaration(&handle, position))?;
-        Some(self.convert_type_in_transaction(&transaction, &handle, &ty))
+        self.with_query_transaction(
+            ide_transaction_manager,
+            telemetry_event,
+            uri,
+            |transaction, handle, notebook_cell| {
+                let module_info = transaction.get_module_info(handle)?;
+                let position = module_info
+                    .from_lsp_position(lsp_types::Position { line, character }, notebook_cell);
+                let ty = transaction
+                    .get_expected_type_at(handle, position)
+                    .or_else(|| transaction.get_type_at_preserving_declaration(handle, position))?;
+                Some(self.convert_type_in_transaction(transaction, handle, &ty))
+            },
+        )
     }
 
     fn resolve_uri_to_path(&self, uri: &Url) -> Option<PathBuf> {

--- a/pyrefly/lib/state/state.rs
+++ b/pyrefly/lib/state/state.rs
@@ -21,6 +21,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::MutexGuard;
 use std::sync::RwLockReadGuard;
+use std::sync::RwLockWriteGuard;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
@@ -1074,6 +1075,16 @@ impl<'a> Transaction<'a> {
 
     pub fn get_config_errors(&self) -> Vec<ConfigError> {
         self.data.state.config_finder.errors()
+    }
+
+    /// The `Require` level this transaction retains `handle` at, or `None` if
+    /// it has no such module.
+    pub fn get_require(&self, handle: &Handle) -> Option<Require> {
+        if let Some(v) = self.data.updated_modules.get(handle) {
+            Some(v.state.require())
+        } else {
+            self.readable.modules.get(handle).map(|v| v.state.require)
+        }
     }
 
     pub fn get_module_info(&self, handle: &Handle) -> Option<Module> {
@@ -3312,6 +3323,15 @@ pub struct CommittingTransaction<'a> {
     committing_transaction_guard: MutexGuard<'a, ()>,
 }
 
+impl<'a> CommittingTransaction<'a> {
+    /// Give up the right to commit, keeping the transaction and its state read
+    /// lock. Unlike acquiring both locks, releasing one cannot deadlock, so
+    /// this imposes no ordering constraint on the caller.
+    pub fn downgrade(self) -> Transaction<'a> {
+        self.transaction
+    }
+}
+
 impl<'a> AsMut<Transaction<'a>> for CommittingTransaction<'a> {
     fn as_mut(&mut self) -> &mut Transaction<'a> {
         &mut self.transaction
@@ -3451,6 +3471,19 @@ impl State {
         let start = Timer::start();
         let readable = self.state.read();
         let state_lock_blocked = start.elapsed();
+        self.transaction_from_guard(readable, default_require, subscriber, state_lock_blocked)
+    }
+
+    /// Build a transaction over the state `readable` observes. Takes the guard
+    /// rather than acquiring one, so a caller already holding the read lock
+    /// reuses it instead of dropping it and racing for another.
+    fn transaction_from_guard<'a>(
+        &'a self,
+        readable: RwLockReadGuard<'a, StateData>,
+        default_require: Require,
+        subscriber: Option<Box<dyn Subscriber + 'a>>,
+        state_lock_blocked: Duration,
+    ) -> Transaction<'a> {
         let now = readable.now;
         let stdlib = readable.stdlib.clone();
         Transaction {
@@ -3521,11 +3554,42 @@ impl State {
         }
     }
 
-    pub fn commit_transaction(
-        &self,
-        transaction: CommittingTransaction,
+    pub fn commit_transaction<'a>(
+        &'a self,
+        transaction: CommittingTransaction<'a>,
         telemetry: Option<&mut TelemetryEvent>,
     ) {
+        // Callers that need to read what was committed use
+        // `commit_transaction_downgrade` instead.
+        drop(self.commit_transaction_inner(transaction, telemetry));
+    }
+
+    /// Commit, then downgrade the write guard and hand back a transaction over
+    /// the state just written. No other commit can land in between, so the
+    /// caller does not have to re-establish what it just committed.
+    pub fn commit_transaction_downgrade<'a>(
+        &'a self,
+        transaction: CommittingTransaction<'a>,
+        telemetry: Option<&mut TelemetryEvent>,
+        default_require: Require,
+    ) -> Transaction<'a> {
+        let state = self.commit_transaction_inner(transaction, telemetry);
+        // Already holding the lock, so there was nothing to wait for.
+        self.transaction_from_guard(
+            RwLockWriteGuard::downgrade(state),
+            default_require,
+            None,
+            Duration::ZERO,
+        )
+    }
+
+    /// Apply the transaction to shared state and hand back the write lock, so
+    /// the caller chooses whether to release or downgrade it.
+    fn commit_transaction_inner<'a>(
+        &'a self,
+        transaction: CommittingTransaction<'a>,
+        telemetry: Option<&mut TelemetryEvent>,
+    ) -> RwLockWriteGuard<'a, StateData> {
         debug!("Committing transaction");
         let CommittingTransaction {
             transaction:
@@ -3614,7 +3678,8 @@ impl State {
             }
         }
 
-        drop(committing_transaction_guard)
+        drop(committing_transaction_guard);
+        state
     }
 
     pub fn run(

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/tsp_unopened_files/helper.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/tsp_unopened_files/helper.py
@@ -1,0 +1,1 @@
+value: int = 1

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/tsp_unopened_files/main.py
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/tsp_unopened_files/main.py
@@ -1,0 +1,3 @@
+import helper
+
+x = helper.value

--- a/pyrefly/lib/test/lsp/lsp_interaction/test_files/tsp_unopened_files/pyproject.toml
+++ b/pyrefly/lib/test/lsp/lsp_interaction/test_files/tsp_unopened_files/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "test-project"
+version = "1.0.0"

--- a/pyrefly/lib/test/lsp/lsp_interaction/util.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/util.rs
@@ -6,55 +6,19 @@
  */
 
 use std::fs;
-use std::path::Path;
 use std::path::PathBuf;
 
 use lsp_types::GotoDefinitionResponse;
 use lsp_types::Location;
-use pyrefly_util::fs_anyhow;
-use tempfile::TempDir;
 
 use crate::module::bundled::BundledStub;
 use crate::module::typeshed::typeshed;
-
-pub fn get_test_files_root() -> TempDir {
-    let mut source_files =
-        std::env::current_dir().expect("std:env::current_dir() unavailable for test");
-    let test_files_path = std::env::var("TEST_FILES_PATH")
-        .expect("TEST_FILES_PATH env var not set: cargo or buck should set this automatically");
-    source_files.push(test_files_path);
-
-    // We copy all files over to a separate temp directory so we are consistent between Cargo and Buck.
-    // In particular, given the current directory, Cargo is likely to find a pyproject.toml, but Buck won't.
-    let t = TempDir::with_prefix("pyrefly_lsp_test").unwrap();
-    copy_dir_recursively(&source_files, t.path());
-
-    t
-}
+pub use crate::test::util::get_test_files_root;
 
 pub fn bundled_typeshed_path() -> PathBuf {
     let mut path = std::env::temp_dir();
     path.push(typeshed().unwrap().get_path_name());
     path
-}
-
-fn copy_dir_recursively(src: &Path, dst: &Path) {
-    if !dst.exists() {
-        std::fs::create_dir_all(dst).unwrap();
-    }
-
-    for entry in fs_anyhow::read_dir(src).unwrap() {
-        let entry = entry.unwrap();
-        let file_type = entry.file_type().unwrap();
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-
-        if file_type.is_dir() {
-            copy_dir_recursively(&src_path, &dst_path);
-        } else {
-            std::fs::copy(&src_path, &dst_path).unwrap();
-        }
-    }
 }
 
 /// Validates that a goto definition response points to the expected symbol.

--- a/pyrefly/lib/test/tsp/tsp_interaction.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction.rs
@@ -16,3 +16,4 @@ pub mod object_model;
 pub mod request_errors;
 pub mod resolve_import;
 pub mod snapshot_changed;
+pub mod unopened_files;

--- a/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/get_type_queries.rs
@@ -439,8 +439,9 @@ fn test_get_computed_type_in_unopened_file() {
 fn test_get_computed_type_in_bundled_typeshed() {
     // The real-world case behind #4228: Pylance never `didOpen`s bundled stdlib
     // stubs, so nodes inside `builtins.pyi` (which no editor opens) must still
-    // resolve. This exercises the by-path lookup that reuses the bundled
-    // typeshed handle the checker already analyzed.
+    // resolve. The handle is rebuilt from the materialized path, which gives a
+    // filesystem module distinct from the `bundled_*` one the checker analyzed;
+    // this pins that the answer is the same either way.
     let builtins = typeshed()
         .unwrap()
         .materialized_path_on_disk()

--- a/pyrefly/lib/test/tsp/tsp_interaction/unopened_files.rs
+++ b/pyrefly/lib/test/tsp/tsp_interaction/unopened_files.rs
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Type queries against files the client never opened.
+//!
+//! Pylance queries modules it has not sent a `didOpen` for, so these go through
+//! the path that solves a module and commits it rather than reading one the
+//! editor is already holding in memory.
+
+use lsp_types::Url;
+use tempfile::TempDir;
+use tsp_types::TypeKind;
+
+use crate::test::tsp::tsp_interaction::object_model::TspInteraction;
+use crate::test::util::get_test_files_root;
+
+/// A project whose open file imports a module the client never opens.
+/// Returns the interaction, the directory (kept alive for the test), the
+/// unopened module's URI, and the current snapshot.
+fn setup_with_unopened_import() -> (TspInteraction, TempDir, String, i32) {
+    let test_files = get_test_files_root();
+    let root = test_files.path().join("tsp_unopened_files");
+
+    let mut tsp = TspInteraction::new();
+    tsp.set_root(root.clone());
+    tsp.initialize(Default::default());
+    tsp.server.did_open("main.py");
+    tsp.client.expect_notification("typeServer/snapshotChanged");
+
+    let snapshot = current_snapshot(&mut tsp);
+    let uri = Url::from_file_path(root.join("helper.py"))
+        .unwrap()
+        .to_string();
+    (tsp, test_files, uri, snapshot)
+}
+
+/// The server's current snapshot. Unlike the shared helper this does not assert
+/// a request id, so tests can ask more than once.
+fn current_snapshot(tsp: &mut TspInteraction) -> i32 {
+    tsp.server.get_snapshot();
+    let resp = tsp.client.receive_response_skip_notifications();
+    serde_json::from_value(resp.result.expect("getSnapshot should succeed")).unwrap()
+}
+
+fn computed_type(
+    tsp: &mut TspInteraction,
+    uri: &str,
+    line: u32,
+    character: u32,
+    snapshot: i32,
+) -> serde_json::Value {
+    tsp.server.get_computed_type(uri, line, character, snapshot);
+    let resp = tsp.client.receive_response_skip_notifications();
+    assert!(
+        resp.error.is_none(),
+        "Expected success, got error: {:?}",
+        resp.error
+    );
+    resp.result.expect("Expected a result")
+}
+
+/// The name of the class a type result resolves to, e.g. `int`.
+fn declaration_name(result: &serde_json::Value) -> &str {
+    result
+        .get("declaration")
+        .and_then(|d| d.get("name"))
+        .and_then(|n| n.as_str())
+        .unwrap_or_else(|| panic!("Expected declaration.name in: {result}"))
+}
+
+#[test]
+fn test_get_declared_type_on_unopened_import() {
+    let (mut tsp, _dir, uri, snapshot) = setup_with_unopened_import();
+
+    tsp.server.get_declared_type(&uri, 0, 0, snapshot);
+    let resp = tsp.client.receive_response_skip_notifications();
+
+    assert!(
+        resp.error.is_none(),
+        "Expected success, got error: {:?}",
+        resp.error
+    );
+    let result = resp.result.expect("Expected a result");
+    assert!(
+        !result.is_null(),
+        "Expected a type for an unopened module, got null"
+    );
+    let kind = result.get("kind").and_then(|v| v.as_u64());
+    assert_eq!(kind, Some(TypeKind::Class as u64), "got: {result}");
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_expected_type_on_unopened_import() {
+    let (mut tsp, _dir, uri, snapshot) = setup_with_unopened_import();
+
+    tsp.server.get_expected_type(&uri, 0, 0, snapshot);
+    let resp = tsp.client.receive_response_skip_notifications();
+
+    assert!(
+        resp.error.is_none(),
+        "Expected success, got error: {:?}",
+        resp.error
+    );
+    assert!(
+        !resp.result.expect("Expected a result").is_null(),
+        "Expected a type for an unopened module, got null"
+    );
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_unopened_file_query_sees_change_on_disk() {
+    // The first query solves the module and commits it. A later edit has to
+    // invalidate that, or every subsequent query answers from the stale solve.
+    let (mut tsp, test_files, uri, snapshot) = setup_with_unopened_import();
+    let root = test_files.path().join("tsp_unopened_files");
+
+    let before = computed_type(&mut tsp, &uri, 0, 0, snapshot);
+    assert_eq!(declaration_name(&before), "int", "got: {before}");
+
+    std::fs::write(root.join("helper.py"), "value: str = \"s\"\n").unwrap();
+    tsp.server.did_change_watched_files("helper.py", "changed");
+    tsp.client.expect_notification("typeServer/snapshotChanged");
+
+    let snapshot = current_snapshot(&mut tsp);
+    let after = computed_type(&mut tsp, &uri, 0, 0, snapshot);
+    assert_eq!(
+        declaration_name(&after),
+        "str",
+        "the committed solve should have been invalidated, got: {after}"
+    );
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_opened_file_query_uses_in_memory_contents_after_unopened_query() {
+    let (mut tsp, _test_files, uri, snapshot) = setup_with_unopened_import();
+
+    let unopened = computed_type(&mut tsp, &uri, 0, 0, snapshot);
+    assert_eq!(declaration_name(&unopened), "int", "got: {unopened}");
+
+    tsp.server.did_open("helper.py");
+    tsp.server
+        .did_change("helper.py", "value: str = \"memory\"\n", 2);
+    tsp.client.expect_notification("typeServer/snapshotChanged");
+
+    let snapshot = current_snapshot(&mut tsp);
+    let opened = computed_type(&mut tsp, &uri, 0, 0, snapshot);
+    assert_eq!(
+        declaration_name(&opened),
+        "str",
+        "the query should use the open file's in-memory contents, got: {opened}"
+    );
+
+    tsp.shutdown();
+}
+
+#[test]
+fn test_get_computed_type_on_path_not_in_state() {
+    // A path the server has never seen and that does not exist on disk is
+    // answered, not dropped or turned into an error.
+    let (mut tsp, test_files, _uri, snapshot) = setup_with_unopened_import();
+
+    let missing = test_files
+        .path()
+        .join("tsp_unopened_files/does_not_exist.py");
+    let uri = Url::from_file_path(&missing).unwrap().to_string();
+    tsp.server.get_computed_type(&uri, 0, 0, snapshot);
+    let resp = tsp.client.receive_response_skip_notifications();
+
+    assert!(
+        resp.error.is_none(),
+        "An unknown path should not be an error: {:?}",
+        resp.error
+    );
+    assert!(
+        resp.result.expect("Expected a result").is_null(),
+        "An unknown path has no type"
+    );
+
+    tsp.shutdown();
+}

--- a/pyrefly/lib/test/util.rs
+++ b/pyrefly/lib/test/util.rs
@@ -6,6 +6,7 @@
  */
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -28,6 +29,7 @@ use pyrefly_python::sys_info::PythonPlatform;
 use pyrefly_python::sys_info::PythonVersion;
 use pyrefly_python::sys_info::SysInfo;
 use pyrefly_util::arc_id::ArcId;
+use pyrefly_util::fs_anyhow;
 use pyrefly_util::prelude::SliceExt;
 use pyrefly_util::thread_pool::TEST_THREAD_COUNT;
 use pyrefly_util::trace::init_tracing;
@@ -38,6 +40,7 @@ use ruff_source_file::PositionEncoding;
 use ruff_source_file::SourceLocation;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
+use tempfile::TempDir;
 
 use crate::binding::binding::KeyExport;
 use crate::config::base::InferReturnTypes;
@@ -55,6 +58,36 @@ use crate::state::state::StateReader;
 use crate::state::subscriber::TestSubscriber;
 use crate::types::class::Class;
 use crate::types::types::Type;
+
+pub fn get_test_files_root() -> TempDir {
+    let mut source_files =
+        std::env::current_dir().expect("std:env::current_dir() unavailable for test");
+    let test_files_path = std::env::var("TEST_FILES_PATH")
+        .expect("TEST_FILES_PATH env var not set: cargo or buck should set this automatically");
+    source_files.push(test_files_path);
+
+    // Copy the fixtures so tests can mutate them and behave consistently under Cargo and Buck.
+    let temp_dir = TempDir::with_prefix("pyrefly_lsp_test").unwrap();
+    copy_dir_recursively(&source_files, temp_dir.path());
+    temp_dir
+}
+
+fn copy_dir_recursively(src: &Path, dst: &Path) {
+    if !dst.exists() {
+        std::fs::create_dir_all(dst).unwrap();
+    }
+
+    for entry in fs_anyhow::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_recursively(&src_path, &dst_path);
+        } else {
+            std::fs::copy(src_path, dst_path).unwrap();
+        }
+    }
+}
 
 pub fn shape_extensions_env() -> TestEnv {
     let path = std::env::var("SHAPE_EXTENSIONS_TEST_PATH")

--- a/pyrefly/lib/tsp/requests/get_computed_type.rs
+++ b/pyrefly/lib/tsp/requests/get_computed_type.rs
@@ -8,10 +8,12 @@
 //! Implementation of the `typeServer/getComputedType` TSP request.
 
 use lsp_server::ResponseError;
+use pyrefly_util::telemetry::TelemetryEvent;
 use tsp_types::GetTypeParams;
 use tsp_types::Type;
 
 use crate::lsp::non_wasm::server::TspInterface;
+use crate::lsp::non_wasm::transaction_manager::TransactionManager;
 use crate::tsp::server::TspServer;
 use crate::tsp::validation::parse_uri;
 
@@ -21,8 +23,10 @@ impl<T: TspInterface> TspServer<T> {
     /// The computed type reflects the type checker's analysis of the code
     /// flow — e.g. after narrowing inside an `isinstance` guard the computed
     /// type of a variable may be more specific than its declared annotation.
-    pub fn handle_get_computed_type(
-        &self,
+    pub fn handle_get_computed_type<'a>(
+        &'a self,
+        ide_transaction_manager: &mut TransactionManager<'a>,
+        telemetry_event: &mut TelemetryEvent,
         params: GetTypeParams,
     ) -> Result<Option<Type>, ResponseError> {
         self.validate_snapshot(params.snapshot)?;
@@ -33,6 +37,8 @@ impl<T: TspInterface> TspServer<T> {
         let start = params.position();
         let end = params.end_position();
         Ok(self.inner().computed_type_at_range(
+            ide_transaction_manager,
+            telemetry_event,
             params.uri(),
             start.line,
             start.character,

--- a/pyrefly/lib/tsp/requests/get_declared_type.rs
+++ b/pyrefly/lib/tsp/requests/get_declared_type.rs
@@ -8,10 +8,12 @@
 //! Implementation of the `typeServer/getDeclaredType` TSP request.
 
 use lsp_server::ResponseError;
+use pyrefly_util::telemetry::TelemetryEvent;
 use tsp_types::GetTypeParams;
 use tsp_types::Type;
 
 use crate::lsp::non_wasm::server::TspInterface;
+use crate::lsp::non_wasm::transaction_manager::TransactionManager;
 use crate::tsp::server::TspServer;
 use crate::tsp::validation::parse_uri;
 
@@ -25,8 +27,10 @@ impl<T: TspInterface> TspServer<T> {
     /// Currently piggy-backs on `type_at_position`, which returns the computed
     /// type. A future improvement can separate the annotation type from the
     /// inferred type in the binding infrastructure.
-    pub fn handle_get_declared_type(
-        &self,
+    pub fn handle_get_declared_type<'a>(
+        &'a self,
+        ide_transaction_manager: &mut TransactionManager<'a>,
+        telemetry_event: &mut TelemetryEvent,
         params: GetTypeParams,
     ) -> Result<Option<Type>, ResponseError> {
         self.validate_snapshot(params.snapshot)?;
@@ -35,8 +39,12 @@ impl<T: TspInterface> TspServer<T> {
         // to notebook paths inside type_at_position.
         parse_uri(params.uri())?;
         let position = params.position();
-        Ok(self
-            .inner()
-            .type_at_position(params.uri(), position.line, position.character))
+        Ok(self.inner().type_at_position(
+            ide_transaction_manager,
+            telemetry_event,
+            params.uri(),
+            position.line,
+            position.character,
+        ))
     }
 }

--- a/pyrefly/lib/tsp/requests/get_expected_type.rs
+++ b/pyrefly/lib/tsp/requests/get_expected_type.rs
@@ -8,10 +8,12 @@
 //! Implementation of the `typeServer/getExpectedType` TSP request.
 
 use lsp_server::ResponseError;
+use pyrefly_util::telemetry::TelemetryEvent;
 use tsp_types::GetTypeParams;
 use tsp_types::Type;
 
 use crate::lsp::non_wasm::server::TspInterface;
+use crate::lsp::non_wasm::transaction_manager::TransactionManager;
 use crate::tsp::server::TspServer;
 use crate::tsp::validation::parse_uri;
 
@@ -22,8 +24,10 @@ impl<T: TspInterface> TspServer<T> {
     /// For example, in `foo(4)` where `def foo(a: int | str)`, the expected
     /// type of the argument `4` is `int | str`. Where no expected-type context
     /// applies, this falls back to the computed type at the position.
-    pub fn handle_get_expected_type(
-        &self,
+    pub fn handle_get_expected_type<'a>(
+        &'a self,
+        ide_transaction_manager: &mut TransactionManager<'a>,
+        telemetry_event: &mut TelemetryEvent,
         params: GetTypeParams,
     ) -> Result<Option<Type>, ResponseError> {
         self.validate_snapshot(params.snapshot)?;
@@ -32,8 +36,12 @@ impl<T: TspInterface> TspServer<T> {
         // to notebook paths inside expected_type_at_position.
         parse_uri(params.uri())?;
         let position = params.position();
-        Ok(self
-            .inner()
-            .expected_type_at_position(params.uri(), position.line, position.character))
+        Ok(self.inner().expected_type_at_position(
+            ide_transaction_manager,
+            telemetry_event,
+            params.uri(),
+            position.line,
+            position.character,
+        ))
     }
 }

--- a/pyrefly/lib/tsp/requests/resolve_import.rs
+++ b/pyrefly/lib/tsp/requests/resolve_import.rs
@@ -17,6 +17,7 @@ use lsp_server::ResponseError;
 use lsp_types::Url;
 use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::module_path::ModulePath;
+use pyrefly_util::telemetry::TelemetryEvent;
 use ruff_python_ast::name::Name;
 use tsp_types::protocol::ResolveImportParams;
 
@@ -40,6 +41,7 @@ impl<T: TspInterface> TspServer<T> {
         id: RequestId,
         params: ResolveImportParams,
         ide_transaction_manager: &mut TransactionManager<'a>,
+        telemetry_event: &mut TelemetryEvent,
         reply: Reply,
     ) {
         // --- 1. Validate snapshot ---
@@ -99,6 +101,12 @@ impl<T: TspInterface> TspServer<T> {
                     .map(|u| u.to_string())
             })
         });
+
+        // Hand the transaction back. `non_committable_transaction` took it out
+        // of the manager, and it may carry a solve that a type query saved
+        // while a recheck held the committing lock; dropping it here would make
+        // the next query redo that work.
+        ide_transaction_manager.save(transaction, telemetry_event);
 
         reply.ok(id, uri_string);
     }

--- a/pyrefly/lib/tsp/server.rs
+++ b/pyrefly/lib/tsp/server.rs
@@ -219,6 +219,7 @@ impl<T: TspInterface> TspServer<T> {
     fn dispatch_tsp_request<'a>(
         &'a self,
         ide_transaction_manager: &mut TransactionManager<'a>,
+        telemetry_event: &mut TelemetryEvent,
         reply: Reply,
         request: &Request,
         msg: TSPRequests,
@@ -236,6 +237,7 @@ impl<T: TspInterface> TspServer<T> {
                     request.id.clone(),
                     params,
                     ide_transaction_manager,
+                    telemetry_event,
                     reply,
                 );
             }
@@ -244,17 +246,17 @@ impl<T: TspInterface> TspServer<T> {
             }
             TSPRequests::GetDeclaredTypeRequest { params, .. } => {
                 self.dispatch_get_type_request(request.id.clone(), params, reply, |p| {
-                    self.handle_get_declared_type(p)
+                    self.handle_get_declared_type(ide_transaction_manager, telemetry_event, p)
                 });
             }
             TSPRequests::GetComputedTypeRequest { params, .. } => {
                 self.dispatch_get_type_request(request.id.clone(), params, reply, |p| {
-                    self.handle_get_computed_type(p)
+                    self.handle_get_computed_type(ide_transaction_manager, telemetry_event, p)
                 });
             }
             TSPRequests::GetExpectedTypeRequest { params, .. } => {
                 self.dispatch_get_type_request(request.id.clone(), params, reply, |p| {
-                    self.handle_get_expected_type(p)
+                    self.handle_get_expected_type(ide_transaction_manager, telemetry_event, p)
                 });
             }
             TSPRequests::ConnectionRequest { .. } => {
@@ -335,7 +337,13 @@ impl<T: TspInterface> TspServer<T> {
                     self.handle_connection_request(request.id.clone(), params, reply);
                 }
                 Some(msg) => {
-                    self.dispatch_tsp_request(ide_transaction_manager, reply, request, msg);
+                    self.dispatch_tsp_request(
+                        ide_transaction_manager,
+                        telemetry_event,
+                        reply,
+                        request,
+                        msg,
+                    );
                 }
                 None => {
                     reply.send(Response::new_err(


### PR DESCRIPTION
Summary:
TSP supports requests on files which have not yet been opened. In this case, we
would create a throw-away transaction that solved the module to
`Step::Solutions` with `Require::Everything`, ran the request handler, and
returned the result. Solving the module for every request is extremely
expensive, but all that work is thrown away between requests. Furthermore, TSP
is fairly chatty, sending hundreds (sometimes thousands) of `getComputedType`
requests.

This change offers a simple but effective solution: when handling a request for
a non-open file, we create a "possibly committable" transaction to raise the
require level for that handle. We are either able to (1) get a committable
transaction which updates the committed state, so future requests share the
earlier solve work, or (2) we get a non-committable transaction, but the
`TransactionManager` maintains a saved state, so that multiple requests can
still share solve work even when a background recheck is happening. This is also
how the Pyrefly LSP works.

To test this change I captured and replayed a Pylance session which had 43,811
`getComputedType` requests (89% of them through the extra connection). Request
costs compared to parent, in ms:

```
  request          target    n      | before p50   p90    total | after p50   p90   total
  getComputedType  non-open  22294  |     16.886  57.82  667.79s |    0.067  0.114   3.43s
  getComputedType  open      21517  |      0.046   0.09    1.25s |    0.059  0.074   1.34s
  getSnapshot      -           191  |      0.069   7.18    1.14s |    0.068  6.632   1.05s
  resolveImport    -           994  |      0.130   1.38    0.58s |    0.087  1.229   0.42s
                                        total 670.95s               total 6.41s
```

Both runs also carried an unrelated `demand` fix that is not part of this stack,
worth roughly 0.2s of the "after" total.

Test Plan:
Answers are unchanged. Response payloads carry allocation-order identifiers
that differ between runs, so responses are compared ignoring digits: 43822 of
43873 (99.88%) match. All 51 that differ are `-32802` snapshot-outdated
responses, never a differing type. Two runs of the same binary differ
structurally in 78 responses, so the gap between the two binaries is within a
single binary's run-to-run variation.

