### PR TITLE
Allow subclass receivers on overloaded constructors

### DIFF
--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -916,12 +916,11 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         };
         let callable = make_callable(def.params.clone(), ret);
         if let Some(cls) = &def.defining_cls {
-            // Constructors are always validated per spec. For other methods,
-            // skip overload variants because self/cls annotations in overloads
-            // are a valid pattern for type narrowing.
-            let is_constructor = stmt.name.id == dunder::INIT || is_dunder_new;
-            let should_validate = is_constructor || !def.metadata.flags.is_overload;
-            if should_validate {
+            // Skip overload variants: self/cls annotations in overloads are a
+            // valid pattern for type narrowing (including constructors). Call-site
+            // overload selection already requires the receiver to match. Keep
+            // validating non-overload definitions and the implementation.
+            if !def.metadata.flags.is_overload {
                 if def.metadata.flags.is_classmethod || is_dunder_new {
                     self.validate_cls_annotation(
                         cls,

--- a/pyrefly/lib/test/constructors.rs
+++ b/pyrefly/lib/test/constructors.rs
@@ -873,10 +873,12 @@ class E(A):
     def __init__(self: A): pass
 
 class C[T]:
+    # Overload stubs may use receiver annotations for selection; validation is
+    # skipped on overload variants (same as ordinary methods).
     @overload
-    def __init__(self: A, x: Literal[True]) -> None: ...  # E: `__init__` method self type `A` is not a superclass of class `C`
+    def __init__(self: A, x: Literal[True]) -> None: ...
     @overload
-    def __init__(self: B, x: Literal[False]) -> None: ...  # E: `__init__` method self type `B` is not a superclass of class `C`
+    def __init__(self: B, x: Literal[False]) -> None: ...
     def __init__(self, x):
         pass
 
@@ -934,13 +936,63 @@ class K:
     def __new__(cls: type[Any]): pass
 
 class C[T]:
+    # Overload stubs may use receiver annotations for selection; validation is
+    # skipped on overload variants (same as ordinary methods).
     @overload
-    def __new__(cls: type[A], x: Literal[True]): ...  # E: `__new__` method cls type `type[A]` is not a superclass of class `C`  # E: Implementation signature `(cls: type[Self@C], x: Unknown) -> Self@C` does not accept all arguments that overload signature `(cls: type[A], x: Literal[True]) -> Self@C`
+    def __new__(cls: type[A], x: Literal[True]): ...  # E: Implementation signature `(cls: type[Self@C], x: Unknown) -> Self@C` does not accept all arguments that overload signature `(cls: type[A], x: Literal[True]) -> Self@C`
     @overload
-    def __new__(cls: type[B], x: Literal[False]): ...  # E: `__new__` method cls type `type[B]` is not a superclass of class `C`  # E: Implementation signature `(cls: type[Self@C], x: Unknown) -> Self@C` does not accept all arguments that overload signature `(cls: type[B], x: Literal[False]) -> Self@C` accepts
+    def __new__(cls: type[B], x: Literal[False]): ...  # E: Implementation signature `(cls: type[Self@C], x: Unknown) -> Self@C` does not accept all arguments that overload signature `(cls: type[B], x: Literal[False]) -> Self@C` accepts
     def __new__(cls, x):
         pass
 
+    "#,
+);
+
+// Regression for https://github.com/facebook/pyrefly/issues/4701:
+// overloaded `__new__` may annotate `cls` with a concrete subclass for overload
+// selection, matching the accepted pattern for ordinary overloaded methods.
+testcase!(
+    test_new_overload_subclass_receiver,
+    r#"
+from typing import assert_type, overload
+
+class Path:
+    @overload
+    def __new__(cls: type[AbsPath], path: str) -> AbsPath: ...
+    @overload
+    def __new__(cls: type[RelPath], path: str) -> RelPath: ...
+    @overload
+    def __new__(cls: type[Path], path: str) -> AbsPath | RelPath: ...
+    def __new__(cls: type[Path], path: str) -> Path:
+        raise NotImplementedError
+
+class AbsPath(Path): ...
+class RelPath(Path): ...
+
+assert_type(Path("file"), AbsPath | RelPath)
+assert_type(AbsPath("file"), AbsPath)
+assert_type(RelPath("file"), RelPath)
+    "#,
+);
+
+// Same pattern for overloaded `__init__` with a concrete subclass `self`.
+testcase!(
+    test_init_overload_subclass_receiver,
+    r#"
+from typing import overload
+
+class InitBase:
+    @overload
+    def __init__(self: InitSubclass, value: int) -> None: ...
+    @overload
+    def __init__(self: InitBase, value: str) -> None: ...
+    def __init__(self, value: int | str):
+        pass
+
+class InitSubclass(InitBase): ...
+
+InitSubclass(1)
+InitBase("x")
     "#,
 );
 


### PR DESCRIPTION
# Summary

Overloaded ordinary methods and classmethods already skip `self`/`cls` superclass validation on overload stubs, so concrete subclass receivers can participate in overload selection. Overloaded `__new__` and `__init__` were still always validated (`should_validate = is_constructor || !is_overload`), which rejected valid patterns such as:

```python
class Path:
    @overload
    def __new__(cls: type[AbsPath], path: str) -> AbsPath: ...
    ...
```

This change treats constructor overload stubs like other overload stubs: skip per-overload receiver superclass checks, while still validating non-overload constructors and implementation signatures.

Fixes #4701

# Test Plan

```text
$ export CARGO_TARGET_DIR=/Users/divyanshbarodiya/Desktop/pyrefly-cargo-target
$ cargo test -p pyrefly --lib subclass_receiver
test test::constructors::test_new_overload_subclass_receiver ... ok
test test::constructors::test_init_overload_subclass_receiver ... ok
test result: ok. 2 passed; 0 failed

$ cargo test -p pyrefly --lib bad_receiver_annotation
test test::constructors::test_init_bad_receiver_annotation ... ok
test test::constructors::test_new_bad_receiver_annotation ... ok
test result: ok. 2 passed; 0 failed

$ cargo test -p pyrefly --lib test::constructors::
test result: ok. 90 passed; 0 failed

$ python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema
Finished successfully
```