### PR TITLE
Infer conditional-expression empty containers from the other branch

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -548,7 +548,12 @@ impl<'a, Ans: LookupAnswer> AnswersSolver<'a, Ans> {
                     Some(false) => self.expr_infer_impl(&x.orelse, hint, errors).into_ty(),
                     None => {
                         let body_type = self.expr_infer_impl(&x.body, hint, errors).into_ty();
-                        let orelse_type = self.expr_infer_impl(&x.orelse, hint, errors).into_ty();
+                        // Like `optional_list or []`, use the preceding branch as a soft hint
+                        // for the next one so an empty container pins its element type.
+                        let orelse_hint = hint.or_else(|| Some(HintRef::soft(&body_type)));
+                        let orelse_type = self
+                            .expr_infer_impl(&x.orelse, orelse_hint, errors)
+                            .into_ty();
                         match self.as_bool(&condition_type, x.test.range(), errors) {
                             Some(true) => body_type,
                             Some(false) => orelse_type,

--- a/pyrefly/lib/test/delayed_inference.rs
+++ b/pyrefly/lib/test/delayed_inference.rs
@@ -108,6 +108,107 @@ def test(x: list[int]) -> None:
 "#,
 );
 
+// Like `x or []`: without an ambient hint, the typed branch of a conditional
+// expression serves as a soft hint so the empty display pins its element type.
+testcase!(
+    test_if_exp_empty_list,
+    r#"
+from typing import assert_type
+
+def condition() -> bool:
+    return True
+
+result = list[int]() if condition() else []
+assert_type(result, list[int])
+"#,
+);
+
+testcase!(
+    test_if_exp_empty_set_and_dict,
+    r#"
+from typing import assert_type
+
+def condition() -> bool:
+    return True
+
+set_result = set[int]() if condition() else set()
+assert_type(set_result, set[int])
+
+dict_result = {"a": 1} if condition() else {}
+assert_type(dict_result, dict[str, int])
+"#,
+);
+
+testcase!(
+    test_if_exp_empty_list_nested,
+    r#"
+from typing import assert_type
+
+def condition() -> bool:
+    return True
+
+nested = [[1]] if condition() else []
+assert_type(nested, list[list[int]])
+"#,
+);
+
+testcase!(
+    test_if_exp_ambient_hint_wins,
+    r#"
+from typing import assert_type
+
+class A: ...
+class B(A): ...
+
+def condition() -> bool:
+    return True
+
+xs: list[A] = [B()] if condition() else []
+assert_type(xs, list[A])
+"#,
+);
+
+testcase!(
+    test_if_exp_unrelated_branches_unaffected,
+    r#"
+from typing import Literal, assert_type
+
+def condition() -> bool:
+    return True
+
+unrelated = 1 if condition() else "s"
+assert_type(unrelated, Literal[1, "s"])
+"#,
+);
+
+testcase!(
+    test_if_exp_both_branches_empty,
+    r#"
+from typing import reveal_type
+
+def condition() -> bool:
+    return True
+
+both_empty = [] if condition() else []
+reveal_type(both_empty)  # E: revealed type: list[Unknown]
+"#,
+);
+
+// Reverse ordering also pins, mirroring `[] or list[int]()`: the orelse hint
+// solves the body's element variable.
+testcase!(
+    test_if_exp_empty_list_reverse,
+    r#"
+from typing import assert_type
+
+def condition() -> bool:
+    return True
+
+reverse = [] if condition() else list[int]()
+assert_type(reverse, list[int])
+"#,
+);
+
 testcase!(
     test_solver_variables,
     r#"


### PR DESCRIPTION
Fixes #4741

## Problem

A conditional expression with one typed and one empty container branch inferred the union of both, keeping a spurious Unknown element type:

```python
def condition() -> bool:
    return True

result = list[int]() if condition() else []
reveal_type(result)  # list[int] | list[Unknown]
```

The reporter noted the same shape already works in short-circuit `or` expressions (`optional_list or []` infers `list[int]`).

## Why it happened

The ternary's union path passed only the ambient hint (from an annotation or first use) to both branches. With no ambient hint, `[]` falls back to a fresh element variable, which degrades to implicit `Any` — displayed as `list[Unknown]`. `boolop` avoids exactly this by feeding each operand the preceding operands' types as a **soft** hint.

## Change

Apply the same relay in the `Expr::If` union path: when there is no ambient hint, the `else` branch is inferred with a soft hint built from the body branch's un-narrowed type. This covers list, set, and dict empty displays alike (they all route through this site). The soft hint carries no error collector, and empty-display fallbacks only commit a decomposed hint after an assignability check, so:

- annotated contexts keep precedence and behave as before,
- unrelated branch pairs (`1 if c else "s"`) are unchanged,
- literal-condition short-circuits still evaluate only the live branch,
- hint-mismatched branches produce byte-identical diagnostics.

## Test plan

- [x] 7 new `testcase!`s in `pyrefly/lib/test/delayed_inference.rs`: the issue repro, set/dict variants, nested `list[list[int]]`, ambient-hint precedence, unrelated pair, both-branches-empty, and the reverse ordering
- [x] `cargo test -p pyrefly --lib -- --skip test::lsp` green (the two `missing-source` LSP interaction failures are pre-existing on `main`)
- [x] Formatting/linting clean