### PR TITLE
[tensor-shapes] add stubs for jax.numpy.fft

### DIFF
--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
@@ -110,3 +110,102 @@ def reshape_shape(shape: IntTuple, newshape: int | tuple[int, ...] | None) -> In
     if len(inferred) == 1:
         return dsl.IntTuple.gradual()
     return dsl.IntTuple(dim for dim in dims)
+
+@type_shape_dsl_function
+def fft_n_shape(shape: IntTuple, n: int, dim: int) -> IntTuple:
+    rank = len(shape)
+    if rank == 0:
+        return dsl.Invalid("FFT requires at least 1-D array")
+    if n < 0:
+        return dsl.Invalid("n must be non-negative")
+    if dim < 0:
+        axis = dim + rank
+    else:
+        axis = dim + 0
+    if axis < 0 or axis >= rank:
+        return dsl.Invalid("FFT axis out of bounds")
+    extent = n + 0
+    return dsl.concat(
+        dsl.concat(shape[:axis], dsl.IntTuple((extent,))), shape[axis + 1 :]
+    )
+
+@type_shape_dsl_function
+def rfft_shape(shape: IntTuple, dim: int) -> IntTuple:
+    rank = len(shape)
+    if rank == 0:
+        return dsl.Invalid("FFT requires at least 1-D array")
+    if dim < 0:
+        axis = dim + rank
+    else:
+        axis = dim + 0
+    if axis < 0 or axis >= rank:
+        return dsl.Invalid("FFT axis out of bounds")
+    extent = shape[axis] // 2 + 1
+    return dsl.concat(
+        dsl.concat(shape[:axis], dsl.IntTuple((extent,))), shape[axis + 1 :]
+    )
+
+@type_shape_dsl_function
+def rfft_n_shape(shape: IntTuple, n: int, dim: int) -> IntTuple:
+    rank = len(shape)
+    if rank == 0:
+        return dsl.Invalid("FFT requires at least 1-D array")
+    if n < 0:
+        return dsl.Invalid("n must be non-negative")
+    if dim < 0:
+        axis = dim + rank
+    else:
+        axis = dim + 0
+    if axis < 0 or axis >= rank:
+        return dsl.Invalid("FFT axis out of bounds")
+    extent = n // 2 + 1
+    return dsl.concat(
+        dsl.concat(shape[:axis], dsl.IntTuple((extent,))), shape[axis + 1 :]
+    )
+
+@type_shape_dsl_function
+def irfft_shape(shape: IntTuple, dim: int) -> IntTuple:
+    rank = len(shape)
+    if rank == 0:
+        return dsl.Invalid("FFT requires at least 1-D array")
+    if dim < 0:
+        axis = dim + rank
+    else:
+        axis = dim + 0
+    if axis < 0 or axis >= rank:
+        return dsl.Invalid("FFT axis out of bounds")
+    extent = 2 * (shape[axis] - 1)
+    return dsl.concat(
+        dsl.concat(shape[:axis], dsl.IntTuple((extent,))), shape[axis + 1 :]
+    )
+
+@type_shape_dsl_function
+def irfft_n_shape(shape: IntTuple, n: int, dim: int) -> IntTuple:
+    rank = len(shape)
+    if rank == 0:
+        return dsl.Invalid("FFT requires at least 1-D array")
+    if n < 0:
+        return dsl.Invalid("n must be non-negative")
+    if dim < 0:
+        axis = dim + rank
+    else:
+        axis = dim + 0
+    if axis < 0 or axis >= rank:
+        return dsl.Invalid("FFT axis out of bounds")
+    extent = n + 0
+    return dsl.concat(
+        dsl.concat(shape[:axis], dsl.IntTuple((extent,))), shape[axis + 1 :]
+    )
+
+@type_shape_dsl_function
+def fftfreq_shape(n: int) -> IntTuple:
+    if n < 0:
+        return dsl.Invalid("n must be non-negative")
+    extent = n + 0
+    return dsl.IntTuple((extent,))
+
+@type_shape_dsl_function
+def rfftfreq_shape(n: int) -> IntTuple:
+    if n < 0:
+        return dsl.Invalid("n must be non-negative")
+    return dsl.IntTuple((n // 2 + 1,))

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
@@ -15,6 +15,8 @@ from jax._shapes import (
 )
 from shape_extensions import broadcast, Flag, Int, IntTuple, IntVar
 
+from . import fft as fft
+
 type _Shape = IntTuple
 type _Axis = int | tuple[int, ...] | None
 # The trailing `None` is not a legal argument to `reshape`. It is present because

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/fft/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/fft/__init__.pyi
@@ -1,0 +1,306 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, overload, Sequence
+
+from jax._array import Array
+from jax._shapes import (
+    fft_n_shape,
+    fftfreq_shape,
+    irfft_n_shape,
+    irfft_shape,
+    rfft_n_shape,
+    rfft_shape,
+    rfftfreq_shape,
+)
+from shape_extensions import Flag, IntTuple
+
+# 1D FFT operations
+@overload
+def fft[Shape: IntTuple](
+    a: Array[Shape],
+    n: None = None,
+    axis: int = -1,
+    norm: str | None = None,
+) -> Array[Shape]: ...
+@overload
+def fft[Shape: IntTuple, N: Flag[int], Dim: Flag[int]](
+    a: Array[Shape],
+    n: N,
+    axis: Dim = -1,
+    norm: str | None = None,
+) -> Array[fft_n_shape(Shape, N, Dim)]: ...
+@overload
+def fft(
+    a: Array,
+    n: int | None = None,
+    axis: int = -1,
+    norm: str | None = None,
+) -> Array: ...
+@overload
+def ifft[Shape: IntTuple](
+    a: Array[Shape],
+    n: None = None,
+    axis: int = -1,
+    norm: str | None = None,
+) -> Array[Shape]: ...
+@overload
+def ifft[Shape: IntTuple, N: Flag[int], Dim: Flag[int]](
+    a: Array[Shape],
+    n: N,
+    axis: Dim = -1,
+    norm: str | None = None,
+) -> Array[fft_n_shape(Shape, N, Dim)]: ...
+@overload
+def ifft(
+    a: Array,
+    n: int | None = None,
+    axis: int = -1,
+    norm: str | None = None,
+) -> Array: ...
+@overload
+def rfft[Shape: IntTuple, Dim: Flag[int]](
+    a: Array[Shape],
+    n: None = None,
+    axis: Dim = -1,
+    norm: str | None = None,
+) -> Array[rfft_shape(Shape, Dim)]: ...
+@overload
+def rfft[Shape: IntTuple, N: Flag[int], Dim: Flag[int]](
+    a: Array[Shape],
+    n: N,
+    axis: Dim = -1,
+    norm: str | None = None,
+) -> Array[rfft_n_shape(Shape, N, Dim)]: ...
+@overload
+def rfft(
+    a: Array,
+    n: int | None = None,
+    axis: int = -1,
+    norm: str | None = None,
+) -> Array: ...
+@overload
+def irfft[Shape: IntTuple, Dim: Flag[int]](
+    a: Array[Shape],
+    n: None = None,
+    axis: Dim = -1,
+    norm: str | None = None,
+) -> Array[irfft_shape(Shape, Dim)]: ...
+@overload
+def irfft[Shape: IntTuple, N: Flag[int], Dim: Flag[int]](
+    a: Array[Shape],
+    n: N,
+    axis: Dim = -1,
+    norm: str | None = None,
+) -> Array[irfft_n_shape(Shape, N, Dim)]: ...
+@overload
+def irfft(
+    a: Array,
+    n: int | None = None,
+    axis: int = -1,
+    norm: str | None = None,
+) -> Array: ...
+@overload
+def hfft[Shape: IntTuple, Dim: Flag[int]](
+    a: Array[Shape],
+    n: None = None,
+    axis: Dim = -1,
+    norm: str | None = None,
+) -> Array[irfft_shape(Shape, Dim)]: ...
+@overload
+def hfft[Shape: IntTuple, N: Flag[int], Dim: Flag[int]](
+    a: Array[Shape],
+    n: N,
+    axis: Dim = -1,
+    norm: str | None = None,
+) -> Array[irfft_n_shape(Shape, N, Dim)]: ...
+@overload
+def hfft(
+    a: Array,
+    n: int | None = None,
+    axis: int = -1,
+    norm: str | None = None,
+) -> Array: ...
+@overload
+def ihfft[Shape: IntTuple, Dim: Flag[int]](
+    a: Array[Shape],
+    n: None = None,
+    axis: Dim = -1,
+    norm: str | None = None,
+) -> Array[rfft_shape(Shape, Dim)]: ...
+@overload
+def ihfft[Shape: IntTuple, N: Flag[int], Dim: Flag[int]](
+    a: Array[Shape],
+    n: N,
+    axis: Dim = -1,
+    norm: str | None = None,
+) -> Array[rfft_n_shape(Shape, N, Dim)]: ...
+@overload
+def ihfft(
+    a: Array,
+    n: int | None = None,
+    axis: int = -1,
+    norm: str | None = None,
+) -> Array: ...
+
+# 2D FFT operations
+@overload
+def fft2[Shape: IntTuple](
+    a: Array[Shape],
+    s: None = None,
+    axes: Sequence[int] = (-2, -1),
+    norm: str | None = None,
+) -> Array[Shape]: ...
+@overload
+def fft2(
+    a: Array,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] = (-2, -1),
+    norm: str | None = None,
+) -> Array: ...
+@overload
+def ifft2[Shape: IntTuple](
+    a: Array[Shape],
+    s: None = None,
+    axes: Sequence[int] = (-2, -1),
+    norm: str | None = None,
+) -> Array[Shape]: ...
+@overload
+def ifft2(
+    a: Array,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] = (-2, -1),
+    norm: str | None = None,
+) -> Array: ...
+@overload
+def rfft2[Shape: IntTuple](
+    a: Array[Shape],
+    s: None = None,
+    axes: Sequence[int] = (-2, -1),
+    norm: str | None = None,
+) -> Array[rfft_shape(Shape, -1)]: ...
+@overload
+def rfft2(
+    a: Array,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] = (-2, -1),
+    norm: str | None = None,
+) -> Array: ...
+@overload
+def irfft2[Shape: IntTuple](
+    a: Array[Shape],
+    s: None = None,
+    axes: Sequence[int] = (-2, -1),
+    norm: str | None = None,
+) -> Array[irfft_shape(Shape, -1)]: ...
+@overload
+def irfft2(
+    a: Array,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] = (-2, -1),
+    norm: str | None = None,
+) -> Array: ...
+
+# ND FFT operations
+@overload
+def fftn[Shape: IntTuple](
+    a: Array[Shape],
+    s: None = None,
+    axes: Sequence[int] | None = None,
+    norm: str | None = None,
+) -> Array[Shape]: ...
+@overload
+def fftn(
+    a: Array,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: str | None = None,
+) -> Array: ...
+@overload
+def ifftn[Shape: IntTuple](
+    a: Array[Shape],
+    s: None = None,
+    axes: Sequence[int] | None = None,
+    norm: str | None = None,
+) -> Array[Shape]: ...
+@overload
+def ifftn(
+    a: Array,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: str | None = None,
+) -> Array: ...
+@overload
+def rfftn[Shape: IntTuple](
+    a: Array[Shape],
+    s: None = None,
+    axes: None = None,
+    norm: str | None = None,
+) -> Array[rfft_shape(Shape, -1)]: ...
+@overload
+def rfftn(
+    a: Array,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: str | None = None,
+) -> Array: ...
+@overload
+def irfftn[Shape: IntTuple](
+    a: Array[Shape],
+    s: None = None,
+    axes: None = None,
+    norm: str | None = None,
+) -> Array[irfft_shape(Shape, -1)]: ...
+@overload
+def irfftn(
+    a: Array,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: str | None = None,
+) -> Array: ...
+
+# Frequency helpers
+@overload
+def fftfreq[N: Flag[int]](
+    n: N,
+    d: Any = 1.0,
+    *,
+    dtype: Any = None,
+    device: Any = None,
+) -> Array[fftfreq_shape(N)]: ...
+@overload
+def fftfreq(
+    n: int,
+    d: Any = 1.0,
+    *,
+    dtype: Any = None,
+    device: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def rfftfreq[N: Flag[int]](
+    n: N,
+    d: Any = 1.0,
+    *,
+    dtype: Any = None,
+    device: Any = None,
+) -> Array[rfftfreq_shape(N)]: ...
+@overload
+def rfftfreq(
+    n: int,
+    d: Any = 1.0,
+    *,
+    dtype: Any = None,
+    device: Any = None,
+) -> Array[IntTuple]: ...
+
+# Shift helpers
+def fftshift[Shape: IntTuple](
+    x: Array[Shape],
+    axes: None | int | Sequence[int] = None,
+) -> Array[Shape]: ...
+def ifftshift[Shape: IntTuple](
+    x: Array[Shape],
+    axes: None | int | Sequence[int] = None,
+) -> Array[Shape]: ...

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_fft.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_fft.py
@@ -1,0 +1,127 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from shape_extensions import assert_shape, IntTuple
+
+
+def generic_fft_preserves_shape[Shape: IntTuple](
+    x: jax.Array[Shape],
+) -> jax.Array[Shape]:
+    return jnp.fft.fft(x)
+
+
+def generic_fftshift_preserves_shape[Shape: IntTuple](
+    x: jax.Array[Shape],
+) -> jax.Array[Shape]:
+    return jnp.fft.fftshift(x)
+
+
+def test_1d_fft_and_ifft() -> None:
+    vec8 = jnp.ones(8)
+    mat48 = jnp.ones((4, 8))
+    tensor248 = jnp.ones((2, 4, 8))
+
+    assert_shape(jnp.fft.fft(vec8), (8,))
+    assert_shape(jnp.fft.ifft(vec8), (8,))
+    assert_shape(jnp.fft.fft(mat48), (4, 8))
+    assert_shape(jnp.fft.ifft(mat48), (4, 8))
+    assert_shape(jnp.fft.fft(tensor248), (2, 4, 8))
+    assert_shape(jnp.fft.ifft(tensor248), (2, 4, 8))
+
+    # Specifying n
+    assert_shape(jnp.fft.fft(vec8, n=16), (16,))
+    assert_shape(jnp.fft.ifft(vec8, n=16), (16,))
+    assert_shape(jnp.fft.fft(mat48, n=16), (4, 16))
+    assert_shape(jnp.fft.fft(mat48, n=16, axis=0), (16, 8))
+
+
+def test_rfft_and_irfft() -> None:
+    vec8 = jnp.ones(8)
+    mat48 = jnp.ones((4, 8))
+
+    # rfft output length is N // 2 + 1
+    assert_shape(jnp.fft.rfft(vec8), (5,))
+    assert_shape(jnp.fft.rfft(mat48), (4, 5))
+    assert_shape(jnp.fft.rfft(mat48, axis=0), (3, 8))
+    assert_shape(jnp.fft.rfft(vec8, n=16), (9,))
+
+    # irfft default output length is 2 * (N - 1)
+    assert_shape(jnp.fft.irfft(vec8), (14,))
+    assert_shape(jnp.fft.irfft(mat48), (4, 14))
+    assert_shape(jnp.fft.irfft(mat48, axis=0), (6, 8))
+    assert_shape(jnp.fft.irfft(vec8, n=16), (16,))
+
+
+def test_hfft_and_ihfft() -> None:
+    vec8 = jnp.ones(8)
+    mat48 = jnp.ones((4, 8))
+
+    assert_shape(jnp.fft.hfft(vec8), (14,))
+    assert_shape(jnp.fft.hfft(mat48), (4, 14))
+    assert_shape(jnp.fft.hfft(vec8, n=16), (16,))
+
+    assert_shape(jnp.fft.ihfft(vec8), (5,))
+    assert_shape(jnp.fft.ihfft(mat48), (4, 5))
+    assert_shape(jnp.fft.ihfft(vec8, n=16), (9,))
+
+
+def test_2d_fft_operations() -> None:
+    mat48 = jnp.ones((4, 8))
+    tensor248 = jnp.ones((2, 4, 8))
+
+    assert_shape(jnp.fft.fft2(mat48), (4, 8))
+    assert_shape(jnp.fft.ifft2(mat48), (4, 8))
+    assert_shape(jnp.fft.fft2(tensor248), (2, 4, 8))
+    assert_shape(jnp.fft.ifft2(tensor248), (2, 4, 8))
+
+    assert_shape(jnp.fft.rfft2(mat48), (4, 5))
+    assert_shape(jnp.fft.rfft2(tensor248), (2, 4, 5))
+
+    assert_shape(jnp.fft.irfft2(mat48), (4, 14))
+    assert_shape(jnp.fft.irfft2(tensor248), (2, 4, 14))
+
+
+def test_nd_fft_operations() -> None:
+    tensor248 = jnp.ones((2, 4, 8))
+
+    assert_shape(jnp.fft.fftn(tensor248), (2, 4, 8))
+    assert_shape(jnp.fft.ifftn(tensor248), (2, 4, 8))
+    assert_shape(jnp.fft.rfftn(tensor248), (2, 4, 5))
+    assert_shape(jnp.fft.irfftn(tensor248), (2, 4, 14))
+
+
+def test_fftfreq_and_rfftfreq() -> None:
+    assert_shape(jnp.fft.fftfreq(8), (8,))
+    assert_shape(jnp.fft.fftfreq(10, d=0.5), (10,))
+    assert_shape(jnp.fft.rfftfreq(8), (5,))
+    assert_shape(jnp.fft.rfftfreq(9), (5,))
+    assert_shape(jnp.fft.rfftfreq(10), (6,))
+
+
+def test_fftshift_and_ifftshift() -> None:
+    mat48 = jnp.ones((4, 8))
+    tensor248 = jnp.ones((2, 4, 8))
+
+    assert_shape(jnp.fft.fftshift(mat48), (4, 8))
+    assert_shape(jnp.fft.ifftshift(mat48), (4, 8))
+    assert_shape(jnp.fft.fftshift(tensor248), (2, 4, 8))
+    assert_shape(jnp.fft.ifftshift(tensor248), (2, 4, 8))
+
+
+def test_fft_rejects_out_of_bounds_axis() -> None:
+    mat48 = jnp.ones((4, 8))
+
+    assert_shape(jnp.fft.rfft(mat48, axis=1), (4, 5))
+    try:
+        # E: Cannot evaluate type-level shape DSL call: FFT axis out of bounds
+        jnp.fft.rfft(mat48, axis=3)
+    except (ValueError, IndexError):
+        pass
+    else:
+        raise AssertionError("expected JAX to reject out-of-bounds FFT axis")


### PR DESCRIPTION
### Summary

Update `tensor-shapes/pyrefly-jax-stubs` with shape annotations for `jax.numpy.linalg` APIs. Followup to #4708,

### Test Plan

Unit test file updated.

### AI usage

Changes in this PR were generated with a Gemini coding agent.