### PR TITLE
feat(baseline): support configurable baseline matching behaviour and file format

### DIFF
--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -526,6 +526,40 @@ impl ImportLookupPathPart<'_> {
     }
 }
 
+/// Fields used to match diagnostics against baseline entries.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BaselineMatchingMode {
+    /// Match by path, error kind, and starting column.
+    #[default]
+    Column,
+    /// Match by path, error kind, and concise description.
+    ConciseDescription,
+}
+
+impl BaselineMatchingMode {
+    fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+/// Amount of diagnostic information written to a baseline file.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BaselineFormat {
+    /// Write all available baseline metadata.
+    #[default]
+    Full,
+    /// Write only the fields required for matching.
+    Minimal,
+}
+
+impl BaselineFormat {
+    fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 #[skip_serializing_none]
 #[derive(Debug, Deserialize, Serialize, Clone, Derivative)]
 #[serde(rename_all = "kebab-case")]
@@ -617,6 +651,14 @@ pub struct ConfigFile {
     /// Severity assigned to errors that match the baseline.
     /// Defaults to `ignore`.
     pub baseline_error_level: Option<Severity>,
+
+    /// Fields used to match diagnostics against baseline entries.
+    #[serde(default, skip_serializing_if = "BaselineMatchingMode::is_default")]
+    pub baseline_matching_mode: BaselineMatchingMode,
+
+    /// Amount of diagnostic information written to the baseline.
+    #[serde(default, skip_serializing_if = "BaselineFormat::is_default")]
+    pub baseline_format: BaselineFormat,
 
     /// Default error output format for CLI checks when `--output-format` is not set.
     pub output_format: Option<OutputFormat>,
@@ -734,6 +776,8 @@ impl Default for ConfigFile {
             typeshed_path: None,
             baseline: None,
             baseline_error_level: None,
+            baseline_matching_mode: BaselineMatchingMode::default(),
+            baseline_format: BaselineFormat::default(),
             min_severity: None,
             output_format: None,
             skip_lsp_config_indexing: false,
@@ -2189,6 +2233,8 @@ mod tests {
                 typeshed_path: None,
                 baseline: None,
                 baseline_error_level: None,
+                baseline_matching_mode: BaselineMatchingMode::Column,
+                baseline_format: BaselineFormat::Full,
                 min_severity: None,
                 skip_lsp_config_indexing: false,
                 extra_file_extensions: Vec::new(),
@@ -2516,6 +2562,8 @@ mod tests {
             typeshed_path: Some(PathBuf::from(typeshed)),
             baseline: Some(PathBuf::from("baseline.json")),
             baseline_error_level: None,
+            baseline_matching_mode: BaselineMatchingMode::Column,
+            baseline_format: BaselineFormat::Full,
             min_severity: None,
             skip_lsp_config_indexing: false,
             extra_file_extensions: Vec::new(),
@@ -2590,6 +2638,8 @@ mod tests {
             typeshed_path: Some(expected_typeshed),
             baseline: Some(test_path.join("baseline.json")),
             baseline_error_level: None,
+            baseline_matching_mode: BaselineMatchingMode::Column,
+            baseline_format: BaselineFormat::Full,
             min_severity: None,
             skip_lsp_config_indexing: false,
             extra_file_extensions: Vec::new(),
@@ -2677,10 +2727,24 @@ mod tests {
         let config_str = r#"
 baseline = "baseline.json"
 baseline-error-level = "warn"
+baseline-matching-mode = "concise_description"
+baseline-format = "minimal"
 "#;
         let config = ConfigFile::parse_config(config_str).unwrap();
         assert_eq!(config.baseline, Some(PathBuf::from("baseline.json")));
         assert_eq!(config.baseline_error_level, Some(Severity::Warn));
+        assert_eq!(
+            config.baseline_matching_mode,
+            BaselineMatchingMode::ConciseDescription
+        );
+        assert_eq!(config.baseline_format, BaselineFormat::Minimal);
+
+        let defaults = ConfigFile::parse_config("").unwrap();
+        assert_eq!(
+            defaults.baseline_matching_mode,
+            BaselineMatchingMode::Column
+        );
+        assert_eq!(defaults.baseline_format, BaselineFormat::Full);
     }
 
     #[test]

--- a/crates/pyrefly_config/src/config.rs
+++ b/crates/pyrefly_config/src/config.rs
@@ -528,7 +528,7 @@ impl ImportLookupPathPart<'_> {
 
 /// Fields used to match diagnostics against baseline entries.
 #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "kebab-case")]
 pub enum BaselineMatchingMode {
     /// Match by path, error kind, and starting column.
     #[default]
@@ -545,7 +545,7 @@ impl BaselineMatchingMode {
 
 /// Amount of diagnostic information written to a baseline file.
 #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "kebab-case")]
 pub enum BaselineFormat {
     /// Write all available baseline metadata.
     #[default]
@@ -2727,7 +2727,7 @@ mod tests {
         let config_str = r#"
 baseline = "baseline.json"
 baseline-error-level = "warn"
-baseline-matching-mode = "concise_description"
+baseline-matching-mode = "concise-description"
 baseline-format = "minimal"
 "#;
         let config = ConfigFile::parse_config(config_str).unwrap();

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -37,6 +37,8 @@ use percent_encoding::CONTROLS;
 use percent_encoding::utf8_percent_encode;
 use pyrefly_build::handle::Handle;
 use pyrefly_config::args::ConfigOverrideArgs;
+use pyrefly_config::config::BaselineFormat;
+use pyrefly_config::config::BaselineMatchingMode;
 use pyrefly_config::config::ConfigFile;
 use pyrefly_config::config::OutputFormat;
 use pyrefly_config::config::SynthesizedPresetReason;
@@ -584,6 +586,12 @@ impl OutputArgs {
                 .baseline_error_level
                 .or_else(|| config.and_then(|config| config.baseline_error_level))
                 .unwrap_or(Severity::Ignore),
+            baseline_matching_mode: config
+                .map(|config| config.baseline_matching_mode)
+                .unwrap_or_default(),
+            baseline_format: config
+                .map(|config| config.baseline_format)
+                .unwrap_or_default(),
             output_format: self
                 .output_format
                 .or_else(|| config.and_then(|config| config.output_format))
@@ -613,6 +621,8 @@ impl OutputArgs {
 struct OutputDefaults {
     baseline: Option<PathBuf>,
     baseline_error_level: Severity,
+    baseline_matching_mode: BaselineMatchingMode,
+    baseline_format: BaselineFormat,
     output_format: OutputFormat,
     min_severity: Severity,
 }
@@ -844,8 +854,17 @@ fn write_baseline_errors_to_file(path: &Path, errors: &BaselineErrors) -> anyhow
     f(path, errors).with_context(|| format!("while writing baseline to `{}`", path.display()))
 }
 
-fn write_baseline_to_file(path: &Path, relative_to: &Path, errors: &[Error]) -> anyhow::Result<()> {
-    write_baseline_errors_to_file(path, &BaselineErrors::from_errors(relative_to, errors))
+fn write_baseline_to_file(
+    path: &Path,
+    relative_to: &Path,
+    errors: &[Error],
+    matching_mode: BaselineMatchingMode,
+    format: BaselineFormat,
+) -> anyhow::Result<()> {
+    write_baseline_errors_to_file(
+        path,
+        &BaselineErrors::from_errors(relative_to, errors).with_format(matching_mode, format),
+    )
 }
 
 fn write_error_json_to_console(relative_to: &Path, errors: &[Error]) -> anyhow::Result<()> {
@@ -1889,6 +1908,7 @@ impl CheckArgs {
             &mut collected,
             defaults.baseline.as_deref(),
             relative_to.as_path(),
+            defaults.baseline_matching_mode,
             self.output.prune_baseline || self.output.error_stale_baseline,
         );
 
@@ -1997,7 +2017,13 @@ impl CheckArgs {
                     error.error_kind(),
                 )
             });
-            write_baseline_to_file(baseline_path, relative_to.as_path(), &new_baseline)?;
+            write_baseline_to_file(
+                baseline_path,
+                relative_to.as_path(),
+                &new_baseline,
+                defaults.baseline_matching_mode,
+                defaults.baseline_format,
+            )?;
         } else if rewriting_baseline {
             let baseline_path = defaults
                 .baseline
@@ -2007,7 +2033,8 @@ impl CheckArgs {
                 baseline_path,
                 &BaselineErrors {
                     errors: retained_baseline_entries,
-                },
+                }
+                .with_format(defaults.baseline_matching_mode, defaults.baseline_format),
             )?;
         }
         if rewriting_baseline {
@@ -2862,8 +2889,30 @@ def go(w: Widget) -> int:
 
         assert_eq!(defaults.baseline, None);
         assert_eq!(defaults.baseline_error_level, Severity::Ignore);
+        assert_eq!(
+            defaults.baseline_matching_mode,
+            BaselineMatchingMode::Column
+        );
+        assert_eq!(defaults.baseline_format, BaselineFormat::Full);
         assert_eq!(defaults.output_format, OutputFormat::default());
         assert_eq!(defaults.min_severity, Severity::Error);
+    }
+
+    #[test]
+    fn output_args_inherit_baseline_matching_and_format() {
+        let output = OutputArgs::parse_from(["pyrefly-check"]);
+        let config = ConfigFile {
+            baseline_matching_mode: BaselineMatchingMode::ConciseDescription,
+            baseline_format: BaselineFormat::Minimal,
+            ..Default::default()
+        };
+        let defaults = output.resolve(Some(&config));
+
+        assert_eq!(
+            defaults.baseline_matching_mode,
+            BaselineMatchingMode::ConciseDescription
+        );
+        assert_eq!(defaults.baseline_format, BaselineFormat::Minimal);
     }
 
     #[test]

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -844,7 +844,10 @@ fn write_error_json_to_file(
         .with_context(|| format!("while writing JSON errors to `{}`", path.display()))
 }
 
-fn write_baseline_errors_to_file(path: &Path, errors: &BaselineErrors) -> anyhow::Result<()> {
+fn write_formatted_baseline_errors_to_file(
+    path: &Path,
+    errors: &BaselineErrors,
+) -> anyhow::Result<()> {
     fn f(path: &Path, errors: &BaselineErrors) -> anyhow::Result<()> {
         let mut writer = BufWriter::new(File::create(path)?);
         serde_json::to_writer_pretty(&mut writer, errors)?;
@@ -854,14 +857,14 @@ fn write_baseline_errors_to_file(path: &Path, errors: &BaselineErrors) -> anyhow
     f(path, errors).with_context(|| format!("while writing baseline to `{}`", path.display()))
 }
 
-fn write_baseline_to_file(
+fn write_baseline_errors_to_file(
     path: &Path,
     relative_to: &Path,
     errors: &[Error],
     matching_mode: BaselineMatchingMode,
     format: BaselineFormat,
 ) -> anyhow::Result<()> {
-    write_baseline_errors_to_file(
+    write_formatted_baseline_errors_to_file(
         path,
         &BaselineErrors::from_errors(relative_to, errors).with_format(matching_mode, format),
     )
@@ -2017,7 +2020,7 @@ impl CheckArgs {
                     error.error_kind(),
                 )
             });
-            write_baseline_to_file(
+            write_baseline_errors_to_file(
                 baseline_path,
                 relative_to.as_path(),
                 &new_baseline,
@@ -2029,8 +2032,8 @@ impl CheckArgs {
                 .baseline
                 .as_ref()
                 .expect("a baseline action requires a baseline path");
-            // Pruning removes entries without applying the current generation format.
-            write_baseline_errors_to_file(
+            // Pruning removes entries and preserves the format of remaining ones.
+            write_formatted_baseline_errors_to_file(
                 baseline_path,
                 &BaselineErrors {
                     errors: retained_baseline_entries,

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -2029,12 +2029,12 @@ impl CheckArgs {
                 .baseline
                 .as_ref()
                 .expect("a baseline action requires a baseline path");
+            // Pruning removes entries without applying the current generation format.
             write_baseline_errors_to_file(
                 baseline_path,
                 &BaselineErrors {
                     errors: retained_baseline_entries,
-                }
-                .with_format(defaults.baseline_matching_mode, defaults.baseline_format),
+                },
             )?;
         }
         if rewriting_baseline {

--- a/pyrefly/lib/error/baseline.rs
+++ b/pyrefly/lib/error/baseline.rs
@@ -8,22 +8,31 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
-use std::path::PathBuf;
 
+use anyhow::Context;
 use anyhow::Result;
 use pyrefly_util::absolutize::Absolutize;
 
+use crate::config::config::BaselineMatchingMode;
 use crate::error::error::Error;
 use crate::error::legacy::BaselineError;
 use crate::error::legacy::BaselineErrors;
 
-/// If an error with an exactly matching path, error slug, and starting column exist in the baseline, we ignore it.
-/// Keys always use absolute paths internally so that comparison is decoupled from path format in baseline file.
+const INVALID_BASELINE_GUIDANCE: &str =
+    "baseline file is invalid; rerun with `--update-baseline` to regenerate it";
+
+/// Keys use absolute paths internally so comparison is independent of the baseline's path format.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct BaselineKey {
     path: String,
     name: String,
-    column: usize,
+    matching_field: BaselineMatchingField,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum BaselineMatchingField {
+    Column(usize),
+    ConciseDescription(String),
 }
 
 /// Normalize a path to an absolute, forward-slash string.
@@ -34,26 +43,51 @@ pub(crate) fn normalize_baseline_path(path: &Path, relative_to: &Path) -> String
 }
 
 impl BaselineKey {
-    fn from_baseline_error(error: &BaselineError, relative_to: &Path) -> Self {
-        Self {
+    fn from_baseline_error(
+        error: &BaselineError,
+        relative_to: &Path,
+        matching_mode: BaselineMatchingMode,
+    ) -> Result<Self> {
+        let matching_field = match matching_mode {
+            BaselineMatchingMode::Column => BaselineMatchingField::Column(error.column.context(
+                "missing field `column`, required by `baseline-matching-mode = \"column\"`",
+            )?),
+            BaselineMatchingMode::ConciseDescription => BaselineMatchingField::ConciseDescription(
+                error.concise_description.clone().context(
+                    "missing field `concise_description`, required by \
+                         `baseline-matching-mode = \"concise_description\"`",
+                )?,
+            ),
+        };
+        Ok(Self {
             path: normalize_baseline_path(Path::new(&error.path), relative_to),
             name: error.name.clone(),
-            column: error.column,
-        }
+            matching_field,
+        })
     }
 
-    fn from_error(error: &Error) -> Self {
+    fn from_error(error: &Error, matching_mode: BaselineMatchingMode) -> Self {
+        let matching_field = match matching_mode {
+            BaselineMatchingMode::Column => {
+                BaselineMatchingField::Column(error.display_range().start.column().get() as usize)
+            }
+            BaselineMatchingMode::ConciseDescription => {
+                BaselineMatchingField::ConciseDescription(error.msg_header().to_owned())
+            }
+        };
         Self {
             path: error.path().as_path().to_string_lossy().replace('\\', "/"),
             name: error.error_kind().to_name().to_owned(),
-            column: error.display_range().start.column().get() as usize,
+            matching_field,
         }
     }
 }
 
 /// A lightweight, keys-only baseline matcher for the language server.
+#[derive(Debug)]
 pub struct BaselineProcessor {
     baseline_keys: HashSet<BaselineKey>,
+    matching_mode: BaselineMatchingMode,
 }
 
 impl BaselineProcessor {
@@ -61,23 +95,36 @@ impl BaselineProcessor {
     /// that was used when the baseline was written (i.e. the resolved
     /// `--relative-to` value), so that relative paths in the file are resolved
     /// correctly.
-    pub fn from_json(content: &str, relative_to: &Path) -> Result<Self> {
-        let baseline_file: BaselineErrors = serde_json::from_str(content)?;
-        Ok(Self::from_baseline_errors(baseline_file, relative_to))
+    pub fn from_json(
+        content: &str,
+        relative_to: &Path,
+        matching_mode: BaselineMatchingMode,
+    ) -> Result<Self> {
+        let baseline_file: BaselineErrors =
+            serde_json::from_str(content).context(INVALID_BASELINE_GUIDANCE)?;
+        Self::from_baseline_errors(baseline_file, relative_to, matching_mode)
+            .context(INVALID_BASELINE_GUIDANCE)
     }
 
-    fn from_baseline_errors(baseline_errors: BaselineErrors, relative_to: &Path) -> Self {
-        Self {
-            baseline_keys: baseline_errors
-                .errors
-                .iter()
-                .map(|error| BaselineKey::from_baseline_error(error, relative_to))
-                .collect(),
-        }
+    fn from_baseline_errors(
+        baseline_errors: BaselineErrors,
+        relative_to: &Path,
+        matching_mode: BaselineMatchingMode,
+    ) -> Result<Self> {
+        let baseline_keys = baseline_errors
+            .errors
+            .iter()
+            .map(|error| BaselineKey::from_baseline_error(error, relative_to, matching_mode))
+            .collect::<Result<_>>()?;
+        Ok(Self {
+            baseline_keys,
+            matching_mode,
+        })
     }
 
     pub fn matches_baseline(&self, error: &Error) -> bool {
-        self.baseline_keys.contains(&BaselineKey::from_error(error))
+        self.baseline_keys
+            .contains(&BaselineKey::from_error(error, self.matching_mode))
     }
 
     /// Baseline suppressions are processed last, after inline and config suppressions.
@@ -106,28 +153,45 @@ fn is_definitely_unused(
 
 /// A baseline matcher that also retains rows and tracks matches for CLI maintenance actions.
 pub struct TrackedBaselineProcessor {
-    entries: Vec<BaselineError>,
+    entries: Vec<(BaselineError, BaselineKey)>,
     keys: HashMap<BaselineKey, bool>,
-    relative_to: PathBuf,
+    matching_mode: BaselineMatchingMode,
 }
 
 impl TrackedBaselineProcessor {
-    pub fn from_json(content: &str, relative_to: &Path) -> Result<Self> {
-        let baseline_file: BaselineErrors = serde_json::from_str(content)?;
-        Ok(Self::from_baseline_errors(baseline_file, relative_to))
+    pub fn from_json(
+        content: &str,
+        relative_to: &Path,
+        matching_mode: BaselineMatchingMode,
+    ) -> Result<Self> {
+        let baseline_file: BaselineErrors =
+            serde_json::from_str(content).context(INVALID_BASELINE_GUIDANCE)?;
+        Self::from_baseline_errors(baseline_file, relative_to, matching_mode)
+            .context(INVALID_BASELINE_GUIDANCE)
     }
 
-    fn from_baseline_errors(baseline_errors: BaselineErrors, relative_to: &Path) -> Self {
-        let entries = baseline_errors.errors;
+    fn from_baseline_errors(
+        baseline_errors: BaselineErrors,
+        relative_to: &Path,
+        matching_mode: BaselineMatchingMode,
+    ) -> Result<Self> {
+        let entries = baseline_errors
+            .errors
+            .into_iter()
+            .map(|error| {
+                let key = BaselineKey::from_baseline_error(&error, relative_to, matching_mode)?;
+                Ok((error, key))
+            })
+            .collect::<Result<Vec<_>>>()?;
         let keys = entries
             .iter()
-            .map(|error| (BaselineKey::from_baseline_error(error, relative_to), false))
+            .map(|(_, key)| (key.clone(), false))
             .collect();
-        Self {
+        Ok(Self {
             entries,
             keys,
-            relative_to: relative_to.to_owned(),
-        }
+            matching_mode,
+        })
     }
 
     /// Baseline suppressions are processed last, after inline and config suppressions.
@@ -139,7 +203,10 @@ impl TrackedBaselineProcessor {
         let mut remaining_errors = Vec::new();
 
         for error in shown_errors.drain(..) {
-            if let Some(matched) = self.keys.get_mut(&BaselineKey::from_error(&error)) {
+            if let Some(matched) = self
+                .keys
+                .get_mut(&BaselineKey::from_error(&error, self.matching_mode))
+            {
                 *matched = true;
                 baseline_errors.push(error);
             } else {
@@ -160,8 +227,7 @@ impl TrackedBaselineProcessor {
         let retained_entries = self
             .entries
             .into_iter()
-            .filter_map(|entry| {
-                let key = BaselineKey::from_baseline_error(&entry, &self.relative_to);
+            .filter_map(|(entry, key)| {
                 let matched = self.keys[&key];
                 let definitely_unused =
                     is_definitely_unused(matched, checked_paths.contains(&key.path), || {
@@ -231,11 +297,11 @@ mod tests {
             ErrorKind::BadReturn,
         );
 
-        let key = BaselineKey::from_error(&error);
+        let key = BaselineKey::from_error(&error, BaselineMatchingMode::Column);
 
         assert_eq!(key.path, "/workspace/test/path.py");
         assert_eq!(key.name, "bad-return");
-        assert_eq!(key.column, 1);
+        assert_eq!(key.matching_field, BaselineMatchingField::Column(1));
     }
 
     #[test]
@@ -259,8 +325,12 @@ mod tests {
         "#;
 
         let baseline_file: BaselineErrors = serde_json::from_str(baseline_json).unwrap();
-        let processor =
-            BaselineProcessor::from_baseline_errors(baseline_file, Path::new("/workspace"));
+        let processor = BaselineProcessor::from_baseline_errors(
+            baseline_file,
+            Path::new("/workspace"),
+            BaselineMatchingMode::Column,
+        )
+        .unwrap();
 
         let module = Module::new(
             ModuleName::from_str("test_module"),
@@ -315,6 +385,82 @@ mod tests {
     }
 
     #[test]
+    fn test_baseline_matching_by_concise_description() {
+        let baseline_json = r#"
+        {
+            "errors": [{
+                "path": "/workspace/test.py",
+                "name": "bad-return",
+                "concise_description": "Expected description"
+            }]
+        }
+        "#;
+        let processor = BaselineProcessor::from_json(
+            baseline_json,
+            Path::new("/workspace"),
+            BaselineMatchingMode::ConciseDescription,
+        )
+        .unwrap();
+        let module = Module::new(
+            ModuleName::from_str("test_module"),
+            ModulePath::filesystem(PathBuf::from("/workspace/test.py")),
+            Arc::new("test content 123456789".to_owned()),
+        );
+
+        let matching = Error::new(
+            module.clone(),
+            TextRange::new(TextSize::new(8), TextSize::new(10)),
+            "Expected description".to_owned(),
+            Vec::new(),
+            ErrorKind::BadReturn,
+        );
+        assert!(processor.matches_baseline(&matching));
+
+        let different_description = Error::new(
+            module,
+            TextRange::new(TextSize::new(0), TextSize::new(2)),
+            "Different description".to_owned(),
+            Vec::new(),
+            ErrorKind::BadReturn,
+        );
+        assert!(!processor.matches_baseline(&different_description));
+    }
+
+    #[test]
+    fn test_baseline_requires_the_configured_matching_field() {
+        let column_only = r#"
+        {"errors": [{"path": "test.py", "name": "bad-return", "column": 1}]}
+        "#;
+        let err = BaselineProcessor::from_json(
+            column_only,
+            Path::new("/workspace"),
+            BaselineMatchingMode::ConciseDescription,
+        )
+        .unwrap_err();
+        let message = format!("{err:#}");
+        assert!(message.contains("baseline file is invalid"));
+        assert!(message.contains("missing field `concise_description`"));
+        assert!(message.contains("rerun with `--update-baseline`"));
+
+        let description_only = r#"
+        {
+            "errors": [{
+                "path": "test.py",
+                "name": "bad-return",
+                "concise_description": "test"
+            }]
+        }
+        "#;
+        let err = BaselineProcessor::from_json(
+            description_only,
+            Path::new("/workspace"),
+            BaselineMatchingMode::Column,
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("missing field `column`"));
+    }
+
+    #[test]
     fn test_unused_entry_count() {
         let baseline_json = serde_json::json!({
             "errors": [
@@ -333,8 +479,12 @@ mod tests {
             ]
         });
         let baseline_file: BaselineErrors = serde_json::from_value(baseline_json).unwrap();
-        let mut processor =
-            TrackedBaselineProcessor::from_baseline_errors(baseline_file, Path::new("/workspace"));
+        let mut processor = TrackedBaselineProcessor::from_baseline_errors(
+            baseline_file,
+            Path::new("/workspace"),
+            BaselineMatchingMode::Column,
+        )
+        .unwrap();
 
         let module = Module::new(
             ModuleName::from_str("test_module"),
@@ -392,8 +542,12 @@ mod tests {
             ]
         });
         let baseline_file: BaselineErrors = serde_json::from_value(baseline_json).unwrap();
-        let mut processor =
-            TrackedBaselineProcessor::from_baseline_errors(baseline_file, Path::new("/workspace"));
+        let mut processor = TrackedBaselineProcessor::from_baseline_errors(
+            baseline_file,
+            Path::new("/workspace"),
+            BaselineMatchingMode::Column,
+        )
+        .unwrap();
 
         let module = Module::new(
             ModuleName::from_str("test_module"),
@@ -443,7 +597,12 @@ mod tests {
         });
 
         let baseline_file: BaselineErrors = serde_json::from_value(baseline_json).unwrap();
-        let processor = BaselineProcessor::from_baseline_errors(baseline_file, &cwd);
+        let processor = BaselineProcessor::from_baseline_errors(
+            baseline_file,
+            &cwd,
+            BaselineMatchingMode::Column,
+        )
+        .unwrap();
 
         let module = Module::new(
             ModuleName::from_str("foo"),
@@ -485,8 +644,12 @@ mod tests {
         });
 
         let baseline_file: BaselineErrors = serde_json::from_value(baseline_json).unwrap();
-        let processor =
-            BaselineProcessor::from_baseline_errors(baseline_file, Path::new("/workspace"));
+        let processor = BaselineProcessor::from_baseline_errors(
+            baseline_file,
+            Path::new("/workspace"),
+            BaselineMatchingMode::Column,
+        )
+        .unwrap();
 
         // Simulate a Windows-style path with backslashes in the error.
         let module = Module::new(
@@ -519,7 +682,12 @@ mod tests {
             }]
         });
         let baseline_file: BaselineErrors = serde_json::from_value(baseline_json).unwrap();
-        let processor = BaselineProcessor::from_baseline_errors(baseline_file, &relative_to);
+        let processor = BaselineProcessor::from_baseline_errors(
+            baseline_file,
+            &relative_to,
+            BaselineMatchingMode::Column,
+        )
+        .unwrap();
 
         let module = Module::new(
             ModuleName::from_str("foo"),

--- a/pyrefly/lib/error/baseline.rs
+++ b/pyrefly/lib/error/baseline.rs
@@ -47,16 +47,32 @@ impl BaselineKey {
         error: &BaselineError,
         relative_to: &Path,
         matching_mode: BaselineMatchingMode,
+        entry_index: usize,
     ) -> Result<Self> {
         let matching_field = match matching_mode {
-            BaselineMatchingMode::Column => BaselineMatchingField::Column(error.column.context(
-                "missing field `column`, required by `baseline-matching-mode = \"column\"`",
-            )?),
+            BaselineMatchingMode::Column => {
+                BaselineMatchingField::Column(error.column.with_context(|| {
+                    format!(
+                        "baseline entry {} (path `{}`, error kind `{}`) is missing field \
+                         `column`, required by \
+                         `baseline-matching-mode = \"column\"`",
+                        entry_index + 1,
+                        error.path,
+                        error.name,
+                    )
+                })?)
+            }
             BaselineMatchingMode::ConciseDescription => BaselineMatchingField::ConciseDescription(
-                error.concise_description.clone().context(
-                    "missing field `concise_description`, required by \
-                         `baseline-matching-mode = \"concise_description\"`",
-                )?,
+                error.concise_description.clone().with_context(|| {
+                    format!(
+                        "baseline entry {} (path `{}`, error kind `{}`) is missing field \
+                         `concise_description`, required by \
+                         `baseline-matching-mode = \"concise-description\"`",
+                        entry_index + 1,
+                        error.path,
+                        error.name,
+                    )
+                })?,
             ),
         };
         Ok(Self {
@@ -114,7 +130,10 @@ impl BaselineProcessor {
         let baseline_keys = baseline_errors
             .errors
             .iter()
-            .map(|error| BaselineKey::from_baseline_error(error, relative_to, matching_mode))
+            .enumerate()
+            .map(|(index, error)| {
+                BaselineKey::from_baseline_error(error, relative_to, matching_mode, index)
+            })
             .collect::<Result<_>>()?;
         Ok(Self {
             baseline_keys,
@@ -178,8 +197,10 @@ impl TrackedBaselineProcessor {
         let entries = baseline_errors
             .errors
             .into_iter()
-            .map(|error| {
-                let key = BaselineKey::from_baseline_error(&error, relative_to, matching_mode)?;
+            .enumerate()
+            .map(|(index, error)| {
+                let key =
+                    BaselineKey::from_baseline_error(&error, relative_to, matching_mode, index)?;
                 Ok((error, key))
             })
             .collect::<Result<Vec<_>>>()?;
@@ -429,7 +450,10 @@ mod tests {
     #[test]
     fn test_baseline_requires_the_configured_matching_field() {
         let column_only = r#"
-        {"errors": [{"path": "test.py", "name": "bad-return", "column": 1}]}
+        {"errors": [
+            {"path": "valid.py", "name": "bad-return", "concise_description": "valid"},
+            {"path": "test.py", "name": "bad-return", "column": 1}
+        ]}
         "#;
         let err = BaselineProcessor::from_json(
             column_only,
@@ -439,6 +463,7 @@ mod tests {
         .unwrap_err();
         let message = format!("{err:#}");
         assert!(message.contains("baseline file is invalid"));
+        assert!(message.contains("baseline entry 2 (path `test.py`, error kind `bad-return`)"));
         assert!(message.contains("missing field `concise_description`"));
         assert!(message.contains("rerun with `--update-baseline`"));
 

--- a/pyrefly/lib/error/legacy.rs
+++ b/pyrefly/lib/error/legacy.rs
@@ -13,6 +13,8 @@ use pyrefly_util::prelude::SliceExt;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::config::config::BaselineFormat;
+use crate::config::config::BaselineMatchingMode;
 use crate::error::error::Error;
 
 pub(crate) fn severity_to_str(severity: Severity) -> String {
@@ -26,6 +28,10 @@ pub(crate) fn severity_to_str(severity: Severity) -> String {
 
 fn default_legacy_severity() -> Severity {
     Severity::Error
+}
+
+fn default_baseline_severity() -> Option<Severity> {
+    Some(default_legacy_severity())
 }
 
 /// Legacy error structure in Pyre1. Needs to be consistent with the following file:
@@ -123,13 +129,18 @@ impl LegacyErrors {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct BaselineError {
-    pub column: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub column: Option<usize>,
     pub path: String,
     /// The kebab-case name of the error kind.
     pub name: String,
-    concise_description: String,
-    #[serde(default = "default_legacy_severity")]
-    severity: Severity,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub concise_description: Option<String>,
+    #[serde(
+        default = "default_baseline_severity",
+        skip_serializing_if = "Option::is_none"
+    )]
+    severity: Option<Severity>,
     /// Optional notebook cell number for errors in notebook files
     #[serde(skip_serializing_if = "Option::is_none")]
     cell: Option<usize>,
@@ -140,15 +151,15 @@ impl BaselineError {
         let error_range = error.display_range();
         let error_path = error.path().as_path();
         Self {
-            column: error_range.start.column().get() as usize,
+            column: Some(error_range.start.column().get() as usize),
             cell: error_range.start.cell().map(|cell| cell.get() as usize),
             path: error_path
                 .relativize_from(relative_to)
                 .to_string_lossy()
                 .replace('\\', "/"), // Normalize Windows backslashes so baseline files are consistent across platforms
             name: error.error_kind().to_name().to_owned(),
-            concise_description: error.msg_header().to_owned(),
-            severity: error.severity(),
+            concise_description: Some(error.msg_header().to_owned()),
+            severity: Some(error.severity()),
         }
     }
 }
@@ -163,6 +174,27 @@ impl BaselineErrors {
         Self {
             errors: errors.map(|e| BaselineError::from_error(relative_to, e)),
         }
+    }
+
+    /// Remove fields that are not needed by a minimal baseline.
+    pub fn with_format(
+        mut self,
+        matching_mode: BaselineMatchingMode,
+        format: BaselineFormat,
+    ) -> Self {
+        if format == BaselineFormat::Minimal {
+            for error in &mut self.errors {
+                if matching_mode != BaselineMatchingMode::Column {
+                    error.column = None;
+                }
+                if matching_mode != BaselineMatchingMode::ConciseDescription {
+                    error.concise_description = None;
+                }
+                error.severity = None;
+                error.cell = None;
+            }
+        }
+        self
     }
 }
 
@@ -229,6 +261,68 @@ mod tests {
             serde_json::to_value(LegacyError::from_error(Path::new("/repo"), &not_compared))
                 .unwrap()["baselined"],
             false
+        );
+    }
+
+    #[test]
+    fn test_baseline_formats() {
+        let module = Module::new(
+            ModuleName::from_str("foo"),
+            ModulePath::filesystem(PathBuf::from("/repo/foo.py")),
+            Arc::new("x = 1\n".to_owned()),
+        );
+        let error = Error::new(
+            module,
+            TextRange::new(TextSize::new(0), TextSize::new(1)),
+            "err".to_owned(),
+            Vec::new(),
+            ErrorKind::BadAssignment,
+        );
+
+        let full = BaselineErrors::from_errors(Path::new("/repo"), std::slice::from_ref(&error))
+            .with_format(BaselineMatchingMode::Column, BaselineFormat::Full);
+        assert_eq!(
+            serde_json::to_value(full).unwrap(),
+            serde_json::json!({
+                "errors": [{
+                    "column": 1,
+                    "path": "foo.py",
+                    "name": "bad-assignment",
+                    "concise_description": "err",
+                    "severity": "error"
+                }]
+            })
+        );
+
+        let minimal_column =
+            BaselineErrors::from_errors(Path::new("/repo"), std::slice::from_ref(&error))
+                .with_format(BaselineMatchingMode::Column, BaselineFormat::Minimal);
+        assert_eq!(
+            serde_json::to_value(minimal_column).unwrap(),
+            serde_json::json!({
+                "errors": [{
+                    "column": 1,
+                    "path": "foo.py",
+                    "name": "bad-assignment"
+                }]
+            })
+        );
+
+        let minimal_description =
+            BaselineErrors::from_errors(Path::new("/repo"), std::slice::from_ref(&error))
+                .with_format(
+                    BaselineMatchingMode::ConciseDescription,
+                    BaselineFormat::Minimal,
+                );
+        assert_eq!(
+            serde_json::to_value(minimal_description).unwrap(),
+            serde_json::json!({
+                "errors": [{
+                    "path": "foo.py",
+                    "name": "bad-assignment",
+                    "concise_description": "err"
+                }]
+            })
         );
     }
 }

--- a/pyrefly/lib/error/legacy.rs
+++ b/pyrefly/lib/error/legacy.rs
@@ -30,10 +30,6 @@ fn default_legacy_severity() -> Severity {
     Severity::Error
 }
 
-fn default_baseline_severity() -> Option<Severity> {
-    Some(default_legacy_severity())
-}
-
 /// Legacy error structure in Pyre1. Needs to be consistent with the following file:
 /// <https://www.internalfb.com/code/fbsource/fbcode/tools/pyre/facebook/arc/lib/error.rs>
 ///
@@ -136,10 +132,7 @@ pub struct BaselineError {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub concise_description: Option<String>,
-    #[serde(
-        default = "default_baseline_severity",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     severity: Option<Severity>,
     /// Optional notebook cell number for errors in notebook files
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -324,5 +317,15 @@ mod tests {
                 }]
             })
         );
+
+        let without_severity = serde_json::json!({
+            "errors": [{
+                "column": 1,
+                "path": "foo.py",
+                "name": "bad-assignment"
+            }]
+        });
+        let parsed: BaselineErrors = serde_json::from_value(without_severity.clone()).unwrap();
+        assert_eq!(serde_json::to_value(parsed).unwrap(), without_severity);
     }
 }

--- a/pyrefly/lib/state/errors.rs
+++ b/pyrefly/lib/state/errors.rs
@@ -37,6 +37,7 @@ use ruff_text_size::TextSize;
 use starlark_map::small_map::SmallMap;
 use starlark_map::small_set::SmallSet;
 
+use crate::config::config::BaselineMatchingMode;
 use crate::config::config::ConfigFile;
 use crate::error::baseline::BaselineProcessor;
 use crate::error::baseline::TrackedBaselineProcessor;
@@ -379,6 +380,7 @@ impl Errors {
         errors: &mut CollectedErrors,
         baseline_path: Option<&Path>,
         relative_to: &Path,
+        matching_mode: BaselineMatchingMode,
         classify_stale_entries: bool,
     ) -> BaselineApplyResult {
         let Some(baseline_path) = baseline_path else {
@@ -403,12 +405,13 @@ impl Errors {
         };
 
         if classify_stale_entries {
-            let mut processor = match TrackedBaselineProcessor::from_json(&content, relative_to)
-                .with_context(fail_ctx)
-            {
-                Ok(p) => p,
-                Err(e) => return BaselineApplyResult::FailedToRead(e),
-            };
+            let mut processor =
+                match TrackedBaselineProcessor::from_json(&content, relative_to, matching_mode)
+                    .with_context(fail_ctx)
+                {
+                    Ok(p) => p,
+                    Err(e) => return BaselineApplyResult::FailedToRead(e),
+                };
             processor.process_errors(&mut errors.ordinary, &mut errors.baseline);
             let checked_paths: HashSet<_> = self
                 .loads
@@ -424,11 +427,12 @@ impl Errors {
                 retained_entries: result.retained_entries,
             }
         } else {
-            let processor =
-                match BaselineProcessor::from_json(&content, relative_to).with_context(fail_ctx) {
-                    Ok(p) => p,
-                    Err(e) => return BaselineApplyResult::FailedToRead(e),
-                };
+            let processor = match BaselineProcessor::from_json(&content, relative_to, matching_mode)
+                .with_context(fail_ctx)
+            {
+                Ok(p) => p,
+                Err(e) => return BaselineApplyResult::FailedToRead(e),
+            };
             processor.process_errors(&mut errors.ordinary, &mut errors.baseline);
             BaselineApplyResult::Applied {
                 unused_entry_count: 0,
@@ -471,7 +475,8 @@ impl Errors {
                     .or_else(|| baseline_path.parent())
                     .unwrap_or_else(|| Path::new(""));
                 let content = fs::read_to_string(baseline_path).ok()?;
-                BaselineProcessor::from_json(&content, relative_to).ok()
+                BaselineProcessor::from_json(&content, relative_to, config.baseline_matching_mode)
+                    .ok()
             });
             if processor
                 .as_ref()

--- a/schemas/pyrefly.json
+++ b/schemas/pyrefly.json
@@ -247,6 +247,18 @@
           "enum": ["ignore", "info", "warn", "error"],
           "default": "ignore"
         },
+        "baseline-matching-mode": {
+          "description": "Fields used to match diagnostics against baseline entries.",
+          "type": "string",
+          "enum": ["column", "concise_description"],
+          "default": "column"
+        },
+        "baseline-format": {
+          "description": "Amount of diagnostic information written to the baseline file.",
+          "type": "string",
+          "enum": ["full", "minimal"],
+          "default": "full"
+        },
         "build-system": {
           "description": "Pyrefly supports integrating into build systems to discover targets to type check and their dependencies. Currently supports Buck2 and custom queries.",
           "type": "object",

--- a/schemas/pyrefly.json
+++ b/schemas/pyrefly.json
@@ -250,7 +250,7 @@
         "baseline-matching-mode": {
           "description": "Fields used to match diagnostics against baseline entries.",
           "type": "string",
-          "enum": ["column", "concise_description"],
+          "enum": ["column", "concise-description"],
           "default": "column"
         },
         "baseline-format": {

--- a/schemas/test-pyproject.toml
+++ b/schemas/test-pyproject.toml
@@ -53,6 +53,8 @@ skip-lsp-config-indexing = false
 # Baseline
 baseline = "baseline.json"
 baseline-error-level = "warn"
+baseline-matching-mode = "concise-description"
+baseline-format = "minimal"
 
 # Error configuration
 [tool.pyrefly.errors]

--- a/schemas/test-pyrefly.toml
+++ b/schemas/test-pyrefly.toml
@@ -52,6 +52,8 @@ skip-lsp-config-indexing = false
 # Baseline
 baseline = "baseline.json"
 baseline-error-level = "warn"
+baseline-matching-mode = "concise-description"
+baseline-format = "minimal"
 
 # Error configuration
 [errors]

--- a/test/baseline.md
+++ b/test/baseline.md
@@ -68,12 +68,75 @@ $ grep '"name": "bad-assignment"' $TMPDIR/baseline_update_from_pyproject/baselin
 [0]
 ```
 
-The written baseline omits fields that are not used for matching.
+The default `full` format includes matching and informational fields.
+
+```scrut {output_stream: stdout}
+$ $JQ -c '.errors[0] | keys' $TMPDIR/baseline_update_from_pyproject/baseline.json
+["column","concise_description","name","path","severity"]
+[0]
+```
+
+The baseline format omits legacy display fields.
 
 ```scrut {output_stream: stdout}
 $ grep -cE '"(line|stop_line|stop_column|code|description)"' $TMPDIR/baseline_update_from_pyproject/baseline.json
 0
 [1]
+```
+
+## Minimal baselines contain only the configured matching fields
+
+```scrut
+$ mkdir -p $TMPDIR/baseline_minimal && \
+> echo "x: str = 1" > $TMPDIR/baseline_minimal/bad.py && \
+> printf 'baseline = "baseline.json"\nbaseline-format = "minimal"\n' > $TMPDIR/baseline_minimal/pyrefly.toml && \
+> cd $TMPDIR/baseline_minimal && \
+> $PYREFLY check --update-baseline --summary=none --output-format=omit-errors >/dev/null 2>/dev/null
+[1]
+```
+
+The default `column` mode needs only the path, error kind, and column.
+
+```scrut {output_stream: stdout}
+$ $JQ -c '.errors[0] | keys' $TMPDIR/baseline_minimal/baseline.json
+["column","name","path"]
+[0]
+```
+
+## A baseline missing the configured matching field explains how to update it
+
+Changing the matching mode makes the column-only baseline invalid.
+
+```scrut {output_stream: stderr}
+$ printf 'baseline = "baseline.json"\nbaseline-format = "minimal"\nbaseline-matching-mode = "concise_description"\n' > $TMPDIR/baseline_minimal/pyrefly.toml && \
+> cd $TMPDIR/baseline_minimal && \
+> $PYREFLY check --summary=none
+*failed to read baseline file*baseline file is invalid*rerun with `--update-baseline`*missing field `concise_description`* (glob)
+[1]
+```
+
+Regenerating the baseline writes the matching fields for the new mode.
+
+```scrut
+$ cd $TMPDIR/baseline_minimal && \
+> $PYREFLY check --update-baseline --summary=none --output-format=omit-errors >/dev/null 2>/dev/null
+[1]
+```
+
+```scrut {output_stream: stdout}
+$ $JQ -c '.errors[0] | keys' $TMPDIR/baseline_minimal/baseline.json
+["concise_description","name","path"]
+[0]
+```
+
+The concise-description mode keeps matching when the diagnostic moves to a
+different column.
+
+```scrut {output_stream: stderr}
+$ printf 'if True:\n    x: str = 1\n' > $TMPDIR/baseline_minimal/bad.py && \
+> cd $TMPDIR/baseline_minimal && \
+> $PYREFLY check --summary=none
+[0]
 ```
 
 ## Updating a baseline requires a path from the CLI or configuration

--- a/test/baseline.md
+++ b/test/baseline.md
@@ -110,7 +110,7 @@ Changing the matching mode makes the column-only baseline invalid.
 ```scrut {output_stream: stderr}
 $ printf 'baseline = "baseline.json"\nbaseline-format = "minimal"\nbaseline-matching-mode = "concise_description"\n' > $TMPDIR/baseline_minimal/pyrefly.toml && \
 > cd $TMPDIR/baseline_minimal && \
-> $PYREFLY check --summary=none
+> $PYREFLY check bad.py --summary=none
 *failed to read baseline file*baseline file is invalid*rerun with `--update-baseline`*missing field `concise_description`* (glob)
 [1]
 ```
@@ -135,7 +135,7 @@ different column.
 ```scrut {output_stream: stderr}
 $ printf 'if True:\n    x: str = 1\n' > $TMPDIR/baseline_minimal/bad.py && \
 > cd $TMPDIR/baseline_minimal && \
-> $PYREFLY check --summary=none
+> $PYREFLY check bad.py --summary=none
 [0]
 ```
 

--- a/test/baseline.md
+++ b/test/baseline.md
@@ -279,11 +279,43 @@ $ grep -c '"name":' $TMPDIR/baseline_prune/baseline.json
 ```
 
 The surviving entry keeps its existing concise description rather than refreshing
-it from the current error. Re-serialization may normalize formatting and fields.
+it from the current error.
 
 ```scrut {output_stream: stdout}
 $ grep -c '"concise_description": "test"' $TMPDIR/baseline_prune/baseline.json
 1
+[0]
+```
+
+## `--prune-baseline` does not apply `baseline-format`
+
+Changing the configured format from full to minimal does not change the fields
+of retained entries while pruning.
+
+```scrut {output_stream: stdout}
+$ mkdir -p $TMPDIR/baseline_prune_full && \
+> echo 'x: str = 1' > $TMPDIR/baseline_prune_full/bad.py && \
+> echo '{"errors":[{"column":10,"path":"bad.py","name":"bad-assignment","concise_description":"test","severity":"error"},{"column":1,"path":"gone.py","name":"bad-return","concise_description":"stale","severity":"error"}]}' > $TMPDIR/baseline_prune_full/baseline.json && \
+> printf 'baseline = "baseline.json"\nbaseline-format = "minimal"\n' > $TMPDIR/baseline_prune_full/pyrefly.toml && \
+> cd $TMPDIR/baseline_prune_full && \
+> $PYREFLY check bad.py --prune-baseline --summary=none --output-format=omit-errors >/dev/null 2>/dev/null && \
+> $JQ -c '.errors[0] | keys' baseline.json
+["column","concise_description","name","path","severity"]
+[0]
+```
+
+Changing the configured format from minimal to full likewise leaves the fields
+of retained entries minimal.
+
+```scrut {output_stream: stdout}
+$ mkdir -p $TMPDIR/baseline_prune_minimal && \
+> echo 'x: str = 1' > $TMPDIR/baseline_prune_minimal/bad.py && \
+> echo '{"errors":[{"column":10,"path":"bad.py","name":"bad-assignment"},{"column":1,"path":"gone.py","name":"bad-return"}]}' > $TMPDIR/baseline_prune_minimal/baseline.json && \
+> printf 'baseline = "baseline.json"\nbaseline-format = "full"\n' > $TMPDIR/baseline_prune_minimal/pyrefly.toml && \
+> cd $TMPDIR/baseline_prune_minimal && \
+> $PYREFLY check bad.py --prune-baseline --summary=none --output-format=omit-errors >/dev/null 2>/dev/null && \
+> $JQ -c '.errors[0] | keys' baseline.json
+["column","name","path"]
 [0]
 ```
 

--- a/test/baseline.md
+++ b/test/baseline.md
@@ -108,7 +108,7 @@ $ $JQ -c '.errors[0] | keys' $TMPDIR/baseline_minimal/baseline.json
 Changing the matching mode makes the column-only baseline invalid.
 
 ```scrut {output_stream: stderr}
-$ printf 'baseline = "baseline.json"\nbaseline-format = "minimal"\nbaseline-matching-mode = "concise_description"\n' > $TMPDIR/baseline_minimal/pyrefly.toml && \
+$ printf 'baseline = "baseline.json"\nbaseline-format = "minimal"\nbaseline-matching-mode = "concise-description"\n' > $TMPDIR/baseline_minimal/pyrefly.toml && \
 > cd $TMPDIR/baseline_minimal && \
 > $PYREFLY check bad.py --summary=none
 *failed to read baseline file*baseline file is invalid*rerun with `--update-baseline`*missing field `concise_description`* (glob)

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -527,7 +527,40 @@ more details on how baseline files work.
     - `baseline` is a **project-level setting** and cannot be overridden in
       [`sub-config`](#sub-configs) sections.
     - Errors suppressed by the baseline file are still shown in the IDE.
-    - Errors are matched with the baseline by file, error code, and column number.
+
+### `baseline-matching-mode`
+
+Controls how diagnostics are matched against baseline entries. `"column"`
+matches the file, error kind, and starting column. `"concise_description"`
+matches the file, error kind, and concise description.
+
+```toml
+baseline-matching-mode = "concise_description"
+```
+
+- Type: `"column"` | `"concise_description"`
+- Default: `"column"`
+- Notes:
+    - `baseline-matching-mode` is a **project-level setting** and cannot be
+      overridden in [`sub-config`](#sub-configs) sections.
+    - After changing modes, regenerate a baseline that does not contain the new
+      mode's required field with `pyrefly check --update-baseline`.
+
+### `baseline-format`
+
+Controls how much information `--update-baseline` writes for each baseline
+entry. `"full"` writes all baseline metadata. `"minimal"` writes only the file,
+error kind, and the field required by `baseline-matching-mode`.
+
+```toml
+baseline-format = "minimal"
+```
+
+- Type: `"full"` | `"minimal"`
+- Default: `"full"`
+- Notes:
+    - `baseline-format` is a **project-level setting** and cannot be overridden
+      in [`sub-config`](#sub-configs) sections.
 
 ### `baseline-error-level`
 

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -540,9 +540,12 @@ baseline-matching-mode = "concise-description"
 
 - Type: `"column"` | `"concise-description"`
 - Default: `"column"`
+- Flag equivalent: none
 - Notes:
     - `baseline-matching-mode` is a **project-level setting** and cannot be
       overridden in [`sub-config`](#sub-configs) sections.
+    - There is intentionally no CLI equivalent because the matching mode is a
+      property of the checked-in baseline and must be consistent for all users.
     - After changing modes, regenerate a baseline that does not contain the new
       mode's required field with `pyrefly check --update-baseline`.
 
@@ -558,9 +561,12 @@ baseline-format = "minimal"
 
 - Type: `"full"` | `"minimal"`
 - Default: `"full"`
+- Flag equivalent: none
 - Notes:
     - `baseline-format` is a **project-level setting** and cannot be overridden
       in [`sub-config`](#sub-configs) sections.
+    - There is intentionally no CLI equivalent so every baseline update uses
+      the same format, avoiding conflicting rewrites.
 
 ### `baseline-error-level`
 

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -531,14 +531,14 @@ more details on how baseline files work.
 ### `baseline-matching-mode`
 
 Controls how diagnostics are matched against baseline entries. `"column"`
-matches the file, error kind, and starting column. `"concise_description"`
+matches the file, error kind, and starting column. `"concise-description"`
 matches the file, error kind, and concise description.
 
 ```toml
-baseline-matching-mode = "concise_description"
+baseline-matching-mode = "concise-description"
 ```
 
-- Type: `"column"` | `"concise_description"`
+- Type: `"column"` | `"concise-description"`
 - Default: `"column"`
 - Notes:
     - `baseline-matching-mode` is a **project-level setting** and cannot be

--- a/website/docs/error-suppressions.mdx
+++ b/website/docs/error-suppressions.mdx
@@ -131,7 +131,21 @@ When the baseline is specified in the configuration file, you don't need to pass
 
 Note that `baseline` is a **project-level setting** and cannot be overridden in [`sub-config`](./configuration.mdx#sub-configs) sections. If you need different baseline files for different parts of your codebase, consider using separate Pyrefly configuration files.
 
-Errors are matched with the baseline by looking at file, error code, and column number.
+`baseline-matching-mode` controls how errors are matched:
+
+- `"column"` (default) matches the file, error kind, and starting column.
+- `"concise_description"` matches the file, error kind, and concise description.
+
+`baseline-format` controls which fields `--update-baseline` writes. `"full"`
+(default) includes all baseline metadata. `"minimal"` includes only the file,
+error kind, and the field required by the configured matching mode:
+
+```toml
+baseline = "baseline.json"
+baseline-matching-mode = "concise_description"
+baseline-format = "minimal"
+```
+
 Note that errors suppressed by the baseline file are still shown in the IDE.
 
 `--baseline-error-level=<ignore|info|warn|error>` and the project-level
@@ -153,7 +167,11 @@ Pyrefly records baseline provenance differently depending on the output format:
 - `sarif`: when a baseline is configured, each result has `baselineState` set to `unchanged` for a match and `new` otherwise.
 - `omit-errors`: the summary includes the number of emitted baselined diagnostics.
 
-If a baseline file is configured but cannot be read or parsed, the run fails with an error rather than proceeding as if no baseline were set. The exception is `--update-baseline`, which regenerates the file from scratch and so tolerates a missing or unparseable baseline.
+If a baseline file is configured but cannot be read, parsed, or does not contain
+the fields required by `baseline-matching-mode`, the run fails with an error.
+Rerun the command with `--update-baseline` to regenerate it using the current
+matching mode and format. Baseline regeneration tolerates a missing or invalid
+existing file.
 
 As you fix errors, the entries that suppressed them become stale. Two flags help keep the baseline current:
 

--- a/website/docs/error-suppressions.mdx
+++ b/website/docs/error-suppressions.mdx
@@ -134,7 +134,7 @@ Note that `baseline` is a **project-level setting** and cannot be overridden in 
 `baseline-matching-mode` controls how errors are matched:
 
 - `"column"` (default) matches the file, error kind, and starting column.
-- `"concise_description"` matches the file, error kind, and concise description.
+- `"concise-description"` matches the file, error kind, and concise description.
 
 `baseline-format` controls which fields `--update-baseline` writes. `"full"`
 (default) includes all baseline metadata. `"minimal"` includes only the file,
@@ -142,7 +142,7 @@ error kind, and the field required by the configured matching mode:
 
 ```toml
 baseline = "baseline.json"
-baseline-matching-mode = "concise_description"
+baseline-matching-mode = "concise-description"
 baseline-format = "minimal"
 ```
 

--- a/website/docs/error-suppressions.mdx
+++ b/website/docs/error-suppressions.mdx
@@ -146,6 +146,9 @@ baseline-matching-mode = "concise-description"
 baseline-format = "minimal"
 ```
 
+Both settings are configuration-only so all users interpret and update the
+checked-in baseline consistently.
+
 Note that errors suppressed by the baseline file are still shown in the IDE.
 
 `--baseline-error-level=<ignore|info|warn|error>` and the project-level


### PR DESCRIPTION
Provides users with some flexibility about how baselines are configured in Pyrefly, as discussed in https://github.com/facebook/pyrefly/issues/4450#issuecomment-5420902969.

**New config options:**

- `baseline-matching-mode = "column" (default) | "concise_description"`: The criteria used to match a finding with a baseline entry.
- `baseline-format = "full" (default) | "minimal"`: The amount of context encoded in the baseline file, with "minimal" only encoding the minimum fields necessary to match a finding with the baseline.