### PR TITLE
[tensor-shapes] add stubs for jax.numpy indexing routines

### DIFF
--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_array.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_array.pyi
@@ -11,6 +11,7 @@ from types import EllipsisType
 from typing import Any, overload, Protocol, Sequence, SupportsIndex
 
 from jax._shapes import (
+    compress_shape,
     diagonal_shape,
     dot_shape,
     matmul_shape,
@@ -22,6 +23,8 @@ from jax._shapes import (
     sort_shape,
     squeeze_shape,
     swapaxes_shape,
+    take_scalar_idx_shape,
+    take_shape,
     trace_shape,
 )
 from jax.typing import DTypeLike
@@ -694,4 +697,57 @@ class Array[Shape: _Shape = _Shape]:
         self,
         min: Any = None,
         max: Any = None,
+    ) -> Array[IntTuple]: ...
+    @overload
+    def take[IdxShape: _Shape, Axis: Flag[int | None] = None](
+        self,
+        indices: Array[IdxShape],
+        axis: Axis = None,
+        out: None = None,
+        mode: str | None = None,
+        unique_indices: bool = False,
+        indices_are_sorted: bool = False,
+        fill_value: Any = None,
+    ) -> Array[take_shape(Shape, IdxShape, Axis)]: ...
+    @overload
+    def take[Axis: Flag[int | None] = None](
+        self,
+        indices: int,
+        axis: Axis = None,
+        out: None = None,
+        mode: str | None = None,
+        unique_indices: bool = False,
+        indices_are_sorted: bool = False,
+        fill_value: Any = None,
+    ) -> Array[take_scalar_idx_shape(Shape, Axis)]: ...
+    @overload
+    def take(
+        self,
+        indices: Any,
+        axis: int | None = None,
+        out: None = None,
+        mode: str | None = None,
+        unique_indices: bool = False,
+        indices_are_sorted: bool = False,
+        fill_value: Any = None,
+    ) -> Array[IntTuple]: ...
+    @overload
+    def compress[Size: Flag[int], Axis: Flag[int | None] = None](
+        self,
+        condition: Any,
+        axis: Axis = None,
+        out: None = None,
+        *,
+        size: Size,
+        fill_value: Any = 0,
+    ) -> Array[compress_shape(Shape, Size, Axis)]: ...
+    @overload
+    def compress(
+        self,
+        condition: Any,
+        axis: int | None = None,
+        out: None = None,
+        *,
+        size: int | None = None,
+        fill_value: Any = 0,
     ) -> Array[IntTuple]: ...

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
@@ -1207,3 +1207,131 @@ def lax_dynamic_slice_shape(shape: IntTuple, slice_sizes: IntTuple) -> IntTuple:
     if len(shape) != len(slice_sizes):
         return dsl.Invalid("slice_sizes must have the same length as operand rank")
     return slice_sizes
+
+@type_shape_dsl_function
+def take_shape(
+    a_shape: IntTuple,
+    idx_shape: IntTuple,
+    axis: int | None,
+) -> IntTuple:
+    if axis is None:
+        return idx_shape
+    if dsl.is_int_value(axis):
+        rank = len(a_shape)
+        if rank == 0:
+            return dsl.Invalid("axis out of bounds")
+        if axis < 0:
+            norm_axis = axis + rank
+        else:
+            norm_axis = axis + 0
+        if norm_axis < 0 or norm_axis >= rank:
+            return dsl.Invalid("axis out of bounds")
+        return dsl.concat(
+            dsl.concat(a_shape[:norm_axis], idx_shape),
+            a_shape[norm_axis + 1 :],
+        )
+    return dsl.Invalid("axis must be an integer or None")
+
+@type_shape_dsl_function
+def take_scalar_idx_shape(
+    a_shape: IntTuple,
+    axis: int | None,
+) -> IntTuple:
+    if axis is None:
+        return dsl.IntTuple(())
+    if dsl.is_int_value(axis):
+        rank = len(a_shape)
+        if rank == 0:
+            return dsl.Invalid("axis out of bounds")
+        if axis < 0:
+            norm_axis = axis + rank
+        else:
+            norm_axis = axis + 0
+        if norm_axis < 0 or norm_axis >= rank:
+            return dsl.Invalid("axis out of bounds")
+        return dsl.concat(a_shape[:norm_axis], a_shape[norm_axis + 1 :])
+    return dsl.Invalid("axis must be an integer or None")
+
+@type_shape_dsl_function
+def take_along_axis_shape(
+    arr_shape: IntTuple,
+    idx_shape: IntTuple,
+    axis: int | None,
+) -> IntTuple:
+    if axis is None:
+        if len(idx_shape) != 1:
+            return dsl.Invalid("take_along_axis indices must be 1D if axis=None")
+        return idx_shape
+    if dsl.is_int_value(axis):
+        rank = len(arr_shape)
+        if rank == 0 or len(idx_shape) != rank:
+            return dsl.Invalid(
+                "indices and arr must have the same number of dimensions"
+            )
+        if axis < 0:
+            norm_axis = axis + rank
+        else:
+            norm_axis = axis + 0
+        if norm_axis < 0 or norm_axis >= rank:
+            return dsl.Invalid("axis out of bounds")
+        extent = idx_shape[norm_axis] + 0
+        return dsl.concat(
+            dsl.concat(arr_shape[:norm_axis], dsl.IntTuple((extent,))),
+            arr_shape[norm_axis + 1 :],
+        )
+    return dsl.Invalid("axis must be an integer or None")
+
+@type_shape_dsl_function
+def compress_shape(
+    a_shape: IntTuple,
+    size: int,
+    axis: int | None,
+) -> IntTuple:
+    if size < 0:
+        return dsl.Invalid("size must be non-negative")
+    extent = size + 0
+    if axis is None:
+        return dsl.IntTuple((extent,))
+    if dsl.is_int_value(axis):
+        rank = len(a_shape)
+        if rank == 0:
+            return dsl.Invalid("axis out of bounds")
+        if axis < 0:
+            norm_axis = axis + rank
+        else:
+            norm_axis = axis + 0
+        if norm_axis < 0 or norm_axis >= rank:
+            return dsl.Invalid("axis out of bounds")
+        return dsl.concat(
+            dsl.concat(a_shape[:norm_axis], dsl.IntTuple((extent,))),
+            a_shape[norm_axis + 1 :],
+        )
+    return dsl.Invalid("axis must be an integer or None")
+
+@type_shape_dsl_function
+def fill_diagonal_shape(shape: IntTuple) -> IntTuple:
+    if len(shape) < 2:
+        return dsl.Invalid("array must be at least 2-d")
+    return shape
+
+@type_shape_dsl_function
+def diag_indices_from_shape(shape: IntTuple) -> IntTuple:
+    rank = len(shape)
+    if rank < 2:
+        return dsl.Invalid("input array must be at least 2-d")
+    if any(shape[i] != shape[0] for i in range(rank)):
+        return dsl.Invalid("All dimensions of input must be of equal length")
+    extent = shape[0] + 0
+    return dsl.IntTuple((extent,))
+
+@type_shape_dsl_function
+def ix_shapes(shapes: IntTuples) -> IntTuples:
+    ranks = dsl.IntTuple((0 if len(shape) == 1 else 1 for shape in shapes))
+    if any(r == 1 for r in ranks):
+        return dsl.Invalid("Arguments to jax.numpy.ix_ must be 1-dimensional")
+    return dsl.IntTuples(
+        (
+            dsl.IntTuple((shape[0] if j == i else 1 for j in range(len(shapes))))
+            for shape, i in zip(shapes, range(len(shapes)))
+        )
+    )

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
@@ -12,18 +12,22 @@ from jax._shapes import (
     atleast_3d_shape,
     broadcast_to_shape,
     column_stack_shape,
+    compress_shape,
     concatenate_shape,
     cross_axes_shape,
     cross_axis_shape,
+    diag_indices_from_shape,
     diagonal_shape,
     dot_shape,
     dstack_shape,
     einsum_shape,
     expand_dims_shape,
+    fill_diagonal_shape,
     flip_shape,
     hstack_shape,
     inner_shape,
     int_min,
+    ix_shapes,
     kron_shape,
     matmul_shape,
     matvec_shape,
@@ -39,6 +43,9 @@ from jax._shapes import (
     squeeze_shape,
     stack_shape,
     swapaxes_shape,
+    take_along_axis_shape,
+    take_scalar_idx_shape,
+    take_shape,
     tensordot_shape,
     top_k_shape,
     trace_shape,
@@ -2981,6 +2988,271 @@ def unique_values(
     size: int | None = None,
     fill_value: Any = None,
 ) -> Array[IntTuple]: ...
+
+# Indexing, Slicing & Masking
+@overload
+def compress[Shape: _Shape, Size: Flag[int], Axis: Flag[int | None] = None](
+    condition: Any,
+    a: Array[Shape],
+    axis: Axis = None,
+    *,
+    size: Size,
+    fill_value: Any = 0,
+    out: None = None,
+) -> Array[compress_shape(Shape, Size, Axis)]: ...
+@overload
+def compress[Shape: _Shape, Axis: Flag[int | None] = None](
+    condition: Any,
+    a: Array[Shape],
+    axis: Axis = None,
+    *,
+    size: int | None = None,
+    fill_value: Any = 0,
+    out: None = None,
+) -> Array[IntTuple]: ...
+@overload
+def compress(
+    condition: Any,
+    a: Any,
+    axis: int | None = None,
+    *,
+    size: int | None = None,
+    fill_value: Any = 0,
+    out: None = None,
+) -> Array[IntTuple]: ...
+def delete(
+    arr: Any,
+    obj: Any,
+    axis: int | None = None,
+    *,
+    assume_unique_indices: bool = False,
+) -> Array[IntTuple]: ...
+@overload
+def extract[Size: IntVar](
+    condition: Any,
+    arr: Any,
+    *,
+    size: Int[Size],
+    fill_value: Any = 0,
+) -> Array[[Size]]: ...
+@overload
+def extract(
+    condition: Any,
+    arr: Any,
+    *,
+    size: int | None = None,
+    fill_value: Any = 0,
+) -> Array[IntTuple]: ...
+@overload
+def fill_diagonal[Shape: _Shape](
+    a: Array[Shape],
+    val: Any,
+    wrap: bool = False,
+    *,
+    inplace: bool = True,
+) -> Array[fill_diagonal_shape(Shape)]: ...
+@overload
+def fill_diagonal(
+    a: Any,
+    val: Any,
+    wrap: bool = False,
+    *,
+    inplace: bool = True,
+) -> Array[IntTuple]: ...
+def insert(
+    arr: Any,
+    obj: Any,
+    values: Any,
+    axis: int | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def place[Shape: _Shape](
+    arr: Array[Shape],
+    mask: Any,
+    vals: Any,
+    *,
+    inplace: bool = True,
+) -> Array[Shape]: ...
+@overload
+def place(
+    arr: Any,
+    mask: Any,
+    vals: Any,
+    *,
+    inplace: bool = True,
+) -> Array[IntTuple]: ...
+@overload
+def put[Shape: _Shape](
+    a: Array[Shape],
+    ind: Any,
+    v: Any,
+    mode: str | None = None,
+    *,
+    inplace: bool = True,
+) -> Array[Shape]: ...
+@overload
+def put(
+    a: Any,
+    ind: Any,
+    v: Any,
+    mode: str | None = None,
+    *,
+    inplace: bool = True,
+) -> Array[IntTuple]: ...
+@overload
+def put_along_axis[Shape: _Shape](
+    arr: Array[Shape],
+    indices: Any,
+    values: Any,
+    axis: int | None,
+    inplace: bool = True,
+    *,
+    mode: str | None = None,
+) -> Array[Shape]: ...
+@overload
+def put_along_axis(
+    arr: Any,
+    indices: Any,
+    values: Any,
+    axis: int | None,
+    inplace: bool = True,
+    *,
+    mode: str | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def take[Shape: _Shape, IdxShape: _Shape, Axis: Flag[int | None] = None](
+    a: Array[Shape],
+    indices: Array[IdxShape],
+    axis: Axis = None,
+    out: None = None,
+    mode: str | None = None,
+    unique_indices: bool = False,
+    indices_are_sorted: bool = False,
+    fill_value: Any = None,
+) -> Array[take_shape(Shape, IdxShape, Axis)]: ...
+@overload
+def take[Shape: _Shape, Axis: Flag[int | None] = None](
+    a: Array[Shape],
+    indices: int,
+    axis: Axis = None,
+    out: None = None,
+    mode: str | None = None,
+    unique_indices: bool = False,
+    indices_are_sorted: bool = False,
+    fill_value: Any = None,
+) -> Array[take_scalar_idx_shape(Shape, Axis)]: ...
+@overload
+def take(
+    a: Any,
+    indices: Any,
+    axis: int | None = None,
+    out: None = None,
+    mode: str | None = None,
+    unique_indices: bool = False,
+    indices_are_sorted: bool = False,
+    fill_value: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def take_along_axis[ArrShape: _Shape, IdxShape: _Shape, Axis: Flag[int | None] = -1](
+    arr: Array[ArrShape],
+    indices: Array[IdxShape],
+    axis: Axis = -1,
+    mode: str | None = None,
+    fill_value: Any = None,
+    *,
+    wrap_negative_indices: bool = True,
+) -> Array[take_along_axis_shape(ArrShape, IdxShape, Axis)]: ...
+@overload
+def take_along_axis(
+    arr: Any,
+    indices: Any,
+    axis: int | None = -1,
+    mode: str | None = None,
+    fill_value: Any = None,
+    *,
+    wrap_negative_indices: bool = True,
+) -> Array[IntTuple]: ...
+def trim_zeros(
+    filt: Any,
+    trim: str = "fb",
+    axis: int | Sequence[int] | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def diag_indices[N: IntVar](
+    n: Int[N],
+    ndim: int = 2,
+) -> tuple[Array[[N]], ...]: ...
+@overload
+def diag_indices(
+    n: int,
+    ndim: int = 2,
+) -> tuple[Array[IntTuple], ...]: ...
+@overload
+def diag_indices_from[Shape: _Shape](
+    arr: Array[Shape],
+) -> tuple[Array[diag_indices_from_shape(Shape)], ...]: ...
+@overload
+def diag_indices_from(
+    arr: Any,
+) -> tuple[Array[IntTuple], ...]: ...
+@overload
+def mask_indices[Size: IntVar](
+    n: int,
+    mask_func: Callable[..., Any],
+    k: int = 0,
+    *,
+    size: Int[Size],
+) -> tuple[Array[[Size]], Array[[Size]]]: ...
+@overload
+def mask_indices(
+    n: int,
+    mask_func: Callable[..., Any],
+    k: int = 0,
+    *,
+    size: int | None = None,
+) -> tuple[Array[IntTuple], Array[IntTuple]]: ...
+def ravel_multi_index(
+    multi_index: Sequence[Any],
+    dims: Sequence[int],
+    mode: str = "raise",
+    order: str = "C",
+    *,
+    dtype: Any = None,
+) -> Array[IntTuple]: ...
+def tril_indices(
+    n: int,
+    k: int = 0,
+    m: int | None = None,
+) -> tuple[Array[IntTuple], Array[IntTuple]]: ...
+def tril_indices_from(
+    arr: Any,
+    k: int = 0,
+) -> tuple[Array[IntTuple], Array[IntTuple]]: ...
+def triu_indices(
+    n: int,
+    k: int = 0,
+    m: int | None = None,
+) -> tuple[Array[IntTuple], Array[IntTuple]]: ...
+def triu_indices_from(
+    arr: Any,
+    k: int = 0,
+) -> tuple[Array[IntTuple], Array[IntTuple]]: ...
+@overload
+def unravel_index[Shape: _Shape](
+    indices: Array[Shape],
+    shape: Any,
+) -> tuple[Array[Shape], ...]: ...
+@overload
+def unravel_index(
+    indices: int,
+    shape: Any,
+) -> tuple[Array[[]], ...]: ...
+@overload
+def ix_[Shapes: IntTuples](
+    *args: Unpack[MapIntTuples[lambda S: Array[S], Shapes]],
+) -> MapIntTuples[lambda S: Array[S], ix_shapes(Shapes)]: ...
+@overload
+def ix_(*args: Array[Any]) -> tuple[Array[IntTuple], ...]: ...
 
 float32: Any
 float64: Any

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_indexing.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_indexing.py
@@ -121,3 +121,247 @@ def test_invalid_index() -> None:
         pass
     else:
         raise AssertionError("expected JAX to reject multiple ellipses")
+
+
+def test_take() -> None:
+    x = jnp.ones((2, 3, 4))
+    idx = jnp.array([[0, 1], [2, 0]])
+
+    # Multi-dimensional indices along axis
+    assert_shape(jnp.take(x, idx, axis=1).shape, (2, 2, 2, 4))
+    assert_shape(x.take(idx, axis=1).shape, (2, 2, 2, 4))
+
+    # Multi-dimensional indices without axis (flattens input)
+    assert_shape(jnp.take(x, idx, axis=None).shape, (2, 2))
+    assert_shape(x.take(idx, axis=None).shape, (2, 2))
+    assert_shape(jnp.take(x, idx).shape, (2, 2))
+    assert_shape(x.take(idx).shape, (2, 2))
+
+    # Scalar index along axis
+    assert_shape(jnp.take(x, 1, axis=1).shape, (2, 4))
+    assert_shape(x.take(1, axis=1).shape, (2, 4))
+
+    # Scalar index without axis
+    assert_shape(jnp.take(x, 1, axis=None).shape, ())
+    assert_shape(x.take(1, axis=None).shape, ())
+    assert_shape(jnp.take(x, 1).shape, ())
+    assert_shape(x.take(1).shape, ())
+
+
+def test_take_rejects_out_of_bounds_axis() -> None:
+    x = jnp.ones((2, 3))
+    assert_shape(jnp.take(x, 0, axis=1).shape, (2,))
+    try:
+        # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+        jnp.take(x, 0, axis=2)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject an out-of-bounds axis")
+
+
+def test_take_along_axis() -> None:
+    x = jnp.ones((2, 3, 4))
+    idx = jnp.zeros((2, 1, 4), dtype=int)
+
+    assert_shape(jnp.take_along_axis(x, idx, axis=1).shape, (2, 1, 4))
+    assert_shape(jnp.take_along_axis(x, idx, axis=-2).shape, (2, 1, 4))
+
+    idx_1d = jnp.zeros(5, dtype=int)
+    assert_shape(jnp.take_along_axis(x, idx_1d, axis=None).shape, (5,))
+
+
+def test_take_along_axis_rejects_mismatched_rank() -> None:
+    x = jnp.ones((2, 3, 4))
+    assert_shape(
+        jnp.take_along_axis(x, jnp.zeros((2, 1, 4), dtype=int), axis=1).shape,
+        (2, 1, 4),
+    )
+    try:
+        # E: Cannot evaluate type-level shape DSL call: indices and arr must have the same number of dimensions
+        jnp.take_along_axis(x, jnp.zeros((2, 1), dtype=int), axis=1)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject mismatched index rank")
+
+
+def test_compress() -> None:
+    x = jnp.ones((2, 3, 4))
+    cond = jnp.array([True, False, True])
+
+    assert_shape(jnp.compress(cond, x, axis=1, size=2).shape, (2, 2, 4))
+    assert_shape(x.compress(cond, axis=1, size=2).shape, (2, 2, 4))
+
+    cond_flat = jnp.array([True, False] * 12)
+    assert_shape(jnp.compress(cond_flat, x, size=5).shape, (5,))
+    assert_shape(x.compress(cond_flat, size=5).shape, (5,))
+
+
+def test_compress_rejects_out_of_bounds_axis() -> None:
+    x = jnp.ones((2, 3))
+    cond = jnp.array([True, False])
+    assert_shape(jnp.compress(cond, x, axis=0, size=1).shape, (1, 3))
+    try:
+        # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+        jnp.compress(cond, x, axis=5, size=1)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject an out-of-bounds axis")
+
+
+def test_extract() -> None:
+    arr = jnp.arange(6)
+    cond = jnp.array([True, False, True, False, True, False])
+    assert_shape(jnp.extract(cond, arr, size=3).shape, (3,))
+
+
+def test_fill_diagonal() -> None:
+    a = jnp.zeros((3, 4))
+    assert_shape(jnp.fill_diagonal(a, 1, inplace=False).shape, (3, 4))
+
+    b = jnp.zeros((3, 3, 3))
+    assert_shape(jnp.fill_diagonal(b, 1, inplace=False).shape, (3, 3, 3))
+
+
+def test_fill_diagonal_rejects_1d() -> None:
+    assert_shape(jnp.fill_diagonal(jnp.zeros((2, 2)), 1, inplace=False).shape, (2, 2))
+    a = jnp.zeros(3)
+    try:
+        # E: Cannot evaluate type-level shape DSL call: array must be at least 2-d
+        jnp.fill_diagonal(a, 1, inplace=False)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject 1-D array")
+
+
+def test_place() -> None:
+    x = jnp.zeros(5)
+    mask = jnp.array([True, False, True, False, False])
+    assert_shape(jnp.place(x, mask, 9, inplace=False).shape, (5,))
+
+
+def test_put() -> None:
+    x = jnp.zeros(5)
+    ind = jnp.array([0, 2])
+    assert_shape(jnp.put(x, ind, 7, inplace=False).shape, (5,))
+
+
+def test_put_along_axis() -> None:
+    y = jnp.zeros((2, 3))
+    ind = jnp.array([[0], [1]])
+    assert_shape(jnp.put_along_axis(y, ind, 4, axis=1, inplace=False).shape, (2, 3))
+
+
+def test_diag_indices() -> None:
+    idx2 = jnp.diag_indices(4, ndim=2)
+    assert len(idx2) == 2
+    assert_shape(idx2[0].shape, (4,))
+    assert_shape(idx2[1].shape, (4,))
+
+    idx3 = jnp.diag_indices(5, ndim=3)
+    assert len(idx3) == 3
+    assert_shape(idx3[0].shape, (5,))
+    assert_shape(idx3[1].shape, (5,))
+    assert_shape(idx3[2].shape, (5,))
+
+
+def test_diag_indices_from() -> None:
+    arr = jnp.zeros((4, 4))
+    idx = jnp.diag_indices_from(arr)
+    assert len(idx) == 2
+    assert_shape(idx[0].shape, (4,))
+    assert_shape(idx[1].shape, (4,))
+
+
+def test_diag_indices_from_rejects_non_square() -> None:
+    arr_sq = jnp.zeros((3, 3))
+    assert_shape(jnp.diag_indices_from(arr_sq)[0].shape, (3,))
+    arr = jnp.zeros((3, 4))
+    try:
+        # E: Cannot evaluate type-level shape DSL call: All dimensions of input must be of equal length
+        jnp.diag_indices_from(arr)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject non-square input")
+
+
+def test_mask_indices() -> None:
+    r, c = jnp.mask_indices(4, jnp.triu, 1, size=6)
+    assert_shape(r.shape, (6,))
+    assert_shape(c.shape, (6,))
+
+
+def test_tril_and_triu_indices() -> None:
+    r, c = jnp.tril_indices(4)
+    assert_shape(r.shape, (10,))
+    assert_shape(c.shape, (10,))
+
+    a = jnp.zeros((4, 4))
+    r2, c2 = jnp.tril_indices_from(a)
+    assert_shape(r2.shape, (10,))
+    assert_shape(c2.shape, (10,))
+
+    r3, c3 = jnp.triu_indices(4)
+    assert_shape(r3.shape, (10,))
+    assert_shape(c3.shape, (10,))
+
+    r4, c4 = jnp.triu_indices_from(a)
+    assert_shape(r4.shape, (10,))
+    assert_shape(c4.shape, (10,))
+
+
+def test_unravel_index() -> None:
+    idx = jnp.array([22, 41, 37])
+    res = jnp.unravel_index(idx, (6, 7, 8))
+    assert len(res) == 3
+    assert_shape(res[0].shape, (3,))
+    assert_shape(res[1].shape, (3,))
+    assert_shape(res[2].shape, (3,))
+
+    res_scalar = jnp.unravel_index(5, (6, 7))
+    assert len(res_scalar) == 2
+    assert_shape(res_scalar[0].shape, ())
+    assert_shape(res_scalar[1].shape, ())
+
+
+def test_ravel_multi_index() -> None:
+    arrs = (jnp.array([3, 6, 6]), jnp.array([4, 5, 1]))
+    res = jnp.ravel_multi_index(arrs, (7, 6))
+    assert_shape(res.shape, (3,))
+
+
+def test_ix() -> None:
+    a = jnp.zeros(2)
+    b = jnp.zeros(3)
+    c = jnp.zeros(4)
+    ix = jnp.ix_(a, b, c)
+    assert len(ix) == 3
+    assert_shape(ix[0].shape, (2, 1, 1))
+    assert_shape(ix[1].shape, (1, 3, 1))
+    assert_shape(ix[2].shape, (1, 1, 4))
+
+
+def test_ix_rejects_non_1d() -> None:
+    assert_shape(jnp.ix_(jnp.zeros(2))[0].shape, (2,))
+    try:
+        # E: Cannot evaluate type-level shape DSL call: Arguments to jax.numpy.ix_ must be 1-dimensional
+        jnp.ix_(jnp.zeros((2, 2)))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject non-1D input")
+
+
+def test_delete_and_insert() -> None:
+    a = jnp.array([1, 2, 3, 4, 5])
+    assert_shape(jnp.delete(a, 1).shape, (4,))
+    assert_shape(jnp.insert(a, 1, 99).shape, (6,))
+
+
+def test_trim_zeros() -> None:
+    a = jnp.array([0, 0, 1, 2, 0])
+    assert_shape(jnp.trim_zeros(a).shape, (2,))


### PR DESCRIPTION
## Summary

Stubs for `jax.numpy.take`, `jax.numpy.put`, and other index-related APIs.

## Test Plan

Updated existing tests & ensured they passed locally:
```
$ uv tool run --from ruff==0.14.3 ruff format --check --config ruff.toml .
332 files already formatted
$ uv tool run --from ruff==0.14.3 ruff check --select I --config ruff.toml .
All checks passed!
$ uv run python test.py --no-test --no-conformance --no-jsonschema
Running formatting...
Finished in 2.74 seconds.
Running linting...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.88s
Finished in 1.13 seconds.
$ uv run python tensor-shapes/pyrefly-jax-stubs/run_pyrefly.py --release
+ cargo build -p pyrefly --release
    Finished `release` profile [optimized + debuginfo] target(s) in 0.53s
PASS stubs (9 files)
PASS arithmetic (1 files)
PASS contractions (1 files)
PASS creation (1 files)
PASS fft (1 files)
PASS indexing (1 files)
PASS lax (1 files)
PASS linalg (1 files)
PASS matmul (1 files)
PASS nn (1 files)
PASS reductions (1 files)
PASS reshape (1 files)
PASS searching-sorting (1 files)
PASS structural (1 files)
```

## AI Disclosure

PR generated with a gemini coding agent.