### PR TITLE
Further improve DataFrame column completions for unpacked keywords

### DIFF
--- a/pyrefly/lib/state/lsp/dict_completions.rs
+++ b/pyrefly/lib/state/lsp/dict_completions.rs
@@ -21,6 +21,7 @@ use ruff_python_ast::ExprCall;
 use ruff_python_ast::ExprDict;
 use ruff_python_ast::ExprStringLiteral;
 use ruff_python_ast::Identifier;
+use ruff_python_ast::Keyword;
 use ruff_python_ast::ModModule;
 use ruff_text_size::Ranged;
 use ruff_text_size::TextRange;
@@ -340,6 +341,94 @@ impl<'a> Transaction<'a> {
         }
     }
 
+    /// Visits an explicit keyword or the entries of a supported unpacked mapping in source order.
+    /// A `None` name is an unknown key or unpack that may override preceding entries.
+    fn visit_keyword_entries<'b>(
+        &self,
+        handle: &Handle,
+        keyword: &'b Keyword,
+        mut visit: impl FnMut(Option<&'b str>, &'b Expr),
+    ) {
+        match (&keyword.arg, &keyword.value) {
+            (Some(name), value) => visit(Some(name.id.as_str()), value),
+            (None, Expr::Dict(dict)) => {
+                for item in &dict.items {
+                    let name = match item.key.as_ref() {
+                        Some(Expr::StringLiteral(key)) => Some(key.value.to_str()),
+                        _ => None,
+                    };
+                    visit(name, &item.value);
+                }
+            }
+            (None, Expr::Call(unpacked))
+                if unpacked.arguments.args.is_empty()
+                    && matches!(
+                        self.get_type_trace(handle, unpacked.func.range()),
+                        Some(Type::ClassDef(class)) if class.is_builtin("dict")
+                    ) =>
+            {
+                for keyword in &unpacked.arguments.keywords {
+                    visit(
+                        keyword.arg.as_ref().map(|name| name.id.as_str()),
+                        &keyword.value,
+                    );
+                }
+            }
+            (None, value) => visit(None, value),
+        }
+    }
+
+    /// Finds the argument containing the literal, resolving inline keyword mappings.
+    fn dataframe_call_argument_slot<'b>(
+        &self,
+        handle: &Handle,
+        call: &'b ExprCall,
+        literal_range: TextRange,
+    ) -> Option<ArgumentSlot<'b>> {
+        let mut slot = None;
+        let mut axis = None;
+        for keyword in &call.arguments.keywords {
+            let mut unpacked_slot = None;
+            self.visit_keyword_entries(handle, keyword, |name, value| {
+                if value.range().contains_range(literal_range) {
+                    unpacked_slot = Some(
+                        name.map(ArgumentSlot::Keyword)
+                            .unwrap_or(ArgumentSlot::UnpackedKeyword),
+                    );
+                } else if let Some(ArgumentSlot::Keyword(current)) = unpacked_slot
+                    && name.is_none_or(|name| name == current)
+                {
+                    // A later duplicate or unknown key can replace the value containing the cursor.
+                    unpacked_slot = Some(ArgumentSlot::UnpackedKeyword);
+                }
+                match name {
+                    Some("axis") => axis = Some(value),
+                    None => axis = None,
+                    _ => {}
+                }
+            });
+            if unpacked_slot.is_some() {
+                slot = unpacked_slot;
+            }
+        }
+        let slot = slot.or_else(|| {
+            call.arguments
+                .args
+                .iter()
+                .any(|arg| arg.range().contains_range(literal_range))
+                .then_some(ArgumentSlot::Positional)
+        })?;
+        if matches!(call.func.as_ref(), Expr::Attribute(attr) if attr.attr.id.as_str() == "drop")
+            && matches!(slot, ArgumentSlot::Keyword("labels"))
+            && (matches!(axis, Some(Expr::StringLiteral(axis)) if axis.value.to_str() == "columns")
+                || matches!(axis, Some(Expr::NumberLiteral(axis)) if axis.value.as_int().and_then(|axis| axis.as_i64()) == Some(1)))
+        {
+            Some(ArgumentSlot::Keyword("columns"))
+        } else {
+            Some(slot)
+        }
+    }
+
     fn expr_has_typed_dict_type(&self, handle: &Handle, expr: &Expr) -> bool {
         self.get_type_trace(handle, expr.range())
             .map(|ty| Self::type_contains_typed_dict(&ty))
@@ -486,24 +575,7 @@ impl<'a> Transaction<'a> {
             let AnyNodeRef::ExprCall(call) = node else {
                 continue;
             };
-            let slot = if let Some(keyword) = call
-                .arguments
-                .keywords
-                .iter()
-                .find(|keyword| keyword.value.range().contains_range(literal_range))
-            {
-                match &keyword.arg {
-                    Some(name) => ArgumentSlot::Keyword(name.id.as_str()),
-                    None => ArgumentSlot::UnpackedKeyword,
-                }
-            } else if call
-                .arguments
-                .args
-                .iter()
-                .any(|arg| arg.range().contains_range(literal_range))
-            {
-                ArgumentSlot::Positional
-            } else {
+            let Some(slot) = self.dataframe_call_argument_slot(handle, call, literal_range) else {
                 continue;
             };
             if let Some(treats_strings_as_columns) = self

--- a/pyrefly/lib/test/lsp/completion.rs
+++ b/pyrefly/lib/test/lsp/completion.rs
@@ -207,6 +207,7 @@ class DataFrame:
     def with_columns(self, *exprs: object, **named_exprs: object) -> "DataFrame": ...
     def filter(self, *predicates: object, **constraints: object) -> "DataFrame": ...
     def sort(self, by: object, *more_by: object, descending: bool = False) -> "DataFrame": ...
+    def group_by(self, *by: object, maintain_order: bool = False, **named_by: object) -> object: ...
     def write_csv(self, file: str) -> None: ...
 "#,
     );
@@ -234,6 +235,7 @@ fn pandas_column_completion_labels(code: &str) -> Vec<String> {
         r#"
 class DataFrame:
     def __init__(self, data: object = None) -> None: ...
+    def drop(self, labels: object = None, *, axis: object = None, columns: object = None) -> object: ...
     def groupby(self, by: object) -> object: ...
     def filter(self, items: object = None, axis: object = None) -> object: ...
 "#,
@@ -247,6 +249,22 @@ class DataFrame:
     let handle = handle_for("main");
     let position = extract_cursors_for_test(code)[0];
     dict_field_labels(&state.transaction(), &handle, position)
+}
+
+fn dataframe_column_completion_code(package: &str, body: &str) -> String {
+    let call = body.lines().last().expect("body must contain a call");
+    let caret = " ".repeat(
+        call.find("\"\"")
+            .expect("call must contain an empty string"),
+    );
+    format!(
+        r#"
+import {package} as lib
+df = lib.DataFrame({{"foo": [1], "bar": [2]}})
+{body}
+#{caret}^
+"#
+    )
 }
 
 #[test]
@@ -799,6 +817,85 @@ df.select(**{"alias": pl.col("")})
 }
 
 #[test]
+fn dataframe_column_completion_recovers_keyword_from_splat() {
+    for call in [
+        r#"df.group_by(**dict(alias=""))"#,
+        r#"df.group_by(**{"alias": ""})"#,
+    ] {
+        assert_eq!(
+            polars_column_completion_labels(&dataframe_column_completion_code("polars", call)),
+            vec!["bar".to_owned(), "foo".to_owned()]
+        );
+    }
+
+    for call in [
+        r#"df.filter(**dict(items=[""]))"#,
+        r#"df.filter(**{"items": [""]})"#,
+        r#"options: dict[str, object] = {}
+df.filter(items=[""], **options)"#,
+        r#"options: dict[str, object] = {}
+df.filter(**dict(items=[""]), **options)"#,
+    ] {
+        assert_eq!(
+            pandas_column_completion_labels(&dataframe_column_completion_code("pandas", call)),
+            vec!["bar".to_owned(), "foo".to_owned()]
+        );
+    }
+}
+
+#[test]
+fn no_column_completion_from_control_keyword_splat() {
+    assert_eq!(
+        polars_column_completion_labels(&dataframe_column_completion_code(
+            "polars",
+            r#"df.group_by(**dict(maintain_order=""))"#,
+        )),
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        polars_column_completion_labels(&dataframe_column_completion_code(
+            "polars",
+            r#"options: dict[str, object] = {}
+df.group_by(**{"alias": "", **options})"#,
+        )),
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        pandas_column_completion_labels(&dataframe_column_completion_code(
+            "pandas",
+            r#"df.filter(**dict(axis=""))"#,
+        )),
+        Vec::<String>::new()
+    );
+}
+
+#[test]
+fn dataframe_column_completion_from_aliased_builtin_dict_splat() {
+    assert_eq!(
+        pandas_column_completion_labels(&dataframe_column_completion_code(
+            "pandas",
+            r#"from builtins import dict as mapping
+df.filter(**mapping(items=[""]))"#,
+        )),
+        vec!["bar".to_owned(), "foo".to_owned()]
+    );
+}
+
+#[test]
+fn no_column_completion_from_shadowed_dict_splat() {
+    assert_eq!(
+        pandas_column_completion_labels(&dataframe_column_completion_code(
+            "pandas",
+            r#"from builtins import dict as mapping
+def dict(**kwargs: object) -> mapping[str, object]:
+    return kwargs
+df.filter(**dict(items=[""]))"#,
+        )),
+        Vec::<String>::new()
+    );
+}
+
+#[test]
 fn named_expression_alias_key_does_not_complete_source_columns() {
     let code = r#"
 import polars as pl
@@ -857,6 +954,41 @@ df.filter(items=[""])
         pandas_column_completion_labels(code),
         vec!["bar".to_owned(), "foo".to_owned()]
     );
+}
+
+#[test]
+fn pandas_column_completion_from_drop_labels_on_column_axis() {
+    for call in [
+        r#"df.drop(labels=[""], axis=1)"#,
+        r#"df.drop(labels=[""], axis="columns")"#,
+        r#"df.drop(**dict(labels=[""], axis=1))"#,
+        r#"df.drop(**{"labels": [""], "axis": "columns"})"#,
+        r#"df.drop(**{"labels": [""], "axis": 0, "axis": 1})"#,
+    ] {
+        assert_eq!(
+            pandas_column_completion_labels(&dataframe_column_completion_code("pandas", call)),
+            vec!["bar".to_owned(), "foo".to_owned()]
+        );
+    }
+}
+
+#[test]
+fn no_pandas_column_completion_from_drop_labels_on_row_axis() {
+    for call in [
+        r#"df.drop(labels=[""])"#,
+        r#"df.drop(labels=[""], axis=0)"#,
+        r#"df.drop(**dict(labels=[""]))"#,
+        r#"df.drop(**{"labels": [""], "axis": 1, "axis": 0})"#,
+        r#"opts: dict[str, object] = {}
+df.drop(labels=[""], **{"axis": 1, **opts})"#,
+        r#"k = "axis"
+df.drop(labels=[""], **{"axis": 1, k: 0})"#,
+    ] {
+        assert_eq!(
+            pandas_column_completion_labels(&dataframe_column_completion_code("pandas", call)),
+            Vec::<String>::new()
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
# Summary

Builds on #4837.

### Problem

* DataFrame column completions could lose argument context inside unpacked keyword mappings.
* Pandas `drop(labels=...)` didn't offer column names when targeting the column axis.

### Solution

* Recover keyword names from inline dictionaries and builtin `dict(...)` calls, respecting duplicate keys, unknown unpacking, and shadowed builtins.
* Offer column completions for `drop(labels=...)` with explicit `axis=1` or `axis="columns"`.

### Also

* Process keyword entries directly, simplifying traversal.

# Test Plan

* Existing unit tests all pass.
* New test coverage added for...
  * keyword unpacking
  * aliased/shadowed `dict`
  * pandas axis handling.