### PR TITLE
[tensor-shapes] add stubs for jax.numpy reduction APIs

### DIFF
--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_array.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_array.pyi
@@ -317,3 +317,161 @@ class Array[Shape: _Shape = _AnyShape]:
         where: Any = ...,
         promote_integers: bool = ...,
     ) -> Array[IntTuple]: ...
+    @overload
+    def all[Axis: Flag[_Axis], KeepDims: Flag[bool]](
+        self,
+        axis: Axis = None,
+        out: Any = None,
+        keepdims: KeepDims = False,
+        *,
+        where: Any = None,
+    ) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+    @overload
+    def all(
+        self,
+        axis: Sequence[int],
+        out: Any = None,
+        keepdims: bool = False,
+        *,
+        where: Any = None,
+    ) -> Array[IntTuple]: ...
+    @overload
+    def any[Axis: Flag[_Axis], KeepDims: Flag[bool]](
+        self,
+        axis: Axis = None,
+        out: Any = None,
+        keepdims: KeepDims = False,
+        *,
+        where: Any = None,
+    ) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+    @overload
+    def any(
+        self,
+        axis: Sequence[int],
+        out: Any = None,
+        keepdims: bool = False,
+        *,
+        where: Any = None,
+    ) -> Array[IntTuple]: ...
+    @overload
+    def std[Axis: Flag[_Axis], KeepDims: Flag[bool]](
+        self,
+        axis: Axis = None,
+        dtype: Any = None,
+        out: Any = None,
+        ddof: int = 0,
+        keepdims: KeepDims = False,
+        *,
+        where: Any = None,
+        mean: Any = None,
+        correction: Any = None,
+    ) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+    @overload
+    def std(
+        self,
+        axis: Sequence[int],
+        dtype: Any = None,
+        out: Any = None,
+        ddof: int = 0,
+        keepdims: bool = False,
+        *,
+        where: Any = None,
+        mean: Any = None,
+        correction: Any = None,
+    ) -> Array[IntTuple]: ...
+    @overload
+    def var[Axis: Flag[_Axis], KeepDims: Flag[bool]](
+        self,
+        axis: Axis = None,
+        dtype: Any = None,
+        out: Any = None,
+        ddof: int = 0,
+        keepdims: KeepDims = False,
+        *,
+        where: Any = None,
+        mean: Any = None,
+        correction: Any = None,
+    ) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+    @overload
+    def var(
+        self,
+        axis: Sequence[int],
+        dtype: Any = None,
+        out: Any = None,
+        ddof: int = 0,
+        keepdims: bool = False,
+        *,
+        where: Any = None,
+        mean: Any = None,
+        correction: Any = None,
+    ) -> Array[IntTuple]: ...
+    @overload
+    def ptp[Axis: Flag[_Axis], KeepDims: Flag[bool]](
+        self,
+        axis: Axis = None,
+        out: Any = None,
+        keepdims: KeepDims = False,
+    ) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+    @overload
+    def ptp(
+        self,
+        axis: Sequence[int],
+        out: Any = None,
+        keepdims: bool = False,
+    ) -> Array[IntTuple]: ...
+    @overload
+    def argmax[Axis: Flag[_Axis], KeepDims: Flag[bool]](
+        self,
+        axis: Axis = None,
+        out: Any = None,
+        keepdims: KeepDims = False,
+    ) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+    @overload
+    def argmax(
+        self,
+        axis: int | None = None,
+        out: Any = None,
+        keepdims: bool | None = None,
+    ) -> Array[IntTuple]: ...
+    @overload
+    def argmin[Axis: Flag[_Axis], KeepDims: Flag[bool]](
+        self,
+        axis: Axis = None,
+        out: Any = None,
+        keepdims: KeepDims = False,
+    ) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+    @overload
+    def argmin(
+        self,
+        axis: int | None = None,
+        out: Any = None,
+        keepdims: bool | None = None,
+    ) -> Array[IntTuple]: ...
+    @overload
+    def cumsum(
+        self,
+        axis: int,
+        dtype: Any = None,
+        out: Any = None,
+    ) -> Array[Shape]: ...
+    @overload
+    def cumsum(
+        self,
+        axis: None = None,
+        dtype: Any = None,
+        out: Any = None,
+    ) -> Array[IntTuple]: ...
+    @overload
+    def cumprod(
+        self,
+        axis: int,
+        dtype: Any = None,
+        out: Any = None,
+    ) -> Array[Shape]: ...
+    @overload
+    def cumprod(
+        self,
+        axis: None = None,
+        dtype: Any = None,
+        out: Any = None,
+    ) -> Array[IntTuple]: ...

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
@@ -1180,6 +1180,679 @@ def min[Shape: _Shape](
     promote_integers: bool = ...,
 ) -> Array[IntTuple]: ...
 
+# Boolean reductions
+@overload
+def all[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    out: Any = None,
+    keepdims: KeepDims = False,
+    *,
+    where: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def all[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    out: Any = None,
+    keepdims: bool = False,
+    *,
+    where: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def any[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    out: Any = None,
+    keepdims: KeepDims = False,
+    *,
+    where: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def any[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    out: Any = None,
+    keepdims: bool = False,
+    *,
+    where: Any = None,
+) -> Array[IntTuple]: ...
+
+# Count nonzero
+@overload
+def count_nonzero[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    keepdims: KeepDims = False,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def count_nonzero[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    keepdims: bool = False,
+) -> Array[IntTuple]: ...
+
+# amax / amin aliases
+@overload
+def amax[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    out: Any = None,
+    keepdims: KeepDims = False,
+    initial: Any = None,
+    where: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def amax[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    out: Any = None,
+    keepdims: bool = False,
+    initial: Any = None,
+    where: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def amin[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    out: Any = None,
+    keepdims: KeepDims = False,
+    initial: Any = None,
+    where: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def amin[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    out: Any = None,
+    keepdims: bool = False,
+    initial: Any = None,
+    where: Any = None,
+) -> Array[IntTuple]: ...
+
+# Standard deviation & variance
+@overload
+def std[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    dtype: Any = None,
+    out: Any = None,
+    ddof: int = 0,
+    keepdims: KeepDims = False,
+    *,
+    where: Any = None,
+    mean: Any = None,
+    correction: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def std[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    dtype: Any = None,
+    out: Any = None,
+    ddof: int = 0,
+    keepdims: bool = False,
+    *,
+    where: Any = None,
+    mean: Any = None,
+    correction: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def var[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    dtype: Any = None,
+    out: Any = None,
+    ddof: int = 0,
+    keepdims: KeepDims = False,
+    *,
+    where: Any = None,
+    mean: Any = None,
+    correction: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def var[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    dtype: Any = None,
+    out: Any = None,
+    ddof: int = 0,
+    keepdims: bool = False,
+    *,
+    where: Any = None,
+    mean: Any = None,
+    correction: Any = None,
+) -> Array[IntTuple]: ...
+
+# Peak-to-peak (ptp)
+@overload
+def ptp[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    out: Any = None,
+    keepdims: KeepDims = False,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def ptp[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    out: Any = None,
+    keepdims: bool = False,
+) -> Array[IntTuple]: ...
+
+# Median
+@overload
+def median[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    out: Any = None,
+    overwrite_input: bool = False,
+    keepdims: KeepDims = False,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def median[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    out: Any = None,
+    overwrite_input: bool = False,
+    keepdims: bool = False,
+) -> Array[IntTuple]: ...
+
+# NaN-safe reductions
+@overload
+def nanmax[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    out: Any = None,
+    keepdims: KeepDims = False,
+    initial: Any = None,
+    where: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def nanmax[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    out: Any = None,
+    keepdims: bool = False,
+    initial: Any = None,
+    where: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def nanmin[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    out: Any = None,
+    keepdims: KeepDims = False,
+    initial: Any = None,
+    where: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def nanmin[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    out: Any = None,
+    keepdims: bool = False,
+    initial: Any = None,
+    where: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def nansum[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    dtype: Any = None,
+    out: Any = None,
+    keepdims: KeepDims = False,
+    initial: Any = None,
+    where: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def nansum[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    dtype: Any = None,
+    out: Any = None,
+    keepdims: bool = False,
+    initial: Any = None,
+    where: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def nanprod[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    dtype: Any = None,
+    out: Any = None,
+    keepdims: KeepDims = False,
+    initial: Any = None,
+    where: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def nanprod[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    dtype: Any = None,
+    out: Any = None,
+    keepdims: bool = False,
+    initial: Any = None,
+    where: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def nanmean[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    dtype: Any = None,
+    out: Any = None,
+    keepdims: KeepDims = False,
+    where: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def nanmean[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    dtype: Any = None,
+    out: Any = None,
+    keepdims: bool = False,
+    where: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def nanstd[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    dtype: Any = None,
+    out: Any = None,
+    ddof: int = 0,
+    keepdims: KeepDims = False,
+    where: Any = None,
+    mean: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def nanstd[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    dtype: Any = None,
+    out: Any = None,
+    ddof: int = 0,
+    keepdims: bool = False,
+    where: Any = None,
+    mean: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def nanvar[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    dtype: Any = None,
+    out: Any = None,
+    ddof: int = 0,
+    keepdims: KeepDims = False,
+    where: Any = None,
+    mean: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def nanvar[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    dtype: Any = None,
+    out: Any = None,
+    ddof: int = 0,
+    keepdims: bool = False,
+    where: Any = None,
+    mean: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def nanmedian[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    out: Any = None,
+    overwrite_input: bool = False,
+    keepdims: KeepDims = False,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def nanmedian[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    out: Any = None,
+    overwrite_input: bool = False,
+    keepdims: bool = False,
+) -> Array[IntTuple]: ...
+
+# Average
+@overload
+def average[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    weights: Any = None,
+    returned: Literal[False] = False,
+    keepdims: KeepDims = False,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def average[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    weights: Any = None,
+    returned: Literal[True] = ...,
+    keepdims: KeepDims = False,
+) -> tuple[
+    Array[reduce_shape(Shape, Axis, KeepDims)],
+    Array[reduce_shape(Shape, Axis, KeepDims)],
+]: ...
+@overload
+def average[Shape: _Shape](
+    a: Array[Shape],
+    axis: Sequence[int],
+    weights: Any = None,
+    returned: bool = False,
+    keepdims: bool = False,
+) -> Array[IntTuple] | tuple[Array[IntTuple], Array[IntTuple]]: ...
+
+# Arg reductions
+@overload
+def argmax[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    out: Any = None,
+    keepdims: KeepDims = False,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def argmax(
+    a: Array[Any],
+    axis: int | None = None,
+    out: Any = None,
+    keepdims: bool | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def argmin[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    out: Any = None,
+    keepdims: KeepDims = False,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def argmin(
+    a: Array[Any],
+    axis: int | None = None,
+    out: Any = None,
+    keepdims: bool | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def nanargmax[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    out: Any = None,
+    keepdims: KeepDims = False,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def nanargmax(
+    a: Array[Any],
+    axis: int | None = None,
+    out: Any = None,
+    keepdims: bool | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def nanargmin[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    axis: Axis = None,
+    out: Any = None,
+    keepdims: KeepDims = False,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def nanargmin(
+    a: Array[Any],
+    axis: int | None = None,
+    out: Any = None,
+    keepdims: bool | None = None,
+) -> Array[IntTuple]: ...
+
+# Cumulative operations
+@overload
+def cumsum[Shape: _Shape](
+    a: Array[Shape],
+    axis: int,
+    dtype: Any = None,
+    out: Any = None,
+) -> Array[Shape]: ...
+@overload
+def cumsum(
+    a: Array[Any],
+    axis: None = None,
+    dtype: Any = None,
+    out: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def cumprod[Shape: _Shape](
+    a: Array[Shape],
+    axis: int,
+    dtype: Any = None,
+    out: Any = None,
+) -> Array[Shape]: ...
+@overload
+def cumprod(
+    a: Array[Any],
+    axis: None = None,
+    dtype: Any = None,
+    out: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def cumulative_sum[Shape: _Shape](
+    x: Array[Shape],
+    /,
+    *,
+    axis: int,
+    dtype: Any = None,
+    include_initial: Literal[False] = False,
+) -> Array[Shape]: ...
+@overload
+def cumulative_sum(
+    x: Array[Any],
+    /,
+    *,
+    axis: int | None = None,
+    dtype: Any = None,
+    include_initial: bool = False,
+) -> Array[IntTuple]: ...
+@overload
+def cumulative_prod[Shape: _Shape](
+    x: Array[Shape],
+    /,
+    *,
+    axis: int,
+    dtype: Any = None,
+    include_initial: Literal[False] = False,
+) -> Array[Shape]: ...
+@overload
+def cumulative_prod(
+    x: Array[Any],
+    /,
+    *,
+    axis: int | None = None,
+    dtype: Any = None,
+    include_initial: bool = False,
+) -> Array[IntTuple]: ...
+@overload
+def nancumsum[Shape: _Shape](
+    a: Array[Shape],
+    axis: int,
+    dtype: Any = None,
+    out: Any = None,
+) -> Array[Shape]: ...
+@overload
+def nancumsum(
+    a: Array[Any],
+    axis: None = None,
+    dtype: Any = None,
+    out: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def nancumprod[Shape: _Shape](
+    a: Array[Shape],
+    axis: int,
+    dtype: Any = None,
+    out: Any = None,
+) -> Array[Shape]: ...
+@overload
+def nancumprod(
+    a: Array[Any],
+    axis: None = None,
+    dtype: Any = None,
+    out: Any = None,
+) -> Array[IntTuple]: ...
+
+# Quantile & Percentile
+@overload
+def quantile[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    q: int | float,
+    axis: Axis = None,
+    out: Any = None,
+    overwrite_input: bool = False,
+    method: str = "linear",
+    keepdims: KeepDims = False,
+    *,
+    weights: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def quantile(
+    a: Array[Any],
+    q: Any,
+    axis: Any = None,
+    out: Any = None,
+    overwrite_input: bool = False,
+    method: str = "linear",
+    keepdims: bool = False,
+    *,
+    weights: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def percentile[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    q: int | float,
+    axis: Axis = None,
+    out: Any = None,
+    overwrite_input: bool = False,
+    method: str = "linear",
+    keepdims: KeepDims = False,
+    *,
+    weights: Any = None,
+    out_sharding: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def percentile(
+    a: Array[Any],
+    q: Any,
+    axis: Any = None,
+    out: Any = None,
+    overwrite_input: bool = False,
+    method: str = "linear",
+    keepdims: bool = False,
+    *,
+    weights: Any = None,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def nanquantile[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    q: int | float,
+    axis: Axis = None,
+    out: Any = None,
+    overwrite_input: bool = False,
+    method: str = "linear",
+    keepdims: KeepDims = False,
+    *,
+    weights: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def nanquantile(
+    a: Array[Any],
+    q: Any,
+    axis: Any = None,
+    out: Any = None,
+    overwrite_input: bool = False,
+    method: str = "linear",
+    keepdims: bool = False,
+    *,
+    weights: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def nanpercentile[Shape: _Shape, Axis: Flag[_Axis], KeepDims: Flag[bool]](
+    a: Array[Shape],
+    q: int | float,
+    axis: Axis = None,
+    out: Any = None,
+    overwrite_input: bool = False,
+    method: str = "linear",
+    keepdims: KeepDims = False,
+    *,
+    weights: Any = None,
+) -> Array[reduce_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def nanpercentile(
+    a: Array[Any],
+    q: Any,
+    axis: Any = None,
+    out: Any = None,
+    overwrite_input: bool = False,
+    method: str = "linear",
+    keepdims: bool = False,
+    *,
+    weights: Any = None,
+) -> Array[IntTuple]: ...
+
+# Differences & Calculus
+def diff(
+    a: Array[Any],
+    n: int = 1,
+    axis: int = -1,
+    prepend: Any = None,
+    append: Any = None,
+) -> Array[IntTuple]: ...
+def ediff1d(
+    ary: Array[Any],
+    to_end: Any = None,
+    to_begin: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def gradient(
+    f: Array[Any],
+    *varargs: Any,
+    axis: int,
+    edge_order: int | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def gradient(
+    f: Array[Any],
+    *varargs: Any,
+    axis: Sequence[int] | None = None,
+    edge_order: int | None = None,
+) -> list[Array[IntTuple]]: ...
+@overload
+def trapezoid[Shape: _Shape, Axis: Flag[_Axis]](
+    y: Array[Shape],
+    x: Any = None,
+    dx: Any = 1.0,
+    axis: Axis = -1,
+) -> Array[reduce_shape(Shape, Axis, False)]: ...
+@overload
+def trapezoid(
+    y: Array[Any],
+    x: Any = None,
+    dx: Any = 1.0,
+    axis: int = -1,
+) -> Array[IntTuple]: ...
+def corrcoef(
+    x: Array[Any],
+    y: Any = None,
+    rowvar: bool = True,
+    dtype: Any = None,
+) -> Array[IntTuple]: ...
+def cov(
+    m: Array[Any],
+    y: Any = None,
+    rowvar: bool = True,
+    bias: bool = False,
+    ddof: int | None = None,
+    fweights: Any = None,
+    aweights: Any = None,
+    dtype: Any = None,
+) -> Array[IntTuple]: ...
+
 float32: Any
 float64: Any
 int32: Any

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_reductions.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_reductions.py
@@ -108,3 +108,166 @@ def test_reduce_rejects_out_of_bounds_axis() -> None:
         pass
     else:
         raise AssertionError("expected JAX to reject an out-of-bounds axis")
+
+
+def test_boolean_reductions() -> None:
+    a = jnp.ones((3, 4))
+
+    assert_shape(jnp.all(a), ())
+    assert_shape(jnp.all(a, axis=0), (4,))
+    assert_shape(jnp.all(a, axis=1, keepdims=True), (3, 1))
+
+    assert_shape(jnp.any(a), ())
+    assert_shape(jnp.any(a, axis=0), (4,))
+    assert_shape(jnp.any(a, axis=1, keepdims=True), (3, 1))
+
+    assert_shape(jnp.count_nonzero(a), ())
+    assert_shape(jnp.count_nonzero(a, axis=0), (4,))
+    assert_shape(jnp.count_nonzero(a, axis=1, keepdims=True), (3, 1))
+
+
+def test_extrema_and_stats_reductions() -> None:
+    a = jnp.ones((3, 4))
+
+    assert_shape(jnp.amax(a), ())
+    assert_shape(jnp.amax(a, axis=0), (4,))
+    assert_shape(jnp.amin(a), ())
+    assert_shape(jnp.amin(a, axis=1), (3,))
+
+    assert_shape(jnp.ptp(a), ())
+    assert_shape(jnp.ptp(a, axis=0), (4,))
+    assert_shape(jnp.ptp(a, axis=1, keepdims=True), (3, 1))
+
+    assert_shape(jnp.std(a), ())
+    assert_shape(jnp.std(a, axis=0), (4,))
+    assert_shape(jnp.std(a, axis=1, keepdims=True), (3, 1))
+
+    assert_shape(jnp.var(a), ())
+    assert_shape(jnp.var(a, axis=0), (4,))
+    assert_shape(jnp.var(a, axis=1, keepdims=True), (3, 1))
+
+    assert_shape(jnp.median(a), ())
+    assert_shape(jnp.median(a, axis=0), (4,))
+    assert_shape(jnp.median(a, axis=1, keepdims=True), (3, 1))
+
+
+def test_nan_reductions() -> None:
+    a = jnp.ones((3, 4))
+
+    assert_shape(jnp.nanmax(a), ())
+    assert_shape(jnp.nanmax(a, axis=0), (4,))
+    assert_shape(jnp.nanmin(a), ())
+    assert_shape(jnp.nanmin(a, axis=1), (3,))
+
+    assert_shape(jnp.nansum(a), ())
+    assert_shape(jnp.nansum(a, axis=0), (4,))
+    assert_shape(jnp.nanprod(a), ())
+    assert_shape(jnp.nanprod(a, axis=1), (3,))
+
+    assert_shape(jnp.nanmean(a), ())
+    assert_shape(jnp.nanmean(a, axis=0), (4,))
+    assert_shape(jnp.nanstd(a), ())
+    assert_shape(jnp.nanstd(a, axis=1), (3,))
+    assert_shape(jnp.nanvar(a), ())
+    assert_shape(jnp.nanvar(a, axis=0), (4,))
+    assert_shape(jnp.nanmedian(a), ())
+    assert_shape(jnp.nanmedian(a, axis=1), (3,))
+
+
+def test_average() -> None:
+    a = jnp.ones((3, 4))
+
+    assert_shape(jnp.average(a), ())
+    assert_shape(jnp.average(a, axis=0), (4,))
+    assert_shape(jnp.average(a, axis=1, keepdims=True), (3, 1))
+
+    avg, w_sum = jnp.average(a, axis=0, returned=True)
+    assert_shape(avg, (4,))
+    assert_shape(w_sum, (4,))
+
+
+def test_arg_reductions() -> None:
+    a = jnp.ones((3, 4))
+
+    assert_shape(jnp.argmax(a), ())
+    assert_shape(jnp.argmax(a, axis=0), (4,))
+    assert_shape(jnp.argmax(a, axis=1), (3,))
+    assert_shape(jnp.argmax(a, axis=1, keepdims=True), (3, 1))
+
+    assert_shape(jnp.argmin(a), ())
+    assert_shape(jnp.argmin(a, axis=0), (4,))
+    assert_shape(jnp.argmin(a, axis=1), (3,))
+
+    assert_shape(jnp.nanargmax(a), ())
+    assert_shape(jnp.nanargmax(a, axis=0), (4,))
+    assert_shape(jnp.nanargmin(a), ())
+    assert_shape(jnp.nanargmin(a, axis=1), (3,))
+
+
+def test_cumulative_ops() -> None:
+    a = jnp.ones((3, 4))
+
+    assert_shape(jnp.cumsum(a, axis=0), (3, 4))
+    assert_shape(jnp.cumsum(a, axis=1), (3, 4))
+    assert_shape(jnp.cumprod(a, axis=0), (3, 4))
+    assert_shape(jnp.cumprod(a, axis=1), (3, 4))
+
+    assert_shape(jnp.cumulative_sum(a, axis=0), (3, 4))
+    assert_shape(jnp.cumulative_prod(a, axis=1), (3, 4))
+
+    assert_shape(jnp.nancumsum(a, axis=0), (3, 4))
+    assert_shape(jnp.nancumprod(a, axis=1), (3, 4))
+
+    assert jnp.cumsum(a).shape == (12,)
+    assert jnp.cumprod(a).shape == (12,)
+
+
+def test_quantile_and_percentile() -> None:
+    a = jnp.ones((3, 4))
+
+    assert_shape(jnp.quantile(a, 0.5), ())
+    assert_shape(jnp.quantile(a, 0.5, axis=0), (4,))
+    assert_shape(jnp.quantile(a, 0.5, axis=1, keepdims=True), (3, 1))
+
+    assert_shape(jnp.percentile(a, 50), ())
+    assert_shape(jnp.percentile(a, 50, axis=0), (4,))
+    assert_shape(jnp.percentile(a, 50, axis=1, keepdims=True), (3, 1))
+
+    assert_shape(jnp.nanquantile(a, 0.5), ())
+    assert_shape(jnp.nanquantile(a, 0.5, axis=0), (4,))
+
+    assert_shape(jnp.nanpercentile(a, 50), ())
+    assert_shape(jnp.nanpercentile(a, 50, axis=0), (4,))
+
+
+def test_diff_gradient_trapezoid() -> None:
+    a = jnp.ones((3, 4))
+
+    assert jnp.diff(a).shape == (3, 3)
+    assert jnp.ediff1d(a).shape == (11,)
+    assert [g.shape for g in jnp.gradient(a)] == [(3, 4), (3, 4)]
+    assert_shape(jnp.trapezoid(a, axis=-1), (3,))
+    assert_shape(jnp.trapezoid(a, axis=0), (4,))
+    assert jnp.corrcoef(a).shape == (3, 3)
+    assert jnp.cov(a).shape == (3, 3)
+
+
+def test_additional_array_methods() -> None:
+    a = jnp.ones((3, 4))
+
+    assert_shape(a.all(), ())
+    assert_shape(a.all(axis=0), (4,))
+    assert_shape(a.any(), ())
+    assert_shape(a.any(axis=1), (3,))
+    assert_shape(a.std(), ())
+    assert_shape(a.std(axis=0), (4,))
+    assert_shape(a.var(), ())
+    assert_shape(a.var(axis=1), (3,))
+    assert_shape(a.ptp(), ())
+    assert_shape(a.ptp(axis=0), (4,))
+    assert_shape(a.argmax(), ())
+    assert_shape(a.argmax(axis=0), (4,))
+    assert_shape(a.argmin(), ())
+    assert_shape(a.argmin(axis=1), (3,))
+    assert_shape(a.cumsum(axis=0), (3, 4))
+    assert_shape(a.cumprod(axis=1), (3, 4))


### PR DESCRIPTION
### Summary

Add tensor shape stubs for `jax.numpy` reduction functions.

### Test Plan

Updated existing unit tests, and tests pass locally:
```
$ uv tool run --from ruff==0.14.3 ruff format --check --config ruff.toml .
326 files already formatted
$ uv tool run --from ruff==0.14.3 ruff check --select I --config ruff.toml .
All checks passed!
$ uv run python test.py --no-test --no-conformance --no-jsonschema
Running formatting...
Finished in 2.66 seconds.
Running linting...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.82s
Finished in 1.04 seconds.
$ uv run python tensor-shapes/pyrefly-jax-stubs/run_pyrefly.py --release
+ cargo build -p pyrefly --release
    Finished `release` profile [optimized + debuginfo] target(s) in 0.56s
PASS stubs (8 files)
PASS arithmetic (1 files)
PASS creation (1 files)
PASS fft (1 files)
PASS lax (1 files)
PASS linalg (1 files)
PASS matmul (1 files)
PASS nn (1 files)
PASS reductions (1 files)
PASS reshape (1 files)
```

### AI disclosure

Change generated with a Gemini coding agent.