### PR TITLE
fix Add support for polars col getattr #4771

### DIFF
--- a/pyrefly/lib/alt/polars_specials.rs
+++ b/pyrefly/lib/alt/polars_specials.rs
@@ -2316,12 +2316,27 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 let b = self.eval_polars_expr(right, schema, errors)?;
                 comparison_value(a, b)
             }
+            Expr::Attribute(_) => {
+                let name = self.polars_col_attribute_name(expr)?;
+                resolve_column(schema, &name, expr.range(), errors).map(ExprValue::Dtype)
+            }
             _ => literal_value(expr),
         }
     }
 
     fn polars_function(&self, func: &Expr) -> Option<PolarsFunction> {
         PolarsFunction::from_callee(&self.expr_infer(func, &self.error_swallower()))
+    }
+
+    fn polars_col_attribute_name(&self, expr: &Expr) -> Option<Name> {
+        let Expr::Attribute(attr) = expr else {
+            return None;
+        };
+        let Type::ClassType(base) = self.expr_infer(&attr.value, &self.error_swallower()) else {
+            return None;
+        };
+        (RuntimeClass::PolarsCol.matches(base.class_object()) && self.is_polars_expr_value(expr))
+            .then(|| attr.attr.id.clone())
     }
 
     /// Prove an expression produces one column, so its output name is well-defined.
@@ -2355,6 +2370,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             | Expr::StringLiteral(_)
             | Expr::BytesLiteral(_)
             | Expr::NoneLiteral(_) => true,
+            Expr::Attribute(_) if self.polars_col_attribute_name(expr).is_some() => true,
             _ => !self.is_polars_expr_value(expr),
         }
     }
@@ -2434,6 +2450,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             | Expr::NoneLiteral(_) => {
                 literal_value(expr).map(|_| Name::new_static(POLARS_LITERAL_OUTPUT_NAME))
             }
+            Expr::Attribute(_) => self.polars_col_attribute_name(expr),
             _ => None,
         }
     }

--- a/pyrefly/lib/test/polars/dataframe.rs
+++ b/pyrefly/lib/test/polars/dataframe.rs
@@ -151,6 +151,7 @@ class Expr:
 from polars.expr.expr import Expr
 class Col:
     def __call__(self, *names: str) -> Expr: ...
+    def __getattr__(self, name: str) -> Expr: ...
 col: Col
 "#,
     );
@@ -2487,6 +2488,21 @@ import polars as pl
 from typing import reveal_type
 df = pl.DataFrame({"a": [1]})
 reveal_type(df.select(pl.col("a")))  # E: revealed type: DataFrame[a: Int64]
+"#,
+);
+
+testcase!(
+    test_select_expr_col_attribute_keeps_name,
+    env_with_polars_stubs(),
+    r#"
+import polars as pl
+from polars import col as c
+from typing import reveal_type
+df = pl.DataFrame({"a": [1], "b": ["x"]})
+reveal_type(df.select(pl.col.a))  # E: revealed type: DataFrame[a: Int64]
+reveal_type(df.select(c.b.alias("renamed")))  # E: revealed type: DataFrame[renamed: String]
+reveal_type(df.select(pl.col.a + c.b))  # E: revealed type: DataFrame[a: Unknown]
+reveal_type(df.select(pl.col.missing))  # E: Column `missing` is not in the DataFrame schema # E: revealed type: DataFrame[missing: Unknown]
 "#,
 );
 


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4771

now Recognizes Polars col attribute expressions and preserves column names/dtypes.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test