### PR TITLE
narrow membership tests against named concrete containers (#4469)

### DIFF
--- a/pyrefly/lib/alt/narrow.rs
+++ b/pyrefly/lib/alt/narrow.rs
@@ -337,6 +337,22 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         self.unions(matches)
     }
 
+    /// Element type of a `list`, `set`, `frozenset`, or `deque`.
+    fn concrete_container_element_type(&self, ty: &Type) -> Option<Type> {
+        let Type::ClassType(cls) = ty else {
+            return None;
+        };
+        let obj = cls.class_object();
+        let is_concrete = obj == self.stdlib.list_object()
+            || obj == self.stdlib.set_object()
+            || obj == self.stdlib.frozenset_object()
+            || cls.has_qname("collections", "deque");
+        if !is_concrete {
+            return None;
+        }
+        self.unwrap_iterable(ty)
+    }
+
     /// Calculate the intersection of a number of types
     pub fn intersects(&self, ts: &[Type]) -> Type {
         match ts {
@@ -1526,10 +1542,20 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 if !self.behaves_like_any(&right_ty)
                     && let Some((key_ty, _)) = self.unwrap_mapping(&right_ty)
                 {
-                    self.intersect(ty, &key_ty)
-                } else {
-                    ty.clone()
+                    return self.intersect(ty, &key_ty);
                 }
+
+                // Membership against a named container narrows like a positive equality check.
+                if !self.behaves_like_any(&right_ty)
+                    && let Some(elem_ty) = self.concrete_container_element_type(&right_ty)
+                    && !self.behaves_like_any(&elem_ty)
+                    // This avoids widening a gradual operand into a union.
+                    && !self.is_subset_eq(ty, &elem_ty)
+                {
+                    return self.narrow_after_equality_match(ty, &elem_ty);
+                }
+
+                ty.clone()
             }
             AtomicNarrowOp::NotIn(v) => {
                 // First, check for literal containers. We also unwrap builtin

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -2047,7 +2047,6 @@ def lookup_resource(registry: dict[str, str]) -> str | None:
 );
 
 testcase!(
-    bug = "Named builtin containers do not narrow membership by element type",
     test_in_named_builtin_container_narrows_element_type,
     r#"
 from collections import deque
@@ -2055,19 +2054,19 @@ from typing import assert_type
 
 def test_set(x: str | None, values: set[str]) -> None:
     if x in values:
-        assert_type(x, str | None)
+        assert_type(x, str)
 
 def test_frozenset(x: str | None, values: frozenset[str]) -> None:
     if x in values:
-        assert_type(x, str | None)
+        assert_type(x, str)
 
 def test_list(x: str | None, values: list[str]) -> None:
     if x in values:
-        assert_type(x, str | None)
+        assert_type(x, str)
 
 def test_deque(x: str | None, values: deque[str]) -> None:
     if x in values:
-        assert_type(x, str | None)
+        assert_type(x, str)
 "#,
 );
 
@@ -2132,21 +2131,21 @@ def test_tuple_control(x: str | None, values: tuple[str, ...]) -> None:
 );
 
 testcase!(
-    bug = "Named container membership does not narrow control flow",
     test_in_named_container_control_flow,
     r#"
 from collections.abc import Container
 from typing import assert_type
 
 def test_not_in(x: str | None, values: set[str]) -> None:
+    # not in does not narrow because x could simply be absent from values.
     if x not in values:
         assert_type(x, str | None)
     else:
-        assert_type(x, str | None)
+        assert_type(x, str)
 
 def test_union_element(x: str | int | None, values: set[str | int]) -> None:
     if x in values:
-        assert_type(x, str | int | None)
+        assert_type(x, int | str)
 
 def test_nullable_element(x: str | None, values: Container[str | None]) -> None:
     if x in values:
@@ -2178,8 +2177,9 @@ def test_nested_any(event_task: Task[Any], bool_task: Task[bool]) -> None:
 "#,
 );
 
+// Equality can hold across disjoint numeric or bytes-like types, so narrowing
+// keeps the wider operand instead of the element type.
 testcase!(
-    bug = "Named container narrowing does not account for equality",
     test_in_named_container_respects_equality,
     r#"
 from typing import Generic, Literal, LiteralString, NewType, TypeVar, assert_type
@@ -2195,27 +2195,27 @@ class User:
 
 def test_newtype(x: bytes | None, values: set[ObjectId]) -> None:
     if x in values:
-        assert_type(x, bytes | None)
+        assert_type(x, bytes)
 
 def test_builtin_subclass(x: int | None, values: set[GenericId[User]]) -> None:
     if x in values:
-        assert_type(x, int | None)
+        assert_type(x, int)
 
 def test_numeric(x: float | None, values: set[int]) -> None:
     if x in values:
-        assert_type(x, float | None)
+        assert_type(x, float)
 
 def test_bool(x: bool | None, values: set[int]) -> None:
     if x in values:
-        assert_type(x, bool | None)
+        assert_type(x, bool)
 
 def test_literal(x: str | None, values: set[Literal["x"]]) -> None:
     if x in values:
-        assert_type(x, str | None)
+        assert_type(x, Literal["x"])
 
 def test_literal_string(x: str | None, values: set[LiteralString]) -> None:
     if x in values:
-        assert_type(x, str | None)
+        assert_type(x, LiteralString)
 "#,
 );
 
@@ -2574,8 +2574,8 @@ def qualified_builtins_frozenset(x: int | str) -> None:
 def non_literal_arg(x: int | str) -> None:
     y = [1, 2]
     if x in frozenset(y):
-        # Can't statically enumerate elements, no narrowing.
-        assert_type(x, int | str)
+        # frozenset(y) still has type frozenset[int], so x narrows to int.
+        assert_type(x, int)
 "#,
 );
 


### PR DESCRIPTION
named containers fell through membership narrowing since only inline literals used their element type. this narrows list, set, frozenset, and deque through the same equality-aware path as ==, so it doesn't over-narrow stuff like float against set[int]. abstract containers and custom `__contains__` stay untouched since they don't have to follow equality.

fixes #4469 

# Test Plan

`python3 test.py`
