### PR TITLE
Fix generic protocol getattr self recursion

### DIFF
--- a/pyrefly/lib/alt/answers_solver.rs
+++ b/pyrefly/lib/alt/answers_solver.rs
@@ -1940,6 +1940,10 @@ pub struct ThreadState {
     /// currently in progress, used as a coinductive guard against recursive protocol checks
     /// (e.g. `__getattr__` annotated with a protocol).
     protocol_member_guard_stack: RefCell<FxHashSet<(Type, ClassType, Name)>>,
+    /// Class-level protocol member checks for generic protocol specializations
+    /// containing placeholder vars. Fresh placeholder vars can otherwise make
+    /// each recursive specialization distinct and bypass the exact guard above.
+    protocol_member_class_guard_stack: RefCell<FxHashSet<(Type, Class, Name)>>,
     /// Tracks whether any coinductive assumption was used during solving
     /// (e.g. recursive protocol member resolution via dynamic fallback).
     coinductive_assumptions_used: Cell<bool>,
@@ -1957,6 +1961,7 @@ impl ThreadState {
             trace_sink_stack: RefCell::new(Vec::new()),
             overload_self_filter_stack: RefCell::new(FxHashSet::default()),
             protocol_member_guard_stack: RefCell::new(FxHashSet::default()),
+            protocol_member_class_guard_stack: RefCell::new(FxHashSet::default()),
             coinductive_assumptions_used: Cell::new(false),
         }
     }
@@ -2446,14 +2451,36 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     /// Mark a protocol member check `(got, protocol_class_type, attr_name)` as in progress.
     /// Returns `true` if it was already active, signaling a coinductive cycle.
     pub(crate) fn enter_protocol_member_check(&self, key: (Type, ClassType, Name)) -> bool {
+        // A generic protocol in an explicit `self` annotation may receive a fresh
+        // placeholder var on every recursive subset query:
+        //
+        //     P[@1] -> P[@2] -> P[@3] -> ...
+        //
+        // These ClassTypes never compare equal, so also use a class-level guard
+        // when the protocol specialization contains placeholder vars.
+        if Type::ClassType(key.1.clone()).may_contain_placeholder_var() {
+            let class_key = (key.0.clone(), key.1.class_object().clone(), key.2.clone());
+            if !self
+                .thread_state
+                .protocol_member_class_guard_stack
+                .borrow_mut()
+                .insert(class_key)
+            {
+                self.thread_state.coinductive_assumptions_used.set(true);
+                return true;
+            }
+        }
+
         let is_cycle = !self
             .thread_state
             .protocol_member_guard_stack
             .borrow_mut()
-            .insert(key);
+            .insert(key.clone());
+
         if is_cycle {
             self.thread_state.coinductive_assumptions_used.set(true);
         }
+
         is_cycle
     }
 
@@ -2462,6 +2489,14 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             .protocol_member_guard_stack
             .borrow_mut()
             .remove(key);
+
+        if Type::ClassType(key.1.clone()).may_contain_placeholder_var() {
+            let class_key = (key.0.clone(), key.1.class_object().clone(), key.2.clone());
+            self.thread_state
+                .protocol_member_class_guard_stack
+                .borrow_mut()
+                .remove(&class_key);
+        }
     }
 
     pub(crate) fn coinductive_assumptions_used(&self) -> bool {

--- a/pyrefly/lib/test/attributes.rs
+++ b/pyrefly/lib/test/attributes.rs
@@ -3184,3 +3184,72 @@ f_int(C())
 f_str(C())  # E: Argument `C` is not assignable to parameter `x` with type `P[str]` in function `f_str`
 "#,
 );
+
+testcase!(
+    test_getattr_self_generic_protocol_recursion,
+    r#"
+from typing import Protocol, TypeVar
+
+T = TypeVar("T", covariant=True)
+
+class P(Protocol[T]):
+    @property
+    def x(self) -> T: ...
+
+class C:
+    def __getattr__(self: P[T], name: str) -> T:
+        raise AttributeError
+
+def f(x: P[int]) -> None: ...
+
+f(C())
+"#,
+);
+
+testcase!(
+    test_getattr_self_generic_protocol_recursion_nonconforming,
+    r#"
+from typing import Protocol, TypeVar
+
+T = TypeVar("T", covariant=True)
+
+class P(Protocol[T]):
+    @property
+    def x(self) -> T: ...
+
+class C:
+    def __getattr__(self: P[T], name: str) -> str:
+        raise AttributeError
+
+def f(x: P[int]) -> None: ...
+
+f(C())  # E: Argument `C` is not assignable to parameter `x` with type `P[int]`
+"#,
+);
+
+testcase!(
+    test_getattr_self_generic_protocol_mutual_recursion,
+    r#"
+from typing import Protocol
+
+class P[T](Protocol):
+    @property
+    def x(self) -> "Q[T]": ...
+
+class Q[T](Protocol):
+    @property
+    def y(self) -> P[T]: ...
+
+class C[T]:
+    def __getattr__(self: P[T], name: str) -> "D[T]":
+        raise AttributeError
+
+class D[T]:
+    def __getattr__(self: Q[T], name: str) -> C[T]:
+        raise AttributeError
+
+def f(x: P[int]) -> None: ...
+
+f(C[int]())
+"#,
+);


### PR DESCRIPTION
# Summary

Fixes #4682

The stack overflow happens when `__getattr__` has a generic protocol-annotated `self`, for example:

```python
from typing import Protocol, TypeVar

T = TypeVar("T", covariant=True)

class P(Protocol[T]):
    @property
    def x(self) -> T: ...

class C:
    def __getattr__(self: P[T], name: str) -> T:
        raise AttributeError

def f(x: P[int]) -> None: ...

f(C())
```

The existing protocol-member recursion guard uses `(got_type, protocol_class_type, member_name)`.

In this case, each recursive subset check can instantiate the generic protocol with a fresh placeholder variable, so the checks can look like `P[@1]`, `P[@2]`, `P[@3]`, etc. Since the exact `ClassType` is different each time, the existing guard does not detect the cycle and eventually overflows the stack.

This adds a class-level guard for protocol specializations containing placeholder variables. It uses `(got_type, protocol_class, member_name)` for those cases, while keeping the existing exact guard for concrete specializations such as `P[int]` and `P[str]`.

I also added tests for:

* the original generic `__getattr__` recursion
* a non-conforming case to make sure the guard does not hide a real type error
* mutually recursive generic protocols

The existing specialization-sensitive and coinductive cache soundness tests still pass.

# Test Plan

Focused regression tests:

```sh
cargo test -p pyrefly test_getattr_self_generic_protocol_recursion -- --nocapture
cargo test -p pyrefly test_getattr_self_generic_protocol_recursion_nonconforming -- --nocapture
cargo test -p pyrefly test_getattr_self_generic_protocol_mutual_recursion -- --nocapture
cargo test -p pyrefly test_getattr_self_protocol_generic_cache_order -- --nocapture
cargo test -p pyrefly test_getattr_coinductive_protocol_cache_soundness -- --nocapture
```

Attribute tests:

```sh
cargo test -p pyrefly 'test::attributes::' -- --nocapture
```

206 passed, 0 failed.

Full library test suite:

```sh
cargo test -p pyrefly --lib
```

8230 passed, 0 failed, 4 ignored.

Also ran:

```sh
cargo fmt --check
git diff --check
```

# AI Usage

Used Sol 5.6 to help write additional regression tests I requested. I validated the changes locally.
