### PR TITLE
Use argument context for Polars column completions

### DIFF
--- a/pyrefly/lib/alt/polars_specials.rs
+++ b/pyrefly/lib/alt/polars_specials.rs
@@ -138,14 +138,6 @@ fn is_pandas_dataframe(cls: &Class) -> bool {
     RuntimeClass::PandasDataFrame.matches(cls)
 }
 
-/// Methods whose arguments may contain column references.
-pub fn is_dataframe_column_method(method: &str) -> bool {
-    matches!(
-        method,
-        "select" | "drop" | "with_columns" | "filter" | "sort" | "group_by" | "groupby"
-    )
-}
-
 /// Apply a binding-time mutation to a tracked frame schema.
 pub fn polars_degrade_for_mutation(
     ty: &Type,
@@ -337,6 +329,15 @@ impl PolarsFunction {
             Some(CalleeKind::Function(FunctionKind::Def(id))) => Some(Self::from_id(&id)),
             _ => None,
         }
+    }
+}
+
+/// For a resolved `polars.col` or `polars.lit`, whether strings name columns rather than values.
+pub(crate) fn polars_function_treats_strings_as_columns(callee: &Type) -> Option<bool> {
+    match PolarsFunction::from_callee(callee)? {
+        PolarsFunction::Col => Some(true),
+        PolarsFunction::Lit => Some(false),
+        _ => None,
     }
 }
 

--- a/pyrefly/lib/state/lsp/dict_completions.rs
+++ b/pyrefly/lib/state/lsp/dict_completions.rs
@@ -13,6 +13,7 @@ use lsp_types::CompletionItemKind;
 use pyrefly_build::handle::Handle;
 use pyrefly_python::ast::Ast;
 use pyrefly_python::short_identifier::ShortIdentifier;
+use pyrefly_types::data_frame::DataFrameKind;
 use pyrefly_types::facet::FacetKind;
 use ruff_python_ast::AnyNodeRef;
 use ruff_python_ast::Expr;
@@ -26,7 +27,7 @@ use ruff_text_size::TextRange;
 use ruff_text_size::TextSize;
 
 use crate::alt::answers_solver::AnswersSolver;
-use crate::alt::polars_specials::is_dataframe_column_method;
+use crate::alt::polars_specials::polars_function_treats_strings_as_columns;
 use crate::binding::binding::Key;
 use crate::binding::narrow::int_from_slice;
 use crate::lsp::wasm::completion::RankedCompletion;
@@ -58,6 +59,13 @@ enum DictKeyLiteralContext {
     /// Example: `cfg[|]`. Completions insert a quoted key since there is no
     /// surrounding string.
     BareSubscript { base_expr: Expr },
+}
+
+#[derive(Clone, Copy)]
+enum ArgumentSlot<'a> {
+    Positional,
+    Keyword(&'a str),
+    UnpackedKeyword,
 }
 
 impl DictKeyLiteralContext {
@@ -267,17 +275,68 @@ impl<'a> Transaction<'a> {
             .collect()
     }
 
-    fn type_is_dataframe(ty: &Type) -> bool {
+    /// `None` means no union member is a DataFrame; `Some(false)` means a DataFrame is involved but
+    /// this slot is not eligible, so an enclosing DataFrame call must not claim the literal.
+    fn dataframe_slot_permitted(
+        ty: &Type,
+        method: &str,
+        slot: ArgumentSlot<'_>,
+        inside_column_helper: bool,
+    ) -> Option<bool> {
         match ty {
-            Type::DataFrame(_) => true,
+            Type::DataFrame(schema) => Some(match (schema.kind, method, slot) {
+                (DataFrameKind::Polars, "select" | "with_columns", _) => true,
+                (DataFrameKind::Polars, "drop" | "filter", ArgumentSlot::Positional) => true,
+                (
+                    DataFrameKind::Polars,
+                    "filter",
+                    ArgumentSlot::Keyword(_) | ArgumentSlot::UnpackedKeyword,
+                ) => inside_column_helper,
+                (
+                    DataFrameKind::Polars,
+                    "sort",
+                    ArgumentSlot::Positional | ArgumentSlot::Keyword("by"),
+                ) => true,
+                (DataFrameKind::Polars, "group_by" | "groupby", ArgumentSlot::Positional) => true,
+                (DataFrameKind::Polars, "group_by" | "groupby", ArgumentSlot::Keyword(name)) => {
+                    name != "maintain_order"
+                }
+                (
+                    DataFrameKind::Pandas,
+                    "drop",
+                    ArgumentSlot::Positional | ArgumentSlot::Keyword("columns"),
+                )
+                | (
+                    DataFrameKind::Pandas,
+                    "filter",
+                    ArgumentSlot::Positional | ArgumentSlot::Keyword("items"),
+                )
+                | (
+                    DataFrameKind::Pandas,
+                    "groupby",
+                    ArgumentSlot::Positional | ArgumentSlot::Keyword("by"),
+                ) => true,
+                _ => false,
+            }),
             Type::Union(u) => {
                 let (first, rest) = u
                     .members
                     .split_first()
                     .expect("a union must contain at least one member");
-                Self::type_is_dataframe(first) && rest.iter().all(Self::type_is_dataframe)
+                let mut result =
+                    Self::dataframe_slot_permitted(first, method, slot, inside_column_helper);
+                for member in rest {
+                    let member_result =
+                        Self::dataframe_slot_permitted(member, method, slot, inside_column_helper);
+                    result = match (result, member_result) {
+                        (None, None) => None,
+                        (Some(left), Some(right)) => Some(left && right),
+                        _ => Some(false),
+                    };
+                }
+                result
             }
-            _ => false,
+            _ => None,
         }
     }
 
@@ -285,11 +344,6 @@ impl<'a> Transaction<'a> {
         self.get_type_trace(handle, expr.range())
             .map(|ty| Self::type_contains_typed_dict(&ty))
             .unwrap_or(false)
-    }
-
-    fn expr_has_dataframe_type(&self, handle: &Handle, expr: &Expr) -> bool {
-        self.get_type_trace(handle, expr.range())
-            .is_some_and(|ty| Self::type_is_dataframe(&ty))
     }
 
     /// Extracts typed dict access from `.get()` method calls.
@@ -426,35 +480,64 @@ impl<'a> Transaction<'a> {
             _ => None,
         })?;
         let literal_range = literal.range();
-        let mut best: Option<(TextSize, Expr)> = None;
+        let mut inside_column_helper = false;
 
         for node in nodes {
             let AnyNodeRef::ExprCall(call) = node else {
                 continue;
             };
-            if !(call.range().start() <= literal_range.start()
-                && literal_range.end() <= call.range().end())
+            let slot = if let Some(keyword) = call
+                .arguments
+                .keywords
+                .iter()
+                .find(|keyword| keyword.value.range().contains_range(literal_range))
             {
+                match &keyword.arg {
+                    Some(name) => ArgumentSlot::Keyword(name.id.as_str()),
+                    None => ArgumentSlot::UnpackedKeyword,
+                }
+            } else if call
+                .arguments
+                .args
+                .iter()
+                .any(|arg| arg.range().contains_range(literal_range))
+            {
+                ArgumentSlot::Positional
+            } else {
+                continue;
+            };
+            if let Some(treats_strings_as_columns) = self
+                .get_type_trace(handle, call.func.range())
+                .and_then(|ty| polars_function_treats_strings_as_columns(&ty))
+            {
+                if !treats_strings_as_columns && !inside_column_helper {
+                    return None;
+                }
+                inside_column_helper = true;
                 continue;
             }
             let Expr::Attribute(attr) = call.func.as_ref() else {
                 continue;
             };
-            if !is_dataframe_column_method(attr.attr.id.as_str())
-                || !self.expr_has_dataframe_type(handle, attr.value.as_ref())
-            {
+            let Some(permitted) = self
+                .get_type_trace(handle, attr.value.range())
+                .and_then(|ty| {
+                    Self::dataframe_slot_permitted(
+                        &ty,
+                        attr.attr.id.as_str(),
+                        slot,
+                        inside_column_helper,
+                    )
+                })
+            else {
                 continue;
-            }
-            let call_len = call.range().len();
-            if best
-                .as_ref()
-                .is_none_or(|(best_len, _)| call_len < *best_len)
-            {
-                best = Some((call_len, attr.value.as_ref().clone()));
-            }
+            };
+            // `locate_node` is innermost-first, so this DataFrame call owns the literal even when
+            // its argument slot does not accept a column.
+            return permitted.then(|| (attr.value.as_ref().clone(), literal));
         }
 
-        best.map(|(_, source_expr)| (source_expr, literal))
+        None
     }
 
     fn dict_literal_string_literal_at(
@@ -467,6 +550,13 @@ impl<'a> Transaction<'a> {
             let AnyNodeRef::ExprDict(dict) = node else {
                 continue;
             };
+            if dict
+                .items
+                .iter()
+                .any(|item| item.value.range().contains(position))
+            {
+                continue;
+            }
             let mut best_in_dict: Option<(u8, TextSize, ExprStringLiteral)> = None;
             for item in &dict.items {
                 let Some(key_expr) = item.key.as_ref() else {

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -174,12 +174,39 @@ fn dict_field_labels(txn: &Transaction<'_>, handle: &Handle, position: TextSize)
 fn polars_column_completion_labels(code: &str) -> Vec<String> {
     let mut env = TestEnv::new();
     env.add_with_path(
+        "polars.expr.expr",
+        "polars/expr/expr.pyi",
+        "class Expr: ...",
+    );
+    env.add_with_path(
+        "polars.functions.col",
+        "polars/functions/col.pyi",
+        r#"
+from polars.expr.expr import Expr
+class Col:
+    def __call__(self, *names: str) -> Expr: ...
+    def __getattr__(self, name: str) -> Expr: ...
+col: Col
+"#,
+    );
+    env.add_with_path(
+        "polars.functions.lit",
+        "polars/functions/lit.pyi",
+        r#"
+from polars.expr.expr import Expr
+def lit(value: object) -> Expr: ...
+"#,
+    );
+    env.add_with_path(
         "polars.dataframe.frame",
         "polars/dataframe/frame.pyi",
         r#"
 class DataFrame:
     def __init__(self, data: object = None) -> None: ...
-    def select(self, *exprs: object) -> "DataFrame": ...
+    def select(self, *exprs: object, **named_exprs: object) -> "DataFrame": ...
+    def with_columns(self, *exprs: object, **named_exprs: object) -> "DataFrame": ...
+    def filter(self, *predicates: object, **constraints: object) -> "DataFrame": ...
+    def sort(self, by: object, *more_by: object, descending: bool = False) -> "DataFrame": ...
     def write_csv(self, file: str) -> None: ...
 "#,
     );
@@ -187,8 +214,9 @@ class DataFrame:
         "polars",
         r#"
 from polars.dataframe.frame import DataFrame as DataFrame
-class Expr: ...
-def col(name: str) -> Expr: ...
+from polars.expr.expr import Expr as Expr
+from polars.functions.col import col as col
+from polars.functions.lit import lit as lit
 "#,
     );
     env.add("main", code);
@@ -207,6 +235,7 @@ fn pandas_column_completion_labels(code: &str) -> Vec<String> {
 class DataFrame:
     def __init__(self, data: object = None) -> None: ...
     def groupby(self, by: object) -> object: ...
+    def filter(self, items: object = None, axis: object = None) -> object: ...
 "#,
     );
     env.add(
@@ -602,6 +631,45 @@ df.select(pl.col(""))
 }
 
 #[test]
+fn dataframe_column_completion_from_aliased_column_helper() {
+    let code = r#"
+from polars import DataFrame, col as column
+df = DataFrame({"foo": [1], "bar": [2]})
+df.filter(foo=column(""))
+#                    ^
+"#;
+    assert_eq!(
+        polars_column_completion_labels(code),
+        vec!["bar".to_owned(), "foo".to_owned()]
+    );
+}
+
+#[test]
+fn dataframe_column_completion_uses_innermost_polars_helper() {
+    let column_code = r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+df.select(pl.lit(pl.col("")))
+#                       ^
+"#;
+    assert_eq!(
+        polars_column_completion_labels(column_code),
+        vec!["bar".to_owned(), "foo".to_owned()]
+    );
+
+    let literal_code = r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+df.select(pl.col(pl.lit("")))
+#                       ^
+"#;
+    assert_eq!(
+        polars_column_completion_labels(literal_code),
+        Vec::<String>::new()
+    );
+}
+
+#[test]
 fn pandas_column_completion_from_method_argument() {
     let code = r#"
 import pandas as pd
@@ -628,6 +696,121 @@ f(df, "")
 }
 
 #[test]
+fn dataframe_column_completion_from_sort_by_keyword() {
+    let code = r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+df.sort(by="")
+#            ^
+"#;
+    assert_eq!(
+        polars_column_completion_labels(code),
+        vec!["bar".to_owned(), "foo".to_owned()]
+    );
+}
+
+#[test]
+fn no_column_completion_from_sort_control_keyword() {
+    let code = r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+df.sort(by="foo", descending="")
+#                             ^
+"#;
+    assert_eq!(polars_column_completion_labels(code), Vec::<String>::new());
+}
+
+// A splat leaves the number of positional arguments unknown, but every positional parameter of
+// these methods names a column, so a literal after one is still a column position.
+#[test]
+fn dataframe_column_completion_after_positional_splat() {
+    let code = r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+keys: list[str] = []
+df.select(*keys, "")
+#                 ^
+"#;
+    assert_eq!(
+        polars_column_completion_labels(code),
+        vec!["bar".to_owned(), "foo".to_owned()]
+    );
+}
+
+// `filter(name=value)` reads the keyword as the column and a direct string value as data.
+#[test]
+fn no_column_completion_from_filter_keyword_value() {
+    let code = r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+df.filter(foo="")
+#              ^
+"#;
+    assert_eq!(polars_column_completion_labels(code), Vec::<String>::new());
+}
+
+#[test]
+fn dataframe_column_completion_from_named_expression_keyword() {
+    let code = r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+df.select(alias="")
+#               ^
+"#;
+    assert_eq!(
+        polars_column_completion_labels(code),
+        vec!["bar".to_owned(), "foo".to_owned()]
+    );
+}
+
+#[test]
+fn dataframe_column_completion_from_keyword_splat() {
+    for code in [
+        r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+df.select(**dict(alias=""))
+#                       ^
+"#,
+        r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+df.select(**{"alias": ""})
+#                      ^
+"#,
+        r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+df.select(**dict(alias=pl.col("")))
+#                              ^
+"#,
+        r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+df.select(**{"alias": pl.col("")})
+#                             ^
+"#,
+    ] {
+        assert_eq!(
+            polars_column_completion_labels(code),
+            vec!["bar".to_owned(), "foo".to_owned()]
+        );
+    }
+}
+
+#[test]
+fn named_expression_alias_key_does_not_complete_source_columns() {
+    let code = r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "bar": [2]})
+df.select(**{"": "bar"})
+#             ^
+"#;
+    let labels = polars_column_completion_labels(code);
+    assert!(!labels.iter().any(|label| label == "foo" || label == "bar"));
+}
+
+#[test]
 fn no_column_completion_from_non_column_dataframe_method() {
     let code = r#"
 import polars as pl
@@ -636,6 +819,44 @@ df.write_csv("")
 #             ^
 "#;
     assert_eq!(polars_column_completion_labels(code), Vec::<String>::new());
+}
+
+#[test]
+fn no_column_completion_falls_through_to_outer_dataframe_call() {
+    for code in [
+        r#"
+import polars as pl
+outer = pl.DataFrame({"outer_column": [1]})
+inner = pl.DataFrame({"inner_column": [1]})
+outer.select(inner.filter(constraint=""))
+#                                     ^
+"#,
+        r#"
+import polars as pl
+outer = pl.DataFrame({"outer_column": [1]})
+frame = pl.DataFrame({"inner_column": [1]})
+def f(cond: bool, unknown: object) -> None:
+    inner = frame if cond else unknown
+    outer.select(inner.filter(constraint=""))
+#                                         ^
+"#,
+    ] {
+        assert_eq!(polars_column_completion_labels(code), Vec::<String>::new());
+    }
+}
+
+#[test]
+fn pandas_column_completion_from_filter_items_keyword() {
+    let code = r#"
+import pandas as pd
+df = pd.DataFrame({"foo": [1], "bar": [2]})
+df.filter(items=[""])
+#                 ^
+"#;
+    assert_eq!(
+        pandas_column_completion_labels(code),
+        vec!["bar".to_owned(), "foo".to_owned()]
+    );
 }
 
 #[test]


### PR DESCRIPTION
# Summary

### Problem

* The method-wide completion rules could offer column names for strings that actually represent data, such as `df.filter(foo="")` or `df.select(pl.lit(""))`, and also for control arguments.

* Dictionary-key completion could also intercept column-name strings in unpacked expressions such as `df.select(**{"alias": ""})`.

### Solution

* Check argument context and dataframe kind when deciding whether to offer column completions. Recognise `col` and `lit` through their resolved callables, preserving the distinction between column references and literal values.

* Keep suggestions tied to the nearest dataframe call, and allow unpacked named-expression values to reach column completion (while retaining normal dict-key handling).

# Test Plan

* All existing unit tests pass.
* Multiple new unit tests added.