### PR TITLE
[tensor-shapes] add stubs for jax.lax array creation & shape manipulation APIs

### DIFF
--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
@@ -936,3 +936,59 @@ def atleast_3d_shape(shape: IntTuple) -> IntTuple:
     if len(shape) == 2:
         return dsl.concat(shape, dsl.IntTuple((1,)))
     return shape
+
+@type_shape_dsl_function
+def broadcast_to_rank_shape(shape: IntTuple, rank: int) -> IntTuple:
+    if rank < len(shape):
+        return dsl.Invalid("rank must be greater than or equal to array rank")
+    diff = rank - len(shape)
+    ones = dsl.IntTuple(1 for i in range(diff))
+    return dsl.concat(ones, shape)
+
+@type_shape_dsl_function
+def collapse_to_end_shape(shape: IntTuple, start: int) -> IntTuple:
+    rank = len(shape)
+    if start < 0:
+        norm_start = start + rank
+    else:
+        norm_start = start + 0
+    if norm_start < 0 or norm_start > rank:
+        return dsl.Invalid("start_dimension out of bounds")
+    collapsed_dim = dsl.prod(shape[norm_start:])
+    return dsl.concat(shape[:norm_start], dsl.IntTuple((collapsed_dim,)))
+
+@type_shape_dsl_function
+def collapse_shape(shape: IntTuple, start: int, stop: int) -> IntTuple:
+    rank = len(shape)
+    if start < 0:
+        norm_start = start + rank
+    else:
+        norm_start = start + 0
+    if stop < 0:
+        norm_stop = stop + rank
+    else:
+        norm_stop = stop + 0
+    if norm_start < 0 or norm_start > rank:
+        return dsl.Invalid("start_dimension out of bounds")
+    if norm_stop < 0 or norm_stop > rank:
+        return dsl.Invalid("stop_dimension out of bounds")
+    if norm_stop < norm_start:
+        return dsl.Invalid("stop_dimension must be >= start_dimension")
+    collapsed_dim = dsl.prod(shape[norm_start:norm_stop])
+    return dsl.concat(
+        dsl.concat(shape[:norm_start], dsl.IntTuple((collapsed_dim,))),
+        shape[norm_stop:],
+    )
+
+@type_shape_dsl_function
+def lax_squeeze_shape(shape: IntTuple, dimensions: tuple[int, ...]) -> IntTuple:
+    rank = len(shape)
+    if any(d < 0 or d >= rank for d in dimensions):
+        return dsl.Invalid("squeeze axis out of bounds")
+    if any(dimensions.count(d) > 1 for d in dimensions):
+        return dsl.Invalid("repeated axis in lax.squeeze")
+    if any(shape[d] != 1 for d in dimensions):
+        return dsl.Invalid(
+            "cannot select an axis to squeeze out which has size not equal to one"
+        )
+    return dsl.IntTuple((shape[i] for i in range(rank) if i not in dimensions))

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/lax/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/lax/__init__.pyi
@@ -3,16 +3,34 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, overload
+from typing import Any, overload, Sequence
 
 from jax._array import Array
-from jax._shapes import lax_broadcast
-from shape_extensions import IntTuple
+from jax._shapes import (
+    broadcast_to_rank_shape,
+    collapse_shape,
+    collapse_to_end_shape,
+    concatenate_shape,
+    lax_broadcast,
+    lax_squeeze_shape,
+    permute_shape,
+    stack_shape,
+)
+from shape_extensions import (
+    Elements,
+    Flag,
+    Int,
+    IntTuple,
+    IntTuples,
+    IntVar,
+    MapIntTuples,
+)
 
 from . import linalg as linalg
 
 type _Shape = IntTuple
 type _Scalar = int | float | complex
+type _Axis = int | tuple[int, ...] | None
 
 # Unary elementwise operators
 def abs[Shape: _Shape](x: Array[Shape]) -> Array[Shape]: ...
@@ -321,3 +339,327 @@ def zeta[Shape: _Shape](x: _Scalar, q: Array[Shape], /) -> Array[Shape]: ...
 def zeta[Shape1: _Shape, Shape2: _Shape](
     x: Array[Shape1], q: Array[Shape2], /
 ) -> Array[lax_broadcast(Shape1, Shape2)]: ...
+
+# -----------------------------------------------------------------------------
+# Array Creation & Constants
+# -----------------------------------------------------------------------------
+
+@overload
+def broadcasted_iota[Shape: _Shape](
+    dtype: Any,
+    shape: Shape,
+    dimension: int,
+    *,
+    out_sharding: Any = None,
+) -> Array[Shape]: ...
+@overload
+def broadcasted_iota(
+    dtype: Any,
+    shape: Sequence[int] | int,
+    dimension: int,
+    *,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def empty(shape: tuple[()], dtype: Any, *, out_sharding: Any = None) -> Array[[]]: ...
+@overload
+def empty[N: IntVar](
+    shape: Int[N], dtype: Any, *, out_sharding: Any = None
+) -> Array[[N]]: ...
+@overload
+def empty[Shape: _Shape](
+    shape: Shape, dtype: Any, *, out_sharding: Any = None
+) -> Array[Shape]: ...
+@overload
+def empty(
+    shape: Sequence[int] | int, dtype: Any, *, out_sharding: Any = None
+) -> Array[IntTuple]: ...
+@overload
+def full(
+    shape: tuple[()],
+    fill_value: Any,
+    dtype: Any = None,
+    *,
+    sharding: Any = None,
+) -> Array[[]]: ...
+@overload
+def full[N: IntVar](
+    shape: Int[N],
+    fill_value: Any,
+    dtype: Any = None,
+    *,
+    sharding: Any = None,
+) -> Array[[N]]: ...
+@overload
+def full[Shape: _Shape](
+    shape: Shape,
+    fill_value: Any,
+    dtype: Any = None,
+    *,
+    sharding: Any = None,
+) -> Array[Shape]: ...
+@overload
+def full(
+    shape: Sequence[int] | int,
+    fill_value: Any,
+    dtype: Any = None,
+    *,
+    sharding: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def full_like[Shape: _Shape](
+    x: Array[Shape],
+    fill_value: Any,
+    dtype: Any = None,
+    shape: None = None,
+    *,
+    sharding: Any = None,
+) -> Array[Shape]: ...
+@overload
+def full_like[N: IntVar](
+    x: Any,
+    fill_value: Any,
+    dtype: Any = None,
+    shape: Int[N] = ...,
+    *,
+    sharding: Any = None,
+) -> Array[[N]]: ...
+@overload
+def full_like[Shape: _Shape](
+    x: Any,
+    fill_value: Any,
+    dtype: Any = None,
+    shape: Shape = ...,
+    *,
+    sharding: Any = None,
+) -> Array[Shape]: ...
+@overload
+def full_like(
+    x: Any,
+    fill_value: Any,
+    dtype: Any = None,
+    shape: Sequence[int] | int | None = None,
+    *,
+    sharding: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def iota[N: IntVar](dtype: Any, size: Int[N]) -> Array[[N]]: ...
+@overload
+def iota(dtype: Any, size: int) -> Array[IntTuple]: ...
+
+# -----------------------------------------------------------------------------
+# Shape Manipulation, Slicing & Reshaping
+# -----------------------------------------------------------------------------
+
+@overload
+def broadcast[Shape: _Shape](
+    operand: Array[Shape],
+    sizes: tuple[()],
+    *,
+    out_sharding: Any = None,
+) -> Array[Shape]: ...
+@overload
+def broadcast[Shape: _Shape, D0: IntVar](
+    operand: Array[Shape],
+    sizes: tuple[Int[D0]],
+    *,
+    out_sharding: Any = None,
+) -> Array[[D0, *Elements[Shape]]]: ...
+@overload
+def broadcast[Shape: _Shape, D0: IntVar, D1: IntVar](
+    operand: Array[Shape],
+    sizes: tuple[Int[D0], Int[D1]],
+    *,
+    out_sharding: Any = None,
+) -> Array[[D0, D1, *Elements[Shape]]]: ...
+@overload
+def broadcast[Shape: _Shape, D0: IntVar, D1: IntVar, D2: IntVar](
+    operand: Array[Shape],
+    sizes: tuple[Int[D0], Int[D1], Int[D2]],
+    *,
+    out_sharding: Any = None,
+) -> Array[[D0, D1, D2, *Elements[Shape]]]: ...
+@overload
+def broadcast(
+    operand: Any,
+    sizes: Sequence[int],
+    *,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def broadcast_in_dim[Shape: _Shape](
+    operand: Any,
+    shape: Shape,
+    broadcast_dimensions: Sequence[int],
+    *,
+    out_sharding: Any = None,
+) -> Array[Shape]: ...
+@overload
+def broadcast_in_dim(
+    operand: Any,
+    shape: Sequence[int] | int,
+    broadcast_dimensions: Sequence[int],
+    *,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def broadcast_like[Shape: _Shape](
+    arr: Any,
+    like_arr: Array[Shape],
+) -> Array[Shape]: ...
+@overload
+def broadcast_like(
+    arr: Any,
+    like_arr: Any,
+) -> Array[IntTuple]: ...
+def broadcast_shapes(*shapes: Sequence[int]) -> tuple[int, ...]: ...
+@overload
+def broadcast_to_rank[Shape: _Shape, Rank: Flag[int]](
+    x: Array[Shape],
+    rank: Rank,
+) -> Array[broadcast_to_rank_shape(Shape, Rank)]: ...
+@overload
+def broadcast_to_rank(
+    x: Any,
+    rank: int,
+) -> Array[IntTuple]: ...
+@overload
+def collapse[Shape: _Shape, Start: Flag[int]](
+    operand: Array[Shape],
+    start_dimension: Start,
+    stop_dimension: None = None,
+) -> Array[collapse_to_end_shape(Shape, Start)]: ...
+@overload
+def collapse[Shape: _Shape, Start: Flag[int], Stop: Flag[int]](
+    operand: Array[Shape],
+    start_dimension: Start,
+    stop_dimension: Stop,
+) -> Array[collapse_shape(Shape, Start, Stop)]: ...
+@overload
+def collapse(
+    operand: Any,
+    start_dimension: int,
+    stop_dimension: int | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def concatenate[Shapes: IntTuples, Dimension: Flag[int] = 0](
+    operands: MapIntTuples[lambda S: Array[S], Shapes],
+    dimension: Dimension = 0,
+) -> Array[concatenate_shape(Shapes, Dimension)]: ...
+@overload
+def concatenate(
+    operands: Any,
+    dimension: int = 0,
+) -> Array[IntTuple]: ...
+def expand_dims(
+    array: Any,
+    dimensions: Sequence[int],
+) -> Array[IntTuple]: ...
+def pad(
+    operand: Any,
+    padding_value: Any,
+    padding_config: Sequence[tuple[int, int, int]],
+) -> Array[IntTuple]: ...
+def padtype_to_pads(
+    in_shape: Sequence[int],
+    window_shape: Sequence[int],
+    window_strides: Sequence[int],
+    padding: str,
+) -> list[tuple[int, int]]: ...
+@overload
+def reshape[NewShape: _Shape](
+    operand: Any,
+    new_sizes: NewShape,
+    dimensions: Sequence[int] | None = None,
+    *,
+    out_sharding: Any = None,
+) -> Array[NewShape]: ...
+@overload
+def reshape(
+    operand: Any,
+    new_sizes: Sequence[int] | int,
+    dimensions: Sequence[int] | None = None,
+    *,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+def rev[Shape: _Shape](
+    operand: Array[Shape],
+    dimensions: Sequence[int],
+) -> Array[Shape]: ...
+def slice(
+    operand: Any,
+    start_indices: Sequence[int],
+    limit_indices: Sequence[int],
+    strides: Sequence[int] | None = None,
+) -> Array[IntTuple]: ...
+def slice_in_dim(
+    operand: Any,
+    start_index: int | None,
+    limit_index: int | None,
+    stride: int = 1,
+    axis: int = 0,
+) -> Array[IntTuple]: ...
+def split(
+    operand: Any,
+    sizes: Sequence[int],
+    axis: int = 0,
+) -> list[Array[IntTuple]]: ...
+@overload
+def squeeze[Shape: _Shape, Dims: Flag[tuple[int, ...]]](
+    array: Array[Shape],
+    dimensions: Dims,
+) -> Array[lax_squeeze_shape(Shape, Dims)]: ...
+@overload
+def squeeze(
+    array: Any,
+    dimensions: Sequence[int],
+) -> Array[IntTuple]: ...
+@overload
+def stack[Shapes: IntTuples, Axis: Flag[int] = 0](
+    operands: MapIntTuples[lambda S: Array[S], Shapes],
+    axis: Axis = 0,
+) -> Array[stack_shape(Shapes, Axis)]: ...
+@overload
+def stack(
+    operands: Any,
+    axis: int = 0,
+) -> Array[IntTuple]: ...
+def tile(
+    operand: Any,
+    reps: Sequence[int],
+) -> Array[IntTuple]: ...
+@overload
+def transpose[Shape: _Shape, Permutation: Flag[_Axis]](
+    operand: Array[Shape],
+    permutation: Permutation,
+) -> Array[permute_shape(Shape, Permutation)]: ...
+@overload
+def transpose(
+    operand: Any,
+    permutation: Sequence[int],
+) -> Array[IntTuple]: ...
+def unstack(
+    x: Any,
+    axis: int = 0,
+) -> tuple[Array[IntTuple], ...]: ...
+
+# Data types & bitcasting
+def bitcast_convert_type(
+    operand: Any,
+    new_dtype: Any,
+) -> Array[IntTuple]: ...
+@overload
+def convert_element_type[Shape: _Shape](
+    operand: Array[Shape],
+    new_dtype: Any,
+) -> Array[Shape]: ...
+@overload
+def convert_element_type(
+    operand: _Scalar | bool,
+    new_dtype: Any,
+) -> Array[[]]: ...
+@overload
+def convert_element_type(
+    operand: Any,
+    new_dtype: Any,
+) -> Array[IntTuple]: ...

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_lax.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_lax.py
@@ -288,3 +288,136 @@ def test_lax_linalg_shape_errors() -> None:
         pass
     else:
         raise AssertionError("expected error")
+
+
+def test_lax_creation() -> None:
+    # broadcasted_iota
+    assert_shape(lax.broadcasted_iota(jnp.int32, (2, 3), 0), (2, 3))
+    assert_shape(lax.broadcasted_iota(jnp.int32, (2, 3, 4), 1), (2, 3, 4))
+
+    # empty
+    assert_shape(lax.empty((), jnp.float32), ())
+    assert_shape(lax.empty(4, jnp.float32), (4,))
+    assert_shape(lax.empty((2, 3), jnp.float32), (2, 3))
+    assert_shape(lax.empty((2, 3, 4), jnp.float32), (2, 3, 4))
+
+    # full
+    assert_shape(lax.full((), 1.0, jnp.float32), ())
+    assert_shape(lax.full(4, 1.0, jnp.float32), (4,))
+    assert_shape(lax.full((2, 3), 1.0, jnp.float32), (2, 3))
+    assert_shape(lax.full((2, 3, 4), 1.0, jnp.float32), (2, 3, 4))
+
+    # full_like
+    arr = jnp.ones((2, 3))
+    assert_shape(lax.full_like(arr, 5.0), (2, 3))
+    assert_shape(lax.full_like(arr, 5.0, shape=(4, 5)), (4, 5))
+    assert_shape(lax.full_like(arr, 5.0, shape=4), (4,))
+
+    # iota
+    assert_shape(lax.iota(jnp.int32, 5), (5,))
+    assert_shape(lax.iota(jnp.float32, 10), (10,))
+
+
+def test_lax_shape_manipulation() -> None:
+    x = jnp.ones((2, 3))
+    t = jnp.ones((2, 3, 4, 5))
+
+    # broadcast
+    assert_shape(lax.broadcast(x, ()), (2, 3))
+    assert_shape(lax.broadcast(x, (4,)), (4, 2, 3))
+    assert_shape(lax.broadcast(x, (4, 5)), (4, 5, 2, 3))
+    assert_shape(lax.broadcast(x, (4, 5, 6)), (4, 5, 6, 2, 3))
+
+    # broadcast_in_dim
+    assert_shape(lax.broadcast_in_dim(x, (2, 4, 3), (0, 2)), (2, 4, 3))
+    assert_shape(lax.broadcast_in_dim(x, (5, 2, 3), (1, 2)), (5, 2, 3))
+
+    # broadcast_like
+    assert_shape(lax.broadcast_like(x, jnp.ones((4, 2, 3))), (4, 2, 3))
+
+    # broadcast_shapes
+    assert lax.broadcast_shapes((2, 1), (3,)) == (2, 3)
+    assert lax.broadcast_shapes((1, 4), (3, 1), (3, 4)) == (3, 4)
+
+    # broadcast_to_rank
+    assert_shape(lax.broadcast_to_rank(x, 2), (2, 3))
+    assert_shape(lax.broadcast_to_rank(x, 4), (1, 1, 2, 3))
+
+    # collapse
+    assert_shape(lax.collapse(t, 1, 3), (2, 12, 5))
+    assert_shape(lax.collapse(t, 0, 4), (120,))
+    assert_shape(lax.collapse(t, 1), (2, 60))
+
+    # concatenate
+    a = jnp.ones((2, 3))
+    b = jnp.ones((2, 4))
+    assert_shape(lax.concatenate([a, b], 1), (2, 7))
+    c = jnp.ones((5, 3))
+    assert_shape(lax.concatenate([a, c], 0), (7, 3))
+
+    # expand_dims
+    res_expand = lax.expand_dims(x, (1, 3))
+    assert res_expand.shape == (2, 1, 3, 1)
+
+    # pad
+    vec = jnp.ones(4)
+    res_pad = lax.pad(vec, 0.0, [(1, 2, 0)])
+    assert res_pad.shape == (7,)
+
+    # padtype_to_pads
+    pads = lax.padtype_to_pads((10,), (3,), (1,), "SAME")
+    assert isinstance(pads, list)
+
+    # reshape
+    assert_shape(lax.reshape(x, (6,)), (6,))
+    assert_shape(lax.reshape(x, (3, 2), (1, 0)), (3, 2))
+
+    # rev
+    assert_shape(lax.rev(x, (0,)), (2, 3))
+    assert_shape(lax.rev(x, (0, 1)), (2, 3))
+
+    # slice
+    res_slice = lax.slice(x, (0, 1), (2, 3))
+    assert res_slice.shape == (2, 2)
+
+    # slice_in_dim
+    res_slice_dim = lax.slice_in_dim(x, 0, 1, axis=0)
+    assert res_slice_dim.shape == (1, 3)
+
+    # split
+    s0, s1 = lax.split(x, (1, 1), axis=0)
+    assert s0.shape == (1, 3) and s1.shape == (1, 3)
+
+    # squeeze
+    sq = jnp.ones((2, 1, 3, 1))
+    assert_shape(lax.squeeze(sq, (1, 3)), (2, 3))
+    assert_shape(lax.squeeze(sq, (3,)), (2, 1, 3))
+
+    # stack
+    assert_shape(lax.stack([a, a, a], 0), (3, 2, 3))
+    assert_shape(lax.stack([a, a], 1), (2, 2, 3))
+
+    # tile
+    res_tile = lax.tile(x, (2, 3))
+    assert res_tile.shape == (4, 9)
+
+    # transpose
+    assert_shape(lax.transpose(x, (1, 0)), (3, 2))
+    assert_shape(lax.transpose(t, (0, 2, 1, 3)), (2, 4, 3, 5))
+
+    # unstack
+    u0, u1 = lax.unstack(x, axis=0)
+    assert u0.shape == (3,) and u1.shape == (3,)
+
+
+def test_lax_dtype_bitcast():
+    x = jnp.ones((2, 3), dtype=jnp.float32)
+
+    # convert_element_type
+    assert_shape(lax.convert_element_type(x, jnp.int32), (2, 3))
+    assert_shape(lax.convert_element_type(5.0, jnp.int32), ())
+    assert_shape(lax.convert_element_type(True, jnp.float32), ())
+
+    # bitcast_convert_type
+    res_bitcast = lax.bitcast_convert_type(x, jnp.int32)
+    assert res_bitcast.shape == (2, 3)


### PR DESCRIPTION
### Summary

Type stubs for `jax.lax` APIs related to array creation (e.g. `broadcasted_iota`, `empty`, `full`, etc.) and shape manipulation (e.g. `broadcast`, `reshape`, etc.).

### Test Plan

Modifies existing test files; tests pass locally:
```
$ uv tool run --from ruff==0.14.3 ruff format --check --config ruff.toml .
329 files already formatted
$ uv tool run --from ruff==0.14.3 ruff check --select I --config ruff.toml .
All checks passed!
+ uv run python test.py --no-test --no-conformance --no-jsonschema
Running formatting...
Finished in 2.62 seconds.
Running linting...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.81s
Finished in 1.04 seconds.
+ uv run python tensor-shapes/pyrefly-jax-stubs/run_pyrefly.py --release
+ cargo build -p pyrefly --release
    Finished `release` profile [optimized + debuginfo] target(s) in 0.57s
PASS stubs (9 files)
PASS arithmetic (1 files)
PASS contractions (1 files)
PASS creation (1 files)
PASS fft (1 files)
PASS lax (1 files)
PASS linalg (1 files)
PASS matmul (1 files)
PASS nn (1 files)
PASS reductions (1 files)
PASS reshape (1 files)
PASS structural (1 files)
```

### AI disclosure

Change generated with a Gemini coding agent.