### PR TITLE
fix: handle generic classes in boolean contexts

### DIFF
--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -2137,6 +2137,33 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     )),
                 }
             }
+            AttributeBase1::GenericAlias(origin) => {
+                let generic_alias =
+                    AttributeBase1::ClassInstance(self.stdlib.generic_alias().clone());
+                let origin = AttributeBase1::ClassObject(origin.clone());
+                let mut candidates = Vec::new();
+                let inherited_from_object = self.field_is_inherited_from(
+                    self.stdlib.generic_alias().class_object(),
+                    dunder_name,
+                    ("builtins", "object"),
+                );
+                for (b, exclude) in [(&generic_alias, inherited_from_object), (&origin, false)] {
+                    if exclude {
+                        continue;
+                    }
+                    let mut acc_candidate = LookupResult::empty();
+                    self.lookup_magic_dunder_attr1(b.clone(), dunder_name, &mut acc_candidate);
+                    if acc_candidate.not_found.is_empty() && acc_candidate.internal_error.is_empty()
+                    {
+                        candidates.push(acc_candidate.found);
+                    }
+                }
+                if candidates.len() == 1 {
+                    acc.found.extend(candidates.into_iter().next().unwrap());
+                } else {
+                    self.lookup_magic_dunder_attr1(generic_alias, dunder_name, acc);
+                }
+            }
             AttributeBase1::ClassInstance(cls)
             | AttributeBase1::SelfType(cls)
             | AttributeBase1::EnumLiteral(LitEnum { class: cls, .. })

--- a/pyrefly/lib/test/operators.rs
+++ b/pyrefly/lib/test/operators.rs
@@ -760,6 +760,24 @@ assert_type(int() or NotBoolable(), int | NotBoolable)
 );
 
 testcase!(
+    test_generic_class_bool_context,
+    r#"
+from typing import Generic, TypeVar, assert_type
+
+_T = TypeVar("_T")
+
+class Foo(Generic[_T]):
+    def __bool__(self) -> bool:
+        return False
+
+def f(cls: type[Foo] | None = None):
+    x = cls or Foo
+    assert_type(x, type[Foo])
+    return x
+"#,
+);
+
+testcase!(
     test_tensor_type_lambda,
     r#"
 from typing import Callable, cast, assert_type


### PR DESCRIPTION
## Summary

Fix a bug where bare references to generic classes could incorrectly resolve an instance `__bool__` method when used in a boolean context.

For example, `type[Foo] | None` could resolve `Foo.__bool__` as though the class object were an instance, producing a `Missing argument self in function Foo.__bool__` error.

This adds explicit handling for `GenericAlias` values during magic dunder lookup so generic class objects follow the same class-object behavior as non-generic classes.

## Linked issue

Fixes #4824

## Test plan

- `cargo test test_generic_class_bool_context`
- `cargo test test_dunder_bool`
- `cargo test test::operators`
- Original issue reproduction with `pyrefly check`
- `cargo fmt -- --check`
- `python3 test.py --no-test --no-tensor-shapes --no-conformance --no-jsonschema`
- `git diff --check`

All checks passed.

## Risk / breaking changes

No public API changes.

The change is limited to magic dunder lookup for generic aliases and adds a focused regression test.