### PR TITLE
Model matmul with gufunc shapes

### DIFF
--- a/crates/pyrefly_types/src/gufunc.rs
+++ b/crates/pyrefly_types/src/gufunc.rs
@@ -10,14 +10,6 @@
 //! Parsing distinguishes the named-dimension subset consumed by shape evaluation from valid
 //! extensions that are not modeled yet and malformed signatures that should produce diagnostics.
 
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "used by the next stacked gufunc DSL integration change"
-    )
-)]
-
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::iter::repeat_n;
@@ -45,6 +37,7 @@ pub(crate) enum GufuncUnsupported {
     FixedSizeDimensions,
 }
 
+#[cfg(test)]
 impl GufuncUnsupported {
     pub(crate) fn message(self) -> String {
         let feature = match self {

--- a/crates/pyrefly_types/src/gufunc.rs
+++ b/crates/pyrefly_types/src/gufunc.rs
@@ -1,0 +1,511 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Parsing for generalized universal function signatures.
+//!
+//! Parsing distinguishes the named-dimension subset consumed by shape evaluation from valid
+//! extensions that are not modeled yet and malformed signatures that should produce diagnostics.
+
+#![cfg_attr(
+    not(test),
+    expect(dead_code, reason = "used by the next stacked gufunc evaluator change")
+)]
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+/// A gufunc signature in the single-output, named-dimension subset supported by shape evaluation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GufuncSignature {
+    pub(crate) inputs: Vec<Vec<String>>,
+    pub(crate) output: Vec<String>,
+}
+
+/// A well-formed signature that shape evaluation does not yet model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GufuncUnsupported {
+    MultipleOutputs,
+    OptionalDimensions,
+    FixedSizeDimensions,
+}
+
+impl GufuncUnsupported {
+    pub(crate) fn message(self) -> String {
+        let feature = match self {
+            Self::MultipleOutputs => "multiple outputs",
+            Self::OptionalDimensions => "optional core dimensions",
+            Self::FixedSizeDimensions => "fixed-size core dimensions",
+        };
+        format!("gufunc: {feature} are not supported")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GufuncSignatureError {
+    UnsupportedCharacter(char),
+    ArrowCount(usize),
+    MissingArguments(&'static str),
+    Expected {
+        expected: &'static str,
+        found: Option<char>,
+    },
+    InvalidFrozenSize(String),
+    InconsistentOptionalDimension(String),
+    MissingOutputDimension(String),
+}
+
+impl GufuncSignatureError {
+    pub(crate) fn message(&self) -> String {
+        match self {
+            Self::UnsupportedCharacter(character) => {
+                format!("gufunc: unsupported character '{character}' in signature")
+            }
+            Self::ArrowCount(count) => {
+                format!("gufunc: signature must contain exactly one '->', got {count}")
+            }
+            Self::MissingArguments(side) => {
+                format!("gufunc: signature must contain at least one {side} argument")
+            }
+            Self::Expected { expected, found } => match found {
+                Some(found) => format!("gufunc: expected {expected}, got '{found}'"),
+                None => format!("gufunc: expected {expected}, got end of signature"),
+            },
+            Self::InvalidFrozenSize(size) => {
+                format!("gufunc: expected a valid positive frozen size, got '{size}'")
+            }
+            Self::InconsistentOptionalDimension(dimension) => format!(
+                "gufunc: core dimension '{dimension}' must use '?' consistently in every occurrence"
+            ),
+            Self::MissingOutputDimension(dimension) => {
+                format!("gufunc: output core dimension '{dimension}' not found in inputs")
+            }
+        }
+    }
+}
+
+pub(crate) enum GufuncClassification {
+    Supported(GufuncSignature),
+    Unsupported(GufuncUnsupported),
+    Invalid(GufuncSignatureError),
+}
+
+#[derive(Default)]
+struct ParsedSide {
+    arguments: Vec<Vec<ParsedDimension>>,
+}
+
+enum ParsedDimension {
+    Named { name: String, optional: bool },
+    Frozen { size: isize, optional: bool },
+}
+
+struct SideParser {
+    characters: Vec<char>,
+    position: usize,
+    side: &'static str,
+}
+
+impl SideParser {
+    fn new(source: &str, side: &'static str) -> Self {
+        Self {
+            characters: source.chars().collect(),
+            position: 0,
+            side,
+        }
+    }
+
+    fn current(&self) -> Option<char> {
+        self.characters.get(self.position).copied()
+    }
+
+    fn consume(&mut self, character: char) -> bool {
+        if self.current() == Some(character) {
+            self.position += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn skip_whitespace(&mut self) {
+        while self
+            .current()
+            .is_some_and(|character| matches!(character, ' ' | '\t'))
+        {
+            self.position += 1;
+        }
+    }
+
+    fn expected<T>(&self, expected: &'static str) -> Result<T, GufuncSignatureError> {
+        Err(GufuncSignatureError::Expected {
+            expected,
+            found: self.current(),
+        })
+    }
+
+    fn parse(mut self) -> Result<ParsedSide, GufuncSignatureError> {
+        self.skip_whitespace();
+        if self.current().is_none() {
+            return Err(GufuncSignatureError::MissingArguments(self.side));
+        }
+
+        let mut parsed = ParsedSide::default();
+        loop {
+            if !self.consume('(') {
+                return self.expected("'('");
+            }
+            self.skip_whitespace();
+            let mut dimensions = Vec::new();
+            if !self.consume(')') {
+                loop {
+                    let start = self.position;
+                    let named = self.current().is_some_and(|character| {
+                        character.is_ascii_alphabetic() || character == '_'
+                    });
+                    if named {
+                        self.position += 1;
+                        while self.current().is_some_and(|character| {
+                            character.is_ascii_alphanumeric() || character == '_'
+                        }) {
+                            self.position += 1;
+                        }
+                    } else if self
+                        .current()
+                        .is_some_and(|character| character.is_ascii_digit())
+                    {
+                        while self
+                            .current()
+                            .is_some_and(|character| character.is_ascii_digit())
+                        {
+                            self.position += 1;
+                        }
+                    } else {
+                        return self.expected("a core dimension name, frozen size, or ')'");
+                    }
+                    let value = self.characters[start..self.position]
+                        .iter()
+                        .collect::<String>();
+                    let optional = self.consume('?');
+                    dimensions.push(if named {
+                        ParsedDimension::Named {
+                            name: value,
+                            optional,
+                        }
+                    } else {
+                        let Ok(size) = value.parse::<isize>() else {
+                            return Err(GufuncSignatureError::InvalidFrozenSize(value));
+                        };
+                        // NumPy rejects sizes at or above `NPY_MAX_INTP`; `isize` has the
+                        // corresponding platform-sized range.
+                        if size <= 0 || size == isize::MAX {
+                            return Err(GufuncSignatureError::InvalidFrozenSize(value));
+                        }
+                        ParsedDimension::Frozen { size, optional }
+                    });
+
+                    self.skip_whitespace();
+                    if self.consume(')') {
+                        break;
+                    }
+                    if !self.consume(',') {
+                        return self.expected("',' or ')'");
+                    }
+                    self.skip_whitespace();
+                }
+            }
+            parsed.arguments.push(dimensions);
+
+            self.skip_whitespace();
+            if self.position == self.characters.len() {
+                return Ok(parsed);
+            }
+            if !self.consume(',') {
+                return self.expected("',' or end of signature");
+            }
+            self.skip_whitespace();
+        }
+    }
+}
+
+/// Parses and classifies a generalized universal function signature.
+pub(crate) fn parse_gufunc_signature(spec: &str) -> GufuncClassification {
+    if let Some(character) = spec.chars().find(|character| {
+        !character.is_ascii_alphanumeric()
+            && !matches!(character, '_' | '?' | '(' | ')' | ',' | '-' | '>')
+            && !matches!(character, ' ' | '\t')
+    }) {
+        return GufuncClassification::Invalid(GufuncSignatureError::UnsupportedCharacter(
+            character,
+        ));
+    }
+
+    let arrow_count = spec.matches("->").count();
+    if arrow_count != 1 {
+        return GufuncClassification::Invalid(GufuncSignatureError::ArrowCount(arrow_count));
+    }
+    let (inputs, outputs) = spec
+        .split_once("->")
+        .expect("the signature has exactly one arrow");
+    let inputs = match SideParser::new(inputs, "input").parse() {
+        Ok(inputs) => inputs,
+        Err(error) => return GufuncClassification::Invalid(error),
+    };
+    let outputs = match SideParser::new(outputs, "output").parse() {
+        Ok(outputs) => outputs,
+        Err(error) => return GufuncClassification::Invalid(error),
+    };
+
+    let mut optional_named_dimensions = HashMap::new();
+    let mut optional_frozen_dimensions = HashMap::new();
+    for dimension in inputs.arguments.iter().chain(&outputs.arguments).flatten() {
+        let inconsistent = match dimension {
+            ParsedDimension::Named { name, optional } => optional_named_dimensions
+                .insert(name.as_str(), *optional)
+                .is_some_and(|previous| previous != *optional),
+            ParsedDimension::Frozen { size, optional } => optional_frozen_dimensions
+                .insert(*size, *optional)
+                .is_some_and(|previous| previous != *optional),
+        };
+        if inconsistent {
+            let name = match dimension {
+                ParsedDimension::Named { name, .. } => name.clone(),
+                ParsedDimension::Frozen { size, .. } => size.to_string(),
+            };
+            return GufuncClassification::Invalid(
+                GufuncSignatureError::InconsistentOptionalDimension(name),
+            );
+        }
+    }
+    let input_dimensions = inputs
+        .arguments
+        .iter()
+        .flatten()
+        .filter_map(|dimension| match dimension {
+            ParsedDimension::Named { name, .. } => Some(name.as_str()),
+            ParsedDimension::Frozen { .. } => None,
+        })
+        .collect::<HashSet<_>>();
+    for dimension in outputs.arguments.iter().flatten() {
+        if let ParsedDimension::Named { name, .. } = dimension
+            && !input_dimensions.contains(name.as_str())
+        {
+            return GufuncClassification::Invalid(GufuncSignatureError::MissingOutputDimension(
+                name.clone(),
+            ));
+        }
+    }
+    if outputs.arguments.len() != 1 {
+        return GufuncClassification::Unsupported(GufuncUnsupported::MultipleOutputs);
+    }
+    if inputs
+        .arguments
+        .iter()
+        .chain(&outputs.arguments)
+        .flatten()
+        .any(|dimension| match dimension {
+            ParsedDimension::Named { optional, .. } | ParsedDimension::Frozen { optional, .. } => {
+                *optional
+            }
+        })
+    {
+        return GufuncClassification::Unsupported(GufuncUnsupported::OptionalDimensions);
+    }
+    if inputs
+        .arguments
+        .iter()
+        .chain(&outputs.arguments)
+        .flatten()
+        .any(|dimension| matches!(dimension, ParsedDimension::Frozen { .. }))
+    {
+        return GufuncClassification::Unsupported(GufuncUnsupported::FixedSizeDimensions);
+    }
+    GufuncClassification::Supported(GufuncSignature {
+        inputs: inputs
+            .arguments
+            .into_iter()
+            .map(|argument| {
+                argument
+                    .into_iter()
+                    .map(|dimension| match dimension {
+                        ParsedDimension::Named { name, .. } => name,
+                        ParsedDimension::Frozen { .. } => {
+                            unreachable!("frozen dimensions were classified as unsupported")
+                        }
+                    })
+                    .collect()
+            })
+            .collect(),
+        output: outputs
+            .arguments
+            .into_iter()
+            .next()
+            .expect("one output")
+            .into_iter()
+            .map(|dimension| match dimension {
+                ParsedDimension::Named { name, .. } => name,
+                ParsedDimension::Frozen { .. } => {
+                    unreachable!("frozen dimensions were classified as unsupported")
+                }
+            })
+            .collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn classify(spec: &str) -> String {
+        match parse_gufunc_signature(spec) {
+            GufuncClassification::Supported(signature) => {
+                format!(
+                    "supported inputs={:?} output={:?}",
+                    signature.inputs, signature.output
+                )
+            }
+            GufuncClassification::Unsupported(unsupported) => {
+                format!("unsupported: {}", unsupported.message())
+            }
+            GufuncClassification::Invalid(error) => format!("invalid: {}", error.message()),
+        }
+    }
+
+    #[test]
+    fn supported_signatures() {
+        assert_eq!(
+            classify("(m,n),(n,p)->(m,p)"),
+            "supported inputs=[[\"m\", \"n\"], [\"n\", \"p\"]] output=[\"m\", \"p\"]"
+        );
+        assert_eq!(classify("(),()->()"), "supported inputs=[[], []] output=[]");
+        assert_eq!(
+            classify(" ( _batch2 , n ) -> ( n , _batch2 ) "),
+            "supported inputs=[[\"_batch2\", \"n\"]] output=[\"n\", \"_batch2\"]"
+        );
+        assert_eq!(
+            classify("(n,n)->(n,n)"),
+            "supported inputs=[[\"n\", \"n\"]] output=[\"n\", \"n\"]"
+        );
+    }
+
+    #[test]
+    fn unsupported_signatures_are_distinct_from_invalid_signatures() {
+        assert_eq!(
+            classify("(n)->(n),(n)"),
+            "unsupported: gufunc: multiple outputs are not supported"
+        );
+        assert_eq!(
+            classify("(m,n?),(n?)->(m)"),
+            "unsupported: gufunc: optional core dimensions are not supported"
+        );
+        assert_eq!(
+            classify("(3),(n)->(n)"),
+            "unsupported: gufunc: fixed-size core dimensions are not supported"
+        );
+        let largest_frozen_size = format!("({})->()", isize::MAX - 1);
+        assert_eq!(
+            classify(&largest_frozen_size),
+            "unsupported: gufunc: fixed-size core dimensions are not supported"
+        );
+        assert_eq!(
+            classify("(03?),(3?)->()"),
+            "unsupported: gufunc: optional core dimensions are not supported"
+        );
+        assert_eq!(
+            classify("(n?)->(missing)"),
+            "invalid: gufunc: output core dimension 'missing' not found in inputs"
+        );
+    }
+
+    #[test]
+    fn malformed_signatures() {
+        assert_eq!(
+            classify("(n),(m)"),
+            "invalid: gufunc: signature must contain exactly one '->', got 0"
+        );
+        assert_eq!(
+            classify("(n)->(n)->(n)"),
+            "invalid: gufunc: signature must contain exactly one '->', got 2"
+        );
+        assert_eq!(
+            classify("->()"),
+            "invalid: gufunc: signature must contain at least one input argument"
+        );
+        assert_eq!(
+            classify("()->"),
+            "invalid: gufunc: signature must contain at least one output argument"
+        );
+        assert_eq!(
+            classify("(n,)->()"),
+            "invalid: gufunc: expected a core dimension name, frozen size, or ')', got ')'"
+        );
+        assert_eq!(
+            classify("(n)(m)->()"),
+            "invalid: gufunc: expected ',' or end of signature, got '('"
+        );
+        assert_eq!(
+            classify("(n)->(m)"),
+            "invalid: gufunc: output core dimension 'm' not found in inputs"
+        );
+        assert_eq!(
+            classify("(n!)->()"),
+            "invalid: gufunc: unsupported character '!' in signature"
+        );
+        assert_eq!(
+            classify("(n?),(n)->()"),
+            "invalid: gufunc: core dimension 'n' must use '?' consistently in every occurrence"
+        );
+        assert_eq!(
+            classify("(n?)->(n)"),
+            "invalid: gufunc: core dimension 'n' must use '?' consistently in every occurrence"
+        );
+        assert_eq!(
+            classify("(0)->()"),
+            "invalid: gufunc: expected a valid positive frozen size, got '0'"
+        );
+        let reserved_maximum = format!("({})->()", isize::MAX);
+        assert_eq!(
+            classify(&reserved_maximum),
+            format!(
+                "invalid: gufunc: expected a valid positive frozen size, got '{}'",
+                isize::MAX
+            )
+        );
+        let overflow = format!("({})->()", isize::MAX as u128 + 1);
+        assert_eq!(
+            classify(&overflow),
+            format!(
+                "invalid: gufunc: expected a valid positive frozen size, got '{}'",
+                isize::MAX as u128 + 1
+            )
+        );
+        assert_eq!(
+            classify("(2n)->()"),
+            "invalid: gufunc: expected ',' or ')', got 'n'"
+        );
+        assert_eq!(
+            classify("(03?),(3)->()"),
+            "invalid: gufunc: core dimension '3' must use '?' consistently in every occurrence"
+        );
+        assert_eq!(
+            classify("(core dim)->()"),
+            "invalid: gufunc: expected ',' or ')', got 'd'"
+        );
+        assert_eq!(
+            classify("(n)- >()"),
+            "invalid: gufunc: signature must contain exactly one '->', got 0"
+        );
+        assert_eq!(classify("n->()"), "invalid: gufunc: expected '(', got 'n'");
+        assert_eq!(
+            classify("(n->()"),
+            "invalid: gufunc: expected ',' or ')', got end of signature"
+        );
+        assert_eq!(
+            classify("(n)->(n"),
+            "invalid: gufunc: expected ',' or ')', got end of signature"
+        );
+    }
+}

--- a/crates/pyrefly_types/src/gufunc.rs
+++ b/crates/pyrefly_types/src/gufunc.rs
@@ -12,17 +12,29 @@
 
 #![cfg_attr(
     not(test),
-    expect(dead_code, reason = "used by the next stacked gufunc evaluator change")
+    expect(
+        dead_code,
+        reason = "used by the next stacked gufunc DSL integration change"
+    )
 )]
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::iter::repeat_n;
+
+use crate::dimension::Int;
+use crate::dimension::ShapeError;
+use crate::shaped_array::IntTuple;
+use crate::shaped_array::IntTupleView;
+use crate::shaped_array::broadcast_dim;
+use crate::shaped_array::broadcast_shapes;
+use crate::shaped_array::is_gradual_shape_middle;
 
 /// A gufunc signature in the single-output, named-dimension subset supported by shape evaluation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GufuncSignature {
-    pub(crate) inputs: Vec<Vec<String>>,
-    pub(crate) output: Vec<String>,
+    inputs: Vec<Vec<String>>,
+    output: Vec<String>,
 }
 
 /// A well-formed signature that shape evaluation does not yet model.
@@ -355,9 +367,240 @@ pub(crate) fn parse_gufunc_signature(spec: &str) -> GufuncClassification {
     })
 }
 
+struct GufuncOperand {
+    batch: IntTuple,
+    core: Vec<Option<Int>>,
+}
+
+fn split_operand(
+    shape: &IntTuple,
+    core_rank: usize,
+    index: usize,
+) -> Result<GufuncOperand, ShapeError> {
+    match shape.view() {
+        IntTupleView::Concrete(dimensions) => {
+            if dimensions.len() < core_rank {
+                return Err(ShapeError::ShapeComputation {
+                    message: format!(
+                        "gufunc: operand {index} requires at least rank {core_rank}, got {}",
+                        dimensions.len()
+                    ),
+                });
+            }
+            let split = dimensions.len() - core_rank;
+            Ok(GufuncOperand {
+                batch: IntTuple::new(dimensions[..split].to_vec()),
+                core: dimensions[split..].iter().cloned().map(Some).collect(),
+            })
+        }
+        IntTupleView::Gradual => Ok(GufuncOperand {
+            batch: IntTuple::shapeless(),
+            core: vec![None; core_rank],
+        }),
+        IntTupleView::Unpacked {
+            prefix,
+            middle,
+            suffix,
+        } if suffix.len() >= core_rank => {
+            let split = suffix.len() - core_rank;
+            Ok(GufuncOperand {
+                batch: IntTuple::unpacked(
+                    prefix.to_vec(),
+                    middle.clone(),
+                    suffix[..split].to_vec(),
+                ),
+                core: suffix[split..].iter().cloned().map(Some).collect(),
+            })
+        }
+        IntTupleView::Unpacked { suffix, .. } => Ok(GufuncOperand {
+            // The variadic middle may supply any of the trailing core dimensions. Neither its
+            // boundary nor the batch dimensions to its left can be aligned soundly, but the
+            // fixed suffix still occupies the rightmost core positions.
+            batch: IntTuple::shapeless(),
+            core: repeat_n(None, core_rank - suffix.len())
+                .chain(suffix.iter().cloned().map(Some))
+                .collect(),
+        }),
+    }
+}
+
+fn known_batch_suffix(batch: &IntTuple) -> &[Int] {
+    match batch.view() {
+        IntTupleView::Concrete(dimensions) => dimensions,
+        IntTupleView::Gradual => &[],
+        IntTupleView::Unpacked { suffix, .. } => suffix,
+    }
+}
+
+/// Broadcast three or more batches collectively so abstract precision and errors do not depend on
+/// operand order. A variadic operand makes the leading rank gradual, while all known right-aligned
+/// dimensions remain available for reconciliation.
+fn broadcast_batches(batches: &[IntTuple]) -> Result<IntTuple, ShapeError> {
+    match batches {
+        [] => unreachable!("a parsed gufunc signature has at least one input"),
+        [batch] => return Ok(batch.clone()),
+        [left, right] => return broadcast_shapes(left, right),
+        _ => {}
+    }
+    if batches.windows(2).all(|pair| pair[0] == pair[1]) {
+        return Ok(batches[0].clone());
+    }
+
+    // A named variadic cannot absorb unmatched concrete batch dimensions because their alignment
+    // with the unknown middle is ambiguous. Preserve that binary-broadcast constraint before the
+    // collective calculation widens variadic ranks to gradual ones.
+    for batch in batches {
+        if let IntTupleView::Unpacked { middle, .. } = batch.view()
+            && !is_gradual_shape_middle(middle)
+        {
+            for concrete in batches {
+                if matches!(concrete.view(), IntTupleView::Concrete(_)) {
+                    broadcast_shapes(batch, concrete)?;
+                }
+            }
+        }
+    }
+
+    let has_variadic_rank = batches
+        .iter()
+        .any(|batch| !matches!(batch.view(), IntTupleView::Concrete(_)));
+    let suffix_rank = batches
+        .iter()
+        .map(|batch| known_batch_suffix(batch).len())
+        .max()
+        .unwrap_or(0);
+    let result = (0..suffix_rank)
+        .rev()
+        .map(|offset| {
+            let mut dimensions = batches
+                .iter()
+                .filter_map(|batch| {
+                    let suffix = known_batch_suffix(batch);
+                    suffix
+                        .len()
+                        .checked_sub(offset + 1)
+                        .map(|index| suffix[index].clone())
+                        .or_else(|| {
+                            (!matches!(batch.view(), IntTupleView::Concrete(_))).then_some(Int::Int)
+                        })
+                })
+                .collect::<Vec<_>>();
+            dimensions.sort();
+            dimensions
+                .into_iter()
+                .try_fold(Int::Literal(1), |result, dimension| {
+                    broadcast_dim(&result, &dimension, suffix_rank - offset - 1)
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(if has_variadic_rank {
+        IntTuple::unpacked(
+            Vec::new(),
+            IntTuple::shapeless().to_shape_arg_type(),
+            result,
+        )
+    } else {
+        IntTuple::new(result)
+    })
+}
+
+/// Evaluate the output shape of a supported single-output gufunc signature.
+pub(crate) fn evaluate_gufunc(
+    signature: &GufuncSignature,
+    operands: &[IntTuple],
+) -> Result<IntTuple, ShapeError> {
+    if operands.len() != signature.inputs.len() {
+        return Err(ShapeError::ShapeComputation {
+            message: format!(
+                "gufunc: expected {} operands, got {}",
+                signature.inputs.len(),
+                operands.len()
+            ),
+        });
+    }
+
+    // This is the historical broadcast operation and must retain its exact behavior for gradual
+    // and variadic shapes as well as concrete ones.
+    if signature.inputs.len() == 2
+        && signature.inputs.iter().all(Vec::is_empty)
+        && signature.output.is_empty()
+    {
+        return broadcast_shapes(&operands[0], &operands[1]);
+    }
+
+    let operands = operands
+        .iter()
+        .zip(&signature.inputs)
+        .enumerate()
+        .map(|(index, (shape, dimensions))| split_operand(shape, dimensions.len(), index))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut extents: HashMap<&str, Option<Int>> = HashMap::new();
+    let mut literals: HashMap<&str, i64> = HashMap::new();
+    for (operand, names) in operands.iter().zip(&signature.inputs) {
+        for (name, dimension) in names.iter().zip(&operand.core) {
+            let Some(dimension) = dimension else {
+                continue;
+            };
+            if let Int::Literal(value) = dimension
+                && let Some(previous) = literals.insert(name, *value)
+                && previous != *value
+            {
+                return Err(ShapeError::ShapeComputation {
+                    message: format!(
+                        "gufunc: core dimension '{name}' has conflicting extents {previous} and {value}"
+                    ),
+                });
+            }
+            extents
+                .entry(name)
+                .and_modify(|extent| {
+                    if extent.as_ref().is_some_and(|known| known != dimension) {
+                        *extent = None;
+                    }
+                })
+                .or_insert_with(|| Some(dimension.clone()));
+        }
+    }
+
+    let output_core = IntTuple::new(
+        signature
+            .output
+            .iter()
+            .map(|name| {
+                literals
+                    .get(name.as_str())
+                    .copied()
+                    .map(Int::Literal)
+                    .or_else(|| extents.get(name.as_str()).cloned().flatten())
+                    .unwrap_or(Int::Int)
+            })
+            .collect(),
+    );
+    let batches = operands
+        .iter()
+        .map(|operand| operand.batch.clone())
+        .collect::<Vec<_>>();
+    Ok(broadcast_batches(&batches)?.concat(&output_core))
+}
+
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use pyrefly_python::module::Module;
+    use pyrefly_python::module_name::ModuleName;
+    use pyrefly_python::module_path::ModulePath;
+    use ruff_python_ast::Identifier;
+    use ruff_python_ast::name::Name;
+    use ruff_text_size::TextRange;
+    use ruff_text_size::TextSize;
+
     use super::*;
+    use crate::type_var_tuple::TypeVarTuple;
+    use crate::types::Type;
 
     fn classify(spec: &str) -> String {
         match parse_gufunc_signature(spec) {
@@ -372,6 +615,37 @@ mod tests {
             }
             GufuncClassification::Invalid(error) => format!("invalid: {}", error.message()),
         }
+    }
+
+    fn signature(spec: &str) -> GufuncSignature {
+        let GufuncClassification::Supported(signature) = parse_gufunc_signature(spec) else {
+            panic!("expected a supported gufunc signature: {spec}");
+        };
+        signature
+    }
+
+    fn shape(dimensions: &[i64]) -> IntTuple {
+        IntTuple::new(dimensions.iter().copied().map(Int::Literal).collect())
+    }
+
+    fn symbolic(ty: Type) -> Int {
+        Int::Symbolic(Box::new(ty))
+    }
+
+    fn gradual_middle() -> Type {
+        IntTuple::shapeless().to_shape_arg_type()
+    }
+
+    fn named_variadic_middle(name: &str) -> Type {
+        Type::TypeVarTuple(TypeVarTuple::new(
+            Identifier::new(Name::new(name), TextRange::empty(TextSize::new(0))),
+            Module::new(
+                ModuleName::from_str("__test__"),
+                ModulePath::filesystem(PathBuf::from("__test__")),
+                Arc::new("fake module contents".to_owned()),
+            ),
+            None,
+        ))
     }
 
     #[test]
@@ -507,5 +781,296 @@ mod tests {
             classify("(n)->(n"),
             "invalid: gufunc: expected ',' or ')', got end of signature"
         );
+    }
+
+    #[test]
+    fn evaluates_scalar_core_and_batched_matrix_multiplication() {
+        assert_eq!(
+            evaluate_gufunc(&signature("(),()->()"), &[shape(&[2, 1]), shape(&[3])])
+                .expect("the batch dimensions should broadcast"),
+            shape(&[2, 3])
+        );
+        assert_eq!(
+            evaluate_gufunc(
+                &signature("(m,n),(n,p)->(m,p)"),
+                &[shape(&[5, 2, 3]), shape(&[1, 3, 4])],
+            )
+            .expect("the batch and core dimensions should be compatible"),
+            shape(&[5, 2, 4])
+        );
+    }
+
+    #[test]
+    fn binary_scalar_core_evaluation_is_exactly_broadcast_shapes() {
+        let signature = signature("(),()->()");
+        let gradual = IntTuple::shapeless();
+        let unpacked = IntTuple::unpacked(
+            vec![Int::Literal(2)],
+            gradual_middle(),
+            vec![Int::Literal(3)],
+        );
+        let cases = [
+            (gradual.clone(), shape(&[2, 3])),
+            (shape(&[4, 1]), unpacked.clone()),
+            (unpacked.clone(), gradual),
+            (unpacked, shape(&[5, 3])),
+            (shape(&[2]), shape(&[3])),
+        ];
+        for (left, right) in cases {
+            assert_eq!(
+                evaluate_gufunc(&signature, &[left.clone(), right.clone()]),
+                broadcast_shapes(&left, &right)
+            );
+        }
+    }
+
+    #[test]
+    fn validates_operand_count_and_minimum_concrete_rank() {
+        assert_eq!(
+            evaluate_gufunc(&signature("(),()->()"), &[shape(&[2])])
+                .expect_err("one operand is missing")
+                .to_string(),
+            "gufunc: expected 2 operands, got 1"
+        );
+        assert_eq!(
+            evaluate_gufunc(
+                &signature("(m,n),(n,p)->(m,p)"),
+                &[shape(&[3]), shape(&[3, 4])],
+            )
+            .expect_err("the first operand has insufficient rank")
+            .to_string(),
+            "gufunc: operand 0 requires at least rank 2, got 1"
+        );
+    }
+
+    #[test]
+    fn core_dimensions_are_exact_and_do_not_broadcast() {
+        assert_eq!(
+            evaluate_gufunc(&signature("(n),(n)->()"), &[shape(&[1]), shape(&[5])])
+                .expect_err("core dimension one must not broadcast")
+                .to_string(),
+            "gufunc: core dimension 'n' has conflicting extents 1 and 5"
+        );
+        assert_eq!(
+            evaluate_gufunc(&signature("(n,n)->(n)"), &[shape(&[3, 4])])
+                .expect_err("repeated core dimensions must agree")
+                .to_string(),
+            "gufunc: core dimension 'n' has conflicting extents 3 and 4"
+        );
+    }
+
+    #[test]
+    fn reconciles_symbolic_core_dimensions_independently() {
+        let n = symbolic(Type::None);
+        let other_n = symbolic(Type::Ellipsis);
+        let p = symbolic(Type::Materialization);
+
+        assert_eq!(
+            evaluate_gufunc(
+                &signature("(m,n),(n,p)->(m,p)"),
+                &[
+                    IntTuple::new(vec![Int::Literal(2), n.clone()]),
+                    IntTuple::new(vec![n.clone(), p.clone()]),
+                ],
+            )
+            .expect("equal symbolic dimensions should remain precise"),
+            IntTuple::new(vec![Int::Literal(2), p.clone()])
+        );
+        assert_eq!(
+            evaluate_gufunc(
+                &signature("(m,n),(n,p)->(m,n,p)"),
+                &[
+                    IntTuple::new(vec![Int::Literal(2), n]),
+                    IntTuple::new(vec![other_n, p.clone()]),
+                ],
+            )
+            .expect("unresolved symbolic equality should widen only its label"),
+            IntTuple::new(vec![Int::Literal(2), Int::Int, p])
+        );
+        assert_eq!(
+            evaluate_gufunc(
+                &signature("(n),(n)->(n)"),
+                &[IntTuple::new(vec![symbolic(Type::None)]), shape(&[7])],
+            )
+            .expect("a literal should constrain an unresolved symbolic dimension"),
+            shape(&[7])
+        );
+    }
+
+    #[test]
+    fn preserves_known_core_suffix_with_gradual_or_variadic_rank() {
+        let equation = signature("(m,n),(n,p)->(m,p)");
+        assert_eq!(
+            evaluate_gufunc(
+                &equation,
+                &[
+                    IntTuple::unpacked(
+                        vec![Int::Literal(7)],
+                        gradual_middle(),
+                        vec![Int::Literal(8), Int::Literal(2), Int::Literal(3)],
+                    ),
+                    shape(&[3, 4]),
+                ],
+            )
+            .expect("the known variadic suffix contains the full core"),
+            IntTuple::unpacked(
+                vec![Int::Literal(7)],
+                gradual_middle(),
+                vec![Int::Literal(8), Int::Literal(2), Int::Literal(4)],
+            )
+        );
+        assert_eq!(
+            evaluate_gufunc(
+                &equation,
+                &[
+                    IntTuple::unpacked(
+                        vec![Int::Literal(2)],
+                        gradual_middle(),
+                        vec![Int::Literal(3)],
+                    ),
+                    shape(&[3, 4]),
+                ],
+            )
+            .expect("an ambiguous core boundary should fall back conservatively"),
+            IntTuple::unpacked(
+                Vec::new(),
+                gradual_middle(),
+                vec![Int::Int, Int::Literal(4)],
+            )
+        );
+        assert_eq!(
+            evaluate_gufunc(&equation, &[IntTuple::shapeless(), shape(&[3, 4])])
+                .expect("a gradual operand should preserve core dimensions known elsewhere"),
+            IntTuple::unpacked(
+                Vec::new(),
+                gradual_middle(),
+                vec![Int::Int, Int::Literal(4)],
+            )
+        );
+        assert_eq!(
+            evaluate_gufunc(
+                &signature("(m,n)->(n)"),
+                &[IntTuple::unpacked(
+                    Vec::new(),
+                    gradual_middle(),
+                    vec![Int::Literal(5)],
+                )],
+            )
+            .expect("a short fixed suffix still determines the rightmost core dimension"),
+            IntTuple::unpacked(Vec::new(), gradual_middle(), vec![Int::Literal(5)])
+        );
+    }
+
+    #[test]
+    fn arbitrary_arity_batch_broadcasting_is_permutation_invariant() {
+        let signature = signature("(),(),()->()");
+        let operands = [
+            IntTuple::shapeless(),
+            IntTuple::unpacked(Vec::new(), gradual_middle(), vec![Int::Literal(3)]),
+            shape(&[1, 3]),
+        ];
+        for permutation in [
+            [0, 1, 2],
+            [0, 2, 1],
+            [1, 0, 2],
+            [1, 2, 0],
+            [2, 0, 1],
+            [2, 1, 0],
+        ] {
+            let permuted = permutation.map(|index| operands[index].clone());
+            assert_eq!(
+                evaluate_gufunc(&signature, &permuted)
+                    .expect("variadic batch fallback should not depend on operand order"),
+                IntTuple::unpacked(
+                    Vec::new(),
+                    gradual_middle(),
+                    vec![Int::Int, Int::Literal(3)],
+                )
+            );
+        }
+
+        let fixed_rank = [
+            IntTuple::new(vec![Int::Int, Int::Literal(1)]),
+            shape(&[1, 5]),
+            shape(&[7, 1]),
+        ];
+        for permutation in [[0, 1, 2], [2, 0, 1], [1, 2, 0]] {
+            let permuted = permutation.map(|index| fixed_rank[index].clone());
+            assert_eq!(
+                evaluate_gufunc(&signature, &permuted)
+                    .expect("fixed-rank batches should broadcast exactly"),
+                shape(&[7, 5])
+            );
+        }
+
+        let conflicting = [shape(&[2, 3]), IntTuple::shapeless(), shape(&[4, 3])];
+        for permutation in [[0, 1, 2], [2, 0, 1], [1, 2, 0]] {
+            let permuted = permutation.map(|index| conflicting[index].clone());
+            assert!(
+                evaluate_gufunc(&signature, &permuted).is_err(),
+                "known incompatible suffixes must conflict in every operand order"
+            );
+        }
+
+        let forced_suffix = [
+            IntTuple::unpacked(
+                Vec::new(),
+                gradual_middle(),
+                vec![Int::Literal(1), Int::Literal(5)],
+            ),
+            IntTuple::unpacked(
+                Vec::new(),
+                gradual_middle(),
+                vec![Int::Literal(3), Int::Literal(1)],
+            ),
+            shape(&[4, 3, 5]),
+        ];
+        assert_eq!(
+            evaluate_gufunc(&signature, &forced_suffix)
+                .expect("known suffix dimensions should constrain gradual dimensions"),
+            IntTuple::unpacked(
+                Vec::new(),
+                gradual_middle(),
+                vec![Int::Literal(4), Int::Literal(3), Int::Literal(5)],
+            )
+        );
+
+        let identical = IntTuple::unpacked(
+            vec![Int::Literal(2)],
+            gradual_middle(),
+            vec![Int::Literal(3)],
+        );
+        assert_eq!(
+            evaluate_gufunc(
+                &signature,
+                &[identical.clone(), identical.clone(), identical.clone()]
+            )
+            .expect("identical variadic batches should retain their full representation"),
+            identical
+        );
+    }
+
+    #[test]
+    fn scalar_operand_does_not_hide_named_variadic_batch_ambiguity() {
+        let signature = signature("(),(),()->()");
+        let operands = [
+            IntTuple::unpacked(Vec::new(), named_variadic_middle("Batch"), Vec::new()),
+            shape(&[2]),
+            shape(&[]),
+        ];
+        for permutation in [
+            [0, 1, 2],
+            [0, 2, 1],
+            [1, 0, 2],
+            [1, 2, 0],
+            [2, 0, 1],
+            [2, 1, 0],
+        ] {
+            let permuted = permutation.map(|index| operands[index].clone());
+            assert!(
+                evaluate_gufunc(&signature, &permuted).is_err(),
+                "a scalar operand must not hide ambiguous named-variadic alignment"
+            );
+        }
     }
 }

--- a/crates/pyrefly_types/src/lib.rs
+++ b/crates/pyrefly_types/src/lib.rs
@@ -32,6 +32,7 @@ pub mod equality;
 pub mod facet;
 pub mod function;
 pub mod globals;
+mod gufunc;
 pub mod heap;
 pub mod keywords;
 pub mod lit_int;

--- a/crates/pyrefly_types/src/shaped_array.rs
+++ b/crates/pyrefly_types/src/shaped_array.rs
@@ -1317,7 +1317,7 @@ fn gradual_shape_middle() -> Type {
     IntTuple::shapeless().to_shape_arg_type()
 }
 
-fn is_gradual_shape_middle(middle: &Type) -> bool {
+pub(crate) fn is_gradual_shape_middle(middle: &Type) -> bool {
     match middle {
         Type::IntTuple(shape) => shape.is_shapeless(),
         Type::Tuple(Tuple::Unbounded(elt)) => elt.is_any() || is_gradual_size(elt),
@@ -1567,7 +1567,7 @@ fn broadcast_concrete(a_dims: &[Int], b_dims: &[Int]) -> Result<IntTuple, ShapeE
 
 /// Broadcast a single pair of dimensions.
 /// Canonicalizes both sides so symbolic expressions that reduce to literals are caught.
-fn broadcast_dim(a_ty: &Int, b_ty: &Int, position: usize) -> Result<Int, ShapeError> {
+pub(crate) fn broadcast_dim(a_ty: &Int, b_ty: &Int, position: usize) -> Result<Int, ShapeError> {
     let a_ty = canonicalize_int_dim(a_ty.clone());
     let b_ty = canonicalize_int_dim(b_ty.clone());
     match (&a_ty, &b_ty) {

--- a/crates/pyrefly_types/src/type_level_dsl.rs
+++ b/crates/pyrefly_types/src/type_level_dsl.rs
@@ -64,7 +64,6 @@ use crate::map_int_tuples::MapIntTuples;
 use crate::quantified::Quantified;
 use crate::shaped_array::IntTuple;
 use crate::shaped_array::IntTupleView;
-use crate::shaped_array::broadcast_shapes;
 use crate::tuple::Tuple;
 use crate::type_var::FlagDomain;
 use crate::type_var::FlagMember;
@@ -1011,13 +1010,6 @@ pub enum TypeShapeDslReturnKind {
         slot: usize,
         kind: TypeShapeDslSlotReturnKind,
     },
-    /// Return the broadcast of two shape parameters.
-    Broadcast {
-        left_slot: usize,
-        right_slot: usize,
-        left_parameters: Box<[usize]>,
-        right_parameters: Box<[usize]>,
-    },
     /// Evaluate a structurally validated expression in the required result domain.
     Expression(TypeShapeDslDomain),
     /// Return an invalid shape computation with a source-provided message.
@@ -1165,7 +1157,6 @@ impl TypeShapeDslComparisonOp {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TypeShapeDslIntrinsic {
     Any,
-    Broadcast,
     Concat,
     Einsum,
     GufuncBroadcast,
@@ -1667,16 +1658,6 @@ impl DslStaticKind {
             Self::IntTuple { parameter_origins } | Self::IntTuples { parameter_origins } => {
                 parameter_origins.clone()
             }
-            _ => None,
-        }
-    }
-
-    fn int_tuple_parameter_origins(&self) -> Option<Box<[usize]>> {
-        match self {
-            Self::UnknownParameters(parameters)
-            | Self::IntTuple {
-                parameter_origins: Some(parameters),
-            } => Some(parameters.clone()),
             _ => None,
         }
     }
@@ -4980,39 +4961,6 @@ impl<'a, F: Fn(&Expr) -> Option<TypeShapeDslIntrinsic>> DslValidator<'a, F> {
                     Self::validate_gradual_call(call)?;
                     TypeShapeDslReturnKind::Gradual(domain)
                 }
-                Some(TypeShapeDslIntrinsic::Broadcast) => {
-                    if call.arguments.args.len() != 2 || !call.arguments.keywords.is_empty() {
-                        return Err(TypeShapeDslDefinitionError {
-                            range: call.arguments.range,
-                            message: "`broadcast` requires exactly two positional arguments",
-                        });
-                    }
-                    let (Expr::Name(_), Expr::Name(_)) =
-                        (&call.arguments.args[0], &call.arguments.args[1])
-                    else {
-                        return Err(TypeShapeDslDefinitionError {
-                            range: call.arguments.range,
-                            message: "`broadcast` arguments must be bare parameter names",
-                        });
-                    };
-                    let left = self.slot(&call.arguments.args[0], flow)?;
-                    let right = self.slot(&call.arguments.args[1], flow)?;
-                    let (Some(left_parameters), Some(right_parameters)) = (
-                        flow.kinds[left].int_tuple_parameter_origins(),
-                        flow.kinds[right].int_tuple_parameter_origins(),
-                    ) else {
-                        return Err(TypeShapeDslDefinitionError {
-                            range: call.arguments.range,
-                            message: "`broadcast` arguments must be IntTuple parameters or immutable aliases of them",
-                        });
-                    };
-                    TypeShapeDslReturnKind::Broadcast {
-                        left_slot: left,
-                        right_slot: right,
-                        left_parameters,
-                        right_parameters,
-                    }
-                }
                 Some(
                     TypeShapeDslIntrinsic::IntTuple
                     | TypeShapeDslIntrinsic::Concat
@@ -5186,7 +5134,7 @@ impl<'a, F: Fn(&Expr) -> Option<TypeShapeDslIntrinsic>> DslValidator<'a, F> {
                 Some(_) => {
                     return Err(TypeShapeDslDefinitionError {
                         range: return_stmt.range,
-                        message: "return value must be a bare parameter name, gradual return, `broadcast(...)`, `dsl.Invalid(...)`, an Int/IntTuple/IntTuples expression, or a validated DSL helper call",
+                        message: "return value must be a bare parameter name, gradual return, `dsl.Invalid(...)`, an Int/IntTuple/IntTuples expression, or a validated DSL helper call",
                     });
                 }
             },
@@ -5215,7 +5163,7 @@ impl<'a, F: Fn(&Expr) -> Option<TypeShapeDslIntrinsic>> DslValidator<'a, F> {
             _ => {
                 return Err(TypeShapeDslDefinitionError {
                     range: return_stmt.range,
-                    message: "return value must be a bare parameter name, gradual return, `broadcast(...)`, `dsl.Invalid(...)`, an Int/IntTuple/IntTuples expression, or a validated DSL helper call",
+                    message: "return value must be a bare parameter name, gradual return, `dsl.Invalid(...)`, an Int/IntTuple/IntTuples expression, or a validated DSL helper call",
                 });
             }
         };
@@ -5738,7 +5686,6 @@ pub struct TypeLevelDslCall {
 /// The identity of a type-level DSL operation.
 #[derive(Debug, Clone, PartialEq, Eq, TypeEq, PartialOrd, Ord, Hash)]
 pub enum TypeLevelDslFunction {
-    Broadcast,
     UserDefined(Arc<ResolvedTypeShapeDslFunction>),
     /// A deferred `shape_extensions.MapIntTuples[<lambda>, <source>]` application.
     MapIntTuples(MapIntTuples),
@@ -5895,7 +5842,7 @@ enum DslControlFlow {
 impl Visit<Type> for TypeLevelDslFunction {
     fn recurse<'a>(&'a self, f: &mut dyn FnMut(&'a Type)) {
         match self {
-            Self::Broadcast | Self::UserDefined(_) => {}
+            Self::UserDefined(_) => {}
             Self::MapIntTuples(map) => map.visit(f),
         }
     }
@@ -5904,21 +5851,13 @@ impl Visit<Type> for TypeLevelDslFunction {
 impl VisitMut<Type> for TypeLevelDslFunction {
     fn recurse_mut(&mut self, f: &mut dyn FnMut(&mut Type)) {
         match self {
-            Self::Broadcast | Self::UserDefined(_) => {}
+            Self::UserDefined(_) => {}
             Self::MapIntTuples(map) => map.visit_mut(f),
         }
     }
 }
 
 impl TypeLevelDslCall {
-    /// Constructs a native two-argument broadcast call.
-    pub fn broadcast(args: Vec<Type>) -> Self {
-        Self {
-            function: TypeLevelDslFunction::Broadcast,
-            args,
-        }
-    }
-
     pub fn user_defined(function: Arc<ResolvedTypeShapeDslFunction>, args: Vec<Type>) -> Self {
         assert_eq!(
             args.len(),
@@ -5933,7 +5872,6 @@ impl TypeLevelDslCall {
 
     pub fn function_name(&self) -> &str {
         match &self.function {
-            TypeLevelDslFunction::Broadcast => "broadcast",
             TypeLevelDslFunction::UserDefined(function) => function.name().as_str(),
             TypeLevelDslFunction::MapIntTuples(_) => "MapIntTuples",
         }
@@ -5942,7 +5880,6 @@ impl TypeLevelDslCall {
     /// Returns the shape-DSL result domain, or `None` for a map of arbitrary result types.
     pub fn result_domain(&self) -> Option<TypeShapeDslDomain> {
         match &self.function {
-            TypeLevelDslFunction::Broadcast => Some(TypeShapeDslDomain::IntTuple),
             TypeLevelDslFunction::UserDefined(function) => Some(function.result_domain()),
             TypeLevelDslFunction::MapIntTuples(map) => map.result_domain(),
         }
@@ -5951,7 +5888,6 @@ impl TypeLevelDslCall {
     /// Returns the gradual result for a call whose precise value cannot be determined.
     pub fn fallback(&self) -> Type {
         match &self.function {
-            TypeLevelDslFunction::Broadcast => IntTuple::shapeless().to_shape_arg_type(),
             TypeLevelDslFunction::UserDefined(function) => match function.result_domain() {
                 TypeShapeDslDomain::Int => gradual_size(),
                 TypeShapeDslDomain::IntTuple => IntTuple::shapeless().to_shape_arg_type(),
@@ -5996,15 +5932,6 @@ impl TypeLevelDslCall {
             DslOutcome::Invalid(error) => Err(error),
         };
         match &self.function {
-            TypeLevelDslFunction::Broadcast => {
-                let [left, right] = self.args.as_slice() else {
-                    unreachable!("native broadcast DSL calls are constructed with two arguments");
-                };
-                project(evaluate_broadcast(
-                    &DslValue::from_shape_type(left),
-                    &DslValue::from_shape_type(right),
-                ))
-            }
             TypeLevelDslFunction::UserDefined(function) => project(function.evaluate(&self.args)),
             TypeLevelDslFunction::MapIntTuples(map) => map.evaluate(),
         }
@@ -6112,14 +6039,6 @@ impl ResolvedTypeShapeDslProgram {
                             }
                             DslOutcome::Value(environment.value(slot).clone())
                         }
-                        TypeShapeDslReturnKind::Broadcast {
-                            left_slot,
-                            right_slot,
-                            ..
-                        } => evaluate_broadcast(
-                            environment.value(left_slot),
-                            environment.value(right_slot),
-                        ),
                         TypeShapeDslReturnKind::Expression(_) => {
                             let expression = return_stmt
                                 .value
@@ -7952,19 +7871,6 @@ impl StructurallyValidatedTypeShapeDslFunction {
                 }
             }
         })
-    }
-}
-
-fn evaluate_broadcast(left: &DslValue, right: &DslValue) -> DslOutcome {
-    let (DslValue::Shape(left), DslValue::Shape(right)) = (left, right) else {
-        if matches!(left, DslValue::Unknown) || matches!(right, DslValue::Unknown) {
-            return DslOutcome::Value(DslValue::Unknown);
-        }
-        unreachable!("validated broadcast operands evaluate to shapes")
-    };
-    match broadcast_shapes(left, right) {
-        Ok(shape) => DslOutcome::Value(DslValue::Shape(shape)),
-        Err(error) => DslOutcome::Invalid(error),
     }
 }
 

--- a/crates/pyrefly_types/src/type_level_dsl.rs
+++ b/crates/pyrefly_types/src/type_level_dsl.rs
@@ -56,6 +56,9 @@ use crate::einsum::parse_einsum_equation;
 use crate::equality::TypeEq as TypeEqTrait;
 use crate::equality::TypeEqCtx;
 use crate::function::FuncDefId;
+use crate::gufunc::GufuncClassification;
+use crate::gufunc::evaluate_gufunc;
+use crate::gufunc::parse_gufunc_signature;
 use crate::literal::Lit;
 use crate::map_int_tuples::MapIntTuples;
 use crate::quantified::Quantified;
@@ -1165,6 +1168,7 @@ pub enum TypeShapeDslIntrinsic {
     Broadcast,
     Concat,
     Einsum,
+    GufuncBroadcast,
     Gradual(TypeShapeDslDomain),
     IsConcreteInt,
     IsIntValue,
@@ -1191,6 +1195,10 @@ pub enum TypeShapeDslExpressionKind {
     IntTupleSlice,
     IntTupleConcat,
     Einsum {
+        shapes: usize,
+        parameter_origins: Option<Box<[usize]>>,
+    },
+    GufuncBroadcast {
         shapes: usize,
         parameter_origins: Option<Box<[usize]>>,
     },
@@ -3599,6 +3607,55 @@ impl<'a, F: Fn(&Expr) -> Option<TypeShapeDslIntrinsic>> DslValidator<'a, F> {
         Ok(())
     }
 
+    fn validate_gufunc_broadcast(
+        &mut self,
+        call: &ExprCall,
+        flow: &DslValidationFlow,
+    ) -> Result<(), TypeShapeDslDefinitionError> {
+        const SHAPES_ERROR: &str =
+            "`dsl._gufunc_broadcast` shapes must be an `IntTuples` parameter or immutable alias";
+        if call.arguments.args.len() != 2
+            || !call.arguments.keywords.is_empty()
+            || call
+                .arguments
+                .args
+                .iter()
+                .any(|argument| matches!(argument, Expr::Starred(_)))
+        {
+            return Err(TypeShapeDslDefinitionError {
+                range: call.arguments.range,
+                message: "`dsl._gufunc_broadcast` requires exactly two positional arguments",
+            });
+        }
+        self.validate_flag_string(&call.arguments.args[0], flow)?;
+        let shapes = &call.arguments.args[1];
+        let Expr::Name(_) = shapes else {
+            return Err(TypeShapeDslDefinitionError {
+                range: shapes.range(),
+                message: SHAPES_ERROR,
+            });
+        };
+        let slot = self.slot(shapes, flow)?;
+        let parameter_origins = match &flow.kinds[slot] {
+            DslStaticKind::UnknownParameters(parameters) => Some(parameters.clone()),
+            DslStaticKind::IntTuples { parameter_origins } => parameter_origins.clone(),
+            _ => {
+                return Err(TypeShapeDslDefinitionError {
+                    range: shapes.range(),
+                    message: SHAPES_ERROR,
+                });
+            }
+        };
+        self.expressions.push(TypeShapeDslExpression {
+            range: call.range(),
+            kind: TypeShapeDslExpressionKind::GufuncBroadcast {
+                shapes: slot,
+                parameter_origins,
+            },
+        });
+        Ok(())
+    }
+
     fn validate_gradual_call(call: &ExprCall) -> Result<(), TypeShapeDslDefinitionError> {
         if call.arguments.args.is_empty() && call.arguments.keywords.is_empty() {
             Ok(())
@@ -3788,10 +3845,16 @@ impl<'a, F: Fn(&Expr) -> Option<TypeShapeDslIntrinsic>> DslValidator<'a, F> {
                 self.validate_einsum(call, flow)?;
                 None
             }
+            Expr::Call(call)
+                if self.intrinsic(&call.func) == Some(TypeShapeDslIntrinsic::GufuncBroadcast) =>
+            {
+                self.validate_gufunc_broadcast(call, flow)?;
+                None
+            }
             _ => {
                 return Err(TypeShapeDslDefinitionError {
                     range: expression.range(),
-                    message: "IntTuple shape expressions support parameters, immutable aliases, restricted slices, `dsl.IntTuple`, `dsl.concat`, and `dsl.einsum`",
+                    message: "IntTuple shape expressions support parameters, immutable aliases, restricted slices, `dsl.IntTuple`, `dsl.concat`, `dsl.einsum`, and `dsl._gufunc_broadcast`",
                 });
             }
         };
@@ -3911,6 +3974,7 @@ impl<'a, F: Fn(&Expr) -> Option<TypeShapeDslIntrinsic>> DslValidator<'a, F> {
                         TypeShapeDslIntrinsic::IntTuple
                             | TypeShapeDslIntrinsic::Concat
                             | TypeShapeDslIntrinsic::Einsum
+                            | TypeShapeDslIntrinsic::GufuncBroadcast
                     )
                 ) =>
             {
@@ -4952,7 +5016,8 @@ impl<'a, F: Fn(&Expr) -> Option<TypeShapeDslIntrinsic>> DslValidator<'a, F> {
                 Some(
                     TypeShapeDslIntrinsic::IntTuple
                     | TypeShapeDslIntrinsic::Concat
-                    | TypeShapeDslIntrinsic::Einsum,
+                    | TypeShapeDslIntrinsic::Einsum
+                    | TypeShapeDslIntrinsic::GufuncBroadcast,
                 ) => {
                     self.validate_int_tuple_expression(returned, flow)?;
                     TypeShapeDslReturnKind::Expression(TypeShapeDslDomain::IntTuple)
@@ -6678,6 +6743,47 @@ impl StructurallyValidatedTypeShapeDslFunction {
                     return DslOutcome::Value(DslValue::Unknown);
                 };
                 match evaluate_einsum(&equation, operands) {
+                    Ok(shape) => DslOutcome::Value(DslValue::Shape(shape)),
+                    Err(error) => DslOutcome::Invalid(error),
+                }
+            }
+            TypeShapeDslExpressionKind::GufuncBroadcast { shapes, .. } => {
+                let Expr::Call(call) = expression else {
+                    unreachable!("validated gufunc broadcast expression is a call")
+                };
+                let spec =
+                    match self.evaluate_expression(&call.arguments.args[0], environment, budget) {
+                        DslOutcome::Value(DslValue::FlagString(spec)) => Some(spec),
+                        DslOutcome::Value(DslValue::FlagNone | DslValue::Unknown) => None,
+                        invalid @ DslOutcome::Invalid(_) => return invalid,
+                        DslOutcome::ExplicitGradual => {
+                            unreachable!("validated value expression cannot return gradual")
+                        }
+                        DslOutcome::Value(_) => {
+                            unreachable!("validated gufunc signature is a string Flag")
+                        }
+                    };
+                let signature = match spec {
+                    Some(spec) => match parse_gufunc_signature(&spec) {
+                        GufuncClassification::Supported(signature) => Some(signature),
+                        GufuncClassification::Unsupported(_unsupported) => None,
+                        GufuncClassification::Invalid(error) => {
+                            return DslOutcome::Invalid(ShapeError::ShapeComputation {
+                                message: error.message(),
+                            });
+                        }
+                    },
+                    None => None,
+                };
+                let operands = match environment.value(shapes) {
+                    DslValue::IntTuples(DslIntTuples::Fixed(operands)) => Some(operands.as_slice()),
+                    DslValue::IntTuples(DslIntTuples::Unbounded(_)) | DslValue::Unknown => None,
+                    _ => unreachable!("validated gufunc operands are an IntTuples value"),
+                };
+                let Some((signature, operands)) = signature.zip(operands) else {
+                    return DslOutcome::Value(DslValue::Unknown);
+                };
+                match evaluate_gufunc(&signature, operands) {
                     Ok(shape) => DslOutcome::Value(DslValue::Shape(shape)),
                     Err(error) => DslOutcome::Invalid(error),
                 }

--- a/pyrefly/lib/alt/type_level_dsl.rs
+++ b/pyrefly/lib/alt/type_level_dsl.rs
@@ -833,29 +833,6 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                             valid_body = false;
                         }
                     }
-                    TypeShapeDslReturnKind::Broadcast {
-                        left_parameters,
-                        right_parameters,
-                        ..
-                    } if result != TypeShapeDslDomain::IntTuple
-                        || !left_parameters.iter().all(|parameter| {
-                            parameter_domains[*parameter]
-                                == TypeShapeDslInputDomain::Value(TypeShapeDslDomain::IntTuple)
-                        })
-                        || !right_parameters.iter().all(|parameter| {
-                            parameter_domains[*parameter]
-                                == TypeShapeDslInputDomain::Value(TypeShapeDslDomain::IntTuple)
-                        }) =>
-                    {
-                        self.error(
-                            errors,
-                            return_.range(),
-                            ErrorKind::InvalidArgument,
-                            "`@type_shape_dsl_function` broadcast return requires two `IntTuple` parameters and an `IntTuple` result"
-                                .to_owned(),
-                        );
-                        valid_body = false;
-                    }
                     TypeShapeDslReturnKind::Gradual(domain) if *domain != result => {
                         self.error(
                             errors,
@@ -883,7 +860,6 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                         valid_body = false;
                     }
                     TypeShapeDslReturnKind::Slot { .. }
-                    | TypeShapeDslReturnKind::Broadcast { .. }
                     | TypeShapeDslReturnKind::Expression(_)
                     | TypeShapeDslReturnKind::Invalid
                     | TypeShapeDslReturnKind::HelperCall(_)
@@ -1026,11 +1002,6 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         match callee.callee_kind() {
             Some(CalleeKind::Function(FunctionKind::TypeShapeDsl(_, function))) => self
                 .parse_user_defined_type_level_dsl_call(call, function, type_form_context, errors),
-            Some(CalleeKind::Function(FunctionKind::Def(id)))
-                if id.has_toplevel_qname("shape_extensions", "broadcast") =>
-            {
-                self.parse_broadcast_type_level_dsl_call(call, type_form_context, errors)
-            }
             _ => self.error(
                 errors,
                 call.func.range(),
@@ -1249,62 +1220,6 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 _ => self.expr_untype(arg, type_form_context, errors),
             },
         }
-    }
-
-    fn parse_broadcast_type_level_dsl_call(
-        &self,
-        call: &ExprCall,
-        type_form_context: TypeFormContext<'_>,
-        errors: &ErrorCollector,
-    ) -> Type {
-        if !call.arguments.keywords.is_empty() {
-            return self.error(
-                errors,
-                call.range(),
-                ErrorKind::InvalidAnnotation,
-                "`broadcast` does not accept keyword arguments".to_owned(),
-            );
-        }
-        if call.arguments.args.len() != 2 {
-            return self.error(
-                errors,
-                call.range(),
-                ErrorKind::InvalidAnnotation,
-                format!(
-                    "Expected 2 arguments for `broadcast`, got {}",
-                    call.arguments.args.len()
-                ),
-            );
-        }
-
-        let argument_context = TypeFormContext::TypeArgument(&type_form_context);
-        let args: Vec<_> = call
-            .arguments
-            .args
-            .iter()
-            .map(|arg| {
-                let ty = self.expr_untype(arg, argument_context, errors);
-                if ty.is_error() {
-                    ty
-                } else if !self.is_int_tuple_dsl_argument(&ty) {
-                    self.error(
-                        errors,
-                        arg.range(),
-                        ErrorKind::InvalidAnnotation,
-                        format!(
-                            "Expected an `IntTuple` argument to `broadcast`, got `{}`",
-                            self.for_display(ty.clone())
-                        ),
-                    )
-                } else {
-                    ty
-                }
-            })
-            .collect();
-        if args.iter().any(Type::is_error) {
-            return Type::any_error();
-        }
-        Type::TypeLevelDslCall(Box::new(TypeLevelDslCall::broadcast(args)))
     }
 
     pub(crate) fn is_int_tuple_dsl_argument(&self, ty: &Type) -> bool {

--- a/pyrefly/lib/alt/type_level_dsl.rs
+++ b/pyrefly/lib/alt/type_level_dsl.rs
@@ -969,9 +969,6 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         let FunctionKind::Def(id) = function_kind else {
             return None;
         };
-        if id.has_toplevel_qname("shape_extensions", "broadcast") {
-            return Some(TypeShapeDslIntrinsic::Broadcast);
-        }
         if id.has_toplevel_qname("builtins", "any") {
             return Some(TypeShapeDslIntrinsic::Any);
         }

--- a/pyrefly/lib/alt/type_level_dsl.rs
+++ b/pyrefly/lib/alt/type_level_dsl.rs
@@ -647,6 +647,14 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                             == TypeShapeDslInputDomain::Value(TypeShapeDslDomain::IntTuples)
                     }))
                     .then_some("`@type_shape_dsl_function` einsum operands must be annotated as `IntTuples`"),
+                    TypeShapeDslExpressionKind::GufuncBroadcast {
+                        parameter_origins: Some(parameters),
+                        ..
+                    } => (!parameters.iter().all(|parameter| {
+                        parameter_domains[*parameter]
+                            == TypeShapeDslInputDomain::Value(TypeShapeDslDomain::IntTuples)
+                    }))
+                    .then_some("`@type_shape_dsl_function` gufunc operands must be annotated as `IntTuples`"),
                     TypeShapeDslExpressionKind::FlagValueSlot {
                         parameter_uses: Some(uses),
                         required,
@@ -691,6 +699,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     | TypeShapeDslExpressionKind::IntTupleSlice
                     | TypeShapeDslExpressionKind::IntTupleConcat
                     | TypeShapeDslExpressionKind::Einsum { .. }
+                    | TypeShapeDslExpressionKind::GufuncBroadcast { .. }
                     | TypeShapeDslExpressionKind::IntTupleConstructor
                     | TypeShapeDslExpressionKind::IntTuplesConstructor
                     | TypeShapeDslExpressionKind::IntTupleProduct
@@ -989,6 +998,9 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         }
         if id.has_toplevel_qname("shape_extensions.dsl", "einsum") {
             return Some(TypeShapeDslIntrinsic::Einsum);
+        }
+        if id.has_toplevel_qname("shape_extensions.dsl", "_gufunc_broadcast") {
+            return Some(TypeShapeDslIntrinsic::GufuncBroadcast);
         }
         let class = id.cls.as_ref()?;
         if id.qname.id().as_str() != "gradual" {

--- a/pyrefly/lib/test/incremental.rs
+++ b/pyrefly/lib/test/incremental.rs
@@ -454,6 +454,66 @@ def leaf(first: Int, second: Int) -> Int:
 }
 
 #[test]
+fn test_type_shape_dsl_broadcast_edit_invalidates_importer() {
+    let mut i = Incremental::with_files(vec![
+        "main".to_owned(),
+        "consumer".to_owned(),
+        "shape_extensions".to_owned(),
+    ]);
+    i.set(
+        "shape_extensions",
+        r#"
+class IntTuple: pass
+def shaped_array[T](*, shape: str): ...
+def type_shape_dsl_function[F](fn: F) -> F: return fn
+
+@type_shape_dsl_function
+def broadcast(left: IntTuple, right: IntTuple) -> IntTuple:
+    return left
+"#,
+    );
+    i.set(
+        "main",
+        r#"
+from shape_extensions import IntTuple, broadcast, shaped_array
+
+@shaped_array(shape="Shape")
+class Tensor[Shape: IntTuple]: ...
+
+def chosen() -> Tensor[broadcast(IntTuple[2], IntTuple[3])]: ...
+"#,
+    );
+    i.set(
+        "consumer",
+        r#"
+from main import Tensor, chosen
+
+result: Tensor[[2]] = chosen()
+"#,
+    );
+    let initial = i.unchecked(&["consumer"]);
+    assert!(initial.errors.collect_display_errors().is_empty());
+
+    i.set(
+        "shape_extensions",
+        r#"
+class IntTuple: pass
+def shaped_array[T](*, shape: str): ...
+def type_shape_dsl_function[F](fn: F) -> F: return fn
+
+@type_shape_dsl_function
+def broadcast(left: IntTuple, right: IntTuple) -> IntTuple:
+    return right
+"#,
+    );
+    let changed = i.unchecked(&["consumer"]);
+    changed.check_recompute(&["consumer", "main", "shape_extensions"]);
+    let errors = changed.errors.collect_display_errors();
+    assert_eq!(errors.len(), 1, "{errors:?}");
+    assert!(errors[0].msg().contains("not assignable to `Tensor[[2]]`"));
+}
+
+#[test]
 fn test_type_shape_dsl_cross_module_helper_cycle_is_rejected() {
     let mut i = Incremental::with_files(vec![
         "left".to_owned(),

--- a/pyrefly/lib/test/shape_dsl.rs
+++ b/pyrefly/lib/test/shape_dsl.rs
@@ -3007,7 +3007,7 @@ def bare_qualified_shape(x: IntTuple) -> IntTuple:
 
 @type_shape_dsl_function
 def nested(x: Int) -> Int:
-    return (official_gradual(),)  # E: return value must be a bare parameter name, gradual return, `broadcast(...)`, `dsl.Invalid(...)`, an Int/IntTuple/IntTuples expression, or a validated DSL helper call  # E: Returned type
+    return (official_gradual(),)  # E: return value must be a bare parameter name, gradual return, `dsl.Invalid(...)`, an Int/IntTuple/IntTuples expression, or a validated DSL helper call  # E: Returned type
 
 @type_shape_dsl_function
 def statement(x: Int) -> Int:

--- a/pyrefly/lib/test/shape_dsl.rs
+++ b/pyrefly/lib/test/shape_dsl.rs
@@ -13438,3 +13438,124 @@ def parameter_shadow(einsum_alias: Int, spec: str, shapes: IntTuples) -> IntTupl
     return einsum_alias(spec, shapes)  # E: DSL helper callee must be a validated  # E: Expected a callable
 "#,
 );
+
+testcase!(
+    test_type_shape_dsl_gufunc_primitive,
+    shape_dsl_base_env(),
+    r#"
+import shape_extensions.dsl as dsl
+from shape_extensions import Flag, Int, IntTuple, IntTuples, IntVar, type_shape_dsl_function
+from typing import assert_type, reveal_type
+
+class ShapeBox[Shape: IntTuple]: ...
+
+@type_shape_dsl_function
+def gufunc(spec: str, shapes: IntTuples) -> IntTuple:
+    return dsl._gufunc_broadcast(spec, shapes)
+
+def matrix_product() -> ShapeBox[gufunc("(m,n),(n,p)->(m,p)", tuple[IntTuple[2, 3], IntTuple[3, 5]])]: ...
+def batched_product() -> ShapeBox[gufunc("(m,n),(n,p)->(m,p)", tuple[IntTuple[7, 2, 3], IntTuple[1, 3, 5]])]: ...
+def scalar_broadcast() -> ShapeBox[gufunc("(),()->()", tuple[IntTuple[2, 1, 4], IntTuple[3, 4]])]: ...
+def unbounded() -> ShapeBox[gufunc("(m,n),(n,p)->(m,p)", tuple[IntTuple[2, 3], ...])]: ...
+def unsupported() -> ShapeBox[gufunc("(n)->(n),(n)", tuple[IntTuple[2]])]: ...
+def unknown[Spec: Flag[str]](spec: Spec) -> ShapeBox[gufunc(Spec, tuple[IntTuple[2]])]: ...
+
+assert_type(matrix_product(), ShapeBox[IntTuple[2, 5]])
+assert_type(batched_product(), ShapeBox[IntTuple[7, 2, 5]])
+assert_type(scalar_broadcast(), ShapeBox[IntTuple[2, 3, 4]])
+assert_type(unbounded(), ShapeBox[IntTuple])
+assert_type(unsupported(), ShapeBox[IntTuple])
+assert_type(unknown("(n)->(n)"), ShapeBox[IntTuple[2]])
+
+def check_unknown[Spec: Flag[str]](spec: Spec) -> None:
+    assert_type(unknown(spec), ShapeBox[IntTuple])
+
+def symbolic[N: IntVar](n: Int[N]) -> ShapeBox[gufunc("(n)->(n)", tuple[IntTuple[N]])]: ...
+def gradual_member() -> ShapeBox[gufunc("(m,n),(n,p)->(m,p)", tuple[IntTuple[2, 3], IntTuple])]: ...
+
+def check_symbolic[N: IntVar](n: Int[N]) -> None:
+    assert_type(symbolic(n), ShapeBox[IntTuple[N]])
+
+reveal_type(gradual_member())  # E: revealed type: ShapeBox[IntTuple[*tuple[int, ...], 2, int]]
+"#,
+);
+
+testcase!(
+    test_type_shape_dsl_gufunc_primitive_errors,
+    shape_dsl_base_env(),
+    r#"
+import shape_extensions.dsl as dsl
+from shape_extensions import IntTuple, IntTuples, type_shape_dsl_function
+
+class ShapeBox[Shape: IntTuple]: ...
+
+@type_shape_dsl_function
+def gufunc(spec: str, shapes: IntTuples) -> IntTuple:
+    return dsl._gufunc_broadcast(spec, shapes)
+
+def malformed() -> ShapeBox[gufunc("(m,n),(n,p)-(m,p)", tuple[IntTuple[2, 3], IntTuple[3, 5]])]: ...
+def wrong_count() -> ShapeBox[gufunc("(m,n),(n,p)->(m,p)", tuple[IntTuple[2, 3]])]: ...
+def wrong_rank() -> ShapeBox[gufunc("(m,n),(n,p)->(m,p)", tuple[IntTuple[2], IntTuple[3, 5]])]: ...
+def core_conflict() -> ShapeBox[gufunc("(n),(n)->()", tuple[IntTuple[1], IntTuple[5]])]: ...
+
+malformed()  # E: Cannot evaluate type-level shape DSL call: gufunc: signature must contain exactly one '->', got 0
+wrong_count()  # E: Cannot evaluate type-level shape DSL call: gufunc: expected 2 operands, got 1
+wrong_rank()  # E: Cannot evaluate type-level shape DSL call: gufunc: operand 0 requires at least rank 2, got 1
+core_conflict()  # E: Cannot evaluate type-level shape DSL call: gufunc: core dimension 'n' has conflicting extents 1 and 5
+"#,
+);
+
+testcase!(
+    test_type_shape_dsl_gufunc_primitive_surface,
+    shape_dsl_base_env(),
+    r#"
+import shape_extensions.dsl as dsl
+from shape_extensions import Int, IntTuple, IntTuples, type_shape_dsl_function
+from shape_extensions.dsl import _gufunc_broadcast as imported_gufunc
+from typing import assert_type
+
+class ShapeBox[Shape: IntTuple]: ...
+
+gufunc_alias = imported_gufunc
+
+@type_shape_dsl_function
+def imported(spec: str, shapes: IntTuples) -> IntTuple:
+    return imported_gufunc(spec, shapes)
+
+@type_shape_dsl_function
+def aliased(spec: str, shapes: IntTuples) -> IntTuple:
+    result = gufunc_alias(spec, shapes)
+    return result
+
+def imported_result() -> ShapeBox[imported("(m,n),(n,p)->(m,p)", tuple[IntTuple[2, 3], IntTuple[3, 5]])]: ...
+def aliased_result() -> ShapeBox[aliased("(n)->(n)", tuple[IntTuple[4]])]: ...
+assert_type(imported_result(), ShapeBox[IntTuple[2, 5]])
+assert_type(aliased_result(), ShapeBox[IntTuple[4]])
+
+def direct() -> ShapeBox[dsl._gufunc_broadcast("(n)->(n)", tuple[IntTuple[4]])]: ...  # E: Expected a type-level DSL function
+
+@type_shape_dsl_function
+def missing(spec: str, shapes: IntTuples) -> IntTuple:
+    return dsl._gufunc_broadcast()  # E: `dsl._gufunc_broadcast` requires exactly two positional arguments  # E: Missing positional arguments `spec`, `shapes`
+
+@type_shape_dsl_function
+def keyword(spec: str, shapes: IntTuples) -> IntTuple:
+    return dsl._gufunc_broadcast(spec=spec, shapes=shapes)  # E: `dsl._gufunc_broadcast` requires exactly two positional arguments  # E: Expected argument `spec` to be positional  # E: Expected argument `shapes` to be positional
+
+@type_shape_dsl_function
+def wrong_spec(spec: int, shapes: IntTuples) -> IntTuple:
+    return dsl._gufunc_broadcast(spec, shapes)  # E: Flag operation requires a compatible Flag parameter  # E: Argument `int` is not assignable to parameter `spec` with type `str`
+
+@type_shape_dsl_function
+def wrong_shapes(spec: str, shape: IntTuple) -> IntTuple:
+    return dsl._gufunc_broadcast(spec, shape)  # E: shapes must be an `IntTuples` parameter or immutable alias  # E: is not assignable to parameter `shapes`
+
+@type_shape_dsl_function
+def wrong_shapes_tuple_of_int(spec: str, shapes: tuple[int, ...]) -> IntTuple:
+    return dsl._gufunc_broadcast(spec, shapes)  # E: gufunc operands must be annotated as `IntTuples`  # E: is not assignable to parameter `shapes`
+
+@type_shape_dsl_function
+def parameter_shadow(gufunc_alias: Int, spec: str, shapes: IntTuples) -> IntTuple:
+    return gufunc_alias(spec, shapes)  # E: DSL helper callee must be a validated  # E: Expected a callable
+"#,
+);

--- a/pyrefly/lib/test/shape_dsl.rs
+++ b/pyrefly/lib/test/shape_dsl.rs
@@ -548,6 +548,31 @@ def diag_extent(n: Int, k: int) -> Int:
 }
 
 #[test]
+fn test_broadcast_is_a_user_defined_type_shape_dsl_function() {
+    let mut env = shape_dsl_base_env();
+    env.add("main", "from shape_extensions import broadcast\n");
+    let (state, handle) = env.to_state();
+    let main = handle("main");
+    let solutions = state
+        .transaction()
+        .get_solutions(&main)
+        .expect("module should solve");
+    let broadcast = solutions.get(&KeyExport(Name::new("broadcast")));
+    assert!(
+        matches!(broadcast, Type::Function(function)
+            if matches!(&function.metadata.kind,
+                FunctionKind::TypeShapeDsl(_, resolved)
+                    if resolved.parameter_domains()
+                        == [
+                            TypeShapeDslInputDomain::Value(TypeShapeDslDomain::IntTuple),
+                            TypeShapeDslInputDomain::Value(TypeShapeDslDomain::IntTuple),
+                        ]
+                        && resolved.result_domain() == TypeShapeDslDomain::IntTuple)),
+        "expected `broadcast` to be a user-defined type-level DSL function, got `{broadcast}`",
+    );
+}
+
+#[test]
 fn test_invalid_type_shape_dsl_function_recovers_as_def() {
     let mut env = shaped_array_env();
     env.add(
@@ -1400,7 +1425,7 @@ def add_expanded(
 ) -> None:
     add_overloaded(*args)  # E: Cannot evaluate type-level shape DSL call: Cannot broadcast dimension Int[2] with dimension Int[4] at position 0
 
-def bad_domain[S0: IntTuple](x: Tensor[S0]) -> Tensor[broadcast(int, S0)]: ...  # E: Expected an `IntTuple` argument to `broadcast`
+def bad_domain[S0: IntTuple](x: Tensor[S0]) -> Tensor[broadcast(int, S0)]: ...  # E: Expected an `IntTuple` argument for parameter `left` (position 1) of `broadcast`
 def bad_arity[S0: IntTuple](x: Tensor[S0]) -> Tensor[broadcast(S0)]: ...  # E: Expected 2 arguments for `broadcast`, got 1
 def bad_keyword[S0: IntTuple](x: Tensor[S0]) -> Tensor[broadcast(S0, right=S0)]: ...  # E: `broadcast` does not accept keyword arguments
 
@@ -1595,23 +1620,23 @@ def shadowed(left: IntTuple, right: IntTuple, native_broadcast: IntTuple) -> Int
 
 @type_shape_dsl_function
 def missing(left: IntTuple, right: IntTuple) -> IntTuple:
-    return native_broadcast(left)  # E: `broadcast` requires exactly two positional arguments
+    return native_broadcast(left)  # E: helper argument domains are incompatible  # E: Missing argument `right`
 
 @type_shape_dsl_function
 def keyword(left: IntTuple, right: IntTuple) -> IntTuple:
-    return native_broadcast(left, right=right)  # E: `broadcast` requires exactly two positional arguments  # E: Unexpected keyword argument
+    return native_broadcast(left, right=right)  # E: DSL helper calls accept only positional arguments
 
 @type_shape_dsl_function
 def expression(left: IntTuple, right: IntTuple) -> IntTuple:
-    return native_broadcast(native_broadcast(left, right), right)  # E: `broadcast` arguments must be bare parameter names
+    return native_broadcast(native_broadcast(left, right), right)  # E: helper arguments must be bare parameter or local names
 
 @type_shape_dsl_function
 def wrong_parameter(left: Int, right: IntTuple) -> IntTuple:
-    return native_broadcast(left, right)  # E: broadcast return requires two `IntTuple` parameters
+    return native_broadcast(left, right)  # E: helper argument domains are incompatible  # E: not assignable to parameter `left`
 
 @type_shape_dsl_function
 def wrong_result(left: IntTuple, right: IntTuple) -> Int:
-    return native_broadcast(left, right)  # E: broadcast return requires two `IntTuple` parameters  # E: Returned type
+    return native_broadcast(left, right)  # E: helper result domain must match  # E: Returned type
 
 def invalid_metadata() -> Tensor[local_lookalike(IntTuple[2], IntTuple[2])]: ...  # E: Expected a type-level DSL function
 "#,
@@ -4497,7 +4522,7 @@ def type_is_boundary[S: IntTuple](x: object) -> TypeIs[Tensor[broadcast(S, S)]]:
 
 def bad_arity() -> Tensor[broadcast(IntTuple[2])]: ...  # E: Expected 2 arguments for `broadcast`, got 1
 def bad_keyword() -> Tensor[broadcast(IntTuple[2], right=IntTuple[2])]: ...  # E: `broadcast` does not accept keyword arguments
-def bad_domain() -> Tensor[broadcast(int, IntTuple[2])]: ...  # E: Expected an `IntTuple` argument to `broadcast`
+def bad_domain() -> Tensor[broadcast(int, IntTuple[2])]: ...  # E: Expected an `IntTuple` argument for parameter `left` (position 1) of `broadcast`
 def bad_dimension() -> Tensor[[broadcast(IntTuple[2], IntTuple[2])]]: ...  # E: Expected a type-level shape DSL call with an `Int` result in a shape dimension, got an `IntTuple` result
 "#,
 );
@@ -11247,7 +11272,7 @@ def invalid_join_broadcast(
     shape: IntTuple, candidate: int, choose_branch: bool,
 ) -> IntTuple:
     right = candidate if choose_branch else 0
-    return broadcast(shape, right)  # E: `broadcast` arguments must be IntTuple parameters
+    return broadcast(shape, right)  # E: helper argument domains are incompatible  # E: not assignable to parameter `right`
 
 @type_shape_dsl_function
 def copy_by_binder(shape: IntTuple) -> IntTuple:

--- a/pyrefly/lib/test/shape_dsl.rs
+++ b/pyrefly/lib/test/shape_dsl.rs
@@ -13559,3 +13559,44 @@ def parameter_shadow(gufunc_alias: Int, spec: str, shapes: IntTuples) -> IntTupl
     return gufunc_alias(spec, shapes)  # E: DSL helper callee must be a validated  # E: Expected a callable
 "#,
 );
+
+testcase!(
+    test_type_shape_dsl_gufunc_public_wrapper,
+    shape_dsl_base_env(),
+    r#"
+import shape_extensions as shapes
+from shape_extensions import Flag, IntTuple, IntTuples, gufunc_broadcast
+from shape_extensions import gufunc_broadcast as imported_gufunc_broadcast
+from shape_extensions import type_shape_dsl_function
+from typing import assert_type
+
+class ShapeBox[Shape: IntTuple]: ...
+
+gufunc_alias = imported_gufunc_broadcast
+
+@type_shape_dsl_function
+def forwarded(spec: str, operands: IntTuples) -> IntTuple:
+    return gufunc_broadcast(spec, operands)
+
+def direct() -> ShapeBox[gufunc_broadcast("(m,n),(n,p)->(m,p)", tuple[IntTuple[2, 3], IntTuple[3, 5]])]: ...
+def module_import() -> ShapeBox[shapes.gufunc_broadcast("(n)->(n)", tuple[IntTuple[4]])]: ...
+def imported_alias() -> ShapeBox[imported_gufunc_broadcast("(n)->(n)", tuple[IntTuple[5]])]: ...
+def assigned_alias() -> ShapeBox[gufunc_alias("(n)->(n)", tuple[IntTuple[6]])]: ...
+def composed() -> ShapeBox[forwarded("(),()->()", tuple[IntTuple[2, 1, 4], IntTuple[3, 4]])]: ...
+def unbounded() -> ShapeBox[gufunc_broadcast("(m,n),(n,p)->(m,p)", tuple[IntTuple[2, 3], ...])]: ...
+
+assert_type(direct(), ShapeBox[IntTuple[2, 5]])
+assert_type(module_import(), ShapeBox[IntTuple[4]])
+assert_type(imported_alias(), ShapeBox[IntTuple[5]])
+assert_type(assigned_alias(), ShapeBox[IntTuple[6]])
+assert_type(composed(), ShapeBox[IntTuple[2, 3, 4]])
+assert_type(unbounded(), ShapeBox[IntTuple])
+
+def forwarded_flag[Spec: Flag[str]](spec: Spec) -> ShapeBox[forwarded(Spec, tuple[IntTuple[7]])]: ...
+
+assert_type(forwarded_flag("(n)->(n)"), ShapeBox[IntTuple[7]])
+
+def check_unknown_flag[Spec: Flag[str]](spec: Spec) -> None:
+    assert_type(forwarded_flag(spec), ShapeBox[IntTuple])
+"#,
+);

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_array.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_array.pyi
@@ -10,7 +10,13 @@
 from typing import Any, overload, Sequence
 
 import shape_extensions
-from jax._shapes import permute_shape, reduce_shape, reshape_shape, reverse_shape
+from jax._shapes import (
+    matmul_shape,
+    permute_shape,
+    reduce_shape,
+    reshape_shape,
+    reverse_shape,
+)
 from shape_extensions import broadcast, Flag, IntTuple, IntVar
 
 type _Shape = IntTuple
@@ -143,25 +149,9 @@ class Array[Shape: _Shape = _AnyShape]:
     def __neg__(self) -> Array[Shape]: ...
     def __pos__(self) -> Array[Shape]: ...
     def __abs__(self) -> Array[Shape]: ...
-    # Declared for 2-D operands only, which makes the operator stricter than
-    # `jnp.matmul`: a batched `@` is reported as unsupported where the function
-    # form is gradual. A gradual fallback overload here would also absorb the
-    # mismatched-inner-dimension error, which is the most valuable check in
-    # these stubs, so the narrower declaration is deliberate.
-    @overload
-    def __matmul__[N: IntVar, M: IntVar, P: IntVar](
-        self: Array[[N, M]], other: Array[[M, P]]
-    ) -> Array[[N, P]]: ...
-    @overload
-    def __matmul__[N: IntVar, M: IntVar](
-        self: Array[[N, M]], other: Array[[M]]
-    ) -> Array[[N]]: ...
-    @overload
-    def __matmul__[M: IntVar, P: IntVar](
-        self: Array[[M]], other: Array[[M, P]]
-    ) -> Array[[P]]: ...
-    @overload
-    def __matmul__[M: IntVar](self: Array[[M]], other: Array[[M]]) -> Array[[]]: ...
+    def __matmul__[OtherShape: _Shape](
+        self, other: Array[OtherShape]
+    ) -> Array[matmul_shape(Shape, OtherShape)]: ...
     @overload
     def transpose(self) -> Array[reverse_shape(Shape)]: ...
     @overload

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
@@ -4,7 +4,12 @@
 # LICENSE file in the root directory of this source tree.
 
 import shape_extensions.dsl as dsl
-from shape_extensions import Int, IntTuple, type_shape_dsl_function
+from shape_extensions import (
+    gufunc_broadcast,
+    Int,
+    IntTuple,
+    type_shape_dsl_function,
+)
 
 @type_shape_dsl_function
 def int_min(a: Int, b: Int) -> Int:
@@ -18,75 +23,20 @@ def int_min(a: Int, b: Int) -> Int:
 
 @type_shape_dsl_function
 def matmul_shape(left: IntTuple, right: IntTuple) -> IntTuple:
-    # 1. Reject operands with rank 0 (scalars)
     if len(left) == 0 or len(right) == 0:
-        return dsl.Invalid("matmul requires at least 1-D operands")
-
-    # (k)(*batch,k,m) -> (*batch,m)
+        return dsl.Invalid("matmul expects at least 1-D arrays")
+    operands = dsl.IntTuples((left, right))
+    if len(left) == 1 and len(right) == 1:
+        spec = "(n),(n)->()"
+        return gufunc_broadcast(spec, operands)
     if len(left) == 1:
-        k_left = left[0]
-        k_right = right[len(right) - 2]
-        if (
-            dsl.is_concrete_int(k_left)
-            and dsl.is_concrete_int(k_right)
-            and k_left != k_right
-        ):
-            return dsl.Invalid("matmul inner dimensions must match")
-        return dsl.IntTuple(
-            right[i] if i < len(right) - 2 else right[len(right) - 1]
-            for i in range(len(right) - 1)
-        )
-
-    # (*batch,k)(k) -> (*batch,)
+        spec = "(n),(n,p)->(p)"
+        return gufunc_broadcast(spec, operands)
     if len(right) == 1:
-        k_left = left[len(left) - 1]
-        k_right = right[0]
-        if (
-            dsl.is_concrete_int(k_left)
-            and dsl.is_concrete_int(k_right)
-            and k_left != k_right
-        ):
-            return dsl.Invalid("matmul inner dimensions must match")
-        return dsl.IntTuple(left[i] for i in range(len(left) - 1))
-
-    # (*batch_left,n,k)(*batch_right,k,m) -> (*broadcast(batch_left,batch_right),n,m)
-    k_left = left[len(left) - 1]
-    k_right = right[len(right) - 2]
-    if (
-        dsl.is_concrete_int(k_left)
-        and dsl.is_concrete_int(k_right)
-        and k_left != k_right
-    ):
-        return dsl.Invalid("matmul inner dimensions must match")
-    if len(left) >= len(right):
-        n_batch = len(left) - 2
-        diff = len(left) - len(right)
-        return dsl.IntTuple(
-            (
-                (
-                    (right[i - diff] if left[i] == 1 else left[i])
-                    if i >= diff
-                    else left[i]
-                )
-                if i < n_batch
-                else (left[len(left) - 2] if i == n_batch else right[len(right) - 1])
-            )
-            for i in range(len(left))
-        )
-    n_batch = len(right) - 2
-    diff = len(right) - len(left)
-    return dsl.IntTuple(
-        (
-            (
-                (right[i] if left[i - diff] == 1 else left[i - diff])
-                if i >= diff
-                else right[i]
-            )
-            if i < n_batch
-            else (left[len(left) - 2] if i == n_batch else right[len(right) - 1])
-        )
-        for i in range(len(right))
-    )
+        spec = "(m,n),(n)->(m)"
+        return gufunc_broadcast(spec, operands)
+    spec = "(m,n),(n,p)->(m,p)"
+    return gufunc_broadcast(spec, operands)
 
 @type_shape_dsl_function
 def reverse_shape(shape: IntTuple) -> IntTuple:

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
@@ -886,6 +886,8 @@ def logaddexp2[Shape: _Shape](
 def logaddexp2[Shape1: _Shape, Shape2: _Shape](
     x1: Array[Shape1], x2: Array[Shape2], /
 ) -> Array[broadcast(Shape1, Shape2)]: ...
+
+# Shape semantics, including vector and batched operands, come from the gufunc-backed helper.
 def matmul[LeftShape: _Shape, RightShape: _Shape](
     a: Array[LeftShape], b: Array[RightShape]
 ) -> Array[matmul_shape(LeftShape, RightShape)]: ...

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_linalg.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_linalg.py
@@ -162,7 +162,7 @@ def test_matmul_rejects_mismatched_inner_dimension() -> None:
 
     assert_shape(jnp.linalg.matmul(a, jnp.ones((4, 5))), (3, 5))
     try:
-        # E: Cannot evaluate type-level shape DSL call: matmul inner dimensions must match
+        # E: Cannot evaluate type-level shape DSL call: gufunc: core dimension 'n' has conflicting extents 4 and 7
         jnp.linalg.matmul(a, jnp.ones((7, 5)))
     except TypeError:
         pass

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_matmul.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_matmul.py
@@ -5,13 +5,16 @@
 
 from __future__ import annotations
 
+from typing import assert_type
+
 import jax
 import jax.numpy as jnp
-from shape_extensions import assert_shape, IntVar
+from shape_extensions import assert_shape, IntTuple, IntVar
 
 N = IntVar("N")
 M = IntVar("M")
 P = IntVar("P")
+B = IntVar("B")
 
 
 # A non-tuple sequence of axes is accepted but gradual; see `test_reductions.py`.
@@ -30,11 +33,11 @@ def generic_matmul[N: IntVar, M: IntVar, P: IntVar](
     return left @ right
 
 
-def reject_mismatched_inner_dimension(
+def symbolic_matmul_dimensions_are_not_rejected(
     left: jax.Array[[N, M]],
     unrelated: jax.Array[[P, M]],
 ) -> None:
-    left @ unrelated  # E: `@` is not supported
+    left @ unrelated
 
 
 def batched_matmul_is_not_rejected(
@@ -43,6 +46,40 @@ def batched_matmul_is_not_rejected(
     """Batched matmul with matching contracting dimension."""
 
     jnp.matmul(x, y)
+
+
+def gufunc_matmul_shapes(
+    left_vector: jax.Array[[M]],
+    right_vector: jax.Array[[P]],
+    matrix: jax.Array[[M, P]],
+    batched: jax.Array[[B, N, M]],
+    broadcasted: jax.Array[[1, M, P]],
+) -> None:
+    assert_type(jnp.matmul(left_vector, matrix), jax.Array[[P]])
+    assert_type(jnp.matmul(matrix, right_vector), jax.Array[[M]])
+    assert_type(jnp.matmul(left_vector, left_vector), jax.Array[[]])
+    assert_type(jnp.matmul(batched, broadcasted), jax.Array[[B, N, P]])
+
+
+def gradual_matmul(
+    left: jax.Array[IntTuple], right: jax.Array[IntTuple]
+) -> jax.Array[IntTuple]:
+    return jnp.matmul(left, right)
+
+
+def reject_invalid_gufunc_matmul_shapes(
+    bad_core: jax.Array[[2, 5, 6]],
+    bad_batch: jax.Array[[3, 4, 6]],
+) -> None:
+    # E: Cannot evaluate type-level shape DSL call: gufunc: core dimension 'n' has conflicting extents 4 and 5
+    jnp.matmul(jnp.ones((2, 3, 4)), bad_core)
+    # E: Cannot evaluate type-level shape DSL call: Cannot broadcast dimension Int[2] with dimension Int[3] at position 0
+    jnp.matmul(jnp.ones((2, 3, 4)), bad_batch)
+
+
+def reject_scalar_matmul(scalar: jax.Array[[]], vector: jax.Array[[M]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: matmul expects at least 1-D arrays
+    jnp.matmul(scalar, vector)
 
 
 def test_operator_matmul() -> None:
@@ -83,6 +120,8 @@ def test_batched_matmul() -> None:
     assert_shape(jnp.matmul(mat34, mat45), (3, 5))
     assert_shape(jnp.matmul(batch_234, mat45), (2, 3, 5))
     assert_shape(jnp.matmul(batch_234, batch_245), (2, 3, 5))
+    assert_shape(batch_234 @ mat45, (2, 3, 5))
+    assert_shape(batch_234 @ batch_245, (2, 3, 5))
 
 
 def test_matmul_contracts_vector_operands() -> None:
@@ -101,7 +140,7 @@ def test_function_matmul_rejects_mismatched_inner_dimension() -> None:
 
     assert_shape(jnp.matmul(a, jnp.ones((4, 5))), (3, 5))
     try:
-        # E: Cannot evaluate type-level shape DSL call: matmul inner dimensions must match
+        # E: Cannot evaluate type-level shape DSL call: gufunc: core dimension 'n' has conflicting extents 4 and 7
         jnp.matmul(a, jnp.ones((7, 5)))
     except TypeError:
         pass

--- a/tensor-shapes/pyrefly-shape-extensions/shape_extensions/__init__.py
+++ b/tensor-shapes/pyrefly-shape-extensions/shape_extensions/__init__.py
@@ -279,12 +279,6 @@ def shaped_array(*, shape: str) -> typing.Callable[[type], type]:
     return decorator
 
 
-def broadcast(*_args: typing.Any) -> IntTuple:
-    """Runtime placeholder for Pyrefly's native type-level broadcast intrinsic."""
-
-    return IntTuple()
-
-
 class MapIntTuples:
     """Map a unary type lambda over an ``IntTuples`` value.
 
@@ -319,6 +313,13 @@ from . import dsl as _dsl
 @type_shape_dsl_function
 def gufunc_broadcast(spec: str, shapes: IntTuples) -> IntTuple:
     return _dsl._gufunc_broadcast(spec, shapes)
+
+
+@type_shape_dsl_function
+def broadcast(left: IntTuple, right: IntTuple) -> IntTuple:
+    spec = "(),()->()"
+    shapes = _dsl.IntTuples((left, right))
+    return gufunc_broadcast(spec, shapes)
 
 
 class IntVar:

--- a/tensor-shapes/pyrefly-shape-extensions/shape_extensions/__init__.py
+++ b/tensor-shapes/pyrefly-shape-extensions/shape_extensions/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     "assert_shape",
     "broadcast",
     "defines_assert_shape",
+    "gufunc_broadcast",
     "shaped_array",
     "type_shape_dsl_function",
 ]
@@ -309,6 +310,15 @@ def type_shape_dsl_function[F: typing.Callable](fn: F) -> F:
     """Runtime no-op for a user-defined type-level shape DSL function."""
 
     return fn
+
+
+from . import dsl as _dsl
+
+
+# Compute the output shape described by a generalized ufunc signature.
+@type_shape_dsl_function
+def gufunc_broadcast(spec: str, shapes: IntTuples) -> IntTuple:
+    return _dsl._gufunc_broadcast(spec, shapes)
 
 
 class IntVar:

--- a/tensor-shapes/pyrefly-shape-extensions/shape_extensions/dsl.py
+++ b/tensor-shapes/pyrefly-shape-extensions/shape_extensions/dsl.py
@@ -11,6 +11,7 @@ Only used inside DSL definition files (e.g. torch/_shapes.pyi), not in
 normal stubs or user code.
 """
 
+# TODO(stroxler): Unquote `typing.TypeIs` when Python 3.13+ is the minimum version.
 import typing
 
 from . import (
@@ -61,7 +62,7 @@ class IntTuples(_IntTuplesSchema):
 def is_concrete_int(value: object) -> typing.TypeGuard[_IntSchema]: ...
 
 
-def is_int_value(value: object) -> typing.TypeIs[int]: ...
+def is_int_value(value: object) -> "typing.TypeIs[int]": ...
 
 
 def concat(

--- a/tensor-shapes/pyrefly-shape-extensions/shape_extensions/dsl.py
+++ b/tensor-shapes/pyrefly-shape-extensions/shape_extensions/dsl.py
@@ -81,3 +81,10 @@ def sum(xs: _IntTupleSchema, /) -> _IntSchema: ...
 def einsum(spec: str, shapes: _IntTuplesSchema, /) -> _IntTupleSchema:
     """Compute the output shape described by an explicit einsum equation."""
     ...
+
+
+def _gufunc_broadcast(spec: str, shapes: _IntTuplesSchema, /) -> _IntTupleSchema:
+    """Compute a gufunc result shape inside a type-level shape DSL function."""
+    raise NotImplementedError(
+        "dsl._gufunc_broadcast is only available inside a type-level shape DSL function"
+    )


### PR DESCRIPTION
Summary: Express JAX `matmul` through gufunc signatures for its four vector and matrix rank combinations. This preserves existing vector behavior while adding precise leading-dimension broadcasting and core-dimension validation for batched calls.

Differential Revision: D118226441
