### PR TITLE
fix Final exhaustive enum identity comparison is incorrectly reported as always false #4748

### DIFF
--- a/pyrefly/lib/alt/operators.rs
+++ b/pyrefly/lib/alt/operators.rs
@@ -1069,7 +1069,8 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         match (left, right) {
             // If both are literals/None, check for predictable results
             (Type::Literal(l1), Type::Literal(l2)) => {
-                if l1 != l2 {
+                // Explicit/implicit literal style is typing metadata, not runtime identity.
+                if l1.value != l2.value {
                     emit_literal_warning(
                         &l1.value.to_string(),
                         &l2.value.to_string(),

--- a/pyrefly/lib/test/unnecessary_comparison.rs
+++ b/pyrefly/lib/test/unnecessary_comparison.rs
@@ -43,6 +43,26 @@ if False is not False:  # E: Identity comparison `False is not False` is always 
 );
 
 testcase!(
+    test_exhaustive_enum_narrowing,
+    r#"
+import inspect
+
+def parameter_kind(parameter: inspect.Parameter) -> str:
+    if parameter.kind is inspect.Parameter.POSITIONAL_ONLY:
+        return "positional-only"
+    elif parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD:
+        return "positional-or-keyword"
+    elif parameter.kind is inspect.Parameter.VAR_POSITIONAL:
+        return "args"
+    elif parameter.kind is inspect.Parameter.KEYWORD_ONLY:
+        return "keyword-only"
+    elif parameter.kind is inspect.Parameter.VAR_KEYWORD:
+        return "kwargs"
+    return "other"
+"#,
+);
+
+testcase!(
     test_non_singleton_same_value_ok,
     r#"
 # Same integer/string literals - no warning (interning varies)


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4748

Identity comparisons now ignore explicit/implicit literal style metadata and correctly recognize equal enum members as singletons

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test