### PR TITLE
Push a notification when the build system status changes (#4855)

### DIFF
--- a/lsp/src/extension.ts
+++ b/lsp/src/extension.ts
@@ -24,8 +24,10 @@ import {
   ServerOptions,
 } from 'vscode-languageclient/node';
 import {
+  TYPE_ERROR_DISPLAY_STATUS_CHANGED_METHOD,
   TYPE_ERROR_DISPLAY_STATUS_VERSION,
   getStatusBarItem,
+  scheduleStatusBarUpdate,
   updateStatusBar,
 } from './status-bar';
 import {runDocstringFoldingCommand} from './docstring';
@@ -164,6 +166,7 @@ export async function activate(context: ExtensionContext) {
       ...((rawInitialisationOptions as any).pyrefly ?? {}),
       typeErrorDisplayStatusVersion: TYPE_ERROR_DISPLAY_STATUS_VERSION,
       customHoverProvider: supportsHoverVerbosity,
+      pushTypeErrorDisplayStatus: true,
     },
   };
 
@@ -227,6 +230,12 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor(async () => {
       await updateStatusBar(client);
+    }),
+  );
+
+  context.subscriptions.push(
+    client.onNotification(TYPE_ERROR_DISPLAY_STATUS_CHANGED_METHOD, () => {
+      scheduleStatusBarUpdate(client);
     }),
   );
 

--- a/lsp/src/status-bar.ts
+++ b/lsp/src/status-bar.ts
@@ -40,6 +40,10 @@ type TypeErrorDisplayStatusV2 = {
   // Version string of the language server binary, or null when the
   // server doesn't know it.
   pyreflyVersion: string | null;
+  // The current status of the build system. Typically, if a build system is
+  // configured, here you would see something like `building`, `ready`,
+  // or `error: <error>`.
+  buildSystem: string | null;
 };
 
 /// Update the status bar based on current configuration
@@ -172,6 +176,9 @@ function renderV2(status: TypeErrorDisplayStatusV2) {
       // (and copyable) while still clickable.
       sections.push(`Docs: [${status.docsUrl}](${status.docsUrl})`);
     }
+  }
+  if (status.buildSystem) {
+    sections.push(`Build system: ${status.buildSystem}`);
   }
   if (status.pyreflyVersion) {
     sections.push(`Pyrefly version: ${status.pyreflyVersion}`);

--- a/lsp/src/status-bar.ts
+++ b/lsp/src/status-bar.ts
@@ -8,7 +8,7 @@
  */
 
 import * as vscode from 'vscode';
-import {LanguageClient} from 'vscode-languageclient/node';
+import {LanguageClient, State} from 'vscode-languageclient/node';
 
 let statusBarItem: vscode.StatusBarItem;
 
@@ -21,6 +21,13 @@ let statusBarItem: vscode.StatusBarItem;
  * dispatch all change together.
  */
 export const TYPE_ERROR_DISPLAY_STATUS_VERSION = 'v2' as const;
+
+/**
+ * Method name of the server→client notification saying our cached status may
+ * be stale.
+ */
+export const TYPE_ERROR_DISPLAY_STATUS_CHANGED_METHOD =
+  'pyrefly/typeErrorDisplayStatusChanged' as const;
 
 /**
  * V2 wire shape for `pyrefly/textDocument/typeErrorDisplayStatus`. The
@@ -105,6 +112,36 @@ export async function updateStatusBar(client: LanguageClient) {
     statusBarItem.hide();
   }
 }
+
+/**
+ * Trailing-debounced `updateStatusBar`, for server-pushed refreshes.
+ *
+ * A single source-database rebuild pushes at least a `building`/`ready` pair,
+ * and a workspace with several configs pushes more, so coalescing keeps this to
+ * one round-trip per burst. The trailing edge also means a build that finishes
+ * within the window never flashes `building` at all.
+ */
+export function scheduleStatusBarUpdate(client: LanguageClient) {
+  if (pushRefreshTimer != null) {
+    clearTimeout(pushRefreshTimer);
+  }
+  pushRefreshTimer = setTimeout(() => {
+    pushRefreshTimer = undefined;
+    if (client.state !== State.Running) {
+      return;
+    }
+    // A push is server-driven and can land while focus sits on a non-Python
+    // editor. Skip rather than let `updateStatusBar` hide the item, which
+    // nothing would undo until the next editor change.
+    if (vscode.window.activeTextEditor?.document.languageId !== 'python') {
+      return;
+    }
+    void updateStatusBar(client);
+  }, PUSH_REFRESH_DEBOUNCE_MS);
+}
+
+const PUSH_REFRESH_DEBOUNCE_MS = 150;
+let pushRefreshTimer: ReturnType<typeof setTimeout> | undefined;
 
 /**
  * V1 renderer: legacy bare-string responses from older binaries. Kept

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -312,6 +312,7 @@ use crate::lsp::non_wasm::queue::QueuedEvent;
 use crate::lsp::non_wasm::safe_delete_file::safe_delete_file_code_action;
 use crate::lsp::non_wasm::stdlib::should_show_stdlib_error;
 use crate::lsp::non_wasm::transaction_manager::TransactionManager;
+use crate::lsp::non_wasm::type_error_display_status::BuildSystemStatus;
 use crate::lsp::non_wasm::type_error_display_status::TypeErrorDisplayStatus;
 pub use crate::lsp::non_wasm::type_error_display_status::TypeErrorDisplayStatusRequest;
 use crate::lsp::non_wasm::type_error_display_status::TypeErrorDisplayStatusResponse;
@@ -897,6 +898,9 @@ pub struct Server {
     sourcedb_queue: HeavyTaskQueue,
     /// Any configs whose find cache should be invalidated.
     invalidated_source_dbs: Mutex<SmallSet<ArcId<Box<dyn SourceDatabase + 'static>>>>,
+    /// State of the most recent build-system source database query, surfaced in
+    /// the status bar.
+    build_system_status: Mutex<Option<BuildSystemStatus>>,
     /// Custom initialization options are provided via initialize_params.initializationOptions
     /// The type should match `LspConfig`
     initialize_params: InitializeParams,
@@ -2700,6 +2704,7 @@ impl Server {
             find_reference_queue: HeavyTaskQueue::new(QueueName::FindReferenceQueue),
             sourcedb_queue: HeavyTaskQueue::new(QueueName::SourceDbQueue),
             invalidated_source_dbs: Mutex::new(SmallSet::new()),
+            build_system_status: Mutex::new(None),
             initialize_params,
             indexing_mode,
             workspace_indexing_limit,
@@ -3046,6 +3051,10 @@ impl Server {
             workspace_disable_type_errors,
             workspace_type_checking_mode,
             self.server_version.clone(),
+            self.build_system_status
+                .lock()
+                .as_ref()
+                .map(BuildSystemStatus::display),
         )
     }
 
@@ -3615,6 +3624,14 @@ impl Server {
         !self.workspaces.workspace_diagnostic_roots().is_empty()
     }
 
+    /// Records the build system's state for the status bar.
+    ///
+    /// Called from the source database queue thread, so it must not take any
+    /// lock the query itself holds.
+    fn set_build_system_status(&self, status: BuildSystemStatus) {
+        *self.build_system_status.lock() = Some(status);
+    }
+
     /// Attempts to requery any open sourced_dbs for open files, and if there are changes,
     /// invalidate find and perform a recheck.
     fn queue_source_db_rebuild_and_recheck(
@@ -3643,8 +3660,25 @@ impl Server {
                     .insert(handle.path().dupe());
             }
             let task_telemetry = SubTaskTelemetry::new(telemetry, telemetry_event);
+            // Mirrors the filter in `ConfigFile::query_source_db` to see if we
+            // will actually kick a build system query off.
+            let queries_build_system = configs_to_paths.keys().any(|config| {
+                config
+                    .source_db
+                    .as_ref()
+                    .is_some_and(|db| db.as_live_source_database().is_some())
+            });
+            if queries_build_system {
+                server.set_build_system_status(BuildSystemStatus::Building);
+            }
             let outcome =
                 ConfigFile::query_source_db(&configs_to_paths, force, Some(task_telemetry));
+            if queries_build_system {
+                server.set_build_system_status(match outcome.error {
+                    Some(error) => BuildSystemStatus::Failed(error),
+                    None => BuildSystemStatus::Ready,
+                });
+            }
             telemetry_event.set_sourcedb_rebuild_stats(outcome.stats);
             if !outcome.reloaded.is_empty() {
                 let mut lock = server.invalidated_source_dbs.lock();

--- a/pyrefly/lib/lsp/non_wasm/server.rs
+++ b/pyrefly/lib/lsp/non_wasm/server.rs
@@ -314,6 +314,8 @@ use crate::lsp::non_wasm::stdlib::should_show_stdlib_error;
 use crate::lsp::non_wasm::transaction_manager::TransactionManager;
 use crate::lsp::non_wasm::type_error_display_status::BuildSystemStatus;
 use crate::lsp::non_wasm::type_error_display_status::TypeErrorDisplayStatus;
+pub use crate::lsp::non_wasm::type_error_display_status::TypeErrorDisplayStatusChangedNotification;
+use crate::lsp::non_wasm::type_error_display_status::TypeErrorDisplayStatusChangedParams;
 pub use crate::lsp::non_wasm::type_error_display_status::TypeErrorDisplayStatusRequest;
 use crate::lsp::non_wasm::type_error_display_status::TypeErrorDisplayStatusResponse;
 use crate::lsp::non_wasm::type_error_display_status::TypeErrorDisplayStatusV2;
@@ -321,6 +323,7 @@ use crate::lsp::non_wasm::type_error_display_status::TypeErrorDisplayStatusVersi
 use crate::lsp::non_wasm::type_error_display_status::default_v2_response;
 use crate::lsp::non_wasm::type_error_display_status::derive_v2_response;
 use crate::lsp::non_wasm::type_error_display_status::negotiate_type_error_display_status_version;
+use crate::lsp::non_wasm::type_error_display_status::should_push_type_error_display_status;
 use crate::lsp::non_wasm::type_hierarchy::collect_class_defs;
 use crate::lsp::non_wasm::type_hierarchy::find_class_at_position_in_ast;
 use crate::lsp::non_wasm::type_hierarchy::prepare_type_hierarchy_item;
@@ -982,6 +985,10 @@ pub struct Server {
     /// [`TypeErrorDisplayStatusVersion::LATEST`] (the richest shape this
     /// server knows about) and a missing field to `V1`.
     type_error_display_status_version: TypeErrorDisplayStatusVersion,
+    /// Whether the client declared, via
+    /// `initializationOptions.pyrefly.pushTypeErrorDisplayStatus`, that it
+    /// handles [`TypeErrorDisplayStatusChangedNotification`].
+    push_type_error_display_status: bool,
     /// Testing-only flag to prevent the next recheck from committing.
     /// When set, the recheck queue task will loop without committing the transaction.
     do_not_commit_recheck: AtomicBool,
@@ -2690,6 +2697,9 @@ impl Server {
         let type_error_display_status_version = negotiate_type_error_display_status_version(
             initialize_params.initialization_options.as_ref(),
         );
+        let push_type_error_display_status = should_push_type_error_display_status(
+            initialize_params.initialization_options.as_ref(),
+        );
 
         let should_request_workspace_settings = initialize_params
             .capabilities
@@ -2738,6 +2748,7 @@ impl Server {
             currently_streaming_diagnostics_for_handles: RwLock::new(None),
             diagnostic_markdown_support,
             type_error_display_status_version,
+            push_type_error_display_status,
             do_not_commit_recheck: AtomicBool::new(false),
             // Will be set to true if we send a workspace/configuration request
             awaiting_initial_workspace_config: AtomicBool::new(should_request_workspace_settings),
@@ -3624,12 +3635,23 @@ impl Server {
         !self.workspaces.workspace_diagnostic_roots().is_empty()
     }
 
-    /// Records the build system's state for the status bar.
+    /// Records the build system's state and, for clients that opted in, tells
+    /// them their cached status-bar payload is stale.
     ///
     /// Called from the source database queue thread, so it must not take any
     /// lock the query itself holds.
     fn set_build_system_status(&self, status: BuildSystemStatus) {
         *self.build_system_status.lock() = Some(status);
+        if self.push_type_error_display_status
+            && self.type_error_display_status_version == TypeErrorDisplayStatusVersion::V2
+        {
+            self.connection
+                .send(Message::Notification(new_notification::<
+                    TypeErrorDisplayStatusChangedNotification,
+                >(
+                    TypeErrorDisplayStatusChangedParams {},
+                )));
+        }
     }
 
     /// Attempts to requery any open sourced_dbs for open files, and if there are changes,

--- a/pyrefly/lib/lsp/non_wasm/type_error_display_status.rs
+++ b/pyrefly/lib/lsp/non_wasm/type_error_display_status.rs
@@ -95,6 +95,29 @@ pub fn negotiate_type_error_display_status_version(
         .unwrap_or_default()
 }
 
+/// What's the current status of the build state that we want to publish to the status
+/// bar?
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BuildSystemStatus {
+    /// A source database query is in flight. A previously built database may
+    /// still be serving results while this is the case.
+    Building,
+    /// The last query succeeded.
+    Ready,
+    /// The last query failed, holding the error rendered for display.
+    Failed(String),
+}
+
+impl BuildSystemStatus {
+    pub fn display(&self) -> String {
+        match self {
+            Self::Building => "building".to_owned(),
+            Self::Ready => "ready".to_owned(),
+            Self::Failed(error) => format!("error: {error}"),
+        }
+    }
+}
+
 /// V2 wire shape for the status-bar response. `label` drives the
 /// status-bar parenthetical (`Pyrefly (Basic)`, `Pyrefly (Legacy)`,
 /// …); `null` means show plain `Pyrefly`. `tooltip` is markdown.
@@ -117,6 +140,8 @@ pub struct TypeErrorDisplayStatusV2 {
     pub docs_url: String,
     /// The version of Pyrefly that's currently running.
     pub pyrefly_version: Option<String>,
+    /// The current status of the build system.
+    pub build_system: Option<String>,
 }
 
 /// Internal sum type covering both wire shapes. `#[serde(untagged)]`
@@ -163,6 +188,7 @@ pub fn default_v2_response(pyrefly_version: Option<String>) -> TypeErrorDisplayS
         tooltip: String::new(),
         docs_url: STATUS_BAR_DOCS_URL.to_owned(),
         pyrefly_version,
+        build_system: None,
     }
 }
 
@@ -182,6 +208,7 @@ pub fn derive_v2_response(
     workspace_disable_type_errors: bool,
     workspace_type_checking_mode: Option<TypeCheckingMode>,
     pyrefly_version: Option<String>,
+    build_system: Option<String>,
 ) -> TypeErrorDisplayStatusV2 {
     let (label, tooltip) = if workspace_disable_type_errors {
         (
@@ -272,6 +299,7 @@ pub fn derive_v2_response(
         tooltip,
         docs_url: STATUS_BAR_DOCS_URL.to_owned(),
         pyrefly_version,
+        build_system,
     }
 }
 
@@ -318,9 +346,48 @@ mod tests {
         use pyrefly_config::migration::run::MigratedConfigSource;
         use pyrefly_config::migration::run::MigratedFromKind;
 
+        use super::super::BuildSystemStatus;
         use super::super::TypeErrorDisplayStatusVersion;
         use super::super::derive_v2_response;
         use crate::state::lsp::TypeCheckingMode;
+
+        #[test]
+        fn no_build_system_yields_null_build_system() {
+            let r = derive_v2_response(
+                None,
+                &ConfigSource::File(PathBuf::from("/proj/pyrefly.toml")),
+                false,
+                false,
+                None,
+                None,
+                None,
+            );
+            assert_eq!(r.build_system, None);
+        }
+
+        #[test]
+        fn build_system_status_survives_workspace_kill_switch() {
+            let r = derive_v2_response(
+                None,
+                &ConfigSource::Synthetic(None),
+                false,
+                true,
+                None,
+                None,
+                Some(BuildSystemStatus::Building.display()),
+            );
+            assert_eq!(r.label.as_deref(), Some("Errors Off"));
+            assert_eq!(r.build_system.as_deref(), Some("building"));
+        }
+
+        #[test]
+        fn failed_build_system_renders_the_error() {
+            assert_eq!(BuildSystemStatus::Ready.display(), "ready");
+            assert_eq!(
+                BuildSystemStatus::Failed("buck2 exited with code 1".to_owned()).display(),
+                "error: buck2 exited with code 1"
+            );
+        }
 
         #[test]
         fn user_override_yields_null_label() {
@@ -330,6 +397,7 @@ mod tests {
                 false,
                 false,
                 Some(TypeCheckingMode::Strict),
+                None,
                 None,
             );
             assert_eq!(r.label, None);
@@ -354,6 +422,7 @@ mod tests {
                 false,
                 None,
                 None,
+                None,
             );
             assert_eq!(r.label.as_deref(), Some("Legacy"));
             assert!(r.tooltip.contains("your `mypy.ini`"));
@@ -369,6 +438,7 @@ mod tests {
                 &ConfigSource::Synthetic(None),
                 false,
                 false,
+                None,
                 None,
                 None,
             );
@@ -388,6 +458,7 @@ mod tests {
                 false,
                 None,
                 None,
+                None,
             );
             assert_eq!(r.label.as_deref(), Some("Default"));
             assert!(r.tooltip.contains("your `pyrightconfig.json`"));
@@ -402,6 +473,7 @@ mod tests {
                 &ConfigSource::Synthetic(None),
                 false,
                 false,
+                None,
                 None,
                 None,
             );
@@ -422,6 +494,7 @@ mod tests {
                 false,
                 None,
                 None,
+                None,
             );
             assert_eq!(r.label.as_deref(), Some("Basic"));
             assert!(r.tooltip.contains("basic"));
@@ -440,6 +513,7 @@ mod tests {
                 false,
                 None,
                 None,
+                None,
             );
             assert_eq!(r.label, None);
             assert!(r.tooltip.is_empty());
@@ -456,6 +530,7 @@ mod tests {
                 &ConfigSource::File(PathBuf::from("/proj/pyrefly.toml")),
                 true,
                 false,
+                None,
                 None,
                 None,
             );
@@ -479,6 +554,7 @@ mod tests {
                 &ConfigSource::File(PathBuf::from("/proj/pyproject.toml")),
                 true,
                 false,
+                None,
                 None,
                 None,
             );
@@ -505,6 +581,7 @@ mod tests {
                 true,
                 None,
                 None,
+                None,
             );
             assert_eq!(r.label.as_deref(), Some("Errors Off"));
             assert!(r.tooltip.contains("python.pyrefly.disableTypeErrors"));
@@ -523,6 +600,7 @@ mod tests {
                 true,
                 None,
                 None,
+                None,
             );
             assert_eq!(r.label.as_deref(), Some("Errors Off"));
             assert!(r.tooltip.contains("python.pyrefly.disableTypeErrors"));
@@ -535,6 +613,7 @@ mod tests {
                 &ConfigSource::File(PathBuf::from("/proj/pyrefly.toml")),
                 true,
                 true,
+                None,
                 None,
                 None,
             );

--- a/pyrefly/lib/lsp/non_wasm/type_error_display_status.rs
+++ b/pyrefly/lib/lsp/non_wasm/type_error_display_status.rs
@@ -168,6 +168,32 @@ impl lsp_types::request::Request for TypeErrorDisplayStatusRequest {
     const METHOD: &'static str = "pyrefly/textDocument/typeErrorDisplayStatus";
 }
 
+/// Parameters of [`TypeErrorDisplayStatusChangedNotification`]. we have an
+/// empty struct here, since JSONRPC requires this to be an object or array.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct TypeErrorDisplayStatusChangedParams {}
+
+/// Tells the client that its cached [`TypeErrorDisplayStatusRequest`] response
+/// may be stale and should be re-requested.
+pub enum TypeErrorDisplayStatusChangedNotification {}
+
+impl lsp_types::notification::Notification for TypeErrorDisplayStatusChangedNotification {
+    type Params = TypeErrorDisplayStatusChangedParams;
+    const METHOD: &'static str = "pyrefly/typeErrorDisplayStatusChanged";
+}
+
+/// Resolve `initializationOptions.pyrefly.pushTypeErrorDisplayStatus`, which
+/// declares that the client handles
+/// [`TypeErrorDisplayStatusChangedNotification`]. Defaults to `false`: a client
+/// that didn't opt in would log every unrecognized notification as a warning.
+pub fn should_push_type_error_display_status(initialization_options: Option<&Value>) -> bool {
+    initialization_options
+        .and_then(|opts| opts.get("pyrefly"))
+        .and_then(|pyrefly| pyrefly.get("pushTypeErrorDisplayStatus"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
 /// URL referenced from the V2 tooltip / docs link. Module-level so the
 /// derivation logic and tests share the exact string the user sees.
 const STATUS_BAR_DOCS_URL: &str = "https://pyrefly.org/en/docs/IDE/";
@@ -739,6 +765,26 @@ mod tests {
                     negotiate_type_error_display_status_version(Some(&opts)),
                     TypeErrorDisplayStatusVersion::LATEST
                 );
+            }
+
+            #[test]
+            fn push_defaults_to_disabled() {
+                use super::super::super::should_push_type_error_display_status;
+                assert!(!should_push_type_error_display_status(None));
+                let opts = serde_json::json!({ "pyrefly": {} });
+                assert!(!should_push_type_error_display_status(Some(&opts)));
+                let opts = serde_json::json!({ "pyrefly": { "pushTypeErrorDisplayStatus": null } });
+                assert!(!should_push_type_error_display_status(Some(&opts)));
+            }
+
+            #[test]
+            fn push_honors_explicit_opt_in() {
+                use super::super::super::should_push_type_error_display_status;
+                let opts = serde_json::json!({ "pyrefly": { "pushTypeErrorDisplayStatus": true } });
+                assert!(should_push_type_error_display_status(Some(&opts)));
+                let opts =
+                    serde_json::json!({ "pyrefly": { "pushTypeErrorDisplayStatus": false } });
+                assert!(!should_push_type_error_display_status(Some(&opts)));
             }
         }
     }

--- a/pyrefly/lib/test/lsp/lsp_interaction.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction.rs
@@ -10,6 +10,7 @@
 // can share it; the modules below import it directly from there.
 
 mod basic;
+mod build_system_status;
 mod call_hierarchy;
 mod code_action_markdown_diagnostic;
 mod code_lens;

--- a/pyrefly/lib/test/lsp/lsp_interaction/build_system_status.rs
+++ b/pyrefly/lib/test/lsp/lsp_interaction/build_system_status.rs
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Coverage for the build-system half of the status-bar payload.
+//!
+//! The regression these guard against is noise: a source database rebuild is
+//! queued on every `didOpen`, so a careless implementation would report build
+//! state — and push a refresh notification — to the overwhelming majority of
+//! projects, which have no build system configured at all.
+
+use lsp_types::Url;
+use lsp_types::notification::Notification as _;
+use pyrefly_lsp_test::IndexingMode;
+use pyrefly_lsp_test::LspArgs;
+use pyrefly_lsp_test::Message;
+use pyrefly_lsp_test::object_model::InitializeSettings;
+use pyrefly_lsp_test::object_model::LspInteraction;
+use pyrefly_lsp_test::object_model::LspInteractionArgs;
+use serde_json::json;
+
+use crate::lsp::non_wasm::type_error_display_status::TypeErrorDisplayStatusChangedNotification;
+use crate::lsp::non_wasm::type_error_display_status::TypeErrorDisplayStatusRequest;
+use crate::test::lsp::lsp_interaction::util::get_test_files_root;
+
+/// A project with no `[build-system]` must neither report a build status nor
+/// push a refresh notification.
+///
+/// `build_system_blocking` makes the (no-op) source database rebuild run inline
+/// during `didOpen` rather than on the queue thread. That is what makes the
+/// absence assertion deterministic: anything the rebuild would have sent is
+/// necessarily ahead of the status response in the message stream, so reaching
+/// that response proves nothing was sent.
+#[cfg(not(windows))]
+#[test]
+fn test_no_build_system_is_silent() {
+    let root = get_test_files_root();
+    let root_path = root.path().join("tests_requiring_config");
+    let scope_uri = Url::from_file_path(root_path.clone()).unwrap();
+
+    let mut interaction = LspInteraction::new_with_args(LspInteractionArgs {
+        args: LspArgs {
+            indexing_mode: IndexingMode::None,
+            workspace_indexing_limit: 0,
+            build_system_blocking: true,
+        },
+        ..Default::default()
+    });
+    interaction.set_root(root_path.clone());
+    interaction
+        .initialize(InitializeSettings {
+            workspace_folders: Some(vec![("test".to_owned(), scope_uri)]),
+            configuration: Some(None),
+            initialization_options: Some(json!({
+                "pyrefly": {
+                    "typeErrorDisplayStatusVersion": "v2",
+                    "pushTypeErrorDisplayStatus": true,
+                }
+            })),
+            ..Default::default()
+        })
+        .unwrap();
+
+    interaction.client.did_open("foo.py");
+
+    let uri = Url::from_file_path(root_path.join("foo.py")).unwrap();
+    let id = interaction
+        .client
+        .send_request::<TypeErrorDisplayStatusRequest>(json!({ "uri": uri }))
+        .id()
+        .clone();
+
+    interaction
+        .client
+        .expect_message("typeErrorDisplayStatus response", |msg| match msg {
+            Message::Notification(n)
+                if n.method == TypeErrorDisplayStatusChangedNotification::METHOD =>
+            {
+                panic!(
+                    "server pushed a status refresh for a project with no build system; \
+                     every non-build-system user would get this on each didOpen"
+                )
+            }
+            Message::Response(r) if r.id == id => {
+                let result = r.result.unwrap();
+                assert_eq!(
+                    result.get("buildSystem"),
+                    Some(&serde_json::Value::Null),
+                    "expected no build-system status, got: {result}"
+                );
+                Some(Ok(()))
+            }
+            _ => None,
+        })
+        .unwrap();
+
+    interaction.shutdown().unwrap();
+}

--- a/website/docs/IDE.mdx
+++ b/website/docs/IDE.mdx
@@ -335,7 +335,9 @@ versioned via `initializationOptions.pyrefly.typeErrorDisplayStatusVersion`:
     "version": "v2",
     "label": "Basic" | "Legacy" | "Default" | "Errors Off" | null,
     "tooltip": "markdown string",
-    "docsUrl": "https://pyrefly.org/..."
+    "docsUrl": "https://pyrefly.org/...",
+    "pyreflyVersion": "1.2.3" | null,
+    "buildSystem": "building" | "ready" | "error: <message>" | null
   }
   ```
   `Basic` / `Legacy` / `Default` are emitted when Pyrefly synthesized
@@ -348,6 +350,11 @@ versioned via `initializationOptions.pyrefly.typeErrorDisplayStatusVersion`:
   render plain `Pyrefly` with no parenthetical. The Pyrefly VS Code
   extension uses V2 to render the status-bar parenthetical (e.g.
   `Pyrefly (Basic)` or `Pyrefly (Errors Off)`).
+
+  `buildSystem` reports the state of the most recent source-database
+  query if any open files have an IDE-compatible one configured. If
+  no open projects have a configured build system, it will be set to
+  `null`, and clients should not render it.
 
 Clients should dispatch on response shape (`typeof resp === 'string'`
 for V1, `resp.version` for V2+) so they can transparently support


### PR DESCRIPTION
Summary:

`typeErrorDisplayStatus` is a request, so the client only learns about
changes when it asks. Build system functionality makes it so we might need to push state from the language server, which complicates this.

Now, we create a new `pyrefly/typeErrorDisplayStatusChanged` notification, which tells the IDE to re-pull the state from the language server.

Reviewed By: kinto0

Differential Revision: D118569337


