### PR TITLE
fix inspect.isclass does not make a TypeForm valid for isinstance #4822

### DIFF
--- a/pyrefly/lib/alt/class/classdef.rs
+++ b/pyrefly/lib/alt/class/classdef.rs
@@ -189,6 +189,13 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             Type::TypeAlias(ta) => {
                 self.unwrap_class_object_silently(&self.get_type_alias(ta).as_value(self.stdlib))
             }
+            Type::Intersect(intersection) => {
+                // A class-object member proves that the intersection is a class object.
+                intersection
+                    .0
+                    .iter()
+                    .find_map(|member| self.unwrap_class_object_silently(member))
+            }
             // Note that for the purposes of type narrowing, we always unwrap Type::Type(Type::ClassType),
             // but it's not always a valid argument to isinstance/issubclass. expr_infer separately checks
             // whether the argument is valid.

--- a/pyrefly/lib/test/narrow.rs
+++ b/pyrefly/lib/test/narrow.rs
@@ -4103,6 +4103,22 @@ def b():
 );
 
 testcase!(
+    test_isclass_typeform_class_info,
+    r#"
+from inspect import isclass
+from typing import TypeVar
+from typing_extensions import TypeForm
+
+T = TypeVar("T")
+
+def matches(value: object, hint: TypeForm[T]) -> bool:
+    if isclass(hint):
+        return isinstance(value, hint)
+    return False
+"#,
+);
+
+testcase!(
     test_isinstance_type_then_issubclass_typeform,
     r#"
 from typing import reveal_type


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4822

TypeForm values narrowed by inspect.isclass now work with isinstance.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test