### PR TITLE
Exempt base-dictated Any positions in @override methods from explicit-any

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -2471,7 +2471,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if ty.is_some_and(Self::is_proxy_method_type) {
             return true;
         }
-        let BindingAnnotation::AnnotateExpr(_, expr, _) = self.bindings().get(annotation) else {
+        let BindingAnnotation::AnnotateExpr(_, expr, _, _) = self.bindings().get(annotation) else {
             return false;
         };
         Self::proxy_method_annotation_syntax_mentions_name(expr)
@@ -2483,7 +2483,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         &self,
         annotation: Idx<KeyAnnotation>,
     ) -> ProxyMethodAnnotationForm {
-        let BindingAnnotation::AnnotateExpr(_, expr, _) = self.bindings().get(annotation) else {
+        let BindingAnnotation::AnnotateExpr(_, expr, _, _) = self.bindings().get(annotation) else {
             return ProxyMethodAnnotationForm::Other;
         };
         self.proxy_method_annotation_expr_form(expr)
@@ -4566,12 +4566,14 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             })
     }
 
-    /// Return the first inherited method signature (parameters and flags) for `name`.
-    pub(crate) fn inherited_method_signature(
+    /// Return the instantiated type of the first inherited member for `name`
+    /// whose type is accepted by `accept`, walking the MRO.
+    pub(crate) fn inherited_member_where(
         &self,
         cls: &Class,
         name: &Name,
-    ) -> Option<(ParamList, FuncFlags)> {
+        accept: impl Fn(&Type) -> bool,
+    ) -> Option<Type> {
         let derived_instance = self.instantiate(cls);
         for ancestor in self.get_mro_for_class(cls).ancestors(self.stdlib) {
             let parent_cls = ancestor.class_object();
@@ -4580,11 +4582,23 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
             };
             let instance = Instance::of_protocol(ancestor, derived_instance.clone());
             let instantiated = member.instantiate_for(self.heap, &instance);
-            if let Some(sig) = Self::callable_params_and_flags(instantiated.ty()) {
-                return Some(sig);
+            let ty = instantiated.ty();
+            if accept(&ty) {
+                return Some(ty);
             }
         }
         None
+    }
+
+    /// Return the first inherited method signature (parameters and flags) for `name`.
+    pub(crate) fn inherited_method_signature(
+        &self,
+        cls: &Class,
+        name: &Name,
+    ) -> Option<(ParamList, FuncFlags)> {
+        Self::callable_params_and_flags(self.inherited_member_where(cls, name, |ty| {
+            Self::callable_params_and_flags(ty.clone()).is_some()
+        })?)
     }
 
     pub fn get_metaclass_attribute(

--- a/pyrefly/lib/alt/class/pydantic.rs
+++ b/pyrefly/lib/alt/class/pydantic.rs
@@ -627,7 +627,9 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         if !metadata.is_pydantic_model() {
             return None;
         }
-        if let BindingAnnotation::AnnotateExpr(_, annotation_expr, _) = self.bindings().get(annot) {
+        if let BindingAnnotation::AnnotateExpr(_, annotation_expr, _, _) =
+            self.bindings().get(annot)
+        {
             let metadata_items = self.get_annotated_metadata(
                 annotation_expr,
                 TypeFormContext::ClassVarAnnotation,

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -152,6 +152,7 @@ use crate::types::annotation::Qualifier;
 use crate::types::callable::Callable;
 use crate::types::callable::Param;
 use crate::types::callable::ParamList;
+use crate::types::callable::Params;
 use crate::types::callable::Required;
 use crate::types::class::AttrsFieldSpecifierKind;
 use crate::types::class::Class;
@@ -280,6 +281,12 @@ impl TypeFormContext {
                 | TypeFormContext::TypeArgument
                 | TypeFormContext::TypeArgumentCallableReturn
                 | TypeFormContext::TypeArgumentForType
+                // Parameter and return annotations report from `solve_annotation`,
+                // which exempts `Any`s dictated by an overridden base signature.
+                | TypeFormContext::ParameterAnnotation
+                | TypeFormContext::ParameterArgsAnnotation
+                | TypeFormContext::ParameterKwargsAnnotation
+                | TypeFormContext::ReturnAnnotation
         )
     }
 
@@ -536,7 +543,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
         errors: &ErrorCollector,
     ) -> Arc<AnnotationWithTarget> {
         match binding {
-            BindingAnnotation::AnnotateExpr(target, x, class_key) => {
+            BindingAnnotation::AnnotateExpr(target, x, class_key, override_method) => {
                 let type_form_context = target.type_form_context();
                 let mut ann = self.expr_annotation(x, type_form_context, errors);
                 if let Some(class_key) = class_key
@@ -569,6 +576,25 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                             "`ProxyMethod` is only valid as a direct class member annotation"
                                 .to_owned(),
                         );
+                    }
+                }
+                // Parameter and return annotations are checked for `explicit-any` here rather
+                // than in `expr_untype` so that an `Any` dictated by the signature of the
+                // method being overridden can be exempted: an `@override` method cannot
+                // narrow or drop the base's `Any` without breaking the override.
+                if matches!(
+                    type_form_context,
+                    TypeFormContext::ParameterAnnotation
+                        | TypeFormContext::ParameterArgsAnnotation
+                        | TypeFormContext::ParameterKwargsAnnotation
+                        | TypeFormContext::ReturnAnnotation
+                ) {
+                    let dictated = matches!(&ann.ty, Some(Type::Any(AnyStyle::Explicit)))
+                        && override_method.as_ref().is_some_and(|method| {
+                            self.override_base_dictates_any(*class_key, method, target)
+                        });
+                    if !dictated && let Some(ty) = &ann.ty {
+                        self.check_explicit_any(ty, x.range(), errors);
                     }
                 }
                 Arc::new(AnnotationWithTarget {
@@ -3664,7 +3690,7 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
     /// Returns `None` for special forms which don't have a source expression.
     pub(crate) fn annotation_range(&self, key: Idx<KeyAnnotation>) -> Option<TextRange> {
         match self.bindings().get(key) {
-            BindingAnnotation::AnnotateExpr(_, expr, _) => Some(expr.range()),
+            BindingAnnotation::AnnotateExpr(_, expr, _, _) => Some(expr.range()),
             BindingAnnotation::SpecialForm(..) => None,
         }
     }
@@ -6915,6 +6941,66 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                 )
                 .emit();
         }
+    }
+
+    /// For a parameter or return annotation of an `@override` method: does the
+    /// base-class signature dictate `Any` at this position? The override cannot
+    /// narrow or drop such an `Any` without breaking the override, so it is
+    /// exempt from `explicit-any`. Only an explicitly-`Any`-annotated base
+    /// position exempts — an unannotated one does not.
+    fn override_base_dictates_any(
+        &self,
+        class_key: Option<Idx<KeyClass>>,
+        method_name: &Name,
+        target: &AnnotationTarget,
+    ) -> bool {
+        let Some(class_key) = class_key else {
+            return false;
+        };
+        let class = &*self.get_idx(class_key);
+        let Some(cls) = &class.0 else {
+            return false;
+        };
+        let Some(base) = self
+            .inherited_member_where(cls, method_name, |ty| !ty.callable_signatures().is_empty())
+        else {
+            return false;
+        };
+        let is_explicit_any = |ty: &Type| matches!(ty, Type::Any(AnyStyle::Explicit));
+        // An async base stores its declared return as `Coroutine[Any, Any, T]`.
+        let return_dictates = |ret: &Type| {
+            is_explicit_any(ret)
+                || self
+                    .unwrap_coroutine(ret)
+                    .is_some_and(|(_, _, ret)| is_explicit_any(&ret))
+        };
+        base.callable_signatures().iter().any(|sig| {
+            let items: &[Param] = match &sig.params {
+                Params::List(params) | Params::Partial(params) => params.items(),
+                _ => &[],
+            };
+            match target {
+                AnnotationTarget::Return(_) => return_dictates(&sig.ret),
+                AnnotationTarget::Param(name) => items.iter().any(|p| match p {
+                    Param::Pos(param_name, ty, _) | Param::KwOnly(param_name, ty, _) => {
+                        param_name.as_str() == name.as_str()
+                            && matches!(ty, Type::Any(AnyStyle::Explicit))
+                    }
+                    Param::PosOnly(Some(param_name), ty, _) => {
+                        param_name.as_str() == name.as_str()
+                            && matches!(ty, Type::Any(AnyStyle::Explicit))
+                    }
+                    _ => false,
+                }),
+                AnnotationTarget::ArgsParam(_) => items.iter().any(|p| {
+                    matches!(p, Param::Varargs(_, ty) if matches!(ty, Type::Any(AnyStyle::Explicit)))
+                }),
+                AnnotationTarget::KwargsParam(_) => items.iter().any(|p| {
+                    matches!(p, Param::Kwargs(_, ty) if matches!(ty, Type::Any(AnyStyle::Explicit)))
+                }),
+                _ => false,
+            }
+        })
     }
 
     /// Type check a delete expression, including ensuring that the target of the

--- a/pyrefly/lib/binding/binding.rs
+++ b/pyrefly/lib/binding/binding.rs
@@ -122,7 +122,7 @@ assert_words!(KeyUndecoratedFunction, 1);
 assert_words!(Binding, 6);
 assert_words!(BindingExpect, 14);
 assert_words!(BindingTypeAlias, 6);
-assert_words!(BindingAnnotation, 13);
+assert_words!(BindingAnnotation, 15);
 assert_words!(BindingClass, 10);
 assert_words!(BindingTParams, 9);
 assert_words!(BindingClassBaseType, 3);
@@ -2985,7 +2985,10 @@ impl AnnotationTarget {
 pub enum BindingAnnotation {
     /// The type is annotated to be this key, will have the outer type removed.
     /// Optionally occurring within a class, in which case Self refers to this class.
-    AnnotateExpr(AnnotationTarget, Expr, Option<Idx<KeyClass>>),
+    /// For a parameter/return annotation of an `@override` method, the final field
+    /// is the method's name, used to exempt annotations dictated by the base
+    /// signature (e.g. from `explicit-any`); `None` otherwise.
+    AnnotateExpr(AnnotationTarget, Expr, Option<Idx<KeyClass>>, Option<Name>),
     /// A special form declaration like `Literal: _SpecialForm`.
     SpecialForm(AnnotationTarget, SpecialForm),
 }
@@ -2993,14 +2996,17 @@ pub enum BindingAnnotation {
 impl DisplayWith<Bindings> for BindingAnnotation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, ctx: &Bindings) -> fmt::Result {
         match self {
-            Self::AnnotateExpr(target, x, class_key) => write!(
+            Self::AnnotateExpr(target, x, class_key, override_method) => write!(
                 f,
-                "AnnotateExpr({target}, {}, {})",
+                "AnnotateExpr({target}, {}, {}, {})",
                 ctx.module().display(x),
                 match class_key {
                     None => "None".to_owned(),
                     Some(t) => ctx.display(*t).to_string(),
-                }
+                },
+                override_method
+                    .as_ref()
+                    .map_or_else(|| "None".to_owned(), ToString::to_string),
             ),
             Self::SpecialForm(target, sf) => write!(f, "SpecialForm({target}, {sf})"),
         }

--- a/pyrefly/lib/binding/bindings.rs
+++ b/pyrefly/lib/binding/bindings.rs
@@ -2121,6 +2121,7 @@ impl<'a> BindingsBuilder<'a> {
         undecorated_idx: Idx<KeyUndecoratedFunction>,
         class_key: Option<Idx<KeyClass>>,
         is_variadic: bool,
+        override_method: Option<Name>,
         ignore_annotation: bool,
     ) {
         let name = x.name();
@@ -2133,7 +2134,12 @@ impl<'a> BindingsBuilder<'a> {
             x.annotation().map(|x| {
                 self.insert_binding(
                     KeyAnnotation::Annotation(ShortIdentifier::new(name)),
-                    BindingAnnotation::AnnotateExpr(target.clone(), x.clone(), class_key),
+                    BindingAnnotation::AnnotateExpr(
+                        target.clone(),
+                        x.clone(),
+                        class_key,
+                        override_method,
+                    ),
                 )
             })
         };

--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -1110,6 +1110,7 @@ impl<'a> BindingsBuilder<'a> {
                         AnnotationTarget::ClassMember(member_name.clone()),
                         annotation_expr,
                         None,
+                        None,
                     ),
                 )
             });

--- a/pyrefly/lib/binding/function.rs
+++ b/pyrefly/lib/binding/function.rs
@@ -287,6 +287,7 @@ impl<'a> BindingsBuilder<'a> {
         undecorated_idx: Idx<KeyUndecoratedFunction>,
         class_key: Option<Idx<KeyClass>>,
         method_self_kind: MethodSelfKind,
+        override_method: Option<Name>,
         ignore_annotations: bool,
     ) {
         let mut self_name = None;
@@ -300,6 +301,7 @@ impl<'a> BindingsBuilder<'a> {
                 undecorated_idx,
                 class_key,
                 false,
+                override_method.clone(),
                 ignore_annotations,
             );
         }
@@ -310,6 +312,7 @@ impl<'a> BindingsBuilder<'a> {
                 undecorated_idx,
                 class_key,
                 true,
+                override_method.clone(),
                 ignore_annotations,
             );
         }
@@ -320,6 +323,7 @@ impl<'a> BindingsBuilder<'a> {
                 undecorated_idx,
                 class_key,
                 true,
+                override_method,
                 ignore_annotations,
             );
         }
@@ -332,6 +336,7 @@ impl<'a> BindingsBuilder<'a> {
         mut x: Expr,
         func_name: &Identifier,
         class_key: Option<Idx<KeyClass>>,
+        override_method: Option<Name>,
         tparams_builder: &mut Option<LegacyTParamCollector>,
     ) -> (TextRange, Idx<KeyAnnotation>) {
         self.ensure_type(&mut x, tparams_builder);
@@ -343,6 +348,7 @@ impl<'a> BindingsBuilder<'a> {
                     AnnotationTarget::Return(func_name.id.clone()),
                     x,
                     class_key,
+                    override_method,
                 ),
             ),
         )
@@ -353,6 +359,7 @@ impl<'a> BindingsBuilder<'a> {
         x: &mut StmtFunctionDef,
         func_name: &Identifier,
         class_key: Option<Idx<KeyClass>>,
+        override_method: Option<Name>,
         usage: &mut Usage,
         parent: &NestingContext,
     ) -> (
@@ -375,8 +382,15 @@ impl<'a> BindingsBuilder<'a> {
             }
         }
 
-        let return_ann_with_range = mem::take(&mut x.returns)
-            .map(|e| self.to_return_annotation_with_range(*e, func_name, class_key, &mut legacy));
+        let return_ann_with_range = mem::take(&mut x.returns).map(|e| {
+            self.to_return_annotation_with_range(
+                *e,
+                func_name,
+                class_key,
+                override_method,
+                &mut legacy,
+            )
+        });
 
         let legacy_tparam_collector = legacy.unwrap();
         self.add_name_definitions(&legacy_tparam_collector);
@@ -399,6 +413,7 @@ impl<'a> BindingsBuilder<'a> {
         class_key: Option<Idx<KeyClass>>,
         is_async: bool,
         method_self_kind: MethodSelfKind,
+        override_method: Option<Name>,
     ) -> (
         YieldsAndReturns,
         Option<SelfAssignments>,
@@ -412,6 +427,7 @@ impl<'a> BindingsBuilder<'a> {
             undecorated_idx,
             class_key,
             method_self_kind,
+            override_method,
             false,
         );
         self.init_static_scope(&body, false);
@@ -456,6 +472,7 @@ impl<'a> BindingsBuilder<'a> {
         class_key: Option<Idx<KeyClass>>,
         is_async: bool,
         method_self_kind: MethodSelfKind,
+        override_method: Option<Name>,
         ignore_annotations: bool,
     ) -> Option<SelfAssignments> {
         // Push a scope to create the parameter keys (but do nothing else with it).
@@ -466,6 +483,7 @@ impl<'a> BindingsBuilder<'a> {
             undecorated_idx,
             class_key,
             method_self_kind,
+            override_method,
             ignore_annotations,
         );
         self.scopes.pop();
@@ -765,6 +783,8 @@ impl<'a> BindingsBuilder<'a> {
 
         let is_unannotated =
             !self.check_unannotated_defs && !is_annotated(&return_ann_with_range, parameters);
+        let override_method =
+            (decorators.is_override && class_key.is_some()).then(|| func_name.id.clone());
         let (is_return_inferred, self_assignments) = if decorators.has_no_type_check
             || (is_unannotated && !self.analyze_unannotated_for_ide)
         {
@@ -778,6 +798,7 @@ impl<'a> BindingsBuilder<'a> {
                 class_key,
                 is_async,
                 method_self_kind,
+                override_method,
                 decorators.has_no_type_check,
             );
             (false, self_assignments)
@@ -793,6 +814,7 @@ impl<'a> BindingsBuilder<'a> {
                 class_key,
                 is_async,
                 method_self_kind,
+                override_method,
             );
             self.analyze_return_type(
                 func_name,
@@ -820,6 +842,7 @@ impl<'a> BindingsBuilder<'a> {
                     class_key,
                     is_async,
                     method_self_kind,
+                    override_method,
                 );
             if !ignore_unused_parameters {
                 self.record_unused_parameters(unused_parameters);
@@ -985,10 +1008,20 @@ impl<'a> BindingsBuilder<'a> {
         self.maybe_record_pytest_fixture_definition(&x, class_key);
 
         let decorators = self.decorators(mem::take(&mut x.decorator_list), def_idx.usage());
+        // Method annotations of an `@override` method may be dictated by the base
+        // signature; stamping the method name lets the solver exempt them.
+        let override_method =
+            (decorators.is_override && class_key.is_some()).then(|| func_name.id.clone());
 
-        self.scopes.push(Scope::annotation(x.range));
-        let (return_ann_with_range, legacy_tparams) =
-            self.function_header(&mut x, &func_name, class_key, def_idx.usage(), parent);
+        self.scopes.push(Scope::annotation(x.range()));
+        let (return_ann_with_range, legacy_tparams) = self.function_header(
+            &mut x,
+            &func_name,
+            class_key,
+            override_method,
+            def_idx.usage(),
+            parent,
+        );
 
         let docstring_range = Docstring::range_from_stmts(x.body.as_slice());
         let calls_super_method = SuperMethodCallFinder::find(&func_name.id, &x.body);

--- a/pyrefly/lib/binding/stmt.rs
+++ b/pyrefly/lib/binding/stmt.rs
@@ -655,6 +655,7 @@ impl<'a> BindingsBuilder<'a> {
                 },
                 annotation.clone(),
                 None,
+                None,
             )
         };
         self.insert_binding(ann_key, ann_val)
@@ -1000,6 +1001,7 @@ impl<'a> BindingsBuilder<'a> {
                         BindingAnnotation::AnnotateExpr(
                             AnnotationTarget::AttrAssign(attr_name.clone()),
                             *x.annotation,
+                            None,
                             None,
                         ),
                     );

--- a/pyrefly/lib/test/inference.rs
+++ b/pyrefly/lib/test/inference.rs
@@ -247,6 +247,209 @@ x: C[int]
 );
 
 testcase!(
+    test_explicit_any_exempt_for_override_dictated_by_base,
+    TestEnv::new().enable_explicit_any_error(),
+    r#"
+from typing import Any, override
+
+class Base:
+    def method(self, value: Any) -> Any: ...  # E: Explicit `Any` is not allowed # E: Explicit `Any` is not allowed
+
+class Child(Base):
+    @override
+    def method(self, value: Any) -> Any:
+        return value
+"#,
+);
+
+testcase!(
+    test_explicit_any_still_reported_for_undictated_override_positions,
+    TestEnv::new().enable_explicit_any_error(),
+    r#"
+from typing import Any, override
+
+class Base:
+    def method(self, value: int) -> int: ...
+
+class Child(Base):
+    @override
+    def method(self, value: Any) -> Any:  # E: Explicit `Any` is not allowed # E: Explicit `Any` is not allowed
+        return 1
+"#,
+);
+
+testcase!(
+    test_explicit_any_still_reported_without_override_decorator,
+    TestEnv::new().enable_explicit_any_error(),
+    r#"
+from typing import Any
+
+class Base:
+    def method(self, value: Any) -> Any: ...  # E: Explicit `Any` is not allowed # E: Explicit `Any` is not allowed
+
+class Child(Base):
+    def method(self, value: Any) -> Any:  # E: Explicit `Any` is not allowed # E: Explicit `Any` is not allowed
+        return value
+"#,
+);
+
+testcase!(
+    test_explicit_any_per_position_granularity,
+    TestEnv::new().enable_explicit_any_error(),
+    r#"
+from typing import Any, override
+
+class Base:
+    def method(self, value: Any) -> Any: ...  # E: Explicit `Any` is not allowed # E: Explicit `Any` is not allowed
+
+class Child(Base):
+    @override
+    def method(self, value: Any, extra: Any = 1) -> Any:  # E: Explicit `Any` is not allowed
+        return value
+"#,
+);
+
+testcase!(
+    test_explicit_any_still_reported_for_override_without_base_member,
+    TestEnv::new().enable_explicit_any_error(),
+    r#"
+from typing import Any, override
+
+class Base:
+    ...
+
+class Child(Base):
+    @override
+    def missing(  # E: Class member `Child.missing` is marked as an override, but no parent class has a matching attribute
+        self, value: Any  # E: Explicit `Any` is not allowed
+    ) -> Any:  # E: Explicit `Any` is not allowed
+        return value
+"#,
+);
+
+testcase!(
+    test_explicit_any_still_reported_when_base_param_unannotated,
+    TestEnv::new().enable_explicit_any_error(),
+    r#"
+from typing import Any, override
+
+class Base:
+    def method(self, value) -> int: ...
+
+class Child(Base):
+    @override
+    def method(self, value: Any) -> int:  # E: Explicit `Any` is not allowed
+        return 1
+"#,
+);
+
+testcase!(
+    test_explicit_any_exempt_for_override_dictated_args_kwargs,
+    TestEnv::new().enable_explicit_any_error(),
+    r#"
+from typing import Any, override
+
+class Base:
+    def method(self, *args: Any, **kwargs: Any) -> None: ...  # E: Explicit `Any` is not allowed # E: Explicit `Any` is not allowed
+
+class Child(Base):
+    @override
+    def method(self, *args: Any, **kwargs: Any) -> None:
+        pass
+"#,
+);
+
+testcase!(
+    test_explicit_any_still_reported_for_args_kwargs_without_base_counterpart,
+    TestEnv::new().enable_explicit_any_error(),
+    r#"
+from typing import Any, override
+
+class Base:
+    def method(self, value: int) -> None: ...
+
+class Child(Base):
+    @override
+    def method(
+        self, value: int, *args: Any, **kwargs: Any  # E: Explicit `Any` is not allowed # E: Explicit `Any` is not allowed
+    ) -> None:
+        pass
+"#,
+);
+
+testcase!(
+    test_explicit_any_still_reported_for_nested_any_in_override,
+    TestEnv::new().enable_explicit_any_error(),
+    r#"
+from typing import Any, override
+
+class Base:
+    def method(self, value: list[int]) -> dict[str, int]: ...
+
+class Child(Base):
+    @override
+    def method(
+        self, value: list[Any]  # E: Explicit `Any` is not allowed
+    ) -> dict[str, Any]:  # E: Explicit `Any` is not allowed
+        return {}
+"#,
+);
+
+testcase!(
+    test_explicit_any_exempt_for_override_dictated_by_one_overload,
+    TestEnv::new().enable_explicit_any_error(),
+    r#"
+from typing import Any, override, overload
+
+class Base:
+    @overload
+    def method(self, value: int) -> int: ...
+    @overload
+    def method(self, value: Any) -> Any: ...  # E: Explicit `Any` is not allowed # E: Explicit `Any` is not allowed
+    def method(self, value):
+        return value
+
+class Child(Base):
+    @override
+    def method(self, value: Any) -> Any:
+        return value
+"#,
+);
+
+testcase!(
+    test_explicit_any_exempt_for_override_from_typing_extensions,
+    TestEnv::new().enable_explicit_any_error(),
+    r#"
+from typing import Any
+from typing_extensions import override
+
+class Base:
+    def method(self, value: Any) -> Any: ...  # E: Explicit `Any` is not allowed # E: Explicit `Any` is not allowed
+
+class Child(Base):
+    @override
+    def method(self, value: Any) -> Any:
+        return value
+"#,
+);
+
+testcase!(
+    test_explicit_any_exempt_for_override_dictated_async_return,
+    TestEnv::new().enable_explicit_any_error(),
+    r#"
+from typing import Any, override
+
+class Base:
+    async def method(self) -> Any: ...  # E: Explicit `Any` is not allowed
+
+class Child(Base):
+    @override
+    async def method(self) -> Any:
+        return 1
+"#,
+);
+
+testcase!(
     test_warn_on_implicit_any_in_attribute,
     TestEnv::new().enable_implicit_any_attribute_error(),
     r#"


### PR DESCRIPTION
Fixes #4548

## Problem

With `explicit-any = "error"`, a `@typing.override` method whose base signature is annotated with `Any` must repeat that `Any` — narrowing or dropping it would break the override — yet the rule fired on exactly those annotations:

```python
import json
from typing import Any, override

class CustomEncoder(json.JSONEncoder):
    @override
    def default(self, o: Any) -> Any:   # 2 explicit-any errors
        return super().default(o)
```

The signature is fixed by typeshed's `json.JSONEncoder.default` (`(self, o: Any) -> Any`), so the diagnostic points at code that cannot be changed. Ruff exempts `@override` methods in its equivalent lint (ANN401) for the same reason.

## Change

- The binding step already knows `is_override` (name-only decorator check) when it registers method annotations; those annotations now carry the method's name when they belong to an `@override` method.
- Parameter and return annotations report `explicit-any` from `solve_annotation` (which has the class context) instead of `expr_untype`; a position is exempt only when the annotation is exactly `Any` **and** the corresponding base position is explicitly annotated `Any`:
  - params matched by name (`*args`/`**kwargs` and return positions included),
  - async base returns unwrapped from `Coroutine[Any, Any, T]`,
  - every overload of an overloaded base considered.
- Everything else still reports: undictated positions, methods without `@override`, `@override` with no base member (bad-override still fires), base positions that merely lack annotations, and nested `Any` like `list[Any]`.

The base's *own* explicit `Any`s still report when the base is user code in the checked project (in the issue's case the base is in typeshed and not checked) — only the dictated override positions are exempt.

## Test plan

- [x] 12 new `testcase!`s in `pyrefly/lib/test/inference.rs` covering: exemption (plain/args-kwargs/overload/typing_extensions/async), still-reporting (undictated positions, no decorator, no base member, unannotated base param, nested `Any`, per-position granularity)
- [x] Issue repro checks clean with `explicit-any = "error"`
- [x] `cargo test -p pyrefly --lib -- --skip test::lsp` green (the two `missing-source` LSP interaction failures are pre-existing on `main`)
- [x] Formatting/linting clean