### PR TITLE
set debug level to 2 in the dev profile to allow inspecting variable values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ codegen-units = 1
 strip = "debuginfo"
 
 [profile.dev]
-debug = 1
+debug = 2
 
 [profile.bench]
 lto = false


### PR DESCRIPTION
# Summary

@connernilsen this is what i was talking about the other day. changing this allows the debugger to see the values of variables at runtime

https://doc.rust-lang.org/cargo/reference/profiles.html#debug

# Test Plan

clicked the "Debug" button on a test and hovered over a variable (tested with the [CodeLLDB](https://github.com/vadimcn/codelldb) extension):

<img width="730" height="361" alt="image" src="https://github.com/user-attachments/assets/4a452f99-4643-4414-8271-9bd80ddb2965" />