### PR TITLE
detect basedpyright config

### DIFF
--- a/crates/pyrefly_config/src/file_kind.rs
+++ b/crates/pyrefly_config/src/file_kind.rs
@@ -19,17 +19,19 @@ use crate::config::ConfigFile;
 pub enum ConfigFileKind {
     MyPy,
     Pyright,
+    BasedPyright,
     Pyrefly,
     Pyproject,
 }
 
 impl ConfigFileKind {
-    pub fn file_name(&self) -> &str {
+    pub fn file_name(&self) -> Option<&str> {
         match self {
-            Self::MyPy => "mypy.ini",
-            Self::Pyright => "pyrightconfig.json",
-            Self::Pyrefly => "pyrefly.toml",
-            Self::Pyproject => "pyproject.toml",
+            Self::MyPy => Some("mypy.ini"),
+            Self::Pyright => Some("pyrightconfig.json"),
+            Self::BasedPyright => None,
+            Self::Pyrefly => Some("pyrefly.toml"),
+            Self::Pyproject => Some("pyproject.toml"),
         }
     }
 
@@ -43,8 +45,10 @@ impl ConfigFileKind {
 
     pub fn check_for_existing_config(&self, path: &Path) -> anyhow::Result<bool> {
         let file_name = self.file_name();
-        if path.ends_with(file_name) && path.exists() {
-            return Ok(true);
+        if let Some(file_name) = file_name {
+            if path.ends_with(file_name) && path.exists() {
+                return Ok(true);
+            }
         }
         if path.ends_with(ConfigFile::PYPROJECT_FILE_NAME) && path.exists() {
             let raw_pyproject = fs_anyhow::read_to_string(path).with_context(|| {
@@ -56,10 +60,15 @@ impl ConfigFileKind {
             return Ok(raw_pyproject.contains(&self.toml_identifier()));
         }
         if path.is_dir() {
-            let custom_file = self.check_for_existing_config(&path.join(file_name));
+            if let Some(file_name) = file_name {
+                let custom_file = self.check_for_existing_config(&path.join(file_name));
+                if custom_file? {
+                    return Ok(true);
+                }
+            }
             let pyproject =
                 self.check_for_existing_config(&path.join(ConfigFile::PYPROJECT_FILE_NAME));
-            return Ok(custom_file? || pyproject?);
+            return Ok(pyproject?);
         }
         Ok(false)
     }

--- a/crates/pyrefly_config/src/migration/config_option_migrater.rs
+++ b/crates/pyrefly_config/src/migration/config_option_migrater.rs
@@ -31,5 +31,6 @@ pub trait ConfigOptionMigrater {
         &self,
         pyright_cfg: &PyrightConfig,
         pyrefly_cfg: &mut ConfigFile,
+        basedpyright: bool,
     ) -> anyhow::Result<()>;
 }

--- a/crates/pyrefly_config/src/migration/error_codes.rs
+++ b/crates/pyrefly_config/src/migration/error_codes.rs
@@ -12,7 +12,7 @@ use crate::config::ConfigFile;
 use crate::migration::config_option_migrater::ConfigOptionMigrater;
 use crate::migration::mypy::util;
 use crate::migration::mypy::util::MypyErrorConfigFlags;
-use crate::migration::pyright::PyrightConfig;
+use crate::migration::pyright::{PyrightConfig, TypeCheckingMode};
 
 /// Configuration option for error codes
 pub struct ErrorCodes;
@@ -67,7 +67,26 @@ impl ConfigOptionMigrater for ErrorCodes {
         &self,
         pyright_cfg: &PyrightConfig,
         pyrefly_cfg: &mut ConfigFile,
+        basedpyright: bool,
     ) -> anyhow::Result<()> {
+        pyrefly_cfg.preset = match pyright_cfg.type_checking_mode {
+            // TODO: "recommended" in basedpyright does enable all rules, but sets the severity to warning
+            // and turns on failOnWarnings. we could do the same here, but for now we just treat both "All"
+            // and "recommended" the same way.
+            Some(TypeCheckingMode::All) | Some(TypeCheckingMode::Recommended) | None => {
+                if basedpyright {
+                    // should also be treated the same as
+                    Some(Preset::All)
+                } else {
+                    None
+                }
+            }
+            Some(TypeCheckingMode::Off) => Some(Preset::Off),
+            // we intentionally don't match other typeCheckingModes such as "strict", because pyright's
+            // isn't necessarily the same as pyrefly's "Strict" preset
+            Some(_) => None,
+        };
+
         // In pyright, error settings are specified in various "report*" fields
         // The PyrightConfig struct already has a method to convert these to an ErrorDisplayConfig
         let error_config = pyright_cfg
@@ -253,7 +272,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let error_codes = ErrorCodes;
-        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         assert!(pyrefly_cfg.root.errors.is_some());
@@ -270,7 +289,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let error_codes = ErrorCodes;
-        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         let errors = pyrefly_cfg.root.errors.as_ref().unwrap();
@@ -288,7 +307,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let error_codes = ErrorCodes;
-        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         let errors = pyrefly_cfg.root.errors.as_ref().unwrap();
@@ -306,7 +325,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let error_codes = ErrorCodes;
-        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         let errors = pyrefly_cfg.root.errors.as_ref().unwrap();
@@ -325,7 +344,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let error_codes = ErrorCodes;
-        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         let errors = pyrefly_cfg.root.errors.as_ref().unwrap();
@@ -343,7 +362,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let error_codes = ErrorCodes;
-        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         let errors = pyrefly_cfg.root.errors.as_ref().unwrap();
@@ -361,7 +380,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let error_codes = ErrorCodes;
-        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         let errors = pyrefly_cfg.root.errors.as_ref().unwrap();
@@ -383,7 +402,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let error_codes = ErrorCodes;
-        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         assert!(pyrefly_cfg.root.errors.is_some());
@@ -408,7 +427,7 @@ mod tests {
         let default_errors = pyrefly_cfg.root.errors.clone();
 
         let error_codes = ErrorCodes;
-        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         // If RuleOverrides.to_config() returns None when all fields are None,
         // this should fail with an error
@@ -556,7 +575,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let error_codes = ErrorCodes;
-        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = error_codes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         assert!(pyrefly_cfg.root.errors.is_some());

--- a/crates/pyrefly_config/src/migration/error_codes.rs
+++ b/crates/pyrefly_config/src/migration/error_codes.rs
@@ -75,7 +75,6 @@ impl ConfigOptionMigrater for ErrorCodes {
             // and "recommended" the same way.
             Some(TypeCheckingMode::All) | Some(TypeCheckingMode::Recommended) | None => {
                 if basedpyright {
-                    // should also be treated the same as
                     Some(Preset::All)
                 } else {
                     None

--- a/crates/pyrefly_config/src/migration/ignore_missing_imports.rs
+++ b/crates/pyrefly_config/src/migration/ignore_missing_imports.rs
@@ -135,6 +135,7 @@ impl ConfigOptionMigrater for IgnoreMissingImports {
         &self,
         _pyright_cfg: &PyrightConfig,
         _pyrefly_cfg: &mut ConfigFile,
+        _basedpyright: bool,
     ) -> anyhow::Result<()> {
         Err(anyhow::anyhow!(
             "Pyright does not have direct equivalents for mypy's import handling options"
@@ -456,7 +457,7 @@ mod tests {
         let default_ignore_imports = pyrefly_cfg.root.ignore_missing_imports.clone();
 
         let ignore_imports = IgnoreMissingImports;
-        let result = ignore_imports.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = ignore_imports.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_err());
         assert_eq!(

--- a/crates/pyrefly_config/src/migration/project_excludes.rs
+++ b/crates/pyrefly_config/src/migration/project_excludes.rs
@@ -44,6 +44,7 @@ impl ConfigOptionMigrater for ProjectExcludes {
         &self,
         pyright_cfg: &PyrightConfig,
         pyrefly_cfg: &mut ConfigFile,
+        _basedpyright: bool,
     ) -> anyhow::Result<()> {
         // In pyright, project excludes are specified in the "exclude" field
         if let Some(excludes) = &pyright_cfg.project_excludes {
@@ -99,7 +100,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let project_excludes = ProjectExcludes;
-        let result = project_excludes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = project_excludes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         assert_eq!(pyrefly_cfg.project_excludes, project_excludes_globs);
@@ -113,7 +114,7 @@ mod tests {
         let default_excludes = pyrefly_cfg.project_excludes.clone();
 
         let project_excludes = ProjectExcludes;
-        let result = project_excludes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = project_excludes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_err());
         assert_eq!(pyrefly_cfg.project_excludes, default_excludes);
@@ -128,7 +129,7 @@ mod tests {
         let default_excludes = pyrefly_cfg.project_excludes.clone();
 
         let project_excludes = ProjectExcludes;
-        let result = project_excludes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = project_excludes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_err());
         assert_eq!(pyrefly_cfg.project_excludes, default_excludes);

--- a/crates/pyrefly_config/src/migration/project_includes.rs
+++ b/crates/pyrefly_config/src/migration/project_includes.rs
@@ -47,6 +47,7 @@ impl ConfigOptionMigrater for ProjectIncludes {
         &self,
         pyright_cfg: &PyrightConfig,
         pyrefly_cfg: &mut ConfigFile,
+        _basedpyright: bool,
     ) -> anyhow::Result<()> {
         // In pyright, project includes are specified in the "include" field
         let includes = match &pyright_cfg.project_includes {
@@ -143,7 +144,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let project_includes = ProjectIncludes;
-        let result = project_includes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = project_includes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         assert_eq!(pyrefly_cfg.project_includes, project_includes_globs);
@@ -157,7 +158,7 @@ mod tests {
         let default_includes = pyrefly_cfg.project_includes.clone();
 
         let project_includes = ProjectIncludes;
-        let result = project_includes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = project_includes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_err());
         assert_eq!(pyrefly_cfg.project_includes, default_includes);
@@ -172,7 +173,7 @@ mod tests {
         let default_includes = pyrefly_cfg.project_includes.clone();
 
         let project_includes = ProjectIncludes;
-        let result = project_includes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = project_includes.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_err());
         assert_eq!(pyrefly_cfg.project_includes, default_includes);

--- a/crates/pyrefly_config/src/migration/pyright.rs
+++ b/crates/pyrefly_config/src/migration/pyright.rs
@@ -47,6 +47,19 @@ impl ExecEnv {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TypeCheckingMode {
+    Off,
+    Basic,
+    Standard,
+    Strict,
+    /// basedpyright only
+    Recommended,
+    /// basedpyright only
+    All,
+}
+
+#[derive(Clone, Debug, Deserialize)]
 pub struct PyrightConfig {
     #[serde(rename = "include")]
     pub project_includes: Option<Globs>,
@@ -60,6 +73,8 @@ pub struct PyrightConfig {
     pub python_platform: Option<String>,
     #[serde(rename = "pythonVersion")]
     pub python_version: Option<PythonVersion>,
+    #[serde(rename = "typeCheckingMode")]
+    pub type_checking_mode: Option<TypeCheckingMode>,
     #[serde(flatten)]
     pub errors: RuleOverrides,
     #[serde(default, rename = "executionEnvironments")]
@@ -83,7 +98,7 @@ impl PyrightConfig {
         Ok(serde_jsonrc::from_str::<Self>(text)?)
     }
 
-    pub fn convert(self) -> ConfigFile {
+    pub fn convert(self, basedpyright: bool) -> ConfigFile {
         let mut cfg = ConfigFile::default();
 
         // Create a list of all config options
@@ -103,7 +118,7 @@ impl PyrightConfig {
         // Iterate through all config options and apply them to the config
         for option in config_options {
             // Ignore errors for now, we can use this in the future if we want to print out error messages or use for logging purpose
-            let _ = option.migrate_from_pyright(&self, &mut cfg);
+            let _ = option.migrate_from_pyright(&self, &mut cfg, basedpyright);
         }
 
         // Pyright does not infer empty container types and unsolved type variables based on their first use.
@@ -573,6 +588,7 @@ pub fn parse_pyproject_toml(raw_file: &str) -> anyhow::Result<ConfigFile> {
     #[derive(Deserialize)]
     struct Tool {
         pyright: Option<PyrightConfig>,
+        basedpyright: Option<PyrightConfig>,
     }
 
     #[derive(Deserialize)]
@@ -580,11 +596,21 @@ pub fn parse_pyproject_toml(raw_file: &str) -> anyhow::Result<ConfigFile> {
         tool: Option<Tool>,
     }
 
-    toml::from_str::<PyProject>(raw_file)?
+    let tool = toml::from_str::<PyProject>(raw_file)?
         .tool
-        .and_then(|tool| tool.pyright)
-        .ok_or(anyhow::anyhow!(PyrightNotFoundError {}))
-        .map(PyrightConfig::convert)
+        .ok_or(anyhow::anyhow!(PyrightNotFoundError {}))?;
+
+    match tool {
+        Tool {
+            pyright: Some(pyright),
+            ..
+        } => Ok(PyrightConfig::convert(pyright, false)),
+        Tool {
+            basedpyright: Some(basedpyright),
+            ..
+        } => Ok(PyrightConfig::convert(basedpyright, true)),
+        _ => Err(anyhow::anyhow!(PyrightNotFoundError {})),
+    }
 }
 
 #[cfg(test)]
@@ -593,7 +619,7 @@ mod tests {
     use pyrefly_python::sys_info::PythonPlatform;
 
     use super::*;
-    use crate::environment::environment::PythonEnvironment;
+    use crate::{base::Preset, environment::environment::PythonEnvironment};
 
     #[test]
     fn test_convert_pyright_config() -> anyhow::Result<()> {
@@ -614,7 +640,7 @@ mod tests {
             }
             "#;
         let pyr = serde_json::from_str::<PyrightConfig>(raw_file)?;
-        let config = pyr.convert();
+        let config = pyr.convert(false);
         assert_eq!(
             config,
             ConfigFile {
@@ -660,7 +686,7 @@ mod tests {
             }
             "#;
         let pyr = serde_json::from_str::<PyrightConfig>(raw_file)?;
-        let config = pyr.convert();
+        let config = pyr.convert(false);
         assert_eq!(
             config,
             ConfigFile {
@@ -719,7 +745,32 @@ executionEnvironments = [
   { root = "src" }
 ]
 "#;
-        parse_pyproject_toml(src).map(|_| ())
+        parse_pyproject_toml(src).map(|result| {
+            assert!(result.preset == None);
+            ()
+        })
+    }
+
+    #[test]
+    fn test_convert_from_pyproject_basedpyright() -> anyhow::Result<()> {
+        let src = r#"[tool.basedpyright]
+"#;
+        parse_pyproject_toml(src).map(|result| {
+            assert!(result.preset == Some(Preset::All));
+            ()
+        })
+    }
+
+    #[test]
+    fn test_convert_from_pyproject_explicit_type_checking_mode_basedpyright() -> anyhow::Result<()>
+    {
+        let src = r#"[tool.basedpyright]
+typeCheckingMode = "basic"
+"#;
+        parse_pyproject_toml(src).map(|result| {
+            assert!(result.preset == None);
+            ()
+        })
     }
 
     #[test]
@@ -735,7 +786,7 @@ executionEnvironments = [
             }
             "#;
         let pyr = serde_jsonrc::from_str::<PyrightConfig>(raw_file)?;
-        let config = pyr.convert();
+        let config = pyr.convert(false);
         assert!(!config.project_includes.is_empty());
         Ok(())
     }

--- a/crates/pyrefly_config/src/migration/python_interpreter.rs
+++ b/crates/pyrefly_config/src/migration/python_interpreter.rs
@@ -42,6 +42,7 @@ impl ConfigOptionMigrater for PythonInterpreter {
         &self,
         _pyright_cfg: &PyrightConfig,
         _pyrefly_cfg: &mut ConfigFile,
+        _basedpyright: bool,
     ) -> anyhow::Result<()> {
         Err(anyhow::anyhow!(
             "Pyright does not have a direct equivalent for python_interpreter_path"
@@ -119,7 +120,8 @@ mod tests {
         let default_interpreter = pyrefly_cfg.interpreters.python_interpreter_path.clone();
 
         let python_interpreter_path = PythonInterpreter;
-        let result = python_interpreter_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result =
+            python_interpreter_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_err());
         assert_eq!(

--- a/crates/pyrefly_config/src/migration/python_platform.rs
+++ b/crates/pyrefly_config/src/migration/python_platform.rs
@@ -33,14 +33,19 @@ impl ConfigOptionMigrater for PythonPlatformConfig {
         &self,
         pyright_cfg: &PyrightConfig,
         pyrefly_cfg: &mut ConfigFile,
+        basedpyright: bool,
     ) -> anyhow::Result<()> {
         // In pyright, python platform is specified in the "pythonPlatform" field
         let platform = match &pyright_cfg.python_platform {
             Some(p) => p,
             None => {
-                return Err(anyhow::anyhow!(
-                    "No python_platform found in pyright config"
-                ));
+                if basedpyright {
+                    "all"
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "No python_platform found in pyright config"
+                    ));
+                }
             }
         };
 
@@ -106,7 +111,7 @@ mod tests {
 
             let python_platform_config = PythonPlatformConfig;
             let result =
-                python_platform_config.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+                python_platform_config.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
             assert!(result.is_ok());
             assert_eq!(
@@ -125,7 +130,8 @@ mod tests {
         let default_platform = pyrefly_cfg.python_environment.python_platform.clone();
 
         let python_platform_config = PythonPlatformConfig;
-        let result = python_platform_config.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result =
+            python_platform_config.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_err());
         assert_eq!(

--- a/crates/pyrefly_config/src/migration/python_version.rs
+++ b/crates/pyrefly_config/src/migration/python_version.rs
@@ -37,6 +37,7 @@ impl ConfigOptionMigrater for PythonVersionConfig {
         &self,
         pyright_cfg: &PyrightConfig,
         pyrefly_cfg: &mut ConfigFile,
+        _basedpyright: bool,
     ) -> anyhow::Result<()> {
         // In pyright, python version is specified in the "pythonVersion" field
         let version = match &pyright_cfg.python_version {
@@ -93,7 +94,8 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let python_version_config = PythonVersionConfig;
-        let result = python_version_config.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result =
+            python_version_config.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         assert_eq!(
@@ -110,7 +112,8 @@ mod tests {
         let default_version = pyrefly_cfg.python_environment.python_version;
 
         let python_version_config = PythonVersionConfig;
-        let result = python_version_config.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result =
+            python_version_config.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_err());
         assert_eq!(

--- a/crates/pyrefly_config/src/migration/run.rs
+++ b/crates/pyrefly_config/src/migration/run.rs
@@ -39,6 +39,7 @@ use crate::pyproject::PyProject;
 pub enum MigratedFromKind {
     Mypy(MigratedConfigSource),
     Pyright(MigratedConfigSource),
+    BasedPyright(MigratedConfigSource),
 }
 
 /// Where the migrated mypy / pyright settings physically lived: a
@@ -105,7 +106,9 @@ pub fn find_and_migrate_in_memory(
         let pyr = PyrightConfig::parse(&raw_file)
             .with_context(|| format!("While parsing pyright config at {}", path.display()))?;
         Ok(Some((
-            pyr.convert(),
+            // unlike with pyproject.toml we have no easy way to tell whether a pyrightconfig.json
+            // is supposed to be for pyright or basedpyright, so we just assume regular pyright
+            pyr.convert(false),
             MigratedFromKind::Pyright(MigratedConfigSource::DedicatedFile),
         )))
     } else if path.file_name() == Some("mypy.ini".as_ref()) {
@@ -124,19 +127,29 @@ pub fn find_and_migrate_in_memory(
         // `Args::load_from_pyproject`.
         let has_mypy = has_toml_section(&raw_file, "tool.mypy");
         let has_pyright = has_toml_section(&raw_file, "tool.pyright");
+        let has_basedpyright = has_toml_section(&raw_file, "tool.basedpyright");
         let ctx = || format!("While parsing pyproject.toml at {}", path.display());
-        match (has_mypy, has_pyright) {
-            (true, _) => Ok(Some((
+        match (has_mypy, has_pyright, has_basedpyright) {
+            (true, _, _) => Ok(Some((
                 mypy::parse_pyproject_config(&raw_file).with_context(ctx)?,
                 MigratedFromKind::Mypy(MigratedConfigSource::PyprojectToml),
             ))),
-            (false, true) => Ok(Some((
+            (false, true, false) => Ok(Some((
                 pyright::parse_pyproject_toml(&raw_file).with_context(ctx)?,
                 MigratedFromKind::Pyright(MigratedConfigSource::PyprojectToml),
             ))),
+            (false, false, true) => Ok(Some((
+                pyright::parse_pyproject_toml(&raw_file).with_context(ctx)?,
+                MigratedFromKind::BasedPyright(MigratedConfigSource::PyprojectToml),
+            ))),
             // No tool sections at all — not a migrate-able config and not a
             // parse error. Treat as "nothing nearby."
-            (false, false) => Ok(None),
+            (false, false, false) => Ok(None),
+            // Both basedpyright and pyright config detected. This is invalid and
+            // is an error in basedpyright so we don't support it.
+            (false, true, true) => Err(anyhow::anyhow!(
+                "Both `[tool.pyright]` and `[tool.basedpyright]` sections are not supported."
+            )),
         }
     } else {
         // `find_upward_config(_, Auto)` only returns one of the three
@@ -310,7 +323,8 @@ impl Args {
             );
             let raw_file = fs_anyhow::read_to_string(&original_config_path)?;
             let pyr = PyrightConfig::parse(&raw_file)?;
-            pyr.convert()
+            // assume pyrightconfig.json is for pyright, not basedpyright
+            pyr.convert(false)
         } else if original_config_path.file_name() == Some("mypy.ini".as_ref()) {
             info!(
                 "Migrating mypy config file from: `{}`",

--- a/crates/pyrefly_config/src/migration/search_path.rs
+++ b/crates/pyrefly_config/src/migration/search_path.rs
@@ -49,6 +49,7 @@ impl ConfigOptionMigrater for SearchPath {
         &self,
         pyright_cfg: &PyrightConfig,
         pyrefly_cfg: &mut ConfigFile,
+        _basedpyright: bool,
     ) -> anyhow::Result<()> {
         // In pyright, search path is specified in the "extraPaths" field
         let search_path = match &pyright_cfg.search_path {
@@ -224,7 +225,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let search_path = SearchPath;
-        let result = search_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = search_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         assert_eq!(
@@ -244,7 +245,7 @@ mod tests {
         let default_search_path = pyrefly_cfg.search_path_from_file.clone();
 
         let search_path = SearchPath;
-        let result = search_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = search_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_err());
         assert_eq!(pyrefly_cfg.search_path_from_file, default_search_path);
@@ -259,7 +260,7 @@ mod tests {
         let default_search_path = pyrefly_cfg.search_path_from_file.clone();
 
         let search_path = SearchPath;
-        let result = search_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = search_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_err());
         assert_eq!(pyrefly_cfg.search_path_from_file, default_search_path);
@@ -277,7 +278,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let search_path = SearchPath;
-        let result = search_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = search_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         assert_eq!(
@@ -297,7 +298,7 @@ mod tests {
         let default_search_path = pyrefly_cfg.search_path_from_file.clone();
 
         let search_path = SearchPath;
-        let result = search_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = search_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_err());
         assert_eq!(pyrefly_cfg.search_path_from_file, default_search_path);
@@ -312,7 +313,7 @@ mod tests {
         let default_search_path = pyrefly_cfg.search_path_from_file.clone();
 
         let search_path = SearchPath;
-        let result = search_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = search_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_err());
         assert_eq!(pyrefly_cfg.search_path_from_file, default_search_path);

--- a/crates/pyrefly_config/src/migration/site_package_path.rs
+++ b/crates/pyrefly_config/src/migration/site_package_path.rs
@@ -27,6 +27,7 @@ impl ConfigOptionMigrater for SitePackagePath {
         &self,
         pyright_cfg: &PyrightConfig,
         pyrefly_cfg: &mut ConfigFile,
+        _basedpyright: bool,
     ) -> anyhow::Result<()> {
         // In pyright, stub path is specified in the "stubPath" field
         let stub_path = match &pyright_cfg.stub_path {
@@ -56,7 +57,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let site_package_path = SitePackagePath;
-        let result = site_package_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = site_package_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         assert_eq!(
@@ -73,7 +74,7 @@ mod tests {
         let default_site_package_path = pyrefly_cfg.python_environment.site_package_path.clone();
 
         let site_package_path = SitePackagePath;
-        let result = site_package_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = site_package_path.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_err());
         assert_eq!(

--- a/crates/pyrefly_config/src/migration/sub_configs.rs
+++ b/crates/pyrefly_config/src/migration/sub_configs.rs
@@ -94,6 +94,7 @@ impl ConfigOptionMigrater for SubConfigs {
         &self,
         pyright_cfg: &PyrightConfig,
         pyrefly_cfg: &mut ConfigFile,
+        _basedpyright: bool,
     ) -> anyhow::Result<()> {
         // In pyright, sub configs are specified in the "executionEnvironments" field
         // Each execution environment has a root path and error settings
@@ -316,7 +317,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let sub_configs = SubConfigs;
-        let result = sub_configs.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = sub_configs.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_ok());
         assert_eq!(pyrefly_cfg.sub_configs.len(), 2);
@@ -357,7 +358,7 @@ mod tests {
         let default_sub_configs = pyrefly_cfg.sub_configs.clone();
 
         let sub_configs = SubConfigs;
-        let result = sub_configs.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = sub_configs.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         assert!(result.is_err());
         assert_eq!(pyrefly_cfg.sub_configs, default_sub_configs);

--- a/crates/pyrefly_config/src/migration/test_util.rs
+++ b/crates/pyrefly_config/src/migration/test_util.rs
@@ -17,6 +17,7 @@ pub fn default_pyright_config() -> PyrightConfig {
         stub_path: None,
         python_platform: None,
         python_version: None,
+        type_checking_mode: None,
         errors: RuleOverrides::default(),
         execution_environments: vec![],
     }

--- a/crates/pyrefly_config/src/migration/untyped_def_behavior.rs
+++ b/crates/pyrefly_config/src/migration/untyped_def_behavior.rs
@@ -51,6 +51,7 @@ impl ConfigOptionMigrater for UntypedDefBehaviorConfig {
         &self,
         _pyright_cfg: &PyrightConfig,
         _pyrefly_cfg: &mut ConfigFile,
+        _basedpyright: bool,
     ) -> anyhow::Result<()> {
         // Pyright doesn't have a direct equivalent to check_untyped_defs
         // We'll return an error to indicate this
@@ -139,7 +140,7 @@ mod tests {
         let mut pyrefly_cfg = ConfigFile::default();
 
         let config = UntypedDefBehaviorConfig;
-        let result = config.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg);
+        let result = config.migrate_from_pyright(&pyright_cfg, &mut pyrefly_cfg, false);
 
         // Pyright doesn't have a direct equivalent to check_untyped_defs, so we expect an error
         assert!(result.is_err());

--- a/pyrefly/lib/commands/check.rs
+++ b/pyrefly/lib/commands/check.rs
@@ -1327,6 +1327,12 @@ fn write_unconfigured_upsell<W: Write>(
                 MigratedFromKind::Pyright(MigratedConfigSource::PyprojectToml) => {
                     ("`[tool.pyright]` in your `pyproject.toml`", "default")
                 }
+                MigratedFromKind::BasedPyright(MigratedConfigSource::DedicatedFile) => {
+                    unreachable!("no such thing as basedpyrightconfig.json")
+                }
+                MigratedFromKind::BasedPyright(MigratedConfigSource::PyprojectToml) => {
+                    ("`[tool.basedpyright]` in your `pyproject.toml`", "default")
+                }
             };
             writeln!(
                 out,

--- a/pyrefly/lib/commands/init.rs
+++ b/pyrefly/lib/commands/init.rs
@@ -268,9 +268,10 @@ impl InitArgs {
         // 1. Check for mypy or pyright configuration
         let found_mypy = ConfigFileKind::MyPy.check_for_existing_config(&path)?;
         let found_pyright = ConfigFileKind::Pyright.check_for_existing_config(&path)?;
+        let found_basedpyright = ConfigFileKind::BasedPyright.check_for_existing_config(&path)?;
 
         // 2. Migrate existing configuration to Pyrefly configuration
-        if found_mypy || found_pyright {
+        if found_mypy || found_pyright || found_basedpyright {
             info!("Found an existing type checking configuration - setting up pyrefly ...");
             return Ok((
                 CommandExitStatus::Success,

--- a/pyrefly/lib/lsp/non_wasm/type_error_display_status.rs
+++ b/pyrefly/lib/lsp/non_wasm/type_error_display_status.rs
@@ -224,6 +224,12 @@ pub fn derive_v2_response(
                         "Default",
                         "default",
                     ),
+                    MigratedFromKind::BasedPyright(MigratedConfigSource::DedicatedFile) => unreachable!("no such thing as basedpyrightconfig.json"),
+                    MigratedFromKind::BasedPyright(MigratedConfigSource::PyprojectToml) => (
+                        "`[tool.basedpyright]` in your `pyproject.toml`",
+                        "Default",
+                        "default",
+                    ),
                 };
                 (
                     Some(preset_label.to_owned()),

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -35,7 +35,7 @@ configure its aspect instead.
 
 On the command line, when no `pyrefly.toml` or `[tool.pyrefly]` section governs the file being checked, Pyrefly automatically selects a synthesized configuration:
 
-- If a `mypy.ini`, `pyrightconfig.json`, or `[tool.mypy]` / `[tool.pyright]` section in `pyproject.toml` is found nearby, Pyrefly migrates it in memory and uses the resulting settings (the same migration `pyrefly init` would commit to disk).
+- If a `mypy.ini`, `pyrightconfig.json`, or `[tool.mypy]` / `[tool.pyright]` / `[tool.basedpyright]` section in `pyproject.toml` is found nearby, Pyrefly migrates it in memory and uses the resulting settings (the same migration `pyrefly init` would commit to disk).
 - If no migratable configuration is found, or migration fails, Pyrefly uses the [**basic preset**](#preset-basic). This enables only high-confidence error kinds (syntax errors, missing imports, division by zero, etc.); other diagnostics are silenced.
 
 This automatic selection behavior is not a preset, so `auto` is not a valid value for [`preset`](#preset) or `--preset`. For the IDE equivalent, including how to override automatic selection, see [`python.pyrefly.typeCheckingMode`](../IDE#pythonpyreflytypecheckingmode).
@@ -123,7 +123,7 @@ we find the config for each file matched by the pattern provided.
 If a `pyrefly.toml` is found, it is parsed and used for type checking, and will
 return an error to the user on invalid types, syntax, values, or unknown config options.
 
-If a `pyproject.toml` with `[tool.pyrefly]` is found, Pyrefly parses and uses that section. The same errors are returned as when loading an invalid `pyrefly.toml`. Without `[tool.pyrefly]`, Pyrefly migrates `[tool.mypy]` or `[tool.pyright]` in memory if present; otherwise it uses the [`basic` preset](#preset-basic).
+If a `pyproject.toml` with `[tool.pyrefly]` is found, Pyrefly parses and uses that section. The same errors are returned as when loading an invalid `pyrefly.toml`. Without `[tool.pyrefly]`, Pyrefly migrates `[tool.mypy]`, `[tool.pyright]` or `[tool.basedpyright]` in memory if present; otherwise it uses the [`basic` preset](#preset-basic).
 
 ### Providing a Config in Single-File Mode
 

--- a/website/docs/migrate/pyright/index.mdx
+++ b/website/docs/migrate/pyright/index.mdx
@@ -55,6 +55,12 @@ Your `pyrightconfig.json` is left in place. Pyrefly only reads its own config
 once one exists, so both checkers keep working and you can back out at any
 point.
 
+:::info If using basedpyright
+If pyrefly detects `[tool.basedpyright]` instead of `[tool.pyright]` in your `pyproject.toml`:
+- `python-platform` defaults to `"all"`
+- `preset` defaults to `"all"`
+:::
+
 ## 2. Check the config was mapped correctly
 
 Read the generated config line by line before committing it. Some configs may


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4382

# Test Plan

- added a new test

- manually tested by running `pyrefly init` on a project with an empty `[tool.basedpyright]` section in  `pyproject.toml`, and confirmed the following `[tool.pyrefly]` section was added:
  ```toml
  [tool.pyrefly]
  python-platform = "all"
  preset = "all"
  infer-with-first-use = false
  ```