### PR TITLE
don't enforce __slots__ on plain subclasses of slotted dataclasses #4616

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -1168,8 +1168,9 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     /// is `true` when `__dict__` appears in slots.
     fn extract_local_slot_names(&self, cls: &Class) -> Option<(SmallSet<Name>, bool)> {
         let metadata = self.get_metadata_for_class(cls);
-        if let Some(dc) = metadata.dataclass_metadata()
-            && dc.kws.slots
+        // An inherited `slots=True` does not synthesize `__slots__` on the subclass.
+        if metadata.has_local_dataclass_slots_request()
+            && let Some(dc) = metadata.dataclass_metadata()
         {
             let mut names = SmallSet::new();
             let has_dict = dc.fields.iter().any(|n| *n == dunder::DICT);

--- a/pyrefly/lib/test/slots.rs
+++ b/pyrefly/lib/test/slots.rs
@@ -75,6 +75,70 @@ class Child(Base):
 "#,
 );
 
+// A plain subclass of `@dataclass(slots=True)` declares no `__slots__`, so at runtime it
+// gets an instance `__dict__` and accepts arbitrary attributes.
+testcase!(
+    test_slots_plain_subclass_of_slotted_dataclass_allows_dynamic,
+    r#"
+from dataclasses import dataclass
+
+@dataclass(slots=True)
+class Foo:
+    x: int
+    y: int
+
+class Bar(Foo):
+    def __init__(self, x: int, y: int) -> None:
+        super().__init__(x, y)
+        self.z = x + y  # OK: Bar is unslotted
+"#,
+);
+
+// The subclass is fully slotted only when it also requests slots, and then enforcement
+// still applies to attributes outside the combined field set.
+testcase!(
+    test_slots_slotted_dataclass_subclass_still_enforced,
+    r#"
+from dataclasses import dataclass
+
+@dataclass(slots=True)
+class Foo:
+    x: int
+    y: int
+
+@dataclass(slots=True)
+class Sub(Foo):
+    w: int
+
+    def method(self) -> None:
+        self.x = 1
+        self.w = 2
+        self.q = 3  # E: not declared in `__slots__`
+"#,
+);
+
+// An unslotted class anywhere in the MRO gives every subclass an instance `__dict__`,
+// even a lower `@dataclass(slots=True)`.
+testcase!(
+    test_slots_slotted_dataclass_below_unslotted_middle_allows_dynamic,
+    r#"
+from dataclasses import dataclass
+
+@dataclass(slots=True)
+class Foo:
+    x: int
+
+class Mid(Foo):
+    pass
+
+@dataclass(slots=True)
+class Grand(Mid):
+    def method(self) -> None:
+        self.x = 1
+        self.z = 2  # OK: Mid is unslotted
+"#,
+);
+
 testcase!(
     test_slots_dict_allows_dynamic,
     r#"


### PR DESCRIPTION
Pyrefly reported a false `missing-attribute` error when a plain subclass of a slotted dataclass assigned new attributes, even though this is valid at runtime. The fix stops slot enforcement from applying to subclasses that do not declare slots themselves.

Fixes #4616


# Test Plan

`python3 test.py`