### PR TITLE
Cut over to all-ruff formatting for code and imports (#4755)

### DIFF
--- a/.github/workflows/pyrefly.yml
+++ b/.github/workflows/pyrefly.yml
@@ -41,10 +41,10 @@ jobs:
       with:
         enable-cache: true
       if: ${{ matrix.os == 'ubuntu-latest' }}
-    - name: Check tensor-shape formatting
-      run: >
-        uv tool run --from ruff==0.16.5 ruff format --check
-        tensor-shapes
+    - name: Check Python formatting (ruff)
+      run: |
+        uv tool run --from ruff==0.16.5 ruff format --check .
+        uv tool run --from ruff==0.16.5 ruff check --select I .
       if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: set windows cargo home
       # we need to set CARGO_HOME to a high-up directory on Windows machines, since some dependencies cloned

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,27 @@ Coding style: All code must be clean, documented and minimal. That means:
   overhead. Even if a piece of code is logically correct, it is not ready for
   review until it is also clean, elegant, and maintainable.
 
+### Formatting
+
+- **Rust:** `cargo fmt` (enforced by `cargo fmt -- --check` in CI)
+- **Python:** All Python is formatted with **ruff** (both code and import sorting):
+  - OSS: `ruff.toml` at repo root — `target-version = py312`, `line-length = 88`, `[lint] select = ["I"]` for isort
+  - Run locally:
+    ```bash
+    ruff format .          # code formatting
+    ruff check --fix --select I .  # import sorting
+    ruff format --check . && ruff check --select I .  # what CI runs
+    ```
+  - Internal (fbsource): formatting is via `pyfmt`, which reads `tools/lint/pyfmt/config.toml`:
+    ```toml
+    ["fbcode/pyrefly"]
+    formatter = "ruff-api"
+    sorter = "ruff-api"
+    target_version = "3.12"
+    ```
+    This matches OSS `ruff.toml` (`target-version = py312`, `line-length = 88`, `lint.select = ["I"]`), and both exclude `crates/pyrefly_bundled` (vendored typeshed stubs).
+    Run `arc f` or `buck2 run fbcode//tools/pyfmt:pyfmt -- fbcode/pyrefly/...`. The linter code still appears as `BLACK` historically, but it now runs ruff-api for both formatting and sorting, matching OSS ruff.
+
 ## Comments and Documentation
 
 - Code should have comments and functions should have docstrings, but both should be

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,2 +1,17 @@
-target-version = "py312"
-extend-exclude = ["tensor-shapes/skills"]
+target-version = "py313"
+line-length = 88
+extend-exclude = [
+    "**/*.md",
+    "conformance/**",
+    "crates/pyrefly_bundled/**",
+    "crates/tsp_types/**",
+    "pyrefly/lib/test/**",
+    "test/**",
+    "website/**",
+]
+
+[lint]
+select = ["I"]
+fixable = ["I"]
+
+[lint.isort]

--- a/scripts/benchmark/lsp_benchmark.py
+++ b/scripts/benchmark/lsp_benchmark.py
@@ -76,7 +76,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-
 JsonObj = Dict[str, Any]
 
 SCRIPT_DIR: Path = Path(__file__).parent

--- a/scripts/compare_typecheckers.py
+++ b/scripts/compare_typecheckers.py
@@ -46,7 +46,7 @@ import time
 import venv
 from datetime import datetime, timezone
 
-from projects import get_mypy_primer_projects, Project
+from projects import Project, get_mypy_primer_projects
 
 
 def run(

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -42,8 +42,8 @@ try:
     # Buck build: use fully-qualified module path
     from pyrefly.scripts.github_utils import (
         ContributorAnalyzer,
-        get_tag_date,
         GitHubClient,
+        get_tag_date,
         load_env_file,
     )
     from pyrefly.scripts.version_helpers import is_prerelease
@@ -52,8 +52,8 @@ except ImportError:
     sys.path.insert(0, str(_SCRIPT_DIR))
     from github_utils import (  # type: ignore[import-not-found]  # noqa: F811
         ContributorAnalyzer,  # pyrefly: ignore
-        get_tag_date,  # pyrefly: ignore
         GitHubClient,  # pyrefly: ignore
+        get_tag_date,  # pyrefly: ignore
         load_env_file,  # pyrefly: ignore
     )
     from version_helpers import (  # type: ignore[import-not-found]  # noqa: F811  # pyrefly: ignore

--- a/scripts/github_utils.py
+++ b/scripts/github_utils.py
@@ -31,7 +31,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-
 # ---------------------------------------------------------------------------
 # Bot filtering
 # ---------------------------------------------------------------------------
@@ -446,9 +445,11 @@ def display_contributors(
 
         github_sorted = sorted(
             github_users.items(),
-            key=lambda x: (-x[1]["commit_count"], x[1]["name"].lower())
-            if sort_by == "commits"
-            else (x[1]["name"].lower(), -x[1]["commit_count"]),
+            key=lambda x: (
+                (-x[1]["commit_count"], x[1]["name"].lower())
+                if sort_by == "commits"
+                else (x[1]["name"].lower(), -x[1]["commit_count"])
+            ),
         )
 
         for i, (_contributor_id, info) in enumerate(github_sorted, 1):
@@ -465,9 +466,11 @@ def display_contributors(
 
         name_sorted = sorted(
             name_based.items(),
-            key=lambda x: (-x[1]["commit_count"], x[1]["name"].lower())
-            if sort_by == "commits"
-            else (x[1]["name"].lower(), -x[1]["commit_count"]),
+            key=lambda x: (
+                (-x[1]["commit_count"], x[1]["name"].lower())
+                if sort_by == "commits"
+                else (x[1]["name"].lower(), -x[1]["commit_count"])
+            ),
         )
 
         for i, (_contributor_id, info) in enumerate(name_sorted, 1):
@@ -483,9 +486,11 @@ def display_contributors(
         print("-" * 80)
         github_sorted = sorted(
             github_users.items(),
-            key=lambda x: (-x[1]["commit_count"], x[1]["name"].lower())
-            if sort_by == "commits"
-            else (x[1]["name"].lower(), -x[1]["commit_count"]),
+            key=lambda x: (
+                (-x[1]["commit_count"], x[1]["name"].lower())
+                if sort_by == "commits"
+                else (x[1]["name"].lower(), -x[1]["commit_count"])
+            ),
         )
         handles = [f"@{info['name']}" for _, info in github_sorted]
         print(f"\n  {', '.join(handles)}")

--- a/scripts/issue_ranker/code_extractor.py
+++ b/scripts/issue_ranker/code_extractor.py
@@ -20,7 +20,7 @@ import re
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from llm_transport import call_llm, LLMError
+from llm_transport import LLMError, call_llm
 
 # Matches ```python or ```py fenced code blocks (optionally indented).
 _PYTHON_FENCE_RE = re.compile(

--- a/scripts/issue_ranker/llm_tests/test_transport.py
+++ b/scripts/issue_ranker/llm_tests/test_transport.py
@@ -14,7 +14,7 @@ import sys
 import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
-from llm_transport import call_llm, call_llm_json, LLMError
+from llm_transport import LLMError, call_llm, call_llm_json
 
 _HAS_API_KEY = bool(
     os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("LLAMA_API_KEY")

--- a/scripts/issue_ranker/passes/categorize.py
+++ b/scripts/issue_ranker/passes/categorize.py
@@ -18,7 +18,7 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
-from llm_transport import call_llm_json, LLMError
+from llm_transport import LLMError, call_llm_json
 
 HAIKU_MODEL = "claude-haiku-4-5-20251001"
 

--- a/scripts/issue_ranker/passes/primer_impact.py
+++ b/scripts/issue_ranker/passes/primer_impact.py
@@ -19,7 +19,7 @@ import re
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
-from llm_transport import call_llm_json, LLMError
+from llm_transport import LLMError, call_llm_json
 
 HAIKU_MODEL = "claude-haiku-4-5-20251001"
 

--- a/scripts/issue_ranker/passes/rank.py
+++ b/scripts/issue_ranker/passes/rank.py
@@ -20,7 +20,7 @@ import sys
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
-from llm_transport import call_llm_json, get_backend, LLMError
+from llm_transport import LLMError, call_llm_json, get_backend
 
 OPUS_MODEL = "claude-opus-4-20250514"
 

--- a/scripts/issue_ranker/passes/score.py
+++ b/scripts/issue_ranker/passes/score.py
@@ -22,7 +22,7 @@ import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
-from llm_transport import call_llm_json, get_backend, LLMError
+from llm_transport import LLMError, call_llm_json, get_backend
 from spec_fetcher import get_spec_excerpt
 
 SONNET_MODEL = "claude-sonnet-4-6"

--- a/scripts/issue_ranker/pipeline.py
+++ b/scripts/issue_ranker/pipeline.py
@@ -25,7 +25,6 @@ from .passes.primer_impact import compute_primer_impact
 from .passes.rank import rank_issues
 from .passes.score import score_all
 
-
 # Cost estimates per call (input + output tokens, approximate)
 _COST_ESTIMATES = {
     "haiku_call": 0.002,  # ~2K tokens in, ~200 out

--- a/scripts/issue_ranker/relationship_resolver.py
+++ b/scripts/issue_ranker/relationship_resolver.py
@@ -12,7 +12,6 @@ import logging
 import re
 from collections import defaultdict
 
-
 # Patterns for relationship markers in issue bodies.
 _DUPLICATE_RE = re.compile(
     r"(?:duplicate\s+of|duplicates?|dupe\s+of)\s+#(\d+)", re.IGNORECASE

--- a/scripts/issue_ranker/tests/test_issue_ranker.py
+++ b/scripts/issue_ranker/tests/test_issue_ranker.py
@@ -40,8 +40,8 @@ from passes.rank import _mechanical_tier
 from relationship_resolver import (
     _BLOCKED_BY_RE,
     _BLOCKS_RE,
-    _build_duplicate_clusters,
     _DUPLICATE_RE,
+    _build_duplicate_clusters,
     resolve_relationships,
 )
 from report_formatter import format_json, format_markdown

--- a/scripts/primer_classifier/classifier.py
+++ b/scripts/primer_classifier/classifier.py
@@ -21,12 +21,12 @@ from typing import Optional
 from .code_fetcher import fetch_files_by_path, fetch_source_context
 from .cross_checker import cross_check_projects
 from .llm_client import (
-    assign_verdict_with_llm,
     CategoryVerdict,
+    LLMError,
+    assign_verdict_with_llm,
     classify_with_llm,
     critique_reasoning,
     generate_suggestions,
-    LLMError,
 )
 from .parser import ErrorEntry, ProjectDiff
 
@@ -301,9 +301,7 @@ def _cross_check_stats(entries: list[ErrorEntry]) -> str:
     return f"    Cross-check: {in_mypy}/{total} also in mypy, {in_pyright}/{total} also in pyright"
 
 
-def _format_errors_for_llm(
-    project: ProjectDiff, cross_check: bool = False
-) -> str:
+def _format_errors_for_llm(project: ProjectDiff, cross_check: bool = False) -> str:
     """Format errors for the LLM prompt.
 
     For projects with <= CATEGORY_THRESHOLD errors, list each individually.
@@ -414,9 +412,7 @@ def _determine_change_type(project: ProjectDiff) -> str:
         return "mixed (some errors added, some removed)"
 
 
-def _compute_structural_signals(
-    project: ProjectDiff, cross_check: bool = False
-) -> str:
+def _compute_structural_signals(project: ProjectDiff, cross_check: bool = False) -> str:
     """Compute structural signals about the project and errors for the LLM.
 
     Returns a string of signals to append to the user prompt, helping the
@@ -427,9 +423,7 @@ def _compute_structural_signals(
 
     # Cross-check signal: summarize how many errors are also in mypy/pyright
     if cross_check and project.added:
-        total, in_mypy, in_pyright, pyrefly_only = _cross_check_counts(
-            project.added
-        )
+        total, in_mypy, in_pyright, pyrefly_only = _cross_check_counts(project.added)
         if total > 0:
             signals.append(
                 f"STRUCTURAL SIGNAL — CROSS-CHECK: {in_mypy}/{total} new errors also reported by mypy, "
@@ -568,9 +562,7 @@ def classify_project(
     # Build cross-check stats string if cross-checking was enabled
     cc_stats = ""
     if cross_check and project.added:
-        total, in_mypy, in_pyright, pyrefly_only = _cross_check_counts(
-            project.added
-        )
+        total, in_mypy, in_pyright, pyrefly_only = _cross_check_counts(project.added)
         if total > 0:
             cc_stats = (
                 f"{in_mypy}/{total} mypy, {in_pyright}/{total} pyright, "
@@ -583,11 +575,11 @@ def classify_project(
         reason="",
         added_count=len(project.added),
         removed_count=len(project.removed),
-        error_kinds=sorted(set(
-            e.error_kind
-            for e in (*project.added, *project.removed)
-            if e.error_kind
-        )),
+        error_kinds=sorted(
+            set(
+                e.error_kind for e in (*project.added, *project.removed) if e.error_kind
+            )
+        ),
         cross_check_stats=cc_stats,
     )
 
@@ -755,7 +747,8 @@ def _enforce_cross_project_consistency(
     """
     # Only consider LLM-classified projects with clear verdicts
     llm_classified = [
-        c for c in classifications
+        c
+        for c in classifications
         if c.method == "llm" and c.verdict in ("regression", "improvement")
     ]
     if len(llm_classified) < 2:
@@ -783,9 +776,7 @@ def _enforce_cross_project_consistency(
             verdict_counts[v] = verdict_counts.get(v, 0) + 1
 
         majority = max(verdict_counts, key=lambda v: verdict_counts[v])
-        minority_count = sum(
-            c for v, c in verdict_counts.items() if v != majority
-        )
+        minority_count = sum(c for v, c in verdict_counts.items() if v != majority)
 
         # Only enforce if majority is clear (> minority)
         if verdict_counts[majority] <= minority_count:
@@ -868,11 +859,13 @@ def classify_all(
             result.ambiguous += 1
 
     # Pass 3: aggregate suggestion generation
-    if generate_suggestion and use_llm and (result.regressions > 0 or result.ambiguous > 0):
+    if (
+        generate_suggestion
+        and use_llm
+        and (result.regressions > 0 or result.ambiguous > 0)
+    ):
         try:
-            suggestion_result = generate_suggestions(
-                result, pyrefly_diff or "", model
-            )
+            suggestion_result = generate_suggestions(result, pyrefly_diff or "", model)
             result.suggestion = suggestion_result
         except Exception as e:
             print(

--- a/scripts/primer_classifier/cross_checker.py
+++ b/scripts/primer_classifier/cross_checker.py
@@ -37,13 +37,13 @@ from compare_typecheckers import (
     setup_project,
 )
 from llm_transport import (
-    get_backend,
-    call_llama_api,
     call_anthropic_api,
+    call_llama_api,
     extract_text,
+    get_backend,
     parse_json_list,
 )
-from projects import get_mypy_primer_projects, Project
+from projects import Project, get_mypy_primer_projects
 
 _CHECKER_TIMEOUT = 300  # 5 minutes per checker
 _BATCH_SIZE = 80  # max pyrefly errors per LLM call to avoid output truncation
@@ -77,9 +77,7 @@ def _run_checker(
             timeout=_CHECKER_TIMEOUT,
         )
     except subprocess.TimeoutExpired:
-        logging.warning(
-            f"  [cross-check] {checker_name} timed out for {project_name}"
-        )
+        logging.warning(f"  [cross-check] {checker_name} timed out for {project_name}")
         return subprocess.CompletedProcess(full_cmd, 1, stdout="", stderr="")
 
 
@@ -110,9 +108,7 @@ def _collect_checker_errors(
         paths = extract_paths_from_cmd(project.pyright_cmd)
         path_args = " ".join(paths) if paths else "."
         python_path = os.path.join(repo_dir, ".venv", "bin", "python")
-        pyright_cmd = (
-            f"pyright --outputjson --pythonpath {python_path} {path_args}"
-        )
+        pyright_cmd = f"pyright --outputjson --pythonpath {python_path} {path_args}"
         result = _run_checker(pyright_cmd, repo_dir, "pyright", project.name)
         pyright_errors = parse_full_errors_pyright(result.stdout or "", repo_dir)
         if result.returncode != 0 and not pyright_errors:
@@ -121,15 +117,14 @@ def _collect_checker_errors(
                 f"stderr={result.stderr if result.stderr else '(empty)'}"
             )
     else:
-        logging.debug(
-            f"  [cross-check] {project.name}: no pyright_cmd configured"
-        )
+        logging.debug(f"  [cross-check] {project.name}: no pyright_cmd configured")
 
     return mypy_errors, pyright_errors
 
 
 def _format_checker_errors(
-    errors: list[dict[str, object]], checker_name: str,
+    errors: list[dict[str, object]],
+    checker_name: str,
 ) -> str:
     """Format checker errors for the LLM prompt."""
     if not errors:
@@ -202,9 +197,7 @@ def _match_errors_batch(
 
     try:
         if backend == "llama":
-            result = call_llama_api(
-                api_key, _MATCH_SYSTEM_PROMPT, user_prompt, model
-            )
+            result = call_llama_api(api_key, _MATCH_SYSTEM_PROMPT, user_prompt, model)
         else:
             result = call_anthropic_api(
                 api_key, _MATCH_SYSTEM_PROMPT, user_prompt, model
@@ -258,7 +251,9 @@ def _match_errors_with_llm(
     # 200K token API limit without this filtering.
     filtered_mypy = _filter_to_relevant_files(mypy_errors, pyrefly_entries)
     filtered_pyright = _filter_to_relevant_files(pyright_errors, pyrefly_entries)
-    if len(filtered_mypy) != len(mypy_errors) or len(filtered_pyright) != len(pyright_errors):
+    if len(filtered_mypy) != len(mypy_errors) or len(filtered_pyright) != len(
+        pyright_errors
+    ):
         logging.info(
             f"  [cross-check] Filtered to relevant files: "
             f"mypy {len(mypy_errors)}->{len(filtered_mypy)}, "
@@ -294,9 +289,7 @@ def _match_errors_with_llm(
     mypy_matches = sum(1 for m in all_matches if m.get("mypy") is True)
     pyright_matches = sum(1 for m in all_matches if m.get("pyright") is True)
     both = sum(
-        1
-        for m in all_matches
-        if m.get("mypy") is True and m.get("pyright") is True
+        1 for m in all_matches if m.get("mypy") is True and m.get("pyright") is True
     )
     neither = sum(
         1

--- a/scripts/primer_classifier/formatter.py
+++ b/scripts/primer_classifier/formatter.py
@@ -31,9 +31,7 @@ _VERDICT_LABEL = {
 }
 
 # Matches full pyrefly source paths (starting with pyrefly/, crates/, or lsp/)
-_SOURCE_FILE_PATTERN = re.compile(
-    r"(?:pyrefly/|crates/|lsp/)[\w/]+\.\w+"
-)
+_SOURCE_FILE_PATTERN = re.compile(r"(?:pyrefly/|crates/|lsp/)[\w/]+\.\w+")
 
 # Matches function names that look like pyrefly internals: must contain an
 # underscore (e.g. check_for_imported_final_reassignment, attr_subset_check).
@@ -92,6 +90,7 @@ def _linkify_files_in_text(text: str) -> str:
 
     # Step 2: linkify internal function names (must contain underscore)
     if file_path:
+
         def func_replacer(match: re.Match) -> str:
             func_name = match.group(1)
             full_match = match.group(0)
@@ -223,8 +222,7 @@ def _build_high_level_summary(result: ClassificationResult) -> str:
 
         reg_parts = []
         reg_parts.append(
-            f"**{len(regressions)} regression(s)** "
-            f"across {', '.join(proj_names)}"
+            f"**{len(regressions)} regression(s)** across {', '.join(proj_names)}"
         )
         if top_kinds:
             kinds_str = ", ".join(f"`{k}`" for k in top_kinds)
@@ -236,8 +234,7 @@ def _build_high_level_summary(result: ClassificationResult) -> str:
     if improvements:
         proj_names = [c.project_name for c in improvements]
         parts.append(
-            f"**{len(improvements)} improvement(s)** "
-            f"across {', '.join(proj_names)}."
+            f"**{len(improvements)} improvement(s)** across {', '.join(proj_names)}."
         )
 
     return " ".join(parts) + "\n"
@@ -250,7 +247,7 @@ def format_markdown(result: ClassificationResult) -> str:
     suggested fixes, and a footer.
     """
     if not result.classifications:
-        return "## Primer Diff Classification\n\n" "No diffs to classify. All clear."
+        return "## Primer Diff Classification\n\nNo diffs to classify. All clear."
 
     lines: list[str] = []
     lines.append("## Primer Diff Classification\n")
@@ -331,8 +328,7 @@ def format_markdown(result: ClassificationResult) -> str:
                 lines.append(f"> {_format_reason(c.reason)}")
                 if c.pr_attribution and c.pr_attribution != "N/A":
                     lines.append(
-                        f"> **Attribution:** "
-                        f"{_linkify_files_in_text(c.pr_attribution)}"
+                        f"> **Attribution:** {_linkify_files_in_text(c.pr_attribution)}"
                     )
                 lines.append("")
 
@@ -350,9 +346,7 @@ def format_markdown(result: ClassificationResult) -> str:
                 lines.append(f"> Files: {linked_files}")
             lines.append(f"> Confidence: {s.confidence}")
             if s.affected_projects:
-                lines.append(
-                    f"> Affected projects: {', '.join(s.affected_projects)}"
-                )
+                lines.append(f"> Affected projects: {', '.join(s.affected_projects)}")
             if s.error_kinds_fixed:
                 kinds_str = ", ".join(f"`{k}`" for k in s.error_kinds_fixed)
                 lines.append(f"> Fixes: {kinds_str}")
@@ -364,8 +358,7 @@ def format_markdown(result: ClassificationResult) -> str:
     lines.append("---")
     lines.append("Was this helpful? React with 👍 or 👎\n")
     lines.append(
-        "<sub>Classification by primer-classifier"
-        f" ({_method_summary(result)})</sub>"
+        f"<sub>Classification by primer-classifier ({_method_summary(result)})</sub>"
     )
 
     return "\n".join(lines)

--- a/scripts/primer_classifier/llm_client.py
+++ b/scripts/primer_classifier/llm_client.py
@@ -29,10 +29,18 @@ from typing import Optional
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from llm_transport import (
     LLMError,
-    get_backend as _get_backend,
-    call_llama_api as _call_llama_api,
+)
+from llm_transport import (
     call_anthropic_api as _call_anthropic_api,
+)
+from llm_transport import (
+    call_llama_api as _call_llama_api,
+)
+from llm_transport import (
     extract_text as _extract_text_from_response,
+)
+from llm_transport import (
+    get_backend as _get_backend,
 )
 
 

--- a/scripts/primer_classifier/parser.py
+++ b/scripts/primer_classifier/parser.py
@@ -36,8 +36,12 @@ class ErrorEntry:
     error_kind: str  # e.g. "bad-return", "missing-import"
     raw_line: str  # the original line from the diff
     cross_checked: bool = False  # True if cross-check ran successfully for this error
-    also_in_mypy: bool = False  # cross-check: mypy also flags this (only meaningful if cross_checked)
-    also_in_pyright: bool = False  # cross-check: pyright also flags this (only meaningful if cross_checked)
+    also_in_mypy: bool = (
+        False  # cross-check: mypy also flags this (only meaningful if cross_checked)
+    )
+    also_in_pyright: bool = (
+        False  # cross-check: pyright also flags this (only meaningful if cross_checked)
+    )
 
     @property
     def line_number(self) -> int:

--- a/scripts/primer_classifier/test_classifier.py
+++ b/scripts/primer_classifier/test_classifier.py
@@ -21,21 +21,23 @@ from unittest.mock import patch
 import pytest
 
 from .classifier import (
+    Classification,
+    ClassificationResult,
+    Suggestion,
+    SuggestionResult,
     _extract_class_name,
     _format_errors_for_llm,
     _is_all_internal_errors,
     _is_wording_change,
     _truncate_source_context,
-    Classification,
-    ClassificationResult,
-    Suggestion,
-    SuggestionResult,
     classify_all,
     classify_project,
 )
 from .code_fetcher import _extract_referenced_modules, _github_url_to_owner_repo
 from .formatter import format_json, format_markdown
 from .llm_client import (
+    CategoryVerdict,
+    LLMResponse,
     _build_suggestion_user_prompt,
     _build_user_prompt,
     _build_verdict_prompt,
@@ -44,12 +46,13 @@ from .llm_client import (
     _get_backend,
     _parse_classification,
     assign_verdict_with_llm,
-    CategoryVerdict,
     generate_suggestions,
-    LLMResponse,
 )
-from .parser import ErrorEntry, parse_error_line, parse_primer_diff, ProjectDiff
+from .parser import ErrorEntry, ProjectDiff, parse_error_line, parse_primer_diff
 from .test_helpers import (
+    GT_BAD_OVERRIDE_ARGS_DIFF,
+    GT_PROTOCOL_SUBTYPING_DIFF,
+    GT_TYPE_CHECKING_DIFF,
     MOCK_GT_SCENARIO_A_RESPONSE,
     MOCK_GT_SCENARIO_B_RESPONSE,
     MOCK_MIXED_SCENARIO_RESPONSE,
@@ -57,9 +60,6 @@ from .test_helpers import (
     MOCK_TYPE_CHECKING_SCENARIO_RESPONSE,
     MOCK_VARIANCE_SCENARIO_RESPONSE,
     MOCK_VARIANCE_SUGGESTION_RESPONSE,
-    GT_BAD_OVERRIDE_ARGS_DIFF,
-    GT_PROTOCOL_SUBTYPING_DIFF,
-    GT_TYPE_CHECKING_DIFF,
     TYPE_CHECKING_DIFF,
     VARIANCE_DIFF,
     build_all_improvements_scenario,
@@ -350,14 +350,14 @@ class TestRealFixtureParsing:
             pytest.skip("No real fixtures directory")
         for fixture in sorted(self.REAL_DIR.glob("*.txt")):
             projects = parse_primer_diff(fixture.read_text())
-            assert (
-                len(projects) > 0
-            ), f"{fixture.name} should parse into at least one project"
+            assert len(projects) > 0, (
+                f"{fixture.name} should parse into at least one project"
+            )
             for p in projects:
                 assert p.name, f"Project in {fixture.name} has no name"
-                assert (
-                    p.added or p.removed
-                ), f"Project {p.name} in {fixture.name} has no changes"
+                assert p.added or p.removed, (
+                    f"Project {p.name} in {fixture.name} has no changes"
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -519,18 +519,25 @@ class TestParseClassification:
 
     def test_pass1_response_without_verdict(self):
         """Pass 1 responses have reason but no verdict — should parse OK."""
-        text = json.dumps({
-            "spec_check": "N/A",
-            "runtime_behavior": "N/A",
-            "mypy_pyright": "N/A",
-            "removal_assessment": "These were false positives",
-            "pr_attribution": "N/A",
-            "reason": "The removed errors were false positives from inference failures",
-            "categories": [{"category": "missing-attr", "reason": "false positives"}],
-        })
+        text = json.dumps(
+            {
+                "spec_check": "N/A",
+                "runtime_behavior": "N/A",
+                "mypy_pyright": "N/A",
+                "removal_assessment": "These were false positives",
+                "pr_attribution": "N/A",
+                "reason": "The removed errors were false positives from inference failures",
+                "categories": [
+                    {"category": "missing-attr", "reason": "false positives"}
+                ],
+            }
+        )
         result = _parse_classification(text)
         assert "verdict" not in result
-        assert result["reason"] == "The removed errors were false positives from inference failures"
+        assert (
+            result["reason"]
+            == "The removed errors were false positives from inference failures"
+        )
         assert len(result["categories"]) == 1
 
     def test_pass1_embedded_in_text_without_verdict(self):
@@ -738,23 +745,30 @@ class TestBuildUserPromptWithDiff:
 
 class TestPrAttributionParsing:
     def test_pr_attribution_parsed_from_response(self):
-        text = json.dumps({
-            "spec_check": "N/A",
-            "runtime_behavior": "N/A",
-            "mypy_pyright": "N/A",
-            "removal_assessment": "N/A",
-            "pr_attribution": "Change to overload_resolution() in alt/answers.rs",
-            "reason": "Fixed false positives",
-            "verdict": "improvement",
-        })
+        text = json.dumps(
+            {
+                "spec_check": "N/A",
+                "runtime_behavior": "N/A",
+                "mypy_pyright": "N/A",
+                "removal_assessment": "N/A",
+                "pr_attribution": "Change to overload_resolution() in alt/answers.rs",
+                "reason": "Fixed false positives",
+                "verdict": "improvement",
+            }
+        )
         result = _parse_classification(text)
-        assert result["pr_attribution"] == "Change to overload_resolution() in alt/answers.rs"
+        assert (
+            result["pr_attribution"]
+            == "Change to overload_resolution() in alt/answers.rs"
+        )
 
     def test_pr_attribution_defaults_to_empty(self):
-        text = json.dumps({
-            "reason": "test",
-            "verdict": "regression",
-        })
+        text = json.dumps(
+            {
+                "reason": "test",
+                "verdict": "regression",
+            }
+        )
         result = _parse_classification(text)
         assert result.get("pr_attribution", "") == ""
 
@@ -766,7 +780,9 @@ class TestLLMResponsePrAttribution:
             reason="removed false positives",
             pr_attribution="Change in alt/answers.rs fixed overload resolution",
         )
-        assert resp.pr_attribution == "Change in alt/answers.rs fixed overload resolution"
+        assert (
+            resp.pr_attribution == "Change in alt/answers.rs fixed overload resolution"
+        )
 
     def test_pr_attribution_default_empty(self):
         resp = LLMResponse(verdict="neutral", reason="wording change")
@@ -806,9 +822,7 @@ class TestClassifyAllWithDiff:
     def test_pyrefly_diff_accepted(self):
         """classify_all accepts pyrefly_diff without error."""
         projects = [
-            ProjectDiff(
-                name="b", added=[self._make_entry(kind="internal-error")]
-            ),
+            ProjectDiff(name="b", added=[self._make_entry(kind="internal-error")]),
         ]
         result = classify_all(
             projects,
@@ -1070,7 +1084,10 @@ class TestTwoPassClassifyProject:
                 ]
                 result = classify_project(p, fetch_code=False, use_llm=True)
                 assert result.verdict == "improvement"
-                assert result.reason == "These missing-attribute errors are false positives"
+                assert (
+                    result.reason
+                    == "These missing-attribute errors are false positives"
+                )
                 assert result.pr_attribution == "Change in solver.rs"
                 assert result.method == "llm"
                 # Pass 1 + Pass 1.5 + Pass 2 (N votes)
@@ -1082,7 +1099,10 @@ class TestTwoPassClassifyProject:
             "reason": "Mixed results",
             "pr_attribution": "N/A",
             "categories": [
-                {"category": "missing-attr", "reason": "false positives from inheritance"},
+                {
+                    "category": "missing-attr",
+                    "reason": "false positives from inheritance",
+                },
                 {"category": "bad-return", "reason": "real type errors caught"},
             ],
         }
@@ -1091,7 +1111,10 @@ class TestTwoPassClassifyProject:
             "corrections": "",
             "reason": "Mixed results",
             "categories": [
-                {"category": "missing-attr", "reason": "false positives from inheritance"},
+                {
+                    "category": "missing-attr",
+                    "reason": "false positives from inheritance",
+                },
                 {"category": "bad-return", "reason": "real type errors caught"},
             ],
         }
@@ -1232,7 +1255,9 @@ class TestGenerateSuggestionsParsing:
         with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True):
             with patch(
                 "primer_classifier.llm_client._call_anthropic_api",
-                return_value={"content": [{"text": json.dumps(MOCK_VARIANCE_SUGGESTION_RESPONSE)}]},
+                return_value={
+                    "content": [{"text": json.dumps(MOCK_VARIANCE_SUGGESTION_RESPONSE)}]
+                },
             ):
                 suggestion = generate_suggestions(result, VARIANCE_DIFF)
                 assert len(suggestion.suggestions) == 1
@@ -1292,15 +1317,21 @@ class TestClassifyAllWithSuggestFlag:
             ) as mock_api:
                 from .llm_client import _VERDICT_VOTES
 
-                mock_api.side_effect = [
-                    {"content": [{"text": json.dumps(pass1_response)}]},  # Pass 1
-                    {"content": [{"text": json.dumps(critique_response)}]},  # Pass 1.5
-                ] + [
-                    {"content": [{"text": json.dumps(pass2_response)}]}  # Pass 2
-                    for _ in range(_VERDICT_VOTES)
-                ] + [
-                    {"content": [{"text": json.dumps(pass3_response)}]},  # Pass 3
-                ]
+                mock_api.side_effect = (
+                    [
+                        {"content": [{"text": json.dumps(pass1_response)}]},  # Pass 1
+                        {
+                            "content": [{"text": json.dumps(critique_response)}]
+                        },  # Pass 1.5
+                    ]
+                    + [
+                        {"content": [{"text": json.dumps(pass2_response)}]}  # Pass 2
+                        for _ in range(_VERDICT_VOTES)
+                    ]
+                    + [
+                        {"content": [{"text": json.dumps(pass3_response)}]},  # Pass 3
+                    ]
+                )
                 result = classify_all(
                     projects,
                     fetch_code=False,
@@ -1310,7 +1341,10 @@ class TestClassifyAllWithSuggestFlag:
                 assert result.regressions == 1
                 assert result.suggestion is not None
                 assert len(result.suggestion.suggestions) == 1
-                assert result.suggestion.suggestions[0].description == "Add is_protocol() check"
+                assert (
+                    result.suggestion.suggestions[0].description
+                    == "Add is_protocol() check"
+                )
                 # Pass 1 + Pass 1.5 + Pass 2 (N votes) + Pass 3
                 assert mock_api.call_count == 2 + _VERDICT_VOTES + 1
 
@@ -1389,7 +1423,10 @@ class TestSuggestionInJsonOutput:
         assert len(data["suggestion"]["suggestions"]) == 1
         assert data["suggestion"]["suggestions"][0]["confidence"] == "medium"
         assert "file_urls" in data["suggestion"]["suggestions"][0]
-        assert "github.com/facebook/pyrefly" in data["suggestion"]["suggestions"][0]["file_urls"][0]
+        assert (
+            "github.com/facebook/pyrefly"
+            in data["suggestion"]["suggestions"][0]["file_urls"][0]
+        )
 
 
 class TestSuggestionOmittedWhenNone:
@@ -1450,7 +1487,9 @@ class TestScenarioVarianceToBroad:
         with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True):
             with patch(
                 "primer_classifier.llm_client._call_anthropic_api",
-                return_value={"content": [{"text": json.dumps(MOCK_VARIANCE_SCENARIO_RESPONSE)}]},
+                return_value={
+                    "content": [{"text": json.dumps(MOCK_VARIANCE_SCENARIO_RESPONSE)}]
+                },
             ):
                 suggestion = generate_suggestions(result, VARIANCE_DIFF)
                 assert len(suggestion.suggestions) == 1
@@ -1478,14 +1517,21 @@ class TestScenarioTypeCheckingExempt:
         with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True):
             with patch(
                 "primer_classifier.llm_client._call_anthropic_api",
-                return_value={"content": [{"text": json.dumps(MOCK_TYPE_CHECKING_SCENARIO_RESPONSE)}]},
+                return_value={
+                    "content": [
+                        {"text": json.dumps(MOCK_TYPE_CHECKING_SCENARIO_RESPONSE)}
+                    ]
+                },
             ):
                 suggestion = generate_suggestions(result, TYPE_CHECKING_DIFF)
                 assert len(suggestion.suggestions) == 1
-                text = suggestion.suggestions[0].description + " " + suggestion.suggestions[0].reasoning
+                text = (
+                    suggestion.suggestions[0].description
+                    + " "
+                    + suggestion.suggestions[0].reasoning
+                )
                 assert any(
-                    kw in text.lower()
-                    for kw in ["type_checking", "exempt", "final"]
+                    kw in text.lower() for kw in ["type_checking", "exempt", "final"]
                 )
 
 
@@ -1507,7 +1553,9 @@ class TestScenarioBadOverride:
         with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True):
             with patch(
                 "primer_classifier.llm_client._call_anthropic_api",
-                return_value={"content": [{"text": json.dumps(MOCK_OVERRIDE_SCENARIO_RESPONSE)}]},
+                return_value={
+                    "content": [{"text": json.dumps(MOCK_OVERRIDE_SCENARIO_RESPONSE)}]
+                },
             ):
                 suggestion = generate_suggestions(result, "diff override.rs")
                 assert len(suggestion.suggestions) >= 1
@@ -1568,7 +1616,9 @@ class TestScenarioMixed:
         with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True):
             with patch(
                 "primer_classifier.llm_client._call_anthropic_api",
-                return_value={"content": [{"text": json.dumps(MOCK_MIXED_SCENARIO_RESPONSE)}]},
+                return_value={
+                    "content": [{"text": json.dumps(MOCK_MIXED_SCENARIO_RESPONSE)}]
+                },
             ):
                 suggestion = generate_suggestions(merged, "diff variance.rs")
                 assert len(suggestion.suggestions) >= 1
@@ -1636,7 +1686,9 @@ class TestGroundTruthMockParsing:
         with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True):
             with patch(
                 "primer_classifier.llm_client._call_anthropic_api",
-                return_value={"content": [{"text": json.dumps(MOCK_GT_SCENARIO_A_RESPONSE)}]},
+                return_value={
+                    "content": [{"text": json.dumps(MOCK_GT_SCENARIO_A_RESPONSE)}]
+                },
             ):
                 suggestion = generate_suggestions(result, GT_PROTOCOL_SUBTYPING_DIFF)
                 assert len(suggestion.suggestions) == 1
@@ -1651,7 +1703,9 @@ class TestGroundTruthMockParsing:
         with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}, clear=True):
             with patch(
                 "primer_classifier.llm_client._call_anthropic_api",
-                return_value={"content": [{"text": json.dumps(MOCK_GT_SCENARIO_B_RESPONSE)}]},
+                return_value={
+                    "content": [{"text": json.dumps(MOCK_GT_SCENARIO_B_RESPONSE)}]
+                },
             ):
                 suggestion = generate_suggestions(result, GT_TYPE_CHECKING_DIFF)
                 assert len(suggestion.suggestions) == 1

--- a/scripts/primer_classifier/test_cross_checker.py
+++ b/scripts/primer_classifier/test_cross_checker.py
@@ -21,23 +21,20 @@ from unittest.mock import patch
 import pytest
 
 from .cross_checker import (
+    _MATCH_SYSTEM_PROMPT,
     _filter_to_relevant_files,
     _format_checker_errors,
     _format_pyrefly_errors,
     _match_errors_with_llm,
-    _MATCH_SYSTEM_PROMPT,
 )
 from .parser import ErrorEntry
-
 
 # ---------------------------------------------------------------------------
 # Test data helpers
 # ---------------------------------------------------------------------------
 
 
-def _make_pyrefly_entry(
-    file: str, line: int, kind: str, message: str
-) -> ErrorEntry:
+def _make_pyrefly_entry(file: str, line: int, kind: str, message: str) -> ErrorEntry:
     return ErrorEntry(
         severity="ERROR",
         file_path=file,
@@ -179,7 +176,9 @@ class TestMatchErrorsMocked:
         ]
 
         mypy_errors = [_make_checker_error("a.py", 10, "return-value", "bad return")]
-        pyright_errors = [_make_checker_error("a.py", 10, "reportReturnType", "bad return")]
+        pyright_errors = [
+            _make_checker_error("a.py", 10, "reportReturnType", "bad return")
+        ]
         result = _match_errors_with_llm(entries, mypy_errors, pyright_errors)
         assert len(result) == 2
         assert result[0]["mypy"] is True
@@ -309,77 +308,109 @@ class TestMatchErrorsLive:
         """All 3 checkers flag the same obvious errors — should all match."""
         pyrefly_entries = [
             _make_pyrefly_entry(
-                "test.py", 2, "bad-return",
-                "Returned type `str` is not assignable to declared return type `int`"
+                "test.py",
+                2,
+                "bad-return",
+                "Returned type `str` is not assignable to declared return type `int`",
             ),
             _make_pyrefly_entry(
-                "test.py", 7, "bad-assignment",
-                "`str` is not assignable to variable `x` with type `int`"
+                "test.py",
+                7,
+                "bad-assignment",
+                "`str` is not assignable to variable `x` with type `int`",
             ),
             _make_pyrefly_entry(
-                "test.py", 9, "bad-argument-type",
-                "Argument `int` is not assignable to parameter `name` with type `str`"
+                "test.py",
+                9,
+                "bad-argument-type",
+                "Argument `int` is not assignable to parameter `name` with type `str`",
             ),
             _make_pyrefly_entry(
-                "test.py", 15, "missing-attribute",
-                "Object of class `Foo` has no attribute `nonexistent_method`"
+                "test.py",
+                15,
+                "missing-attribute",
+                "Object of class `Foo` has no attribute `nonexistent_method`",
             ),
         ]
 
         mypy_errors = [
             _make_checker_error(
-                "test.py", 2, "return-value",
-                'Incompatible return value type (got "str", expected "int")'
+                "test.py",
+                2,
+                "return-value",
+                'Incompatible return value type (got "str", expected "int")',
             ),
             _make_checker_error(
-                "test.py", 7, "assignment",
-                'Incompatible types in assignment (expression has type "str", variable has type "int")'
+                "test.py",
+                7,
+                "assignment",
+                'Incompatible types in assignment (expression has type "str", variable has type "int")',
             ),
             _make_checker_error(
-                "test.py", 9, "arg-type",
-                'Argument 1 to "greet" has incompatible type "int"; expected "str"'
+                "test.py",
+                9,
+                "arg-type",
+                'Argument 1 to "greet" has incompatible type "int"; expected "str"',
             ),
             _make_checker_error(
-                "test.py", 15, "attr-defined",
-                '"Foo" has no attribute "nonexistent_method"'
+                "test.py",
+                15,
+                "attr-defined",
+                '"Foo" has no attribute "nonexistent_method"',
             ),
         ]
 
         pyright_errors = [
             _make_checker_error(
-                "test.py", 2, "reportReturnType",
-                'Type "Literal[\'hello\']" is not assignable to return type "int"'
+                "test.py",
+                2,
+                "reportReturnType",
+                'Type "Literal[\'hello\']" is not assignable to return type "int"',
             ),
             _make_checker_error(
-                "test.py", 7, "reportAssignmentType",
-                'Type "Literal[\'not an int\']" is not assignable to declared type "int"'
+                "test.py",
+                7,
+                "reportAssignmentType",
+                'Type "Literal[\'not an int\']" is not assignable to declared type "int"',
             ),
             _make_checker_error(
-                "test.py", 9, "reportArgumentType",
-                'Argument of type "Literal[42]" cannot be assigned to parameter "name" of type "str"'
+                "test.py",
+                9,
+                "reportArgumentType",
+                'Argument of type "Literal[42]" cannot be assigned to parameter "name" of type "str"',
             ),
             _make_checker_error(
-                "test.py", 15, "reportAttributeAccessIssue",
-                'Cannot access attribute "nonexistent_method" for class "Foo"'
+                "test.py",
+                15,
+                "reportAttributeAccessIssue",
+                'Cannot access attribute "nonexistent_method" for class "Foo"',
             ),
         ]
 
         matches = _match_errors_with_llm(pyrefly_entries, mypy_errors, pyright_errors)
         assert len(matches) == 4
         for m in matches:
-            assert m.get("mypy") is True, f"Expected mypy=True for index {m.get('index')}"
-            assert m.get("pyright") is True, f"Expected pyright=True for index {m.get('index')}"
+            assert m.get("mypy") is True, (
+                f"Expected mypy=True for index {m.get('index')}"
+            )
+            assert m.get("pyright") is True, (
+                f"Expected pyright=True for index {m.get('index')}"
+            )
 
     def test_pyrefly_only_errors(self):
         """Errors unique to pyrefly — mypy/pyright don't flag them."""
         pyrefly_entries = [
             _make_pyrefly_entry(
-                "test.py", 5, "inconsistent-overload-default",
-                "Default value for parameter `x` is inconsistent across overloads"
+                "test.py",
+                5,
+                "inconsistent-overload-default",
+                "Default value for parameter `x` is inconsistent across overloads",
             ),
             _make_pyrefly_entry(
-                "test.py", 10, "redundant-cast",
-                "Redundant cast: `int` is the same type as `int`"
+                "test.py",
+                10,
+                "redundant-cast",
+                "Redundant cast: `int` is the same type as `int`",
             ),
         ]
 
@@ -389,38 +420,52 @@ class TestMatchErrorsLive:
             _make_checker_error("other.py", 200, "syntax", "Syntax error"),
         ]
         pyright_errors = [
-            _make_checker_error("other.py", 100, "reportMissingImports", "Import not found"),
+            _make_checker_error(
+                "other.py", 100, "reportMissingImports", "Import not found"
+            ),
         ]
 
         matches = _match_errors_with_llm(pyrefly_entries, mypy_errors, pyright_errors)
         assert len(matches) == 2
         for m in matches:
-            assert m.get("mypy") is not True, f"Expected mypy=False for index {m.get('index')}"
-            assert m.get("pyright") is not True, f"Expected pyright=False for index {m.get('index')}"
+            assert m.get("mypy") is not True, (
+                f"Expected mypy=False for index {m.get('index')}"
+            )
+            assert m.get("pyright") is not True, (
+                f"Expected pyright=False for index {m.get('index')}"
+            )
 
     def test_mixed_co_reported_and_unique(self):
         """Mix of co-reported and pyrefly-only errors."""
         pyrefly_entries = [
             _make_pyrefly_entry(
-                "main.py", 10, "bad-return",
-                "Returned type `str` is not assignable to declared return type `int`"
+                "main.py",
+                10,
+                "bad-return",
+                "Returned type `str` is not assignable to declared return type `int`",
             ),
             _make_pyrefly_entry(
-                "main.py", 50, "redundant-cast",
-                "Redundant cast: `int` is the same type as `int`"
+                "main.py",
+                50,
+                "redundant-cast",
+                "Redundant cast: `int` is the same type as `int`",
             ),
         ]
 
         mypy_errors = [
             _make_checker_error(
-                "main.py", 10, "return-value",
-                'Incompatible return value type (got "str", expected "int")'
+                "main.py",
+                10,
+                "return-value",
+                'Incompatible return value type (got "str", expected "int")',
             ),
         ]
         pyright_errors = [
             _make_checker_error(
-                "main.py", 10, "reportReturnType",
-                'Type "str" is not assignable to return type "int"'
+                "main.py",
+                10,
+                "reportReturnType",
+                'Type "str" is not assignable to return type "int"',
             ),
         ]
 
@@ -439,21 +484,27 @@ class TestMatchErrorsLive:
         """Errors on slightly different lines should still match."""
         pyrefly_entries = [
             _make_pyrefly_entry(
-                "utils.py", 100, "bad-argument-type",
-                "Argument `int` is not assignable to parameter `name` with type `str`"
+                "utils.py",
+                100,
+                "bad-argument-type",
+                "Argument `int` is not assignable to parameter `name` with type `str`",
             ),
         ]
 
         mypy_errors = [
             _make_checker_error(
-                "utils.py", 102, "arg-type",
-                'Argument 1 to "process" has incompatible type "int"; expected "str"'
+                "utils.py",
+                102,
+                "arg-type",
+                'Argument 1 to "process" has incompatible type "int"; expected "str"',
             ),
         ]
         pyright_errors = [
             _make_checker_error(
-                "utils.py", 97, "reportArgumentType",
-                'Argument of type "int" cannot be assigned to parameter "name" of type "str"'
+                "utils.py",
+                97,
+                "reportArgumentType",
+                'Argument of type "int" cannot be assigned to parameter "name" of type "str"',
             ),
         ]
 
@@ -466,15 +517,19 @@ class TestMatchErrorsLive:
         """Only mypy was run (no pyright errors) — pyright should be False."""
         pyrefly_entries = [
             _make_pyrefly_entry(
-                "test.py", 5, "bad-return",
-                "Returned type `str` is not assignable to declared return type `int`"
+                "test.py",
+                5,
+                "bad-return",
+                "Returned type `str` is not assignable to declared return type `int`",
             ),
         ]
 
         mypy_errors = [
             _make_checker_error(
-                "test.py", 5, "return-value",
-                'Incompatible return value type (got "str", expected "int")'
+                "test.py",
+                5,
+                "return-value",
+                'Incompatible return value type (got "str", expected "int")',
             ),
         ]
 
@@ -487,15 +542,19 @@ class TestMatchErrorsLive:
         """Only pyright was run (no mypy errors) — mypy should be False."""
         pyrefly_entries = [
             _make_pyrefly_entry(
-                "test.py", 5, "missing-attribute",
-                "Object of class `Foo` has no attribute `bar`"
+                "test.py",
+                5,
+                "missing-attribute",
+                "Object of class `Foo` has no attribute `bar`",
             ),
         ]
 
         pyright_errors = [
             _make_checker_error(
-                "test.py", 5, "reportAttributeAccessIssue",
-                'Cannot access attribute "bar" for class "Foo"'
+                "test.py",
+                5,
+                "reportAttributeAccessIssue",
+                'Cannot access attribute "bar" for class "Foo"',
             ),
         ]
 

--- a/scripts/primer_classifier/test_helpers.py
+++ b/scripts/primer_classifier/test_helpers.py
@@ -259,7 +259,9 @@ def build_gt_protocol_subtyping_scenario() -> ClassificationResult:
             pr_attribution="Change in calculate_abstract_members() in class_metadata.rs "
             "switched from fields() to class_body_fields(), excluding synthesized fields",
             categories=[
-                CategoryVerdict("bad-override", "regression", "Protocol subtyping false positives"),
+                CategoryVerdict(
+                    "bad-override", "regression", "Protocol subtyping false positives"
+                ),
             ],
         ),
         Classification(
@@ -272,7 +274,9 @@ def build_gt_protocol_subtyping_scenario() -> ClassificationResult:
             method="llm",
             pr_attribution="Same calculate_abstract_members() change in class_metadata.rs",
             categories=[
-                CategoryVerdict("bad-override", "regression", "Protocol subtyping false positives"),
+                CategoryVerdict(
+                    "bad-override", "regression", "Protocol subtyping false positives"
+                ),
             ],
         ),
         Classification(
@@ -285,7 +289,9 @@ def build_gt_protocol_subtyping_scenario() -> ClassificationResult:
             method="llm",
             pr_attribution="calculate_abstract_members() in class_metadata.rs",
             categories=[
-                CategoryVerdict("bad-override", "regression", "Protocol subtyping false positives"),
+                CategoryVerdict(
+                    "bad-override", "regression", "Protocol subtyping false positives"
+                ),
             ],
         ),
         Classification(
@@ -297,7 +303,9 @@ def build_gt_protocol_subtyping_scenario() -> ClassificationResult:
             method="llm",
             pr_attribution="calculate_abstract_members() in class_metadata.rs",
             categories=[
-                CategoryVerdict("bad-override", "regression", "Protocol subtyping false positives"),
+                CategoryVerdict(
+                    "bad-override", "regression", "Protocol subtyping false positives"
+                ),
             ],
         ),
         Classification(
@@ -310,7 +318,11 @@ def build_gt_protocol_subtyping_scenario() -> ClassificationResult:
             method="llm",
             pr_attribution="Improved protocol handling resolved previously unresolved types",
             categories=[
-                CategoryVerdict("reveal-type", "improvement", "Type inference improved from @_ to concrete"),
+                CategoryVerdict(
+                    "reveal-type",
+                    "improvement",
+                    "Type inference improved from @_ to concrete",
+                ),
             ],
         ),
     ]
@@ -366,7 +378,9 @@ def build_gt_type_checking_scenario() -> ClassificationResult:
             pr_attribution="check_for_imported_final_reassignment() in bindings.rs "
             "does not exempt feature-detection patterns in try/except blocks",
             categories=[
-                CategoryVerdict("bad-assignment", "regression", "Final reassignment false positive"),
+                CategoryVerdict(
+                    "bad-assignment", "regression", "Final reassignment false positive"
+                ),
             ],
         ),
         Classification(
@@ -380,7 +394,9 @@ def build_gt_type_checking_scenario() -> ClassificationResult:
             pr_attribution="check_for_imported_final_reassignment() in bindings.rs "
             "does not exempt TYPE_CHECKING reassignment",
             categories=[
-                CategoryVerdict("bad-assignment", "regression", "TYPE_CHECKING reassignment FP"),
+                CategoryVerdict(
+                    "bad-assignment", "regression", "TYPE_CHECKING reassignment FP"
+                ),
             ],
         ),
         Classification(
@@ -393,7 +409,9 @@ def build_gt_type_checking_scenario() -> ClassificationResult:
             method="llm",
             pr_attribution="check_for_imported_final_reassignment() in bindings.rs",
             categories=[
-                CategoryVerdict("bad-assignment", "regression", "TYPE_CHECKING reassignment FP"),
+                CategoryVerdict(
+                    "bad-assignment", "regression", "TYPE_CHECKING reassignment FP"
+                ),
             ],
         ),
         Classification(
@@ -406,7 +424,9 @@ def build_gt_type_checking_scenario() -> ClassificationResult:
             method="llm",
             pr_attribution="check_for_imported_final_reassignment() in bindings.rs",
             categories=[
-                CategoryVerdict("bad-assignment", "regression", "TYPE_CHECKING reassignment FP"),
+                CategoryVerdict(
+                    "bad-assignment", "regression", "TYPE_CHECKING reassignment FP"
+                ),
             ],
         ),
     ]
@@ -469,7 +489,9 @@ def build_gt_bad_override_args_scenario() -> ClassificationResult:
             pr_attribution="Stricter override checking in solver/subset.rs without "
             "*args: Any, **kwargs: Any escape hatch",
             categories=[
-                CategoryVerdict("bad-override", "regression", "*args/**kwargs override FP"),
+                CategoryVerdict(
+                    "bad-override", "regression", "*args/**kwargs override FP"
+                ),
             ],
         ),
         Classification(
@@ -481,7 +503,9 @@ def build_gt_bad_override_args_scenario() -> ClassificationResult:
             method="llm",
             pr_attribution="solver/subset.rs override checking too strict",
             categories=[
-                CategoryVerdict("bad-override", "regression", "*args/**kwargs override FP"),
+                CategoryVerdict(
+                    "bad-override", "regression", "*args/**kwargs override FP"
+                ),
             ],
         ),
         Classification(
@@ -493,7 +517,9 @@ def build_gt_bad_override_args_scenario() -> ClassificationResult:
             method="llm",
             pr_attribution="solver/subset.rs override checking",
             categories=[
-                CategoryVerdict("bad-override", "regression", "*args/**kwargs override FP"),
+                CategoryVerdict(
+                    "bad-override", "regression", "*args/**kwargs override FP"
+                ),
             ],
         ),
     ]
@@ -539,7 +565,9 @@ def build_gt_pure_improvement_scenario() -> ClassificationResult:
             method="llm",
             pr_attribution="Protocol handling improvements resolved previously unresolved types",
             categories=[
-                CategoryVerdict("reveal-type", "improvement", "Type inference improved"),
+                CategoryVerdict(
+                    "reveal-type", "improvement", "Type inference improved"
+                ),
             ],
         ),
     ]

--- a/scripts/primer_classifier/test_llm_live.py
+++ b/scripts/primer_classifier/test_llm_live.py
@@ -21,8 +21,8 @@ from .test_helpers import (
     GT_BAD_OVERRIDE_ARGS_DIFF,
     GT_PROTOCOL_SUBTYPING_DIFF,
     GT_TYPE_CHECKING_DIFF,
-    VARIANCE_DIFF,
     TYPE_CHECKING_DIFF,
+    VARIANCE_DIFF,
     assert_actionable,
     build_all_improvements_scenario,
     build_gt_all_neutral_scenario,
@@ -30,10 +30,9 @@ from .test_helpers import (
     build_gt_protocol_subtyping_scenario,
     build_gt_pure_improvement_scenario,
     build_gt_type_checking_scenario,
-    build_variance_scenario,
     build_type_checking_scenario,
+    build_variance_scenario,
 )
-
 
 # ---------------------------------------------------------------------------
 # Live LLM suggestion quality tests (Pass 3)
@@ -58,9 +57,9 @@ class TestSuggestionQualityLive:
         assert "protocol" in text.lower(), f"Expected 'protocol', got: {text}"
         # Should reference the actual file from the diff
         all_files = [f for s in suggestion.suggestions for f in s.files]
-        assert any(
-            "variance" in f for f in all_files
-        ), f"Expected variance file reference, got: {all_files}"
+        assert any("variance" in f for f in all_files), (
+            f"Expected variance file reference, got: {all_files}"
+        )
 
     def test_type_checking_exempt_live(self):
         result = build_type_checking_scenario()
@@ -70,14 +69,14 @@ class TestSuggestionQualityLive:
         text = " ".join(
             s.description + " " + s.reasoning for s in suggestion.suggestions
         )
-        assert any(
-            kw in text.lower() for kw in ["type_checking", "exempt", "final"]
-        ), f"Expected TYPE_CHECKING/exempt/final, got: {text}"
+        assert any(kw in text.lower() for kw in ["type_checking", "exempt", "final"]), (
+            f"Expected TYPE_CHECKING/exempt/final, got: {text}"
+        )
         # Should reference the actual file from the diff
         all_files = [f for s in suggestion.suggestions for f in s.files]
-        assert any(
-            "stmt" in f or "binding" in f for f in all_files
-        ), f"Expected stmt/binding file reference, got: {all_files}"
+        assert any("stmt" in f or "binding" in f for f in all_files), (
+            f"Expected stmt/binding file reference, got: {all_files}"
+        )
 
     def test_no_regressions_skips_live(self):
         result = build_all_improvements_scenario()
@@ -109,12 +108,17 @@ class TestGroundTruthLive:
         )
         assert any(
             kw in text.lower()
-            for kw in ["calculate_abstract_members", "class_metadata", "synthesized", "class_body_fields"]
+            for kw in [
+                "calculate_abstract_members",
+                "class_metadata",
+                "synthesized",
+                "class_body_fields",
+            ]
         ), f"Expected function/file reference, got: {text}"
         all_files = [f for s in suggestion.suggestions for f in s.files]
-        assert any(
-            "class_metadata" in f for f in all_files
-        ), f"Expected class_metadata file reference, got: {all_files}"
+        assert any("class_metadata" in f for f in all_files), (
+            f"Expected class_metadata file reference, got: {all_files}"
+        )
         # Actionability check on first suggestion
         assert_actionable(suggestion.suggestions[0])
 
@@ -129,12 +133,16 @@ class TestGroundTruthLive:
         )
         assert any(
             kw in text.lower()
-            for kw in ["check_for_imported_final_reassignment", "bindings", "type_checking"]
+            for kw in [
+                "check_for_imported_final_reassignment",
+                "bindings",
+                "type_checking",
+            ]
         ), f"Expected function/file reference, got: {text}"
         all_files = [f for s in suggestion.suggestions for f in s.files]
-        assert any(
-            "bindings" in f for f in all_files
-        ), f"Expected bindings file reference, got: {all_files}"
+        assert any("bindings" in f for f in all_files), (
+            f"Expected bindings file reference, got: {all_files}"
+        )
         # Check affected projects
         all_projects = [p for s in suggestion.suggestions for p in s.affected_projects]
         for proj in ["urllib3", "trio", "zulip", "ibis"]:
@@ -153,10 +161,9 @@ class TestGroundTruthLive:
         text = " ".join(
             s.description + " " + s.reasoning for s in suggestion.suggestions
         )
-        assert any(
-            kw in text.lower()
-            for kw in ["subset", "args", "kwargs", "any"]
-        ), f"Expected override/args reference, got: {text}"
+        assert any(kw in text.lower() for kw in ["subset", "args", "kwargs", "any"]), (
+            f"Expected override/args reference, got: {text}"
+        )
         assert_actionable(suggestion.suggestions[0])
 
     def test_scenario_d_pure_improvement_skips_live(self):

--- a/scripts/test_setup_primer_deps.py
+++ b/scripts/test_setup_primer_deps.py
@@ -16,7 +16,6 @@ import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from setup_primer_deps import main
 
 
@@ -40,7 +39,9 @@ class TestMain:
     @patch("setup_primer_deps.os.path.exists", return_value=False)
     @patch("setup_primer_deps.setup_project")
     @patch("setup_primer_deps.get_mypy_primer_projects")
-    def test_known_project_no_venv(self, mock_projects, mock_setup, mock_exists, capsys):
+    def test_known_project_no_venv(
+        self, mock_projects, mock_setup, mock_exists, capsys
+    ):
         """Known project but no venv created — should succeed without printing paths."""
         project = MagicMock()
         project.name = "testproj"
@@ -71,7 +72,8 @@ class TestMain:
         mock_projects.return_value = [project]
 
         mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0,
+            args=[],
+            returncode=0,
             stdout="--site-package-path=/path/to/site-packages\n",
         )
 
@@ -95,7 +97,9 @@ class TestMain:
         mock_projects.return_value = [project]
 
         mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=1, stdout="",
+            args=[],
+            returncode=1,
+            stdout="",
         )
 
         with patch.object(sys, "argv", ["setup_primer_deps.py", "testproj"]):

--- a/scripts/version_helpers.py
+++ b/scripts/version_helpers.py
@@ -27,7 +27,6 @@ import argparse
 import re
 import sys
 
-
 _SEMVER_RE: re.Pattern[str] = re.compile(
     r"^(\d+)\.(\d+)\.(\d+)(?:-dev\.(\d+))?$",
 )

--- a/tensor-shapes/bootstrap_venv.py
+++ b/tensor-shapes/bootstrap_venv.py
@@ -28,7 +28,6 @@ from pathlib import Path
 
 from shape_testing import DEFAULT_VENV, TENSOR_SHAPES_ROOT
 
-
 PYTHON_VERSION = "3.12"
 REQUIREMENTS: Path = TENSOR_SHAPES_ROOT / "test-requirements.txt"
 

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/__init__.pyi
@@ -5,4 +5,5 @@
 
 from jax._array import Array as Array
 
-from . import nn as nn, numpy as numpy
+from . import nn as nn
+from . import numpy as numpy

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_array.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_array.pyi
@@ -7,11 +7,11 @@
 # `jax.numpy` can refer to it without importing its own parent package. Real
 # JAX splits it out for the same reason, as `jax._src.basearray`.
 
-from typing import Any, overload, Sequence
+from typing import Any, Sequence, overload
 
 import shape_extensions
 from jax._shapes import permute_shape, reduce_shape, reshape_shape, reverse_shape
-from shape_extensions import broadcast, Flag, IntTuple, IntVar
+from shape_extensions import Flag, IntTuple, IntVar, broadcast
 
 type _Shape = IntTuple
 type _AnyShape = tuple[Any, ...]

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/nn/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/nn/__init__.pyi
@@ -3,10 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, overload, Sequence
+from typing import Any, Sequence, overload
 
 from jax._array import Array
-from shape_extensions import broadcast, IntTuple
+from shape_extensions import IntTuple, broadcast
 
 type _Shape = IntTuple
 

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
@@ -3,9 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, overload, Sequence
+from typing import Any, Sequence, overload
 
-from jax._array import Array as Array, Array as ndarray
+from jax._array import Array as Array
+from jax._array import Array as ndarray
 from jax._shapes import (
     matmul_shape,
     permute_shape,
@@ -13,7 +14,7 @@ from jax._shapes import (
     reshape_shape,
     reverse_shape,
 )
-from shape_extensions import broadcast, Flag, Int, IntTuple, IntVar
+from shape_extensions import Flag, Int, IntTuple, IntVar, broadcast
 
 from . import fft as fft
 

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/fft/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/fft/__init__.pyi
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, overload, Sequence
+from typing import Any, Sequence, overload
 
 from jax._array import Array
 from jax._shapes import (

--- a/tensor-shapes/pyrefly-jax-stubs/run_pyrefly.py
+++ b/tensor-shapes/pyrefly-jax-stubs/run_pyrefly.py
@@ -12,12 +12,10 @@ import argparse
 import sys
 from pathlib import Path
 
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from shape_testing import check_suites, pyrefly_command  # noqa: E402
 from suites import SUITES  # noqa: E402
-
 
 PACKAGE_ROOT: Path = Path(__file__).resolve().parent
 

--- a/tensor-shapes/pyrefly-jax-stubs/run_runtime_tests.py
+++ b/tensor-shapes/pyrefly-jax-stubs/run_runtime_tests.py
@@ -16,12 +16,10 @@ import argparse
 import sys
 from pathlib import Path
 
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from shape_testing import run_suites  # noqa: E402
 from suites import SUITES  # noqa: E402
-
 
 PACKAGE_ROOT: Path = Path(__file__).resolve().parent
 

--- a/tensor-shapes/pyrefly-jax-stubs/suites.py
+++ b/tensor-shapes/pyrefly-jax-stubs/suites.py
@@ -8,11 +8,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from shape_testing import Suite  # noqa: E402
-
 
 _PACKAGE_ROOT: Path = Path(__file__).resolve().parent
 

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_creation.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_creation.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import jax.numpy as jnp
 from shape_extensions import assert_shape
 
-
 # A multi-argument `arange` has a length the DSL cannot compute, and a shape
 # outside the exact ranks is gradual, so `assert_shape` cannot be used for
 # either. See `arange` and the constructors in `jax/numpy/__init__.pyi`.

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_fft.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_fft.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
-from shape_extensions import assert_shape, IntTuple
+from shape_extensions import IntTuple, assert_shape
 
 
 def generic_fft_preserves_shape[Shape: IntTuple](

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_matmul.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_matmul.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
-from shape_extensions import assert_shape, IntVar
-
+from shape_extensions import IntVar, assert_shape
 
 N = IntVar("N")
 M = IntVar("M")

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_nn.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_nn.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 import jax
 import jax.nn as jnn
 import jax.numpy as jnp
-from shape_extensions import assert_shape, IntVar
-
+from shape_extensions import IntVar, assert_shape
 
 N = IntVar("N")
 M = IntVar("M")

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_reductions.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_reductions.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
-from shape_extensions import assert_shape, IntVar
-
+from shape_extensions import IntVar, assert_shape
 
 N = IntVar("N")
 M = IntVar("M")

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_reshape.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_reshape.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
-from shape_extensions import assert_shape, IntVar
-
+from shape_extensions import IntVar, assert_shape
 
 N = IntVar("N")
 M = IntVar("M")

--- a/tensor-shapes/pyrefly-numpy-stubs/examples/physical_science.py
+++ b/tensor-shapes/pyrefly-numpy-stubs/examples/physical_science.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
-from shape_extensions import assert_shape, Int, IntVar
+from shape_extensions import Int, IntVar, assert_shape
 
 N = IntVar("N")
 D = IntVar("D")

--- a/tensor-shapes/pyrefly-numpy-stubs/examples/stats.py
+++ b/tensor-shapes/pyrefly-numpy-stubs/examples/stats.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
-from shape_extensions import assert_shape, IntVar
+from shape_extensions import IntVar, assert_shape
 
 N = IntVar("N")
 P = IntVar("P")

--- a/tensor-shapes/pyrefly-numpy-stubs/numpy-stubs/__init__.pyi
+++ b/tensor-shapes/pyrefly-numpy-stubs/numpy-stubs/__init__.pyi
@@ -7,9 +7,10 @@ from typing import Any, Literal, overload
 
 import shape_extensions
 from numpy._shapes import diag_extent, matmul_shape, reduce_shape
-from shape_extensions import broadcast, Flag, Int, IntTuple, IntVar
+from shape_extensions import Flag, Int, IntTuple, IntVar, broadcast
 
-from . import linalg as linalg, random as random
+from . import linalg as linalg
+from . import random as random
 
 type _Shape = IntTuple
 type _AnyShape = tuple[Any, ...]

--- a/tensor-shapes/pyrefly-numpy-stubs/run_pyrefly.py
+++ b/tensor-shapes/pyrefly-numpy-stubs/run_pyrefly.py
@@ -12,12 +12,10 @@ import argparse
 import sys
 from pathlib import Path
 
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from shape_testing import check_suites, pyrefly_command  # noqa: E402
 from suites import SUITES  # noqa: E402
-
 
 PACKAGE_ROOT: Path = Path(__file__).resolve().parent
 

--- a/tensor-shapes/pyrefly-numpy-stubs/run_runtime_tests.py
+++ b/tensor-shapes/pyrefly-numpy-stubs/run_runtime_tests.py
@@ -16,12 +16,10 @@ import argparse
 import sys
 from pathlib import Path
 
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from shape_testing import run_suites  # noqa: E402
 from suites import SUITES  # noqa: E402
-
 
 PACKAGE_ROOT: Path = Path(__file__).resolve().parent
 

--- a/tensor-shapes/pyrefly-numpy-stubs/suites.py
+++ b/tensor-shapes/pyrefly-numpy-stubs/suites.py
@@ -8,11 +8,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from shape_testing import Suite  # noqa: E402
-
 
 _PACKAGE_ROOT: Path = Path(__file__).resolve().parent
 

--- a/tensor-shapes/pyrefly-numpy-stubs/test/test_creation_basics.py
+++ b/tensor-shapes/pyrefly-numpy-stubs/test/test_creation_basics.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Any, assert_type
 
 import numpy as np
-from shape_extensions import assert_shape, IntVar
+from shape_extensions import IntVar, assert_shape
 
 GRADUAL_SHAPE_RUNTIME_TESTS = {
     "test_diag_dtype_and_broad_offset",

--- a/tensor-shapes/pyrefly-numpy-stubs/test/test_linalg.py
+++ b/tensor-shapes/pyrefly-numpy-stubs/test/test_linalg.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import assert_type
 
 import numpy as np
-from shape_extensions import assert_shape, Int, IntTuple, IntVar
+from shape_extensions import Int, IntTuple, IntVar, assert_shape
 
 N = IntVar("N")
 M = IntVar("M")

--- a/tensor-shapes/pyrefly-numpy-stubs/test/test_math_ufuncs.py
+++ b/tensor-shapes/pyrefly-numpy-stubs/test/test_math_ufuncs.py
@@ -5,10 +5,10 @@
 
 from __future__ import annotations
 
-from typing import Any, assert_type, cast, Literal
+from typing import Any, Literal, assert_type, cast
 
 import numpy as np
-from shape_extensions import assert_shape, IntTuple
+from shape_extensions import IntTuple, assert_shape
 
 GRADUAL_SHAPE_RUNTIME_TESTS = {
     "test_binary_ufuncs_fall_back_for_unknown_shapes",

--- a/tensor-shapes/pyrefly-numpy-stubs/test/test_reductions.py
+++ b/tensor-shapes/pyrefly-numpy-stubs/test/test_reductions.py
@@ -5,10 +5,10 @@
 
 from __future__ import annotations
 
-from typing import Any, assert_type, cast, Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal, assert_type, cast
 
 import numpy as np
-from shape_extensions import assert_shape, Int, IntTuple, IntVar
+from shape_extensions import Int, IntTuple, IntVar, assert_shape
 
 
 def make_array(shape: Any) -> Any:

--- a/tensor-shapes/pyrefly-shape-extensions/shape_extensions/dsl.py
+++ b/tensor-shapes/pyrefly-shape-extensions/shape_extensions/dsl.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 
 import typing
 
-from . import Int as _IntSchema, IntTuple as _IntTupleSchema
+from . import Int as _IntSchema
+from . import IntTuple as _IntTupleSchema
 
 
 def shape_dsl_function(fn: typing.Callable) -> typing.Callable:

--- a/tensor-shapes/pyrefly-shape-extensions/shape_extensions/torchscript.py
+++ b/tensor-shapes/pyrefly-shape-extensions/shape_extensions/torchscript.py
@@ -28,7 +28,9 @@ import ast
 import textwrap
 
 from . import *  # noqa: F401, F403
-from . import __all__ as _shape_extensions_all, _return_int, Int as _Int
+from . import Int as _Int
+from . import __all__ as _shape_extensions_all
+from . import _return_int
 
 __all__ = [*_shape_extensions_all, "remove_shape_types_from_torch_sources"]
 

--- a/tensor-shapes/pyrefly-torch-stubs/examples/apg.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/apg.py
@@ -21,7 +21,7 @@
 # - [x] APGBackbone.output_dim (property)
 # - [x] APGBackbone.forward
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/background_matting.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/background_matting.py
@@ -42,7 +42,7 @@ Key patterns exercised:
   NLayerDiscriminator. Included as factories for completeness.
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/bert.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/bert.py
@@ -11,7 +11,7 @@ Original: pytorch/benchmark/torchbenchmark/models/BERT_pytorch/bert_pytorch/mode
 
 import math
 from collections.abc import Callable
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/dcgan.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/dcgan.py
@@ -9,7 +9,7 @@ DCGAN from TorchBenchmark with shape annotations.
 Original: pytorch/benchmark/torchbenchmark/models/dcgan/__init__.py
 """
 
-from typing import Any, assert_type, Final, overload, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Final, assert_type, overload
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/deeprecommender.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/deeprecommender.py
@@ -35,7 +35,7 @@ Key patterns exercised:
 - Masked loss computation on sparse data
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/demucs.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/demucs.py
@@ -37,7 +37,7 @@ Now ported (previously omitted):
 - center_trim: symbolic slice bounds from .size() diffs, returns Tensor[[B, C, R]]
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/densenet.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/densenet.py
@@ -25,7 +25,7 @@ Port notes:
     num_layers=[6,6,6,6], num_classes=10) since channel arithmetic is dynamic
 """
 
-from typing import Any, assert_type, overload, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type, overload
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/dlrm.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/dlrm.py
@@ -48,7 +48,7 @@ Key patterns exercised:
 - Quantized embeddings for memory-efficient inference
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/drq.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/drq.py
@@ -39,7 +39,7 @@ Key patterns exercised:
 """
 
 import math
-from typing import Any, assert_type, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type, cast
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/finalmlp.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/finalmlp.py
@@ -11,6 +11,7 @@
 # This adaptation adds tensor shape type annotations for pyrefly.
 
 from dataclasses import dataclass, field
+
 # ## Inventory
 # - [x] FinalMLPConfig — dataclass; Dims: mlp1_output_dim, mlp2_output_dim, num_heads, num_output_features; int: num_layers
 # - [x] MLP.__init__ — Dims: input_dim, output_dim; int: hidden_units (list)
@@ -22,8 +23,7 @@ from dataclasses import dataclass, field
 # - [x] FinalMLPBackbone.__init__ — Dims: num_features, emb_dim; config provides rest
 # - [x] FinalMLPBackbone.output_dim — property
 # - [x] FinalMLPBackbone.forward
-
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/gptfast.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/gptfast.py
@@ -5,18 +5,17 @@
 
 import math
 from dataclasses import dataclass
-from typing import Any, assert_type, TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict, assert_type
 
 import torch
 import torch.nn as nn
 from shape_extensions import Elements, IntTuple
 from torch.nn import functional as F
 from torch.nn.attention.flex_attention import (
-    _mask_mod_signature,
     BlockMask,
+    _mask_mod_signature,
     flex_attention,
 )
-
 
 if TYPE_CHECKING:
     from shape_extensions import Int, IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/examples/learning_to_paint.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/learning_to_paint.py
@@ -23,7 +23,7 @@ Port notes:
   torch.sigmoid and scalar __rsub__ are shape-preserving and work correctly
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/llama.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/llama.py
@@ -41,7 +41,7 @@ Key patterns exercised:
 
 import math
 from dataclasses import dataclass
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/masknet.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/masknet.py
@@ -26,7 +26,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/mixtral_moe.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/mixtral_moe.py
@@ -31,7 +31,7 @@
 # - [x] apply_rotary_emb — standalone function
 
 from dataclasses import dataclass
-from typing import Any, assert_type, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type, cast
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/mobilenetv2.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/mobilenetv2.py
@@ -18,7 +18,7 @@
 # - [x] MobileNetV2._forward_impl
 # - [x] MobileNetV2.forward
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/nanogpt.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/nanogpt.py
@@ -15,7 +15,7 @@ https://github.com/huggingface/transformers/blob/main/src/transformers/models/gp
 import inspect
 import math
 from dataclasses import dataclass
-from typing import Any, assert_type, TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/openpose.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/openpose.py
@@ -18,7 +18,7 @@
 # - [x] handpose_model.forward
 
 from collections import OrderedDict
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/resnet.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/resnet.py
@@ -9,7 +9,7 @@ Phlippe ResNet from TorchBenchmark with shape annotations.
 Original: pytorch/benchmark/torchbenchmark/models/phlippe_resnet/__init__.py
 """
 
-from typing import Any, assert_type, overload, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type, overload
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/runtime/gptfast_future_annotations.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/runtime/gptfast_future_annotations.py
@@ -10,18 +10,17 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import Any, assert_type, Optional, TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, Optional, TypedDict, assert_type
 
 import torch
 import torch.nn as nn
 from shape_extensions import Elements, IntTuple
 from torch.nn import functional as F
 from torch.nn.attention.flex_attention import (
-    _mask_mod_signature,
     BlockMask,
+    _mask_mod_signature,
     flex_attention,
 )
-
 
 if TYPE_CHECKING:
     from shape_extensions import Int, IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/examples/runtime/gptfast_future_annotations_runnable.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/runtime/gptfast_future_annotations_runnable.py
@@ -14,18 +14,17 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import Any, Optional, TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, Optional, TypedDict
 
 import torch
 import torch.nn as nn
 from shape_extensions import Elements, IntTuple
 from torch.nn import functional as F
 from torch.nn.attention.flex_attention import (
-    _mask_mod_signature,
     BlockMask,
+    _mask_mod_signature,
     flex_attention,
 )
-
 
 if TYPE_CHECKING:
     from shape_extensions import Int, IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/examples/runtime/gptfast_sym_int_var.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/runtime/gptfast_sym_int_var.py
@@ -14,24 +14,23 @@ syntax, providing runtime-safe type variable declarations that support arithmeti
 import math
 from dataclasses import dataclass
 from typing import (
+    TYPE_CHECKING,
     Any,
-    assert_type,
     Generic,
     Optional,
-    TYPE_CHECKING,
     TypedDict,
     TypeVar,
+    assert_type,
 )
 
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
 from torch.nn.attention.flex_attention import (
-    _mask_mod_signature,
     BlockMask,
+    _mask_mod_signature,
     flex_attention,
 )
-
 
 if TYPE_CHECKING:
     from shape_extensions import Elements, Int, IntTuple, IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/examples/runtime/gptfast_sym_int_var_runnable.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/runtime/gptfast_sym_int_var_runnable.py
@@ -21,8 +21,8 @@ from shape_extensions import Elements, Int, IntTuple, IntVar
 from torch import Tensor
 from torch.nn import functional as F
 from torch.nn.attention.flex_attention import (
-    _mask_mod_signature,
     BlockMask,
+    _mask_mod_signature,
     flex_attention,
 )
 

--- a/tensor-shapes/pyrefly-torch-stubs/examples/runtime/nanogpt_future_annotations.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/runtime/nanogpt_future_annotations.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import inspect
 import math
 from dataclasses import dataclass
-from typing import Any, assert_type, TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/runtime/nanogpt_future_annotations_runnable.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/runtime/nanogpt_future_annotations_runnable.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import inspect
 import math
 from dataclasses import dataclass
-from typing import Any, TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/runtime/nanogpt_sym_int_var.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/runtime/nanogpt_sym_int_var.py
@@ -18,7 +18,7 @@ syntax, providing runtime-safe type variable declarations that support arithmeti
 import inspect
 import math
 from dataclasses import dataclass
-from typing import Any, assert_type, Generic, TYPE_CHECKING, TypedDict, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypedDict, TypeVar, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/sam.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/sam.py
@@ -54,7 +54,7 @@ Key patterns exercised:
 """
 
 import math
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/soft_actor_critic.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/soft_actor_critic.py
@@ -27,7 +27,7 @@ Port notes:
 """
 
 import math
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/speech_transformer.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/speech_transformer.py
@@ -31,7 +31,7 @@ Port notes:
 - np.power(d_k, 0.5) replaced with d_k ** 0.5 (no numpy dependency)
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/squeezenet.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/squeezenet.py
@@ -16,7 +16,7 @@ cannot be validated, so each pool recovers gradually rather than nesting a
 ceil correction per stage; the classifier restores the exact output shape.
 """
 
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/stargan.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/stargan.py
@@ -34,7 +34,7 @@ Key patterns exercised:
 - Dual-head discriminator: patch source + domain classifier
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/super_slomo.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/super_slomo.py
@@ -24,7 +24,7 @@ Port notes:
     negation, permute all work; tensor-as-index (t[ind]) returns shapeless Tensor
 """
 
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/tacotron2.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/tacotron2.py
@@ -38,7 +38,7 @@ Key patterns exercised:
 - ConvNorm / LinearNorm wrapper classes
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/tts_angular.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/tts_angular.py
@@ -47,7 +47,7 @@ Key patterns exercised:
 - Sliding window embedding extraction for inference
 """
 
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/unet.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/unet.py
@@ -18,7 +18,7 @@ Port notes:
     clear type signature; the original uses a runtime bilinear flag
 """
 
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/examples/wavernn.py
+++ b/tensor-shapes/pyrefly-torch-stubs/examples/wavernn.py
@@ -22,7 +22,7 @@
 # - [x] WaveRNN.infer
 
 import math
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/run_pyrefly.py
+++ b/tensor-shapes/pyrefly-torch-stubs/run_pyrefly.py
@@ -12,12 +12,10 @@ import argparse
 import sys
 from pathlib import Path
 
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from shape_testing import check_suites, pyrefly_command  # noqa: E402
 from suites import SUITES  # noqa: E402
-
 
 PACKAGE_ROOT: Path = Path(__file__).resolve().parent
 

--- a/tensor-shapes/pyrefly-torch-stubs/run_runtime_tests.py
+++ b/tensor-shapes/pyrefly-torch-stubs/run_runtime_tests.py
@@ -10,7 +10,6 @@ import sys
 import unittest
 from pathlib import Path
 
-
 SUITES = {
     "annotation": [
         "test_annotation_runtime.py",

--- a/tensor-shapes/pyrefly-torch-stubs/suites.py
+++ b/tensor-shapes/pyrefly-torch-stubs/suites.py
@@ -8,11 +8,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from shape_testing import Suite  # noqa: E402
-
 
 _JAXTYPING_FIXTURES: Path = (
     Path(__file__).resolve().parent / "test" / "jaxtyping" / "fixtures"

--- a/tensor-shapes/pyrefly-torch-stubs/test/jaxtyping/fixtures/jaxtyping/__init__.pyi
+++ b/tensor-shapes/pyrefly-torch-stubs/test/jaxtyping/fixtures/jaxtyping/__init__.pyi
@@ -9,28 +9,76 @@
 
 from typing import (
     Annotated as BFloat16,
+)
+from typing import (
     Annotated as Bool,
+)
+from typing import (
     Annotated as Complex,
-    Annotated as Complex128,
+)
+from typing import (
     Annotated as Complex64,
+)
+from typing import (
+    Annotated as Complex128,
+)
+from typing import (
     Annotated as Float,
+)
+from typing import (
     Annotated as Float16,
+)
+from typing import (
     Annotated as Float32,
+)
+from typing import (
     Annotated as Float64,
+)
+from typing import (
     Annotated as Inexact,
+)
+from typing import (
     Annotated as Int,
-    Annotated as Int16,
-    Annotated as Int32,
-    Annotated as Int64,
+)
+from typing import (
     Annotated as Int8,
+)
+from typing import (
+    Annotated as Int16,
+)
+from typing import (
+    Annotated as Int32,
+)
+from typing import (
+    Annotated as Int64,
+)
+from typing import (
     Annotated as Integer,
+)
+from typing import (
     Annotated as Key,
+)
+from typing import (
     Annotated as Num,
+)
+from typing import (
     Annotated as Real,
+)
+from typing import (
     Annotated as Shaped,
+)
+from typing import (
     Annotated as UInt,
-    Annotated as UInt16,
-    Annotated as UInt32,
-    Annotated as UInt64,
+)
+from typing import (
     Annotated as UInt8,
+)
+from typing import (
+    Annotated as UInt16,
+)
+from typing import (
+    Annotated as UInt32,
+)
+from typing import (
+    Annotated as UInt64,
 )

--- a/tensor-shapes/pyrefly-torch-stubs/test/jaxtyping/test_ops.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/jaxtyping/test_ops.py
@@ -18,7 +18,6 @@ import torch
 from jaxtyping import Float, Shaped
 from torch import Tensor
 
-
 # --- Matmul (meta-shape op) ---
 
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/jaxtyping/test_syntax.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/jaxtyping/test_syntax.py
@@ -12,7 +12,6 @@ arithmetic (dim+1, n-1), parenthesized arithmetic, scalar, leading space.
 from jaxtyping import Shaped
 from torch import Tensor
 
-
 # --- Anonymous dim: _ ---
 
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_check_symbolic_binding.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_check_symbolic_binding.py
@@ -5,7 +5,7 @@
 
 """Test what happens when we use wrong expected type"""
 
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_compare_generic_tensor.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_compare_generic_tensor.py
@@ -5,7 +5,7 @@
 
 """Compare regular generics vs Tensor+Dim generics"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_concat_flatten_types.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_concat_flatten_types.py
@@ -5,7 +5,7 @@
 
 """Test concat and flatten actual return types."""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_functional_pool_errors.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_functional_pool_errors.py
@@ -8,7 +8,6 @@ from typing import cast, reveal_type
 import torch.nn.functional as F
 from torch import Tensor
 
-
 rank_one = cast(Tensor[[8]], ...)
 rank_two = cast(Tensor[[3, 8]], ...)
 rank_three = cast(Tensor[[2, 3, 8]], ...)

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_int_any.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_int_any.py
@@ -9,7 +9,7 @@ This test documents that int literals can be assigned to Int types,
 including bare Int, Int[Any], or passed to functions with type parameters.
 """
 
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 from shape_extensions import IntVar
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_int_unification.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_int_unification.py
@@ -5,7 +5,7 @@
 
 """Test type variable unification in Int expressions"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_interpolate_errors.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_interpolate_errors.py
@@ -9,7 +9,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
-
 rank_two = cast(Tensor[[3, 8]], ...)
 rank_three = cast(Tensor[[2, 3, 8]], ...)
 rank_four = cast(Tensor[[2, 3, 8, 8]], ...)

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_invalid_int_bound_parameters.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_invalid_int_bound_parameters.py
@@ -12,7 +12,7 @@ bounded by exactly `Int` names a dimension. Anything else fails the bound check,
 and no shape ever comes back carrying the caller's unrelated type parameter.
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn.functional as F

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_literal_shape_check.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_literal_shape_check.py
@@ -5,7 +5,7 @@
 
 """Test if type checking works with literal tensor types"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_movedim.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_movedim.py
@@ -7,7 +7,6 @@ import torch
 from shape_extensions import Int, IntVar
 from torch import Tensor
 
-
 x: Tensor[[2, 3, 4]] = torch.randn(2, 3, 4)
 
 torch.moveaxis(x, 3, 0)  # E: source dimension out of range

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_tensor_arithmetic.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_tensor_arithmetic.py
@@ -5,7 +5,7 @@
 
 """Test tensor arithmetic shape behavior, including scalar preservation and broadcasting."""
 
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 from shape_extensions import Elements, IntTuple, IntVar
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_tensor_expr_equiv.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_tensor_expr_equiv.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 
 from shape_extensions import IntVar
 
-
 if TYPE_CHECKING:
     from torch import Tensor
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_tensor_generic_exprs.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_tensor_generic_exprs.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 
 from shape_extensions import IntVar
 
-
 if TYPE_CHECKING:
     from torch import Tensor
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_tensor_indexing.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_tensor_indexing.py
@@ -9,7 +9,7 @@ Integer indexing reduces dimensionality by 1.
 Slice indexing preserves rank: result dim = stop - start.
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import Elements, IntTuple, IntVar
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_tensor_subtyping.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_tensor_subtyping.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING
 
 from shape_extensions import IntVar
 
-
 if TYPE_CHECKING:
     from torch import Tensor
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_typevar_substitution_bug.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_typevar_substitution_bug.py
@@ -5,7 +5,7 @@
 
 """More detailed test of type variable substitution"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_view_errors.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_view_errors.py
@@ -5,7 +5,7 @@
 
 """Test view/reshape validation errors"""
 
-from typing import assert_type, reveal_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type, reveal_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/runtime_tests/test_annotation_runtime.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/runtime_tests/test_annotation_runtime.py
@@ -26,13 +26,13 @@ from typing import Generic, TypedDict
 
 import torch
 from shape_extensions import (
-    assert_shape,
     D,
-    defines_assert_shape,
     Int,
     IntTuple,
     IntVar,
     TypeVarTuple,
+    assert_shape,
+    defines_assert_shape,
 )
 
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/runtime_tests/test_annotation_runtime_future.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/runtime_tests/test_annotation_runtime_future.py
@@ -17,10 +17,10 @@ annotations when using PEP 695 TypeVar (shape_extensions.IntVar solves it differ
 from __future__ import annotations
 
 import unittest
-from typing import assert_type, Generic
+from typing import Generic, assert_type
 
 import torch
-from shape_extensions import assert_shape, Int, IntVar
+from shape_extensions import Int, IntVar, assert_shape
 
 
 class TestSubscriptRuntime(unittest.TestCase):

--- a/tensor-shapes/pyrefly-torch-stubs/test/runtime_tests/test_torchscript_stripper_runtime.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/runtime_tests/test_torchscript_stripper_runtime.py
@@ -10,7 +10,7 @@ import inspect
 import textwrap
 import typing
 import unittest
-from typing import assert_type, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, assert_type
 
 import shape_extensions.torchscript
 import torch

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_adaptive_pool_symbolic.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_adaptive_pool_symbolic.py
@@ -9,7 +9,7 @@ Adaptive pooling should support both literal and symbolic dimensions in output_s
 Previously only worked with literal tuples.
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_arange_zero.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_arange_zero.py
@@ -5,7 +5,7 @@
 
 """Test to understand bare Tensor type"""
 
-from typing import assert_type, reveal_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type, reveal_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_assert_type_tensor.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_assert_type_tensor.py
@@ -5,7 +5,7 @@
 
 """Test that assert_type works with Tensor types for automated type checking"""
 
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_bitwise_ops.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_bitwise_ops.py
@@ -5,10 +5,9 @@
 
 """Test bitwise operators on boolean and integer tensors"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
-
 
 if TYPE_CHECKING:
     from torch import Tensor

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_canonicalization.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_canonicalization.py
@@ -14,7 +14,7 @@ Each test documents:
 2. What types are structurally compatible (via assignment to expected type)
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_cat_inline.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_cat_inline.py
@@ -5,7 +5,7 @@
 
 """Test cat with inline tuple literal"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 if TYPE_CHECKING:
     import torch

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_class_generics_verify.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_class_generics_verify.py
@@ -8,7 +8,7 @@ Verify: Do class-level generics work properly?
 Testing user's claim that class generics DO propagate to methods
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_comparison_simple.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_comparison_simple.py
@@ -5,7 +5,7 @@
 
 """Test comparison operator shape preservation"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 if TYPE_CHECKING:
     from torch import Tensor

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_conv2d_tuple.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_conv2d_tuple.py
@@ -11,7 +11,7 @@ Scalar inputs continue to bind normally. This test verifies both paths work
 without errors.
 """
 
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_debug_div.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_debug_div.py
@@ -9,7 +9,7 @@ When a scalar expression evaluates to Any (e.g. 2**n where n is a non-literal
 int), it could also be an unknown-rank Tensor, so broadcasting is gradual.
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_dim_binding_debug.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_dim_binding_debug.py
@@ -5,7 +5,7 @@
 
 """Debug test for Dim-bounded type parameter binding to expressions"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_dim_comprehensive.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_dim_comprehensive.py
@@ -8,10 +8,9 @@
 This file tests the Int/Int type system independent of Tensor shapes.
 """
 
-from typing import Any, assert_type, Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal, assert_type
 
 from shape_extensions import IntVar
-
 
 if TYPE_CHECKING:
     from shape_extensions import Int

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_dropout.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_dropout.py
@@ -5,7 +5,7 @@
 
 """Test to understand bare Tensor type"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_dynamic_init.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_dynamic_init.py
@@ -10,7 +10,7 @@ Key question: How do runtime dimension values (passed to __init__)
 connect to generic type parameters?
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_fancy_indexing.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_fancy_indexing.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_gru.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_gru.py
@@ -9,7 +9,7 @@ GRU output shapes depend on input_size, hidden_size, num_layers, and
 bidirectional — all captured from __init__ and used in nn_gru_forward_ir.
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_indexing_typed.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_indexing_typed.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_int_bound_parameters.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_int_bound_parameters.py
@@ -12,7 +12,7 @@ no dimension to keep and lowers to the gradual size — widening only the extent
 that the argument feeds, never the rank or the untouched axes.
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn.functional as F

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_issue_03_direct_self_attr.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_issue_03_direct_self_attr.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_issue_04_tensor_ops.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_issue_04_tensor_ops.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_issue_05_single_arg_int.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_issue_05_single_arg_int.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_issue_06_complex_expressions.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_issue_06_complex_expressions.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_issue_08_tuple_slicing.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_issue_08_tuple_slicing.py
@@ -3,10 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
-
 
 if TYPE_CHECKING:
     from shape_extensions import Int

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_issue_08b_starred_unpack.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_issue_08b_starred_unpack.py
@@ -3,10 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
-
 
 if TYPE_CHECKING:
     from shape_extensions import Int

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_issue_09_ellipsis_indexing.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_issue_09_ellipsis_indexing.py
@@ -3,10 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
-
 
 if TYPE_CHECKING:
     from torch import Tensor

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_lazy_linear.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_lazy_linear.py
@@ -9,7 +9,7 @@ LazyLinear accepts any input features (in_features inferred at first forward)
 but preserves out_features in the output shape.
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_linear.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_linear.py
@@ -5,7 +5,7 @@
 
 """Test to understand bare Tensor type"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_linear_subscript.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_linear_subscript.py
@@ -5,7 +5,7 @@
 
 """Test what type C[3 * N] produces"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_literal_ints.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_literal_ints.py
@@ -5,7 +5,7 @@
 
 # Tests for literal int support in meta-shapes
 # Demonstrates: size() literal tracking, numel() literals, dim() literals
-from typing import assert_type, cast, Literal
+from typing import Literal, assert_type, cast
 
 import torch
 from shape_extensions import Elements, Int, IntTuple, IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_masked_fill.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_masked_fill.py
@@ -5,10 +5,9 @@
 
 """Test masked_fill broadcasting behavior"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
-
 
 if TYPE_CHECKING:
     from torch import Tensor

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_matmul_bug.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_matmul_bug.py
@@ -7,7 +7,7 @@
 Investigate @ operator bug with symbolic dimensions
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_matmul_method.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_matmul_method.py
@@ -5,7 +5,7 @@
 
 """Test if .matmul() method works vs @ operator"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_matmul_vs_at.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_matmul_vs_at.py
@@ -7,7 +7,7 @@
 Compare @ operator vs torch.matmul
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_meta_shape_basic.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_meta_shape_basic.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # Test meta-shape function integration
-from typing import Any, assert_type, Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal, assert_type
 
 import torch
 import torch.nn.functional as F

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_module_stubs.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_module_stubs.py
@@ -9,7 +9,7 @@ convolution, pooling, loss, and misc modules.
 """
 
 from collections.abc import Callable
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_moduledict_typeddict.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_moduledict_typeddict.py
@@ -12,7 +12,7 @@ This tests that ModuleDict[T: TypedDict] allows:
 3. Item access also returns the TypedDict field type: module_dict["key"] → FieldType
 """
 
-from typing import Any, assert_type, TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_modulelist.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_modulelist.py
@@ -5,7 +5,7 @@
 
 """Test to understand bare Tensor type"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
 from torch.nn import Module, ModuleList

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_negative_dim_annotation.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_negative_dim_annotation.py
@@ -3,10 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
-
 
 if TYPE_CHECKING:
     from torch import Tensor

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_negative_slice.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_negative_slice.py
@@ -5,10 +5,9 @@
 
 """Test slicing with negative indices"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
-
 
 if TYPE_CHECKING:
     from torch import Tensor

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_nested_modules.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_nested_modules.py
@@ -8,7 +8,7 @@ Test nested nn.Module patterns
 Critical for real PyTorch code organization
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_nn_module_callable.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_nn_module_callable.py
@@ -7,7 +7,7 @@
 Test that nn.Module instances are callable (automatically redirect to forward method).
 """
 
-from typing import assert_type, Protocol, TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_nn_module_proper.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_nn_module_proper.py
@@ -8,7 +8,7 @@ Test nn.Module with proper class-level generics
 This tests the USER'S correct pattern, not my buggy one!
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_nn_modules.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_nn_modules.py
@@ -17,7 +17,7 @@ Key Findings:
 Recommended Pattern: nn.Module subclasses with generic methods
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_overload_narrowing.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_overload_narrowing.py
@@ -7,7 +7,7 @@
 Test overload-based narrowing as an alternative to generic parameter narrowing.
 """
 
-from typing import assert_type, overload, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type, overload
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_parameter_list.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_parameter_list.py
@@ -5,7 +5,7 @@
 
 """Test nn.ParameterList generic typing."""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_parameter_with_unknown.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_parameter_with_unknown.py
@@ -5,7 +5,7 @@
 
 """Test nn.Parameter with unknown shapes"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_parameters_buffers.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_parameters_buffers.py
@@ -8,7 +8,7 @@ Test nn.Module parameters and buffers with typed shapes
 Critical for models with learnable weights
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_phase1_shape_ops.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_phase1_shape_ops.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # Phase 1.1: Missing shape operations tests
-from typing import Any, assert_type, Literal, reveal_type
+from typing import Any, Literal, assert_type, reveal_type
 
 import torch
 from shape_extensions import Int, IntTuple, IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_phase6_specialized.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_phase6_specialized.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # Phase 6: Specialized operations tests (FFT, Loss, Padding, Random, Properties)
-from typing import Any, assert_type, Literal
+from typing import Any, Literal, assert_type
 
 import torch
 import torch.fft

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_pool_shape_helper.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_pool_shape_helper.py
@@ -10,7 +10,7 @@ shared surface is pinned here through a local stub that matches the functional
 pooling surface.
 """
 
-from typing import assert_type, reveal_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type, reveal_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_recursive_skip.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_recursive_skip.py
@@ -16,7 +16,7 @@ C + i*K channels (avoids needing exponentials in the expression language).
 Keeps things 1D (just [B, C]) to focus on the recursion, not spatial dims.
 """
 
-from typing import assert_type, overload, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type, overload
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_register_buffer.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_register_buffer.py
@@ -10,7 +10,7 @@ This tests that when Buffer or Parameter are assigned in __init__,
 Pyrefly correctly tracks the instance attributes.
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_relu_identity.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_relu_identity.py
@@ -5,10 +5,9 @@
 
 """Test relu shape preservation - for testing IdentityMetaShape removal"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
-
 
 if TYPE_CHECKING:
     import torch

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_remaining_ops.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_remaining_ops.py
@@ -8,7 +8,7 @@ Test remaining ~35 operations with symbolic dimensions
 Covers FFT variants, loss functions, creation ops, indexing, and specialized operations
 """
 
-from typing import Any, assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type
 
 import torch
 import torch.fft

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_repeat_expand_symbolic.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_repeat_expand_symbolic.py
@@ -9,10 +9,9 @@ These operations must work with symbolic dimensions like Int[N] returned from x.
 Previously failed when iter_shape_dims() filtered out Type::Quantified dimensions.
 """
 
-from typing import assert_type, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type, cast
 
 from shape_extensions import Elements, IntTuple, IntVar
-
 
 if TYPE_CHECKING:
     from torch import Tensor

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_reshape_direct_carriers.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_reshape_direct_carriers.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections.abc import Sequence
-from typing import assert_type, reveal_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type, reveal_type
 
 import torch
 from shape_extensions import IntTuple

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_reshape_negative_one.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_reshape_negative_one.py
@@ -5,7 +5,7 @@
 
 """Test .reshape() with -1 for automatic dimension"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_scaled_dot_product_attention.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_scaled_dot_product_attention.py
@@ -5,7 +5,7 @@
 
 """Test scaled_dot_product_attention shape inference"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_self_callable.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_self_callable.py
@@ -10,7 +10,7 @@ This tests that when a method in an nn.Module subclass calls self(x),
 it properly redirects to self.forward(x) and type checks correctly.
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_sequential.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_sequential.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_sequential_modulelist.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_sequential_modulelist.py
@@ -10,7 +10,7 @@ Note: These containers may have limitations because they're type-erased
 (they hold generic Module objects, not specifically typed ones)
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_shape_property.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_shape_property.py
@@ -5,7 +5,7 @@
 
 """Test that .shape property returns literal dimensions like .size()"""
 
-from typing import assert_type, Literal
+from typing import Literal, assert_type
 
 import torch
 from torch import Tensor

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_shapeless_matmul.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_shapeless_matmul.py
@@ -5,7 +5,7 @@
 
 """Test matmul with mixed shaped and shapeless tensors"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_simple_at.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_simple_at.py
@@ -5,7 +5,7 @@
 
 """Simple test for @ operator"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_size_bare.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_size_bare.py
@@ -5,7 +5,7 @@
 
 """Check what size() returns for bare Tensor"""
 
-from typing import Any, assert_type, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, assert_type, cast
 
 from shape_extensions import Int, IntTuple
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_size_literal.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_size_literal.py
@@ -5,7 +5,7 @@
 
 """Test if size(-1) works with literal"""
 
-from typing import assert_type, Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, assert_type
 
 import torch
 from shape_extensions import IntTuple

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_slice_2d.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_slice_2d.py
@@ -5,7 +5,7 @@
 
 """Test that slicing a 2D tensor preserves dimensionality"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_slice_patterns.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_slice_patterns.py
@@ -5,10 +5,9 @@
 
 """Test different slicing patterns"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
-
 
 if TYPE_CHECKING:
     from torch import Tensor

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_slice_shapeless.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_slice_shapeless.py
@@ -5,7 +5,7 @@
 
 """Test to understand bare Tensor type"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 if TYPE_CHECKING:
     from torch import Tensor

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_split.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_split.py
@@ -5,7 +5,7 @@
 
 """Test to understand bare Tensor type"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 from shape_extensions import IntVar
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_sym_int_var.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_sym_int_var.py
@@ -13,7 +13,7 @@ This test verifies that:
 4. Shape arithmetic (N+1, N*2) works in annotations
 """
 
-from typing import assert_type, Generic, TYPE_CHECKING
+from typing import TYPE_CHECKING, Generic, assert_type
 
 from shape_extensions import Elements, IntTuple, IntVar
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_tensor_fancy_indexing.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_tensor_fancy_indexing.py
@@ -10,7 +10,7 @@ Pyrefly does not yet model the broadcast shape of multiple tensor indices.
 
 from __future__ import annotations
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_tensor_representation_consistency.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_tensor_representation_consistency.py
@@ -5,7 +5,7 @@
 
 """Test that bare Tensor and nn.Parameter(bare_tensor) have consistent representations"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_tensor_shape_property.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_tensor_shape_property.py
@@ -9,10 +9,9 @@ The .shape property on a shaped Tensor should return a tuple type
 where each element is Literal[n] for the corresponding dimension.
 """
 
-from typing import Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from shape_extensions import IntVar
-
 
 if TYPE_CHECKING:
     from shape_extensions import Int

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_topk_simple.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_topk_simple.py
@@ -5,7 +5,7 @@
 
 """Test topk with shaped tensor"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_tuple_indexing.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_tuple_indexing.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_tuple_vs_tensor_variadic.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_tuple_vs_tensor_variadic.py
@@ -5,7 +5,7 @@
 
 """Compare variadic tuple vs tensor behavior"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntTuple

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_variadic_broadcast.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_variadic_broadcast.py
@@ -10,7 +10,7 @@ broadcasting should degrade to shapeless batch dims rather than erroring.
 The concrete suffix dims should still be broadcast correctly.
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_variadic_function.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_variadic_function.py
@@ -5,7 +5,7 @@
 
 """Test variadic generic function type argument inference"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntTuple

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_variadic_size.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_variadic_size.py
@@ -5,7 +5,7 @@
 
 """Test that .size() works on tensors with variadic shapes"""
 
-from typing import assert_type, Literal
+from typing import Literal, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_variadic_tuple_subset.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_variadic_tuple_subset.py
@@ -19,7 +19,7 @@ Two fixes are tested:
 
 from __future__ import annotations
 
-from typing import assert_type, Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, assert_type
 
 import torch.nn as nn
 import torch.nn.functional as F

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_variadic_view.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_variadic_view.py
@@ -9,7 +9,7 @@ The view DSL computes prod(self.shape) for -1 inference. When the tensor has
 variadic batch dims (*Bs), it preserves the fixed target rank and known dimensions.
 """
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 import torch.nn as nn

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_view_comprehensive.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_view_comprehensive.py
@@ -5,7 +5,7 @@
 
 """Comprehensive test suite for .view()/.reshape() with symbolic dimensions"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_view_debug.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_view_debug.py
@@ -5,7 +5,7 @@
 
 """Debug .view() argument passing"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_view_negative_one.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_view_negative_one.py
@@ -5,7 +5,7 @@
 
 """Test .view() with -1 for automatic dimension"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_view_reshape.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_view_reshape.py
@@ -5,7 +5,7 @@
 
 """Test .view() and .reshape() with symbolic dimensions"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 from shape_extensions import IntVar

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_view_valid.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_view_valid.py
@@ -5,7 +5,7 @@
 
 """Test view with just -1"""
 
-from typing import assert_type, TYPE_CHECKING
+from typing import TYPE_CHECKING, assert_type
 
 import torch
 

--- a/tensor-shapes/pyrefly-torch-stubs/torch-stubs/__init__.pyi
+++ b/tensor-shapes/pyrefly-torch-stubs/torch-stubs/__init__.pyi
@@ -14,10 +14,10 @@ extend that legacy path.
 
 import builtins
 from collections.abc import Sequence
-from typing import Any, overload, Self, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Self, overload
 
 import shape_extensions
-from shape_extensions import broadcast, Elements, Flag, IntTuple, IntVar, uses_shape_dsl
+from shape_extensions import Elements, Flag, IntTuple, IntVar, broadcast, uses_shape_dsl
 
 # `Generator` is not defined anywhere in this package, and resolving it relies
 # on how a partial stub package is looked up. The `py.typed` file here contains

--- a/tensor-shapes/pyrefly-torch-stubs/torch-stubs/_shapes.pyi
+++ b/tensor-shapes/pyrefly-torch-stubs/torch-stubs/_shapes.pyi
@@ -7,13 +7,13 @@ import shape_extensions.dsl as dsl
 from shape_extensions import Int, IntTuple, type_shape_dsl_function
 from shape_extensions.dsl import (
     Error,
+    ShapedArray,
+    Unknown,
     parse_einsum_equation,
     prod,
     shape_dsl_function,
-    ShapedArray,
     sum,
     symint,
-    Unknown,
 )
 
 # TODO(stroxler): Use `IntTuple` slicing here once it preserves the symbolic-rank cases covered by

--- a/tensor-shapes/pyrefly-torch-stubs/torch-stubs/distributions/__init__.pyi
+++ b/tensor-shapes/pyrefly-torch-stubs/torch-stubs/distributions/__init__.pyi
@@ -22,9 +22,17 @@ from torch import Tensor
 # pyd.beta.Beta, pyd.categorical.Categorical, etc. access patterns
 from . import (
     beta as beta,
+)
+from . import (
     categorical as categorical,
+)
+from . import (
     constraints as constraints,
+)
+from . import (
     transformed_distribution as transformed_distribution,
+)
+from . import (
     transforms as transforms,
 )
 

--- a/tensor-shapes/pyrefly-torch-stubs/torch-stubs/nn/__init__.pyi
+++ b/tensor-shapes/pyrefly-torch-stubs/torch-stubs/nn/__init__.pyi
@@ -8,22 +8,23 @@ Type stubs for torch.nn module.
 """
 
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Generic,
     Iterable,
     Iterator,
-    overload,
     Self,
-    TYPE_CHECKING,
     TypedDict,
     TypeVar,
+    overload,
 )
 
 from shape_extensions import Elements, Flag, IntTuple, IntVar
 
 if TYPE_CHECKING:
-    from shape_extensions import Int as _Int, ProxyMethod, uses_shape_dsl
+    from shape_extensions import Int as _Int
+    from shape_extensions import ProxyMethod, uses_shape_dsl
     from torch import Tensor
     from torch._shapes import (
         flatten_shape,
@@ -38,7 +39,8 @@ if TYPE_CHECKING:
     )
 
 # Re-export submodules
-from . import functional as functional, init as init
+from . import functional as functional
+from . import init as init
 
 # Base class for all neural network modules
 class Module:

--- a/tensor-shapes/pyrefly-torch-stubs/torch-stubs/nn/attention/__init__.pyi
+++ b/tensor-shapes/pyrefly-torch-stubs/torch-stubs/nn/attention/__init__.pyi
@@ -6,7 +6,11 @@
 """Type stubs for torch.nn.attention module."""
 
 from torch.nn.attention.flex_attention import (
-    _mask_mod_signature as _mask_mod_signature,
     BlockMask as BlockMask,
+)
+from torch.nn.attention.flex_attention import (
+    _mask_mod_signature as _mask_mod_signature,
+)
+from torch.nn.attention.flex_attention import (
     flex_attention as flex_attention,
 )

--- a/tensor-shapes/pyrefly-torch-stubs/torch-stubs/nn/functional.pyi
+++ b/tensor-shapes/pyrefly-torch-stubs/torch-stubs/nn/functional.pyi
@@ -12,7 +12,8 @@ import builtins
 from typing import Literal, overload
 
 import shape_extensions
-from shape_extensions import Elements, Flag, Int as _Int, IntTuple, IntVar
+from shape_extensions import Elements, Flag, IntTuple, IntVar
+from shape_extensions import Int as _Int
 from torch._shapes import (
     adaptive_pool1d_shape,
     adaptive_pool2d_shape,

--- a/tensor-shapes/run_all_shape_tests.py
+++ b/tensor-shapes/run_all_shape_tests.py
@@ -15,7 +15,6 @@ import time
 from collections.abc import Sequence
 from pathlib import Path
 
-
 SCRIPT_DIR: Path = Path(__file__).resolve().parent
 REPO_ROOT: Path = SCRIPT_DIR.parent
 

--- a/tensor-shapes/run_tests.py
+++ b/tensor-shapes/run_tests.py
@@ -24,8 +24,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from shape_testing import pyrefly_command, TENSOR_SHAPES_ROOT, venv_python
-
+from shape_testing import TENSOR_SHAPES_ROOT, pyrefly_command, venv_python
 
 PACKAGES: tuple[str, ...] = (
     "pyrefly-torch-stubs",

--- a/tensor-shapes/shape_testing.py
+++ b/tensor-shapes/shape_testing.py
@@ -26,7 +26,6 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable
 
-
 TENSOR_SHAPES_ROOT: Path = Path(__file__).resolve().parent
 REPO_ROOT: Path = TENSOR_SHAPES_ROOT.parent
 SHAPE_EXTENSIONS_ROOT: Path = TENSOR_SHAPES_ROOT / "pyrefly-shape-extensions"

--- a/test.py
+++ b/test.py
@@ -23,7 +23,7 @@ import time
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
-from typing import final, Generator, Iterable
+from typing import Generator, Iterable, final
 
 SCRIPT_PATH: Path = Path(__file__).parent
 


### PR DESCRIPTION
Summary:

**High-level**

I enabled ruff formatting for open-source to try to reduce the number of failed PR imports on tensor-shapes, but I didn't realize that our internal linter configures both a "formatter" and a "sorter" (for import sorting).

I don't see any advantage to making contributors use `usort` (which is slower and requires an extra tool) so I'm cutting sorting over to ruff and making the OSS flow also sort (which is available in ruff but is a separate command from `ruff format`.

Vendored python files are excluded in both configs, I was surprised to see
that wasn't already the case. I don't think we should be reformatting vendored
stubs.

**Details**

Pyrefly was using ruff for code formatting internally (formatter=ruff-api in pyfmt config) but usort for imports, while OSS ruff.toml was formatter-only. This caused internal BLACK lint errors that were actually ruff vs usort import sorting mismatches, and OSS CI only checked tensor-shapes formatting.

This diff cuts over both sides to all-ruff. Now OSS and internal formatting should be byte-identical.

Reviewed By: kinto0

Differential Revision: D118137467
