### PR TITLE
Add JetBrains IDE config directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/criterion/
 criterion/
 *.bench
 criterion-*/
+
+.idea/


### PR DESCRIPTION
This gitignores the `.idea` directory, used by JetBrains IDEs for repo-local configuration, so IntelliJ IDEA users don't get tripped up by accidentally committing it.