### PR TITLE
fix(bench): resolve relative PyTorch checkout paths

### DIFF
--- a/pyrefly/benches/pytorch/common.rs
+++ b/pyrefly/benches/pytorch/common.rs
@@ -127,7 +127,7 @@ fn pytorch_root() -> Option<PathBuf> {
     if let Some(root) = override_root
         && root.join(SENTINEL).exists()
     {
-        return Some(root);
+        return fs::canonicalize(&root).ok();
     }
 
     if let Some(root) = buck_resource_root() {


### PR DESCRIPTION
## Summary

Fixes a panic when `PYREFLY_PYTORCH_BENCH_PATH` is set to a valid relative PyTorch checkout path.

The benchmark path override was returned unchanged, allowing a relative path to reach `Url::from_file_path(...).unwrap()`, which rejects relative paths and causes the benchmark to panic.

This change canonicalizes a valid override path before returning it, so relative checkout paths are resolved to absolute paths while existing absolute paths continue to work unchanged.

## Linked issue

Fixes #4828

## Test plan

- `cargo fmt -- --check`
- `cargo bench -p pyrefly --bench pytorch --no-run`
- `cargo test -p pyrefly_util`
- `git diff --check`
- Verified a relative `PYREFLY_PYTORCH_BENCH_PATH` using a minimal PyTorch checkout fixture with `cargo bench -p pyrefly --bench pytorch -- --list`

All checks passed.

## Risk / breaking changes

No public API changes.

The change is limited to resolving the existing PyTorch benchmark path override to a canonical absolute path.