### PR TITLE
Fix cls diagnostic wording and quoted type[] hover

### DIFF
--- a/crates/pyrefly_types/src/display.rs
+++ b/crates/pyrefly_types/src/display.rs
@@ -1564,6 +1564,11 @@ impl<'a> TypeDisplayContext<'a> {
                 }
                 output.write_str("type[Any]")
             }
+            // `ClassDef` already renders as `type[C]`; wrapping again would print
+            // `type[type[C]]` (e.g. for a quoted name inside `type['C']`).
+            Type::Type(ty) if matches!(ty.as_ref(), Type::ClassDef(_)) => {
+                self.fmt_helper_generic(ty, false, output)
+            }
             Type::Type(ty) => {
                 if self.always_display_builtins_module_name {
                     output.write_str("builtins.")?;

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -2772,7 +2772,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                                 range,
                                 ErrorKind::InvalidAnnotation,
                                 format!(
-                                    "`{method_name}` method self type `{}` is not a superclass of class `{cls_name}`",
+                                    "`{method_name}`: `{}` is not a superclass of class `{cls_name}`",
                                     self.for_display(self_ty.clone()),
                                 ),
                             )
@@ -2817,13 +2817,14 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                         && !self.type_order().has_superclass(cls, cls_ty.class_object())
                         && !self.type_order().is_protocol(cls_ty.class_object())
                     {
+                        // Compare class to class (not `type[X]` to class `Y`).
                         errors
                             .error_builder(
                                 range,
                                 ErrorKind::InvalidAnnotation,
                                 format!(
-                                    "`{method_name}` method self type `{}` is not a superclass of class `{cls_name}`",
-                                    self.for_display(self_ty.clone()),
+                                    "`{method_name}`: `{}` is not a superclass of class `{cls_name}`",
+                                    self.for_display((**inner).clone()),
                                 ),
                             )
                             .emit();
@@ -2859,13 +2860,14 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                             .has_superclass(cls, inner_cls.class_object())
                         && !self.type_order().is_protocol(inner_cls.class_object())
                     {
+                        // Compare class to class (not `type[X]` to class `Y`).
                         errors
                             .error_builder(
                                 range,
                                 ErrorKind::InvalidAnnotation,
                                 format!(
-                                    "`{method_name}` method cls type `{}` is not a superclass of class `{cls_name}`",
-                                    self.for_display(cls_ty.clone()),
+                                    "`{method_name}`: `{}` is not a superclass of class `{cls_name}`",
+                                    self.for_display((**f).clone()),
                                 ),
                             )
                             .emit();

--- a/pyrefly/lib/state/lsp.rs
+++ b/pyrefly/lib/state/lsp.rs
@@ -956,6 +956,27 @@ impl<'a> Transaction<'a> {
     ) -> Option<Type> {
         let module = self.get_ast(handle)?;
         let covering_nodes = Ast::locate_node(&module, position);
+
+        // Quoted forward references are rewritten during binding to `Name` nodes
+        // whose ranges match the string *content* (without quotes). Prefer that
+        // trace so hovering `Child` in `type['Child']` yields `type[Child]`
+        // (ClassDef), not the enclosing `type[...]` expression (`type[type[Child]]`).
+        // See https://github.com/facebook/pyrefly/issues/4703.
+        if let Some(AnyNodeRef::ExprStringLiteral(literal)) = covering_nodes
+            .iter()
+            .find(|node| matches!(node, AnyNodeRef::ExprStringLiteral(_)))
+        {
+            for part in literal.value.iter() {
+                let content_range = part.content_range();
+                if content_range.contains(position)
+                    && let Some(ty) =
+                        self.get_type_trace_for_surface(handle, content_range, for_display)
+                {
+                    return Some(ty);
+                }
+            }
+        }
+
         for node in covering_nodes {
             if node.as_expr_ref().is_none() {
                 continue;

--- a/pyrefly/lib/test/constructors.rs
+++ b/pyrefly/lib/test/constructors.rs
@@ -389,7 +389,7 @@ testcase!(
     r#"
 from typing import assert_type
 class Meta(type):
-    def __call__(cls: 'type[C[str]]', *args, **kwargs): ...  # E: `__call__` method self type `type[C[str]]` is not a superclass of class `Meta`
+    def __call__(cls: 'type[C[str]]', *args, **kwargs): ...  # E: `__call__`: `C[str]` is not a superclass of class `Meta`
 class C[T](metaclass=Meta):
     def __init__(self, x: T):
         pass
@@ -868,15 +868,15 @@ from typing import Literal, assert_type, overload
 class A: ...
 class B: ...
 class D:
-    def __init__(self: A): pass  # E: `__init__` method self type `A` is not a superclass of class `D`
+    def __init__(self: A): pass  # E: `__init__`: `A` is not a superclass of class `D`
 class E(A):
     def __init__(self: A): pass
 
 class C[T]:
     @overload
-    def __init__(self: A, x: Literal[True]) -> None: ...  # E: `__init__` method self type `A` is not a superclass of class `C`
+    def __init__(self: A, x: Literal[True]) -> None: ...  # E: `__init__`: `A` is not a superclass of class `C`
     @overload
-    def __init__(self: B, x: Literal[False]) -> None: ...  # E: `__init__` method self type `B` is not a superclass of class `C`
+    def __init__(self: B, x: Literal[False]) -> None: ...  # E: `__init__`: `B` is not a superclass of class `C`
     def __init__(self, x):
         pass
 
@@ -917,7 +917,7 @@ from typing import Literal, assert_type, overload, Self, Any
 class A: ...
 class B: ...
 class D:
-    def __new__(cls: type[A]): pass  # E: `__new__` method cls type `type[A]` is not a superclass of class `D`
+    def __new__(cls: type[A]): pass  # E: `__new__`: `A` is not a superclass of class `D`
 class E(A):
     def __new__(cls: type[A]): pass
 class F:
@@ -935,9 +935,9 @@ class K:
 
 class C[T]:
     @overload
-    def __new__(cls: type[A], x: Literal[True]): ...  # E: `__new__` method cls type `type[A]` is not a superclass of class `C`  # E: Implementation signature `(cls: type[Self@C], x: Unknown) -> Self@C` does not accept all arguments that overload signature `(cls: type[A], x: Literal[True]) -> Self@C`
+    def __new__(cls: type[A], x: Literal[True]): ...  # E: `__new__`: `A` is not a superclass of class `C`  # E: Implementation signature `(cls: type[Self@C], x: Unknown) -> Self@C` does not accept all arguments that overload signature `(cls: type[A], x: Literal[True]) -> Self@C`
     @overload
-    def __new__(cls: type[B], x: Literal[False]): ...  # E: `__new__` method cls type `type[B]` is not a superclass of class `C`  # E: Implementation signature `(cls: type[Self@C], x: Unknown) -> Self@C` does not accept all arguments that overload signature `(cls: type[B], x: Literal[False]) -> Self@C` accepts
+    def __new__(cls: type[B], x: Literal[False]): ...  # E: `__new__`: `B` is not a superclass of class `C`  # E: Implementation signature `(cls: type[Self@C], x: Unknown) -> Self@C` does not accept all arguments that overload signature `(cls: type[B], x: Literal[False]) -> Self@C` accepts
     def __new__(cls, x):
         pass
 

--- a/pyrefly/lib/test/lsp/hover_type.rs
+++ b/pyrefly/lib/test/lsp/hover_type.rs
@@ -22,6 +22,35 @@ fn get_test_report(state: &State, handle: &Handle, position: TextSize) -> String
 }
 
 #[test]
+fn quoted_class_in_type_subscript_hover() {
+    // Regression for https://github.com/facebook/pyrefly/issues/4703:
+    // a quoted class inside `type[...]` must not hover as `type[type[Child]]`.
+    let code = r#"
+class Child: ...
+class Holder:
+    value: type['Child']
+#                   ^
+    other: type[Child]
+#                    ^
+"#;
+    let report = get_batched_lsp_operations_report_allow_error(&[("main", code)], get_test_report);
+    assert_eq!(
+        r#"
+# main.py
+4 |     value: type['Child']
+                        ^
+Hover Result: `type[Child]`
+
+6 |     other: type[Child]
+                         ^
+Hover Result: `type[Child]`
+"#
+        .trim(),
+        report.trim(),
+    );
+}
+
+#[test]
 fn basic_test() {
     let code = r#"
 from typing import Literal

--- a/pyrefly/lib/test/typing_self.rs
+++ b/pyrefly/lib/test/typing_self.rs
@@ -770,9 +770,9 @@ testcase!(
     r#"
 class A: ...
 class D:
-    def __init__(self: A): pass  # E: `__init__` method self type `A` is not a superclass of class `D`
-    def f(self: A): pass  # E: `f` method self type `A` is not a superclass of class `D`
-    def g(self: type[A]): pass  # E: `g` method self type `type[A]` is not a superclass of class `D`
+    def __init__(self: A): pass  # E: `__init__`: `A` is not a superclass of class `D`
+    def f(self: A): pass  # E: `f`: `A` is not a superclass of class `D`
+    def g(self: type[A]): pass  # E: `g`: `A` is not a superclass of class `D`
     def h(self: D): pass # Ok
     "#,
 );
@@ -808,10 +808,25 @@ class D:
     @classmethod
     def f(cls: A): pass  # E: `f` method cls type `A` is not a valid `type[...]` annotation
     @classmethod
-    def g(cls: type[A]): pass  # E: `g` method cls type `type[A]` is not a superclass of class `D`
+    def g(cls: type[A]): pass  # E: `g`: `A` is not a superclass of class `D`
     @classmethod
     def h(cls: type[D]): pass # Ok
 "#,
+);
+
+testcase!(
+    test_classmethod_subclass_cls_diagnostic_wording,
+    r#"
+# Regression for https://github.com/facebook/pyrefly/issues/4703:
+# compare class to class in the diagnostic, not `type[Child]` to class `Base`.
+class Base:
+    @classmethod
+    def method(cls: type[Child]) -> None:  # E: `method`: `Child` is not a superclass of class `Base`
+        pass
+
+class Child(Base):
+    pass
+    "#,
 );
 
 testcase!(


### PR DESCRIPTION
# Summary

Fixes two presentation issues from #4703:

1. **`invalid-annotation` for `cls`/`self` receivers** — compare class to class (`Child` is not a superclass of class `Base`) instead of mixing a class-object type with a class name (`type[Child]` … superclass of class `Base`).
2. **Hover on quoted names inside `type['Child']`** — prefer type traces at the string *content* range (where rewritten forward-ref `Name` nodes are recorded) so hover shows `type[Child]` like an unquoted `type[Child]`, not `type[type[Child]]` from the enclosing `type[...]` expression.

Also avoids double-rendering `Type::Type(ClassDef(_))` in the display layer, since `ClassDef` already prints as `type[C]`.

Fixes #4703

# Test Plan

```text
$ export CARGO_TARGET_DIR=/Users/divyanshbarodiya/Desktop/pyrefly-cargo-target
$ cargo test -p pyrefly --lib quoted_class_in_type_subscript_hover
test test::lsp::hover_type::quoted_class_in_type_subscript_hover ... ok

$ cargo test -p pyrefly --lib classmethod_subclass_cls_diagnostic_wording
test test::typing_self::test_classmethod_subclass_cls_diagnostic_wording ... ok
# emits: `method`: `Child` is not a superclass of class `Base`

$ cargo test -p pyrefly --lib bad_receiver_annotation
test result: ok. 2 passed; 0 failed

$ cargo test -p pyrefly --lib 'test::constructors::'
test result: ok. 88 passed; 0 failed

$ cargo test -p pyrefly --lib 'test::typing_self::'
test result: ok. 48 passed; 0 failed

$ cargo test -p pyrefly --lib 'test::lsp::hover_type::'
test result: ok. 23 passed; 0 failed

$ python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema
Finished successfully
```