### PR TITLE
fix union get expanded in hover #3248

### DIFF
--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -38,6 +38,7 @@ use ruff_python_ast::ExprBinOp;
 use ruff_python_ast::ExprCall;
 use ruff_python_ast::ExprSubscript;
 use ruff_python_ast::Identifier;
+use ruff_python_ast::Operator;
 use ruff_python_ast::TypeParams;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
@@ -7063,6 +7064,24 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             .0
     }
 
+    /// Build a union display type from already flattened annotation operands.
+    fn union_display_type(
+        &self,
+        operands: Vec<&Expr>,
+        type_form_context: TypeFormContext<'_>,
+    ) -> Option<Type> {
+        let swallower = self.error_swallower();
+        let type_argument_context = TypeFormContext::TypeArgument(&type_form_context);
+        let mut changed = false;
+        let members = operands.map(|operand| {
+            let (ty, display_ty) =
+                self.expr_untype_with_display(operand, type_argument_context, &swallower);
+            changed |= display_ty.is_some();
+            display_ty.unwrap_or(ty)
+        });
+        changed.then(|| self.unions(members))
+    }
+
     fn expr_untype_with_display(
         &self,
         x: &Expr,
@@ -7112,6 +7131,52 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                         type_form_context.untype_context(),
                         true,
                     )
+                } else if let Expr::Subscript(ExprSubscript { value, slice, .. }) = x {
+                    let swallower = self.error_swallower();
+                    let special_form = match self.expr_infer(value, &swallower) {
+                        Type::Type(inner) => match *inner {
+                            Type::SpecialForm(special_form) => Some(special_form),
+                            _ => None,
+                        },
+                        _ => None,
+                    };
+                    let arguments = Ast::unpack_slice(slice);
+                    match (special_form, arguments) {
+                        (Some(SpecialForm::Optional), [argument]) => {
+                            let (_, display_ty) = self.expr_untype_with_display(
+                                argument,
+                                TypeFormContext::TypeArgument(&type_form_context),
+                                &swallower,
+                            );
+                            display_ty.map(|display_ty| self.heap.mk_optional(display_ty))
+                        }
+                        (Some(SpecialForm::Union), arguments) => {
+                            self.union_display_type(arguments.iter().collect(), type_form_context)
+                        }
+                        _ => None,
+                    }
+                } else if let Expr::BinOp(ExprBinOp {
+                    op: Operator::BitOr,
+                    ..
+                }) = x
+                {
+                    let mut pending = vec![x];
+                    let mut operands = Vec::new();
+                    while let Some(operand) = pending.pop() {
+                        match operand {
+                            Expr::BinOp(ExprBinOp {
+                                left,
+                                op: Operator::BitOr,
+                                right,
+                                ..
+                            }) => {
+                                pending.push(right);
+                                pending.push(left);
+                            }
+                            _ => operands.push(operand),
+                        }
+                    }
+                    self.union_display_type(operands, type_form_context)
                 } else {
                     None
                 };

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -656,6 +656,53 @@ def handle(messages: Messages, payload: Payload[str]) -> Payload[int]: ...
 }
 
 #[test]
+fn hover_preserves_implicit_union_aliases_in_imported_function_signatures() {
+    let main = r#"
+import lib
+
+lib.relationship
+#   ^
+"#;
+    let lib = r#"
+from collections.abc import Callable, Sequence
+from typing import Any, Optional, Union
+
+class ColumnClause[T]: ...
+class DMLColumnRole: ...
+class Mapped[T]: ...
+class _HasClauseElement[T]: ...
+
+_ORMColCollectionElement = Union[
+    ColumnClause[Any], DMLColumnRole, Mapped[Any], _HasClauseElement[Any]
+]
+_ORMColCollectionArgument = Union[
+    str,
+    Sequence[_ORMColCollectionElement],
+    Callable[[], Sequence[_ORMColCollectionElement]],
+    Callable[[], _ORMColCollectionElement],
+    _ORMColCollectionElement,
+]
+
+def relationship(
+    foreign_keys: Optional[_ORMColCollectionArgument] = None,
+    remote_side: Optional[_ORMColCollectionArgument] = None,
+    union_arg: Union[_ORMColCollectionArgument, None] = None,
+    pipe_arg: _ORMColCollectionArgument | None = None,
+) -> None: ...
+"#;
+    let report =
+        get_batched_lsp_operations_report(&[("main", main), ("lib", lib)], get_test_report);
+    assert_eq!(
+        report
+            .matches("_ORMColCollectionArgument | None = None")
+            .count(),
+        4,
+        "got: {report}"
+    );
+    assert!(!report.contains("ColumnClause[Any]"), "got: {report}");
+}
+
+#[test]
 fn hover_over_inline_ignore_comment() {
     let code = r#"
 a: int = "test"  # pyrefly: ignore


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #3248

Hover signatures now preserve aliases nested in `Optional[T]`, `Union[T, None]`, and `T | None`, while semantic checking still uses expanded types.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test