### PR TITLE
add clippy and rustfmt components to `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "stable"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
# Summary

prevents this error when running `./test.py --fmt` or `./test.py --lint`:

```console
$ ./test.py --fmt
Running formatting...
error: 'cargo-fmt' is not installed for the toolchain 'stable-x86_64-unknown-linux-gnu'
To install, run `rustup component add rustfmt`
```

# Test Plan

```
$ ./test.py --fmt
Running formatting...
info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
info: latest update on 2026-09-03, rust version 1.98.1 (48a229cea 2026-09-01)
info: downloading component 'clippy'
info: downloading component 'rustfmt'
info: installing component 'clippy'
info: installing component 'rustfmt'
```
