### PR TITLE
docs: document WebAssembly sandbox build and API

### DIFF
--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -269,3 +269,12 @@ That repository contains:
 - Example configuration snippets for your project and CI
 
 To get started, follow the setup steps in the repo’s [README](https://github.com/facebook/pyrefly-pre-commit#readme).
+
+----
+
+## Browser / WebAssembly
+
+The [sandbox](https://pyrefly.org/sandbox/) runs Pyrefly in the browser via
+WebAssembly. That path is for trying Pyrefly online and for website
+development, not a replacement for the CLI or IDE extension. See
+[WebAssembly](./wasm.mdx).

--- a/website/docs/pyrefly-faq.mdx
+++ b/website/docs/pyrefly-faq.mdx
@@ -78,6 +78,13 @@ Great question. We have made a substantial investment in Pyrefly, use it interna
 
 See our [README.md](https://github.com/facebook/pyrefly/blob/main/README.md) for the high level design. We plan to add more detailed documentation along with announcements on [https://engineering.fb.com](https://engineering.fb.com/)
 
+## Can I run Pyrefly in the browser / WebAssembly?
+
+Yes, in the [sandbox](https://pyrefly.org/sandbox/). Pyrefly compiles to
+WebAssembly for that playground. The WASM crate is **not** a stable embeddable
+API yet. See [WebAssembly](./wasm.mdx) for how to build it and what `State`
+currently exposes.
+
 ## I don't like Python's Type System. Stop wasting your time.
 
 Tell us more - seriously! We want to hear your objections to typing. We hope that better tooling, improvements to the type system and well typed libraries will help provide make development easier. If all else fails our fast code navigation and inference algorithm might spark joy in your IDE, so give us a chance.

--- a/website/docs/wasm.mdx
+++ b/website/docs/wasm.mdx
@@ -1,0 +1,141 @@
+---
+title: WebAssembly
+slug: /wasm
+description: How Pyrefly's WebAssembly build is used, built, and what the current API covers
+---
+
+{/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */}
+
+# WebAssembly
+
+Pyrefly can compile to WebAssembly so a browser can run the type checker and a
+subset of language-server features without a native `pyrefly` binary. That is
+how the [Pyrefly sandbox](https://pyrefly.org/sandbox/) works.
+
+:::warning Not a stable embeddable API
+
+The WASM crate exists to power the sandbox. Maintainers have not settled a
+complete, backwards-compatible API for embedding Pyrefly in other web apps.
+Method names and payloads can change. Use the sandbox if you want to try
+Pyrefly in a browser; treat `pyrefly_wasm` as an internal interface if you
+build from source.
+
+:::
+
+## Try it in the browser
+
+Open the [sandbox](https://pyrefly.org/sandbox/). You can type-check Python,
+see errors, hover, go to definition, completions, inlay hints, and semantic
+tokens. No local install is required.
+
+The sandbox loads the WASM module, then talks to a `State` object (see
+[Current API](#current-api)).
+
+## Who this is for
+
+| You want… | Use |
+| --- | --- |
+| Type-check a project on your machine | [Install](./installation.mdx) the CLI (`pip`, `uv`, …) |
+| IDE features | [IDE installation](./IDE.mdx) |
+| Play with Pyrefly in a browser | [Sandbox](https://pyrefly.org/sandbox/) |
+| Change sandbox behavior or rebuild WASM | This page + `pyrefly_wasm/` and `website/` |
+
+There is no published npm package and no supported “drop this `.wasm` into
+any site” workflow yet.
+
+## Build from source
+
+The crate lives in
+[`pyrefly_wasm/`](https://github.com/facebook/pyrefly/tree/main/pyrefly_wasm).
+The website wires it into the sandbox under `website/src/sandbox/`.
+
+### Prerequisites
+
+- Linux or macOS (website WASM workflows are not supported on native Windows;
+  use WSL).
+- [Rust](https://rustup.rs/) with `wasm32-unknown-unknown`.
+- [`wasm-pack`](https://rustwasm.github.io/wasm-pack/installer/) and
+  [`wasm-opt`](https://github.com/WebAssembly/binaryen) (`wasm-opt` must be on
+  `PATH`; `wasm-pack`’s bundled optimizer is disabled because it is outdated).
+- Clang / LLVM. On macOS: `brew install llvm`. On Fedora/CentOS:
+  `sudo dnf install clang`. If zstd fails to compile on a Mac, put Homebrew
+  LLVM first on `PATH` (`llvm-config --version` should resolve).
+- Node.js and Yarn, if you will run the website.
+
+### Build the crate
+
+From the repository root:
+
+```bash
+cd pyrefly_wasm
+./build.sh
+```
+
+That runs `wasm-pack` for the `web` target and then `wasm-opt -Os`. Pass
+`--BUILD_FOR_TEST` to target `nodejs` (used by website Jest tests).
+
+Output lands in `pyrefly_wasm/target/` (`pyrefly_wasm.js` and
+`pyrefly_wasm_bg.wasm`). Copy those into the sandbox (or test) paths the
+website README describes when you need a local rebuild.
+
+### Run the website with a local WASM build
+
+See [`website/README.md`](https://github.com/facebook/pyrefly/blob/main/website/README.md).
+In short:
+
+```bash
+cd website
+yarn install-with-wasm-deps   # first time: build WASM + yarn install
+yarn start-with-wasm          # rebuild WASM and start Docusaurus
+```
+
+`yarn start` / `yarn install` only work on the static docs and do not rebuild
+WASM.
+
+## Current API
+
+`pyrefly_wasm` exports a `State` class (`new State(version)`) wrapping the
+in-tree playground. JavaScript names:
+
+| Method | Role |
+| --- | --- |
+| `updateSandboxFiles(files, forceUpdate)` | Replace the virtual project (`Record<string, string>` of path → source). Returns an optional error string. |
+| `updateSingleFile(filename, content)` | Update one file. |
+| `setActiveFile(filename)` | Choose which file later queries apply to. |
+| `getErrors()` | Type errors for the project. |
+| `hover(line, column)` | Hover payload at a 0-based position, or `null`. |
+| `gotoDefinition(line, column)` | Definition ranges, or `null`. |
+| `autoComplete(line, column)` | Completions. |
+| `inlayHint(callArgumentNames)` | Inlay hints. |
+| `semanticTokens(range)` | Semantic tokens for an optional range. |
+| `semanticTokensLegend()` | Token types/modifiers legend. |
+
+Positions match the playground (`line` / `column` as `i32`). Payloads are
+serde-serialized into JS; there is no TypeScript `.d.ts` from `wasm-pack`
+(`--no-typescript`). The sandbox keeps a local
+[`PyreflyState`](https://github.com/facebook/pyrefly/blob/main/website/src/sandbox/Sandbox.tsx)
+interface.
+
+Some native features are compiled out with
+`#[cfg(not(target_arch = "wasm32"))]`. If a WASM build fails with `could not
+find … in the crate root`, that crate is likely excluded from the WASM
+target. See [`pyrefly_wasm/README.md`](https://github.com/facebook/pyrefly/blob/main/pyrefly_wasm/README.md).
+
+## Configuration
+
+Sandbox files are an in-memory project, not your disk workspace. There is no
+separate “WASM config” documented beyond what the playground/`State` accepts
+when creating the instance (`version` is the Python version string passed to
+`State`). For CLI and IDE configuration, use the
+[configuration reference](./configuration.mdx).
+
+## Related source
+
+- [`pyrefly_wasm/README.md`](https://github.com/facebook/pyrefly/blob/main/pyrefly_wasm/README.md) — crate build notes
+- [`website/README.md`](https://github.com/facebook/pyrefly/blob/main/website/README.md) — sandbox and docs site
+- [Sandbox](/sandbox)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -39,7 +39,7 @@ let docsSidebar = [
         description:
             'Never used a type system before or just new to Pyrefly? Start here!',
         collapsed: false,
-        items: ['installation', 'configuration'],
+        items: ['installation', 'configuration', 'wasm'],
     },
     {
         type: 'doc' as const,


### PR DESCRIPTION
# Summary

Fixes #3582

Adds a Getting Started page for Pyrefly's WebAssembly build: what it is for (the [sandbox](https://pyrefly.org/sandbox/)), how to build `pyrefly_wasm`, how the website scripts wire it, and the current `State` methods.

The page states the maintainer constraint from the issue thread: this is not a stable embeddable API yet. Installation and the FAQ link to it.

AI usage: an assistant drafted the page from `pyrefly_wasm/lib.rs`, `build.sh`, and the website README; I checked the API table against the crate and the sandbox `PyreflyState` type.

# Test Plan

- Reviewed the new `website/docs/wasm.mdx` against `pyrefly_wasm/lib.rs` and `website/src/sandbox/Sandbox.tsx`.
- Sidebar id `wasm` matches the filename; links use existing doc paths.