### PR TITLE
Treat builtin type constructor constants as implicitly typed in `pyrefly coverage`

### DIFF
--- a/pyrefly/lib/commands/coverage/collect.rs
+++ b/pyrefly/lib/commands/coverage/collect.rs
@@ -434,6 +434,28 @@ fn is_schema_class(bindings: &Bindings, answers: &Answers, cls_binding: &ClassBi
         })
 }
 
+/// Builtin classes whose constructor names the type it yields. Iterator adapters are left out.
+const IMPLICIT_BUILTIN_CONSTRUCTORS: &[&str] = &[
+    "bool",
+    "bytearray",
+    "bytes",
+    "complex",
+    "dict",
+    "float",
+    "frozendict",
+    "frozenset",
+    "int",
+    "list",
+    "memoryview",
+    "object",
+    "range",
+    "sentinel",
+    "set",
+    "slice",
+    "str",
+    "tuple",
+];
+
 fn parse_variables(
     module: &Module,
     bindings: &Bindings,
@@ -443,11 +465,21 @@ fn parse_variables(
     functions: &[Function],
     classes: &[ReportClass],
 ) -> Vec<Variable> {
-    fn untyped_if_call(expr: &Expr) -> SlotCounts {
-        if let Expr::Call(_) = expr {
-            SlotCounts::untyped()
-        } else {
+    /// Only a call hides its type at the assignment site, unless it is a builtin constructor.
+    fn untyped_if_call(answers: &Answers, idx: Idx<Key>, expr: &Expr) -> SlotCounts {
+        let Expr::Call(call) = expr else {
+            return SlotCounts::default();
+        };
+
+        if let Expr::Name(n) = call.func.as_ref()
+            && IMPLICIT_BUILTIN_CONSTRUCTORS.contains(&n.id.as_str())
+            && answers
+                .get_idx(idx)
+                .is_some_and(|t| matches!(t.ty(), Type::ClassType(cls) if cls.is_builtin(&n.id)))
+        {
             SlotCounts::default()
+        } else {
+            SlotCounts::untyped()
         }
     }
 
@@ -527,12 +559,10 @@ fn parse_variables(
                     // Functions and classes are handled by parse_functions/parse_classes;
                     // skip them here even when excluded (e.g. @type_check_only).
                     Binding::Function { .. } | Binding::ClassDef(..) => continue,
-                    // IMPLICIT: non-call assignments have 0 slots;
-                    // call assignments are untyped (1 slot)
-                    Binding::NameAssign(na) => untyped_if_call(na.expr.as_ref()),
+                    Binding::NameAssign(na) => untyped_if_call(answers, *idx, na.expr.as_ref()),
                     Binding::MultiTargetAssign(_, rhs_idx, _, _) => match bindings.get(*rhs_idx) {
                         Binding::Function { .. } | Binding::ClassDef(..) => continue,
-                        Binding::Expr(_, expr) => untyped_if_call(expr.as_ref()),
+                        Binding::Expr(_, expr) => untyped_if_call(answers, *idx, expr.as_ref()),
                         _ => {
                             unreachable!(
                                 "MultiTargetAssign RHS should be Expr, Function, or ClassDef"

--- a/pyrefly/lib/test/coverage/test_files/variables.expected.json
+++ b/pyrefly/lib/test/coverage/test_files/variables.expected.json
@@ -6,10 +6,13 @@
     "test.x",
     "test.y",
     "test.z",
+    "test.NO_RESULT",
+    "test.EMPTY",
+    "test.DOUBLED",
     "test.some_func",
     "test.SomeClass"
   ],
-  "line_count": 20,
+  "line_count": 23,
   "symbol_reports": [
     {
       "kind": "attr",
@@ -60,6 +63,42 @@
       }
     },
     {
+      "kind": "attr",
+      "name": "test.NO_RESULT",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 12,
+        "column": 1
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.EMPTY",
+      "n_typable": 0,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 0,
+      "location": {
+        "line": 13,
+        "column": 1
+      }
+    },
+    {
+      "kind": "attr",
+      "name": "test.DOUBLED",
+      "n_typable": 1,
+      "n_typed": 0,
+      "n_any": 0,
+      "n_untyped": 1,
+      "location": {
+        "line": 14,
+        "column": 1
+      }
+    },
+    {
       "kind": "function",
       "name": "test.some_func",
       "n_typable": 1,
@@ -67,7 +106,7 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 14,
+        "line": 17,
         "column": 1
       }
     },
@@ -79,24 +118,24 @@
       "n_any": 0,
       "n_untyped": 0,
       "location": {
-        "line": 18,
+        "line": 21,
         "column": 1
       }
     }
   ],
   "type_ignores": [],
-  "n_typable": 3,
+  "n_typable": 4,
   "n_typed": 3,
   "n_any": 0,
-  "n_untyped": 0,
-  "coverage": 100.0,
-  "strict_coverage": 100.0,
+  "n_untyped": 1,
+  "coverage": 75.0,
+  "strict_coverage": 75.0,
   "n_functions": 1,
   "n_methods": 0,
   "n_function_params": 0,
   "n_method_params": 0,
   "n_classes": 1,
-  "n_attrs": 4,
+  "n_attrs": 7,
   "n_properties": 0,
   "n_type_ignores": 0
 }

--- a/pyrefly/lib/test/coverage/test_files/variables.py
+++ b/pyrefly/lib/test/coverage/test_files/variables.py
@@ -9,6 +9,9 @@ T = TypeVar("T")
 x = 42
 y: Callable[[int], int] = lambda n: n
 z: str = "hello"
+NO_RESULT = object()
+EMPTY = frozenset()
+DOUBLED = map(str, [1, 2])
 
 
 def some_func() -> None:


### PR DESCRIPTION
# Summary

Before, `pyrefly coverage check` would report stuff like `SPAM = 1` as implicitly typed, but `MISSING = object()` as untyped, because it only exempted literal values. 

This also exempts the builtin type constructors lik `object()` and `frozenset()` as implicitly typed, so that `pyrefly coverage` will no longer require those to be annotated.

# Test Plan

Tests added.