### PR TITLE
fix inconsistent syntax highlighting for field of type inspect._ParameterKind #4751

### DIFF
--- a/pyrefly/lib/lsp/wasm/semantic_tokens.rs
+++ b/pyrefly/lib/lsp/wasm/semantic_tokens.rs
@@ -6,12 +6,15 @@
  */
 
 use lsp_types::SemanticToken;
+use lsp_types::SemanticTokenType;
 use pyrefly_build::handle::Handle;
 use ruff_text_size::TextRange;
 
+use crate::alt::attr::AttrDefinition;
 use crate::binding::binding::Key;
 use crate::state::lsp::FindPreference;
 use crate::state::lsp::ImportBehavior;
+use crate::state::lsp::attribute_symbol_kind_from_type;
 use crate::state::semantic_tokens::SemanticTokenBuilder;
 use crate::state::semantic_tokens::SemanticTokensLegends;
 use crate::state::semantic_tokens::disabled_ranges_for_module;
@@ -38,7 +41,28 @@ impl Transaction<'_> {
 
         builder.process_ast(
             &ast,
-            &|range| self.get_type_trace(handle, range),
+            &|range, base_range, name| {
+                let ty = self.get_type_trace(handle, range)?;
+                let kind = attribute_symbol_kind_from_type(&ty)
+                    .to_lsp_semantic_token_type_with_modifiers()
+                    .0;
+                // Enum-valued fields can have the same type as enum members, so
+                // confirm that the attribute's definitions are enum members.
+                if kind == SemanticTokenType::PROPERTY
+                    && let Some(base) = self.get_type_trace(handle, base_range)
+                    && self.ad_hoc_solve(handle, "semantic_token_enum_member", |solver| {
+                        let definitions = solver.completions(base, Some(name), false);
+                        !definitions.is_empty()
+                            && definitions.iter().all(|info| {
+                                matches!(&info.definition, AttrDefinition::FullyResolved { cls, .. }
+                                    if solver.get_enum_member(cls, name).is_some())
+                            })
+                    }) == Some(true)
+                {
+                    return Some(SemanticTokenType::ENUM_MEMBER);
+                }
+                Some(kind)
+            },
             &|key: &Key| {
                 let find_preference = FindPreference {
                     import_behavior: ImportBehavior::StopAtRenamedImports,

--- a/pyrefly/lib/state/semantic_tokens.rs
+++ b/pyrefly/lib/state/semantic_tokens.rs
@@ -263,24 +263,28 @@ fn range_overlaps(limit_range: Option<TextRange>, range: TextRange) -> bool {
 /// Classify an attribute's resolved type into a semantic token kind. For a union,
 /// every member must agree on the same kind; any disagreement (or a member that is
 /// a plain attribute) falls back to `PROPERTY`.
-fn attribute_semantic_token_type(ty: Type) -> SemanticTokenType {
+fn attribute_semantic_token_type(ty: Type, accessed_on_class: bool) -> SemanticTokenType {
     match ty {
         Type::Union(union) => {
             let mut members = union.members.into_iter();
             let Some(first) = members.next() else {
                 return SemanticTokenType::PROPERTY;
             };
-            let kind = attribute_semantic_token_type(first);
+            let kind = attribute_semantic_token_type(first, accessed_on_class);
             if kind == SemanticTokenType::PROPERTY {
                 return SemanticTokenType::PROPERTY;
             }
-            if members.all(|member| attribute_semantic_token_type(member) == kind) {
+            if members
+                .all(|member| attribute_semantic_token_type(member, accessed_on_class) == kind)
+            {
                 kind
             } else {
                 SemanticTokenType::PROPERTY
             }
         }
-        Type::Literal(lit) if matches!(lit.value, Lit::Enum(_)) => SemanticTokenType::ENUM_MEMBER,
+        Type::Literal(lit) if accessed_on_class && matches!(lit.value, Lit::Enum(_)) => {
+            SemanticTokenType::ENUM_MEMBER
+        }
         _ => {
             attribute_symbol_kind_from_type(&ty)
                 .to_lsp_semantic_token_type_with_modifiers()
@@ -421,8 +425,10 @@ impl SemanticTokenBuilder {
         get_type_of_attribute: &dyn Fn(TextRange) -> Option<Type>,
         get_symbol_kind: &dyn Fn(&Key) -> Option<(ModuleName, SymbolKind)>,
     ) {
+        let accessed_on_class = get_type_of_attribute(attr.value.range())
+            .is_some_and(|ty| matches!(ty, Type::ClassDef(_) | Type::Type(_)));
         let kind = get_type_of_attribute(attr.range())
-            .map(attribute_semantic_token_type)
+            .map(|ty| attribute_semantic_token_type(ty, accessed_on_class))
             .unwrap_or(SemanticTokenType::PROPERTY);
         self.push_if_in_range(attr.attr.range(), kind, Vec::new());
         attr.value

--- a/pyrefly/lib/state/semantic_tokens.rs
+++ b/pyrefly/lib/state/semantic_tokens.rs
@@ -17,13 +17,10 @@ use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_python::symbol_kind::SymbolKind;
 use pyrefly_python::sys_info::SysInfo;
-use pyrefly_types::literal::Lit;
-use pyrefly_types::types::Type;
 use pyrefly_util::visit::Visit as _;
 use ruff_python_ast::Arguments;
 use ruff_python_ast::ExceptHandler;
 use ruff_python_ast::Expr;
-use ruff_python_ast::ExprAttribute;
 use ruff_python_ast::ExprContext;
 use ruff_python_ast::ModModule;
 use ruff_python_ast::Pattern;
@@ -39,7 +36,6 @@ use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
 
 use crate::binding::binding::Key;
-use crate::state::lsp::attribute_symbol_kind_from_type;
 
 const SELF_PARAMETER_MODIFIER: SemanticTokenModifier = SemanticTokenModifier::new("selfParameter");
 const BYTE_STRING_MODIFIER: SemanticTokenModifier = SemanticTokenModifier::new("byteString");
@@ -260,39 +256,6 @@ fn range_overlaps(limit_range: Option<TextRange>, range: TextRange) -> bool {
     })
 }
 
-/// Classify an attribute's resolved type into a semantic token kind. For a union,
-/// every member must agree on the same kind; any disagreement (or a member that is
-/// a plain attribute) falls back to `PROPERTY`.
-fn attribute_semantic_token_type(ty: Type, accessed_on_class: bool) -> SemanticTokenType {
-    match ty {
-        Type::Union(union) => {
-            let mut members = union.members.into_iter();
-            let Some(first) = members.next() else {
-                return SemanticTokenType::PROPERTY;
-            };
-            let kind = attribute_semantic_token_type(first, accessed_on_class);
-            if kind == SemanticTokenType::PROPERTY {
-                return SemanticTokenType::PROPERTY;
-            }
-            if members
-                .all(|member| attribute_semantic_token_type(member, accessed_on_class) == kind)
-            {
-                kind
-            } else {
-                SemanticTokenType::PROPERTY
-            }
-        }
-        Type::Literal(lit) if accessed_on_class && matches!(lit.value, Lit::Enum(_)) => {
-            SemanticTokenType::ENUM_MEMBER
-        }
-        _ => {
-            attribute_symbol_kind_from_type(&ty)
-                .to_lsp_semantic_token_type_with_modifiers()
-                .0
-        }
-    }
-}
-
 pub struct SemanticTokenWithFullRange {
     pub range: TextRange,
     pub token_type: SemanticTokenType,
@@ -419,26 +382,10 @@ impl SemanticTokenBuilder {
         });
     }
 
-    fn process_attribute_expr(
-        &mut self,
-        attr: &ExprAttribute,
-        get_type_of_attribute: &dyn Fn(TextRange) -> Option<Type>,
-        get_symbol_kind: &dyn Fn(&Key) -> Option<(ModuleName, SymbolKind)>,
-    ) {
-        let accessed_on_class = get_type_of_attribute(attr.value.range())
-            .is_some_and(|ty| matches!(ty, Type::ClassDef(_) | Type::Type(_)));
-        let kind = get_type_of_attribute(attr.range())
-            .map(|ty| attribute_semantic_token_type(ty, accessed_on_class))
-            .unwrap_or(SemanticTokenType::PROPERTY);
-        self.push_if_in_range(attr.attr.range(), kind, Vec::new());
-        attr.value
-            .visit(&mut |x| self.process_expr(x, get_type_of_attribute, get_symbol_kind));
-    }
-
     fn process_expr(
         &mut self,
         x: &Expr,
-        get_type_of_attribute: &dyn Fn(TextRange) -> Option<Type>,
+        get_attribute_kind: &dyn Fn(TextRange, TextRange, &Name) -> Option<SemanticTokenType>,
         get_symbol_kind: &dyn Fn(&Key) -> Option<(ModuleName, SymbolKind)>,
     ) {
         match x {
@@ -466,46 +413,46 @@ impl SemanticTokenBuilder {
             }
             Expr::Call(call) => {
                 self.process_arguments(&call.arguments);
-                x.recurse(&mut |x| self.process_expr(x, get_type_of_attribute, get_symbol_kind));
+                x.recurse(&mut |x| self.process_expr(x, get_attribute_kind, get_symbol_kind));
             }
             Expr::Attribute(attr) => {
-                self.process_attribute_expr(attr, get_type_of_attribute, get_symbol_kind);
+                let kind = get_attribute_kind(attr.range(), attr.value.range(), &attr.attr.id)
+                    .unwrap_or(SemanticTokenType::PROPERTY);
+                self.push_if_in_range(attr.attr.range(), kind, Vec::new());
+                attr.value
+                    .visit(&mut |x| self.process_expr(x, get_attribute_kind, get_symbol_kind));
             }
             // Comprehensions need special handling because the Visit trait doesn't visit targets
             Expr::ListComp(list_comp) => {
                 for comp in &list_comp.generators {
-                    comp.target.visit(&mut |e| {
-                        self.process_expr(e, get_type_of_attribute, get_symbol_kind)
-                    });
+                    comp.target
+                        .visit(&mut |e| self.process_expr(e, get_attribute_kind, get_symbol_kind));
                 }
-                x.recurse(&mut |e| self.process_expr(e, get_type_of_attribute, get_symbol_kind));
+                x.recurse(&mut |e| self.process_expr(e, get_attribute_kind, get_symbol_kind));
             }
             Expr::SetComp(set_comp) => {
                 for comp in &set_comp.generators {
-                    comp.target.visit(&mut |e| {
-                        self.process_expr(e, get_type_of_attribute, get_symbol_kind)
-                    });
+                    comp.target
+                        .visit(&mut |e| self.process_expr(e, get_attribute_kind, get_symbol_kind));
                 }
-                x.recurse(&mut |e| self.process_expr(e, get_type_of_attribute, get_symbol_kind));
+                x.recurse(&mut |e| self.process_expr(e, get_attribute_kind, get_symbol_kind));
             }
             Expr::DictComp(dict_comp) => {
                 for comp in &dict_comp.generators {
-                    comp.target.visit(&mut |e| {
-                        self.process_expr(e, get_type_of_attribute, get_symbol_kind)
-                    });
+                    comp.target
+                        .visit(&mut |e| self.process_expr(e, get_attribute_kind, get_symbol_kind));
                 }
-                x.recurse(&mut |e| self.process_expr(e, get_type_of_attribute, get_symbol_kind));
+                x.recurse(&mut |e| self.process_expr(e, get_attribute_kind, get_symbol_kind));
             }
             Expr::Generator(generator) => {
                 for comp in &generator.generators {
-                    comp.target.visit(&mut |e| {
-                        self.process_expr(e, get_type_of_attribute, get_symbol_kind)
-                    });
+                    comp.target
+                        .visit(&mut |e| self.process_expr(e, get_attribute_kind, get_symbol_kind));
                 }
-                x.recurse(&mut |e| self.process_expr(e, get_type_of_attribute, get_symbol_kind));
+                x.recurse(&mut |e| self.process_expr(e, get_attribute_kind, get_symbol_kind));
             }
             _ => {
-                x.recurse(&mut |x| self.process_expr(x, get_type_of_attribute, get_symbol_kind));
+                x.recurse(&mut |x| self.process_expr(x, get_attribute_kind, get_symbol_kind));
             }
         }
     }
@@ -694,13 +641,13 @@ impl SemanticTokenBuilder {
     pub fn process_ast(
         &mut self,
         ast: &ModModule,
-        get_type_of_attribute: &dyn Fn(TextRange) -> Option<Type>,
+        get_attribute_kind: &dyn Fn(TextRange, TextRange, &Name) -> Option<SemanticTokenType>,
         get_symbol_kind: &dyn Fn(&Key) -> Option<(ModuleName, SymbolKind)>,
     ) {
         for s in &ast.body {
             self.process_stmt(s, false, get_symbol_kind);
         }
-        ast.visit(&mut |e| self.process_expr(e, get_type_of_attribute, get_symbol_kind));
+        ast.visit(&mut |e| self.process_expr(e, get_attribute_kind, get_symbol_kind));
     }
 
     pub fn all_tokens_sorted(self) -> Vec<SemanticTokenWithFullRange> {

--- a/pyrefly/lib/test/lsp/semantic_tokens.rs
+++ b/pyrefly/lib/test/lsp/semantic_tokens.rs
@@ -1030,6 +1030,91 @@ token-type: enumMember
 }
 
 #[test]
+fn narrowed_enum_instance_attribute_test() {
+    let code = r#"
+from enum import Enum
+
+class E(Enum):
+    A = 1
+    B = 2
+
+class Holder:
+    kind: E
+
+def f(holder: Holder) -> None:
+    if holder.kind is E.A:
+        pass
+    elif holder.kind is E.B:
+        pass
+"#;
+    assert_full_semantic_tokens(
+        &[("main", code)],
+        r#"
+# main.py
+line: 1, column: 5, length: 4, text: enum
+token-type: namespace
+
+line: 1, column: 17, length: 4, text: Enum
+token-type: class
+
+line: 3, column: 6, length: 1, text: E
+token-type: class
+
+line: 3, column: 8, length: 4, text: Enum
+token-type: class
+
+line: 4, column: 4, length: 1, text: A
+token-type: variable, token-modifiers: [readonly]
+
+line: 5, column: 4, length: 1, text: B
+token-type: variable, token-modifiers: [readonly]
+
+line: 7, column: 6, length: 6, text: Holder
+token-type: class
+
+line: 8, column: 4, length: 4, text: kind
+token-type: variable
+
+line: 8, column: 10, length: 1, text: E
+token-type: class
+
+line: 10, column: 4, length: 1, text: f
+token-type: function
+
+line: 10, column: 6, length: 6, text: holder
+token-type: parameter
+
+line: 10, column: 14, length: 6, text: Holder
+token-type: class
+
+line: 11, column: 7, length: 6, text: holder
+token-type: parameter
+
+line: 11, column: 14, length: 4, text: kind
+token-type: property
+
+line: 11, column: 22, length: 1, text: E
+token-type: class
+
+line: 11, column: 24, length: 1, text: A
+token-type: enumMember
+
+line: 13, column: 9, length: 6, text: holder
+token-type: parameter
+
+line: 13, column: 16, length: 4, text: kind
+token-type: property
+
+line: 13, column: 24, length: 1, text: E
+token-type: class
+
+line: 13, column: 26, length: 1, text: B
+token-type: enumMember
+"#,
+    );
+}
+
+#[test]
 fn type_alias_test() {
     let code = r#"
 type A = int

--- a/pyrefly/lib/test/lsp/semantic_tokens.rs
+++ b/pyrefly/lib/test/lsp/semantic_tokens.rs
@@ -1030,6 +1030,77 @@ token-type: enumMember
 }
 
 #[test]
+fn enum_member_definition_test() {
+    let mut env = TestEnv::new();
+    env.add(
+        "fixtures",
+        r#"
+from enum import Enum
+from typing import ClassVar, Literal
+
+class E(Enum):
+    A = 1
+    ALIAS = A
+
+    @property
+    def kind(self) -> Literal[E.A]:
+        return E.A
+
+class F(Enum):
+    A = 1
+
+class Holder:
+    kind: ClassVar[Literal[E.A]] = E.A
+    A: ClassVar[Literal[E.A]] = E.A
+
+holder: Holder
+e: E
+enum_class: type[E]
+union_class: type[E] | type[F]
+mixed_class: type[E] | type[Holder]
+"#,
+    );
+    for (expression, receiver_kind, attribute_kind) in [
+        ("E.A", "class", "enumMember"),
+        ("E.ALIAS", "class", "enumMember"),
+        ("e.A", "variable", "enumMember"),
+        ("enum_class.A", "class", "enumMember"),
+        ("union_class.A", "class", "enumMember"),
+        ("mixed_class.A", "class", "property"),
+        ("Holder.kind", "class", "property"),
+        ("Holder.A", "class", "property"),
+        ("holder.kind", "variable", "property"),
+        ("e.kind", "variable", "property"),
+    ] {
+        let (receiver, attribute) = expression.split_once('.').unwrap();
+        let code = format!("from fixtures import *\n{expression}\n");
+        let expected = format!(
+            "# main.py
+line: 0, column: 5, length: 8, text: fixtures
+token-type: namespace
+
+line: 0, column: 21, length: 1, text: *
+token-type: namespace
+
+line: 1, column: 0, length: {}, text: {receiver}
+token-type: {receiver_kind}
+
+line: 1, column: {}, length: {}, text: {attribute}
+token-type: {attribute_kind}",
+            receiver.len(),
+            receiver.len() + 1,
+            attribute.len(),
+        );
+        assert_full_semantic_tokens_with_syntax_and_env(
+            &[("main", &code)],
+            false,
+            env.clone(),
+            &expected,
+        );
+    }
+}
+
+#[test]
 fn narrowed_enum_instance_attribute_test() {
     let code = r#"
 from enum import Enum


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4751

fixes incorrect semantic highlighting for narrowed enum instance attributes.

Previously, holder.kind could be classified as an enumMember after narrowing.

Now instance attributes such as holder.kind remain property, actual enum members accessed through the enum class, such as E.A, remain enumMember.


# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test