### PR TITLE
Ask for mechanical refactors in their own commit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,13 @@ Coding style: All code must be clean, documented and minimal. That means:
 - When adding or modifying configuration options or command line flags, the corresponding
   docs should be updated.
 
+## Structuring commits
+
+Keep mechanical refactors separate from behavior changes. If a change requires
+extracting a helper, renaming a type, or moving code between modules before the
+real change makes sense, put that groundwork in its own commit so the commit
+that changes behavior stays small and reviewable.
+
 ## Commit Messages
 
 The purpose of a commit message is to convey a commit's intent and rationale to the reader.


### PR DESCRIPTION
Summary:
Review feedback on D117790479: a commit that extracted a `Reply` type and
also changed how requests are routed would have been easier to read as two
commits. Write the preference down so it happens without a reviewer asking.

Test Plan:
Documentation only.