### PR TITLE
Accept shaped arrays and scalars in broadcasting APIs

### DIFF
--- a/pyrefly/lib/alt.rs
+++ b/pyrefly/lib/alt.rs
@@ -23,6 +23,7 @@ pub mod operators;
 pub mod overload;
 pub mod polars_specials;
 pub mod regex;
+pub mod scalar_as_shape;
 pub mod shape_flag;
 pub mod singledispatch;
 pub mod solve;

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -44,6 +44,7 @@ use crate::alt::expr::ExprOptions;
 use crate::alt::expr::TypeOrExpr;
 use crate::alt::map_int_tuples::MapIntTuplesPatternArgument;
 use crate::alt::map_int_tuples::map_int_tuples_parameter_pattern;
+use crate::alt::scalar_as_shape::is_scalar_as_shape_parameter;
 use crate::alt::shape_flag::extend_shape_flag_vars_from_targs;
 use crate::alt::shape_flag::shape_flag_vars;
 use crate::alt::solve::Iterable;
@@ -502,6 +503,7 @@ impl CallArgPreEval<'_> {
         param_name: Option<&Name>,
         vararg: bool,
         is_self_arg: bool,
+        scalar_as_shape_conversions: &mut usize,
         range: TextRange,
         arg_errors: &ErrorCollector,
         call_errors: &ErrorCollector,
@@ -516,6 +518,29 @@ impl CallArgPreEval<'_> {
             })
             .with_context(context.map(|ctx| ctx()))
         };
+        if is_scalar_as_shape_parameter(hint) {
+            let ty = match self {
+                Self::Star {
+                    prefix,
+                    middle,
+                    suffix,
+                    consumed,
+                    ..
+                } => Self::star_element(solver, prefix, middle, suffix, *consumed, vararg),
+                _ => self.inferred_type(solver, arg_errors),
+            };
+            self.advance_after_match(vararg);
+            *scalar_as_shape_conversions += usize::from(solver.check_scalar_as_shape_argument(
+                &ty,
+                hint,
+                range,
+                call_errors,
+                tcc,
+                call_context,
+            ));
+            solver.maybe_error_unknown_argument_type(&ty, range, arg_errors);
+            return Some(ty);
+        }
         // A shape-extension map at a parameter root carries an ordinary `Sequence` view, but its
         // source must be recovered from the argument before that view is checked.
         if let Some(pattern) = map_int_tuples_parameter_pattern(hint) {
@@ -699,21 +724,36 @@ impl MatchedParam {
 #[derive(Debug, Clone)]
 pub struct ArgMap {
     pub range_to_param: HashMap<TextRange, MatchedParam>,
+    /// Parameters in argument-matching order. Unlike `range_to_param`, this retains every
+    /// element contributed by a single starred argument.
+    pub matched_params: Vec<(TextRange, MatchedParam)>,
     /// Required parameters that were left unmatched
     pub unmatched_params: SmallSet<Option<Name>>,
+    /// Number of `matched_params` entries that used a scalar-to-empty-shape conversion.
+    pub scalar_as_shape_conversions: usize,
+    /// Whether overload matching involved a gradual argument whose runtime type is unknown.
+    pub has_gradual_argument: bool,
+    /// Whether graduality came from an expanded argument that ordinary materialization cannot
+    /// reconstruct from the original call expression.
+    pub has_unmaterialized_gradual_argument: bool,
 }
 
 impl ArgMap {
     pub fn new() -> Self {
         Self {
             range_to_param: HashMap::new(),
+            matched_params: Vec::new(),
             unmatched_params: SmallSet::new(),
+            scalar_as_shape_conversions: 0,
+            has_gradual_argument: false,
+            has_unmaterialized_gradual_argument: false,
         }
     }
 
     fn insert(&mut self, range: TextRange, ty: Type, name: Option<Name>) -> Option<MatchedParam> {
-        self.range_to_param
-            .insert(range, MatchedParam::new(ty, name))
+        let matched = MatchedParam::new(ty, name);
+        self.matched_params.push((range, matched.clone()));
+        self.range_to_param.insert(range, matched)
     }
 }
 
@@ -1118,6 +1158,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                                 name,
                                 false,
                                 is_self_arg,
+                                &mut argmap.scalar_as_shape_conversions,
                                 arg.range(),
                                 arg_errors,
                                 call_errors,
@@ -1125,6 +1166,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                                 call_context,
                             )
                         };
+                        argmap.has_gradual_argument |= arg_ty.as_ref().is_some_and(Type::is_any);
                         if let Some(name) = name
                             && let Some(ty) = unhinted_arg_ty.or(arg_ty)
                         {
@@ -1159,12 +1201,14 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                             name,
                             true,
                             is_self_arg,
+                            &mut argmap.scalar_as_shape_conversions,
                             arg.range(),
                             arg_errors,
                             call_errors,
                             context,
                             call_context,
                         );
+                        argmap.has_gradual_argument |= arg_ty.as_ref().is_some_and(Type::is_any);
                         if bound_args.is_some() {
                             if let Some(name) = name {
                                 variadic_name = Some(name);
@@ -1552,19 +1596,35 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                                 unexpected_keyword_error(name, kw.range);
                             }
                             if let Some(want) = &hint {
-                                self.check_type_with_options(
-                                    &field.ty,
-                                    want,
-                                    kw.range,
-                                    TypeCheckOptions::new(call_errors, &|| {
-                                        TypeCheckContext::of_kind(TypeCheckKind::CallArgument(
-                                            Some(name.clone()),
-                                            callable_name.cloned(),
-                                        ))
-                                        .with_context(context.map(|ctx| ctx()))
-                                    })
-                                    .with_call_context(call_context),
-                                );
+                                argmap.insert(kw.range, (*want).clone(), Some(name.clone()));
+                                argmap.has_gradual_argument |= field.ty.is_any();
+                                argmap.has_unmaterialized_gradual_argument |= field.ty.is_any();
+                                let check_context = || {
+                                    TypeCheckContext::of_kind(TypeCheckKind::CallArgument(
+                                        Some(name.clone()),
+                                        callable_name.cloned(),
+                                    ))
+                                    .with_context(context.map(|ctx| ctx()))
+                                };
+                                if is_scalar_as_shape_parameter(want) {
+                                    argmap.scalar_as_shape_conversions +=
+                                        usize::from(self.check_scalar_as_shape_argument(
+                                            &field.ty,
+                                            want,
+                                            kw.range,
+                                            call_errors,
+                                            &check_context,
+                                            call_context,
+                                        ));
+                                } else {
+                                    self.check_type_with_options(
+                                        &field.ty,
+                                        want,
+                                        kw.range,
+                                        TypeCheckOptions::new(call_errors, &check_context)
+                                            .with_call_context(call_context),
+                                    );
+                                }
                             }
                         }
                     } else {
@@ -1575,22 +1635,37 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                                     &self.heap.mk_class_type(self.stdlib.str().clone()),
                                 ) {
                                     if let Some((name, Some(want))) = kwargs.as_ref() {
-                                        self.check_type_with_options(
-                                            &value,
-                                            want,
-                                            kw.range,
-                                            TypeCheckOptions::new(call_errors, &|| {
-                                                TypeCheckContext::of_kind(
-                                                    TypeCheckKind::CallKwArgs(
-                                                        None,
-                                                        name.cloned(),
-                                                        callable_name.cloned(),
-                                                    ),
-                                                )
-                                                .with_context(context.map(|ctx| ctx()))
-                                            })
-                                            .with_call_context(call_context),
-                                        );
+                                        argmap.insert(kw.range, (*want).clone(), name.cloned());
+                                        argmap.has_gradual_argument |= value.is_any();
+                                        argmap.has_unmaterialized_gradual_argument |=
+                                            value.is_any();
+                                        let check_context = || {
+                                            TypeCheckContext::of_kind(TypeCheckKind::CallKwArgs(
+                                                None,
+                                                name.cloned(),
+                                                callable_name.cloned(),
+                                            ))
+                                            .with_context(context.map(|ctx| ctx()))
+                                        };
+                                        if is_scalar_as_shape_parameter(want) {
+                                            argmap.scalar_as_shape_conversions +=
+                                                usize::from(self.check_scalar_as_shape_argument(
+                                                    &value,
+                                                    want,
+                                                    kw.range,
+                                                    call_errors,
+                                                    &check_context,
+                                                    call_context,
+                                                ));
+                                        } else {
+                                            self.check_type_with_options(
+                                                &value,
+                                                want,
+                                                kw.range,
+                                                TypeCheckOptions::new(call_errors, &check_context)
+                                                    .with_call_context(call_context),
+                                            );
+                                        }
                                     };
                                     splat_kwargs.push((value, kw.range));
                                 } else {
@@ -1672,7 +1747,24 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                         })
                         .with_context(context.map(|ctx| ctx()))
                     };
-                    let arg_ty = if let Some(pattern) = hint
+                    let arg_ty = if let Some((_, hint)) = &hint
+                        && is_scalar_as_shape_parameter(hint)
+                    {
+                        let ty = match kw.value {
+                            TypeOrExpr::Expr(expr) => self.expr_infer(expr, arg_errors),
+                            TypeOrExpr::Type(ty, _) => (*ty).clone(),
+                        };
+                        argmap.scalar_as_shape_conversions +=
+                            usize::from(self.check_scalar_as_shape_argument(
+                                &ty,
+                                hint,
+                                kw.range,
+                                call_errors,
+                                tcc,
+                                call_context,
+                            ));
+                        ty
+                    } else if let Some(pattern) = hint
                         .as_ref()
                         .and_then(|(_, hint)| map_int_tuples_parameter_pattern(hint))
                     {
@@ -1725,6 +1817,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                             }
                         }
                     };
+                    argmap.has_gradual_argument |= arg_ty.is_any();
                     self.maybe_error_unknown_argument_type(&arg_ty, kw.range, arg_errors);
                     record(bound_args, &id.id, unhinted_arg_ty.unwrap_or(arg_ty));
                 }
@@ -1793,19 +1886,35 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     Required::Optional(None) => {}
                 }
                 for (ty, range) in &splat_kwargs {
-                    self.check_type_with_options(
-                        ty,
-                        want,
-                        *range,
-                        TypeCheckOptions::new(call_errors, &|| {
-                            TypeCheckContext::of_kind(TypeCheckKind::CallUnpackKwArg(
-                                (*name).clone(),
-                                callable_name.cloned(),
-                            ))
-                            .with_context(context.map(|ctx| ctx()))
-                        })
-                        .with_call_context(call_context),
-                    );
+                    let check_context = || {
+                        TypeCheckContext::of_kind(TypeCheckKind::CallUnpackKwArg(
+                            (*name).clone(),
+                            callable_name.cloned(),
+                        ))
+                        .with_context(context.map(|ctx| ctx()))
+                    };
+                    argmap.insert(*range, (*want).clone(), Some((*name).clone()));
+                    argmap.has_gradual_argument |= ty.is_any();
+                    argmap.has_unmaterialized_gradual_argument |= ty.is_any();
+                    if is_scalar_as_shape_parameter(want) {
+                        argmap.scalar_as_shape_conversions +=
+                            usize::from(self.check_scalar_as_shape_argument(
+                                ty,
+                                want,
+                                *range,
+                                call_errors,
+                                &check_context,
+                                call_context,
+                            ));
+                    } else {
+                        self.check_type_with_options(
+                            ty,
+                            want,
+                            *range,
+                            TypeCheckOptions::new(call_errors, &check_context)
+                                .with_call_context(call_context),
+                        );
+                    }
                 }
             }
         }
@@ -1842,19 +1951,21 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     .params
                     .visit_mut(&mut |ty| self.solver().expand_with_bounds(ty));
             }
-            arg.post_check(
+            let arg_ty = arg.post_check(
                 self,
                 callable_name,
                 &hint,
                 name,
                 false,
                 false,
+                &mut argmap.scalar_as_shape_conversions,
                 range,
                 arg_errors,
                 call_errors,
                 context,
                 call_context,
             );
+            argmap.has_gradual_argument |= arg_ty.as_ref().is_some_and(Type::is_any);
         }
         let num_extra_positional_args = extra_positional_args.len();
         if let Some(arg_range) = extra_arg_pos

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -1193,6 +1193,11 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             FunctionParameter::Annotated(idx) => {
                 let param_ty = self.get_idx(*idx).annotation.get_type().clone();
                 let annot_range = self.annotation_range(*idx);
+                let invalid_scalar_as_shape_default = self.report_scalar_as_shape_default_error(
+                    &param_ty,
+                    default.map(Ranged::range),
+                    errors,
+                );
                 let make_context = || {
                     TypeCheckContext::of_kind(TypeCheckKind::FunctionParameterDefault(
                         name.id.clone(),
@@ -1211,7 +1216,8 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                         }))
                 ) if i.as_i64().is_some() && matches!(inner.as_ref(), Type::Quantified(_))
                 ) || (default.is_some()
-                    && self.is_shape_flag_parameter_type(&param_ty));
+                    && self.is_shape_flag_parameter_type(&param_ty))
+                    || invalid_scalar_as_shape_default;
                 let check: Option<(&Type, &dyn Fn() -> TypeCheckContext)> = if skip_check {
                     None
                 } else {

--- a/pyrefly/lib/alt/overload.rs
+++ b/pyrefly/lib/alt/overload.rs
@@ -800,6 +800,26 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             // https://typing.python.org/en/latest/spec/overload.html#overload-call-evaluation.
             let spec_compliant = self.solver().spec_compliant_overloads;
             if matched_overloads.len() > 1 {
+                let dominated = matched_overloads
+                    .iter()
+                    .enumerate()
+                    .map(|(i, candidate)| {
+                        matched_overloads.iter().enumerate().any(|(j, other)| {
+                            i != j
+                                && self
+                                    .compare_scalar_as_shape_overloads(
+                                        &other.argmap,
+                                        &candidate.argmap,
+                                    )
+                                    .is_gt()
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                matched_overloads = matched_overloads
+                    .into_iter()
+                    .zip(dominated)
+                    .filter_map(|(overload, dominated)| (!dominated).then_some(overload))
+                    .collect();
                 // Step 4: if any arguments supply an unknown number of args and at least one
                 // overload has a corresponding variadic parameter, eliminate overloads without
                 // this parameter.
@@ -833,7 +853,11 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     }
                 }
             }
-            if matched_overloads.len() > 1 {
+            if matched_overloads.len() > 1
+                && !matched_overloads.iter().any(|overload| {
+                    self.scalar_as_shape_preserves_expanded_gradual_ambiguity(&overload.argmap)
+                })
+            {
                 // Step 5, part 1: for each overload, check whether it's the case that all possible
                 // materializations of each argument are assignable to the corresponding parameter.
                 // If so, eliminate all subsequent overloads.

--- a/pyrefly/lib/alt/scalar_as_shape.rs
+++ b/pyrefly/lib/alt/scalar_as_shape.rs
@@ -1,0 +1,536 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Solver integration for the experimental `shape_extensions.ScalarAsShape` marker.
+
+use std::cmp::Ordering;
+
+use pyrefly_python::module_name::ModuleName;
+use pyrefly_types::shaped_array::IntTuple;
+use pyrefly_types::type_alias::TypeAliasData;
+use pyrefly_types::type_alias::TypeAliasIndex;
+use pyrefly_types::types::AnyStyle;
+use pyrefly_types::types::Type;
+use pyrefly_util::visit::Visit;
+use ruff_text_size::TextRange;
+
+use crate::alt::answers::LookupAnswer;
+use crate::alt::answers_solver::AnswersSolver;
+use crate::alt::answers_solver::TypeCheckOptions;
+use crate::alt::callable::ArgMap;
+use crate::alt::solve::TypeFormContext;
+use crate::config::error_kind::ErrorKind;
+use crate::error::collector::ErrorCollector;
+use crate::error::context::TypeCheckContext;
+use crate::solver::solver::CallContext;
+use crate::solver::solver::Subset;
+use crate::solver::solver::SubsetError;
+use crate::solver::solver::SubsetWithSnapshotResult;
+use crate::solver::solver::VarSnapshot;
+use crate::types::class::Class;
+use crate::types::type_var::Restriction;
+
+#[derive(Clone)]
+struct ScalarAsShape {
+    source: Type,
+    shape: Type,
+}
+
+type AliasKey = (ModuleName, TypeAliasIndex);
+
+impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
+    pub(crate) fn is_subset_callable_parameter(
+        &mut self,
+        actual: &Type,
+        parameter: &Type,
+    ) -> Result<(), SubsetError> {
+        let actual = if let Some((ordinary, markers)) = split_scalar_as_shape_parameter(actual) {
+            let mut accepted = ordinary.into_iter().collect::<Vec<_>>();
+            let mut first_shape_error = None;
+            for marker in markers {
+                match self.with_speculative_subset_branch(&[&marker.shape], |me| {
+                    me.is_subset_eq(
+                        &IntTuple::new(Vec::new()).to_shape_arg_type(),
+                        &marker.shape,
+                    )
+                }) {
+                    SubsetWithSnapshotResult::Ok => accepted.push(marker.source),
+                    SubsetWithSnapshotResult::Err(error) => {
+                        first_shape_error.get_or_insert(error);
+                    }
+                }
+            }
+            if accepted.is_empty() {
+                return Err(first_shape_error.unwrap_or(SubsetError::Other));
+            }
+            self.solver.unions(accepted, self.type_order)
+        } else {
+            actual.clone()
+        };
+        let Some((ordinary, markers)) = split_scalar_as_shape_parameter(parameter) else {
+            return self.is_subset_eq(&actual, parameter);
+        };
+        let actual_members = match &actual {
+            Type::Union(union) => union.members.iter().collect::<Vec<_>>(),
+            _ => vec![&actual],
+        };
+        for actual in actual_members {
+            if let Some(ordinary) = &ordinary
+                && self
+                    .with_speculative_subset_branch(&[actual, ordinary], |me| {
+                        me.is_subset_eq(actual, ordinary)
+                    })
+                    .is_ok()
+            {
+                continue;
+            }
+            if matches!(actual, Type::Any(_) | Type::Never(_)) {
+                continue;
+            }
+            let mut shape_error = None;
+            let mut matched = false;
+            for marker in &markers {
+                let mut source_matched = false;
+                let result = self.with_speculative_subset_branch(
+                    &[actual, &marker.source, &marker.shape],
+                    |me| {
+                        me.is_subset_eq(actual, &marker.source)?;
+                        source_matched = true;
+                        me.is_subset_eq(
+                            &IntTuple::new(Vec::new()).to_shape_arg_type(),
+                            &marker.shape,
+                        )
+                    },
+                );
+                match result {
+                    SubsetWithSnapshotResult::Ok => {
+                        matched = true;
+                        break;
+                    }
+                    SubsetWithSnapshotResult::Err(error) => {
+                        if source_matched {
+                            shape_error.get_or_insert(error);
+                        }
+                    }
+                }
+            }
+            if matched {
+                continue;
+            }
+            if let Some(error) = shape_error {
+                return Err(error);
+            }
+            let mut accepted = ordinary.clone().into_iter().collect::<Vec<_>>();
+            accepted.extend(markers.iter().map(|marker| marker.source.clone()));
+            return self
+                .is_subset_eq(actual, &self.solver.unions(accepted, self.type_order))
+                .and(Err(SubsetError::Other));
+        }
+        Ok(())
+    }
+}
+
+fn alias_key(alias: &TypeAliasData) -> Option<AliasKey> {
+    match alias {
+        TypeAliasData::Ref(reference) => Some((reference.module_name, reference.index)),
+        TypeAliasData::Value(_) => None,
+    }
+}
+
+fn scalar_as_shape(ty: &Type) -> Option<ScalarAsShape> {
+    let Type::ClassType(cls) = ty else {
+        return None;
+    };
+    if !cls.has_qname("shape_extensions", "ScalarAsShape") {
+        return None;
+    }
+    let [source, shape] = cls.targs().as_slice() else {
+        return None;
+    };
+    Some(ScalarAsShape {
+        source: source.clone(),
+        shape: shape.clone(),
+    })
+}
+
+fn contains_scalar_as_shape(ty: &Type) -> bool {
+    ty.any(|ty| scalar_as_shape(ty).is_some())
+}
+
+fn is_direct_parameter_position(context: TypeFormContext<'_>) -> bool {
+    match context {
+        TypeFormContext::ParameterAnnotation
+        | TypeFormContext::ParameterArgsAnnotation
+        | TypeFormContext::ParameterKwargsAnnotation
+        | TypeFormContext::TypeAlias => true,
+        TypeFormContext::UnionMember(parent) => is_direct_parameter_position(*parent),
+        _ => false,
+    }
+}
+
+fn scalar_as_shape_actual_members(actual: &Type) -> Vec<Type> {
+    if let Type::Union(union) = actual {
+        return union.members.clone();
+    }
+    let restriction = match actual {
+        Type::Quantified(q) if q.is_type_var() => Some(q.restriction()),
+        Type::TypeVar(type_var) => Some(type_var.restriction()),
+        _ => None,
+    };
+    match restriction {
+        Some(Restriction::Bound(Type::Union(union))) => union.members.clone(),
+        Some(Restriction::Bound(bound)) => vec![bound.clone()],
+        Some(Restriction::Constraints(constraints)) => constraints.clone(),
+        Some(Restriction::Flag(_) | Restriction::Unrestricted) | None => vec![actual.clone()],
+    }
+}
+
+fn split_scalar_as_shape_parameter(ty: &Type) -> Option<(Option<Type>, Vec<ScalarAsShape>)> {
+    if let Some(marker) = scalar_as_shape(ty) {
+        return Some((None, vec![marker]));
+    }
+    let Type::Union(union) = ty else {
+        return None;
+    };
+    let mut ordinary = Vec::new();
+    let mut markers = Vec::new();
+    for member in &union.members {
+        if let Some(marker) = scalar_as_shape(member) {
+            markers.push(marker);
+        } else {
+            ordinary.push(member.clone());
+        }
+    }
+    if markers.is_empty() {
+        None
+    } else {
+        Some((
+            (!ordinary.is_empty()).then(|| Type::union(ordinary)),
+            markers,
+        ))
+    }
+}
+
+pub(crate) fn is_scalar_as_shape_parameter(ty: &Type) -> bool {
+    let is_marker = |ty: &Type| matches!(ty, Type::ClassType(cls) if cls.has_qname("shape_extensions", "ScalarAsShape"));
+    is_marker(ty) || matches!(ty, Type::Union(union) if union.members.iter().any(is_marker))
+}
+
+impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
+    fn collect_scalar_as_shape_markers(
+        &self,
+        ty: &Type,
+        markers: &mut Vec<ScalarAsShape>,
+        invalid_position: &mut bool,
+    ) {
+        let mut worklist = vec![(ty.clone(), true, Vec::new())];
+        let mut seen_aliases: Vec<(TypeAliasData, bool)> = Vec::new();
+        while let Some((candidate, direct, path)) = worklist.pop() {
+            if let Type::TypeAlias(alias) | Type::UntypedAlias(alias) = &candidate {
+                let mut path = path;
+                if let Some(key) = alias_key(alias) {
+                    if path.contains(&key) {
+                        if let TypeAliasData::Ref(reference) = &**alias
+                            && let Some(args) = &reference.args
+                        {
+                            // Stopping recursive alias expansion does not change the syntactic
+                            // position of its specialization arguments.
+                            worklist.extend(
+                                args.as_slice()
+                                    .iter()
+                                    .cloned()
+                                    .map(|arg| (arg, direct, path.clone())),
+                            );
+                        }
+                        continue;
+                    }
+                    path.push(key);
+                }
+                if seen_aliases
+                    .iter()
+                    .any(|(seen, seen_direct)| seen == &**alias && *seen_direct == direct)
+                {
+                    continue;
+                }
+                seen_aliases.push(((**alias).clone(), direct));
+                worklist.push((self.untype_alias(alias), direct, path));
+            } else if let Some(marker) = scalar_as_shape(&candidate) {
+                *invalid_position |= !direct;
+                worklist.push((marker.source.clone(), false, path.clone()));
+                worklist.push((marker.shape.clone(), false, path));
+                markers.push(marker);
+            } else if let Type::Union(union) = &candidate
+                && direct
+            {
+                worklist.extend(
+                    union
+                        .members
+                        .iter()
+                        .cloned()
+                        .map(|member| (member, true, path.clone())),
+                );
+            } else {
+                candidate.recurse(&mut |child| worklist.push((child.clone(), false, path.clone())));
+            }
+        }
+    }
+
+    pub(crate) fn is_scalar_as_shape_class(&self, cls: &Class) -> bool {
+        cls.has_toplevel_qname("shape_extensions", "ScalarAsShape")
+    }
+
+    pub(crate) fn validate_scalar_as_shape_annotation(
+        &self,
+        ty: Type,
+        range: TextRange,
+        context: TypeFormContext<'_>,
+        errors: &ErrorCollector,
+    ) -> Type {
+        let mut markers = Vec::new();
+        let mut invalid_position = false;
+        self.collect_scalar_as_shape_markers(&ty, &mut markers, &mut invalid_position);
+        if markers.is_empty() {
+            return ty;
+        }
+        if markers.iter().any(|marker| {
+            matches!(marker.source, Type::Any(AnyStyle::Implicit))
+                && matches!(marker.shape, Type::Any(AnyStyle::Implicit))
+        }) {
+            return self.error(
+                errors,
+                range,
+                ErrorKind::BadSpecialization,
+                "`ScalarAsShape` requires two type arguments".to_owned(),
+            );
+        }
+        if !is_direct_parameter_position(context) || invalid_position {
+            return self.error(
+                errors,
+                range,
+                ErrorKind::InvalidAnnotation,
+                "`shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member"
+                    .to_owned(),
+            );
+        }
+        for marker in markers {
+            if marker.source.any(|source| {
+                matches!(
+                    source,
+                    Type::Any(AnyStyle::Explicit | AnyStyle::Implicit) | Type::Never(_)
+                )
+            }) {
+                return self.error(
+                    errors,
+                    range,
+                    ErrorKind::InvalidAnnotation,
+                    format!(
+                        "First argument to `ScalarAsShape` may not contain `Any` or `Never`, got `{}`",
+                        self.for_display(marker.source)
+                    ),
+                );
+            }
+            if !self.is_int_tuple_dsl_argument(&marker.shape) {
+                return self.error(
+                    errors,
+                    range,
+                    ErrorKind::InvalidAnnotation,
+                    format!(
+                        "Second argument to `ScalarAsShape` must be an `IntTuple`, got `{}`",
+                        self.for_display(marker.shape)
+                    ),
+                );
+            }
+        }
+        ty
+    }
+
+    pub(crate) fn scalar_as_shape_parameter_body_type(&self, ty: Type) -> Type {
+        let Some((ordinary, markers)) = split_scalar_as_shape_parameter(&ty) else {
+            return ty;
+        };
+        let mut body = ordinary.into_iter().collect::<Vec<_>>();
+        body.extend(markers.into_iter().map(|marker| marker.source));
+        self.unions(body)
+    }
+
+    pub(crate) fn compare_scalar_as_shape_overloads(
+        &self,
+        left: &ArgMap,
+        right: &ArgMap,
+    ) -> Ordering {
+        // Preserve normal overload selection unless this call actually used the marker conversion.
+        if left.has_gradual_argument
+            || right.has_gradual_argument
+            || left.scalar_as_shape_conversions == 0 && right.scalar_as_shape_conversions == 0
+        {
+            return Ordering::Equal;
+        }
+        let at_least_as_specific = |left: &ArgMap, right: &ArgMap| {
+            left.matched_params.len() == right.matched_params.len()
+                && left.matched_params.iter().zip(&right.matched_params).all(
+                    |((left_range, left), (right_range, right))| {
+                        if left_range != right_range {
+                            return false;
+                        }
+                        let left = self.scalar_as_shape_parameter_body_type(left.ty.clone());
+                        let right = self.scalar_as_shape_parameter_body_type(right.ty.clone());
+                        let snapshot = self
+                            .solver()
+                            .snapshot_for_speculative_inference(&[&left, &right]);
+                        let result = self.is_subset_eq(&left, &right);
+                        self.solver().restore_vars(snapshot);
+                        result
+                    },
+                )
+        };
+        match (
+            at_least_as_specific(left, right),
+            at_least_as_specific(right, left),
+        ) {
+            (true, false) => Ordering::Greater,
+            (false, true) => Ordering::Less,
+            (true, true) => right
+                .scalar_as_shape_conversions
+                .cmp(&left.scalar_as_shape_conversions),
+            (false, false) => Ordering::Equal,
+        }
+    }
+
+    pub(crate) fn scalar_as_shape_preserves_expanded_gradual_ambiguity(
+        &self,
+        argmap: &ArgMap,
+    ) -> bool {
+        argmap.has_unmaterialized_gradual_argument && argmap.scalar_as_shape_conversions > 0
+    }
+
+    pub(crate) fn check_scalar_as_shape_argument(
+        &self,
+        actual: &Type,
+        parameter: &Type,
+        range: TextRange,
+        errors: &ErrorCollector,
+        tcc: &dyn Fn() -> TypeCheckContext,
+        call_context: &CallContext<'_>,
+    ) -> bool {
+        let (ordinary, markers) = split_scalar_as_shape_parameter(parameter)
+            .expect("callers check for a ScalarAsShape parameter");
+        let check_speculative = |got: &Type,
+                                 want: &Type,
+                                 attempt_errors: &ErrorCollector,
+                                 check_tcc: &dyn Fn() -> TypeCheckContext,
+                                 snapshot: &VarSnapshot| {
+            self.check_type_with_options(
+                got,
+                want,
+                range,
+                TypeCheckOptions::new(attempt_errors, check_tcc).with_call_context(call_context),
+            )
+            .is_none()
+                && !self.solver().has_new_instantiation_errors(snapshot)
+        };
+
+        let actual_members = scalar_as_shape_actual_members(actual);
+        let empty_shape = IntTuple::new(Vec::new()).to_shape_arg_type();
+        let shape_tcc = || tcc().for_scalar_as_shape();
+        let transaction = self
+            .solver()
+            .snapshot_for_speculative_inference(&[actual, parameter]);
+        let mut converted = false;
+        for actual in &actual_members {
+            if let Some(ordinary) = &ordinary {
+                let snapshot = self
+                    .solver()
+                    .snapshot_for_speculative_inference(&[actual, ordinary]);
+                let attempt_errors = self.error_collector();
+                if check_speculative(actual, ordinary, &attempt_errors, tcc, &snapshot) {
+                    errors.extend(attempt_errors);
+                    continue;
+                }
+                self.solver().restore_vars(snapshot);
+            }
+
+            if matches!(actual, Type::Any(_) | Type::Never(_)) {
+                continue;
+            }
+
+            let mut first_shape_errors = None;
+            let mut matched = false;
+            for marker in &markers {
+                let snapshot = self.solver().snapshot_for_speculative_inference(&[
+                    actual,
+                    &marker.source,
+                    &marker.shape,
+                ]);
+                let attempt_errors = self.error_collector();
+                if check_speculative(actual, &marker.source, &attempt_errors, tcc, &snapshot) {
+                    let shape_matched = check_speculative(
+                        &empty_shape,
+                        &marker.shape,
+                        &attempt_errors,
+                        &shape_tcc,
+                        &snapshot,
+                    );
+                    if shape_matched {
+                        errors.extend(attempt_errors);
+                        converted = true;
+                        matched = true;
+                        break;
+                    }
+                    if attempt_errors.is_empty() {
+                        self.report_type_error(
+                            &empty_shape,
+                            &marker.shape,
+                            &attempt_errors,
+                            range,
+                            &shape_tcc,
+                            SubsetError::Other,
+                        );
+                    }
+                    self.solver().restore_vars(snapshot);
+                    if first_shape_errors.is_none() {
+                        first_shape_errors = Some(attempt_errors);
+                    }
+                    continue;
+                }
+                self.solver().restore_vars(snapshot);
+            }
+            if matched {
+                continue;
+            }
+            self.solver().restore_vars(transaction);
+            if let Some(first_shape_errors) = first_shape_errors {
+                errors.extend(first_shape_errors);
+                return false;
+            }
+
+            let mut accepted = ordinary.clone().into_iter().collect::<Vec<_>>();
+            accepted.extend(markers.iter().map(|marker| marker.source.clone()));
+            let accepted = self.unions(accepted);
+            self.report_type_error(actual, &accepted, errors, range, tcc, SubsetError::Other);
+            return false;
+        }
+        converted
+    }
+
+    pub(crate) fn report_scalar_as_shape_default_error(
+        &self,
+        ty: &Type,
+        default_range: Option<TextRange>,
+        errors: &ErrorCollector,
+    ) -> bool {
+        let Some(range) = default_range.filter(|_| contains_scalar_as_shape(ty)) else {
+            return false;
+        };
+        self.error(
+            errors,
+            range,
+            ErrorKind::InvalidAnnotation,
+            "A parameter using `ScalarAsShape` may not have a default".to_owned(),
+        );
+        true
+    }
+}

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -4777,7 +4777,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 finalize(target, ty)
             }
         };
-        self.map_int_tuples_parameter_body_type(ty)
+        self.scalar_as_shape_parameter_body_type(self.map_int_tuples_parameter_body_type(ty))
     }
 
     /// Handle `Binding::TypeVarTuple` - process TypeVarTuple definition.
@@ -6683,6 +6683,14 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             ty @ Type::DataFrame(_) => Some(ty),
             // Handle bare class definitions (e.g., Dim, Module) by canonicalizing them to type forms
             Type::ClassDef(cls) => {
+                if self.is_scalar_as_shape_class(&cls) {
+                    return Some(self.error(
+                        errors,
+                        range,
+                        ErrorKind::BadSpecialization,
+                        "`ScalarAsShape` requires two type arguments".to_owned(),
+                    ));
+                }
                 let canonicalized =
                     self.canonicalize_all_class_types(Type::ClassDef(cls), range, errors);
                 self.untype_opt_with_context(canonicalized, range, errors, context)
@@ -7090,6 +7098,8 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             }
         };
         let result = self.validate_type_form(result, x.range(), type_form_context, errors);
+        let result =
+            self.validate_scalar_as_shape_annotation(result, x.range(), type_form_context, errors);
         let result = self.interpret_map_int_tuples_at_annotation_root(result, type_form_context);
         if type_form_context.can_report_explicit_any() {
             self.check_explicit_any(&result, x.range(), errors);

--- a/pyrefly/lib/error/context.rs
+++ b/pyrefly/lib/error/context.rs
@@ -143,6 +143,30 @@ impl TypeCheckContext {
             None => self,
         }
     }
+
+    pub fn for_scalar_as_shape(self) -> Self {
+        let Self {
+            kind,
+            context,
+            annotations,
+        } = self;
+        let kind = match kind {
+            TypeCheckKind::CallArgument(param, function)
+            | TypeCheckKind::CallVarArgs(_, param, function)
+            | TypeCheckKind::CallKwArgs(_, param, function) => {
+                TypeCheckKind::ScalarAsShape(param, function)
+            }
+            TypeCheckKind::CallUnpackKwArg(param, function) => {
+                TypeCheckKind::ScalarAsShape(Some(param), function)
+            }
+            _ => unreachable!("ScalarAsShape conversion requires a call argument context"),
+        };
+        Self {
+            kind,
+            context,
+            annotations,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -167,6 +191,8 @@ pub enum TypeCheckKind {
     CallKwArgs(Option<Name>, Option<Name>, Option<FunctionKind>),
     /// Unpacked keyword argument against named parameter.
     CallUnpackKwArg(Name, Option<FunctionKind>),
+    /// Check that treating a scalar argument as shape `()` satisfies the parameter's shape.
+    ScalarAsShape(Option<Name>, Option<FunctionKind>),
     /// Check of a parameter's default value against its type annotation.
     FunctionParameterDefault(Name),
     /// Check against the key type of a dict.
@@ -242,6 +268,7 @@ impl TypeCheckKind {
             Self::CallVarArgs(..) => ErrorKind::BadArgumentType,
             Self::CallKwArgs(..) => ErrorKind::BadArgumentType,
             Self::CallUnpackKwArg(..) => ErrorKind::BadArgumentType,
+            Self::ScalarAsShape(..) => ErrorKind::BadArgumentType,
             Self::FunctionParameterDefault(..) => ErrorKind::BadFunctionDefinition,
             Self::DictKey | Self::DictValue | Self::TypedDictKey(_, _) => ErrorKind::BadAssignment,
             Self::TypedDictUnpacking => ErrorKind::BadUnpacking,

--- a/pyrefly/lib/error/display.rs
+++ b/pyrefly/lib/error/display.rs
@@ -115,6 +115,18 @@ impl TypeCheckKind {
                     function_suffix(func_id.as_ref(), current_module),
                 )
             }
+            Self::ScalarAsShape(param, func_id) => {
+                let param_desc = match param {
+                    Some(name) => format!("parameter `{name}`"),
+                    None => "parameter".to_owned(),
+                };
+                format!(
+                    "Scalar argument is treated as having shape `()`, which is not assignable to {} with shape `{}`{}",
+                    param_desc,
+                    ctx.display(want),
+                    function_suffix(func_id.as_ref(), current_module),
+                )
+            }
             Self::CallVarArgs(arg_is_unpacked, param, func_id) => {
                 let arg_desc = if *arg_is_unpacked {
                     "Unpacked argument"

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -3385,7 +3385,7 @@ impl<'subset> CallContext<'subset> {
 }
 
 /// A helper to implement subset ergonomically.
-/// Should only be used within `crate::subset`, which implements part of it.
+/// Core subset logic lives in `solver::subset`; extension modules may add narrowly scoped methods.
 pub struct Subset<'solver, 'subset, Ans: LookupAnswer> {
     pub(crate) solver: &'solver Solver,
     pub type_order: TypeOrder<'solver, Ans>,
@@ -3437,6 +3437,39 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
         deferred_vars: SmallMap<ArgumentKey, SmallSet<Var>>,
     ) {
         self.witness_deferred_vars = deferred_vars;
+    }
+
+    /// Run a speculative subset branch, retaining its state only when it succeeds without
+    /// introducing an inconsistent variable solution.
+    pub(crate) fn with_speculative_subset_branch(
+        &mut self,
+        types: &[&Type],
+        check: impl FnOnce(&mut Self) -> Result<(), SubsetError>,
+    ) -> SubsetWithSnapshotResult {
+        let vars = self.solver.snapshot_for_speculative_inference(types);
+        let subset_cache = self.subset_cache.clone();
+        let class_protocol_assumptions = self.class_protocol_assumptions.clone();
+        let witness_deferred_vars = self.snapshot_witness_deferred_vars();
+        let coinductive_assumptions_used = self.coinductive_assumptions_used;
+        let type_order_coinductive = self.type_order.coinductive_assumptions_used();
+        let result = match (check(self), self.solver.has_new_instantiation_errors(&vars)) {
+            (Ok(()), false) => SubsetWithSnapshotResult::Ok,
+            (Ok(()), true) => SubsetWithSnapshotResult::Err(SubsetError::Other),
+            (Err(error), _) => SubsetWithSnapshotResult::Err(error),
+        };
+        match result {
+            SubsetWithSnapshotResult::Ok => SubsetWithSnapshotResult::Ok,
+            SubsetWithSnapshotResult::Err(error) => {
+                self.solver.restore_vars(vars);
+                self.subset_cache = subset_cache;
+                self.class_protocol_assumptions = class_protocol_assumptions;
+                self.restore_witness_deferred_vars(witness_deferred_vars);
+                self.coinductive_assumptions_used = coinductive_assumptions_used;
+                self.type_order
+                    .set_coinductive_assumptions_used(type_order_coinductive);
+                SubsetWithSnapshotResult::Err(error)
+            }
+        }
     }
 
     /// Check one overload branch's constraints as a transaction during quantified finishing.

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -275,7 +275,7 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
                     Some(Param::PosOnly(_, l, l_req) | Param::Pos(_, l, l_req)),
                     Some(Param::PosOnly(_, u, u_req)),
                 ) if (*u_req == Required::Required || matches!(l_req, Required::Optional(_))) => {
-                    self.is_subset_eq(u, l)?;
+                    self.is_subset_callable_parameter(u, l)?;
                     l_arg = l_args.next();
                     u_arg = u_args.next();
                 }
@@ -285,7 +285,7 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
                     if l_name != u_name {
                         return Err(SubsetError::PosParamName(l_name.clone(), u_name.clone()));
                     }
-                    self.is_subset_eq(u, l)?;
+                    self.is_subset_callable_parameter(u, l)?;
                     l_arg = l_args.next();
                     u_arg = u_args.next();
                 }
@@ -414,13 +414,13 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
                     u_arg = u_args.next();
                 }
                 (Some(Param::Varargs(_, l)), Some(Param::PosOnly(_, u, _))) => {
-                    self.is_subset_eq(u, l)?;
+                    self.is_subset_callable_parameter(u, l)?;
                     u_arg = u_args.next();
                 }
                 (Some(Param::Varargs(_, l)), Some(Param::Pos(name, u, _))) => {
                     // Param::Pos can be passed positionally or by name, so if it matches *args
                     // we need to make sure it matches an optional kw-only argument or *kwargs
-                    self.is_subset_eq(u, l)?;
+                    self.is_subset_callable_parameter(u, l)?;
                     u_param_matched_with_l_varargs.push((name, u));
                     u_arg = u_args.next();
                 }
@@ -461,7 +461,7 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
                     u_arg = u_args.next();
                 }
                 (Some(Param::Varargs(_, l)), Some(Param::Varargs(_, u))) => {
-                    self.is_subset_eq(u, l)?;
+                    self.is_subset_callable_parameter(u, l)?;
                     l_arg = l_args.next();
                     u_arg = u_args.next();
                 }
@@ -570,7 +570,7 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
                 l_kwargs
             }
             (Some(l), Some(u)) => {
-                self.is_subset_eq(&u, &l)?;
+                self.is_subset_callable_parameter(&u, &l)?;
                 Some(l)
             }
             (None, Some(_)) => {
@@ -587,9 +587,9 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
                 if l_req {
                     return Err(SubsetError::Other);
                 }
-                self.is_subset_eq(u_ty, &l_ty)?;
+                self.is_subset_callable_parameter(u_ty, &l_ty)?;
             } else if let Some(l_ty) = &l_kwargs {
-                self.is_subset_eq(u_ty, l_ty)?;
+                self.is_subset_callable_parameter(u_ty, l_ty)?;
             } else {
                 return Err(SubsetError::Other);
             }
@@ -600,9 +600,9 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
                 if !*u_req && l_req {
                     return Err(SubsetError::Other);
                 }
-                self.is_subset_eq(u_ty, &l_ty)?;
+                self.is_subset_callable_parameter(u_ty, &l_ty)?;
             } else if let Some(l_ty) = &l_kwargs {
-                self.is_subset_eq(u_ty, l_ty)?;
+                self.is_subset_callable_parameter(u_ty, l_ty)?;
             } else {
                 return Err(SubsetError::Other);
             }

--- a/pyrefly/lib/test/mod.rs
+++ b/pyrefly/lib/test/mod.rs
@@ -71,6 +71,7 @@ mod query;
 mod recursive_alias;
 mod redundant_cast;
 mod returns;
+mod scalar_as_shape;
 mod scope;
 mod self_cls_default;
 mod semantic_syntax_errors;

--- a/pyrefly/lib/test/scalar_as_shape.rs
+++ b/pyrefly/lib/test/scalar_as_shape.rs
@@ -1,0 +1,449 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::test::util::shape_extensions_env;
+use crate::testcase;
+
+testcase!(
+    scalar_as_shape_binds_empty_shape,
+    shape_extensions_env(),
+    r#"
+from typing import Any, Callable, Never, Protocol, TypedDict, assert_type
+from shape_extensions import IntTuple, ScalarAsShape, shaped_array
+
+@shaped_array(shape="Shape")
+class Array[Shape: IntTuple]: ...
+
+type Scalar = bool | int | float | complex
+type ArrayLike[Shape: IntTuple] = Array[Shape] | ScalarAsShape[Scalar, Shape]
+type MultiScalar[Shape: IntTuple] = (
+    ScalarAsShape[int, IntTuple[2]] | ScalarAsShape[int, Shape]
+)
+type MixedScalar[Shape: IntTuple] = (
+    ScalarAsShape[float, IntTuple[2]] | ScalarAsShape[int, Shape]
+)
+type SplitScalar[Shape: IntTuple] = (
+    ScalarAsShape[int, Shape] | ScalarAsShape[float, IntTuple[2]]
+)
+type GenericMultiScalar[T, Shape: IntTuple] = (
+    ScalarAsShape[T, IntTuple[2]] | ScalarAsShape[T, Shape]
+)
+type OrdinaryConstrained = int | ScalarAsShape[float, IntTuple[2]]
+type OrdinaryGeneric[Shape: IntTuple] = int | ScalarAsShape[float, Shape]
+
+def unary[Shape: IntTuple](x: ArrayLike[Shape]) -> Array[Shape]: ...
+def direct[Shape: IntTuple](x: ScalarAsShape[Scalar, Shape]) -> Array[Shape]: ...
+def binary[Left: IntTuple, Right: IntTuple](
+    left: ArrayLike[Left], right: ArrayLike[Right]
+) -> tuple[Array[Left], Array[Right]]: ...
+def ternary[A: IntTuple, B: IntTuple, C: IntTuple](
+    a: ArrayLike[A], b: ArrayLike[B], c: ArrayLike[C]
+) -> tuple[Array[A], Array[B], Array[C]]: ...
+def same_shape[Shape: IntTuple](
+    left: ArrayLike[Shape], right: ArrayLike[Shape]
+) -> Array[Shape]: ...
+def fixed_shape(x: ScalarAsShape[int, IntTuple[2]]) -> None: ...
+def multi_scalar[Shape: IntTuple](x: MultiScalar[Shape]) -> Array[Shape]: ...
+def variadic[Shape: IntTuple](*values: ScalarAsShape[int, Shape]) -> Array[Shape]: ...
+def keyword_variadic[Shape: IntTuple](
+    **values: ScalarAsShape[int, Shape],
+) -> Array[Shape]: ...
+def splat_scalars[Shape: IntTuple](
+    *values: ScalarAsShape[Scalar, Shape],
+) -> Array[Shape]: ...
+def split_scalar[Shape: IntTuple](x: SplitScalar[Shape]) -> Array[Shape]: ...
+def ordinary_constrained(x: OrdinaryConstrained) -> None: ...
+def ordinary_generic[Shape: IntTuple](x: OrdinaryGeneric[Shape]) -> Array[Shape]: ...
+def scalar_kwargs[Shape: IntTuple](
+    **values: ScalarAsShape[int, Shape],
+) -> Array[Shape]: ...
+def generic_then_valid[T: str, Shape: IntTuple](
+    x: ScalarAsShape[T, Shape] | ScalarAsShape[int, Shape],
+) -> Array[Shape]: ...
+def bounded_valid_target[Shape: IntTuple](
+    x: ScalarAsShape[int, Shape] | ScalarAsShape[float, Shape],
+) -> Array[Shape]: ...
+def bounded_invalid_target[Shape: IntTuple](
+    x: ScalarAsShape[int, Shape] | ScalarAsShape[str, IntTuple[2]],
+) -> Array[Shape]: ...
+
+def use_array(array: Array[[2, 3]]) -> None:
+    assert_type(unary(array), Array[[2, 3]])
+    assert_type(binary(array, 1), tuple[Array[[2, 3]], Array[[]]])
+    assert_type(binary(1, array), tuple[Array[[]], Array[[2, 3]]])
+    assert_type(
+        ternary(array, 1.0, 1j),
+        tuple[Array[[2, 3]], Array[[]], Array[[]]],
+    )
+    same_shape(1, array)  # E: Argument `Array[[2, 3]]` is not assignable to parameter `right`
+    same_shape(array, 1)  # E: Scalar argument is treated as having shape `()`, which is not assignable to parameter `right` with shape `IntTuple[2, 3]`
+
+assert_type(unary(True), Array[[]])
+assert_type(unary(x=True), Array[[]])
+assert_type(direct(True), Array[[]])
+assert_type(unary(1), Array[[]])
+assert_type(unary(1.0), Array[[]])
+assert_type(unary(1j), Array[[]])
+assert_type(multi_scalar(1), Array[[]])
+assert_type(variadic(1, 2), Array[[]])
+assert_type(keyword_variadic(left=1, right=2), Array[[]])
+fixed_shape(1)  # E: Scalar argument is treated as having shape `()`, which is not assignable to parameter `x` with shape `IntTuple[2]`
+
+def use_splats(
+    valid: tuple[int, *tuple[float, ...], complex],
+    invalid: tuple[int, *tuple[float, ...], str],
+) -> None:
+    assert_type(splat_scalars(*valid), Array[[]])
+    splat_scalars(*invalid)  # E: Argument `str` is not assignable to parameter `*values`
+
+def use_scalar_union(value: int | float) -> None:
+    split_scalar(value)  # E: Scalar argument is treated as having shape `()`, which is not assignable to parameter `x` with shape `IntTuple[2]`
+    ordinary_constrained(value)  # E: Scalar argument is treated as having shape `()`, which is not assignable to parameter `x` with shape `IntTuple[2]`
+    assert_type(ordinary_generic(value), Array[[]])
+
+def use_mixed_array_scalar_unions(
+    array_first: Array[[2, 3]] | int,
+    scalar_first: int | Array[[2, 3]],
+) -> None:
+    unary(array_first)  # E: is not assignable to parameter `x`
+    unary(scalar_first)  # E: is not assignable to parameter `x`
+
+def use_array_first_bound[T: Array[[2, 3]] | int](value: T) -> None:
+    unary(value)  # E: is not assignable to parameter `x`
+
+def use_scalar_first_bound[T: int | Array[[2, 3]]](value: T) -> None:
+    unary(value)  # E: is not assignable to parameter `x`
+
+class ScalarKeywordArguments(TypedDict):
+    left: int
+    right: int
+
+class InvalidScalarKeywordArguments(TypedDict):
+    left: int
+    right: str
+
+def use_typed_dict_kwargs(
+    valid: ScalarKeywordArguments,
+    invalid: InvalidScalarKeywordArguments,
+) -> None:
+    assert_type(scalar_kwargs(**valid), Array[[]])
+    scalar_kwargs(**invalid)  # E: Argument `str` is not assignable to parameter `right`
+
+assert_type(generic_then_valid(1), Array[[]])
+
+def use_valid_bound[T: int | float](value: T) -> None:
+    assert_type(bounded_valid_target(value), Array[[]])
+
+def use_invalid_bound[T: int | str](value: T) -> None:
+    bounded_invalid_target(value)  # E: Scalar argument is treated as having shape `()`, which is not assignable to parameter `x` with shape `IntTuple[2]`
+
+unary("not a scalar")  # E: Argument `Literal['not a scalar']` is not assignable to parameter `x`
+
+def use_any(any_value: Any) -> None:
+    assert_type(unary(any_value), Array[IntTuple])
+
+def use_unknown(value) -> None:
+    assert_type(unary(value), Array[IntTuple])
+
+def unreachable(never: Never) -> None:
+    assert_type(unary(never), Array[IntTuple])
+
+def body[Shape: IntTuple](x: ScalarAsShape[int, Shape]) -> int:
+    assert_type(x, int)
+    return x
+
+type ScalarShape[Shape: IntTuple] = ScalarAsShape[Scalar, Shape]
+type ScalarShapeAlias[Shape: IntTuple] = ScalarShape[Shape]
+
+def aliased_body[Shape: IntTuple](x: ScalarShapeAlias[Shape]) -> Scalar:
+    assert_type(x, Scalar)
+    return x
+
+def callback[Shape: IntTuple](x: ScalarAsShape[int, Shape]) -> int:
+    return x
+
+def arraylike_callback[Shape: IntTuple](x: ArrayLike[Shape]) -> Array[Shape]: ...
+
+callable_value: Callable[[int], int] = callback
+scalar_arraylike_callable: Callable[[int], Array[[]]] = arraylike_callback
+array_arraylike_callable: Callable[[Array[[2, 3]]], Array[[2, 3]]] = arraylike_callback
+
+class CallbackProtocol(Protocol):
+    def __call__(self, x: int) -> int: ...
+
+protocol_value: CallbackProtocol = callback
+
+class MarkerCallbackProtocol(Protocol):
+    def __call__(self, x: ScalarAsShape[int, IntTuple]) -> int: ...
+
+marker_protocol_value: MarkerCallbackProtocol = callback
+
+def union_marker_callback[Shape: IntTuple](
+    x: int | ScalarAsShape[float, Shape],
+) -> int:
+    return 0
+
+class UnionMarkerCallbackProtocol(Protocol):
+    def __call__(self, x: ScalarAsShape[float, IntTuple]) -> int: ...
+
+union_marker_protocol_value: UnionMarkerCallbackProtocol = union_marker_callback
+
+def multi_scalar_callback[Shape: IntTuple](x: MultiScalar[Shape]) -> int:
+    return 0
+
+def mixed_scalar_callback[Shape: IntTuple](x: MixedScalar[Shape]) -> int:
+    return 0
+
+multi_scalar_protocol_value: CallbackProtocol = multi_scalar_callback
+mixed_scalar_protocol_value: CallbackProtocol = mixed_scalar_callback
+
+def generic_marker_callback[T, Shape: IntTuple](
+    x: ScalarAsShape[T, Shape],
+) -> T:
+    return x
+
+def generic_multi_scalar_callback[T, Shape: IntTuple](
+    x: GenericMultiScalar[T, Shape],
+) -> T:
+    return x
+
+class GenericMarkerProtocol[T](Protocol):
+    def __call__[Shape: IntTuple](
+        self, x: ScalarAsShape[T, Shape]
+    ) -> T: ...
+
+generic_marker_protocol_value: GenericMarkerProtocol[int] = generic_marker_callback
+generic_multi_protocol_value: CallbackProtocol = generic_multi_scalar_callback
+
+def constrained_union_callback[Shape: IntTuple](
+    x: ScalarAsShape[int, Shape] | ScalarAsShape[float, IntTuple[2]],
+) -> None: ...
+
+constrained_union_callable: Callable[[int | float], None] = constrained_union_callback  # E: is not assignable to `(float | int) -> None`
+
+def first_shape_error_callback(
+    x: ScalarAsShape[int, IntTuple[2]] | ScalarAsShape[int, IntTuple[3]],
+) -> None: ...
+
+first_shape_error_callable: Callable[[int], None] = first_shape_error_callback  # E: is not assignable to `(int) -> None`
+
+class ScalarArrayLikeProtocol(Protocol):
+    def __call__(self, x: int) -> Array[[]]: ...
+
+class ArrayArrayLikeProtocol(Protocol):
+    def __call__(self, x: Array[[2, 3]]) -> Array[[2, 3]]: ...
+
+scalar_protocol_value: ScalarArrayLikeProtocol = arraylike_callback
+array_protocol_value: ArrayArrayLikeProtocol = arraylike_callback
+
+def decorator(f: Callable[[int], int]) -> Callable[[int], int]:
+    return f
+
+@decorator
+def decorated(x: ScalarAsShape[int, IntTuple]) -> int:
+    return x
+
+class Base:
+    def method(self, x: int) -> int:
+        return x
+
+class Child(Base):
+    def method[Shape: IntTuple](self, x: ScalarAsShape[int, Shape]) -> int:
+        return x
+
+class MultiScalarChild(Base):
+    def method[Shape: IntTuple](self, x: MultiScalar[Shape]) -> int:
+        return 0
+
+class MixedScalarChild(Base):
+    def method[Shape: IntTuple](self, x: MixedScalar[Shape]) -> int:
+        return 0
+"#,
+);
+
+testcase!(
+    scalar_as_shape_prefers_ordinary_union_arm,
+    shape_extensions_env(),
+    r#"
+from typing import assert_type
+from shape_extensions import IntTuple, ScalarAsShape, shaped_array
+
+@shaped_array(shape="Shape")
+class Array[Shape: IntTuple]: ...
+
+type PreferOrdinary[Shape: IntTuple] = int | ScalarAsShape[int, Shape]
+
+def f[Shape: IntTuple](x: PreferOrdinary[Shape]) -> Array[Shape]: ...
+
+assert_type(f(1), Array[IntTuple])
+"#,
+);
+
+testcase!(
+    scalar_as_shape_does_not_beat_exact_overload,
+    shape_extensions_env(),
+    r#"
+from typing import Any, Literal, TypedDict, assert_type, overload
+from shape_extensions import IntTuple, ScalarAsShape, shaped_array
+
+@shaped_array(shape="Shape")
+class Array[Shape: IntTuple]: ...
+
+type ArrayLike[Shape: IntTuple] = Array[Shape] | ScalarAsShape[int, Shape]
+
+@overload
+def choose[Shape: IntTuple](x: ScalarAsShape[int, Shape]) -> Array[Shape]: ...
+@overload
+def choose(x: int) -> Literal["exact"]: ...
+def choose(x: object) -> object:
+    return x
+
+assert_type(choose(1), Literal["exact"])
+
+def ambiguous_calls(any_value: Any, unknown_value) -> None:
+    assert_type(choose(any_value), Any)
+    assert_type(choose(unknown_value), Any)
+
+@overload
+def choose_specific(x: object) -> Literal["object"]: ...
+@overload
+def choose_specific[Shape: IntTuple](
+    x: ScalarAsShape[int, Shape],
+) -> Literal["scalar"]: ...
+def choose_specific(x: object) -> str:
+    return ""
+
+assert_type(choose_specific(1), Literal["scalar"])
+
+@overload
+def choose_fewer[A: IntTuple, B: IntTuple](
+    x: ScalarAsShape[int, A], y: ScalarAsShape[int, B]
+) -> Literal["two"]: ...
+@overload
+def choose_fewer[A: IntTuple](
+    x: ScalarAsShape[int, A], y: int
+) -> Literal["one"]: ...
+def choose_fewer(x: int, y: int) -> str:
+    return ""
+
+assert_type(choose_fewer(1, 2), Literal["one"])
+
+@overload
+def choose_star[Shape: IntTuple](
+    first: ScalarAsShape[int, Shape], second: int
+) -> Literal["converted"]: ...
+@overload
+def choose_star(first: int, second: int) -> Literal["exact"]: ...
+def choose_star(first: int, second: int) -> str:
+    return ""
+
+assert_type(choose_star(*(1, 2)), Literal["exact"])
+
+@overload
+def choose_gradual[Shape: IntTuple](
+    first: ScalarAsShape[int, Shape], second: int
+) -> Literal["scalar"]: ...
+@overload
+def choose_gradual(first: object, second: object) -> Literal["object"]: ...
+def choose_gradual(first: object, second: object) -> str:
+    return ""
+
+def gradual_overload_calls(any_value: Any, unknown_value) -> None:
+    assert_type(choose_gradual(1, any_value), Any)
+    assert_type(choose_gradual(1, unknown_value), Any)
+
+class GradualKeywordArguments(TypedDict):
+    second: Any
+
+def gradual_kwargs(values: GradualKeywordArguments) -> None:
+    assert_type(choose_gradual(1, **values), Any)
+
+@overload
+def ordinary_gradual(first: int, second: int) -> Literal["int"]: ...
+@overload
+def ordinary_gradual(first: object, second: object) -> Literal["object"]: ...
+def ordinary_gradual(first: object, second: object) -> str:
+    return ""
+
+def ordinary_gradual_kwargs(values: GradualKeywordArguments) -> None:
+    assert_type(ordinary_gradual(1, **values), Literal["int"])
+
+@overload
+def arraylike_gradual[Shape: IntTuple](
+    first: ArrayLike[Shape], second: int
+) -> Literal["arraylike"]: ...
+@overload
+def arraylike_gradual(first: object, second: object) -> Literal["object"]: ...
+def arraylike_gradual(first: object, second: object) -> str:
+    return ""
+
+class ArrayLikeGradualKeywordArguments(TypedDict):
+    first: Array[[2, 3]]
+    second: Any
+
+def arraylike_gradual_kwargs(values: ArrayLikeGradualKeywordArguments) -> None:
+    assert_type(arraylike_gradual(**values), Literal["arraylike"])
+"#,
+);
+
+testcase!(
+    scalar_as_shape_rejects_invalid_positions,
+    shape_extensions_env(),
+    r#"
+from typing import Any, Never
+from shape_extensions import IntTuple, ScalarAsShape
+
+type Scalar = int | float
+type ScalarShape[Shape: IntTuple] = ScalarAsShape[Scalar, Shape]
+type Nested[Shape: IntTuple] = list[ScalarAsShape[Scalar, Shape]]  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+type AliasOfAlias[Shape: IntTuple] = ScalarShape[Shape]
+type IndirectNested[Shape: IntTuple] = list[AliasOfAlias[Shape]]  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+type Alias2[Shape: IntTuple] = AliasOfAlias[Shape]
+type Alias3[Shape: IntTuple] = Alias2[Shape]
+type Alias4[Shape: IntTuple] = Alias3[Shape]
+type Alias5[Shape: IntTuple] = Alias4[Shape]
+type Alias6[Shape: IntTuple] = Alias5[Shape]
+type Alias7[Shape: IntTuple] = Alias6[Shape]
+type Alias8[Shape: IntTuple] = Alias7[Shape]
+type Alias9[Shape: IntTuple] = Alias8[Shape]
+type DeepNested[Shape: IntTuple] = list[Alias9[Shape]]  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+type DiamondLeft[Shape: IntTuple] = Alias9[Shape]
+type DiamondRight[Shape: IntTuple] = Alias9[Shape]
+type Diamond[Shape: IntTuple] = tuple[
+    DiamondLeft[Shape],  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+    DiamondRight[Shape],  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+]
+type Recursive[Shape: IntTuple] = ScalarShape[Shape] | list[Recursive[Shape]]  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+type RecursiveGeneric[T] = T | list[RecursiveGeneric[T]]
+type Shared[T] = tuple[RecursiveGeneric[T], RecursiveGeneric[T]]
+type Rotate[T, U] = T | list[Rotate[U, U]]
+
+def bad_return() -> ScalarShape[IntTuple]: ...  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+def bad_nested[Shape: IntTuple](x: list[ScalarShape[Shape]]) -> None: ...  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+def bad_nested_source[Shape: IntTuple](x: ScalarAsShape[ScalarShape[Shape], Shape]) -> None: ...  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+def bad_shape(x: ScalarAsShape[Scalar, int]) -> None: ...  # E: Second argument to `ScalarAsShape` must be an `IntTuple`, got `int`
+def bad_any[Shape: IntTuple](x: ScalarAsShape[Any, Shape]) -> None: ...  # E: First argument to `ScalarAsShape` may not contain `Any` or `Never`, got `Any`
+def bad_unknown[Shape: IntTuple](x: ScalarAsShape[list, Shape]) -> None: ...  # E: First argument to `ScalarAsShape` may not contain `Any` or `Never`, got `list[Unknown]`
+def bad_never[Shape: IntTuple](x: ScalarAsShape[Never, Shape]) -> None: ...  # E: First argument to `ScalarAsShape` may not contain `Any` or `Never`, got `Never`
+def bad_default[Shape: IntTuple](x: ScalarShape[Shape] = 0) -> None: ...  # E: A parameter using `ScalarAsShape` may not have a default
+def bad_specializations[Shape: IntTuple](
+    x: tuple[RecursiveGeneric[int], RecursiveGeneric[ScalarShape[Shape]]],  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+) -> None: ...
+def okay_shared(x: Shared[int]) -> None: ...
+def bad_shared[Shape: IntTuple](x: Shared[ScalarShape[Shape]]) -> None: ...  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+def bad_rotated_specialization[Shape: IntTuple](x: Rotate[int, ScalarShape[Shape]]) -> None: ...  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+
+local: ScalarShape[IntTuple]  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+
+class C:
+    field: ScalarShape[IntTuple]  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+
+class BadBase(ScalarAsShape[int, IntTuple]): ...  # E: `shape_extensions.ScalarAsShape` is supported only directly in a callable parameter annotation or as a direct union member
+
+bare: ScalarAsShape  # E: `ScalarAsShape` requires two type arguments
+"#,
+);

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/lax/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/lax/__init__.pyi
@@ -5,6 +5,7 @@
 
 from typing import Any, overload
 
+import numpy as np
 from jax._array import Array
 from jax._shapes import lax_broadcast
 from shape_extensions import IntTuple
@@ -12,7 +13,7 @@ from shape_extensions import IntTuple
 from . import linalg as linalg
 
 type _Shape = IntTuple
-type _Scalar = int | float | complex
+type _Scalar = bool | int | float | complex | np.generic
 
 # Unary elementwise operators
 def abs[Shape: _Shape](x: Array[Shape]) -> Array[Shape]: ...

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
@@ -5,6 +5,7 @@
 
 from typing import Any, Callable, Literal, overload, Sequence, Unpack
 
+import numpy as np
 from jax._array import Array as Array, Array as ndarray
 from jax._shapes import (
     broadcast_to_shape,
@@ -49,11 +50,16 @@ from shape_extensions import (
     IntTuples,
     IntVar,
     MapIntTuples,
+    ScalarAsShape,
 )
 
 from . import fft as fft, linalg as linalg
 
 type _Shape = IntTuple
+type _Scalar = bool | int | float | complex | np.generic
+type _ArrayLike[Shape: _Shape] = (
+    Array[Shape] | np.ndarray[Shape, Any] | ScalarAsShape[_Scalar, Shape]
+)
 type _Axis = int | tuple[int, ...] | None
 # The trailing `None` is not a legal argument to `reshape`. It is present because
 # an `int | tuple[int, ...]` parameter cannot be iterated inside a DSL function
@@ -1124,7 +1130,7 @@ def maximum[Shape: _Shape](
 ) -> Array[Shape]: ...
 @overload
 def maximum[Shape1: _Shape, Shape2: _Shape](
-    x1: Array[Shape1], x2: Array[Shape2], /
+    x1: _ArrayLike[Shape1], x2: _ArrayLike[Shape2], /
 ) -> Array[broadcast(Shape1, Shape2)]: ...
 @overload
 def minimum[Shape: _Shape](
@@ -1246,6 +1252,16 @@ def true_divide[Shape: _Shape](
 def true_divide[Shape1: _Shape, Shape2: _Shape](
     x1: Array[Shape1], x2: Array[Shape2], /
 ) -> Array[broadcast(Shape1, Shape2)]: ...
+def where[
+    ConditionShape: _Shape,
+    XShape: _Shape,
+    YShape: _Shape,
+](
+    condition: _ArrayLike[ConditionShape],
+    x: _ArrayLike[XShape],
+    y: _ArrayLike[YShape],
+    /,
+) -> Array[broadcast(broadcast(ConditionShape, XShape), YShape)]: ...
 @overload
 def transpose[Shape: _Shape](
     a: Array[Shape], axes: None = None

--- a/tensor-shapes/pyrefly-jax-stubs/pyproject.toml
+++ b/tensor-shapes/pyrefly-jax-stubs/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Typing :: Stubs Only",
 ]
 dependencies = [
+  "pyrefly-numpy-stubs==0.0.0",
   "pyrefly-shape-extensions==0.0.0",
 ]
 

--- a/tensor-shapes/pyrefly-jax-stubs/pyrefly.toml
+++ b/tensor-shapes/pyrefly-jax-stubs/pyrefly.toml
@@ -1,6 +1,7 @@
 search_path = [
     ".",
     "../pyrefly-shape-extensions",
+    "../pyrefly-numpy-stubs",
 ]
 
 python_version = "3.13"

--- a/tensor-shapes/pyrefly-jax-stubs/suites.py
+++ b/tensor-shapes/pyrefly-jax-stubs/suites.py
@@ -36,6 +36,7 @@ def _suites() -> list[Suite]:
         Suite(
             name=path.stem.removeprefix("test_").replace("_", "-"),
             patterns=(f"test/{path.name}",),
+            extra_search_paths=(_PACKAGE_ROOT.parent / "pyrefly-numpy-stubs",),
             expectations=True,
         )
         for path in paths

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_arithmetic.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_arithmetic.py
@@ -5,8 +5,18 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import jax.numpy as jnp
+import numpy as np
 from shape_extensions import assert_shape
+
+if TYPE_CHECKING:
+    numpy_int: np.int32
+    numpy_bool: np.bool_
+else:
+    numpy_int = np.int32(1)
+    numpy_bool = np.bool_(True)
 
 
 def test_elementwise_operators_preserve_shape() -> None:
@@ -32,6 +42,9 @@ def test_scalar_operands_preserve_shape() -> None:
     assert_shape(2.0 * a, (3, 4))
     assert_shape(a / 2.0, (3, 4))
     assert_shape(v**2, (5,))
+    assert_shape(jnp.maximum(a, numpy_int), (3, 4))
+    assert_shape(jnp.maximum(numpy_int, a), (3, 4))
+    assert_shape(jnp.where(numpy_bool, a, 0), (3, 4))
 
 
 def test_complex_scalars_preserve_shape() -> None:
@@ -88,6 +101,47 @@ def test_binary_functions_accept_scalars() -> None:
     assert_shape(jnp.divide(a, 2.0), (3, 4))
     assert_shape(jnp.maximum(a, 0), (3, 4))
     assert_shape(jnp.minimum(0, a), (3, 4))
+
+
+def test_maximum_accepts_arrays_and_scalars() -> None:
+    column = jnp.ones((3, 1))
+    row = jnp.ones((1, 4))
+
+    assert_shape(jnp.maximum(column, row), (3, 4))
+    assert_shape(jnp.maximum(column, 0), (3, 1))
+    assert_shape(jnp.maximum(0, row), (1, 4))
+    assert_shape(jnp.maximum(0, 1), ())
+    assert_shape(jnp.maximum(np.ones((3, 1)), row), (3, 4))
+
+
+def test_where_accepts_arrays_and_scalars() -> None:
+    condition = jnp.ones((3, 1), dtype=bool)
+    row = jnp.ones((1, 4))
+    full = jnp.ones((3, 4))
+
+    assert_shape(jnp.where(condition, row, full), (3, 4))
+    assert_shape(jnp.where(condition, row, 0), (3, 4))
+    assert_shape(jnp.where(condition, 0, row), (3, 4))
+    assert_shape(jnp.where(True, condition, row), (3, 4))
+    assert_shape(jnp.where(full, 1, 0), (3, 4))
+    assert_shape(jnp.where(True, full, 0), (3, 4))
+    assert_shape(jnp.where(True, 0, full), (3, 4))
+    assert_shape(jnp.where(True, 1, 0), ())
+
+
+def test_where_rejects_incompatible_broadcast() -> None:
+    condition = jnp.ones((3, 4), dtype=bool)
+    incompatible = jnp.ones(5)
+
+    assert_shape(jnp.where(condition, 1, 0), (3, 4))
+    try:
+        jnp.where(  # E: Cannot evaluate type-level shape DSL call
+            condition, incompatible, 0
+        )
+    except (TypeError, ValueError):
+        pass
+    else:
+        raise AssertionError("expected JAX to reject incompatible shapes")
 
 
 def test_elementwise_unary_functions_preserve_shape() -> None:

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_arraylike.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_arraylike.py
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from shape_extensions import assert_shape, IntTuple
+
+type JaxOrNumpyArray[Shape: IntTuple] = jax.Array[Shape] | np.ndarray[Shape, Any]
+
+
+def preserve_shape[Shape: IntTuple](
+    value: JaxOrNumpyArray[Shape],
+) -> jax.Array[Shape]:
+    return cast(Any, value)
+
+
+def preserve_shapes[LeftShape: IntTuple, RightShape: IntTuple](
+    left: JaxOrNumpyArray[LeftShape],
+    right: JaxOrNumpyArray[RightShape],
+) -> tuple[jax.Array[LeftShape], jax.Array[RightShape]]:
+    return cast(Any, (left, right))
+
+
+def test_union_alias_infers_shape_from_jax_array() -> None:
+    assert_shape(preserve_shape(jnp.ones((2, 3))), (2, 3))
+
+
+def test_union_alias_infers_shape_from_numpy_array() -> None:
+    assert_shape(preserve_shape(np.ones((4, 5))), (4, 5))
+
+
+def test_union_alias_infers_independent_shapes_for_mixed_inputs() -> None:
+    left, right = preserve_shapes(jnp.ones((3, 1)), np.ones((1, 4)))
+
+    assert_shape(left, (3, 1))
+    assert_shape(right, (1, 4))

--- a/tensor-shapes/pyrefly-shape-extensions/shape_extensions/__init__.py
+++ b/tensor-shapes/pyrefly-shape-extensions/shape_extensions/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     "IntVar",
     "MapIntTuples",
     "ProxyMethod",
+    "ScalarAsShape",
     "SymbolicArithExpr",
     "TypeVarTuple",
     "assert_shape",
@@ -154,6 +155,12 @@ class Flag[T]:
 
 class ProxyMethod[T]:
     """Type-checker marker for method forwarding annotations."""
+
+    pass
+
+
+class ScalarAsShape[Source, Shape]:
+    """Treat a scalar parameter as having the specified array shape."""
 
     pass
 

--- a/tensor-shapes/shape_testing.py
+++ b/tensor-shapes/shape_testing.py
@@ -217,6 +217,9 @@ def check_suites(
         raise ValueError(f"no suites to check under {package_root}")
 
     failed = 0
+    stub_extra_search_paths = tuple(
+        dict.fromkeys(path for suite in suites for path in suite.extra_search_paths)
+    )
     for suite in [STUB_SUITE, *suites] if check_stubs else suites:
         files = suite.files(package_root)
         command = [
@@ -230,7 +233,11 @@ def check_suites(
         if suite.expectations:
             command.append("--expectations")
         for search_path in (
-            *suite.extra_search_paths,
+            *(
+                stub_extra_search_paths
+                if suite is STUB_SUITE
+                else suite.extra_search_paths
+            ),
             package_root,
             SHAPE_EXTENSIONS_ROOT,
         ):


### PR DESCRIPTION
Summary: Introduce a reusable JAX array-like alias that preserves shapes from JAX and NumPy arrays while treating scalar inputs as empty shapes. Use it to express `maximum` and three-argument `where` without combinatorial overloads.

Differential Revision: D118557925


