### PR TITLE
Add a stub coverage inspection tool (#4852)

### DIFF
--- a/.github/workflows/pyrefly.yml
+++ b/.github/workflows/pyrefly.yml
@@ -40,7 +40,7 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         enable-cache: true
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+        cache-dependency-glob: tensor-shapes/test-requirements.txt
     - name: Check Python formatting (ruff)
       run: |
         uv tool run --from ruff==0.14.3 ruff format --check --config ruff.toml .
@@ -85,16 +85,15 @@ jobs:
       run: env -u GITHUB_ACTIONS scrut test test
       if: ${{ matrix.os != 'windows-latest' }}
     # Every library's stub tests run in one step rather than one job per
-    # library. Type checking runs on the whole matrix: it needs no virtualenv,
-    # and the runners carry Windows-specific interpreter and `.exe` path
-    # handling that nothing else would exercise. Only the runtime half is
-    # Ubuntu-only, so that torch and jax are not installed three times to run
-    # platform-independent assertions.
-    - name: Run tensor-shape type checks
-      run: python tensor-shapes/run_tests.py --release --static-only
+    # library. Type checking runs on the whole matrix because the runners carry
+    # Windows-specific interpreter and `.exe` path handling that nothing else
+    # would exercise. Static fallback needs the installed array libraries, so
+    # the virtualenv is bootstrapped on every platform. Runtime assertions are
+    # platform-independent and run only on Ubuntu.
     - name: Bootstrap tensor-shapes virtualenv
       run: python tensor-shapes/bootstrap_venv.py
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+    - name: Run tensor-shape type checks
+      run: python tensor-shapes/run_tests.py --release --static-only
     - name: Run tensor-shape runtime tests
       run: python tensor-shapes/run_tests.py --runtime-only
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/tensor-shapes/STUB_COVERAGE.md
+++ b/tensor-shapes/STUB_COVERAGE.md
@@ -1,0 +1,72 @@
+# Stub overlay coverage
+
+The NumPy, JAX, and Torch shape packages are partial PEP 561 stub packages. A
+module supplied by one of these packages replaces that module's normal typing
+surface, so every public name omitted from the overlay becomes unavailable to
+users of the shape stubs.
+
+`stub_coverage.py` compares each shipped stub module with the corresponding
+runtime module. It parses declarations from the `.pyi` file and uses the union
+of public `dir()` entries and names in `__all__` for the runtime library. A
+computed stub `__all__` falls back to declaration discovery rather than
+preventing inspection. The tool also compares explicitly configured classes
+such as `torch.Tensor` and `numpy.ndarray`.
+
+Class comparisons use every runtime-visible member and declarations made
+directly on the configured stub class. A future target that inherits stub
+members may therefore over-report those inherited names as gaps.
+
+Each package has a `stub_coverage.toml` configuration. Overlay-only modules and
+incidental runtime names can be excluded there.
+
+## Configuration
+
+The two required top-level keys are `runtime_package` and `stub_directory`.
+All collection keys are optional:
+
+```toml
+runtime_package = "package"
+stub_directory = "package-stubs"
+skip_modules = ["package.overlay_only"]
+
+[module_excludes]
+"package.module" = ["incidental_runtime_name"]
+
+[member_excludes]
+"package.module.Class" = ["incidental_runtime_member"]
+
+[[member_targets]]
+stub_module = "package.module"
+stub_class = "Class"
+runtime_module = "package.module"
+runtime_class = "Class"
+```
+
+`runtime_package` is the importable package being inspected. `stub_directory`
+is the overlay tree relative to the configuration file. `skip_modules` lists
+overlay modules that have no corresponding runtime module. `module_excludes`
+maps fully qualified runtime modules to public names that should not count as
+gaps. `member_excludes` maps a composite `<stub_module>.<stub_class>` key to
+runtime-visible members that should not count as gaps. Dotted keys in both
+tables must be quoted as shown above.
+
+Each `member_targets` table compares one class. Its four required fields name
+the module and class in the overlay (`stub_module`, `stub_class`) and at runtime
+(`runtime_module`, `runtime_class`). Unknown top-level keys and unknown member
+target fields are rejected.
+
+Run the inspection with the shared test virtualenv:
+
+```bash
+~/.tensor-shapes-venv/bin/python tensor-shapes/stub_coverage.py \
+  tensor-shapes/pyrefly-torch-stubs/stub_coverage.toml
+```
+
+The default output gives counts by module and class. Add `--show-names` for a
+human-readable inventory or `--json` for machine-readable analysis. Replace
+`torch` with `numpy` or `jax` for the other packages.
+
+This is currently an inspection tool rather than a CI ratchet: it does not
+compare against checked-in snapshots or fail based on the number of gaps. The
+checker reports the installed library version but does not enforce it; the
+shared virtualenv is currently kept stable by `test-requirements.txt`.

--- a/tensor-shapes/pyrefly-jax-stubs/stub_coverage.toml
+++ b/tensor-shapes/pyrefly-jax-stubs/stub_coverage.toml
@@ -1,0 +1,9 @@
+runtime_package = "jax"
+stub_directory = "jax-stubs"
+skip_modules = ["jax._array", "jax._shapes"]
+
+[[member_targets]]
+stub_module = "jax._array"
+stub_class = "Array"
+runtime_module = "jax"
+runtime_class = "Array"

--- a/tensor-shapes/pyrefly-numpy-stubs/stub_coverage.toml
+++ b/tensor-shapes/pyrefly-numpy-stubs/stub_coverage.toml
@@ -1,0 +1,9 @@
+runtime_package = "numpy"
+stub_directory = "numpy-stubs"
+skip_modules = ["numpy._shapes"]
+
+[[member_targets]]
+stub_module = "numpy"
+stub_class = "ndarray"
+runtime_module = "numpy"
+runtime_class = "ndarray"

--- a/tensor-shapes/pyrefly-torch-stubs/stub_coverage.toml
+++ b/tensor-shapes/pyrefly-torch-stubs/stub_coverage.toml
@@ -1,0 +1,15 @@
+runtime_package = "torch"
+stub_directory = "torch-stubs"
+skip_modules = ["torch._shapes"]
+
+[[member_targets]]
+stub_module = "torch"
+stub_class = "Tensor"
+runtime_module = "torch"
+runtime_class = "Tensor"
+
+[[member_targets]]
+stub_module = "torch"
+stub_class = "device"
+runtime_module = "torch"
+runtime_class = "device"

--- a/tensor-shapes/stub_coverage.py
+++ b/tensor-shapes/stub_coverage.py
@@ -1,0 +1,563 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Check partial stub packages against the libraries they shadow."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib
+import importlib.metadata
+import io
+import json
+import keyword
+import sys
+import tokenize
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class MemberTarget:
+    stub_module: str
+    stub_class: str
+    runtime_module: str
+    runtime_class: str
+
+
+@dataclass(frozen=True)
+class Config:
+    runtime_package: str
+    stub_directory: Path
+    skip_modules: frozenset[str]
+    module_excludes: dict[str, frozenset[str]]
+    member_excludes: dict[str, frozenset[str]]
+    member_targets: tuple[MemberTarget, ...]
+
+
+_CONFIG_KEYS = frozenset(
+    {
+        "runtime_package",
+        "stub_directory",
+        "skip_modules",
+        "module_excludes",
+        "member_excludes",
+        "member_targets",
+    }
+)
+_MEMBER_TARGET_KEYS = frozenset(
+    {"stub_module", "stub_class", "runtime_module", "runtime_class"}
+)
+
+
+def _validate_keys(
+    values: dict[str, Any],
+    *,
+    allowed: frozenset[str],
+    required: frozenset[str],
+    context: str,
+) -> None:
+    missing = required - values.keys()
+    if missing:
+        raise ValueError(
+            f"{context} is missing required keys: {', '.join(sorted(missing))}"
+        )
+    unknown = values.keys() - allowed
+    if unknown:
+        raise ValueError(f"{context} has unknown keys: {', '.join(sorted(unknown))}")
+
+
+def _load_member_targets(value: Any) -> tuple[MemberTarget, ...]:
+    if not isinstance(value, list):
+        raise ValueError("member_targets must be an array of tables")
+    result = []
+    for index, target in enumerate(value):
+        if not isinstance(target, dict):
+            raise ValueError(f"member_targets[{index}] must be a table")
+        _validate_keys(
+            target,
+            allowed=_MEMBER_TARGET_KEYS,
+            required=_MEMBER_TARGET_KEYS,
+            context=f"member_targets[{index}]",
+        )
+        result.append(
+            MemberTarget(
+                stub_module=target["stub_module"],
+                stub_class=target["stub_class"],
+                runtime_module=target["runtime_module"],
+                runtime_class=target["runtime_class"],
+            )
+        )
+    return tuple(result)
+
+
+def load_config(path: Path) -> Config:
+    """Load paths relative to a package's coverage configuration."""
+    with path.open("rb") as config_file:
+        raw = tomllib.load(config_file)
+    _validate_keys(
+        raw,
+        allowed=_CONFIG_KEYS,
+        required=frozenset({"runtime_package", "stub_directory"}),
+        context=f"configuration {path}",
+    )
+    return Config(
+        runtime_package=raw["runtime_package"],
+        stub_directory=path.parent / raw["stub_directory"],
+        skip_modules=frozenset(raw.get("skip_modules", [])),
+        module_excludes={
+            module: frozenset(names)
+            for module, names in raw.get("module_excludes", {}).items()
+        },
+        member_excludes={
+            member: frozenset(names)
+            for member, names in raw.get("member_excludes", {}).items()
+        },
+        member_targets=_load_member_targets(raw.get("member_targets", [])),
+    )
+
+
+def _starts_parameterized_type_alias(
+    tokens: list[tokenize.TokenInfo], index: int
+) -> bool:
+    """Return whether `tokens[index]` starts `type Alias[...]`."""
+    following = (
+        token
+        for token in tokens[index + 1 :]
+        if token.type not in {tokenize.COMMENT, tokenize.NL}
+    )
+    alias = next(following, None)
+    bracket = next(following, None)
+    return (
+        alias is not None
+        and alias.type == tokenize.NAME
+        and not keyword.iskeyword(alias.string)
+        and bracket is not None
+        and bracket.string == "["
+    )
+
+
+def module_name(stub_directory: Path, path: Path, runtime_package: str) -> str:
+    """Convert a path in a PEP 561 `*-stubs` tree to its runtime module."""
+    relative = path.relative_to(stub_directory)
+    parts = list(relative.parts)
+    if parts[-1] == "__init__.pyi":
+        parts.pop()
+    else:
+        parts[-1] = Path(parts[-1]).stem
+    return ".".join((runtime_package, *parts))
+
+
+def _statements(statements: list[ast.stmt]) -> list[ast.stmt]:
+    """Flatten conditional declarations while preserving lexical scope."""
+    result = []
+    for statement in statements:
+        result.append(statement)
+        if isinstance(statement, ast.If):
+            result.extend(_statements(statement.body))
+            result.extend(_statements(statement.orelse))
+        elif isinstance(statement, (ast.Try, ast.TryStar)):
+            result.extend(_statements(statement.body))
+            result.extend(_statements(statement.orelse))
+            result.extend(_statements(statement.finalbody))
+            for handler in statement.handlers:
+                result.extend(_statements(handler.body))
+        elif isinstance(statement, (ast.For, ast.AsyncFor, ast.While)):
+            result.extend(_statements(statement.body))
+            result.extend(_statements(statement.orelse))
+        elif isinstance(statement, (ast.With, ast.AsyncWith)):
+            result.extend(_statements(statement.body))
+        elif isinstance(statement, ast.Match):
+            for case in statement.cases:
+                result.extend(_statements(case.body))
+    return result
+
+
+def _assigned_names(target: ast.expr) -> set[str]:
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, ast.Starred):
+        return _assigned_names(target.value)
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return set().union(*(_assigned_names(item) for item in target.elts))
+    return set()
+
+
+def _declared_names(statements: list[ast.stmt]) -> set[str]:
+    """Return names declared by statements in one lexical scope."""
+    result = set()
+    for statement in _statements(statements):
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            result.add(statement.name)
+        elif isinstance(statement, ast.Assign):
+            for target in statement.targets:
+                result.update(_assigned_names(target))
+        elif isinstance(statement, ast.AnnAssign):
+            result.update(_assigned_names(statement.target))
+        elif isinstance(statement, ast.TypeAlias):
+            result.update(_assigned_names(statement.name))
+    return result
+
+
+def _literal_strings(value: ast.expr) -> set[str] | None:
+    if not isinstance(value, (ast.List, ast.Tuple)):
+        return None
+    result = set()
+    for item in value.elts:
+        if not isinstance(item, ast.Constant) or not isinstance(item.value, str):
+            return None
+        result.add(item.value)
+    return result
+
+
+def _literal_all(tree: ast.Module) -> set[str] | None:  # noqa: C901
+    """Return every possible literal `__all__`, or `None` if it is computed."""
+    result: set[str] = set()
+    found = False
+    initialized = False
+    top_level = set(tree.body)
+    for statement in _statements(tree.body):
+        if isinstance(statement, ast.Expr) and isinstance(statement.value, ast.Call):
+            call = statement.value
+            if (
+                isinstance(call.func, ast.Attribute)
+                and isinstance(call.func.value, ast.Name)
+                and call.func.value.id == "__all__"
+            ):
+                found = True
+                if not initialized or call.keywords or len(call.args) != 1:
+                    return None
+                if call.func.attr == "append":
+                    value = call.args[0]
+                    if not isinstance(value, ast.Constant) or not isinstance(
+                        value.value, str
+                    ):
+                        return None
+                    result.add(value.value)
+                elif call.func.attr == "extend":
+                    values = _literal_strings(call.args[0])
+                    if values is None:
+                        return None
+                    result.update(values)
+                else:
+                    return None
+                continue
+        if isinstance(statement, ast.AugAssign):
+            if "__all__" not in _assigned_names(statement.target):
+                continue
+            found = True
+            if not initialized or not isinstance(statement.op, ast.Add):
+                return None
+            values = _literal_strings(statement.value)
+            if values is None:
+                return None
+            result.update(values)
+            continue
+        if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = (
+            statement.targets
+            if isinstance(statement, ast.Assign)
+            else [statement.target]
+        )
+        if not any("__all__" in _assigned_names(target) for target in targets):
+            continue
+        found = True
+        value = statement.value
+        if value is None:
+            continue
+        values = _literal_strings(value)
+        if values is None:
+            return None
+        if statement in top_level:
+            result = values
+        else:
+            result.update(values)
+        initialized = True
+    return result if found else None
+
+
+def parse_stub(path: Path) -> ast.Module:  # noqa: C901
+    """Parse a stub while running under the suite's Python 3.12 virtualenv.
+
+    The overlays use PEP 696 type-parameter defaults, which Python 3.12 cannot
+    parse. Removing those defaults is safe here because coverage only needs the
+    declaration tree, not annotation semantics.
+    """
+    tokens = list(
+        tokenize.generate_tokens(io.StringIO(path.read_text(encoding="utf-8")).readline)
+    )
+    output: list[tokenize.TokenInfo] = []
+    declaration = False
+    saw_name = False
+    type_parameter_depth = 0
+    skipping_default = False
+    for index, token in enumerate(tokens):
+        kind, value = token.type, token.string
+        if type_parameter_depth:
+            if value in {"(", "[", "{"}:
+                type_parameter_depth += 1
+            elif value in {")", "]", "}"}:
+                if value == "]" and type_parameter_depth == 1:
+                    type_parameter_depth = 0
+                    skipping_default = False
+                else:
+                    type_parameter_depth -= 1
+            elif value == "=" and type_parameter_depth == 1:
+                skipping_default = True
+                continue
+            elif value == "," and type_parameter_depth == 1:
+                skipping_default = False
+            if skipping_default:
+                continue
+            output.append(token)
+            continue
+
+        if kind == tokenize.NAME and (
+            value in {"class", "def"}
+            or (value == "type" and _starts_parameterized_type_alias(tokens, index))
+        ):
+            declaration = True
+            saw_name = False
+        elif declaration and kind == tokenize.NAME:
+            saw_name = True
+        elif declaration and saw_name and value == "[":
+            type_parameter_depth = 1
+        elif declaration and saw_name and value in {"(", ":"}:
+            declaration = False
+        elif declaration and kind not in {tokenize.COMMENT, tokenize.NL}:
+            declaration = False
+        output.append(token)
+    return ast.parse(tokenize.untokenize(output), filename=str(path))
+
+
+def stub_exports(path: Path, tree: ast.Module | None = None) -> set[str]:
+    """Return names that a stub exposes from one module."""
+    if tree is None:
+        tree = parse_stub(path)
+    explicit_all = _literal_all(tree)
+    # `__all__` controls star imports, not whether direct attribute access is
+    # valid. Include it to recognize re-exports, but retain every declaration.
+    exports: set[str] = set() if explicit_all is None else set(explicit_all)
+    exports.update(_declared_names(tree.body))
+    for statement in _statements(tree.body):
+        if isinstance(statement, (ast.Import, ast.ImportFrom)):
+            for alias in statement.names:
+                if alias.name == "*":
+                    raise ValueError(f"{path} uses an unsupported star import")
+                # PEP 484 only treats an import as a stub re-export when it uses
+                # an explicit alias (usually `from x import Y as Y`).
+                if alias.asname is not None:
+                    exports.add(alias.asname)
+    return exports - {"__all__"}
+
+
+def stub_class_members(
+    path: Path, class_name: str, tree: ast.Module | None = None
+) -> set[str]:
+    """Return members declared directly on a class in a stub."""
+    if tree is None:
+        tree = parse_stub(path)
+    members: set[str] = set()
+    found = False
+    for statement in _statements(tree.body):
+        if isinstance(statement, ast.ClassDef) and statement.name == class_name:
+            found = True
+            members.update(_declared_names(statement.body))
+    if not found:
+        raise ValueError(f"{path} does not declare class {class_name}")
+    return {name for name in members if not name.startswith("_")}
+
+
+def runtime_exports(module: Any) -> set[str]:
+    """Return the best available approximation of a module's public API."""
+    exports = {name for name in dir(module) if not name.startswith("_")}
+    explicit_all = getattr(module, "__all__", None)
+    if explicit_all is not None and not isinstance(explicit_all, str):
+        try:
+            all_names = {name for name in explicit_all if isinstance(name, str)}
+        except TypeError as error:
+            name = getattr(module, "__name__", type(module).__name__)
+            raise ValueError(
+                f"runtime module {name} has a non-iterable __all__"
+            ) from error
+        exports.update(all_names)
+    return exports
+
+
+def runtime_class_members(runtime_class: type[Any]) -> set[str]:
+    """Return public members declared by a runtime class or its bases."""
+    return {
+        name
+        for base in runtime_class.__mro__
+        for name in vars(base)
+        if not name.startswith("_")
+    }
+
+
+def _import_runtime_module(name: str) -> Any:
+    """Import a configured module with an actionable configuration error."""
+    try:
+        return importlib.import_module(name)
+    except ModuleNotFoundError as error:
+        raise ValueError(
+            f"cannot import runtime module {name}; check the configured module name "
+            "and installed package"
+        ) from error
+
+
+def _validate_exclusion_targets(config: Config, stub_modules: set[str]) -> None:
+    member_targets = {
+        f"{target.stub_module}.{target.stub_class}" for target in config.member_targets
+    }
+    for field, configured, valid in (
+        ("skip_modules", config.skip_modules, stub_modules),
+        ("module_excludes", config.module_excludes.keys(), stub_modules),
+        ("member_excludes", config.member_excludes.keys(), member_targets),
+    ):
+        unknown = configured - valid
+        if unknown:
+            raise ValueError(
+                f"{field} has entries with no matching stub target: "
+                f"{', '.join(sorted(unknown))}"
+            )
+
+
+def collect(config: Config) -> dict[str, dict[str, list[str]]]:
+    """Collect the declarations missing from an overlay."""
+    if not config.stub_directory.is_dir():
+        raise ValueError(f"stub directory is not a directory: {config.stub_directory}")
+    stub_files = sorted(config.stub_directory.rglob("*.pyi"))
+    if not stub_files:
+        raise ValueError(
+            f"stub directory contains no .pyi files: {config.stub_directory}"
+        )
+    paths_by_module: dict[str, Path] = {}
+    for stub_file in stub_files:
+        name = module_name(config.stub_directory, stub_file, config.runtime_package)
+        previous = paths_by_module.get(name)
+        if previous is not None:
+            raise ValueError(
+                f"stub paths {previous} and {stub_file} both map to runtime module "
+                f"{name}"
+            )
+        paths_by_module[name] = stub_file
+
+    _validate_exclusion_targets(config, set(paths_by_module))
+
+    modules: dict[str, list[str]] = {}
+    trees_by_path: dict[Path, ast.Module] = {}
+    for name, stub_file in paths_by_module.items():
+        if name in config.skip_modules:
+            continue
+        runtime_module = _import_runtime_module(name)
+        tree = parse_stub(stub_file)
+        trees_by_path[stub_file] = tree
+        modules[name] = sorted(
+            runtime_exports(runtime_module)
+            - stub_exports(stub_file, tree)
+            - config.module_excludes.get(name, frozenset())
+        )
+
+    members: dict[str, list[str]] = {}
+    for target in config.member_targets:
+        stub_file = paths_by_module.get(target.stub_module)
+        if stub_file is None:
+            raise ValueError(f"no stub file found for {target.stub_module}")
+        key = f"{target.stub_module}.{target.stub_class}"
+        runtime_module = _import_runtime_module(target.runtime_module)
+        try:
+            runtime_class = getattr(runtime_module, target.runtime_class)
+        except AttributeError as error:
+            raise ValueError(
+                f"runtime module {target.runtime_module} has no class "
+                f"{target.runtime_class}; fix or remove member_targets entry {key}"
+            ) from error
+        tree = trees_by_path.get(stub_file)
+        if tree is None:
+            tree = parse_stub(stub_file)
+            trees_by_path[stub_file] = tree
+        stub_members = stub_class_members(stub_file, target.stub_class, tree)
+        excluded_members = config.member_excludes.get(key, frozenset())
+        members[key] = sorted(
+            name
+            for name in runtime_class_members(runtime_class)
+            if name not in stub_members and name not in excluded_members
+        )
+    return {"modules": modules, "members": members}
+
+
+def format_report(
+    package: str,
+    version: str,
+    gaps: dict[str, dict[str, list[str]]],
+    *,
+    show_names: bool,
+) -> str:
+    """Format a compact inventory, optionally including every missing name."""
+    gap_count = sum(
+        len(names) for section in gaps.values() for names in section.values()
+    )
+    declaration = "declaration" if gap_count == 1 else "declarations"
+    lines = [f"{package} {version}: {gap_count} missing {declaration}"]
+    for section in ("modules", "members"):
+        lines.append(f"\n{section.capitalize()}:")
+        for name, missing in gaps[section].items():
+            lines.append(f"  {name}: {len(missing)}")
+            if show_names and missing:
+                lines.append("    " + ", ".join(missing))
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config", type=Path)
+    parser.add_argument(
+        "--show-names",
+        action="store_true",
+        help="include every missing declaration in text output (JSON always does)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the complete inventory as JSON",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        config = load_config(args.config.resolve())
+        gaps = collect(config)
+    except (OSError, SyntaxError, ValueError, tokenize.TokenError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    try:
+        version = importlib.metadata.version(config.runtime_package)
+    except importlib.metadata.PackageNotFoundError:
+        version = "unknown"
+
+    if args.json:
+        print(
+            json.dumps(
+                {"package": config.runtime_package, "version": version, **gaps},
+                indent=2,
+            )
+        )
+    else:
+        print(
+            format_report(
+                config.runtime_package,
+                version,
+                gaps,
+                show_names=args.show_names,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tensor-shapes/test_stub_coverage.py
+++ b/tensor-shapes/test_stub_coverage.py
@@ -1,0 +1,510 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import ast
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import mock
+
+import stub_coverage
+from stub_coverage import (
+    collect,
+    Config,
+    format_report,
+    load_config,
+    main,
+    MemberTarget,
+    module_name,
+    parse_stub,
+    runtime_class_members,
+    runtime_exports,
+    stub_class_members,
+    stub_exports,
+)
+
+
+class StubCoverageTest(unittest.TestCase):
+    def test_config_keys_are_validated(self) -> None:
+        cases = (
+            (
+                'runtime_package = "package"\nstub_directory = "stubs"\n'
+                "unknown = true\n",
+                "configuration .* has unknown keys: unknown",
+            ),
+            (
+                'runtime_package = "package"\n',
+                "configuration .* is missing required keys: stub_directory",
+            ),
+            (
+                'runtime_package = "package"\nstub_directory = "stubs"\n'
+                "[[member_targets]]\n"
+                'stub_module = "package"\n'
+                'stub_class = "Class"\n'
+                'runtime_module = "package"\n',
+                r"member_targets\[0\] is missing required keys: runtime_class",
+            ),
+            (
+                'runtime_package = "package"\nstub_directory = "stubs"\n'
+                "[[member_targets]]\n"
+                'stub_module = "package"\n'
+                'stub_class = "Class"\n'
+                'runtime_module = "package"\n'
+                'runtime_class = "Class"\n'
+                "unknown = true\n",
+                r"member_targets\[0\] has unknown keys: unknown",
+            ),
+            (
+                'runtime_package = "package"\nstub_directory = "stubs"\n'
+                'member_targets = ["Class"]\n',
+                r"member_targets\[0\] must be a table",
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "stub_coverage.toml"
+            for contents, message in cases:
+                with self.subTest(message=message):
+                    path.write_text(contents)
+                    with self.assertRaisesRegex(ValueError, message):
+                        load_config(path)
+
+    def test_stub_declarations(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "example.pyi"
+            path.write_text(
+                """
+from elsewhere import Exported as Exported, Internal
+
+__all__ = ["Exported"]
+
+type Alias = int
+
+class Box[T = int]:
+    value: T
+    def method(self) -> None: ...
+
+def function[T: int = int](value: T) -> T: ...
+"""
+            )
+            self.assertEqual(
+                stub_exports(path),
+                {"Alias", "Box", "Exported", "function"},
+            )
+            self.assertEqual(stub_class_members(path, "Box"), {"method", "value"})
+
+    def test_conditional_class_members_are_unioned(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "example.pyi"
+            path.write_text(
+                """
+if sys.version_info >= (3, 13):
+    class Versioned:
+        newer: int
+else:
+    class Versioned:
+        older: int
+"""
+            )
+            self.assertEqual(stub_class_members(path, "Versioned"), {"newer", "older"})
+
+    def test_parameterized_alias_defaults_and_incremental_all(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "example.pyi"
+            path.write_text(
+                """
+__all__: list[str]
+__all__ = ["Alias"]
+__all__ += ["loop_name", "with_name", "match_name"]
+
+type Alias[T = int] = list[T]
+for item in values:
+    loop_name, *rest = item
+with context:
+    with_name: int
+match value:
+    case _:
+        match_name: int
+"""
+            )
+            self.assertEqual(
+                stub_exports(path),
+                {"Alias", "loop_name", "match_name", "rest", "with_name"},
+            )
+
+    def test_literal_all_append_and_extend(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "example.pyi"
+            path.write_text(
+                """
+from elsewhere import Appended, Extended1, Extended2
+
+__all__ = []
+__all__.append("Appended")
+__all__.extend(["Extended1", "Extended2"])
+"""
+            )
+            self.assertEqual(
+                stub_exports(path),
+                {"Appended", "Extended1", "Extended2"},
+            )
+
+    def test_conditional_all_branches_are_unioned(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "example.pyi"
+            path.write_text(
+                """
+from elsewhere import New, Old
+
+if sys.version_info >= (3, 13):
+    __all__ = ["New"]
+else:
+    __all__ = ["Old"]
+"""
+            )
+            self.assertEqual(stub_exports(path), {"New", "Old"})
+
+    def test_top_level_all_reassignment_replaces_previous_value(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "example.pyi"
+            path.write_text(
+                """
+from elsewhere import Current, Previous
+
+__all__ = ["Previous"]
+__all__ = ["Current"]
+"""
+            )
+            self.assertEqual(stub_exports(path), {"Current"})
+
+    def test_computed_all_falls_back_to_declarations(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "example.pyi"
+            path.write_text(
+                """
+from elsewhere import Exported as Exported
+
+__all__ = exported_names()
+__all__ += ["Unknown"]
+
+def function() -> None: ...
+"""
+            )
+            self.assertEqual(stub_exports(path), {"Exported", "function"})
+
+    def test_uninitialized_all_augmentation_falls_back_to_declarations(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "example.pyi"
+            path.write_text(
+                """
+from elsewhere import Exported as Exported
+
+__all__ += ["Unknown"]
+"""
+            )
+            self.assertEqual(stub_exports(path), {"Exported"})
+
+    def test_computed_all_extension_falls_back_to_declarations(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "example.pyi"
+            path.write_text(
+                """
+from elsewhere import Exported as Exported, Hidden
+
+__all__ = ["Hidden"]
+__all__.extend(exported_names())
+"""
+            )
+            self.assertEqual(stub_exports(path), {"Exported"})
+
+    def test_type_soft_keyword_uses_are_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "example.pyi"
+            path.write_text(
+                """
+type: Annotated[int, lambda x=1: x]
+runtime_type = type(Annotated[int, lambda x=1: x])
+"""
+            )
+            self.assertEqual(stub_exports(path), {"runtime_type", "type"})
+
+    def test_type_expression_does_not_trigger_parameter_rewriting(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "example.pyi"
+            path.write_text("value = type is registry[lambda x=1: x]\n")
+            tree = parse_stub(path)
+            self.assertEqual(
+                ast.unparse(tree),
+                "value = type is registry[lambda x=1: x]",
+            )
+
+    def test_stub_parse_errors_preserve_source_positions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "example.pyi"
+            path.write_text(
+                "class Box[\n    T = int,\n]:\n    pass\n\ndef broken() return None\n"
+            )
+            with self.assertRaises(SyntaxError) as context:
+                parse_stub(path)
+            self.assertEqual(context.exception.lineno, 6)
+            self.assertEqual(context.exception.offset, 14)
+
+    def test_module_name(self) -> None:
+        root = Path("package-stubs")
+        self.assertEqual(module_name(root, root / "__init__.pyi", "package"), "package")
+        self.assertEqual(
+            module_name(root, root / "nested" / "api.pyi", "package"),
+            "package.nested.api",
+        )
+
+    def test_collect_rejects_missing_or_empty_stub_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            empty = root / "empty"
+            empty.mkdir()
+            for stub_directory, message in (
+                (root / "missing", "stub directory is not a directory"),
+                (empty, "stub directory contains no .pyi files"),
+            ):
+                with self.subTest(stub_directory=stub_directory):
+                    config = Config(
+                        runtime_package="unused",
+                        stub_directory=stub_directory,
+                        skip_modules=frozenset(),
+                        module_excludes={},
+                        member_excludes={},
+                        member_targets=(),
+                    )
+                    with self.assertRaisesRegex(ValueError, message):
+                        collect(config)
+
+    def test_collect_rejects_duplicate_module_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            stub_directory = Path(directory)
+            (stub_directory / "module").mkdir()
+            (stub_directory / "module.pyi").write_text("")
+            (stub_directory / "module" / "__init__.pyi").write_text("")
+            config = Config(
+                runtime_package="package",
+                stub_directory=stub_directory,
+                skip_modules=frozenset(),
+                module_excludes={},
+                member_excludes={},
+                member_targets=(),
+            )
+            with self.assertRaisesRegex(
+                ValueError,
+                "both map to runtime module package.module",
+            ):
+                collect(config)
+
+    def test_collect_reports_invalid_runtime_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            stub_directory = Path(directory)
+            (stub_directory / "__init__.pyi").write_text("class Missing: ...\n")
+            cases = (
+                (
+                    Config(
+                        runtime_package="missing_runtime_package",
+                        stub_directory=stub_directory,
+                        skip_modules=frozenset(),
+                        module_excludes={},
+                        member_excludes={},
+                        member_targets=(),
+                    ),
+                    "cannot import runtime module missing_runtime_package",
+                ),
+                (
+                    Config(
+                        runtime_package="sys",
+                        stub_directory=stub_directory,
+                        skip_modules=frozenset(),
+                        module_excludes={},
+                        member_excludes={},
+                        member_targets=(
+                            MemberTarget(
+                                stub_module="sys",
+                                stub_class="Missing",
+                                runtime_module="sys",
+                                runtime_class="Missing",
+                            ),
+                        ),
+                    ),
+                    "runtime module sys has no class Missing; "
+                    "fix or remove member_targets entry sys.Missing",
+                ),
+            )
+            for config, message in cases:
+                with self.subTest(message=message):
+                    with self.assertRaisesRegex(ValueError, message):
+                        collect(config)
+
+    def test_collect_rejects_exclusions_without_matching_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            stub_directory = Path(directory)
+            (stub_directory / "__init__.pyi").write_text("")
+            cases = (
+                (
+                    {"missing"},
+                    {},
+                    {},
+                    "skip_modules has entries with no matching stub target: missing",
+                ),
+                (
+                    set(),
+                    {"missing": frozenset()},
+                    {},
+                    "module_excludes has entries with no matching stub target: missing",
+                ),
+                (
+                    set(),
+                    {},
+                    {"sys.Missing": frozenset()},
+                    "member_excludes has entries with no matching stub target: sys.Missing",
+                ),
+            )
+            for skip_modules, module_excludes, member_excludes, message in cases:
+                with self.subTest(message=message):
+                    config = Config(
+                        runtime_package="sys",
+                        stub_directory=stub_directory,
+                        skip_modules=frozenset(skip_modules),
+                        module_excludes=module_excludes,
+                        member_excludes=member_excludes,
+                        member_targets=(),
+                    )
+                    with self.assertRaisesRegex(ValueError, message):
+                        collect(config)
+
+    def test_collect_parses_each_stub_once(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            stub_directory = Path(directory)
+            (stub_directory / "__init__.pyi").write_text("class int: ...\n")
+            config = Config(
+                runtime_package="builtins",
+                stub_directory=stub_directory,
+                skip_modules=frozenset(),
+                module_excludes={},
+                member_excludes={},
+                member_targets=(
+                    MemberTarget(
+                        stub_module="builtins",
+                        stub_class="int",
+                        runtime_module="builtins",
+                        runtime_class="int",
+                    ),
+                ),
+            )
+            with mock.patch.object(
+                stub_coverage, "parse_stub", wraps=parse_stub
+            ) as mocked_parse:
+                collect(config)
+            mocked_parse.assert_called_once()
+
+    def test_runtime_exports_include_all_public_names(self) -> None:
+        class Module:
+            __all__ = ["listed", "_listed_private"]
+            listed = None
+            visible = None
+            _listed_private = None
+            _private = None
+
+        self.assertEqual(
+            runtime_exports(Module()),
+            {"listed", "visible", "_listed_private"},
+        )
+
+    def test_runtime_exports_reject_non_iterable_all(self) -> None:
+        class Module:
+            __name__ = "package"
+            __all__ = 1
+
+        with self.assertRaisesRegex(
+            ValueError, "runtime module package has a non-iterable __all__"
+        ):
+            runtime_exports(Module())
+
+    def test_runtime_class_members_include_bases_but_not_metaclass(self) -> None:
+        class Meta(type):
+            metaclass_only = None
+
+        class Base:
+            inherited = None
+
+        class Child(Base, metaclass=Meta):
+            direct = None
+
+        self.assertEqual(runtime_class_members(Child), {"direct", "inherited"})
+
+    def test_report_can_include_names(self) -> None:
+        gaps = {"modules": {"package": ["missing"]}, "members": {}}
+        self.assertEqual(
+            format_report("package", "1.0", gaps, show_names=True),
+            "package 1.0: 1 missing declaration\n\n"
+            "Modules:\n"
+            "  package: 1\n"
+            "    missing\n\n"
+            "Members:",
+        )
+
+    def test_main_reports_validation_errors_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "stub_coverage.toml"
+            path.write_text('runtime_package = "package"\n')
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                result = main([str(path)])
+            self.assertEqual(result, 2)
+            self.assertRegex(
+                stderr.getvalue(),
+                r"^error: configuration .* is missing required keys: stub_directory\n$",
+            )
+
+    def test_main_reports_file_toml_and_stub_errors_without_tracebacks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            malformed = root / "malformed.toml"
+            malformed.write_text("invalid =\n")
+            invalid_stub_directory = root / "stubs"
+            invalid_stub_directory.mkdir()
+            (invalid_stub_directory / "__init__.pyi").write_text("value =\n")
+            invalid_stub = root / "invalid_stub.toml"
+            invalid_stub.write_text(
+                'runtime_package = "sys"\nstub_directory = "stubs"\n'
+            )
+            for path, message in (
+                (root / "missing.toml", "No such file or directory"),
+                (malformed, "Invalid value"),
+                (invalid_stub, "invalid syntax"),
+            ):
+                with self.subTest(path=path):
+                    stderr = io.StringIO()
+                    with redirect_stderr(stderr):
+                        result = main([str(path)])
+                    self.assertEqual(result, 2)
+                    self.assertIn(message, stderr.getvalue())
+                    self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_main_reports_token_errors_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            stub_directory = root / "stubs"
+            stub_directory.mkdir()
+            (stub_directory / "__init__.pyi").write_text('value = """\n')
+            config = root / "stub_coverage.toml"
+            config.write_text('runtime_package = "sys"\nstub_directory = "stubs"\n')
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                result = main([str(config)])
+            self.assertEqual(result, 2)
+            self.assertIn("EOF in multi-line string", stderr.getvalue())
+            self.assertNotIn("Traceback", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:

Partial stub packages replace each module they provide, so omissions can hide runtime APIs without a local signal. Add a reusable inspection tool that compares Torch, NumPy, and JAX runtime exports with their shape-aware overlays, including selected class members. The report is intentionally informational for now: it records versions and supports text or JSON output without enforcing a snapshot.

Reviewed By: avikchaudhuri

Differential Revision: D118978820


