### PR TITLE
Update overload selection for spec change (take 2) (#4782)

### DIFF
--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -834,7 +834,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 }
             }
             if matched_overloads.len() > 1 {
-                // Step 5, part 1: for each overload, check whether it's the case that all possible
+                // Step 5: for each overload, check whether it's the case that all possible
                 // materializations of each argument are assignable to the corresponding parameter.
                 // If so, eliminate all subsequent overloads.
                 //
@@ -956,37 +956,23 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     }
 
     fn disambiguate_overloads(&self, matched_overloads: &[CalledOverload<'_>]) -> Option<usize> {
-        // When a call to an overloaded function may match multiple overloads, the spec says to
-        // return Any when the return types are not all equivalent.
-        // However, neither mypy nor pyright fully follows this part of the spec, and many
-        // third-party libraries have come to rely on mypy and pyright's behavior. So we do the
-        // following for ecosystem compatibility:
+        // Step 6: does there exist a return type that is consistent with all materializations of
+        // every other return type? If so, use this return type. Else, return Any.
         //
-        // Step 6: does there exist a return type such that (1) all materializations of every other
-        // return type are assignable to it, and (2) the return type is assignable to every other
-        // return type? If so, use this return type. Else, return Any.
-        //
-        // We check materializations rather than assignability for (1) so that we end up with the
-        // most "general" return type. E.g., if the candidates are `A[None]` and `A[Any]`, we want
-        // to select `A[Any]`.
+        // We check materializations so that we end up with the most "general" return type. E.g.,
+        // if the candidates are `A[None]` and `A[Any]`, we want to select `A[Any]`.
         //
         // First, find a candidate return type.
         let mut candidate = 0;
         for (i, o) in matched_overloads.iter().enumerate().skip(1) {
-            if !self.is_subset_eq(&o.res.materialize(), &matched_overloads[candidate].res) {
+            if !self.is_consistent(&o.res.materialize(), &matched_overloads[candidate].res) {
                 candidate = i;
             }
         }
         // We've already checked every return type after the candidate.
         // Check every return type before the candidate.
         for o in matched_overloads.iter().take(candidate) {
-            if !self.is_subset_eq(&o.res.materialize(), &matched_overloads[candidate].res) {
-                return None;
-            }
-        }
-        // Check that the candidate is assignable to every other return type.
-        for o in matched_overloads.iter() {
-            if !self.is_subset_eq(&matched_overloads[candidate].res, &o.res) {
+            if !self.is_consistent(&o.res.materialize(), &matched_overloads[candidate].res) {
                 return None;
             }
         }

--- a/pyrefly/lib/test/overload.rs
+++ b/pyrefly/lib/test/overload.rs
@@ -2492,3 +2492,41 @@ if TYPE_CHECKING:
     def f(a: str): ...
     "#,
 );
+
+testcase!(
+    test_union_with_any_ambiguity,
+    r#"
+from typing import Any, assert_type, overload
+
+@overload
+def f(x: int) -> float | Any: ...
+@overload
+def f(x: str) -> Any: ...
+def f(x) -> Any: ...
+
+def g(x: Any):
+    assert_type(f(x), Any)
+    "#,
+);
+
+testcase!(
+    bug = "`int` should not be considered a subtype of `float`",
+    test_int_float_ambiguity,
+    r#"
+from typing import Any, assert_type, overload
+
+@overload
+def f(x: int) -> int | Any: ...
+@overload
+def f(x: str) -> float: ...
+def f(x) -> Any: ...
+
+def g(x: Any):
+    # This is technically wrong: pyrefly permits operations like `.hex()` on values typed as
+    # `float`, which `int` does not permit. This is weirdness related to how we implement
+    # the `int`/`float`/`complex` special case in the spec and not specific to overloads. One way
+    # to make it correct would be to implement https://github.com/python/typing-council/issues/46
+    # and treat `float` as meaning `int | float` in type expressions.
+    assert_type(f(x), int | Any)
+    "#,
+);


### PR DESCRIPTION
Summary:

embarrassed-bunny 

D118074925 moved too fast and implemented only half of https://github.com/python/typing-council/issues/65. The selected return type needs to be assignable to all candidates *and permit all operations that are supported on any candidate*. Now it should be mostly right.

The one place where I know it's still wrong is due to pyrefly's int/float/complex special case, which we implement by making int assignable to float, and int and float assignable to complex. Because of this, pyrefly will think that between `int | Any` and `float`, it can pick `int | Any`, even though `int` does not permit all operations supported on `float`.

This is preexisting subtyping weirdness (https://typing.python.org/en/latest/spec/special-types.html#special-cases-for-float-and-complex explicitly says "`complex`, `float`, and `int` are not subtypes of each other"!), so overload evaluation is not the right place to fix or special-case it.

Mypy primer error delta vs. my previous fix attempt:
```
Error kind                Added  Removed      Net
----------------------  -------  -------  -------
unknown-argument-type       116      251     -135
unknown-variable-type       104      171      -67
assert-type                  76       60      +16
unused-call-result            2      126     -124
[all other error kinds have <100 added or removed errors apiece]
----------------------  -------  -------  -------
Total                       349      903     -554
```

Differential Revision: D118372348


