### PR TITLE
Check Ruff formatting in GitHub CI (#4709)

### DIFF
--- a/.github/workflows/pyrefly.yml
+++ b/.github/workflows/pyrefly.yml
@@ -36,6 +36,17 @@ jobs:
     - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+    - name: Check tensor-shape formatting
+      run: >
+        uv tool run --from ruff==0.16.5 ruff format --check
+        --exclude 'tensor-shapes/skills/**'
+        tensor-shapes
+      if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: set windows cargo home
       # we need to set CARGO_HOME to a high-up directory on Windows machines, since some dependencies cloned
       # by Cargo have long paths and will cause builds/tests to fail
@@ -82,11 +93,6 @@ jobs:
     # platform-independent assertions.
     - name: Run tensor-shape type checks
       run: python tensor-shapes/run_tests.py --release --static-only
-    - name: Install uv
-      uses: astral-sh/setup-uv@v5
-      with:
-        enable-cache: true
-      if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Bootstrap tensor-shapes virtualenv
       run: python tensor-shapes/bootstrap_venv.py
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/TENSOR_SHAPES_CONTRIBUTING.md
+++ b/TENSOR_SHAPES_CONTRIBUTING.md
@@ -390,7 +390,19 @@ the DSL through realistic PyTorch signatures.
 
 ## Pre-Commit Checks
 
-Before handing off changes, run formatting and linting:
+Python files in the tensor-shape packages use Ruff's formatter, rather than
+Black. Format them from the repository root with the same Ruff version as CI:
+
+```bash
+uv tool run --from ruff==0.16.5 ruff format \
+  --exclude 'tensor-shapes/skills/**' \
+  tensor-shapes
+```
+
+The `skills` directory is documentation rather than corpus source and is
+excluded because Ruff also formats Python snippets embedded in Markdown.
+
+Before handing off changes, also run the repository formatting and linting:
 
 ```bash
 ./test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema

--- a/tensor-shapes/pyrefly-jax-stubs/README.md
+++ b/tensor-shapes/pyrefly-jax-stubs/README.md
@@ -24,5 +24,12 @@ expected.
 and every `test/test_*.py`, and those same test files then run against real
 JAX, so a stub that is self-consistent but wrong still fails.
 
+Before submitting a change, format this package with Ruff from the repository
+root:
+
+```bash
+uv tool run --from ruff==0.16.5 ruff format tensor-shapes/pyrefly-jax-stubs
+```
+
 Anything not listed above is simply absent rather than modeled loosely, so it is
 reported as a missing attribute rather than inferred gradually.


### PR DESCRIPTION
Summary:

External tensor-shape contributors had no documented way to reproduce the formatter used by the repository, and GitHub CI did not catch formatting drift. Document the pinned Ruff command and add a fast CI job that checks the full tensor-shapes source corpus.

The documentation-only `tensor-shapes/skills` directory is excluded because Ruff also reformats fenced examples that are not corpus source.

Differential Revision: D117895283


