### PR TITLE
[tensor-shapes] add stubs for jax.lax.linalg

### DIFF
--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
@@ -280,3 +280,217 @@ def lax_broadcast(left: IntTuple, right: IntTuple) -> IntTuple:
     return dsl.IntTuple(
         (right[i] if left[i] == 1 else left[i]) for i in range(len(left))
     )
+
+@type_shape_dsl_function
+def symmetric_product_shape(a_shape: IntTuple, c_shape: IntTuple) -> IntTuple:
+    if len(a_shape) < 2 or len(c_shape) < 2:
+        return dsl.Invalid("symmetric_product requires at least 2-D arrays")
+    m_a = a_shape[len(a_shape) - 2]
+    m_c1 = c_shape[len(c_shape) - 2]
+    m_c2 = c_shape[len(c_shape) - 1]
+    if m_c1 != m_c2:
+        return dsl.Invalid("c_matrix must be square")
+    if m_a != m_c1:
+        return dsl.Invalid(
+            "leading core dimensions of a_matrix and c_matrix must match"
+        )
+    batch_a = a_shape[: len(a_shape) - 2]
+    batch_c = c_shape[: len(c_shape) - 2]
+    if len(batch_a) == 0 and len(batch_c) == 0:
+        return dsl.IntTuple((m_a, m_a))
+    if len(batch_a) == 0:
+        return dsl.concat(batch_c, dsl.IntTuple((m_a, m_a)))
+    if len(batch_c) == 0:
+        return dsl.concat(batch_a, dsl.IntTuple((m_a, m_a)))
+    if len(batch_a) != len(batch_c):
+        return dsl.Invalid("arrays must have the same number of batch dimensions")
+    if any(
+        batch_a[i] != batch_c[i] and batch_a[i] != 1 and batch_c[i] != 1
+        for i in range(len(batch_a))
+    ):
+        return dsl.Invalid("incompatible batch shapes for broadcasting")
+    batch = dsl.IntTuple(
+        (batch_c[i] if batch_a[i] == 1 else batch_a[i]) for i in range(len(batch_a))
+    )
+    return dsl.concat(batch, dsl.IntTuple((m_a, m_a)))
+
+@type_shape_dsl_function
+def triangular_solve_shape(
+    a_shape: IntTuple, b_shape: IntTuple, left_side: bool
+) -> IntTuple:
+    if len(a_shape) < 2 or len(b_shape) < 2:
+        return dsl.Invalid("triangular_solve requires at least 2-D arrays")
+    m_a = a_shape[len(a_shape) - 2]
+    n_a = a_shape[len(a_shape) - 1]
+    if m_a != n_a:
+        return dsl.Invalid("a matrix must be square")
+    m_b = b_shape[len(b_shape) - 2]
+    n_b = b_shape[len(b_shape) - 1]
+    if left_side:
+        if m_a != m_b:
+            return dsl.Invalid("incompatible shapes for triangular_solve")
+    else:
+        if m_a != n_b:
+            return dsl.Invalid("incompatible shapes for triangular_solve")
+    batch_a = a_shape[: len(a_shape) - 2]
+    batch_b = b_shape[: len(b_shape) - 2]
+    if len(batch_a) == 0 and len(batch_b) == 0:
+        return dsl.IntTuple((m_b, n_b))
+    if len(batch_a) == 0:
+        return dsl.concat(batch_b, dsl.IntTuple((m_b, n_b)))
+    if len(batch_b) == 0:
+        return dsl.concat(batch_a, dsl.IntTuple((m_b, n_b)))
+    if len(batch_a) != len(batch_b):
+        return dsl.Invalid("arrays must have the same number of batch dimensions")
+    if any(
+        batch_a[i] != batch_b[i] and batch_a[i] != 1 and batch_b[i] != 1
+        for i in range(len(batch_a))
+    ):
+        return dsl.Invalid("incompatible batch shapes for broadcasting")
+    batch = dsl.IntTuple(
+        (batch_b[i] if batch_a[i] == 1 else batch_a[i]) for i in range(len(batch_a))
+    )
+    return dsl.concat(batch, dsl.IntTuple((m_b, n_b)))
+
+@type_shape_dsl_function
+def cholesky_update_shape(r_shape: IntTuple, w_shape: IntTuple) -> IntTuple:
+    if len(r_shape) < 2 or len(w_shape) < 1:
+        return dsl.Invalid(
+            "cholesky_update requires at least 2-D matrix and 1-D vector"
+        )
+    n_r1 = r_shape[len(r_shape) - 2]
+    n_r2 = r_shape[len(r_shape) - 1]
+    if n_r1 != n_r2:
+        return dsl.Invalid("r_matrix must be square")
+    n_w = w_shape[len(w_shape) - 1]
+    if n_r1 != n_w:
+        return dsl.Invalid("r_matrix and w_vector dimensions must match")
+    batch_r = r_shape[: len(r_shape) - 2]
+    batch_w = w_shape[: len(w_shape) - 1]
+    if len(batch_r) == 0 and len(batch_w) == 0:
+        return dsl.IntTuple((n_r1, n_r1))
+    if len(batch_r) == 0:
+        return dsl.concat(batch_w, dsl.IntTuple((n_r1, n_r1)))
+    if len(batch_w) == 0:
+        return dsl.concat(batch_r, dsl.IntTuple((n_r1, n_r1)))
+    if len(batch_r) != len(batch_w):
+        return dsl.Invalid("arrays must have the same number of batch dimensions")
+    if any(
+        batch_r[i] != batch_w[i] and batch_r[i] != 1 and batch_w[i] != 1
+        for i in range(len(batch_r))
+    ):
+        return dsl.Invalid("incompatible batch shapes for broadcasting")
+    batch = dsl.IntTuple(
+        (batch_w[i] if batch_r[i] == 1 else batch_r[i]) for i in range(len(batch_r))
+    )
+    return dsl.concat(batch, dsl.IntTuple((n_r1, n_r1)))
+
+@type_shape_dsl_function
+def householder_product_shape(a_shape: IntTuple, taus_shape: IntTuple) -> IntTuple:
+    if len(a_shape) < 2 or len(taus_shape) < 1:
+        return dsl.Invalid(
+            "householder_product requires at least 2-D matrix and 1-D taus"
+        )
+    batch_a = a_shape[: len(a_shape) - 2]
+    batch_t = taus_shape[: len(taus_shape) - 1]
+    m = a_shape[len(a_shape) - 2]
+    n = a_shape[len(a_shape) - 1]
+    if len(batch_a) == 0 and len(batch_t) == 0:
+        return dsl.IntTuple((m, n))
+    if len(batch_a) == 0:
+        return dsl.concat(batch_t, dsl.IntTuple((m, n)))
+    if len(batch_t) == 0:
+        return dsl.concat(batch_a, dsl.IntTuple((m, n)))
+    if len(batch_a) != len(batch_t):
+        return dsl.Invalid("arrays must have the same number of batch dimensions")
+    if any(
+        batch_a[i] != batch_t[i] and batch_a[i] != 1 and batch_t[i] != 1
+        for i in range(len(batch_a))
+    ):
+        return dsl.Invalid("incompatible batch shapes for broadcasting")
+    batch = dsl.IntTuple(
+        (batch_t[i] if batch_a[i] == 1 else batch_a[i]) for i in range(len(batch_a))
+    )
+    return dsl.concat(batch, dsl.IntTuple((m, n)))
+
+@type_shape_dsl_function
+def ormqr_shape(a_shape: IntTuple, taus_shape: IntTuple, c_shape: IntTuple) -> IntTuple:
+    if len(a_shape) < 2 or len(taus_shape) < 1 or len(c_shape) < 2:
+        return dsl.Invalid("ormqr requires at least 2-D arrays")
+    batch_c = c_shape[: len(c_shape) - 2]
+    m = c_shape[len(c_shape) - 2]
+    n = c_shape[len(c_shape) - 1]
+    if len(batch_c) == 0:
+        return dsl.IntTuple((m, n))
+    return dsl.concat(batch_c, dsl.IntTuple((m, n)))
+
+@type_shape_dsl_function
+def tridiagonal_solve_shape(
+    dl_shape: IntTuple,
+    d_shape: IntTuple,
+    du_shape: IntTuple,
+    b_shape: IntTuple,
+) -> IntTuple:
+    if len(dl_shape) < 1 or len(d_shape) < 1 or len(du_shape) < 1 or len(b_shape) < 2:
+        return dsl.Invalid(
+            "tridiagonal_solve requires at least 1-D diagonals and 2-D b"
+        )
+    n_dl = dl_shape[len(dl_shape) - 1]
+    n_d = d_shape[len(d_shape) - 1]
+    n_du = du_shape[len(du_shape) - 1]
+    n_b = b_shape[len(b_shape) - 2]
+    k_b = b_shape[len(b_shape) - 1]
+    if n_dl != n_d or n_du != n_d or n_b != n_d:
+        return dsl.Invalid("tridiagonal_solve dimension mismatch")
+    batch_dl = dl_shape[: len(dl_shape) - 1]
+    batch_b = b_shape[: len(b_shape) - 2]
+    if len(batch_dl) == 0 and len(batch_b) == 0:
+        return dsl.IntTuple((n_d, k_b))
+    if len(batch_dl) == 0:
+        return dsl.concat(batch_b, dsl.IntTuple((n_d, k_b)))
+    if len(batch_b) == 0:
+        return dsl.concat(batch_dl, dsl.IntTuple((n_d, k_b)))
+    if len(batch_dl) != len(batch_b):
+        return dsl.Invalid("arrays must have the same number of batch dimensions")
+    if any(
+        batch_dl[i] != batch_b[i] and batch_dl[i] != 1 and batch_b[i] != 1
+        for i in range(len(batch_dl))
+    ):
+        return dsl.Invalid("incompatible batch shapes for broadcasting")
+    batch = dsl.IntTuple(
+        (batch_b[i] if batch_dl[i] == 1 else batch_dl[i]) for i in range(len(batch_dl))
+    )
+    return dsl.concat(batch, dsl.IntTuple((n_d, k_b)))
+
+@type_shape_dsl_function
+def hessenberg_taus_shape(a_shape: IntTuple) -> IntTuple:
+    if len(a_shape) < 2:
+        return dsl.Invalid("hessenberg requires at least 2-D array")
+    n1 = a_shape[len(a_shape) - 2]
+    n2 = a_shape[len(a_shape) - 1]
+    if n1 != n2:
+        return dsl.Invalid("hessenberg requires a square matrix")
+    batch = a_shape[: len(a_shape) - 2]
+    return dsl.concat(batch, dsl.IntTuple((n1 - 1,)))
+
+@type_shape_dsl_function
+def tridiagonal_d_shape(a_shape: IntTuple) -> IntTuple:
+    if len(a_shape) < 2:
+        return dsl.Invalid("tridiagonal requires at least 2-D array")
+    n1 = a_shape[len(a_shape) - 2]
+    n2 = a_shape[len(a_shape) - 1]
+    if n1 != n2:
+        return dsl.Invalid("tridiagonal requires a square matrix")
+    batch = a_shape[: len(a_shape) - 2]
+    return dsl.concat(batch, dsl.IntTuple((n1,)))
+
+@type_shape_dsl_function
+def tridiagonal_diag_minus_one_shape(a_shape: IntTuple) -> IntTuple:
+    if len(a_shape) < 2:
+        return dsl.Invalid("tridiagonal requires at least 2-D array")
+    n1 = a_shape[len(a_shape) - 2]
+    n2 = a_shape[len(a_shape) - 1]
+    if n1 != n2:
+        return dsl.Invalid("tridiagonal requires a square matrix")
+    batch = a_shape[: len(a_shape) - 2]
+    return dsl.concat(batch, dsl.IntTuple((n1 - 1,)))

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/lax/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/lax/__init__.pyi
@@ -9,6 +9,8 @@ from jax._array import Array
 from jax._shapes import lax_broadcast
 from shape_extensions import IntTuple
 
+from . import linalg as linalg
+
 type _Shape = IntTuple
 type _Scalar = int | float | complex
 

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/lax/linalg/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/lax/linalg/__init__.pyi
@@ -1,0 +1,253 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import enum
+from typing import Any, Literal, overload
+
+from jax._array import Array
+from jax._shapes import (
+    cholesky_update_shape,
+    hessenberg_taus_shape,
+    householder_product_shape,
+    int_min,
+    ormqr_shape,
+    symmetric_product_shape,
+    triangular_solve_shape,
+    tridiagonal_d_shape,
+    tridiagonal_diag_minus_one_shape,
+    tridiagonal_solve_shape,
+)
+from shape_extensions import Elements, Flag, Int, IntTuple, IntVar
+
+type _Shape = IntTuple
+
+class EigImplementation(enum.Enum): ...
+class EighImplementation(enum.Enum): ...
+class SvdAlgorithm(enum.Enum): ...
+
+def cholesky[Batch: IntTuple, N: IntVar](
+    x: Array[[*Elements[Batch], N, N]],
+    *,
+    symmetrize_input: bool = True,
+) -> Array[[*Elements[Batch], N, N]]: ...
+def cholesky_update[RShape: _Shape, WShape: _Shape](
+    r_matrix: Array[RShape],
+    w_vector: Array[WShape],
+) -> Array[cholesky_update_shape(RShape, WShape)]: ...
+def eig[Batch: IntTuple, N: IntVar](
+    x: Array[[*Elements[Batch], N, N]],
+    *,
+    compute_left_eigenvectors: bool = True,
+    compute_right_eigenvectors: bool = True,
+    enable_eigvec_derivs: bool = False,
+    implementation: EigImplementation | str | None = None,
+    use_magma: bool | None = None,
+) -> list[Array[Any]]: ...
+def eigh[Batch: IntTuple, N: IntVar](
+    x: Array[[*Elements[Batch], N, N]],
+    *,
+    lower: bool = True,
+    symmetrize_input: bool = True,
+    sort_eigenvalues: bool = True,
+    subset_by_index: tuple[int, int] | None = None,
+    implementation: EighImplementation | str | None = None,
+) -> tuple[Array[[*Elements[Batch], N, N]], Array[[*Elements[Batch], N]]]: ...
+def hessenberg[AShape: _Shape](
+    a: Array[AShape],
+) -> tuple[Array[AShape], Array[hessenberg_taus_shape(AShape)]]: ...
+def householder_product[AShape: _Shape, TShape: _Shape](
+    a: Array[AShape],
+    taus: Array[TShape],
+) -> Array[householder_product_shape(AShape, TShape)]: ...
+def lu[Batch: IntTuple, M: IntVar, N: IntVar](
+    x: Array[[*Elements[Batch], M, N]],
+) -> tuple[
+    Array[[*Elements[Batch], M, N]],
+    Array[[*Elements[Batch], int_min(Int[M], Int[N])]],
+    Array[[*Elements[Batch], int_min(Int[M], Int[N])]],
+]: ...
+def lu_pivots_to_permutation[Batch: IntTuple, K: IntVar, N: IntVar](
+    pivots: Array[[*Elements[Batch], K]],
+    permutation_size: Int[N],
+) -> Array[[*Elements[Batch], N]]: ...
+def ormqr[AShape: _Shape, TShape: _Shape, CShape: _Shape](
+    a: Array[AShape],
+    taus: Array[TShape],
+    c: Array[CShape],
+    *,
+    left: bool = True,
+    transpose: bool = False,
+) -> Array[ormqr_shape(AShape, TShape, CShape)]: ...
+def qdwh[Batch: IntTuple, M: IntVar, N: IntVar](
+    x: Array[[*Elements[Batch], M, N]],
+    *,
+    is_hermitian: bool = False,
+    max_iterations: int | None = None,
+    eps: float | None = None,
+    dynamic_shape: tuple[int, int] | None = None,
+) -> tuple[
+    Array[[*Elements[Batch], M, N]],
+    Array[[*Elements[Batch], N, N]],
+    Array[[]],
+    Array[[]],
+]: ...
+@overload
+def qr[Batch: IntTuple, M: IntVar, N: IntVar](
+    x: Array[[*Elements[Batch], M, N]],
+    *,
+    pivoting: Literal[False] = False,
+    full_matrices: Literal[True] = True,
+    use_magma: bool | None = None,
+) -> tuple[Array[[*Elements[Batch], M, M]], Array[[*Elements[Batch], M, N]]]: ...
+@overload
+def qr[Batch: IntTuple, M: IntVar, N: IntVar](
+    x: Array[[*Elements[Batch], M, N]],
+    *,
+    pivoting: Literal[False] = False,
+    full_matrices: Literal[False],
+    use_magma: bool | None = None,
+) -> tuple[
+    Array[[*Elements[Batch], M, int_min(Int[M], Int[N])]],
+    Array[[*Elements[Batch], int_min(Int[M], Int[N]), N]],
+]: ...
+@overload
+def qr[Batch: IntTuple, M: IntVar, N: IntVar](
+    x: Array[[*Elements[Batch], M, N]],
+    *,
+    pivoting: Literal[True],
+    full_matrices: Literal[True] = True,
+    use_magma: bool | None = None,
+) -> tuple[
+    Array[[*Elements[Batch], M, M]],
+    Array[[*Elements[Batch], M, N]],
+    Array[[*Elements[Batch], N]],
+]: ...
+@overload
+def qr[Batch: IntTuple, M: IntVar, N: IntVar](
+    x: Array[[*Elements[Batch], M, N]],
+    *,
+    pivoting: Literal[True],
+    full_matrices: Literal[False],
+    use_magma: bool | None = None,
+) -> tuple[
+    Array[[*Elements[Batch], M, int_min(Int[M], Int[N])]],
+    Array[[*Elements[Batch], int_min(Int[M], Int[N]), N]],
+    Array[[*Elements[Batch], N]],
+]: ...
+@overload
+def qr(
+    x: Array[Any],
+    *,
+    pivoting: bool = False,
+    full_matrices: bool = True,
+    use_magma: bool | None = None,
+) -> (
+    tuple[Array[IntTuple], Array[IntTuple]]
+    | tuple[Array[IntTuple], Array[IntTuple], Array[IntTuple]]
+): ...
+def schur[Batch: IntTuple, N: IntVar](
+    x: Array[[*Elements[Batch], N, N]],
+    *,
+    compute_schur_vectors: bool = True,
+    sort_eig_vals: bool = False,
+    select_callable: Any = None,
+) -> tuple[Array[[*Elements[Batch], N, N]], Array[[*Elements[Batch], N, N]]]: ...
+@overload
+def svd[Batch: IntTuple, M: IntVar, N: IntVar](
+    x: Array[[*Elements[Batch], M, N]],
+    *,
+    full_matrices: Literal[True] = True,
+    compute_uv: Literal[True] = True,
+    subset_by_index: tuple[int, int] | None = None,
+    algorithm: SvdAlgorithm | str | None = None,
+) -> tuple[
+    Array[[*Elements[Batch], M, M]],
+    Array[[*Elements[Batch], int_min(Int[M], Int[N])]],
+    Array[[*Elements[Batch], N, N]],
+]: ...
+@overload
+def svd[Batch: IntTuple, M: IntVar, N: IntVar](
+    x: Array[[*Elements[Batch], M, N]],
+    *,
+    full_matrices: Literal[False],
+    compute_uv: Literal[True] = True,
+    subset_by_index: tuple[int, int] | None = None,
+    algorithm: SvdAlgorithm | str | None = None,
+) -> tuple[
+    Array[[*Elements[Batch], M, int_min(Int[M], Int[N])]],
+    Array[[*Elements[Batch], int_min(Int[M], Int[N])]],
+    Array[[*Elements[Batch], int_min(Int[M], Int[N]), N]],
+]: ...
+@overload
+def svd[Batch: IntTuple, M: IntVar, N: IntVar](
+    x: Array[[*Elements[Batch], M, N]],
+    *,
+    full_matrices: bool = True,
+    compute_uv: Literal[False],
+    subset_by_index: tuple[int, int] | None = None,
+    algorithm: SvdAlgorithm | str | None = None,
+) -> Array[[*Elements[Batch], int_min(Int[M], Int[N])]]: ...
+@overload
+def svd(
+    x: Array[Any],
+    *,
+    full_matrices: bool = True,
+    compute_uv: bool = True,
+    subset_by_index: tuple[int, int] | None = None,
+    algorithm: SvdAlgorithm | str | None = None,
+) -> Array[IntTuple] | tuple[Array[IntTuple], Array[IntTuple], Array[IntTuple]]: ...
+def symmetric_product[AShape: _Shape, CShape: _Shape](
+    a_matrix: Array[AShape],
+    c_matrix: Array[CShape],
+    *,
+    alpha: float = 1.0,
+    beta: float = 0.0,
+    symmetrize_output: bool = False,
+) -> Array[symmetric_product_shape(AShape, CShape)]: ...
+def triangular_solve[AShape: _Shape, BShape: _Shape, LeftSide: Flag[bool] = False](
+    a: Array[AShape],
+    b: Array[BShape],
+    *,
+    left_side: LeftSide = False,
+    lower: bool = False,
+    transpose_a: bool = False,
+    conjugate_a: bool = False,
+    unit_diagonal: bool = False,
+) -> Array[triangular_solve_shape(AShape, BShape, LeftSide)]: ...
+def tridiagonal[AShape: _Shape](
+    a: Array[AShape],
+    *,
+    lower: bool = True,
+) -> tuple[
+    Array[AShape],
+    Array[tridiagonal_d_shape(AShape)],
+    Array[tridiagonal_diag_minus_one_shape(AShape)],
+    Array[tridiagonal_diag_minus_one_shape(AShape)],
+]: ...
+def tridiagonal_solve[DLShape: _Shape, DShape: _Shape, DUShape: _Shape, BShape: _Shape](
+    dl: Array[DLShape],
+    d: Array[DShape],
+    du: Array[DUShape],
+    b: Array[BShape],
+    *,
+    perturb_singular: bool = False,
+) -> Array[tridiagonal_solve_shape(DLShape, DShape, DUShape, BShape)]: ...
+
+cholesky_p: Any
+cholesky_update_p: Any
+eig_p: Any
+eigh_p: Any
+hessenberg_p: Any
+householder_product_p: Any
+lu_p: Any
+lu_pivots_to_permutation_p: Any
+ormqr_p: Any
+qr_p: Any
+schur_p: Any
+svd_p: Any
+symmetric_product_p: Any
+triangular_solve_p: Any
+tridiagonal_p: Any
+tridiagonal_solve_p: Any

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_lax.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_lax.py
@@ -143,3 +143,148 @@ def test_binary_rejects_incompatible_dimensions() -> None:
         raise AssertionError(
             "expected JAX to reject incompatible dimensions in lax.add"
         )
+
+
+def test_lax_linalg() -> None:
+    x = jnp.ones((2, 2))
+    x_batch = jnp.ones((4, 2, 2))
+    x_rec = jnp.ones((2, 3))
+    x_rec_batch = jnp.ones((4, 2, 3))
+
+    assert_shape(lax.linalg.cholesky(x), (2, 2))
+    assert_shape(lax.linalg.cholesky(x_batch), (4, 2, 2))
+
+    r = jnp.ones((2, 2))
+    w = jnp.ones(2)
+    assert_shape(lax.linalg.cholesky_update(r, w), (2, 2))
+
+    eig_out = lax.linalg.eig(x)
+    assert [e.shape for e in eig_out] == [(2,), (2, 2), (2, 2)]
+
+    eig_out_batch = lax.linalg.eig(x_batch)
+    assert [e.shape for e in eig_out_batch] == [(4, 2), (4, 2, 2), (4, 2, 2)]
+
+    v, eig_w = lax.linalg.eigh(x)
+    assert_shape(v, (2, 2))
+    assert_shape(eig_w, (2,))
+
+    v_batch, eig_w_batch = lax.linalg.eigh(x_batch)
+    assert_shape(v_batch, (4, 2, 2))
+    assert_shape(eig_w_batch, (4, 2))
+
+    h_mat, taus = lax.linalg.hessenberg(x)
+    assert_shape(h_mat, (2, 2))
+    assert_shape(taus, (1,))
+
+    a_house = jnp.ones((3, 2))
+    taus_house = jnp.ones(2)
+    assert_shape(lax.linalg.householder_product(a_house, taus_house), (3, 2))
+
+    lu_out, piv, perm = lax.linalg.lu(x_rec)
+    assert_shape(lu_out, (2, 3))
+    assert_shape(piv, (2,))
+    assert_shape(perm, (2,))
+
+    assert_shape(lax.linalg.lu_pivots_to_permutation(piv, 2), (2,))
+
+    c_mat = jnp.ones((3, 4))
+    assert_shape(lax.linalg.ormqr(a_house, taus_house, c_mat, left=True), (3, 4))
+
+    u_qdwh, h_qdwh, iters, conv = lax.linalg.qdwh(x)
+    assert_shape(u_qdwh, (2, 2))
+    assert_shape(h_qdwh, (2, 2))
+    assert_shape(iters, ())
+    assert_shape(conv, ())
+
+    q, r_qr = lax.linalg.qr(x_rec, full_matrices=True)
+    assert_shape(q, (2, 2))
+    assert_shape(r_qr, (2, 3))
+
+    q_red, r_red = lax.linalg.qr(x_rec, full_matrices=False)
+    assert_shape(q_red, (2, 2))
+    assert_shape(r_red, (2, 3))
+
+    t_schur, z_schur = lax.linalg.schur(x)
+    assert_shape(t_schur, (2, 2))
+    assert_shape(z_schur, (2, 2))
+
+    u_svd, s_svd, vt_svd = lax.linalg.svd(x_rec, full_matrices=True)
+    assert_shape(u_svd, (2, 2))
+    assert_shape(s_svd, (2,))
+    assert_shape(vt_svd, (3, 3))
+
+    u_svd_r, s_svd_r, vt_svd_r = lax.linalg.svd(x_rec, full_matrices=False)
+    assert_shape(u_svd_r, (2, 2))
+    assert_shape(s_svd_r, (2,))
+    assert_shape(vt_svd_r, (2, 3))
+
+    assert_shape(lax.linalg.svd(x_rec, compute_uv=False), (2,))
+
+    a_sym = jnp.ones((2, 3))
+    c_sym = jnp.ones((2, 2))
+    assert_shape(lax.linalg.symmetric_product(a_sym, c_sym), (2, 2))
+    assert_shape(
+        lax.linalg.symmetric_product(jnp.ones((4, 2, 3)), jnp.ones((4, 2, 2))),
+        (4, 2, 2),
+    )
+
+    b_left = jnp.ones((2, 3))
+    assert_shape(lax.linalg.triangular_solve(r, b_left, left_side=True), (2, 3))
+    b_right = jnp.ones((3, 2))
+    assert_shape(lax.linalg.triangular_solve(r, b_right, left_side=False), (3, 2))
+
+    tri_a, tri_d, tri_e, tri_tau = lax.linalg.tridiagonal(x)
+    assert_shape(tri_a, (2, 2))
+    assert_shape(tri_d, (2,))
+    assert_shape(tri_e, (1,))
+    assert_shape(tri_tau, (1,))
+
+    dl = jnp.ones(2)
+    d = jnp.ones(2)
+    du = jnp.ones(2)
+    b_tri = jnp.ones((2, 3))
+    assert_shape(lax.linalg.tridiagonal_solve(dl, d, du, b_tri), (2, 3))
+    assert_shape(
+        lax.linalg.tridiagonal_solve(
+            jnp.ones((4, 2)), jnp.ones((4, 2)), jnp.ones((4, 2)), jnp.ones((4, 2, 3))
+        ),
+        (4, 2, 3),
+    )
+
+
+def test_lax_linalg_shape_errors() -> None:
+    assert_shape(
+        lax.linalg.symmetric_product(jnp.ones((2, 3)), jnp.ones((2, 2))), (2, 2)
+    )
+
+    try:
+        # E: Cannot evaluate type-level shape DSL call: leading core dimensions of a_matrix and c_matrix must match
+        lax.linalg.symmetric_product(jnp.ones((2, 3)), jnp.ones((3, 3)))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError")
+
+    try:
+        # E: Cannot evaluate type-level shape DSL call: c_matrix must be square
+        lax.linalg.symmetric_product(jnp.ones((2, 3)), jnp.ones((2, 4)))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError")
+
+    try:
+        # E: Cannot evaluate type-level shape DSL call: incompatible shapes for triangular_solve
+        lax.linalg.triangular_solve(jnp.ones((2, 2)), jnp.ones((3, 3)), left_side=True)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError")
+
+    try:
+        # E: Cannot evaluate type-level shape DSL call: r_matrix must be square
+        lax.linalg.cholesky_update(jnp.ones((2, 3)), jnp.ones(2))
+    except (TypeError, ValueError):
+        pass
+    else:
+        raise AssertionError("expected error")


### PR DESCRIPTION
### Summary

Add tensor shape stubs for `jax.lax.linalg` APIs.

Note: once #4770 is in, we may be able to simplify a number of these because the shape semantics are expressible in terms of gufunc_broadcast.

### Test Plan

Updated existing unit tests, and tests pass locally:
```
$ uv tool run --from ruff==0.14.3 ruff format --check --config ruff.toml .
327 files already formatted
$ uv tool run --from ruff==0.14.3 ruff check --select I --config ruff.toml .
All checks passed!
$ uv run python test.py --no-test --no-conformance --no-jsonschema
Running formatting...
Finished in 2.62 seconds.
Running linting...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.85s
Finished in 1.07 seconds.
$ uv run python tensor-shapes/pyrefly-jax-stubs/run_pyrefly.py --release
+ cargo build -p pyrefly --release
    Finished `release` profile [optimized + debuginfo] target(s) in 0.55s
PASS stubs (9 files)
PASS arithmetic (1 files)
PASS creation (1 files)
PASS fft (1 files)
PASS lax (1 files)
PASS linalg (1 files)
PASS matmul (1 files)
PASS nn (1 files)
PASS reductions (1 files)
PASS reshape (1 files)
```

### AI disclosure

Change mostly generated with a Gemini coding agent.