### PR TITLE
Ignore __new__ parameters during variance inference

### DIFF
--- a/pyrefly/lib/alt/class/variance_inference.rs
+++ b/pyrefly/lib/alt/class/variance_inference.rs
@@ -422,7 +422,7 @@ fn on_class<'s>(
     // todo zeina: check if we need to check for things like __init_subclass__
     // in pyre 1, we didn't need to.
     for (name, field) in fields.iter() {
-        if name == &dunder::INIT {
+        if name == &dunder::INIT || name == &dunder::NEW {
             continue;
         }
 

--- a/pyrefly/lib/test/variance_inference.rs
+++ b/pyrefly/lib/test/variance_inference.rs
@@ -171,6 +171,20 @@ vinv5_1: ShouldBeInvariant5[float] = ShouldBeInvariant5[int](1)  # E:
 );
 
 testcase!(
+    test_dunder_new_does_not_constrain_variance,
+    r#"
+from typing import Self
+
+class ShouldBeCovariant[T]:
+    def __new__(cls, value: T) -> Self: ...
+    def get(self) -> T: ...
+
+upcast: ShouldBeCovariant[float] = ShouldBeCovariant[int](1)
+downcast: ShouldBeCovariant[int] = ShouldBeCovariant[float](1.0)  # E:
+"#,
+);
+
+testcase!(
     test_attrs_set_and_get,
     r#"
 class ShouldBeCovariant1[T]:


### PR DESCRIPTION
# Summary

Skip `__new__` while collecting class members for inferred variance, just as variance inference already skips `__init__`. Constructor parameters therefore no longer make an otherwise covariant type parameter invariant.

Adds a regression covering a generic class that accepts `T` in `__new__` and returns `T` from another method.

Fixes #4693

# Test Plan

- `cargo fmt --check`
- `cargo test -p pyrefly test_dunder_new_does_not_constrain_variance`
