### PR TITLE
fix Concrete type not assignable to gradual type when TypeVarTuple is involved #4609

### DIFF
--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -16,6 +16,7 @@ use pyrefly_types::literal::Lit;
 use pyrefly_types::literal::LitStyle;
 use pyrefly_types::meta_shape_dsl::MetaShapeFunction;
 use pyrefly_types::meta_shape_dsl::ShapeTransform;
+use pyrefly_types::simplify::simplify_tuples;
 use pyrefly_types::tuple::Tuple;
 use pyrefly_types::typed_dict::ExtraItems;
 use pyrefly_types::types::TArgs;
@@ -1271,11 +1272,18 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             }
             let unpacked_args_ty = match middle.len() {
                 0 => self.heap.mk_concrete_tuple(prefix),
-                1 => self.heap.mk_unpacked_tuple(
-                    prefix,
-                    self.heap.mk_unbounded_tuple(middle.pop().unwrap()),
-                    suffix,
-                ),
+                1 => {
+                    // A TypeVarTuple element becomes `tuple[*Ts]`. Flatten that tuple into
+                    // the surrounding prefix and suffix before checking assignability.
+                    self.heap.mk_tuple(simplify_tuples(
+                        Tuple::unpacked(
+                            prefix,
+                            self.heap.mk_unbounded_tuple(middle.pop().unwrap()),
+                            suffix,
+                        ),
+                        self.heap,
+                    ))
+                }
                 _ => {
                     let unpacked_variadic_args_count = middle
                         .iter()

--- a/pyrefly/lib/test/type_var_tuple.rs
+++ b/pyrefly/lib/test/type_var_tuple.rs
@@ -222,6 +222,45 @@ def test[*Ts, T](f: Callable[[*Ts], T], t: tuple[*Ts], *args: *Ts):
 "#,
 );
 
+// https://github.com/facebook/pyrefly/issues/4609
+testcase!(
+    test_type_var_tuple_callable_gradual_fixed_params,
+    r#"
+from typing import Any, Callable
+
+class K[*Ts]:
+    func: Callable[[Any, *Ts], None]
+    suffix: Callable[[*Ts, Any], None]
+    both: Callable[[Any, *Ts, Any], None]
+
+def g[*Ts](x: int, *xs: *Ts):
+    K[*Ts]().func(x, *xs)
+    K[*Ts]().suffix(*xs, x)
+    K[*Ts]().both(x, *xs, x)
+"#,
+);
+
+testcase!(
+    test_type_var_tuple_callable_covariant_fixed_params,
+    r#"
+from typing import Callable
+
+class K[*Ts]:
+    prefix: Callable[[float, *Ts], None]
+    suffix: Callable[[*Ts, float], None]
+    both: Callable[[float, *Ts, float], None]
+
+def g[*Ts](x: int, y: str, *xs: *Ts):
+    k = K[*Ts]()
+    k.prefix(x, *xs)
+    k.suffix(*xs, x)
+    k.both(x, *xs, x)
+    k.prefix(y, *xs)  # E: Unpacked argument `tuple[str, *Ts]` is not assignable to varargs type `tuple[float, *Ts]`
+    k.suffix(*xs, y)  # E: Unpacked argument `tuple[*Ts, str]` is not assignable to varargs type `tuple[*Ts, float]`
+    k.both(x, *xs, y)  # E: Unpacked argument `tuple[int, *Ts, str]` is not assignable to varargs type `tuple[float, *Ts, float]`
+"#,
+);
+
 testcase!(
     test_type_var_tuple_callable_resolves_to_empty,
     r#"


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4609

removes an extra tuple wrapper around forwarded `*Ts` arguments before checking assignability.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test