### PR TITLE
fix __all__ and __slots__ related code actions, go to, etc #4344

### DIFF
--- a/pyrefly/lib/export/exports.rs
+++ b/pyrefly/lib/export/exports.rs
@@ -304,11 +304,32 @@ impl Exports {
             .entries
             .iter()
             .find_map(|entry| match entry {
-                DunderAllEntry::Name(range, name) if range.contains_inclusive(position) => {
+                DunderAllEntry::Name(range, name) | DunderAllEntry::Remove(range, name)
+                    if range.contains_inclusive(position) =>
+                {
                     Some((*range, name.clone()))
                 }
                 _ => None,
             })
+    }
+
+    /// Return the ranges and names of all entries in a user-specified `__all__`.
+    pub fn dunder_all_names(&self) -> Option<impl Iterator<Item = (TextRange, &Name)>> {
+        match self.definitions.dunder_all.kind {
+            DunderAllKind::Specified => Some(
+                self.definitions
+                    .dunder_all
+                    .entries
+                    .iter()
+                    .filter_map(|entry| match entry {
+                        DunderAllEntry::Name(range, name) | DunderAllEntry::Remove(range, name) => {
+                            Some((*range, name))
+                        }
+                        _ => None,
+                    }),
+            ),
+            DunderAllKind::Inferred | DunderAllKind::Unresolvable(_) => None,
+        }
     }
 
     pub fn is_submodule_imported_implicitly(&self, name: &Name) -> bool {

--- a/pyrefly/lib/lsp/wasm/hover.rs
+++ b/pyrefly/lib/lsp/wasm/hover.rs
@@ -10,6 +10,7 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
+use dupe::Dupe;
 use lsp_types::Hover;
 use lsp_types::HoverContents;
 use lsp_types::MarkupContent;
@@ -947,7 +948,7 @@ pub fn get_hover_with_verbosity(
         return Some(result);
     }
 
-    let type_ = resolve_hovered_type(transaction, handle, ast.as_deref(), position)?;
+    let mut type_ = resolve_hovered_type(transaction, handle, ast.as_deref(), position)?;
 
     // `a and b and c` is a single flat BoolOp, so hovering any operator in the
     // chain highlights the whole expression. `not` highlights its unary expression.
@@ -969,7 +970,6 @@ pub fn get_hover_with_verbosity(
                 })
         });
 
-    let fallback_name_from_type = fallback_hover_name_from_type(&type_);
     let keyword_argument_identifier = keyword_argument_identifier(transaction, handle, position);
     let definition = transaction
         .find_definition(
@@ -991,6 +991,27 @@ pub fn get_hover_with_verbosity(
                     item.module.code_at(item.definition_range) == identifier.id.as_str()
                 })
         });
+    if ast.as_deref().is_some_and(|ast| {
+        Ast::locate_node(ast, position)
+            .iter()
+            .any(|node| matches!(node, AnyNodeRef::ExprStringLiteral(_)))
+    }) && let Some(definition) = &definition
+    {
+        let definition_handle = Handle::new(
+            definition.module.name(),
+            definition.module.path().dupe(),
+            handle.sys_info().dupe(),
+        );
+        if let Some(definition_type) = transaction
+            .get_type_at_for_display(&definition_handle, definition.definition_range.start())
+        {
+            type_ = definition_type;
+        }
+    }
+    if let Some(symbol_type) = transaction.symbol_literal_type(handle, position) {
+        type_ = symbol_type;
+    }
+    let fallback_name_from_type = fallback_hover_name_from_type(&type_);
     let (kind, name, docstring_range, module) = if let Some(FindDefinitionItemWithDocstring {
         metadata,
         definition_range: definition_location,

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -51,14 +51,18 @@ use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprCall;
 use ruff_python_ast::ExprContext;
 use ruff_python_ast::ExprName;
+use ruff_python_ast::ExprStringLiteral;
 use ruff_python_ast::Identifier;
 use ruff_python_ast::Keyword;
 use ruff_python_ast::ModModule;
 use ruff_python_ast::Stmt;
+use ruff_python_ast::StmtAssign;
 use ruff_python_ast::StmtClassDef;
 use ruff_python_ast::StmtImportFrom;
 use ruff_python_ast::UnaryOp;
 use ruff_python_ast::name::Name;
+use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::visitor::walk_stmt;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
@@ -122,6 +126,120 @@ struct OperatorDunder {
     base_type: Type,
     dunder_name: Name,
     range: TextRange,
+}
+
+#[derive(Clone)]
+enum SymbolLiteralContext {
+    DunderAll,
+    DunderSlots { class_name: Identifier },
+}
+
+#[derive(Clone)]
+struct SymbolLiteral {
+    range: TextRange,
+    content_range: Option<TextRange>,
+    name: Name,
+    context: SymbolLiteralContext,
+}
+
+fn string_literal_content_range(expr: &ExprStringLiteral) -> Option<TextRange> {
+    Some(expr.as_single_part_string()?.content_range())
+}
+
+fn slot_literals(value: &Expr) -> Option<Vec<&ExprStringLiteral>> {
+    match value {
+        Expr::StringLiteral(literal) => Some(vec![literal]),
+        Expr::Tuple(tuple) => tuple
+            .elts
+            .iter()
+            .map(|expr| match expr {
+                Expr::StringLiteral(literal) => Some(literal),
+                _ => None,
+            })
+            .collect(),
+        Expr::List(list) => list
+            .elts
+            .iter()
+            .map(|expr| match expr {
+                Expr::StringLiteral(literal) => Some(literal),
+                _ => None,
+            })
+            .collect(),
+        Expr::Dict(dict) => dict
+            .items
+            .iter()
+            .map(|item| match item.key.as_ref() {
+                Some(Expr::StringLiteral(literal)) => Some(literal),
+                _ => None,
+            })
+            .collect(),
+        _ => None,
+    }
+}
+
+fn slots_from_assignment(assign: &StmtAssign, class_name: &Identifier) -> Vec<SymbolLiteral> {
+    if !assign
+        .targets
+        .iter()
+        .any(|target| matches!(target, Expr::Name(name) if name.id == *dunder::SLOTS))
+    {
+        return Vec::new();
+    }
+    slot_literals(&assign.value)
+        .into_iter()
+        .flatten()
+        .map(|literal| SymbolLiteral {
+            range: literal.range(),
+            content_range: string_literal_content_range(literal),
+            name: Name::new(literal.value.to_str()),
+            context: SymbolLiteralContext::DunderSlots {
+                class_name: class_name.clone(),
+            },
+        })
+        .collect()
+}
+
+fn collect_slot_literals(module: &ModModule) -> Vec<SymbolLiteral> {
+    struct Collector {
+        class_name: Option<Identifier>,
+        literals: Vec<SymbolLiteral>,
+    }
+
+    impl<'a> Visitor<'a> for Collector {
+        fn visit_stmt(&mut self, stmt: &'a Stmt) {
+            match stmt {
+                Stmt::ClassDef(class) => {
+                    let enclosing_class = self.class_name.replace(class.name.clone());
+                    for stmt in &class.body {
+                        self.visit_stmt(stmt);
+                    }
+                    self.class_name = enclosing_class;
+                }
+                Stmt::FunctionDef(_) => {
+                    let enclosing_class = self.class_name.take();
+                    walk_stmt(self, stmt);
+                    self.class_name = enclosing_class;
+                }
+                Stmt::Assign(assign) => {
+                    if let Some(class_name) = &self.class_name {
+                        self.literals
+                            .extend(slots_from_assignment(assign, class_name));
+                    }
+                    walk_stmt(self, stmt);
+                }
+                _ => walk_stmt(self, stmt),
+            }
+        }
+    }
+
+    let mut collector = Collector {
+        class_name: None,
+        literals: Vec::new(),
+    };
+    for stmt in &module.body {
+        collector.visit_stmt(stmt);
+    }
+    collector.literals
 }
 
 fn callee_kind_from_call(call: &ExprCall) -> CalleeKind {
@@ -2640,6 +2758,90 @@ impl<'a> Transaction<'a> {
         None
     }
 
+    fn symbol_literals(&self, handle: &Handle) -> Vec<SymbolLiteral> {
+        let Some(ast) = self.get_ast(handle) else {
+            return Vec::new();
+        };
+        let mut literals =
+            self.get_exports_data(handle)
+                .dunder_all_names()
+                .into_iter()
+                .flatten()
+                .map(|(range, name)| {
+                    let content_range = Ast::locate_node(&ast, range.start()).into_iter().find_map(
+                        |node| match node {
+                            AnyNodeRef::ExprStringLiteral(literal) if literal.range() == range => {
+                                string_literal_content_range(literal)
+                            }
+                            _ => None,
+                        },
+                    );
+                    SymbolLiteral {
+                        range,
+                        content_range,
+                        name: name.clone(),
+                        context: SymbolLiteralContext::DunderAll,
+                    }
+                })
+                .collect::<Vec<_>>();
+        literals.extend(collect_slot_literals(&ast));
+        literals
+    }
+
+    fn symbol_literal_at(&self, handle: &Handle, position: TextSize) -> Option<SymbolLiteral> {
+        self.symbol_literals(handle)
+            .into_iter()
+            .find(|literal| literal.range.contains_inclusive(position))
+    }
+
+    /// Return the referenced attribute type for a `__slots__` string entry.
+    pub(crate) fn symbol_literal_type(&self, handle: &Handle, position: TextSize) -> Option<Type> {
+        let literal = self.symbol_literal_at(handle, position)?;
+        let SymbolLiteralContext::DunderSlots { class_name } = literal.context else {
+            return None;
+        };
+        let class_type =
+            self.get_type(handle, &Key::Definition(ShortIdentifier::new(&class_name)))?;
+        self.ad_hoc_solve(handle, "slot_literal_type", |solver| {
+            let Type::ClassDef(class) = class_type else {
+                return None;
+            };
+            let instance_type =
+                Type::ClassType(solver.promote_nontypeddict_silently_to_classtype(&class));
+            solver
+                .completions(instance_type, Some(&literal.name), true)
+                .into_iter()
+                .find_map(|attribute| attribute.ty)
+        })?
+    }
+
+    fn find_definition_for_symbol_literal(
+        &self,
+        handle: &Handle,
+        literal: &SymbolLiteral,
+        preference: FindPreference,
+    ) -> Option<FindDefinitionItemWithDocstring> {
+        match &literal.context {
+            SymbolLiteralContext::DunderAll => {
+                self.find_definition_for_dunder_all_entry(handle, literal.range.start(), preference)
+            }
+            SymbolLiteralContext::DunderSlots { class_name } => {
+                let class_type =
+                    self.get_type(handle, &Key::Definition(ShortIdentifier::new(class_name)))?;
+                self.find_attribute_definition_for_base_type(
+                    handle,
+                    preference,
+                    class_type,
+                    &literal.name,
+                )
+                .ok()?
+                .into_vec()
+                .into_iter()
+                .next()
+            }
+        }
+    }
+
     fn find_definition_for_keyword_argument(
         &self,
         handle: &Handle,
@@ -2745,8 +2947,9 @@ impl<'a> Transaction<'a> {
         if covering_nodes
             .iter()
             .any(|node| matches!(node, AnyNodeRef::ExprStringLiteral(_)))
+            && let Some(literal) = self.symbol_literal_at(handle, position)
             && let Some(definition) =
-                self.find_definition_for_dunder_all_entry(handle, position, preference)
+                self.find_definition_for_symbol_literal(handle, &literal, preference)
         {
             return Ok(vec1![definition]);
         }
@@ -4099,6 +4302,7 @@ impl<'a> Transaction<'a> {
 
     pub fn prepare_rename(&self, handle: &Handle, position: TextSize) -> Option<TextRange> {
         let identifier_context = self.identifier_at(handle, position);
+        let symbol_literal = self.symbol_literal_at(handle, position);
 
         let definitions = self
             .find_definition(
@@ -4121,7 +4325,9 @@ impl<'a> Transaction<'a> {
             }
         }
 
-        Some(identifier_context?.identifier.range)
+        identifier_context
+            .map(|context| context.identifier.range)
+            .or_else(|| symbol_literal?.content_range)
     }
 
     pub fn find_local_references(
@@ -4344,6 +4550,12 @@ impl<'a> Transaction<'a> {
                 &definition_name,
             ));
         }
+        references.extend(self.symbol_literal_references_from_definition(
+            handle,
+            &definition_name,
+            definition_range,
+            module,
+        ));
         references.sort_by_key(|range| range.start());
         references.dedup();
         Some(references)
@@ -4376,6 +4588,35 @@ impl<'a> Transaction<'a> {
             module,
             definition_range,
         )
+    }
+    fn symbol_literal_references_from_definition(
+        &self,
+        handle: &Handle,
+        definition_name: &Name,
+        definition_range: TextRange,
+        definition_module: &Module,
+    ) -> Vec<TextRange> {
+        self.symbol_literals(handle)
+            .into_iter()
+            .filter(|literal| &literal.name == definition_name)
+            .filter_map(|literal| {
+                let definition = self.find_definition_for_symbol_literal(
+                    handle,
+                    &literal,
+                    FindPreference {
+                        import_behavior: ImportBehavior::StopAtRenamedImports,
+                        ..Default::default()
+                    },
+                )?;
+                if definition.module.path() == definition_module.path()
+                    && definition.definition_range == definition_range
+                {
+                    literal.content_range
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     fn local_attribute_references_from_local_definition(

--- a/pyrefly/lib/test/lsp/definition.rs
+++ b/pyrefly/lib/test/lsp/definition.rs
@@ -2072,6 +2072,31 @@ Definition Result:
 }
 
 #[test]
+fn dunder_slots_entry_definition_test() {
+    let code = r#"
+class C:
+    __slots__ = ("foo",)
+#                  ^
+
+    def __init__(self) -> None:
+        self.foo = 1
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert_eq!(
+        r#"
+# main.py
+3 |     __slots__ = ("foo",)
+                       ^
+Definition Result:
+7 |         self.foo = 1
+                 ^^^
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn string_literal_not_in_dunder_all() {
     let pkg = r#"
 class Foo:

--- a/pyrefly/lib/test/lsp/hover.rs
+++ b/pyrefly/lib/test/lsp/hover.rs
@@ -33,6 +33,26 @@ fn get_test_report(state: &State, handle: &Handle, position: TextSize) -> String
     }
 }
 
+#[test]
+fn hover_symbol_literals() {
+    let code = r#"
+foo: int = 1
+__all__ = ["foo"]
+#            ^
+
+class C:
+    __slots__ = ("bar",)
+#                  ^
+
+    def __init__(self) -> None:
+        self.bar: str = ""
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_test_report);
+    assert!(report.contains("(variable) foo: int"), "got: {report}");
+    assert!(report.contains("(attribute) bar: str"), "got: {report}");
+    assert!(!report.contains("Literal"), "got: {report}");
+}
+
 fn get_test_report_at_verbosity(
     state: &State,
     handle: &Handle,

--- a/pyrefly/lib/test/lsp/local_find_refs.rs
+++ b/pyrefly/lib/test/lsp/local_find_refs.rs
@@ -102,6 +102,102 @@ References:
 }
 
 #[test]
+fn dunder_all_entries_are_symbol_references() {
+    let code = r#"
+foo = 1
+# ^
+__all__ = ["foo"]
+#            ^
+__all__.remove("foo")
+#                ^
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], |state, handle, position| {
+        get_test_report(state, handle, position, true)
+    });
+    assert_eq!(
+        r#"
+# main.py
+2 | foo = 1
+      ^
+References:
+2 | foo = 1
+    ^^^
+4 | __all__ = ["foo"]
+                ^^^
+6 | __all__.remove("foo")
+                    ^^^
+
+4 | __all__ = ["foo"]
+                 ^
+References:
+2 | foo = 1
+    ^^^
+4 | __all__ = ["foo"]
+                ^^^
+6 | __all__.remove("foo")
+                    ^^^
+
+6 | __all__.remove("foo")
+                     ^
+References:
+2 | foo = 1
+    ^^^
+4 | __all__ = ["foo"]
+                ^^^
+6 | __all__.remove("foo")
+                    ^^^
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
+fn dunder_slots_entries_are_attribute_references() {
+    let code = r#"
+class C:
+    __slots__ = ("foo",)
+#                  ^
+
+    def __init__(self) -> None:
+        self.foo = 1
+#            ^
+
+    def get(self) -> int:
+        return self.foo
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], |state, handle, position| {
+        get_test_report(state, handle, position, true)
+    });
+    assert_eq!(
+        r#"
+# main.py
+3 |     __slots__ = ("foo",)
+                       ^
+References:
+3 |     __slots__ = ("foo",)
+                      ^^^
+7 |         self.foo = 1
+                 ^^^
+11 |         return self.foo
+                         ^^^
+
+7 |         self.foo = 1
+                 ^
+References:
+3 |     __slots__ = ("foo",)
+                      ^^^
+7 |         self.foo = 1
+                 ^^^
+11 |         return self.foo
+                         ^^^
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn references_to_aliased_submodule_stop_at_import() {
     let main = r#"
 from xxx import yyy as zzz

--- a/pyrefly/lib/test/lsp/rename.rs
+++ b/pyrefly/lib/test/lsp/rename.rs
@@ -31,6 +31,51 @@ fn get_test_report(state: &State, handle: &Handle, position: TextSize) -> String
     )
 }
 
+fn get_prepare_rename_report(state: &State, handle: &Handle, position: TextSize) -> String {
+    let transaction = state.transaction();
+    let range = transaction.prepare_rename(handle, position).unwrap();
+    let module_info = transaction.get_module_info(handle).unwrap();
+    format!(
+        "Rename range:\n{}",
+        code_frame_of_source_at_range(module_info.contents(), range)
+    )
+}
+
+#[test]
+fn prepare_rename_symbol_literals() {
+    let code = r#"
+foo = 1
+__all__ = ["foo"]
+#            ^
+
+class C:
+    __slots__ = ("bar",)
+#                  ^
+
+    def __init__(self) -> None:
+        self.bar = 1
+"#;
+    let report = get_batched_lsp_operations_report(&[("main", code)], get_prepare_rename_report);
+    assert_eq!(
+        r#"
+# main.py
+3 | __all__ = ["foo"]
+                 ^
+Rename range:
+3 | __all__ = ["foo"]
+                ^^^
+
+7 |     __slots__ = ("bar",)
+                       ^
+Rename range:
+7 |     __slots__ = ("bar",)
+                      ^^^
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
 #[test]
 fn test_rename_parameter_updates_keyword_arguments() {
     let code = r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4344

`__all__` and `__slots__` string entries now support go-to-definition, references, rename, and accurate hover types.

Rename edits only string contents, preserving quotes.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test