### PR TITLE
Fix internal error on TypeForm attribute access (fixes #4747)

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -2694,9 +2694,11 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             Type::Annotated(_, _) => acc.push(AttributeBase1::ClassInstance(
                 self.stdlib.generic_alias().clone(),
             )),
+            Type::TypeForm(_) => {
+                acc.push(AttributeBase1::ClassInstance(self.stdlib.object().clone()))
+            }
             // TODO: check to see which ones should have class representations
             Type::SpecialForm(_)
-            | Type::TypeForm(_)
             | Type::TypeLevelDslCall(_)
             | Type::Unpack(_)
             | Type::Concatenate(_, _)

--- a/pyrefly/lib/test/typeform.rs
+++ b/pyrefly/lib/test/typeform.rs
@@ -221,3 +221,29 @@ X: TypeForm[int] = int
 x: X = 0  # E: Expected a type form, got instance of `TypeForm[int]`
     "#,
 );
+
+testcase!(
+    test_typeform_attribute_access,
+    r#"
+import typing
+from typing import TypeVar
+from typing_extensions import TypeForm
+
+T = TypeVar("T")
+
+def field_names(tp: TypeForm[T]):
+    if typing.is_typeddict(tp):
+        return tp.__annotations__.keys()
+    return ()
+    "#,
+);
+
+testcase!(
+    test_typeform_attribute_access_unknown,
+    r#"
+from typing_extensions import TypeForm
+
+def f(tp: TypeForm[int]):
+    tp.not_a_real_attribute  # E: Object of class `object` has no attribute `not_a_real_attribute`
+    "#,
+);


### PR DESCRIPTION
accessing any attribute on a `TypeForm[T]` crashed pyrefly with an internal error since it had no attribute base defined. the fix falls back to object's attribute base and now resolves normally or gives an ordinary "no attribute" error instead of crashing

Fixes #4747

# Test Plan

`python3 test.py`
