### PR TITLE
[tensor-shapes] add stubs for jax.numpy einsum & tensor contractions

### DIFF
--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_array.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_array.pyi
@@ -12,10 +12,13 @@ from typing import Any, overload, Sequence
 import shape_extensions
 from jax._shapes import (
     matmul_shape,
+    diagonal_shape,
+    dot_shape,
     permute_shape,
     reduce_shape,
     reshape_shape,
     reverse_shape,
+    trace_shape,
 )
 from shape_extensions import broadcast, Flag, IntTuple, IntVar
 
@@ -464,4 +467,52 @@ class Array[Shape: _Shape = _AnyShape]:
         axis: None = None,
         dtype: Any = None,
         out: Any = None,
+    ) -> Array[IntTuple]: ...
+    def dot[OtherShape: _Shape](
+        self,
+        b: Array[OtherShape],
+        *,
+        precision: Any = None,
+        preferred_element_type: Any = None,
+        out_sharding: Any = None,
+    ) -> Array[dot_shape(Shape, OtherShape)]: ...
+    @overload
+    def diagonal[
+        Offset: Flag[int] = 0,
+        Axis1: Flag[int] = 0,
+        Axis2: Flag[int] = 1,
+    ](
+        self,
+        offset: Offset = 0,
+        axis1: Axis1 = 0,
+        axis2: Axis2 = 1,
+    ) -> Array[diagonal_shape(Shape, Offset, Axis1, Axis2)]: ...
+    @overload
+    def diagonal(
+        self,
+        offset: int = 0,
+        axis1: int = 0,
+        axis2: int = 1,
+    ) -> Array[IntTuple]: ...
+    @overload
+    def trace[
+        Offset: Flag[int] = 0,
+        Axis1: Flag[int] = 0,
+        Axis2: Flag[int] = 1,
+    ](
+        self,
+        offset: Offset = 0,
+        axis1: Axis1 = 0,
+        axis2: Axis2 = 1,
+        dtype: Any = None,
+        out: None = None,
+    ) -> Array[trace_shape(Shape, Offset, Axis1, Axis2)]: ...
+    @overload
+    def trace(
+        self,
+        offset: int = 0,
+        axis1: int = 0,
+        axis2: int = 1,
+        dtype: Any = None,
+        out: None = None,
     ) -> Array[IntTuple]: ...

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_array.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_array.pyi
@@ -11,9 +11,9 @@ from typing import Any, overload, Sequence
 
 import shape_extensions
 from jax._shapes import (
-    matmul_shape,
     diagonal_shape,
     dot_shape,
+    matmul_shape,
     permute_shape,
     reduce_shape,
     reshape_shape,

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
@@ -447,3 +447,182 @@ def tridiagonal_diag_minus_one_shape(a_shape: IntTuple) -> IntTuple:
         return dsl.Invalid("tridiagonal requires a square matrix")
     batch = a_shape[: len(a_shape) - 2]
     return dsl.concat(batch, dsl.IntTuple((n1 - 1,)))
+
+@type_shape_dsl_function
+def einsum_shape(spec: str, shapes: IntTuples) -> IntTuple:
+    return dsl.einsum(spec, shapes)
+
+@type_shape_dsl_function
+def dot_shape(left: IntTuple, right: IntTuple) -> IntTuple:
+    if len(left) == 0:
+        return right
+    if len(right) == 0:
+        return left
+    if len(left) == 1 and len(right) == 1:
+        if left[0] != right[0]:
+            return dsl.Invalid("dot dimensions must match")
+        return dsl.IntTuple(())
+    if len(right) == 1:
+        if left[len(left) - 1] != right[0]:
+            return dsl.Invalid("dot inner dimensions must match")
+        return left[: len(left) - 1]
+    if len(left) == 1:
+        if left[0] != right[len(right) - 2]:
+            return dsl.Invalid("dot inner dimensions must match")
+        return dsl.concat(
+            right[: len(right) - 2], dsl.IntTuple((right[len(right) - 1],))
+        )
+    if left[len(left) - 1] != right[len(right) - 2]:
+        return dsl.Invalid("dot inner dimensions must match")
+    return dsl.concat(
+        left[: len(left) - 1],
+        dsl.concat(right[: len(right) - 2], dsl.IntTuple((right[len(right) - 1],))),
+    )
+
+@type_shape_dsl_function
+def inner_shape(left: IntTuple, right: IntTuple) -> IntTuple:
+    if len(left) == 0:
+        return right
+    if len(right) == 0:
+        return left
+    if left[len(left) - 1] != right[len(right) - 1]:
+        return dsl.Invalid("inner dimensions must match")
+    if len(left) == 1 and len(right) == 1:
+        return dsl.IntTuple(())
+    return dsl.concat(left[: len(left) - 1], right[: len(right) - 1])
+
+@type_shape_dsl_function
+def kron_shape(a_shape: IntTuple, b_shape: IntTuple) -> IntTuple:
+    if len(a_shape) == 0:
+        return b_shape
+    if len(b_shape) == 0:
+        return a_shape
+    if len(a_shape) >= len(b_shape):
+        diff = len(a_shape) - len(b_shape)
+        return dsl.IntTuple(
+            a_shape[i] * (1 if i < diff else b_shape[i - diff])
+            for i in range(len(a_shape))
+        )
+    diff_pos = len(b_shape) - len(a_shape)
+    return dsl.IntTuple(
+        (1 if i < diff_pos else a_shape[i - diff_pos]) * b_shape[i]
+        for i in range(len(b_shape))
+    )
+
+@type_shape_dsl_function
+def matvec_shape(left: IntTuple, right: IntTuple) -> IntTuple:
+    if len(left) < 2 or len(right) < 1:
+        return dsl.Invalid("matvec requires at least 2-D matrix and 1-D vector")
+    m = left[len(left) - 2]
+    k_left = left[len(left) - 1]
+    k_right = right[len(right) - 1]
+    if (
+        dsl.is_concrete_int(k_left)
+        and dsl.is_concrete_int(k_right)
+        and k_left != k_right
+    ):
+        return dsl.Invalid("matvec inner dimensions must match")
+    b_left_len = len(left) - 2
+    b_right_len = len(right) - 1
+    if b_left_len >= b_right_len:
+        diff = b_left_len - b_right_len
+        return dsl.IntTuple(
+            (
+                (
+                    (right[i - diff] if left[i] == 1 else left[i])
+                    if i >= diff
+                    else left[i]
+                )
+                if i < b_left_len
+                else m
+            )
+            for i in range(b_left_len + 1)
+        )
+    diff = b_right_len - b_left_len
+    return dsl.IntTuple(
+        (
+            (
+                (right[i] if left[i - diff] == 1 else left[i - diff])
+                if i >= diff
+                else right[i]
+            )
+            if i < b_right_len
+            else m
+        )
+        for i in range(b_right_len + 1)
+    )
+
+@type_shape_dsl_function
+def vecmat_shape(left: IntTuple, right: IntTuple) -> IntTuple:
+    if len(left) < 1 or len(right) < 2:
+        return dsl.Invalid("vecmat requires at least 1-D vector and 2-D matrix")
+    k_left = left[len(left) - 1]
+    k_right = right[len(right) - 2]
+    m = right[len(right) - 1]
+    if (
+        dsl.is_concrete_int(k_left)
+        and dsl.is_concrete_int(k_right)
+        and k_left != k_right
+    ):
+        return dsl.Invalid("vecmat inner dimensions must match")
+    b_left_len = len(left) - 1
+    b_right_len = len(right) - 2
+    if b_left_len >= b_right_len:
+        diff = b_left_len - b_right_len
+        return dsl.IntTuple(
+            (
+                (
+                    (right[i - diff] if left[i] == 1 else left[i])
+                    if i >= diff
+                    else left[i]
+                )
+                if i < b_left_len
+                else m
+            )
+            for i in range(b_left_len + 1)
+        )
+    diff = b_right_len - b_left_len
+    return dsl.IntTuple(
+        (
+            (
+                (right[i] if left[i - diff] == 1 else left[i - diff])
+                if i >= diff
+                else right[i]
+            )
+            if i < b_right_len
+            else m
+        )
+        for i in range(b_right_len + 1)
+    )
+
+@type_shape_dsl_function
+def tensordot_shape(left: IntTuple, right: IntTuple, dims: int) -> IntTuple:
+    if dims < 0:
+        return dsl.Invalid("tensordot dims must be non-negative")
+    if dims > len(left) or dims > len(right):
+        return dsl.Invalid("tensordot dims exceeds input rank")
+    if any(left[len(left) - dims + i] != right[i] for i in range(dims)):
+        return dsl.Invalid("tensordot contracted dimensions must match")
+    return dsl.concat(left[: len(left) - dims], right[dims:])
+
+@type_shape_dsl_function
+def diagonal_shape(shape: IntTuple, offset: int, axis1: int, axis2: int) -> IntTuple:
+    if len(shape) < 2:
+        return dsl.Invalid("diagonal requires at least 2-D array")
+    d0 = shape[0]
+    d1 = shape[1]
+    if d0 == d1:
+        return dsl.concat(shape[2:], dsl.IntTuple((d0,)))
+    if dsl.is_concrete_int(d0) and dsl.is_concrete_int(d1):
+        if d0 < d1:
+            return dsl.concat(shape[2:], dsl.IntTuple((d0,)))
+        return dsl.concat(shape[2:], dsl.IntTuple((d1,)))
+    return dsl.concat(shape[2:], dsl.IntTuple((dsl.Int.gradual(),)))
+
+@type_shape_dsl_function
+def trace_shape(shape: IntTuple, offset: int, axis1: int, axis2: int) -> IntTuple:
+    if len(shape) < 2:
+        return dsl.Invalid("trace requires at least 2-D array")
+    if len(shape) == 2:
+        return dsl.IntTuple(())
+    return shape[2:]

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
@@ -8,6 +8,7 @@ from shape_extensions import (
     gufunc_broadcast,
     Int,
     IntTuple,
+    IntTuples,
     type_shape_dsl_function,
 )
 
@@ -626,3 +627,88 @@ def trace_shape(shape: IntTuple, offset: int, axis1: int, axis2: int) -> IntTupl
     if len(shape) == 2:
         return dsl.IntTuple(())
     return shape[2:]
+
+@type_shape_dsl_function
+def cross_axes_shape(
+    a_shape: IntTuple,
+    b_shape: IntTuple,
+    axisa: int,
+    axisb: int,
+    axisc: int,
+) -> IntTuple:
+    rank_a = len(a_shape)
+    rank_b = len(b_shape)
+    if rank_a == 0 or rank_b == 0:
+        return dsl.Invalid("cross requires at least 1-D arrays")
+
+    if axisa < 0:
+        norm_axisa = axisa + rank_a
+    else:
+        norm_axisa = axisa + 0
+    if norm_axisa < 0 or norm_axisa >= rank_a:
+        return dsl.Invalid("axisa out of bounds")
+
+    if axisb < 0:
+        norm_axisb = axisb + rank_b
+    else:
+        norm_axisb = axisb + 0
+    if norm_axisb < 0 or norm_axisb >= rank_b:
+        return dsl.Invalid("axisb out of bounds")
+
+    dim_a = a_shape[norm_axisa]
+    dim_b = b_shape[norm_axisb]
+    if dsl.is_concrete_int(dim_a) and dim_a != 2 and dim_a != 3:
+        return dsl.Invalid("Dimension must be either 2 or 3 for cross product")
+    if dsl.is_concrete_int(dim_b) and dim_b != 2 and dim_b != 3:
+        return dsl.Invalid("Dimension must be either 2 or 3 for cross product")
+
+    batch_a = dsl.concat(a_shape[:norm_axisa], a_shape[norm_axisa + 1 :])
+    batch_b = dsl.concat(b_shape[:norm_axisb], b_shape[norm_axisb + 1 :])
+    len_a = len(batch_a)
+    len_b = len(batch_b)
+    if len_a >= len_b:
+        diff_a = len_a - len_b
+        batch = dsl.IntTuple(
+            (
+                (batch_b[i - diff_a] if batch_a[i] == 1 else batch_a[i])
+                if i >= diff_a
+                else batch_a[i]
+            )
+            for i in range(len_a)
+        )
+    else:
+        diff_b = len_b - len_a
+        batch = dsl.IntTuple(
+            (
+                (batch_a[i - diff_b] if batch_b[i] == 1 else batch_b[i])
+                if i >= diff_b
+                else batch_b[i]
+            )
+            for i in range(len_b)
+        )
+
+    if dim_a == 2 and dim_b == 2:
+        return batch
+
+    if dim_a == 3 or dim_b == 3:
+        out_rank = len(batch) + 1
+        if axisc < 0:
+            norm_axisc = axisc + out_rank
+        else:
+            norm_axisc = axisc + 0
+        if norm_axisc < 0 or norm_axisc >= out_rank:
+            return dsl.Invalid("axisc out of bounds")
+        return dsl.concat(
+            dsl.concat(batch[:norm_axisc], dsl.IntTuple((3,))),
+            batch[norm_axisc:],
+        )
+
+    return dsl.IntTuple.gradual()
+
+@type_shape_dsl_function
+def cross_axis_shape(
+    a_shape: IntTuple,
+    b_shape: IntTuple,
+    axis: int,
+) -> IntTuple:
+    return cross_axes_shape(a_shape, b_shape, axis, axis, axis)

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
@@ -514,87 +514,17 @@ def kron_shape(a_shape: IntTuple, b_shape: IntTuple) -> IntTuple:
 def matvec_shape(left: IntTuple, right: IntTuple) -> IntTuple:
     if len(left) < 2 or len(right) < 1:
         return dsl.Invalid("matvec requires at least 2-D matrix and 1-D vector")
-    m = left[len(left) - 2]
-    k_left = left[len(left) - 1]
-    k_right = right[len(right) - 1]
-    if (
-        dsl.is_concrete_int(k_left)
-        and dsl.is_concrete_int(k_right)
-        and k_left != k_right
-    ):
-        return dsl.Invalid("matvec inner dimensions must match")
-    b_left_len = len(left) - 2
-    b_right_len = len(right) - 1
-    if b_left_len >= b_right_len:
-        diff = b_left_len - b_right_len
-        return dsl.IntTuple(
-            (
-                (
-                    (right[i - diff] if left[i] == 1 else left[i])
-                    if i >= diff
-                    else left[i]
-                )
-                if i < b_left_len
-                else m
-            )
-            for i in range(b_left_len + 1)
-        )
-    diff = b_right_len - b_left_len
-    return dsl.IntTuple(
-        (
-            (
-                (right[i] if left[i - diff] == 1 else left[i - diff])
-                if i >= diff
-                else right[i]
-            )
-            if i < b_right_len
-            else m
-        )
-        for i in range(b_right_len + 1)
-    )
+    operands = dsl.IntTuples((left, right))
+    spec = "(m,n),(n)->(m)"
+    return gufunc_broadcast(spec, operands)
 
 @type_shape_dsl_function
 def vecmat_shape(left: IntTuple, right: IntTuple) -> IntTuple:
     if len(left) < 1 or len(right) < 2:
         return dsl.Invalid("vecmat requires at least 1-D vector and 2-D matrix")
-    k_left = left[len(left) - 1]
-    k_right = right[len(right) - 2]
-    m = right[len(right) - 1]
-    if (
-        dsl.is_concrete_int(k_left)
-        and dsl.is_concrete_int(k_right)
-        and k_left != k_right
-    ):
-        return dsl.Invalid("vecmat inner dimensions must match")
-    b_left_len = len(left) - 1
-    b_right_len = len(right) - 2
-    if b_left_len >= b_right_len:
-        diff = b_left_len - b_right_len
-        return dsl.IntTuple(
-            (
-                (
-                    (right[i - diff] if left[i] == 1 else left[i])
-                    if i >= diff
-                    else left[i]
-                )
-                if i < b_left_len
-                else m
-            )
-            for i in range(b_left_len + 1)
-        )
-    diff = b_right_len - b_left_len
-    return dsl.IntTuple(
-        (
-            (
-                (right[i] if left[i - diff] == 1 else left[i - diff])
-                if i >= diff
-                else right[i]
-            )
-            if i < b_right_len
-            else m
-        )
-        for i in range(b_right_len + 1)
-    )
+    operands = dsl.IntTuples((left, right))
+    spec = "(n),(n,m)->(m)"
+    return gufunc_broadcast(spec, operands)
 
 @type_shape_dsl_function
 def tensordot_shape(left: IntTuple, right: IntTuple, dims: int) -> IntTuple:

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
@@ -608,25 +608,100 @@ def tensordot_shape(left: IntTuple, right: IntTuple, dims: int) -> IntTuple:
 
 @type_shape_dsl_function
 def diagonal_shape(shape: IntTuple, offset: int, axis1: int, axis2: int) -> IntTuple:
-    if len(shape) < 2:
+    rank = len(shape)
+    if rank < 2:
         return dsl.Invalid("diagonal requires at least 2-D array")
-    d0 = shape[0]
-    d1 = shape[1]
-    if d0 == d1:
-        return dsl.concat(shape[2:], dsl.IntTuple((d0,)))
-    if dsl.is_concrete_int(d0) and dsl.is_concrete_int(d1):
-        if d0 < d1:
-            return dsl.concat(shape[2:], dsl.IntTuple((d0,)))
-        return dsl.concat(shape[2:], dsl.IntTuple((d1,)))
-    return dsl.concat(shape[2:], dsl.IntTuple((dsl.Int.gradual(),)))
+
+    if axis1 < 0:
+        norm_axis1 = axis1 + rank
+    else:
+        norm_axis1 = axis1 + 0
+    if norm_axis1 < 0 or norm_axis1 >= rank:
+        return dsl.Invalid("axis1 out of bounds")
+
+    if axis2 < 0:
+        norm_axis2 = axis2 + rank
+    else:
+        norm_axis2 = axis2 + 0
+    if norm_axis2 < 0 or norm_axis2 >= rank:
+        return dsl.Invalid("axis2 out of bounds")
+
+    if norm_axis1 == norm_axis2:
+        return dsl.Invalid("axis1 and axis2 cannot be the same")
+
+    d1 = shape[norm_axis1]
+    d2 = shape[norm_axis2]
+
+    zero_tuple = dsl.IntTuple((0,))
+    zero = zero_tuple[0]
+    offset_tuple = dsl.IntTuple((offset + 0,))
+    offset_dim = offset_tuple[0]
+
+    remaining = dsl.IntTuple(
+        (shape[i] for i in range(rank) if i != norm_axis1 and i != norm_axis2)
+    )
+
+    if offset == 0:
+        if d1 == d2:
+            return dsl.concat(remaining, dsl.IntTuple((d1,)))
+        if dsl.is_concrete_int(d1) and dsl.is_concrete_int(d2):
+            if d1 < d2:
+                return dsl.concat(remaining, dsl.IntTuple((d1,)))
+            return dsl.concat(remaining, dsl.IntTuple((d2,)))
+        return dsl.concat(remaining, dsl.IntTuple((dsl.Int.gradual(),)))
+
+    if offset > 0:
+        limit = d2 - offset_dim
+        if d1 == limit:
+            return dsl.concat(remaining, dsl.IntTuple((d1,)))
+        if dsl.is_concrete_int(d1) and dsl.is_concrete_int(limit):
+            if limit < zero:
+                return dsl.concat(remaining, dsl.IntTuple((zero,)))
+            if d1 < limit:
+                return dsl.concat(remaining, dsl.IntTuple((d1,)))
+            return dsl.concat(remaining, dsl.IntTuple((limit,)))
+        return dsl.concat(remaining, dsl.IntTuple((dsl.Int.gradual(),)))
+
+    limit = d1 + offset_dim
+    if limit == d2:
+        return dsl.concat(remaining, dsl.IntTuple((d2,)))
+    if dsl.is_concrete_int(limit) and dsl.is_concrete_int(d2):
+        if limit < zero:
+            return dsl.concat(remaining, dsl.IntTuple((zero,)))
+        if limit < d2:
+            return dsl.concat(remaining, dsl.IntTuple((limit,)))
+        return dsl.concat(remaining, dsl.IntTuple((d2,)))
+    return dsl.concat(remaining, dsl.IntTuple((dsl.Int.gradual(),)))
 
 @type_shape_dsl_function
 def trace_shape(shape: IntTuple, offset: int, axis1: int, axis2: int) -> IntTuple:
-    if len(shape) < 2:
+    rank = len(shape)
+    if rank < 2:
         return dsl.Invalid("trace requires at least 2-D array")
-    if len(shape) == 2:
+
+    if axis1 < 0:
+        norm_axis1 = axis1 + rank
+    else:
+        norm_axis1 = axis1 + 0
+    if norm_axis1 < 0 or norm_axis1 >= rank:
+        return dsl.Invalid("axis1 out of bounds")
+
+    if axis2 < 0:
+        norm_axis2 = axis2 + rank
+    else:
+        norm_axis2 = axis2 + 0
+    if norm_axis2 < 0 or norm_axis2 >= rank:
+        return dsl.Invalid("axis2 out of bounds")
+
+    if norm_axis1 == norm_axis2:
+        return dsl.Invalid("axis1 and axis2 cannot be the same")
+
+    if rank == 2:
         return dsl.IntTuple(())
-    return shape[2:]
+
+    return dsl.IntTuple(
+        (shape[i] for i in range(rank) if i != norm_axis1 and i != norm_axis2)
+    )
 
 @type_shape_dsl_function
 def cross_axes_shape(

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
@@ -3,18 +3,36 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Callable, Literal, overload, Sequence
+from typing import Any, Callable, Literal, overload, Sequence, Unpack
 
 from jax._array import Array as Array, Array as ndarray
 from jax._shapes import (
+    diagonal_shape,
+    dot_shape,
+    einsum_shape,
+    inner_shape,
     int_min,
+    kron_shape,
     matmul_shape,
+    matvec_shape,
     permute_shape,
     reduce_shape,
     reshape_shape,
     reverse_shape,
+    tensordot_shape,
+    trace_shape,
+    vecmat_shape,
 )
-from shape_extensions import broadcast, Flag, Int, IntTuple, IntVar
+from shape_extensions import (
+    broadcast,
+    Elements,
+    Flag,
+    Int,
+    IntTuple,
+    IntTuples,
+    IntVar,
+    MapIntTuples,
+)
 
 from . import fft as fft, linalg as linalg
 
@@ -888,9 +906,167 @@ def logaddexp2[Shape1: _Shape, Shape2: _Shape](
 ) -> Array[broadcast(Shape1, Shape2)]: ...
 
 # Shape semantics, including vector and batched operands, come from the gufunc-backed helper.
+def cross[Shape1: _Shape, Shape2: _Shape](
+    a: Array[Shape1],
+    b: Array[Shape2],
+    /,
+    axisa: int = -1,
+    axisb: int = -1,
+    axisc: int = -1,
+    axis: int | None = None,
+) -> Array[broadcast(Shape1, Shape2)]: ...
+@overload
+def diagonal[
+    Shape: _Shape,
+    Offset: Flag[int] = 0,
+    Axis1: Flag[int] = 0,
+    Axis2: Flag[int] = 1,
+](
+    a: Array[Shape],
+    offset: Offset = 0,
+    axis1: Axis1 = 0,
+    axis2: Axis2 = 1,
+) -> Array[diagonal_shape(Shape, Offset, Axis1, Axis2)]: ...
+@overload
+def diagonal(
+    a: Array[Any],
+    offset: int = 0,
+    axis1: int = 0,
+    axis2: int = 1,
+) -> Array[IntTuple]: ...
+def dot[LeftShape: _Shape, RightShape: _Shape](
+    a: Array[LeftShape],
+    b: Array[RightShape],
+    *,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    out_sharding: Any = None,
+) -> Array[dot_shape(LeftShape, RightShape)]: ...
+@overload
+def einsum[Spec: Flag[str], Shapes: IntTuples](
+    subscripts: Spec,
+    /,
+    *operands: Unpack[MapIntTuples[lambda S: Array[S], Shapes]],
+    out: None = None,
+    optimize: str | bool | Sequence[tuple[int, ...]] = "auto",
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    _dot_general: Any = ...,
+    out_sharding: Any = None,
+) -> Array[einsum_shape(Spec, Shapes)]: ...
+@overload
+def einsum(
+    subscripts: str,
+    /,
+    *operands: Array[Any] | Sequence[Any],
+    out: None = None,
+    optimize: str | bool | Sequence[tuple[int, ...]] = "auto",
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    _dot_general: Any = ...,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+def einsum_path(
+    subscripts: str,
+    /,
+    *operands: Array[Any] | Sequence[Any],
+    optimize: bool | str | Sequence[tuple[int, ...]] = "auto",
+) -> tuple[list[tuple[int, ...]], Any]: ...
+def inner[LeftShape: _Shape, RightShape: _Shape](
+    a: Array[LeftShape],
+    b: Array[RightShape],
+    *,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+) -> Array[inner_shape(LeftShape, RightShape)]: ...
+def kron[AShape: _Shape, BShape: _Shape](
+    a: Array[AShape],
+    b: Array[BShape],
+) -> Array[kron_shape(AShape, BShape)]: ...
 def matmul[LeftShape: _Shape, RightShape: _Shape](
     a: Array[LeftShape], b: Array[RightShape]
 ) -> Array[matmul_shape(LeftShape, RightShape)]: ...
+def matvec[LeftShape: _Shape, RightShape: _Shape](
+    x1: Array[LeftShape],
+    x2: Array[RightShape],
+    /,
+) -> Array[matvec_shape(LeftShape, RightShape)]: ...
+@overload
+def outer[M: IntVar, N: IntVar](
+    a: Array[[M]],
+    b: Array[[N]],
+    out: None = None,
+) -> Array[[M, N]]: ...
+@overload
+def outer(
+    a: Array[Any] | Sequence[Any],
+    b: Array[Any] | Sequence[Any],
+    out: None = None,
+) -> Array[IntTuple]: ...
+@overload
+def tensordot[Left: _Shape, Right: _Shape, Dims: Flag[int] = 2](
+    a: Array[Left],
+    b: Array[Right],
+    axes: Dims = 2,
+    *,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    out_sharding: Any = None,
+) -> Array[tensordot_shape(Left, Right, Dims)]: ...
+@overload
+def tensordot(
+    a: Array[Any],
+    b: Array[Any],
+    axes: int | Sequence[int] | Sequence[Sequence[int]] = 2,
+    *,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def trace[
+    Shape: _Shape,
+    Offset: Flag[int] = 0,
+    Axis1: Flag[int] = 0,
+    Axis2: Flag[int] = 1,
+](
+    a: Array[Shape],
+    offset: Offset = 0,
+    axis1: Axis1 = 0,
+    axis2: Axis2 = 1,
+    dtype: Any = None,
+    out: None = None,
+) -> Array[trace_shape(Shape, Offset, Axis1, Axis2)]: ...
+@overload
+def trace(
+    a: Array[Any],
+    offset: int = 0,
+    axis1: int = 0,
+    axis2: int = 1,
+    dtype: Any = None,
+    out: None = None,
+) -> Array[IntTuple]: ...
+def vdot[Shape1: _Shape, Shape2: _Shape](
+    a: Array[Shape1],
+    b: Array[Shape2],
+    *,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+) -> Array[[]]: ...
+def vecdot[Shape1: _Shape, Shape2: _Shape, Axis: Flag[_Axis] = -1](
+    x1: Array[Shape1],
+    x2: Array[Shape2],
+    /,
+    *,
+    axis: Axis = -1,
+    precision: Any = None,
+    preferred_element_type: Any = None,
+) -> Array[reduce_shape(broadcast(Shape1, Shape2), Axis, False)]: ...
+def vecmat[LeftShape: _Shape, RightShape: _Shape](
+    x1: Array[LeftShape],
+    x2: Array[RightShape],
+    /,
+) -> Array[vecmat_shape(LeftShape, RightShape)]: ...
 @overload
 def maximum[Shape: _Shape](
     x1: Array[Shape], x2: int | float | complex, /

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
@@ -7,6 +7,8 @@ from typing import Any, Callable, Literal, overload, Sequence, Unpack
 
 from jax._array import Array as Array, Array as ndarray
 from jax._shapes import (
+    cross_axes_shape,
+    cross_axis_shape,
     diagonal_shape,
     dot_shape,
     einsum_shape,
@@ -904,17 +906,47 @@ def logaddexp2[Shape: _Shape](
 def logaddexp2[Shape1: _Shape, Shape2: _Shape](
     x1: Array[Shape1], x2: Array[Shape2], /
 ) -> Array[broadcast(Shape1, Shape2)]: ...
-
-# Shape semantics, including vector and batched operands, come from the gufunc-backed helper.
-def cross[Shape1: _Shape, Shape2: _Shape](
+@overload
+def cross[
+    Shape1: _Shape,
+    Shape2: _Shape,
+    Axis: Flag[int],
+](
     a: Array[Shape1],
     b: Array[Shape2],
     /,
     axisa: int = -1,
     axisb: int = -1,
     axisc: int = -1,
+    *,
+    axis: Axis,
+) -> Array[cross_axis_shape(Shape1, Shape2, Axis)]: ...
+@overload
+def cross[
+    Shape1: _Shape,
+    Shape2: _Shape,
+    AxisA: Flag[int] = -1,
+    AxisB: Flag[int] = -1,
+    AxisC: Flag[int] = -1,
+](
+    a: Array[Shape1],
+    b: Array[Shape2],
+    /,
+    axisa: AxisA = -1,
+    axisb: AxisB = -1,
+    axisc: AxisC = -1,
+    axis: None = None,
+) -> Array[cross_axes_shape(Shape1, Shape2, AxisA, AxisB, AxisC)]: ...
+@overload
+def cross(
+    a: Array[Any],
+    b: Array[Any],
+    /,
+    axisa: int = -1,
+    axisb: int = -1,
+    axisc: int = -1,
     axis: int | None = None,
-) -> Array[broadcast(Shape1, Shape2)]: ...
+) -> Array[IntTuple]: ...
 @overload
 def diagonal[
     Shape: _Shape,

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/linalg/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/linalg/__init__.pyi
@@ -7,6 +7,7 @@ from typing import Any, Literal, overload, Sequence
 
 from jax._array import Array
 from jax._shapes import (
+    cross_axis_shape,
     int_min,
     matmul_shape,
     reduce_shape,
@@ -26,13 +27,26 @@ def cond[Batch: IntTuple, M: IntVar, N: IntVar](
     x: Array[[*Elements[Batch], M, N]],
     p: Any = None,
 ) -> Array[Batch]: ...
-def cross[Shape1: _Shape, Shape2: _Shape](
+@overload
+def cross[
+    Shape1: _Shape,
+    Shape2: _Shape,
+    Axis: Flag[int] = -1,
+](
     x1: Array[Shape1],
     x2: Array[Shape2],
     /,
     *,
+    axis: Axis = -1,
+) -> Array[cross_axis_shape(Shape1, Shape2, Axis)]: ...
+@overload
+def cross(
+    x1: Array[Any],
+    x2: Array[Any],
+    /,
+    *,
     axis: int = -1,
-) -> Array[broadcast(Shape1, Shape2)]: ...
+) -> Array[IntTuple]: ...
 def det[Batch: IntTuple, N: IntVar](
     a: Array[[*Elements[Batch], N, N]],
 ) -> Array[Batch]: ...

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_contractions.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_contractions.py
@@ -158,11 +158,36 @@ def test_diagonal_and_trace() -> None:
     mat = jnp.ones((3, 3))
     rect = jnp.ones((4, 5))
     batch_mat = jnp.ones((2, 3, 3))
+    t3d = jnp.ones((2, 3, 4))
 
+    # 2D diagonal
     assert_shape(jnp.diagonal(mat), (3,))
     assert_shape(jnp.diagonal(rect), (4,))
     assert_shape(mat.diagonal(), (3,))
 
+    # 2D diagonal with positive and negative offsets
+    assert_shape(jnp.diagonal(mat, offset=1), (2,))
+    assert_shape(jnp.diagonal(mat, offset=-1), (2,))
+    assert_shape(jnp.diagonal(mat, offset=2), (1,))
+    assert_shape(mat.diagonal(offset=1), (2,))
+
+    assert_shape(jnp.diagonal(rect, offset=1), (4,))
+    assert_shape(jnp.diagonal(rect, offset=2), (3,))
+    assert_shape(jnp.diagonal(rect, offset=-1), (3,))
+    assert_shape(jnp.diagonal(rect, offset=-2), (2,))
+
+    # 3D diagonal with axis1, axis2
+    assert_shape(jnp.diagonal(t3d), (4, 2))
+    assert_shape(jnp.diagonal(t3d, axis1=0, axis2=2), (3, 2))
+    assert_shape(jnp.diagonal(t3d, axis1=1, axis2=2), (2, 3))
+    assert_shape(jnp.diagonal(t3d, axis1=-2, axis2=-1), (2, 3))
+    assert_shape(jnp.diagonal(t3d, offset=2, axis1=1, axis2=2), (2, 2))
+    assert_shape(t3d.diagonal(axis1=1, axis2=2), (2, 3))
+
+    # Trace
     assert_shape(jnp.trace(mat), ())
     assert_shape(mat.trace(), ())
     assert_shape(jnp.trace(batch_mat), (3,))
+    assert_shape(jnp.trace(batch_mat, axis1=1, axis2=2), (2,))
+    assert_shape(jnp.trace(t3d, axis1=1, axis2=2), (2,))
+    assert_shape(t3d.trace(axis1=1, axis2=2), (2,))

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_contractions.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_contractions.py
@@ -121,8 +121,28 @@ def test_vecdot() -> None:
 
 
 def test_cross() -> None:
+    # 3D vectors
     assert_shape(jnp.cross(jnp.ones(3), jnp.ones(3)), (3,))
     assert_shape(jnp.cross(jnp.ones((2, 3)), jnp.ones((2, 3))), (2, 3))
+
+    # 2D vectors
+    assert_shape(jnp.cross(jnp.ones(2), jnp.ones(2)), ())
+    assert_shape(jnp.cross(jnp.ones((4, 2)), jnp.ones((4, 2))), (4,))
+
+    # Mixed 2D and 3D
+    assert_shape(jnp.cross(jnp.ones((4, 2)), jnp.ones((4, 3))), (4, 3))
+    assert_shape(jnp.cross(jnp.ones((4, 3)), jnp.ones((4, 2))), (4, 3))
+
+    # axis parameter
+    assert_shape(jnp.cross(jnp.ones((3, 4)), jnp.ones((3, 4)), axis=0), (3, 4))
+    assert_shape(jnp.cross(jnp.ones((2, 4)), jnp.ones((2, 4)), axis=0), (4,))
+
+    # axisa, axisb, axisc
+    assert_shape(jnp.cross(jnp.ones((4, 3)), jnp.ones((4, 3)), axisc=0), (3, 4))
+    assert_shape(
+        jnp.cross(jnp.ones((3, 4)), jnp.ones((4, 3)), axisa=0, axisb=1, axisc=0),
+        (3, 4),
+    )
 
 
 def test_tensordot() -> None:

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_contractions.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_contractions.py
@@ -1,0 +1,148 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from shape_extensions import assert_shape
+
+
+def test_einsum() -> None:
+    v1 = jnp.ones(3)
+    v2 = jnp.ones(3)
+    a = jnp.ones((2, 3))
+    b = jnp.ones((3, 4))
+    batch_a = jnp.ones((5, 2, 3))
+    batch_b = jnp.ones((5, 3, 4))
+
+    # Dot product
+    assert_shape(jnp.einsum("i,i->", v1, v2), ())
+
+    # Outer product
+    assert_shape(jnp.einsum("i,j->ij", v1, v2), (3, 3))
+
+    # Matrix multiplication
+    assert_shape(jnp.einsum("ij,jk->ik", a, b), (2, 4))
+
+    # Batch matrix multiplication
+    assert_shape(jnp.einsum("bij,bjk->bik", batch_a, batch_b), (5, 2, 4))
+
+    # Transpose
+    assert_shape(jnp.einsum("ij->ji", a), (3, 2))
+
+    # Diagonal
+    assert_shape(jnp.einsum("ii->i", jnp.ones((3, 3))), (3,))
+
+    # Trace
+    assert_shape(jnp.einsum("ii->", jnp.ones((3, 3))), ())
+
+
+def test_einsum_path() -> None:
+    a = jnp.ones((2, 3))
+    b = jnp.ones((3, 4))
+    path, _ = jnp.einsum_path("ij,jk->ik", a, b)
+    assert len(path) > 0
+    assert_shape(jnp.einsum("ij,jk->ik", a, b), (2, 4))
+
+
+def test_dot() -> None:
+    v1 = jnp.ones(3)
+    v2 = jnp.ones(3)
+    mat23 = jnp.ones((2, 3))
+    mat34 = jnp.ones((3, 4))
+    tensor234 = jnp.ones((2, 3, 4))
+    tensor45 = jnp.ones((4, 5))
+
+    # 1D dot 1D -> scalar ()
+    assert_shape(jnp.dot(v1, v2), ())
+    assert_shape(v1.dot(v2), ())
+
+    # 2D dot 2D -> 2D
+    assert_shape(jnp.dot(mat23, mat34), (2, 4))
+    assert_shape(mat23.dot(mat34), (2, 4))
+
+    # 2D dot 1D -> 1D
+    assert_shape(jnp.dot(mat23, v1), (2,))
+    assert_shape(mat23.dot(v1), (2,))
+
+    # 1D dot 2D -> 1D
+    assert_shape(jnp.dot(jnp.ones(2), mat23), (3,))
+    assert_shape(jnp.ones(2).dot(mat23), (3,))
+
+    # 3D dot 2D -> 3D
+    assert_shape(jnp.dot(tensor234, tensor45), (2, 3, 5))
+    assert_shape(tensor234.dot(tensor45), (2, 3, 5))
+
+
+def test_vdot() -> None:
+    assert_shape(jnp.vdot(jnp.ones(3), jnp.ones(3)), ())
+    assert_shape(jnp.vdot(jnp.ones((2, 3)), jnp.ones((2, 3))), ())
+
+
+def test_inner() -> None:
+    assert_shape(jnp.inner(jnp.ones(3), jnp.ones(3)), ())
+    assert_shape(jnp.inner(jnp.ones((2, 3)), jnp.ones((4, 3))), (2, 4))
+    assert_shape(jnp.inner(jnp.ones((2, 3, 4)), jnp.ones((5, 4))), (2, 3, 5))
+    assert_shape(jnp.inner(jnp.ones((2, 3, 4)), jnp.ones((5, 6, 4))), (2, 3, 5, 6))
+
+
+def test_outer() -> None:
+    assert_shape(jnp.outer(jnp.ones(3), jnp.ones(4)), (3, 4))
+    assert jnp.outer(jnp.ones((2, 3)), jnp.ones((4, 5))).shape == (6, 20)
+
+
+def test_kron() -> None:
+    assert_shape(jnp.kron(jnp.ones(2), jnp.ones(3)), (6,))
+    assert_shape(jnp.kron(jnp.ones((2, 3)), jnp.ones((4, 5))), (8, 15))
+    assert_shape(jnp.kron(jnp.ones(2), jnp.ones((4, 5))), (4, 10))
+
+
+def test_matvec_and_vecmat() -> None:
+    mat = jnp.ones((2, 3))
+    vec = jnp.ones(3)
+    batch_mat = jnp.ones((4, 2, 3))
+    batch_vec = jnp.ones((4, 3))
+
+    assert_shape(jnp.matvec(mat, vec), (2,))
+    assert_shape(jnp.matvec(batch_mat, vec), (4, 2))
+    assert_shape(jnp.matvec(batch_mat, batch_vec), (4, 2))
+
+    assert_shape(jnp.vecmat(jnp.ones(2), mat), (3,))
+    assert_shape(jnp.vecmat(jnp.ones(2), batch_mat), (4, 3))
+    assert_shape(jnp.vecmat(jnp.ones((4, 2)), batch_mat), (4, 3))
+
+
+def test_vecdot() -> None:
+    assert_shape(jnp.vecdot(jnp.ones(3), jnp.ones(3)), ())
+    assert_shape(jnp.vecdot(jnp.ones((2, 3)), jnp.ones((2, 3))), (2,))
+    assert_shape(jnp.vecdot(jnp.ones((2, 3)), jnp.ones((2, 3)), axis=0), (3,))
+
+
+def test_cross() -> None:
+    assert_shape(jnp.cross(jnp.ones(3), jnp.ones(3)), (3,))
+    assert_shape(jnp.cross(jnp.ones((2, 3)), jnp.ones((2, 3))), (2, 3))
+
+
+def test_tensordot() -> None:
+    assert_shape(jnp.tensordot(jnp.ones((2, 3)), jnp.ones((2, 3)), axes=2), ())
+    assert_shape(jnp.tensordot(jnp.ones((2, 3)), jnp.ones((3, 4)), axes=1), (2, 4))
+    assert_shape(
+        jnp.tensordot(jnp.ones((2, 3, 4)), jnp.ones((3, 4, 5)), axes=2),
+        (2, 5),
+    )
+
+
+def test_diagonal_and_trace() -> None:
+    mat = jnp.ones((3, 3))
+    rect = jnp.ones((4, 5))
+    batch_mat = jnp.ones((2, 3, 3))
+
+    assert_shape(jnp.diagonal(mat), (3,))
+    assert_shape(jnp.diagonal(rect), (4,))
+    assert_shape(mat.diagonal(), (3,))
+
+    assert_shape(jnp.trace(mat), ())
+    assert_shape(mat.trace(), ())
+    assert_shape(jnp.trace(batch_mat), (3,))


### PR DESCRIPTION
### Summary

Add tensor shape stubs for `jax.numpy` einsum & other tensor contractions

### Test Plan

Updated existing unit tests, and tests pass locally:
```
$ uv tool run --from ruff==0.14.3 ruff format --check --config ruff.toml .
328 files already formatted
$ uv tool run --from ruff==0.14.3 ruff check --select I --config ruff.toml .
All checks passed!
$ uv run python test.py --no-test --no-conformance --no-jsonschema
Running formatting...
Finished in 2.69 seconds.
Running linting...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.91s
Finished in 1.15 seconds.
$ uv run python tensor-shapes/pyrefly-jax-stubs/run_pyrefly.py --release
+ cargo build -p pyrefly --release
    Finished `release` profile [optimized + debuginfo] target(s) in 0.61s
PASS stubs (9 files)
PASS arithmetic (1 files)
PASS contractions (1 files)
PASS creation (1 files)
PASS fft (1 files)
PASS lax (1 files)
PASS linalg (1 files)
PASS matmul (1 files)
PASS nn (1 files)
PASS reductions (1 files)
PASS reshape (1 files)
```

### AI disclosure

Change generated with a Gemini coding agent.