### PR TITLE
Fix Ruff import formatting in shape DSL

### DIFF
--- a/tensor-shapes/pyrefly-shape-extensions/shape_extensions/dsl.py
+++ b/tensor-shapes/pyrefly-shape-extensions/shape_extensions/dsl.py
@@ -19,7 +19,6 @@ from . import (
     IntTuples as _IntTuplesSchema,
 )
 
-
 # DSL builtins: these exist so that DSL definition files can import them
 # and avoid unbound-name errors. The DSL compiler recognizes these names
 # as builtins regardless of the Python-level definitions here.


### PR DESCRIPTION
Summary: Normalize the whitespace after the shape DSL imports so the pinned GitHub Ruff import-order check passes.

Differential Revision: D118307281


