### PR TITLE
[tensor-shapes] add stubs for jax.lax reduction, selection, and sorting APIs

### DIFF
--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
@@ -1023,3 +1023,141 @@ def top_k_shape(shape: IntTuple, k: int, axis: int) -> IntTuple:
         dsl.concat(shape[:norm_axis], dsl.IntTuple((extent,))),
         shape[norm_axis + 1 :],
     )
+
+@type_shape_dsl_function
+def lax_reduce_shape(shape: IntTuple, axes: tuple[int, ...]) -> IntTuple:
+    rank = len(shape)
+    if any(axis < 0 or axis >= rank for axis in axes):
+        return dsl.Invalid("axis out of bounds")
+    if any(axes.count(axis) > 1 for axis in axes):
+        return dsl.Invalid("duplicate axis")
+    return dsl.IntTuple((shape[i] for i in range(rank) if i not in axes))
+
+@type_shape_dsl_function
+def lax_axis_reduce_shape(shape: IntTuple, axis: int) -> IntTuple:
+    rank = len(shape)
+    if axis < 0 or axis >= rank:
+        return dsl.Invalid("axis out of bounds")
+    return dsl.concat(shape[:axis], shape[axis + 1 :])
+
+@type_shape_dsl_function
+def lax_scan_shape(shape: IntTuple, axis: int) -> IntTuple:
+    rank = len(shape)
+    if axis < 0 or axis >= rank:
+        return dsl.Invalid("axis out of bounds")
+    return shape
+
+@type_shape_dsl_function
+def lax_associative_scan_shape(shape: IntTuple, axis: int) -> IntTuple:
+    rank = len(shape)
+    if axis < 0:
+        norm_axis = axis + rank
+    else:
+        norm_axis = axis + 0
+    if norm_axis < 0 or norm_axis >= rank:
+        return dsl.Invalid("axis out of bounds")
+    return shape
+
+@type_shape_dsl_function
+def lax_clamp_shape(
+    min_shape: IntTuple, x_shape: IntTuple, max_shape: IntTuple
+) -> IntTuple:
+    if len(min_shape) != 0:
+        if len(min_shape) != len(x_shape) or any(
+            min_shape[i] != x_shape[i] for i in range(len(x_shape))
+        ):
+            return dsl.Invalid(
+                "clamp requires min.shape == operand.shape or min.shape == ()"
+            )
+    if len(max_shape) != 0:
+        if len(max_shape) != len(x_shape) or any(
+            max_shape[i] != x_shape[i] for i in range(len(x_shape))
+        ):
+            return dsl.Invalid(
+                "clamp requires max.shape == operand.shape or max.shape == ()"
+            )
+    return x_shape
+
+@type_shape_dsl_function
+def lax_clamp_min_scalar_shape(x_shape: IntTuple, max_shape: IntTuple) -> IntTuple:
+    if len(max_shape) != 0:
+        if len(max_shape) != len(x_shape) or any(
+            max_shape[i] != x_shape[i] for i in range(len(x_shape))
+        ):
+            return dsl.Invalid(
+                "clamp requires max.shape == operand.shape or max.shape == ()"
+            )
+    return x_shape
+
+@type_shape_dsl_function
+def lax_clamp_max_scalar_shape(min_shape: IntTuple, x_shape: IntTuple) -> IntTuple:
+    if len(min_shape) != 0:
+        if len(min_shape) != len(x_shape) or any(
+            min_shape[i] != x_shape[i] for i in range(len(x_shape))
+        ):
+            return dsl.Invalid(
+                "clamp requires min.shape == operand.shape or min.shape == ()"
+            )
+    return x_shape
+
+@type_shape_dsl_function
+def lax_select_shape(
+    pred_shape: IntTuple, true_shape: IntTuple, false_shape: IntTuple
+) -> IntTuple:
+    if len(true_shape) != len(false_shape) or any(
+        true_shape[i] != false_shape[i] for i in range(len(true_shape))
+    ):
+        return dsl.Invalid("select cases must have the same shapes")
+    if len(pred_shape) != 0:
+        if len(pred_shape) != len(true_shape) or any(
+            pred_shape[i] != true_shape[i] for i in range(len(true_shape))
+        ):
+            return dsl.Invalid(
+                "select `which` must be scalar or have the same shape as cases"
+            )
+    return true_shape
+
+@type_shape_dsl_function
+def lax_select_scalar_pred_shape(
+    true_shape: IntTuple, false_shape: IntTuple
+) -> IntTuple:
+    if len(true_shape) != len(false_shape) or any(
+        true_shape[i] != false_shape[i] for i in range(len(true_shape))
+    ):
+        return dsl.Invalid("select cases must have the same shapes")
+    return true_shape
+
+@type_shape_dsl_function
+def lax_select_n_shape(which_shape: IntTuple, case_shape: IntTuple) -> IntTuple:
+    if len(which_shape) != 0:
+        if len(which_shape) != len(case_shape) or any(
+            which_shape[i] != case_shape[i] for i in range(len(case_shape))
+        ):
+            return dsl.Invalid(
+                "select `which` must be scalar or have the same shape as cases"
+            )
+    return case_shape
+
+@type_shape_dsl_function
+def lax_sort_shape(shape: IntTuple, dimension: int) -> IntTuple:
+    rank = len(shape)
+    if rank == 0:
+        return dsl.Invalid("axis out of bounds")
+    if dimension < 0 - rank or dimension >= rank:
+        return dsl.Invalid("axis out of bounds")
+    return shape
+
+@type_shape_dsl_function
+def lax_sort_key_val_shape(
+    keys_shape: IntTuple, values_shape: IntTuple, dimension: int
+) -> IntTuple:
+    if len(keys_shape) != len(values_shape) or any(
+        keys_shape[i] != values_shape[i] for i in range(len(keys_shape))
+    ):
+        return dsl.Invalid("Arguments to sort must have equal shapes")
+    rank = len(keys_shape)
+    if rank == 0:
+        return dsl.Invalid("axis out of bounds")
+    if dimension < 0 - rank or dimension >= rank:
+        return dsl.Invalid("axis out of bounds")
+    return keys_shape

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/lax/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/lax/__init__.pyi
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, overload, Sequence
+from typing import Any, Callable, overload, Sequence
 
 from jax._array import Array
 from jax._shapes import (
@@ -11,10 +11,23 @@ from jax._shapes import (
     collapse_shape,
     collapse_to_end_shape,
     concatenate_shape,
+    lax_associative_scan_shape,
+    lax_axis_reduce_shape,
     lax_broadcast,
+    lax_clamp_max_scalar_shape,
+    lax_clamp_min_scalar_shape,
+    lax_clamp_shape,
+    lax_reduce_shape,
+    lax_scan_shape,
+    lax_select_n_shape,
+    lax_select_scalar_pred_shape,
+    lax_select_shape,
+    lax_sort_key_val_shape,
+    lax_sort_shape,
     lax_squeeze_shape,
     permute_shape,
     stack_shape,
+    top_k_shape,
 )
 from shape_extensions import (
     Elements,
@@ -663,3 +676,437 @@ def convert_element_type(
     operand: Any,
     new_dtype: Any,
 ) -> Array[IntTuple]: ...
+
+# Reductions, Scans & Window Operations
+@overload
+def argmax[Shape: _Shape, Axis: Flag[int]](
+    operand: Array[Shape],
+    axis: Axis,
+    index_dtype: Any = ...,
+) -> Array[lax_axis_reduce_shape(Shape, Axis)]: ...
+@overload
+def argmax(
+    operand: Any,
+    axis: int,
+    index_dtype: Any = ...,
+) -> Array[IntTuple]: ...
+@overload
+def argmin[Shape: _Shape, Axis: Flag[int]](
+    operand: Array[Shape],
+    axis: Axis,
+    index_dtype: Any = ...,
+) -> Array[lax_axis_reduce_shape(Shape, Axis)]: ...
+@overload
+def argmin(
+    operand: Any,
+    axis: int,
+    index_dtype: Any = ...,
+) -> Array[IntTuple]: ...
+@overload
+def associative_scan[Shape: _Shape, Axis: Flag[int] = 0](
+    fn: Callable[[Any, Any], Any],
+    elems: Array[Shape],
+    reverse: bool = False,
+    axis: Axis = 0,
+) -> Array[lax_associative_scan_shape(Shape, Axis)]: ...
+@overload
+def associative_scan(
+    fn: Callable[[Any, Any], Any],
+    elems: Any,
+    reverse: bool = False,
+    axis: int = 0,
+) -> Any: ...
+@overload
+def cumlogsumexp[Shape: _Shape, Axis: Flag[int] = 0](
+    operand: Array[Shape],
+    axis: Axis = 0,
+    reverse: bool = False,
+) -> Array[lax_scan_shape(Shape, Axis)]: ...
+@overload
+def cumlogsumexp(
+    operand: Any,
+    axis: int = 0,
+    reverse: bool = False,
+) -> Array[IntTuple]: ...
+@overload
+def cummax[Shape: _Shape, Axis: Flag[int] = 0](
+    operand: Array[Shape],
+    axis: Axis = 0,
+    reverse: bool = False,
+) -> Array[lax_scan_shape(Shape, Axis)]: ...
+@overload
+def cummax(
+    operand: Any,
+    axis: int = 0,
+    reverse: bool = False,
+) -> Array[IntTuple]: ...
+@overload
+def cummin[Shape: _Shape, Axis: Flag[int] = 0](
+    operand: Array[Shape],
+    axis: Axis = 0,
+    reverse: bool = False,
+) -> Array[lax_scan_shape(Shape, Axis)]: ...
+@overload
+def cummin(
+    operand: Any,
+    axis: int = 0,
+    reverse: bool = False,
+) -> Array[IntTuple]: ...
+@overload
+def cumprod[Shape: _Shape, Axis: Flag[int] = 0](
+    operand: Array[Shape],
+    axis: Axis = 0,
+    reverse: bool = False,
+) -> Array[lax_scan_shape(Shape, Axis)]: ...
+@overload
+def cumprod(
+    operand: Any,
+    axis: int = 0,
+    reverse: bool = False,
+) -> Array[IntTuple]: ...
+@overload
+def cumsum[Shape: _Shape, Axis: Flag[int] = 0](
+    operand: Array[Shape],
+    axis: Axis = 0,
+    reverse: bool = False,
+) -> Array[lax_scan_shape(Shape, Axis)]: ...
+@overload
+def cumsum(
+    operand: Any,
+    axis: int = 0,
+    reverse: bool = False,
+) -> Array[IntTuple]: ...
+@overload
+def reduce[Shape: _Shape, Dims: Flag[tuple[int, ...]]](
+    operands: Array[Shape],
+    init_values: Any,
+    computation: Callable[[Any, Any], Any],
+    dimensions: Dims,
+    out_sharding: Any = None,
+) -> Array[lax_reduce_shape(Shape, Dims)]: ...
+@overload
+def reduce(
+    operands: Any,
+    init_values: Any,
+    computation: Callable[..., Any],
+    dimensions: Sequence[int],
+    out_sharding: Any = None,
+) -> Any: ...
+@overload
+def reduce_and[Shape: _Shape, Axes: Flag[tuple[int, ...]]](
+    operand: Array[Shape],
+    axes: Axes,
+) -> Array[lax_reduce_shape(Shape, Axes)]: ...
+@overload
+def reduce_and(
+    operand: Any,
+    axes: Sequence[int],
+) -> Array[IntTuple]: ...
+@overload
+def reduce_max[Shape: _Shape, Axes: Flag[tuple[int, ...]]](
+    operand: Array[Shape],
+    axes: Axes,
+    *,
+    out_sharding: Any = None,
+) -> Array[lax_reduce_shape(Shape, Axes)]: ...
+@overload
+def reduce_max(
+    operand: Any,
+    axes: Sequence[int],
+    *,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def reduce_min[Shape: _Shape, Axes: Flag[tuple[int, ...]]](
+    operand: Array[Shape],
+    axes: Axes,
+    *,
+    out_sharding: Any = None,
+) -> Array[lax_reduce_shape(Shape, Axes)]: ...
+@overload
+def reduce_min(
+    operand: Any,
+    axes: Sequence[int],
+    *,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def reduce_or[Shape: _Shape, Axes: Flag[tuple[int, ...]]](
+    operand: Array[Shape],
+    axes: Axes,
+) -> Array[lax_reduce_shape(Shape, Axes)]: ...
+@overload
+def reduce_or(
+    operand: Any,
+    axes: Sequence[int],
+) -> Array[IntTuple]: ...
+@overload
+def reduce_precision[Shape: _Shape](
+    operand: Array[Shape],
+    exponent_bits: int,
+    mantissa_bits: int,
+) -> Array[Shape]: ...
+@overload
+def reduce_precision(
+    operand: float | int,
+    exponent_bits: int,
+    mantissa_bits: int,
+) -> Array[[]]: ...
+@overload
+def reduce_precision(
+    operand: Any,
+    exponent_bits: int,
+    mantissa_bits: int,
+) -> Array[IntTuple]: ...
+@overload
+def reduce_prod[Shape: _Shape, Axes: Flag[tuple[int, ...]]](
+    operand: Array[Shape],
+    axes: Axes,
+) -> Array[lax_reduce_shape(Shape, Axes)]: ...
+@overload
+def reduce_prod(
+    operand: Any,
+    axes: Sequence[int],
+) -> Array[IntTuple]: ...
+@overload
+def reduce_sum[Shape: _Shape, Axes: Flag[tuple[int, ...]]](
+    operand: Array[Shape],
+    axes: Axes,
+    *,
+    out_sharding: Any = None,
+) -> Array[lax_reduce_shape(Shape, Axes)]: ...
+@overload
+def reduce_sum(
+    operand: Any,
+    axes: Sequence[int],
+    *,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def reduce_window[Shape: _Shape](
+    operand: Array[Shape],
+    init_value: Any,
+    computation: Callable[..., Any],
+    window_dimensions: Sequence[int],
+    window_strides: Sequence[int] | None = None,
+    padding: str | Sequence[tuple[int, int]] = "VALID",
+    base_dilation: Sequence[int] | None = None,
+    window_dilation: Sequence[int] | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def reduce_window(
+    operand: Any,
+    init_value: Any,
+    computation: Callable[..., Any],
+    window_dimensions: Sequence[int],
+    window_strides: Sequence[int] | None = None,
+    padding: str | Sequence[tuple[int, int]] = "VALID",
+    base_dilation: Sequence[int] | None = None,
+    window_dilation: Sequence[int] | None = None,
+) -> Any: ...
+def reduce_window_shape_tuple(
+    operand_shape: Sequence[int],
+    window_dimensions: Sequence[int],
+    window_strides: Sequence[int],
+    padding: Sequence[tuple[int, int]],
+    base_dilation: Sequence[int] | None = None,
+    window_dilation: Sequence[int] | None = None,
+) -> tuple[int, ...]: ...
+@overload
+def reduce_xor[Shape: _Shape, Axes: Flag[tuple[int, ...]]](
+    operand: Array[Shape],
+    axes: Axes,
+) -> Array[lax_reduce_shape(Shape, Axes)]: ...
+@overload
+def reduce_xor(
+    operand: Any,
+    axes: Sequence[int],
+) -> Array[IntTuple]: ...
+
+# Selection, Sorting & Searching
+@overload
+def approx_max_k[Shape: _Shape, K: Flag[int], Dim: Flag[int] = -1](
+    operand: Array[Shape],
+    k: K,
+    reduction_dimension: Dim = -1,
+    recall_target: float = 0.95,
+    reduction_input_size_override: int = -1,
+    aggregate_to_topk: bool = True,
+) -> tuple[
+    Array[top_k_shape(Shape, K, Dim)],
+    Array[top_k_shape(Shape, K, Dim)],
+]: ...
+@overload
+def approx_max_k(
+    operand: Any,
+    k: int,
+    reduction_dimension: int = -1,
+    recall_target: float = 0.95,
+    reduction_input_size_override: int = -1,
+    aggregate_to_topk: bool = True,
+) -> tuple[Array[IntTuple], Array[IntTuple]]: ...
+@overload
+def approx_min_k[Shape: _Shape, K: Flag[int], Dim: Flag[int] = -1](
+    operand: Array[Shape],
+    k: K,
+    reduction_dimension: Dim = -1,
+    recall_target: float = 0.95,
+    reduction_input_size_override: int = -1,
+    aggregate_to_topk: bool = True,
+) -> tuple[
+    Array[top_k_shape(Shape, K, Dim)],
+    Array[top_k_shape(Shape, K, Dim)],
+]: ...
+@overload
+def approx_min_k(
+    operand: Any,
+    k: int,
+    reduction_dimension: int = -1,
+    recall_target: float = 0.95,
+    reduction_input_size_override: int = -1,
+    aggregate_to_topk: bool = True,
+) -> tuple[Array[IntTuple], Array[IntTuple]]: ...
+@overload
+def clamp[Shape: _Shape](
+    min: _Scalar,
+    x: Array[Shape],
+    max: _Scalar,
+) -> Array[Shape]: ...
+@overload
+def clamp[Shape: _Shape, ShapeMin: _Shape](
+    min: Array[ShapeMin],
+    x: Array[Shape],
+    max: _Scalar,
+) -> Array[lax_clamp_max_scalar_shape(ShapeMin, Shape)]: ...
+@overload
+def clamp[Shape: _Shape, ShapeMax: _Shape](
+    min: _Scalar,
+    x: Array[Shape],
+    max: Array[ShapeMax],
+) -> Array[lax_clamp_min_scalar_shape(Shape, ShapeMax)]: ...
+@overload
+def clamp[Shape: _Shape, ShapeMin: _Shape, ShapeMax: _Shape](
+    min: Array[ShapeMin],
+    x: Array[Shape],
+    max: Array[ShapeMax],
+) -> Array[lax_clamp_shape(ShapeMin, Shape, ShapeMax)]: ...
+@overload
+def clamp(
+    min: _Scalar,
+    x: _Scalar,
+    max: _Scalar,
+) -> Array[[]]: ...
+@overload
+def clamp(
+    min: Any,
+    x: Any,
+    max: Any,
+) -> Array[IntTuple]: ...
+@overload
+def select[Shape: _Shape, Shape2: _Shape](
+    pred: bool | int,
+    on_true: Array[Shape],
+    on_false: Array[Shape2],
+) -> Array[lax_select_scalar_pred_shape(Shape, Shape2)]: ...
+@overload
+def select[Shape: _Shape, Shape2: _Shape, PredShape: _Shape](
+    pred: Array[PredShape],
+    on_true: Array[Shape],
+    on_false: Array[Shape2],
+) -> Array[lax_select_shape(PredShape, Shape, Shape2)]: ...
+@overload
+def select(
+    pred: bool | int,
+    on_true: _Scalar,
+    on_false: _Scalar,
+) -> Array[[]]: ...
+@overload
+def select(
+    pred: Any,
+    on_true: Any,
+    on_false: Any,
+) -> Array[IntTuple]: ...
+@overload
+def select_n[Shape: _Shape, WhichShape: _Shape](
+    which: Array[WhichShape],
+    *cases: Array[Shape],
+) -> Array[lax_select_n_shape(WhichShape, Shape)]: ...
+@overload
+def select_n[Shape: _Shape](
+    which: bool | int,
+    *cases: Array[Shape],
+) -> Array[Shape]: ...
+@overload
+def select_n(
+    which: bool | int,
+    *cases: _Scalar,
+) -> Array[[]]: ...
+@overload
+def select_n(
+    which: Any,
+    *cases: Any,
+) -> Array[IntTuple]: ...
+@overload
+def sort[Shape: _Shape, Dim: Flag[int] = -1](
+    operand: Array[Shape],
+    dimension: Dim = -1,
+    is_stable: bool = True,
+    num_keys: int = 1,
+) -> Array[lax_sort_shape(Shape, Dim)]: ...
+@overload
+def sort[Shape: _Shape, Dim: Flag[int] = -1](
+    operand: tuple[Array[Shape], Array[Shape]],
+    dimension: Dim = -1,
+    is_stable: bool = True,
+    num_keys: int = 1,
+) -> tuple[Array[lax_sort_shape(Shape, Dim)], Array[lax_sort_shape(Shape, Dim)]]: ...
+@overload
+def sort[Shape: _Shape, Dim: Flag[int] = -1](
+    operand: Sequence[Array[Shape]],
+    dimension: Dim = -1,
+    is_stable: bool = True,
+    num_keys: int = 1,
+) -> tuple[Array[lax_sort_shape(Shape, Dim)], ...]: ...
+@overload
+def sort(
+    operand: Any,
+    dimension: int = -1,
+    is_stable: bool = True,
+    num_keys: int = 1,
+) -> Any: ...
+@overload
+def sort_key_val[Shape1: _Shape, Shape2: _Shape, Dim: Flag[int] = -1](
+    keys: Array[Shape1],
+    values: Array[Shape2],
+    dimension: Dim = -1,
+    is_stable: bool = True,
+) -> tuple[
+    Array[lax_sort_key_val_shape(Shape1, Shape2, Dim)],
+    Array[lax_sort_key_val_shape(Shape1, Shape2, Dim)],
+]: ...
+@overload
+def sort_key_val(
+    keys: Any,
+    values: Any,
+    dimension: int = -1,
+    is_stable: bool = True,
+) -> tuple[Array[IntTuple], Array[IntTuple]]: ...
+@overload
+def top_k[Shape: _Shape, K: Flag[int], Axis: Flag[int] = -1](
+    operand: Array[Shape],
+    k: K,
+    *,
+    axis: Axis = -1,
+    is_stable: bool = True,
+) -> tuple[
+    Array[top_k_shape(Shape, K, Axis)],
+    Array[top_k_shape(Shape, K, Axis)],
+]: ...
+@overload
+def top_k(
+    operand: Any,
+    k: int,
+    *,
+    axis: int = -1,
+    is_stable: bool = True,
+) -> tuple[Array[IntTuple], Array[IntTuple]]: ...

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_lax.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_lax.py
@@ -420,3 +420,280 @@ def test_lax_dtype_bitcast():
     # bitcast_convert_type
     res_bitcast = lax.bitcast_convert_type(x, jnp.int32)
     assert res_bitcast.shape == (2, 3)
+
+
+def reject_lax_argmax_out_of_bounds(x: jax.Array[[2, 3, 4]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+    lax.argmax(x, axis=3, index_dtype=jnp.int32)
+
+
+def reject_lax_argmax_negative_axis(x: jax.Array[[2, 3, 4]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+    lax.argmax(x, axis=-1, index_dtype=jnp.int32)
+
+
+def reject_lax_argmin_negative_axis(x: jax.Array[[2, 3, 4]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+    lax.argmin(x, axis=-1, index_dtype=jnp.int32)
+
+
+def reject_lax_cumsum_negative_axis(x: jax.Array[[2, 3, 4]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+    lax.cumsum(x, axis=-1)
+
+
+def reject_lax_cummax_out_of_bounds(x: jax.Array[[2, 3, 4]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+    lax.cummax(x, axis=3)
+
+
+def reject_lax_associative_scan_out_of_bounds(x: jax.Array[[2, 3, 4]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+    lax.associative_scan(lax.add, x, axis=3)
+
+
+def reject_lax_associative_scan_negative_out_of_bounds(
+    x: jax.Array[[2, 3, 4]],
+) -> None:
+    # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+    lax.associative_scan(lax.add, x, axis=-4)
+
+
+def reject_lax_reduce_sum_out_of_bounds(x: jax.Array[[2, 3, 4]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+    lax.reduce_sum(x, (3,))
+
+
+def reject_lax_reduce_sum_negative_axis(x: jax.Array[[2, 3, 4]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+    lax.reduce_sum(x, (-1,))
+
+
+def reject_lax_reduce_sum_duplicate_axis(x: jax.Array[[2, 3, 4]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: duplicate axis
+    lax.reduce_sum(x, (0, 0))
+
+
+def reject_lax_approx_max_k_out_of_bounds(x: jax.Array[[2, 3, 4]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+    lax.approx_max_k(x, 2, reduction_dimension=3)
+
+
+def reject_lax_approx_min_k_negative_k(x: jax.Array[[2, 3, 4]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: k must be non-negative
+    lax.approx_min_k(x, -1)
+
+
+def reject_lax_clamp_mismatched_min(
+    x: jax.Array[[2, 3, 4]], bad_min: jax.Array[[3, 4]]
+) -> None:
+    # E: Cannot evaluate type-level shape DSL call: clamp requires min.shape == operand.shape or min.shape == ()
+    lax.clamp(bad_min, x, 1.0)
+
+
+def reject_lax_clamp_mismatched_max(
+    x: jax.Array[[2, 3, 4]], bad_max: jax.Array[[3, 4]]
+) -> None:
+    # E: Cannot evaluate type-level shape DSL call: clamp requires max.shape == operand.shape or max.shape == ()
+    lax.clamp(0.0, x, bad_max)
+
+
+def reject_lax_select_mismatched_cases(
+    x: jax.Array[[2, 3, 4]], y: jax.Array[[2, 3]]
+) -> None:
+    # E: Cannot evaluate type-level shape DSL call: select cases must have the same shapes
+    lax.select(True, x, y)
+
+
+def reject_lax_select_mismatched_pred(
+    pred: jax.Array[[4]], x: jax.Array[[2, 3, 4]], y: jax.Array[[2, 3, 4]]
+) -> None:
+    # E: Cannot evaluate type-level shape DSL call: select `which` must be scalar or have the same shape as cases
+    lax.select(pred, x, y)
+
+
+def reject_lax_select_n_mismatched_which(
+    which: jax.Array[[4]], x: jax.Array[[2, 3, 4]], y: jax.Array[[2, 3, 4]]
+) -> None:
+    # E: Cannot evaluate type-level shape DSL call: select `which` must be scalar or have the same shape as cases
+    lax.select_n(which, x, y)
+
+
+def reject_lax_sort_out_of_bounds(x: jax.Array[[2, 3, 4]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+    lax.sort(x, dimension=3)
+
+
+def reject_lax_sort_key_val_mismatched(
+    x: jax.Array[[2, 3, 4]], bad_val: jax.Array[[2, 3]]
+) -> None:
+    # E: Cannot evaluate type-level shape DSL call: Arguments to sort must have equal shapes
+    lax.sort_key_val(x, bad_val)
+
+
+def reject_lax_top_k_out_of_bounds(x: jax.Array[[2, 3, 4]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+    lax.top_k(x, 2, axis=3)
+
+
+def reject_lax_top_k_negative_k(x: jax.Array[[2, 3, 4]]) -> None:
+    # E: Cannot evaluate type-level shape DSL call: k must be non-negative
+    lax.top_k(x, -1)
+
+
+def test_lax_argmax_argmin() -> None:
+    x = jnp.ones((2, 3, 4))
+    assert_shape(lax.argmax(x, axis=0, index_dtype=jnp.int32).shape, (3, 4))
+    assert_shape(lax.argmax(x, axis=1, index_dtype=jnp.int32).shape, (2, 4))
+    assert_shape(lax.argmax(x, axis=2, index_dtype=jnp.int32).shape, (2, 3))
+    assert_shape(lax.argmin(x, axis=0, index_dtype=jnp.int32).shape, (3, 4))
+    assert_shape(lax.argmin(x, axis=1, index_dtype=jnp.int32).shape, (2, 4))
+    assert_shape(lax.argmin(x, axis=2, index_dtype=jnp.int32).shape, (2, 3))
+
+
+def test_lax_scans() -> None:
+    x = jnp.ones((2, 3, 4))
+    # associative_scan
+    assert_shape(lax.associative_scan(lax.add, x, axis=0).shape, (2, 3, 4))
+    assert_shape(
+        lax.associative_scan(lax.add, x, axis=1, reverse=True).shape, (2, 3, 4)
+    )
+    assert_shape(lax.associative_scan(lax.add, x, axis=-1).shape, (2, 3, 4))
+    assert_shape(lax.associative_scan(lax.add, x).shape, (2, 3, 4))
+
+    # cumlogsumexp
+    assert_shape(lax.cumlogsumexp(x, axis=0).shape, (2, 3, 4))
+    assert_shape(lax.cumlogsumexp(x, axis=1, reverse=True).shape, (2, 3, 4))
+    assert_shape(lax.cumlogsumexp(x).shape, (2, 3, 4))
+
+    # cummax, cummin, cumprod, cumsum
+    assert_shape(lax.cummax(x, axis=0).shape, (2, 3, 4))
+    assert_shape(lax.cummax(x).shape, (2, 3, 4))
+    assert_shape(lax.cummin(x, axis=1).shape, (2, 3, 4))
+    assert_shape(lax.cummin(x).shape, (2, 3, 4))
+    assert_shape(lax.cumprod(x, axis=2).shape, (2, 3, 4))
+    assert_shape(lax.cumprod(x).shape, (2, 3, 4))
+    assert_shape(lax.cumsum(x, axis=0).shape, (2, 3, 4))
+    assert_shape(lax.cumsum(x).shape, (2, 3, 4))
+
+
+def test_lax_reductions() -> None:
+    x = jnp.ones((2, 3, 4))
+    b = jnp.array([[[True, False, True, False]] * 3] * 2)
+
+    # reduce
+    assert_shape(lax.reduce(x, 0.0, lax.add, (0, 2)).shape, (3,))
+    assert_shape(lax.reduce(x, 0.0, lax.add, ()).shape, (2, 3, 4))
+    assert_shape(lax.reduce(x, 0.0, lax.add, (0, 1, 2)).shape, ())
+
+    # reduce_sum, reduce_prod, reduce_max, reduce_min
+    assert_shape(lax.reduce_sum(x, (1,)).shape, (2, 4))
+    assert_shape(lax.reduce_sum(x, (0, 1, 2)).shape, ())
+    assert_shape(lax.reduce_prod(x, ()).shape, (2, 3, 4))
+    assert_shape(lax.reduce_prod(x, (0, 2)).shape, (3,))
+    assert_shape(lax.reduce_max(x, (2,)).shape, (2, 3))
+    assert_shape(lax.reduce_min(x, (0,)).shape, (3, 4))
+
+    # reduce_and, reduce_or, reduce_xor
+    assert_shape(lax.reduce_and(b, (0,)).shape, (3, 4))
+    assert_shape(lax.reduce_or(b, (1, 2)).shape, (2,))
+    assert_shape(lax.reduce_xor(b, (2,)).shape, (2, 3))
+
+
+def test_lax_reduce_precision() -> None:
+    x = jnp.ones((2, 3, 4))
+    assert_shape(lax.reduce_precision(x, 8, 7).shape, (2, 3, 4))
+    assert_shape(lax.reduce_precision(3.14, 8, 7).shape, ())
+
+
+def test_lax_reduce_window() -> None:
+    x = jnp.ones((2, 4, 6))
+    res_window = lax.reduce_window(x, 0.0, lax.add, (1, 2, 2), (1, 1, 1), "VALID")
+    assert res_window.shape == (2, 3, 5)
+
+    res_tuple = lax.reduce_window_shape_tuple(
+        (2, 4, 6), (1, 2, 2), (1, 1, 1), ((0, 0), (0, 0), (0, 0))
+    )
+    assert res_tuple == (2, 3, 5)
+    # Satisfy assert_shape requirement for the test
+    assert_shape(x.shape, (2, 4, 6))
+
+
+def test_lax_approx_max_min_k() -> None:
+    x = jnp.ones((2, 3, 4))
+    val_max, idx_max = lax.approx_max_k(x, 2, reduction_dimension=1)
+    assert_shape(val_max.shape, (2, 2, 4))
+    assert_shape(idx_max.shape, (2, 2, 4))
+
+    val_min, idx_min = lax.approx_min_k(x, 3, reduction_dimension=-1)
+    assert_shape(val_min.shape, (2, 3, 3))
+    assert_shape(idx_min.shape, (2, 3, 3))
+
+
+def test_lax_clamp() -> None:
+    x = jnp.ones((2, 3, 4))
+    assert_shape(lax.clamp(0.0, x, 1.0).shape, (2, 3, 4))
+    assert_shape(lax.clamp(jnp.zeros((2, 3, 4)), x, 1.0).shape, (2, 3, 4))
+    assert_shape(lax.clamp(0.0, x, jnp.ones((2, 3, 4))).shape, (2, 3, 4))
+    assert_shape(
+        lax.clamp(jnp.zeros((2, 3, 4)), x, jnp.ones((2, 3, 4))).shape, (2, 3, 4)
+    )
+    assert_shape(lax.clamp(0.0, 5.0, 1.0).shape, ())
+
+
+def test_lax_select() -> None:
+    x = jnp.ones((2, 3, 4))
+    y = jnp.zeros((2, 3, 4))
+    pred_0d = jnp.array(True)
+    pred_3d = jnp.ones((2, 3, 4), dtype=bool)
+
+    assert_shape(lax.select(True, x, y).shape, (2, 3, 4))
+    assert_shape(lax.select(pred_0d, x, y).shape, (2, 3, 4))
+    assert_shape(lax.select(pred_3d, x, y).shape, (2, 3, 4))
+    assert_shape(lax.select(True, 1.0, 2.0).shape, ())
+
+
+def test_lax_select_n() -> None:
+    x = jnp.ones((2, 3, 4))
+    y = jnp.zeros((2, 3, 4))
+    which_0d = jnp.array(0)
+    which_3d = jnp.zeros((2, 3, 4), dtype=jnp.int32)
+
+    assert_shape(lax.select_n(0, x, y).shape, (2, 3, 4))
+    assert_shape(lax.select_n(which_0d, x, y).shape, (2, 3, 4))
+    assert_shape(lax.select_n(which_3d, x, y, x).shape, (2, 3, 4))
+    assert_shape(lax.select_n(0, 1.0, 2.0).shape, ())
+
+
+def test_lax_sort() -> None:
+    x = jnp.ones((2, 3, 4))
+    y = jnp.ones((2, 3, 4))
+
+    assert_shape(lax.sort(x).shape, (2, 3, 4))
+    assert_shape(lax.sort(x, dimension=0).shape, (2, 3, 4))
+    assert_shape(lax.sort(x, dimension=-1).shape, (2, 3, 4))
+
+    s1, s2 = lax.sort((x, y), dimension=1)
+    assert_shape(s1.shape, (2, 3, 4))
+    assert_shape(s2.shape, (2, 3, 4))
+
+
+def test_lax_sort_key_val() -> None:
+    x = jnp.ones((2, 3, 4))
+    y = jnp.ones((2, 3, 4))
+
+    sk, sv = lax.sort_key_val(x, y, dimension=-1)
+    assert_shape(sk.shape, (2, 3, 4))
+    assert_shape(sv.shape, (2, 3, 4))
+
+
+def test_lax_top_k() -> None:
+    x = jnp.ones((2, 3, 4))
+
+    top_v, top_i = lax.top_k(x, 2)
+    assert_shape(top_v.shape, (2, 3, 2))
+    assert_shape(top_i.shape, (2, 3, 2))
+
+    top_v0, top_i0 = lax.top_k(x, 1, axis=0)
+    assert_shape(top_v0.shape, (1, 3, 4))
+    assert_shape(top_i0.shape, (1, 3, 4))


### PR DESCRIPTION
## Summary

New stubs for a handful of `jax.lax` APIs.

## Test Plan

Added tests to existing `test_lax.py` file; tests pass locally:
```
$ uv tool run --from ruff==0.14.3 ruff format --check --config ruff.toml .
332 files already formatted
$ uv tool run --from ruff==0.14.3 ruff check --select I --config ruff.toml .
All checks passed!
$ uv run python test.py --no-test --no-conformance --no-jsonschema
Running formatting...
Finished in 2.71 seconds.
Running linting...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.91s
Finished in 1.15 seconds.
$ uv run python tensor-shapes/pyrefly-jax-stubs/run_pyrefly.py --release
+ cargo build -p pyrefly --release
    Finished `release` profile [optimized + debuginfo] target(s) in 0.54s
PASS stubs (9 files)
PASS arithmetic (1 files)
PASS contractions (1 files)
PASS creation (1 files)
PASS fft (1 files)
PASS indexing (1 files)
PASS lax (1 files)
PASS linalg (1 files)
PASS matmul (1 files)
PASS nn (1 files)
PASS reductions (1 files)
PASS reshape (1 files)
PASS searching-sorting (1 files)
PASS structural (1 files)
```

## AI disclosure

Changes were generated using a gemini coding agent.