### PR TITLE
Model polars join(..., coalesce=...) (#4833)

### DIFF
--- a/pyrefly/lib/alt/polars_specials.rs
+++ b/pyrefly/lib/alt/polars_specials.rs
@@ -473,7 +473,7 @@ impl JoinHow {
         })
     }
 
-    fn coalesces(self) -> bool {
+    fn coalesces_by_default(self) -> bool {
         matches!(self, Self::Inner | Self::Left | Self::Right)
     }
 }
@@ -2897,7 +2897,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         Some(dataframe_type_with_columns(schema, columns))
     }
 
-    /// Merge schemas for joins with same-name keys and default coalescing.
+    /// Merge schemas for joins with same-name keys, honoring the `how` and `coalesce` arguments.
     fn polars_join(&self, base: &Type, args: &Arguments, errors: &ErrorCollector) -> Option<Type> {
         let Type::DataFrame(schema) = base else {
             return None;
@@ -2910,6 +2910,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         };
         let mut on = None;
         let mut how = JoinHow::Inner;
+        let mut coalesce = None;
         for kw in &args.keywords {
             let Some(arg) = &kw.arg else {
                 return None;
@@ -2918,6 +2919,12 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 "on" => on = Some(&kw.value),
                 "how" => {
                     how = JoinHow::parse(self.polars_string_literal(&kw.value)?.as_str())?;
+                }
+                // An explicit `None` is the runtime default, so leave it to `how`.
+                "coalesce" => {
+                    if !matches!(&kw.value, Expr::NoneLiteral(_)) {
+                        coalesce = Some(self.polars_bool_literal(&kw.value)?);
+                    }
                 }
                 _ => return None,
             }
@@ -2964,27 +2971,30 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 .find(|(column, _)| column == name)
                 .map(|(_, dtype)| dtype.clone())
         };
-        // A coalesced key keeps the primary side's dtype, so paired keys with differing dtypes could
-        // be cast or rejected at runtime; fall back rather than pick one side.
-        if how.coalesces()
-            && key_set.iter().any(|name| {
-                column_dtype(&schema.columns, name) != column_dtype(&other.columns, name)
-            })
+        // Polars rejects a join whose paired keys have differing dtypes, so fall back.
+        if key_set
+            .iter()
+            .any(|name| column_dtype(&schema.columns, name) != column_dtype(&other.columns, name))
         {
             return None;
         }
         let not_key = |(name, _): &&(Name, PolarsDType)| !key_set.contains(name);
+        // Coalescing keeps one copy of each shared key; otherwise the secondary side's copy stays
+        // and is suffixed below. A right join's secondary side is the left frame, not the right.
+        let coalesce_keys = coalesce.unwrap_or(how.coalesces_by_default());
+        let drop_secondary_keys = |columns: &[(Name, PolarsDType)]| -> Vec<(Name, PolarsDType)> {
+            if coalesce_keys {
+                columns.iter().filter(not_key).cloned().collect()
+            } else {
+                columns.to_vec()
+            }
+        };
         let (base_columns, other_columns): (Vec<_>, Vec<_>) = match how {
             JoinHow::Semi | JoinHow::Anti => (schema.columns.clone(), Vec::new()),
-            JoinHow::Inner | JoinHow::Left => (
-                schema.columns.clone(),
-                other.columns.iter().filter(not_key).cloned().collect(),
-            ),
-            JoinHow::Full | JoinHow::Cross => (schema.columns.clone(), other.columns.clone()),
-            JoinHow::Right => (
-                schema.columns.iter().filter(not_key).cloned().collect(),
-                other.columns.clone(),
-            ),
+            JoinHow::Right => (drop_secondary_keys(&schema.columns), other.columns.clone()),
+            JoinHow::Inner | JoinHow::Left | JoinHow::Full | JoinHow::Cross => {
+                (schema.columns.clone(), drop_secondary_keys(&other.columns))
+            }
         };
         let completeness = match how {
             JoinHow::Semi | JoinHow::Anti => schema.completeness,

--- a/pyrefly/lib/test/polars/dataframe.rs
+++ b/pyrefly/lib/test/polars/dataframe.rs
@@ -4418,29 +4418,16 @@ reveal_type(d1.join(d2, on="k", how="inner"))  # E: Column `k` is not in the Dat
 );
 
 testcase!(
-    test_join_coalesced_key_dtype_mismatch_falls_back,
+    test_join_key_dtype_mismatch_falls_back,
     env_with_polars_stubs(),
     r#"
 import polars as pl
 from typing import reveal_type
-# A coalesced key with differing dtypes is cast or rejected at runtime, so we fall back rather
-# than pick one side's dtype.
 d1 = pl.DataFrame(schema={"k": pl.Int64, "a": pl.Int64})
 d2 = pl.DataFrame(schema={"k": pl.Float64, "b": pl.Int64})
 reveal_type(d1.join(d2, on="k", how="inner"))  # E: revealed type: DataFrame
-"#,
-);
-
-testcase!(
-    test_join_full_dtype_mismatch_kept_separately,
-    env_with_polars_stubs(),
-    r#"
-import polars as pl
-from typing import reveal_type
-# A full join keeps both keys, so differing key dtypes never coalesce and the schema stands.
-d1 = pl.DataFrame(schema={"k": pl.Int64, "a": pl.Int64})
-d2 = pl.DataFrame(schema={"k": pl.Float64, "b": pl.Int64})
-reveal_type(d1.join(d2, on="k", how="full"))  # E: revealed type: DataFrame[k: Int64, a: Int64, k_right: Float64, b: Int64]
+reveal_type(d1.join(d2, on="k", how="full"))  # E: revealed type: DataFrame
+reveal_type(d1.join(d2, on="k", how="full", coalesce=False))  # E: revealed type: DataFrame
 "#,
 );
 
@@ -4587,15 +4574,57 @@ reveal_type(d1.join(d2, left_on="kl", right_on="kr", how="inner"))  # E: reveale
 );
 
 testcase!(
-    test_join_explicit_coalesce_falls_back,
+    test_join_coalesce_none_matches_default,
+    env_join(),
+    r#"
+from frames import left, right
+from typing import reveal_type
+reveal_type(left.join(right, on="k", how="inner", coalesce=None))  # E: revealed type: DataFrame[k: Int64, a: Float64, b: String, a_right: Int64, c: Boolean]
+"#,
+);
+
+testcase!(
+    test_join_coalesce_true_matches_default_for_inner,
+    env_join(),
+    r#"
+from frames import left, right
+from typing import reveal_type
+reveal_type(left.join(right, on="k", how="inner", coalesce=True))  # E: revealed type: DataFrame[k: Int64, a: Float64, b: String, a_right: Int64, c: Boolean]
+"#,
+);
+
+testcase!(
+    test_join_coalesce_false_keeps_secondary_key_suffixed,
+    env_join(),
+    r#"
+from frames import left, right
+from typing import reveal_type
+reveal_type(left.join(right, on="k", how="inner", coalesce=False))  # E: revealed type: DataFrame[k: Int64, a: Float64, b: String, k_right: Int64, a_right: Int64, c: Boolean]
+reveal_type(left.join(right, on="k", how="right", coalesce=False))  # E: revealed type: DataFrame[k: Int64, a: Float64, b: String, k_right: Int64, a_right: Int64, c: Boolean]
+"#,
+);
+
+testcase!(
+    test_join_full_coalesce_overrides_default,
+    env_join(),
+    r#"
+from frames import left, right
+from typing import reveal_type
+reveal_type(left.join(right, on="k", how="full", coalesce=True))  # E: revealed type: DataFrame[k: Int64, a: Float64, b: String, a_right: Int64, c: Boolean]
+reveal_type(left.join(right, on="k", how="full", coalesce=False))  # E: revealed type: DataFrame[k: Int64, a: Float64, b: String, k_right: Int64, a_right: Int64, c: Boolean]
+"#,
+);
+
+testcase!(
+    test_join_non_literal_coalesce_falls_back,
     env_with_polars_stubs(),
     r#"
 import polars as pl
 from typing import reveal_type
-# An explicit coalesce= is not yet modeled, so we fall back.
 d1 = pl.DataFrame(schema={"k": pl.Int64, "a": pl.Int64})
 d2 = pl.DataFrame(schema={"k": pl.Int64, "b": pl.Int64})
-reveal_type(d1.join(d2, on="k", how="inner", coalesce=False))  # E: revealed type: DataFrame
+def f(flag: bool) -> None:
+    reveal_type(d1.join(d2, on="k", how="inner", coalesce=flag))  # E: revealed type: DataFrame
 "#,
 );
 


### PR DESCRIPTION
# Summary

Add support for coalesce= in join so it keeps the schema and merges keys correctly

also we fix schema representation to match runtime spec where we have a dtype mismatch on join keys 

Fixes #4833

# Test Plan

`python3 test.py`