### PR TITLE
fix Add autocompletion on polars col getattr #4836

### DIFF
--- a/pyrefly/lib/alt/polars_specials.rs
+++ b/pyrefly/lib/alt/polars_specials.rs
@@ -102,6 +102,11 @@ pub fn is_polars_series(cls: &Class) -> bool {
     RuntimeClass::PolarsSeries.matches(cls)
 }
 
+/// Identifies the callable object that also supports `pl.col.name` access.
+pub fn is_polars_col(cls: &Class) -> bool {
+    RuntimeClass::PolarsCol.matches(cls)
+}
+
 fn is_polars_expr(cls: &Class) -> bool {
     RuntimeClass::PolarsExpr.matches(cls)
 }
@@ -328,7 +333,7 @@ impl PolarsFunction {
 
     fn from_callee(callee: &Type) -> Option<Self> {
         if let Type::ClassType(cls) = callee
-            && RuntimeClass::PolarsCol.matches(cls.class_object())
+            && is_polars_col(cls.class_object())
         {
             return Some(Self::Col);
         }
@@ -2439,7 +2444,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         let Type::ClassType(base) = self.expr_infer(&attr.value, &self.error_swallower()) else {
             return None;
         };
-        (RuntimeClass::PolarsCol.matches(base.class_object()) && self.is_polars_expr_value(expr))
+        (is_polars_col(base.class_object()) && self.is_polars_expr_value(expr))
             .then(|| attr.attr.id.clone())
     }
 

--- a/pyrefly/lib/lsp/wasm/completion.rs
+++ b/pyrefly/lib/lsp/wasm/completion.rs
@@ -40,6 +40,7 @@ use ruff_text_size::TextSize;
 use starlark_map::small_set::SmallSet;
 
 use crate::alt::attr::AttrInfo;
+use crate::alt::polars_specials::is_polars_col;
 use crate::binding::binding::Binding;
 use crate::binding::binding::Key;
 use crate::export::exports::Export;
@@ -1157,6 +1158,29 @@ impl Transaction<'_> {
                 if let Some(answers) = self.get_answers(handle)
                     && let Some(base_type) = answers.get_type_trace(base_range)
                 {
+                    // Polars resolves `col.name` against the enclosing DataFrame operation.
+                    if let Type::ClassType(cls) = &base_type
+                        && is_polars_col(cls.class_object())
+                        && let Some(nodes) = covering_nodes.as_deref()
+                        && let Some(source) = self.dataframe_call_source(
+                            handle,
+                            nodes,
+                            TextRange::empty(position),
+                            true,
+                        )
+                        && let Some(ty) = self.get_type_trace(handle, source.range())
+                        && let Some(columns) = Self::collect_dataframe_columns(&ty)
+                    {
+                        for label in columns {
+                            if is_valid_identifier(&label) {
+                                result.push(RankedCompletion::new(CompletionItem {
+                                    label,
+                                    kind: Some(CompletionItemKind::FIELD),
+                                    ..Default::default()
+                                }));
+                            }
+                        }
+                    }
                     self.add_attribute_completions_for_type(
                         handle,
                         base_type,

--- a/pyrefly/lib/state/lsp/dict_completions.rs
+++ b/pyrefly/lib/state/lsp/dict_completions.rs
@@ -378,19 +378,19 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    /// Finds the argument containing the literal, resolving inline keyword mappings.
+    /// Finds the argument containing the expression, resolving inline keyword mappings.
     fn dataframe_call_argument_slot<'b>(
         &self,
         handle: &Handle,
         call: &'b ExprCall,
-        literal_range: TextRange,
+        range: TextRange,
     ) -> Option<ArgumentSlot<'b>> {
         let mut slot = None;
         let mut axis = None;
         for keyword in &call.arguments.keywords {
             let mut unpacked_slot = None;
             self.visit_keyword_entries(handle, keyword, |name, value| {
-                if value.range().contains_range(literal_range) {
+                if value.range().contains_range(range) {
                     unpacked_slot = Some(
                         name.map(ArgumentSlot::Keyword)
                             .unwrap_or(ArgumentSlot::UnpackedKeyword),
@@ -415,7 +415,7 @@ impl<'a> Transaction<'a> {
             call.arguments
                 .args
                 .iter()
-                .any(|arg| arg.range().contains_range(literal_range))
+                .any(|arg| arg.range().contains_range(range))
                 .then_some(ArgumentSlot::Positional)
         })?;
         if matches!(call.func.as_ref(), Expr::Attribute(attr) if attr.attr.id.as_str() == "drop")
@@ -568,14 +568,24 @@ impl<'a> Transaction<'a> {
             AnyNodeRef::ExprStringLiteral(literal) => Some((*literal).clone()),
             _ => None,
         })?;
-        let literal_range = literal.range();
-        let mut inside_column_helper = false;
+        let source_expr = self.dataframe_call_source(handle, &nodes, literal.range(), false)?;
+        Some((source_expr.clone(), literal))
+    }
 
+    /// Finds the nearest enclosing column operation and returns its DataFrame receiver.
+    /// `inside_column_helper` is true when completing an explicit column reference.
+    pub(crate) fn dataframe_call_source<'b>(
+        &self,
+        handle: &Handle,
+        nodes: &[AnyNodeRef<'b>],
+        range: TextRange,
+        mut inside_column_helper: bool,
+    ) -> Option<&'b Expr> {
         for node in nodes {
             let AnyNodeRef::ExprCall(call) = node else {
                 continue;
             };
-            let Some(slot) = self.dataframe_call_argument_slot(handle, call, literal_range) else {
+            let Some(slot) = self.dataframe_call_argument_slot(handle, call, range) else {
                 continue;
             };
             if let Some(treats_strings_as_columns) = self
@@ -604,9 +614,9 @@ impl<'a> Transaction<'a> {
             else {
                 continue;
             };
-            // `locate_node` is innermost-first, so this DataFrame call owns the literal even when
+            // `locate_node` is innermost-first, so this DataFrame call owns the expression even when
             // its argument slot does not accept a column.
-            return permitted.then(|| (attr.value.as_ref().clone(), literal));
+            return permitted.then_some(attr.value.as_ref());
         }
 
         None
@@ -803,7 +813,8 @@ impl<'a> Transaction<'a> {
         Self::add_literal_completions_from_type(&field_ty, completions, true);
     }
 
-    fn collect_dataframe_columns(ty: &Type) -> Option<BTreeSet<String>> {
+    /// Collects column names that are present in every member of a DataFrame union.
+    pub(crate) fn collect_dataframe_columns(ty: &Type) -> Option<BTreeSet<String>> {
         match ty {
             Type::DataFrame(schema) => Some(
                 schema

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -176,7 +176,10 @@ fn polars_column_completion_labels(code: &str) -> Vec<String> {
     env.add_with_path(
         "polars.expr.expr",
         "polars/expr/expr.pyi",
-        "class Expr: ...",
+        r#"
+class Expr:
+    def alias(self, name: str) -> "Expr": ...
+"#,
     );
     env.add_with_path(
         "polars.functions.col",
@@ -685,6 +688,105 @@ df.select(pl.col(pl.lit("")))
         polars_column_completion_labels(literal_code),
         Vec::<String>::new()
     );
+}
+
+#[test]
+fn polars_col_attribute_completion() {
+    for expression in [
+        "df.select(pl.col.|)",
+        "df.select(pl.col.|",
+        "df.select(pl.col.f|)",
+        "df.select(pl.col.f|.alias(\"renamed\"))",
+        "df.select(column.|)",
+        "df.with_columns(pl.col.|)",
+        "df.filter(pl.col.|)",
+        "df.filter(foo=pl.col.|)",
+        "df.group_by(**dict(alias=pl.col.|))",
+        "df.group_by(**{\"alias\": pl.col.|})",
+        "df.select(pl.lit(pl.col.|))",
+        "outer.select(df.select(pl.col.|))",
+    ] {
+        let cursor = expression.find('|').unwrap();
+        let expression = expression.replace('|', "");
+        let code = format!(
+            r#"
+import polars as pl
+from polars import col as column
+df = pl.DataFrame({{"foo": [1], "bar": [2]}})
+outer = pl.DataFrame({{"other": [3]}})
+{expression}
+#{:width$}^
+"#,
+            "",
+            width = cursor - 1,
+        );
+        assert_eq!(
+            polars_column_completion_labels(&code),
+            vec!["bar".to_owned(), "foo".to_owned()],
+            "{expression}",
+        );
+    }
+}
+
+#[test]
+fn polars_col_attribute_completion_valid_identifiers() {
+    let code = r#"
+import polars as pl
+df = pl.DataFrame({"foo": [1], "two words": [2], "class": [3], "match": [4], "123": [5]})
+df.select(pl.col.)
+#                ^
+"#;
+    assert_eq!(
+        polars_column_completion_labels(code),
+        vec!["foo".to_owned(), "match".to_owned()]
+    );
+}
+
+#[test]
+fn polars_col_attribute_completion_requires_context() {
+    for expression in [
+        "pl.col.|",
+        "df.write_csv(pl.col.|)",
+        "df.sort(\"foo\", descending=pl.col.|)",
+        "df.group_by(**dict(maintain_order=pl.col.|))",
+        "df.group_by(**{\"maintain_order\": pl.col.|})",
+        "df.select(df.write_csv(pl.col.|))",
+        "df.select(unrelated.|)",
+        "df.select(pl.col(\"foo\").|)",
+        "unknown.select(pl.col.|)",
+    ] {
+        let cursor = expression.find('|').unwrap();
+        let expression = expression.replace('|', "");
+        let code = format!(
+            r#"
+import polars as pl
+df = pl.DataFrame({{"foo": [1], "bar": [2]}})
+class Col:
+    def __getattr__(self, name: str) -> object: ...
+unrelated = Col()
+unknown: pl.DataFrame
+{expression}
+#{:width$}^
+"#,
+            "",
+            width = cursor - 1,
+        );
+        assert_eq!(polars_column_completion_labels(&code), Vec::<String>::new());
+    }
+}
+
+#[test]
+fn polars_col_attribute_completion_intersects_union_columns() {
+    let code = r#"
+import polars as pl
+def f(cond: bool) -> None:
+    a = pl.DataFrame({"id": [1], "x": [1]})
+    b = pl.DataFrame({"id": [1], "y": [1]})
+    df = a if cond else b
+    df.select(pl.col.)
+#                    ^
+"#;
+    assert_eq!(polars_column_completion_labels(code), vec!["id".to_owned()]);
 }
 
 #[test]


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4836

`pl.col.` now suggests columns from the enclosing DataFrame operation, including imported aliases and partial names.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test