### PR TITLE
Suppress unknown-name for global declarations the function itself defines

### DIFF
--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -92,6 +92,7 @@ use crate::binding::pytest::PytestBindingInfo;
 use crate::binding::pytest::is_pytest_fixture_function;
 use crate::binding::scope::Exportable;
 use crate::binding::scope::FlowStyle;
+use crate::binding::scope::MutableCaptureError;
 use crate::binding::scope::NameReadInfo;
 use crate::binding::scope::ScopeTrace;
 use crate::binding::scope::Scopes;
@@ -1454,9 +1455,14 @@ impl<'a> BindingsBuilder<'a> {
                 Binding::Forward(idx)
             }
             Err(error) => {
-                let should_suppress = matches!(kind, MutableCaptureKind::Nonlocal)
+                let should_suppress = (matches!(kind, MutableCaptureKind::Nonlocal)
                     && self.scopes.in_module_or_class_top_level()
-                    && !self.scopes.in_class_body();
+                    && !self.scopes.in_class_body())
+                    || (matches!(kind, MutableCaptureKind::Global)
+                        && matches!(error, MutableCaptureError::NotFound)
+                        && self
+                            .scopes
+                            .global_capture_self_defined(Hashed::new(&name.id)));
                 if !should_suppress {
                     self.error(name.range, ErrorKind::UnknownName, error.message(name));
                 }

--- a/pyrefly/lib/binding/scope.rs
+++ b/pyrefly/lib/binding/scope.rs
@@ -265,6 +265,9 @@ enum StaticStyle {
 struct MutableCapture {
     kind: MutableCaptureKind,
     original: Result<Box<StaticInfo>, MutableCaptureError>,
+    /// Does the declaring scope itself give the name a value (e.g. `global x; x = 1`)?
+    /// Such a capture creates the outer-scope name instead of requiring one to exist.
+    has_value_definition: bool,
 }
 
 impl MutableCapture {
@@ -333,6 +336,7 @@ impl StaticStyle {
                     Self::MutableCapture(MutableCapture {
                         kind: *kind,
                         original,
+                        has_value_definition: definition.has_value_definition,
                     })
                 }
                 DefinitionStyle::Annotated(.., ann) => {
@@ -2059,6 +2063,26 @@ impl Scopes {
             return Some(static_info.range);
         }
         None
+    }
+
+    /// Does a `global` declaration of `name` in the current function/method scope
+    /// come with a value definition in that same scope (e.g. `global x; x = 1`)?
+    /// Such a declaration legally creates the module-level name at runtime, so it
+    /// must not be reported as referencing a missing outer definition.
+    pub fn global_capture_self_defined(&self, name: Hashed<&Name>) -> bool {
+        let current = self.current();
+        matches!(current.kind, ScopeKind::Function(_) | ScopeKind::Method(_))
+            && matches!(
+                current.stat.0.get_hashed(name),
+                Some(StaticInfo {
+                    style: StaticStyle::MutableCapture(MutableCapture {
+                        kind: MutableCaptureKind::Global,
+                        has_value_definition: true,
+                        ..
+                    }),
+                    ..
+                })
+            )
     }
 
     /// Check if a name has a nonlocal binding in an enclosing scope.

--- a/pyrefly/lib/export/definitions.rs
+++ b/pyrefly/lib/export/definitions.rs
@@ -114,6 +114,25 @@ pub struct Definition {
     /// True while every definition site is inside an `if __name__ == "__main__":` body.
     /// Such names resolve in-module but are not importable, so the export surface excludes them.
     pub main_guard_only: bool,
+    /// True if any definition site assigns or imports a value, as opposed to merely
+    /// declaring the name (`global`/`nonlocal`) or deleting it. Only meaningful when
+    /// `style` is `MutableCapture`: a capture whose own scope defines a value
+    /// (`global x; x = 1`) legally creates the outer-scope name, so it needs no
+    /// pre-existing outer definition.
+    pub has_value_definition: bool,
+}
+
+/// Does this definition style give the name a value in the current scope?
+/// `global`/`nonlocal` declarations and `del` do not; implicit globals are
+/// injected module-level, not defined here.
+fn is_value_definition(style: &DefinitionStyle) -> bool {
+    !matches!(
+        style,
+        DefinitionStyle::MutableCapture(..)
+            | DefinitionStyle::Delete
+            | DefinitionStyle::ImplicitGlobal
+            | DefinitionStyle::ImportInvalidRelative
+    )
 }
 
 impl Definition {
@@ -126,6 +145,7 @@ impl Definition {
 
     fn merge(&mut self, other: DefinitionStyle, range: TextRange, in_main_guard: bool) {
         self.main_guard_only &= in_main_guard;
+        self.has_value_definition |= is_value_definition(&other);
         // To ensure binding code cannot produce invalid lookups, we ensure that
         // `self.style` and `self.range` always match.
         if other < self.style {
@@ -351,6 +371,7 @@ impl Definitions {
                     docstring_range: None,
                     last_range: TextRange::default(),
                     main_guard_only: false,
+                    has_value_definition: false,
                 },
             );
         }
@@ -439,6 +460,7 @@ impl DefinitionsBuilder {
             return;
         }
         let in_main_guard = self.in_main_guard;
+        let has_value_definition = is_value_definition(&style);
         match self.inner.definitions.entry(x.clone()) {
             Entry::Occupied(mut e) => {
                 e.get_mut().merge(style, range, in_main_guard);
@@ -451,6 +473,7 @@ impl DefinitionsBuilder {
                     docstring_range: body.and_then(Docstring::range_from_stmts),
                     last_range: range,
                     main_guard_only: in_main_guard,
+                    has_value_definition,
                 });
             }
         }

--- a/pyrefly/lib/test/scope.rs
+++ b/pyrefly/lib/test/scope.rs
@@ -398,6 +398,79 @@ global a  # E: Could not find name `a`
 );
 
 testcase!(
+    test_global_assign_without_module_definition,
+    r#"
+def set_workload_id(value: str) -> None:
+    global workload_id
+    workload_id = value
+
+
+set_workload_id("test")
+assert globals()["workload_id"] == "test"
+"#,
+);
+
+testcase!(
+    test_global_read_without_definition_still_errors,
+    r#"
+def f() -> None:
+    global a  # E: Could not find name `a`
+    print(a)
+"#,
+);
+
+testcase!(
+    test_global_assign_nested_in_if,
+    r#"
+def f(cond: bool) -> None:
+    global a
+    if cond:
+        a = 1
+
+
+def g(cond: bool) -> None:
+    if cond:
+        global b
+        b = 2
+"#,
+);
+
+testcase!(
+    test_global_del_does_not_define,
+    r#"
+def f() -> None:
+    global z  # E: Could not find name `z`
+    del z
+"#,
+);
+
+testcase!(
+    test_global_assign_before_declaration_still_errors,
+    r#"
+def f() -> None:
+    x = 1
+    global x  # E: `x` was assigned in the current scope before the global declaration
+"#,
+);
+
+testcase!(
+    test_global_assign_at_module_top_level_still_errors,
+    r#"
+global a  # E: Could not find name `a`
+a = 1
+"#,
+);
+
+testcase!(
+    test_global_assign_in_class_body_still_errors,
+    r#"
+class C:
+    global cx  # E: Could not find name `cx`
+    cx = 1
+"#,
+);
+
+testcase!(
     test_nonlocal_not_found,
     r#"
 def f() -> None:


### PR DESCRIPTION
Fixes #4785

## Problem

A `global` declaration inside a function errored with `unknown-name` ("Could not find name `x`") whenever the module had no module-level definition of `x` — even when the declaring function assigns `x` itself:

```python
def set_workload_id(value: str) -> None:
    global workload_id  # ERROR: Could not find name `workload_id`
    workload_id = value
```

`global x; x = value` is a legal way to create the module-level name at runtime, so the declaration should not error.

## Why it happened

The mutable-capture lookup for `global` names consults module-scope statics (plus a builtin fallback) only, and a function's global-assign intentionally never publishes a module-scope static — so the lookup cannot find the very name the function is about to define.

## Change

The definitions phase already merges every definition site in a scope, so it knows whether the scope gives the name a value beyond the capture declaration:

- `Definition` records whether any definition site is a value definition (assignment or import; `del` and other capture declarations do not count).
- The flag is threaded through the `MutableCapture` static.
- `declare_mutable_capture` suppresses only the not-found error for `global` declarations in function/method scopes whose own body defines the name.

Everything else is unchanged: undefined reads (`global a; print(a)` with no definition anywhere), assignments textually before the declaration (`x = 1; global x`), module top-level and class-body declarations, and all `nonlocal` behavior keep erroring exactly as before.

## Test plan

- [x] New `testcase!`s in `pyrefly/lib/test/scope.rs`: the issue repro, undefined-read still errors, nested-if assignments (both orders), `del` doesn't define, assignment-before-declaration keeps its error, module top-level and class-body keep erroring
- [x] `cargo test -p pyrefly --lib` green (the two pre-existing `missing-source` LSP interaction failures also fail on unmodified `main`)
- [x] Formatting/linting clean