### PR TITLE
Diagnose Polars `join` suffix collisions and defer selector/pattern keys

### DIFF
--- a/crates/pyrefly_config/src/error_kind.rs
+++ b/crates/pyrefly_config/src/error_kind.rs
@@ -167,7 +167,7 @@ pub enum ErrorKind {
     DirectAbstractBaseInstantiation,
     /// Division, floor division, or modulo by a literal zero value.
     DivisionByZero,
-    /// A Polars projection produces more than one column with the same name.
+    /// A Polars operation produces more than one column with the same name.
     DuplicateColumn,
     /// A function has an empty body despite declaring a non-None return type.
     EmptyBody,

--- a/pyrefly/lib/alt/polars_specials.rs
+++ b/pyrefly/lib/alt/polars_specials.rs
@@ -686,12 +686,20 @@ fn resolve_column(
     }
 }
 
+/// Returns the first repeated column name.
+fn first_duplicate_column(columns: &[(Name, PolarsDType)]) -> Option<&Name> {
+    let mut seen = SmallSet::with_capacity(columns.len());
+    columns
+        .iter()
+        .find_map(|(name, _)| (!seen.insert(name)).then_some(name))
+}
+
 fn report_duplicate_column(name: &Name, range: TextRange, errors: &ErrorCollector) {
     errors
         .error_builder(
             range,
             ErrorKind::DuplicateColumn,
-            format!("Projection produces duplicate column `{name}`"),
+            format!("Operation produces duplicate column `{name}`"),
         )
         .emit();
 }
@@ -936,6 +944,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         args: &Arguments,
         errors: &ErrorCollector,
     ) -> Option<Type> {
+        // Pandas DataFrames have methods with some of the same names, but different semantics.
         if matches!(base, Type::DataFrame(schema) if schema.kind == DataFrameKind::Pandas) {
             return None;
         }
@@ -1203,8 +1212,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         for ((name, _), replacement) in columns.iter_mut().zip(new_columns) {
             *name = replacement;
         }
-        let mut seen = SmallSet::new();
-        !columns.iter().any(|(name, _)| !seen.insert(name.clone()))
+        first_duplicate_column(columns).is_none()
     }
 
     fn infer_polars_csv_schema(
@@ -2888,20 +2896,6 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         Some(dataframe_type_with_columns(schema, columns))
     }
 
-    fn join_key_names(&self, on: &Expr) -> Option<Vec<(Name, TextRange)>> {
-        if let Some(name) = self.polars_column_name(on) {
-            return Some(vec![(name, on.range())]);
-        }
-        let elts = match on {
-            Expr::List(list) => &list.elts,
-            Expr::Tuple(tuple) => &tuple.elts,
-            _ => return None,
-        };
-        elts.iter()
-            .map(|elt| self.polars_column_name(elt).map(|name| (name, elt.range())))
-            .collect()
-    }
-
     /// Merge schemas for joins with same-name keys and default coalescing.
     fn polars_join(&self, base: &Type, args: &Arguments, errors: &ErrorCollector) -> Option<Type> {
         let Type::DataFrame(schema) = base else {
@@ -2930,7 +2924,15 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         let keys = match (how, on) {
             (JoinHow::Cross, None) => Vec::new(),
             (JoinHow::Cross, Some(_)) | (_, None) => return None,
-            (_, Some(on)) => self.join_key_names(on)?,
+            // A key must name one column of each frame to be resolved against their schemas, so a
+            // selector or pattern, which names a set, is as opaque here as a dynamic string.
+            (_, Some(on)) => positional_elements(on)
+                .iter()
+                .map(|element| match self.polars_column_arg(element) {
+                    ColumnArg::Named(name) => Some((name, element.range())),
+                    ColumnArg::Opaque | ColumnArg::Expr => None,
+                })
+                .collect::<Option<Vec<_>>>()?,
         };
         let Type::DataFrame(other) = self.expr_infer(other_expr, &self.error_swallower()) else {
             return None;
@@ -2998,10 +3000,9 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             };
             columns.push((out, ty));
         }
-        // A suffixed name that already exists is a runtime `DuplicateError`, so fall back rather than
-        // emit a schema with a duplicate column.
-        let mut seen = SmallSet::new();
-        if columns.iter().any(|(name, _)| !seen.insert(name.clone())) {
+        // Polars raises `DuplicateError` when suffixing creates a repeated output name.
+        if let Some(name) = first_duplicate_column(&columns) {
+            report_duplicate_column(name, other_expr.range(), errors);
             return None;
         }
         self.expr_infer(other_expr, errors);
@@ -3037,8 +3038,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         }
         let mut columns = schema.columns.clone();
         columns.extend(other.columns.iter().cloned());
-        let mut seen = SmallSet::new();
-        if columns.iter().any(|(name, _)| !seen.insert(name.clone())) {
+        if first_duplicate_column(&columns).is_some() {
             return None;
         }
         self.expr_infer(other_expr, errors);

--- a/pyrefly/lib/test/polars/dataframe.rs
+++ b/pyrefly/lib/test/polars/dataframe.rs
@@ -2113,7 +2113,7 @@ testcase!(
 import polars as pl
 from typing import reveal_type
 df = pl.DataFrame({"a": [1], "b": ["x"]})
-reveal_type(df[["a", "a"]])  # E: Projection produces duplicate column `a` # E: revealed type: DataFrame
+reveal_type(df[["a", "a"]])  # E: Operation produces duplicate column `a` # E: revealed type: DataFrame
 "#,
 );
 
@@ -2279,7 +2279,7 @@ testcase!(
 import polars as pl
 from typing import reveal_type
 df = pl.DataFrame({"a": [1], "b": ["x"]})
-reveal_type(df.select("a", "a"))  # E: Projection produces duplicate column `a` # E: revealed type: DataFrame
+reveal_type(df.select("a", "a"))  # E: Operation produces duplicate column `a` # E: revealed type: DataFrame
 "#,
 );
 
@@ -2302,7 +2302,7 @@ from typing import reveal_type
 df = pl.DataFrame({"a": [1]})
 result = df.select(
     1,
-    2,  # E: Projection produces duplicate column `literal`
+    2,  # E: Operation produces duplicate column `literal`
     "d",  # E: Column `d` is not in the DataFrame schema
 )
 reveal_type(result)  # E: revealed type: DataFrame
@@ -2334,8 +2334,8 @@ import polars as pl
 df = pl.DataFrame({"a": [1]})
 df.select(
     1,
-    2,  # E: Projection produces duplicate column `literal`
-    3,  # E: Projection produces duplicate column `literal`
+    2,  # E: Operation produces duplicate column `literal`
+    3,  # E: Operation produces duplicate column `literal`
 )
 "#,
 );
@@ -2351,7 +2351,7 @@ expr = pl.col("a")
 result = df.select(
     expr,
     1,
-    2,  # E: Projection produces duplicate column `literal`
+    2,  # E: Operation produces duplicate column `literal`
     "missing",  # E: Column `missing` is not in the DataFrame schema
 )
 reveal_type(result)  # E: revealed type: DataFrame
@@ -2371,7 +2371,7 @@ td: Cols = {"a": [1]}
 df = pl.DataFrame(td)
 result = df.select(
     1,
-    2,  # E: Projection produces duplicate column `literal`
+    2,  # E: Operation produces duplicate column `literal`
     "missing",
 )
 reveal_type(result)  # E: revealed type: DataFrame
@@ -2752,7 +2752,7 @@ testcase!(
 import polars as pl
 from typing import reveal_type
 df = pl.DataFrame({"a": [1], "b": ["x"]})
-reveal_type(df.select(pl.col("a"), pl.col("b").alias("a")))  # E: Projection produces duplicate column `a` # E: revealed type: DataFrame
+reveal_type(df.select(pl.col("a"), pl.col("b").alias("a")))  # E: Operation produces duplicate column `a` # E: revealed type: DataFrame
 "#,
 );
 
@@ -4445,16 +4445,41 @@ reveal_type(d1.join(d2, on="k", how="full"))  # E: revealed type: DataFrame[k: I
 );
 
 testcase!(
-    test_join_suffix_collision_falls_back,
+    test_join_suffix_collision_reported,
     env_with_polars_stubs(),
     r#"
 import polars as pl
 from typing import reveal_type
-# The right `a` would become `a_right`, which already exists on the left, a runtime DuplicateError,
-# so we fall back rather than emit a schema with a duplicate column.
+# The right `a` becomes `a_right`, which already exists
+# on the left, so Polars raises a DuplicateError.
 d1 = pl.DataFrame(schema={"k": pl.Int64, "a": pl.Int64, "a_right": pl.Int64})
 d2 = pl.DataFrame(schema={"k": pl.Int64, "a": pl.Int64})
-reveal_type(d1.join(d2, on="k", how="inner"))  # E: revealed type: DataFrame
+reveal_type(d1.join(d2, on="k", how="inner"))  # E: Operation produces duplicate column `a_right` # E: revealed type: DataFrame
+"#,
+);
+
+testcase!(
+    test_join_rhs_internal_suffix_collision_reported,
+    env_with_polars_stubs(),
+    r#"
+import polars as pl
+from typing import assert_type
+d1 = pl.DataFrame(schema={"k": pl.Int64, "a": pl.Int64})
+d2 = pl.DataFrame(schema={"k": pl.Int64, "a": pl.Int64, "a_right": pl.Int64})
+assert_type(d1.join(d2, on="k", how="inner"), pl.DataFrame)  # E: Operation produces duplicate column `a_right`
+"#,
+);
+
+testcase!(
+    test_join_semi_anti_accept_colliding_schemas,
+    env_with_polars_stubs(),
+    r#"
+import polars as pl
+from typing import reveal_type
+d1 = pl.DataFrame(schema={"k": pl.Int64, "a": pl.Int64, "a_right": pl.Int64})
+d2 = pl.DataFrame(schema={"k": pl.Int64, "a": pl.Int64})
+reveal_type(d1.join(d2, on="k", how="semi"))  # E: revealed type: DataFrame[k: Int64, a: Int64, a_right: Int64]
+reveal_type(d1.join(d2, on="k", how="anti"))  # E: revealed type: DataFrame[k: Int64, a: Int64, a_right: Int64]
 "#,
 );
 
@@ -4584,6 +4609,22 @@ from typing import reveal_type
 d1 = pl.DataFrame(schema={"k": pl.Int64, "a": pl.Int64})
 d2 = pl.DataFrame(schema={"k": pl.Int64, "a": pl.Int64})
 reveal_type(d1.join(d2, on="k", how="inner", suffix="_r"))  # E: revealed type: DataFrame
+"#,
+);
+
+// A selector or pattern names a set of columns rather than one, so it cannot be matched against
+// either schema. Without this the names would be looked up literally and reported as missing.
+testcase!(
+    test_join_selector_keys_fall_back,
+    env_with_polars_stubs(),
+    r#"
+import polars as pl
+from typing import reveal_type
+left = pl.DataFrame({"id": [1], "a": [2]})
+right = pl.DataFrame({"id": [1], "b": [3]})
+reveal_type(left.join(right, on="*"))  # E: revealed type: DataFrame
+reveal_type(left.join(right, on="^id$"))  # E: revealed type: DataFrame
+reveal_type(left.join(right, on=["id", "*"]))  # E: revealed type: DataFrame
 "#,
 );
 
@@ -5839,7 +5880,7 @@ from typing import reveal_type
 df = pl.DataFrame({"a": [1], "b": ["x"]})
 result = df.lazy().select(
     "a",
-    "a",  # E: Projection produces duplicate column `a`
+    "a",  # E: Operation produces duplicate column `a`
 )
 reveal_type(result)  # E: revealed type: LazyFrame
 "#,

--- a/website/docs/dataframes.mdx
+++ b/website/docs/dataframes.mdx
@@ -475,6 +475,10 @@ Pyrefly models common ways to combine complete Polars schemas.
 - `join` supports same-name `on=` keys and the `semi`, `anti`, `inner`, `left`,
   `right`, `full`, and `cross` modes with default suffix and coalesce behavior.
 
+A `join` whose suffixed name collides with a column that already exists is a
+`duplicate-column` error. A selector, wildcard, or regex in `on` names a set of
+columns rather than one, so the join is left unmodeled.
+
 Separate `left_on` and `right_on` keys, custom suffixes, explicit coalesce
 settings, other concat modes, mismatched concat schemas, and `hstack` with a
 list of Series are not modeled.
@@ -582,9 +586,9 @@ configuration.
   the first non-null value.
 - [`column-schema-mismatch`](../error-kinds/#column-schema-mismatch) reports
   statically known data names that do not match declared schema names.
-- [`duplicate-column`](../error-kinds/#duplicate-column) reports a projection
-  that would produce two columns with the same name, which Polars rejects when
-  an eager projection runs or a lazy projection is collected.
+- [`duplicate-column`](../error-kinds/#duplicate-column) reports an operation
+  that would produce two columns with the same name, such as a projection with
+  duplicate output names or a join suffix collision.
 
 ---
 

--- a/website/docs/error-kinds.mdx
+++ b/website/docs/error-kinds.mdx
@@ -563,7 +563,7 @@ z = 10 % 0   # error: division by zero
 
 ## duplicate-column
 
-A Polars projection produces more than one column with the same name. Polars rejects duplicate output names when an eager projection runs or a lazy projection is collected.
+A Polars operation produces more than one column with the same name. Pyrefly reports this for projections with duplicate output names and join suffix collisions that Polars rejects at execution.
 
 ```python
 import polars as pl


### PR DESCRIPTION
# Summary

### Problem

* Polars `join` ops can produce duplicate column names when a disambiguating suffix is applied; for example, a right-hand `colx` becoming `colx_<suffix>` when that suffixed name already exists. `pyrefly` would miss this (it raises `DuplicateError` at runtime).

* Wildcard and regex join keys (such as `"*"` and `"^id$"`) get interpreted as literal column names, producing incorrect `unknown-column` diagnostics.

### Solution

* Detect suffix collisions in `join` output schemas and report `duplicate-column`.

* Use the existing column-argument classification to leave wildcard and regex `on` keys unresolved (note: I'll take a look at adding proper `selector`[^1] support to the Polars "on" parameter - not unreasonable to think that should work 🤔).

* Share `duplicate-name` detection between `join` ops, `hstack`, and CSV renaming.

## Also

* Generalised the diagnostic wording and documentation to cover both projections _and_ joins (eg: prefer use of "operation" over "projection").

# Test Plan

* All existing Polars tests pass (`cargo test --quiet test::polars`).
* Added new coverage for right-hand suffix collisions, valid `semi`/`anti` joins with otherwise-colliding schemas, and wildcard/regex key fallback.

[^1]: [Polars Selectors](https://docs.pola.rs/api/python/stable/reference/selectors.html)