### PR TITLE
enable the `dbg_macro` clippy rule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,9 @@ resolver = "2"
 [workspace.package]
 license = "MIT"
 repository = "https://github.com/facebook/pyrefly"
+
+[workspace.lints.clippy]
+dbg_macro = "deny"
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(fbcode_build)"]}

--- a/crates/pyrefly_bench_harness/Cargo.toml
+++ b/crates/pyrefly_bench_harness/Cargo.toml
@@ -12,3 +12,6 @@ license = "MIT"
 pyrefly = { path = "../../pyrefly" }
 pyrefly_config = { path = "../pyrefly_config" }
 pyrefly_util = { path = "../pyrefly_util" }
+
+[lints]
+workspace = true

--- a/crates/pyrefly_build/Cargo.toml
+++ b/crates/pyrefly_build/Cargo.toml
@@ -29,5 +29,5 @@ pretty_assertions = { version = "1.4.1", features = ["alloc"], default-features 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 which = "8.0.5"
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(fbcode_build)"]}
+[lints]
+workspace = true

--- a/crates/pyrefly_bundled/Cargo.toml
+++ b/crates/pyrefly_bundled/Cargo.toml
@@ -19,3 +19,6 @@ zstd = "0.13.3"
 sha2 = "0.10.6"
 tar = "0.4.46"
 zstd = { version = "0.13.3", features = ["experimental", "zstdmt"] }
+
+[lints]
+workspace = true

--- a/crates/pyrefly_config/Cargo.toml
+++ b/crates/pyrefly_config/Cargo.toml
@@ -42,3 +42,6 @@ tempfile = "3.27.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 uv-pep440 = "0.0.76"
 which = "8.0.5"
+
+[lints]
+workspace = true

--- a/crates/pyrefly_derive/Cargo.toml
+++ b/crates/pyrefly_derive/Cargo.toml
@@ -17,3 +17,6 @@ proc-macro = true
 proc-macro2 = { version = "1.0.107", features = ["span-locations"] }
 quote = "1.0.47"
 syn = { version = "3", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+
+[lints]
+workspace = true

--- a/crates/pyrefly_glean_schema/Cargo.toml
+++ b/crates/pyrefly_glean_schema/Cargo.toml
@@ -12,3 +12,6 @@ license = "MIT"
 serde = { version = "1.0.229", features = ["derive", "rc"] }
 serde_json = { version = "1.0.151", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_repr = "0.1.21"
+
+[lints]
+workspace = true

--- a/crates/pyrefly_graph/Cargo.toml
+++ b/crates/pyrefly_graph/Cargo.toml
@@ -12,3 +12,6 @@ license = "MIT"
 dupe = "0.9.1"
 pyrefly_util = { path = "../pyrefly_util" }
 starlark_map = "0.14.2"
+
+[lints]
+workspace = true

--- a/crates/pyrefly_lsp_test/Cargo.toml
+++ b/crates/pyrefly_lsp_test/Cargo.toml
@@ -18,3 +18,6 @@ pretty_assertions = { version = "1.4.1", features = ["alloc"], default-features 
 pyrefly = { path = "../../pyrefly" }
 pyrefly_util = { path = "../pyrefly_util" }
 serde_json = { version = "1.0.151", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
+
+[lints]
+workspace = true

--- a/crates/pyrefly_python/Cargo.toml
+++ b/crates/pyrefly_python/Cargo.toml
@@ -34,3 +34,6 @@ vec1 = { version = "1.12.1", features = ["serde"] }
 [dev-dependencies]
 serde_json = { version = "1.0.151", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 toml = { version = "1.1.4", features = ["preserve_order"] }
+
+[lints]
+workspace = true

--- a/crates/pyrefly_types/Cargo.toml
+++ b/crates/pyrefly_types/Cargo.toml
@@ -23,3 +23,6 @@ ruff_text_size = "0.0.11"
 starlark_map = "0.14.2"
 static_assertions = "1.1.0"
 vec1 = { version = "1.12.1", features = ["serde"] }
+
+[lints]
+workspace = true

--- a/crates/pyrefly_util/Cargo.toml
+++ b/crates/pyrefly_util/Cargo.toml
@@ -56,5 +56,5 @@ tempfile = "3.27.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 watchman_client = "0.9"
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(fbcode_build)"]}
+[lints]
+workspace = true

--- a/crates/tsp_types/Cargo.toml
+++ b/crates/tsp_types/Cargo.toml
@@ -13,3 +13,6 @@ lsp-server = "0.10.0"
 serde = { version = "1.0.229", features = ["derive", "rc"] }
 serde_json = { version = "1.0.151", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_repr = "0.1.21"
+
+[lints]
+workspace = true

--- a/pyrefly/Cargo.toml
+++ b/pyrefly/Cargo.toml
@@ -106,5 +106,5 @@ mimalloc = { version = "0.1.52", default-features = false }
 debug-stack-overflow = ["dep:backtrace-on-stack-overflow"]
 default = []
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(fbcode_build)"]}
+[lints]
+workspace = true


### PR DESCRIPTION
# Summary

after @connernilsen pointed out that i accidentally committed a `dbg!` macro, i wondered if there was a clippy rule to prevent such mistakes (see https://github.com/facebook/pyrefly/pull/4729#discussion_r3888493732). turns out there is!

note that enabling a rule globally seems to be nowhere near as straightforward as it is in most other linters, so i had to make some other changes:

- i had to set `workspace = true` in each package (https://github.com/rust-lang/rust-clippy/issues/16541#issuecomment-3881220162)
- i also had to move the existing `unexpected_cfgs` config out of the individual packages into the global config, to workaround https://github.com/rust-lang/cargo/issues/13157 

# Test Plan

intentionally inserted a `dbg!` macro and ran `cargo clippy`:

```
error: the `dbg!` macro is intended as a debugging tool
  --> crates/pyrefly_config/src/migration/error_codes.rs:72:9
   |
72 |         dbg!(&pyright_cfg.type_checking_mode);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#dbg_macro
   = note: requested on the command line with `-D clippy::dbg-macro`
help: remove the invocation before committing it to a version control system
   |
72 -         dbg!(&pyright_cfg.type_checking_mode);
72 +         &pyright_cfg.type_checking_mode;
   |

error: could not compile `pyrefly_config` (lib) due to 1 previous error
```