### PR TITLE
[tensor-shapes] add stubs for jax.numpy.linalg submodule

### DIFF
--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
@@ -4,34 +4,89 @@
 # LICENSE file in the root directory of this source tree.
 
 import shape_extensions.dsl as dsl
-from shape_extensions import IntTuple, type_shape_dsl_function
+from shape_extensions import Int, IntTuple, type_shape_dsl_function
+
+@type_shape_dsl_function
+def int_min(a: Int, b: Int) -> Int:
+    if a == b:
+        return a
+    if dsl.is_concrete_int(a) and dsl.is_concrete_int(b):
+        if a < b:
+            return a
+        return b
+    return dsl.Int.gradual()
 
 @type_shape_dsl_function
 def matmul_shape(left: IntTuple, right: IntTuple) -> IntTuple:
-    # TODO(stroxler): Model batched matmul, which broadcasts the leading
-    # dimensions. Batched calls are common in JAX, so an unmodeled rank yields a
-    # gradual shape rather than an error: rejecting valid code would be worse
-    # than not checking it.
-    if len(left) > 2 or len(right) > 2 or len(left) == 0 or len(right) == 0:
-        return dsl.IntTuple.gradual()
-    # The contracted dimension is the last of the left operand and the first of
-    # the right, whatever the ranks. A 1-D operand contributes no axis to the
-    # result, so `(N, M) @ (M,)` is `(N,)` and `(M,) @ (M,)` is a scalar.
-    left_inner = left[len(left) - 1]
-    right_inner = right[0]
+    # 1. Reject operands with rank 0 (scalars)
+    if len(left) == 0 or len(right) == 0:
+        return dsl.Invalid("matmul requires at least 1-D operands")
+
+    # (k)(*batch,k,m) -> (*batch,m)
+    if len(left) == 1:
+        k_left = left[0]
+        k_right = right[len(right) - 2]
+        if (
+            dsl.is_concrete_int(k_left)
+            and dsl.is_concrete_int(k_right)
+            and k_left != k_right
+        ):
+            return dsl.Invalid("matmul inner dimensions must match")
+        return dsl.IntTuple(
+            right[i] if i < len(right) - 2 else right[len(right) - 1]
+            for i in range(len(right) - 1)
+        )
+
+    # (*batch,k)(k) -> (*batch,)
+    if len(right) == 1:
+        k_left = left[len(left) - 1]
+        k_right = right[0]
+        if (
+            dsl.is_concrete_int(k_left)
+            and dsl.is_concrete_int(k_right)
+            and k_left != k_right
+        ):
+            return dsl.Invalid("matmul inner dimensions must match")
+        return dsl.IntTuple(left[i] for i in range(len(left) - 1))
+
+    # (*batch_left,n,k)(*batch_right,k,m) -> (*broadcast(batch_left,batch_right),n,m)
+    k_left = left[len(left) - 1]
+    k_right = right[len(right) - 2]
     if (
-        dsl.is_concrete_int(left_inner)
-        and dsl.is_concrete_int(right_inner)
-        and left_inner != right_inner
+        dsl.is_concrete_int(k_left)
+        and dsl.is_concrete_int(k_right)
+        and k_left != k_right
     ):
         return dsl.Invalid("matmul inner dimensions must match")
-    if len(left) == 1 and len(right) == 1:
-        return dsl.IntTuple(())
-    if len(left) == 1:
-        return dsl.IntTuple((right[1],))
-    if len(right) == 1:
-        return dsl.IntTuple((left[0],))
-    return dsl.IntTuple((left[0], right[1]))
+    if len(left) >= len(right):
+        n_batch = len(left) - 2
+        diff = len(left) - len(right)
+        return dsl.IntTuple(
+            (
+                (
+                    (right[i - diff] if left[i] == 1 else left[i])
+                    if i >= diff
+                    else left[i]
+                )
+                if i < n_batch
+                else (left[len(left) - 2] if i == n_batch else right[len(right) - 1])
+            )
+            for i in range(len(left))
+        )
+    n_batch = len(right) - 2
+    diff = len(right) - len(left)
+    return dsl.IntTuple(
+        (
+            (
+                (right[i] if left[i - diff] == 1 else left[i - diff])
+                if i >= diff
+                else right[i]
+            )
+            if i < n_batch
+            else (left[len(left) - 2] if i == n_batch else right[len(right) - 1])
+        )
+        for i in range(len(right))
+    )
 
 @type_shape_dsl_function
 def reverse_shape(shape: IntTuple) -> IntTuple:

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
@@ -15,7 +15,7 @@ from jax._shapes import (
 )
 from shape_extensions import broadcast, Flag, Int, IntTuple, IntVar
 
-from . import fft as fft
+from . import fft as fft, linalg as linalg
 
 type _Shape = IntTuple
 type _Axis = int | tuple[int, ...] | None
@@ -482,6 +482,9 @@ def logaddexp2[Shape: _Shape](
 def logaddexp2[Shape1: _Shape, Shape2: _Shape](
     x1: Array[Shape1], x2: Array[Shape2], /
 ) -> Array[broadcast(Shape1, Shape2)]: ...
+def matmul[LeftShape: _Shape, RightShape: _Shape](
+    a: Array[LeftShape], b: Array[RightShape]
+) -> Array[matmul_shape(LeftShape, RightShape)]: ...
 @overload
 def maximum[Shape: _Shape](
     x1: Array[Shape], x2: int | float | complex, /
@@ -614,11 +617,6 @@ def true_divide[Shape: _Shape](
 def true_divide[Shape1: _Shape, Shape2: _Shape](
     x1: Array[Shape1], x2: Array[Shape2], /
 ) -> Array[broadcast(Shape1, Shape2)]: ...
-
-# This MVP models only two-dimensional operands, matching the NumPy stubs.
-def matmul[LeftShape: _Shape, RightShape: _Shape](
-    a: Array[LeftShape], b: Array[RightShape]
-) -> Array[matmul_shape(LeftShape, RightShape)]: ...
 @overload
 def transpose[Shape: _Shape](
     a: Array[Shape], axes: None = None

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/linalg/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/linalg/__init__.pyi
@@ -1,0 +1,297 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Literal, overload, Sequence
+
+from jax._array import Array
+from jax._shapes import (
+    int_min,
+    matmul_shape,
+    reduce_shape,
+)
+from shape_extensions import broadcast, Elements, Flag, Int, IntTuple, IntVar
+
+type _Shape = IntTuple
+type _Axis = int | tuple[int, ...] | None
+
+def cholesky[Batch: IntTuple, N: IntVar](
+    a: Array[[*Elements[Batch], N, N]],
+    *,
+    upper: bool = False,
+    symmetrize_input: bool = True,
+) -> Array[[*Elements[Batch], N, N]]: ...
+def cond[Batch: IntTuple, M: IntVar, N: IntVar](
+    x: Array[[*Elements[Batch], M, N]],
+    p: Any = None,
+) -> Array[Batch]: ...
+def cross[Shape1: _Shape, Shape2: _Shape](
+    x1: Array[Shape1],
+    x2: Array[Shape2],
+    /,
+    *,
+    axis: int = -1,
+) -> Array[broadcast(Shape1, Shape2)]: ...
+def det[Batch: IntTuple, N: IntVar](
+    a: Array[[*Elements[Batch], N, N]],
+) -> Array[Batch]: ...
+def diagonal[Shape: _Shape](
+    x: Array[Shape],
+    /,
+    *,
+    offset: int = 0,
+) -> Array[IntTuple]: ...
+def eig[Batch: IntTuple, N: IntVar](
+    a: Array[[*Elements[Batch], N, N]],
+) -> tuple[Array[[*Elements[Batch], N]], Array[[*Elements[Batch], N, N]]]: ...
+def eigh[Batch: IntTuple, N: IntVar](
+    a: Array[[*Elements[Batch], N, N]],
+    UPLO: str | None = None,
+    symmetrize_input: bool = True,
+) -> tuple[Array[[*Elements[Batch], N]], Array[[*Elements[Batch], N, N]]]: ...
+def eigvals[Batch: IntTuple, N: IntVar](
+    a: Array[[*Elements[Batch], N, N]],
+) -> Array[[*Elements[Batch], N]]: ...
+def eigvalsh[Batch: IntTuple, N: IntVar](
+    a: Array[[*Elements[Batch], N, N]],
+    UPLO: str | None = "L",
+    *,
+    symmetrize_input: bool = True,
+) -> Array[[*Elements[Batch], N]]: ...
+def inv[Batch: IntTuple, N: IntVar](
+    a: Array[[*Elements[Batch], N, N]],
+) -> Array[[*Elements[Batch], N, N]]: ...
+def lstsq[Batch: IntTuple, M: IntVar, N: IntVar](
+    a: Array[[*Elements[Batch], M, N]],
+    b: Array[[*Elements[Batch], M]],
+    rcond: float | None = None,
+    *,
+    numpy_resid: bool = False,
+) -> tuple[
+    Array[[*Elements[Batch], N]],
+    Array[IntTuple],
+    Array[Batch],
+    Array[[*Elements[Batch], int_min(Int[M], Int[N])]],
+]: ...
+def matmul[LeftShape: _Shape, RightShape: _Shape](
+    x1: Array[LeftShape],
+    x2: Array[RightShape],
+    /,
+    *,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+) -> Array[matmul_shape(LeftShape, RightShape)]: ...
+@overload
+def matrix_norm[Batch: IntTuple, M: IntVar, N: IntVar](
+    x: Array[[*Elements[Batch], M, N]],
+    /,
+    *,
+    keepdims: Literal[False] = False,
+    ord: Any = "fro",
+) -> Array[Batch]: ...
+@overload
+def matrix_norm[Batch: IntTuple, M: IntVar, N: IntVar](
+    x: Array[[*Elements[Batch], M, N]],
+    /,
+    *,
+    keepdims: Literal[True],
+    ord: Any = "fro",
+) -> Array[[*Elements[Batch], 1, 1]]: ...
+@overload
+def matrix_norm(
+    x: Array[Any],
+    /,
+    *,
+    keepdims: bool = False,
+    ord: Any = "fro",
+) -> Array[IntTuple]: ...
+def matrix_power[Batch: IntTuple, N: IntVar](
+    a: Array[[*Elements[Batch], N, N]],
+    n: int,
+) -> Array[[*Elements[Batch], N, N]]: ...
+def matrix_rank[Batch: IntTuple, N: IntVar, K: IntVar](
+    M: Array[[*Elements[Batch], N, K]],
+    rtol: Any = None,
+    *,
+    hermitian: bool = False,
+    tol: Any = None,
+) -> Array[Batch]: ...
+def matrix_transpose[Batch: IntTuple, M: IntVar, N: IntVar](
+    x: Array[[*Elements[Batch], M, N]],
+    /,
+) -> Array[[*Elements[Batch], N, M]]: ...
+def multi_dot(
+    arrays: Sequence[Array[Any]],
+    *,
+    precision: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def norm[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    x: Array[Shape],
+    ord: Any = None,
+    axis: Axis = None,
+    keepdims: KeepDims = False,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def norm[Shape: _Shape](
+    x: Array[Shape],
+    ord: Any = None,
+    axis: Sequence[int] = ...,
+    keepdims: bool = False,
+) -> Array[IntTuple]: ...
+@overload
+def outer[N: IntVar, M: IntVar](
+    x1: Array[[N]],
+    x2: Array[[M]],
+    /,
+) -> Array[[N, M]]: ...
+@overload
+def outer(
+    x1: Array[Any],
+    x2: Array[Any],
+    /,
+) -> Array[IntTuple]: ...
+def pinv[Batch: IntTuple, M: IntVar, N: IntVar](
+    a: Array[[*Elements[Batch], M, N]],
+    rtol: Any = None,
+    hermitian: bool = False,
+    *,
+    rcond: Any = None,
+) -> Array[[*Elements[Batch], N, M]]: ...
+@overload
+def qr[Batch: IntTuple, M: IntVar, N: IntVar](
+    a: Array[[*Elements[Batch], M, N]],
+    mode: Literal["reduced"] = "reduced",
+) -> tuple[
+    Array[[*Elements[Batch], M, int_min(Int[M], Int[N])]],
+    Array[[*Elements[Batch], int_min(Int[M], Int[N]), N]],
+]: ...
+@overload
+def qr[Batch: IntTuple, M: IntVar, N: IntVar](
+    a: Array[[*Elements[Batch], M, N]],
+    mode: Literal["r"],
+) -> Array[[*Elements[Batch], int_min(Int[M], Int[N]), N]]: ...
+@overload
+def qr[Batch: IntTuple, M: IntVar, N: IntVar](
+    a: Array[[*Elements[Batch], M, N]],
+    mode: Literal["complete"],
+) -> tuple[Array[[*Elements[Batch], M, M]], Array[[*Elements[Batch], M, N]]]: ...
+@overload
+def qr(
+    a: Array[Any],
+    mode: str = "reduced",
+) -> tuple[Array[IntTuple], Array[IntTuple]] | Array[IntTuple]: ...
+def slogdet[Batch: IntTuple, N: IntVar](
+    a: Array[[*Elements[Batch], N, N]],
+    *,
+    method: str | None = None,
+) -> tuple[Array[Batch], Array[Batch]]: ...
+@overload
+def solve[Batch: IntTuple, N: IntVar](
+    a: Array[[*Elements[Batch], N, N]],
+    b: Array[[N]],
+) -> Array[[*Elements[Batch], N]]: ...
+@overload
+def solve[Batch: IntTuple, N: IntVar, M: IntVar](
+    a: Array[[*Elements[Batch], N, N]],
+    b: Array[[*Elements[Batch], N, M]],
+) -> Array[[*Elements[Batch], N, M]]: ...
+@overload
+def svd[Batch: IntTuple, M: IntVar, N: IntVar](
+    a: Array[[*Elements[Batch], M, N]],
+    full_matrices: Literal[False],
+    compute_uv: Literal[True] = True,
+    hermitian: bool = False,
+    subset_by_index: Any = None,
+) -> tuple[
+    Array[[*Elements[Batch], M, int_min(Int[M], Int[N])]],
+    Array[[*Elements[Batch], int_min(Int[M], Int[N])]],
+    Array[[*Elements[Batch], int_min(Int[M], Int[N]), N]],
+]: ...
+@overload
+def svd[Batch: IntTuple, M: IntVar, N: IntVar](
+    a: Array[[*Elements[Batch], M, N]],
+    full_matrices: Literal[True] = True,
+    compute_uv: Literal[True] = True,
+    hermitian: bool = False,
+    subset_by_index: Any = None,
+) -> tuple[
+    Array[[*Elements[Batch], M, M]],
+    Array[[*Elements[Batch], int_min(Int[M], Int[N])]],
+    Array[[*Elements[Batch], N, N]],
+]: ...
+@overload
+def svd[Batch: IntTuple, M: IntVar, N: IntVar](
+    a: Array[[*Elements[Batch], M, N]],
+    full_matrices: bool = ...,
+    *,
+    compute_uv: Literal[False],
+    hermitian: bool = False,
+    subset_by_index: Any = None,
+) -> Array[[*Elements[Batch], int_min(Int[M], Int[N])]]: ...
+@overload
+def svd(
+    a: Array[Any],
+    full_matrices: bool = True,
+    compute_uv: bool = True,
+    hermitian: bool = False,
+    subset_by_index: Any = None,
+) -> tuple[Array[IntTuple], Array[IntTuple], Array[IntTuple]] | Array[IntTuple]: ...
+def svdvals[Batch: IntTuple, M: IntVar, N: IntVar](
+    x: Array[[*Elements[Batch], M, N]],
+    /,
+) -> Array[[*Elements[Batch], int_min(Int[M], Int[N])]]: ...
+def tensordot[Shape1: _Shape, Shape2: _Shape](
+    x1: Array[Shape1],
+    x2: Array[Shape2],
+    /,
+    *,
+    axes: Any = 2,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+def tensorinv[Shape: _Shape](
+    a: Array[Shape],
+    ind: int = 2,
+) -> Array[IntTuple]: ...
+def tensorsolve[Shape1: _Shape, Shape2: _Shape](
+    a: Array[Shape1],
+    b: Array[Shape2],
+    axes: tuple[int, ...] | None = None,
+) -> Array[IntTuple]: ...
+def trace[Shape: _Shape](
+    x: Array[Shape],
+    /,
+    *,
+    offset: int = 0,
+    dtype: Any = None,
+) -> Array[IntTuple]: ...
+def vecdot[Shape1: _Shape, Shape2: _Shape](
+    x1: Array[Shape1],
+    x2: Array[Shape2],
+    /,
+    *,
+    axis: int = -1,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def vector_norm[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    x: Array[Shape],
+    /,
+    *,
+    axis: Axis = None,
+    keepdims: KeepDims = False,
+    ord: Any = 2,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def vector_norm(
+    x: Array[Any],
+    /,
+    *,
+    axis: Sequence[int] = ...,
+    keepdims: bool = False,
+    ord: Any = 2,
+) -> Array[IntTuple]: ...

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_linalg.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_linalg.py
@@ -1,0 +1,265 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from shape_extensions import assert_shape, Elements, IntTuple, IntVar
+
+
+def square_svd_components[N: IntVar](
+    x: jax.Array[[N, N]],
+) -> tuple[jax.Array[[N, N]], jax.Array[[N]], jax.Array[[N, N]]]:
+    return jnp.linalg.svd(x, full_matrices=False)
+
+
+def test_svd_reduced_wide_matrix() -> None:
+    x = jnp.ones((3, 5))
+
+    u, s, vt = jnp.linalg.svd(x, full_matrices=False)
+
+    assert_shape(u, (3, 3))
+    assert_shape(s, (3,))
+    assert_shape(vt, (3, 5))
+
+
+def test_svd_reduced_tall_matrix() -> None:
+    x = jnp.ones((5, 3))
+
+    u, s, vt = jnp.linalg.svd(x, full_matrices=False)
+
+    assert_shape(u, (5, 3))
+    assert_shape(s, (3,))
+    assert_shape(vt, (3, 3))
+
+
+def test_svd_reduced_square_matrix() -> None:
+    x = jnp.ones((4, 4))
+
+    u, s, vt = jnp.linalg.svd(x, full_matrices=False)
+
+    assert_shape(u, (4, 4))
+    assert_shape(s, (4,))
+    assert_shape(vt, (4, 4))
+
+    u_c, s_c, vt_c = square_svd_components(x)
+    assert_shape(u_c, (4, 4))
+    assert_shape(s_c, (4,))
+    assert_shape(vt_c, (4, 4))
+
+
+def test_svd_compute_uv_false() -> None:
+    x = jnp.ones((5, 3))
+
+    s = jnp.linalg.svd(x, compute_uv=False)
+
+    assert_shape(s, (3,))
+    assert_shape(jnp.linalg.svdvals(x), (3,))
+
+
+def test_svd_full_matrices() -> None:
+    x = jnp.ones((3, 5))
+
+    u, s, vt = jnp.linalg.svd(x, full_matrices=True)
+
+    assert_shape(u, (3, 3))
+    assert_shape(s, (3,))
+    assert_shape(vt, (5, 5))
+
+
+def test_qr_reduced() -> None:
+    wide = jnp.ones((3, 5))
+    tall = jnp.ones((5, 3))
+
+    q_w, r_w = jnp.linalg.qr(wide, mode="reduced")
+    assert_shape(q_w, (3, 3))
+    assert_shape(r_w, (3, 5))
+
+    q_t, r_t = jnp.linalg.qr(tall, mode="reduced")
+    assert_shape(q_t, (5, 3))
+    assert_shape(r_t, (3, 3))
+
+
+def test_qr_r_mode() -> None:
+    tall = jnp.ones((5, 3))
+
+    r = jnp.linalg.qr(tall, mode="r")
+    assert_shape(r, (3, 3))
+
+
+def test_solve_vector_rhs() -> None:
+    a = jnp.eye(3)
+    b = jnp.ones(3)
+
+    assert_shape(jnp.linalg.solve(a, b), (3,))
+
+
+def test_solve_matrix_rhs() -> None:
+    a = jnp.eye(3)
+    b = jnp.ones((3, 2))
+
+    assert_shape(jnp.linalg.solve(a, b), (3, 2))
+
+
+def test_inv_and_matrix_power() -> None:
+    a = jnp.eye(4)
+
+    assert_shape(jnp.linalg.inv(a), (4, 4))
+    assert_shape(jnp.linalg.matrix_power(a, 3), (4, 4))
+    assert_shape(jnp.linalg.cholesky(a), (4, 4))
+
+
+def test_eigh_and_eig() -> None:
+    a = jnp.eye(5)
+
+    w_h, v_h = jnp.linalg.eigh(a)
+    assert_shape(w_h, (5,))
+    assert_shape(v_h, (5, 5))
+    assert_shape(jnp.linalg.eigvalsh(a), (5,))
+
+    w, v = jnp.linalg.eig(a)
+    assert_shape(w, (5,))
+    assert_shape(v, (5, 5))
+    assert_shape(jnp.linalg.eigvals(a), (5,))
+
+
+def test_scalar_matrix_properties() -> None:
+    a = jnp.eye(3)
+    rect = jnp.ones((3, 4))
+
+    assert_shape(jnp.linalg.det(a), ())
+    sign, logdet = jnp.linalg.slogdet(a)
+    assert_shape(sign, ())
+    assert_shape(logdet, ())
+    assert_shape(jnp.linalg.matrix_rank(rect), ())
+    assert_shape(jnp.linalg.cond(a), ())
+
+
+def test_matrix_transpose() -> None:
+    x = jnp.ones((3, 4))
+    batched = jnp.ones((2, 3, 4))
+
+    assert_shape(jnp.linalg.matrix_transpose(x), (4, 3))
+    assert_shape(jnp.linalg.matrix_transpose(batched), (2, 4, 3))
+
+
+def test_matmul() -> None:
+    mat23 = jnp.ones((2, 3))
+    mat34 = jnp.ones((3, 4))
+    vec3 = jnp.ones(3)
+
+    assert_shape(jnp.linalg.matmul(mat23, mat34), (2, 4))
+    assert_shape(jnp.linalg.matmul(mat23, vec3), (2,))
+    assert_shape(jnp.linalg.matmul(vec3, mat34), (4,))
+    assert_shape(jnp.linalg.matmul(vec3, vec3), ())
+
+
+def test_matmul_rejects_mismatched_inner_dimension() -> None:
+    a = jnp.ones((3, 4))
+
+    assert_shape(jnp.linalg.matmul(a, jnp.ones((4, 5))), (3, 5))
+    try:
+        # E: Cannot evaluate type-level shape DSL call: matmul inner dimensions must match
+        jnp.linalg.matmul(a, jnp.ones((7, 5)))
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject mismatched inner dimensions")
+
+
+def test_batched_matmul() -> None:
+    vec4 = jnp.ones(4)
+    mat45 = jnp.ones((4, 5))
+    batch_234 = jnp.ones((2, 3, 4))
+    batch_245 = jnp.ones((2, 4, 5))
+
+    # (k)(*batch, k, m) -> (*batch, m)
+    assert_shape(jnp.linalg.matmul(vec4, batch_245), (2, 5))
+
+    # (*batch, n, k)(k) -> (*batch, n)
+    assert_shape(jnp.linalg.matmul(batch_234, vec4), (2, 3))
+
+    # (*batch_left, n, k)(*batch_right, k, m) -> (*broadcast(batch_left, batch_right), n, m)
+    assert_shape(jnp.linalg.matmul(batch_234, mat45), (2, 3, 5))
+    assert_shape(jnp.linalg.matmul(batch_234, batch_245), (2, 3, 5))
+
+
+def test_outer_and_cross() -> None:
+    v1 = jnp.ones(3)
+    v2 = jnp.ones(4)
+
+    assert_shape(jnp.linalg.outer(v1, v2), (3, 4))
+    assert_shape(jnp.linalg.cross(v1, v1), (3,))
+
+
+def test_pinv_and_lstsq() -> None:
+    a = jnp.ones((4, 3))
+    b = jnp.ones(4)
+
+    assert_shape(jnp.linalg.pinv(a), (3, 4))
+    x, residuals, rank, s = jnp.linalg.lstsq(a, b)
+    assert_shape(x, (3,))
+    assert_shape(rank, ())
+    assert_shape(s, (3,))
+
+
+def test_norm_variations() -> None:
+    vec = jnp.ones(5)
+    mat = jnp.ones((3, 4))
+    cube = jnp.ones((2, 3, 4))
+
+    assert_shape(jnp.linalg.norm(vec), ())
+    assert_shape(jnp.linalg.norm(mat, axis=0), (4,))
+    assert_shape(jnp.linalg.norm(mat, axis=-1, keepdims=True), (3, 1))
+    assert_shape(jnp.linalg.vector_norm(mat, axis=1), (3,))
+    assert_shape(jnp.linalg.matrix_norm(mat), ())
+    assert_shape(jnp.linalg.matrix_norm(mat, keepdims=True), (1, 1))
+    assert_shape(jnp.linalg.matrix_norm(cube), (2,))
+    assert_shape(jnp.linalg.matrix_norm(cube, keepdims=True), (2, 1, 1))
+
+
+def generic_batched_cholesky[Batch: IntTuple, N: IntVar](
+    x: jax.Array[[*Elements[Batch], N, N]],
+) -> jax.Array[[*Elements[Batch], N, N]]:
+    return jnp.linalg.cholesky(x)
+
+
+def test_batched_linalg_operations() -> None:
+    batch_eye = jnp.ones((2, 4, 4))
+    batch_mat = jnp.ones((2, 4, 5))
+    batch_vec = jnp.ones((2, 4))
+
+    assert_shape(jnp.linalg.cholesky(batch_eye), (2, 4, 4))
+    assert_shape(generic_batched_cholesky(batch_eye), (2, 4, 4))
+    assert_shape(jnp.linalg.inv(batch_eye), (2, 4, 4))
+    assert_shape(jnp.linalg.matrix_power(batch_eye, 2), (2, 4, 4))
+    assert_shape(jnp.linalg.det(batch_eye), (2,))
+    sign, logdet = jnp.linalg.slogdet(batch_eye)
+    assert_shape(sign, (2,))
+    assert_shape(logdet, (2,))
+    assert_shape(jnp.linalg.matrix_rank(batch_mat), (2,))
+    assert_shape(jnp.linalg.cond(batch_eye), (2,))
+
+    w, v = jnp.linalg.eigh(batch_eye)
+    assert_shape(w, (2, 4))
+    assert_shape(v, (2, 4, 4))
+    assert_shape(jnp.linalg.eigvalsh(batch_eye), (2, 4))
+
+    q, r = jnp.linalg.qr(batch_mat, mode="reduced")
+    assert_shape(q, (2, 4, 4))
+    assert_shape(r, (2, 4, 5))
+
+    u, s, vt = jnp.linalg.svd(batch_mat, full_matrices=False)
+    assert_shape(u, (2, 4, 4))
+    assert_shape(s, (2, 4))
+    assert_shape(vt, (2, 4, 5))
+    assert_shape(jnp.linalg.svdvals(batch_mat), (2, 4))
+
+    vec4 = jnp.ones(4)
+    assert_shape(jnp.linalg.solve(batch_eye, vec4), (2, 4))
+    batch_rhs = jnp.ones((2, 4, 3))
+    assert_shape(jnp.linalg.solve(batch_eye, batch_rhs), (2, 4, 3))
+    assert_shape(jnp.linalg.pinv(batch_mat), (2, 5, 4))

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_matmul.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_matmul.py
@@ -38,13 +38,9 @@ def reject_mismatched_inner_dimension(
 
 
 def batched_matmul_is_not_rejected(
-    x: jax.Array[[N, M, P]], y: jax.Array[[M, P]]
+    x: jax.Array[[N, M, P]], y: jax.Array[[P, M]]
 ) -> None:
-    """Batched matmul is unmodeled, so its result is gradual rather than an error.
-
-    There is deliberately no expected error here: the suite runs with
-    `--expectations`, so this call failing to check would fail the test.
-    """
+    """Batched matmul with matching contracting dimension."""
 
     jnp.matmul(x, y)
 
@@ -63,6 +59,30 @@ def test_function_matmul() -> None:
     assert_shape(jnp.matmul(left, right), (2, 7))
     # JAX names both operands, unlike the ufuncs, which are positional-only.
     assert_shape(jnp.matmul(a=left, b=right), (2, 7))
+
+
+def test_batched_matmul() -> None:
+    vec4 = jnp.ones(4)
+    mat34 = jnp.ones((3, 4))
+    mat45 = jnp.ones((4, 5))
+    batch_234 = jnp.ones((2, 3, 4))
+    batch_245 = jnp.ones((2, 4, 5))
+
+    # 1D @ 1D -> ()
+    assert_shape(jnp.matmul(vec4, vec4), ())
+
+    # 1D @ ND -> (*batch, m)
+    assert_shape(jnp.matmul(vec4, mat45), (5,))
+    assert_shape(jnp.matmul(vec4, batch_245), (2, 5))
+
+    # ND @ 1D -> (*batch, n)
+    assert_shape(jnp.matmul(mat34, vec4), (3,))
+    assert_shape(jnp.matmul(batch_234, vec4), (2, 3))
+
+    # ND @ ND -> (*broadcast(batch_left, batch_right), n, m)
+    assert_shape(jnp.matmul(mat34, mat45), (3, 5))
+    assert_shape(jnp.matmul(batch_234, mat45), (2, 3, 5))
+    assert_shape(jnp.matmul(batch_234, batch_245), (2, 3, 5))
 
 
 def test_matmul_contracts_vector_operands() -> None:


### PR DESCRIPTION
### Summary

Update `tensor-shapes/pyrefly-jax-stubs` with shape annotations for `jax.numpy.linalg` APIs. Followup to #4708.

This also includes improving the `matmul_shape` DSL function and applying it to `jax.numpy.matmul`.

### Test Plan

Unit test file updated; new `test_linalg.py` file created. Tests pass locally:
```
$ uv tool run --from ruff==0.16.5 ruff format tensor-shapes
254 files left unchanged
$ uv run python test.py --no-test --no-conformance --no-jsonschema
Running formatting...
Finished in 2.62 seconds.
Running linting...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.65s
Finished in 0.88 seconds.
$ uv run python tensor-shapes/pyrefly-jax-stubs/run_pyrefly.py --release
+ cargo build -p pyrefly --release
    Finished `release` profile [optimized + debuginfo] target(s) in 0.74s
PASS stubs (7 files)
PASS arithmetic (1 files)
PASS creation (1 files)
PASS fft (1 files)
PASS linalg (1 files)
PASS matmul (1 files)
PASS nn (1 files)
PASS reductions (1 files)
PASS reshape (1 files)
```


### AI usage

Changes in this PR were generated with a Gemini coding agent.