### PR TITLE
[tensor-shapes] add stubs for lax indexing & contractions

### DIFF
--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
@@ -1166,3 +1166,44 @@ def lax_sort_key_val_shape(
     if dimension < 0 - rank or dimension >= rank:
         return dsl.Invalid("axis out of bounds")
     return keys_shape
+
+@type_shape_dsl_function
+def lax_dynamic_index_in_dim_shape(
+    shape: IntTuple, axis: int, keepdims: bool
+) -> IntTuple:
+    rank = len(shape)
+    if axis < 0 - rank or axis >= rank:
+        return dsl.Invalid("axis out of bounds")
+    if axis < 0:
+        norm_axis = axis + rank
+    else:
+        norm_axis = axis + 0
+    if keepdims:
+        return dsl.concat(
+            dsl.concat(shape[:norm_axis], dsl.IntTuple((1,))),
+            shape[norm_axis + 1 :],
+        )
+    return dsl.concat(shape[:norm_axis], shape[norm_axis + 1 :])
+
+@type_shape_dsl_function
+def lax_dynamic_slice_in_dim_shape(
+    shape: IntTuple, slice_size: int, axis: int
+) -> IntTuple:
+    rank = len(shape)
+    if axis < 0 - rank or axis >= rank:
+        return dsl.Invalid("axis out of bounds")
+    if axis < 0:
+        norm_axis = axis + rank
+    else:
+        norm_axis = axis + 0
+    extent = slice_size + 0
+    return dsl.concat(
+        dsl.concat(shape[:norm_axis], dsl.IntTuple((extent,))),
+        shape[norm_axis + 1 :],
+    )
+
+@type_shape_dsl_function
+def lax_dynamic_slice_shape(shape: IntTuple, slice_sizes: IntTuple) -> IntTuple:
+    if len(shape) != len(slice_sizes):
+        return dsl.Invalid("slice_sizes must have the same length as operand rank")
+    return slice_sizes

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/lax/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/lax/__init__.pyi
@@ -11,12 +11,16 @@ from jax._shapes import (
     collapse_shape,
     collapse_to_end_shape,
     concatenate_shape,
+    dot_shape,
     lax_associative_scan_shape,
     lax_axis_reduce_shape,
     lax_broadcast,
     lax_clamp_max_scalar_shape,
     lax_clamp_min_scalar_shape,
     lax_clamp_shape,
+    lax_dynamic_index_in_dim_shape,
+    lax_dynamic_slice_in_dim_shape,
+    lax_dynamic_slice_shape,
     lax_reduce_shape,
     lax_scan_shape,
     lax_select_n_shape,
@@ -28,6 +32,28 @@ from jax._shapes import (
     permute_shape,
     stack_shape,
     top_k_shape,
+)
+from jax._src.lax.convolution import (
+    ConvDimensionNumbers as ConvDimensionNumbers,
+    ConvGeneralDilatedDimensionNumbers as ConvGeneralDilatedDimensionNumbers,
+)
+from jax._src.lax.fft import FftType as FftType
+from jax._src.lax.lax import (
+    AccuracyMode as AccuracyMode,
+    DotAlgorithm as DotAlgorithm,
+    DotAlgorithmPreset as DotAlgorithmPreset,
+    DotDimensionNumbers as DotDimensionNumbers,
+    Precision as Precision,
+    PrecisionLike as PrecisionLike,
+    RaggedDotDimensionNumbers as RaggedDotDimensionNumbers,
+    RandomAlgorithm as RandomAlgorithm,
+    RoundingMethod as RoundingMethod,
+    Tolerance as Tolerance,
+)
+from jax._src.lax.slicing import (
+    GatherDimensionNumbers as GatherDimensionNumbers,
+    GatherScatterMode as GatherScatterMode,
+    ScatterDimensionNumbers as ScatterDimensionNumbers,
 )
 from jax.typing import DTypeLike
 from shape_extensions import (
@@ -658,6 +684,496 @@ def unstack(
     x: Any,
     axis: int = 0,
 ) -> tuple[Array[IntTuple], ...]: ...
+
+# Dynamic Slicing & Gather/Scatter
+
+@overload
+def dynamic_index_in_dim[
+    Shape: _Shape,
+    Axis: Flag[int] = 0,
+    KeepDims: Flag[bool] = True,
+](
+    operand: Array[Shape],
+    index: Any,
+    axis: Axis = 0,
+    keepdims: KeepDims = True,
+    *,
+    allow_negative_indices: bool = True,
+) -> Array[lax_dynamic_index_in_dim_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def dynamic_index_in_dim(
+    operand: Any,
+    index: Any,
+    axis: int = 0,
+    keepdims: bool = True,
+    *,
+    allow_negative_indices: bool = True,
+) -> Array[IntTuple]: ...
+@overload
+def dynamic_slice[Shape: _Shape, SliceSizes: _Shape](
+    operand: Array[Shape],
+    start_indices: Any,
+    slice_sizes: SliceSizes,
+    *,
+    allow_negative_indices: bool | Sequence[bool] = True,
+) -> Array[lax_dynamic_slice_shape(Shape, SliceSizes)]: ...
+@overload
+def dynamic_slice(
+    operand: Any,
+    start_indices: Any,
+    slice_sizes: Sequence[int],
+    *,
+    allow_negative_indices: bool | Sequence[bool] = True,
+) -> Array[IntTuple]: ...
+@overload
+def dynamic_slice_in_dim[Shape: _Shape, SliceSize: Flag[int], Axis: Flag[int] = 0](
+    operand: Array[Shape],
+    start_index: Any,
+    slice_size: SliceSize,
+    axis: Axis = 0,
+    *,
+    allow_negative_indices: bool = True,
+) -> Array[lax_dynamic_slice_in_dim_shape(Shape, SliceSize, Axis)]: ...
+@overload
+def dynamic_slice_in_dim(
+    operand: Any,
+    start_index: Any,
+    slice_size: int,
+    axis: int = 0,
+    *,
+    allow_negative_indices: bool = True,
+) -> Array[IntTuple]: ...
+@overload
+def dynamic_update_index_in_dim[Shape: _Shape](
+    operand: Array[Shape],
+    update: Any,
+    index: Any,
+    axis: int,
+    *,
+    allow_negative_indices: bool = True,
+) -> Array[Shape]: ...
+@overload
+def dynamic_update_index_in_dim(
+    operand: Any,
+    update: Any,
+    index: Any,
+    axis: int,
+    *,
+    allow_negative_indices: bool = True,
+) -> Array[IntTuple]: ...
+@overload
+def dynamic_update_slice[Shape: _Shape](
+    operand: Array[Shape],
+    update: Any,
+    start_indices: Any,
+    *,
+    allow_negative_indices: bool | Sequence[bool] = True,
+) -> Array[Shape]: ...
+@overload
+def dynamic_update_slice(
+    operand: Any,
+    update: Any,
+    start_indices: Any,
+    *,
+    allow_negative_indices: bool | Sequence[bool] = True,
+) -> Array[IntTuple]: ...
+@overload
+def dynamic_update_slice_in_dim[Shape: _Shape](
+    operand: Array[Shape],
+    update: Any,
+    start_index: Any,
+    axis: int,
+    *,
+    allow_negative_indices: bool = True,
+) -> Array[Shape]: ...
+@overload
+def dynamic_update_slice_in_dim(
+    operand: Any,
+    update: Any,
+    start_index: Any,
+    axis: int,
+    *,
+    allow_negative_indices: bool = True,
+) -> Array[IntTuple]: ...
+def gather(
+    operand: Array[Any],
+    start_indices: Array[Any],
+    dimension_numbers: GatherDimensionNumbers,
+    slice_sizes: Sequence[int],
+    *,
+    unique_indices: bool = False,
+    indices_are_sorted: bool = False,
+    mode: str | GatherScatterMode | None = None,
+    fill_value: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def index_in_dim[Shape: _Shape, Axis: Flag[int] = 0, KeepDims: Flag[bool] = True](
+    operand: Array[Shape],
+    index: int,
+    axis: Axis = 0,
+    keepdims: KeepDims = True,
+) -> Array[lax_dynamic_index_in_dim_shape(Shape, Axis, KeepDims)]: ...
+@overload
+def index_in_dim(
+    operand: Any,
+    index: int,
+    axis: int = 0,
+    keepdims: bool = True,
+) -> Array[IntTuple]: ...
+def index_take(
+    src: Array[Any],
+    idxs: Array[Any],
+    axes: Sequence[int],
+) -> Array[IntTuple]: ...
+@overload
+def scatter[Shape: _Shape](
+    operand: Array[Shape],
+    scatter_indices: Any,
+    updates: Any,
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | GatherScatterMode | None = None,
+) -> Array[Shape]: ...
+@overload
+def scatter(
+    operand: Any,
+    scatter_indices: Any,
+    updates: Any,
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | GatherScatterMode | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def scatter_add[Shape: _Shape](
+    operand: Array[Shape],
+    scatter_indices: Any,
+    updates: Any,
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | GatherScatterMode | None = None,
+) -> Array[Shape]: ...
+@overload
+def scatter_add(
+    operand: Any,
+    scatter_indices: Any,
+    updates: Any,
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | GatherScatterMode | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def scatter_apply[Shape: _Shape](
+    operand: Array[Shape],
+    scatter_indices: Any,
+    func: Callable[[Any], Any],
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    update_shape: Sequence[int] = (),
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | GatherScatterMode | None = None,
+) -> Array[Shape]: ...
+@overload
+def scatter_apply(
+    operand: Any,
+    scatter_indices: Any,
+    func: Callable[[Any], Any],
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    update_shape: Sequence[int] = (),
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | GatherScatterMode | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def scatter_max[Shape: _Shape](
+    operand: Array[Shape],
+    scatter_indices: Any,
+    updates: Any,
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | GatherScatterMode | None = None,
+) -> Array[Shape]: ...
+@overload
+def scatter_max(
+    operand: Any,
+    scatter_indices: Any,
+    updates: Any,
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | GatherScatterMode | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def scatter_min[Shape: _Shape](
+    operand: Array[Shape],
+    scatter_indices: Any,
+    updates: Any,
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | GatherScatterMode | None = None,
+) -> Array[Shape]: ...
+@overload
+def scatter_min(
+    operand: Any,
+    scatter_indices: Any,
+    updates: Any,
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | GatherScatterMode | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def scatter_mul[Shape: _Shape](
+    operand: Array[Shape],
+    scatter_indices: Any,
+    updates: Any,
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | GatherScatterMode | None = None,
+) -> Array[Shape]: ...
+@overload
+def scatter_mul(
+    operand: Any,
+    scatter_indices: Any,
+    updates: Any,
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | GatherScatterMode | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def scatter_sub[Shape: _Shape](
+    operand: Array[Shape],
+    scatter_indices: Any,
+    updates: Any,
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | GatherScatterMode | None = None,
+) -> Array[Shape]: ...
+@overload
+def scatter_sub(
+    operand: Any,
+    scatter_indices: Any,
+    updates: Any,
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: str | GatherScatterMode | None = None,
+) -> Array[IntTuple]: ...
+
+# Linear Algebra, Contractions & Convolutions
+
+@overload
+def batch_matmul[Batch: IntTuple, M: IntVar, K: IntVar, N: IntVar](
+    lhs: Array[[*Elements[Batch], M, K]],
+    rhs: Array[[*Elements[Batch], K, N]],
+    precision: PrecisionLike = None,
+) -> Array[[*Elements[Batch], M, N]]: ...
+@overload
+def batch_matmul(
+    lhs: Any,
+    rhs: Any,
+    precision: PrecisionLike = None,
+) -> Array[IntTuple]: ...
+def conv(
+    lhs: Any,
+    rhs: Any,
+    window_strides: Sequence[int],
+    padding: str | Sequence[tuple[int, int]],
+    precision: PrecisionLike = None,
+    preferred_element_type: DTypeLike | None = None,
+) -> Array[IntTuple]: ...
+def conv_dimension_numbers(
+    lhs_shape: Sequence[int],
+    rhs_shape: Sequence[int],
+    dimension_numbers: Any,
+) -> ConvDimensionNumbers: ...
+def conv_general_dilated(
+    lhs: Any,
+    rhs: Any,
+    window_strides: Sequence[int],
+    padding: str | Sequence[tuple[int, int]],
+    lhs_dilation: Sequence[int] | None = None,
+    rhs_dilation: Sequence[int] | None = None,
+    dimension_numbers: ConvGeneralDilatedDimensionNumbers = None,
+    feature_group_count: int = 1,
+    batch_group_count: int = 1,
+    precision: PrecisionLike = None,
+    preferred_element_type: DTypeLike | None = None,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+def conv_general_dilated_local(
+    lhs: Any,
+    rhs: Any,
+    window_strides: Sequence[int],
+    padding: str | Sequence[tuple[int, int]],
+    filter_shape: Sequence[int],
+    lhs_dilation: Sequence[int] | None = None,
+    rhs_dilation: Sequence[int] | None = None,
+    dimension_numbers: ConvGeneralDilatedDimensionNumbers = None,
+    precision: PrecisionLike = None,
+) -> Array[IntTuple]: ...
+def conv_general_dilated_patches(
+    lhs: Any,
+    filter_shape: Sequence[int],
+    window_strides: Sequence[int],
+    padding: str | Sequence[tuple[int, int]],
+    lhs_dilation: Sequence[int] | None = None,
+    rhs_dilation: Sequence[int] | None = None,
+    dimension_numbers: ConvGeneralDilatedDimensionNumbers = None,
+    precision: PrecisionLike = None,
+    preferred_element_type: DTypeLike | None = None,
+) -> Array[IntTuple]: ...
+def conv_general_permutations(
+    dimension_numbers: Any,
+) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]: ...
+def conv_general_shape_tuple(
+    lhs_shape: Sequence[int],
+    rhs_shape: Sequence[int],
+    window_strides: Sequence[int],
+    padding: str | Sequence[tuple[int, int]],
+    dimension_numbers: Any,
+) -> tuple[int, ...]: ...
+def conv_shape_tuple(
+    lhs_shape: Sequence[int],
+    rhs_shape: Sequence[int],
+    strides: Sequence[int],
+    pads: Sequence[tuple[int, int]],
+    batch_group_count: int = 1,
+) -> tuple[int, ...]: ...
+def conv_transpose(
+    lhs: Any,
+    rhs: Any,
+    strides: Sequence[int],
+    padding: str | Sequence[tuple[int, int]],
+    rhs_dilation: Sequence[int] | None = None,
+    dimension_numbers: ConvGeneralDilatedDimensionNumbers = None,
+    transpose_kernel: bool = False,
+    precision: PrecisionLike = None,
+    preferred_element_type: DTypeLike | None = None,
+    use_consistent_padding: bool = False,
+) -> Array[IntTuple]: ...
+def conv_transpose_shape_tuple(
+    lhs_shape: Sequence[int],
+    rhs_shape: Sequence[int],
+    window_strides: Sequence[int],
+    padding: str | Sequence[tuple[int, int]],
+    dimension_numbers: Any,
+) -> tuple[int, ...]: ...
+def conv_with_general_padding(
+    lhs: Any,
+    rhs: Any,
+    window_strides: Sequence[int],
+    padding: str | Sequence[tuple[int, int]],
+    lhs_dilation: Sequence[int] | None,
+    rhs_dilation: Sequence[int] | None,
+    precision: PrecisionLike = None,
+    preferred_element_type: DTypeLike | None = None,
+) -> Array[IntTuple]: ...
+def custom_linear_solve(
+    matvec: Callable[..., Any],
+    b: Any,
+    solve: Callable[[Callable[..., Any], Any], Any],
+    transpose_solve: Callable[[Callable[..., Any], Any], Any] | None = None,
+    symmetric: bool = False,
+    has_aux: bool = False,
+) -> Any: ...
+def custom_root(
+    f: Callable[..., Any],
+    initial_guess: Any,
+    solve: Callable[[Callable[..., Any], Any], Any],
+    tangent_solve: Callable[[Callable[..., Any], Any], Any],
+    has_aux: bool = False,
+) -> Any: ...
+@overload
+def dot[Shape1: _Shape, Shape2: _Shape](
+    lhs: Array[Shape1],
+    rhs: Array[Shape2],
+    *,
+    dimension_numbers: None = None,
+    precision: PrecisionLike = None,
+    preferred_element_type: DTypeLike | None = None,
+    out_sharding: Any = None,
+) -> Array[dot_shape(Shape1, Shape2)]: ...
+@overload
+def dot(
+    lhs: Any,
+    rhs: Any,
+    *,
+    dimension_numbers: Any = None,
+    precision: PrecisionLike = None,
+    preferred_element_type: DTypeLike | None = None,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+def dot_general(
+    lhs: Any,
+    rhs: Any,
+    dimension_numbers: DotDimensionNumbers,
+    precision: PrecisionLike = None,
+    preferred_element_type: DTypeLike | None = None,
+    *,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+@overload
+def ragged_dot[M: IntVar, K: IntVar, G: IntVar, N: IntVar](
+    lhs: Array[[M, K]],
+    rhs: Array[[G, K, N]],
+    group_sizes: Array[[G]],
+    precision: PrecisionLike = None,
+    preferred_element_type: DTypeLike | None = None,
+    group_offset: Any = None,
+    out_sharding: Any = None,
+) -> Array[[M, N]]: ...
+@overload
+def ragged_dot(
+    lhs: Any,
+    rhs: Any,
+    group_sizes: Any,
+    precision: PrecisionLike = None,
+    preferred_element_type: DTypeLike | None = None,
+    group_offset: Any = None,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+def ragged_dot_general(
+    lhs: Any,
+    rhs: Any,
+    group_sizes: Any,
+    ragged_dot_dimension_numbers: Any,
+    precision: PrecisionLike = None,
+    preferred_element_type: DTypeLike | None = None,
+    group_offset: Any = None,
+    out_sharding: Any = None,
+) -> Array[IntTuple]: ...
+def scaled_dot(
+    lhs: Any,
+    rhs: Any,
+    *,
+    lhs_scale: Any = None,
+    rhs_scale: Any = None,
+    dimension_numbers: Any = None,
+    preferred_element_type: DTypeLike | None = None,
+) -> Array[IntTuple]: ...
 
 # Data types & bitcasting
 def bitcast_convert_type(

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_lax.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_lax.py
@@ -697,3 +697,213 @@ def test_lax_top_k() -> None:
     top_v0, top_i0 = lax.top_k(x, 1, axis=0)
     assert_shape(top_v0.shape, (1, 3, 4))
     assert_shape(top_i0.shape, (1, 3, 4))
+
+
+def test_lax_dynamic_slicing() -> None:
+    x = jnp.ones((3, 4, 5))
+    assert_shape(lax.dynamic_index_in_dim(x, 1, axis=1, keepdims=True).shape, (3, 1, 5))
+    assert_shape(lax.dynamic_index_in_dim(x, 1, axis=1, keepdims=False).shape, (3, 5))
+    assert_shape(
+        lax.dynamic_index_in_dim(x, 0, axis=-1, keepdims=True).shape, (3, 4, 1)
+    )
+    assert_shape(lax.dynamic_index_in_dim(x, 0, axis=-1, keepdims=False).shape, (3, 4))
+
+    assert_shape(lax.dynamic_slice(x, (1, 1, 1), (2, 2, 3)).shape, (2, 2, 3))
+
+    assert_shape(lax.dynamic_slice_in_dim(x, 1, 2, axis=1).shape, (3, 2, 5))
+    assert_shape(lax.dynamic_slice_in_dim(x, 0, 2, axis=-1).shape, (3, 4, 2))
+    assert_shape(
+        lax.dynamic_slice_in_dim(x, 0, 2, axis=-1, allow_negative_indices=False).shape,
+        (3, 4, 2),
+    )
+    assert_shape(
+        lax.dynamic_slice_in_dim(x, 0, 2, axis=-1, allow_negative_indices=True).shape,
+        (3, 4, 2),
+    )
+
+    up1 = jnp.zeros((3, 1, 5))
+    assert_shape(lax.dynamic_update_index_in_dim(x, up1, 1, axis=1).shape, (3, 4, 5))
+
+    up2 = jnp.zeros((2, 2, 3))
+    assert_shape(lax.dynamic_update_slice(x, up2, (1, 1, 1)).shape, (3, 4, 5))
+
+    up3 = jnp.zeros((3, 2, 5))
+    assert_shape(lax.dynamic_update_slice_in_dim(x, up3, 1, axis=1).shape, (3, 4, 5))
+
+    assert_shape(lax.index_in_dim(x, 1, axis=1, keepdims=True).shape, (3, 1, 5))
+    assert_shape(lax.index_in_dim(x, 1, axis=1, keepdims=False).shape, (3, 5))
+
+    src = jnp.ones((5, 4))
+    idxs = jnp.array([[0, 1, 2]])
+    res_it = lax.index_take(src, idxs, (0,))
+    assert isinstance(res_it, jax.Array)
+
+
+def test_lax_gather_scatter() -> None:
+    operand = jnp.ones((5, 3))
+    indices = jnp.array([[1], [2]])
+    g_dnums = lax.GatherDimensionNumbers(
+        offset_dims=(1,),
+        collapsed_slice_dims=(0,),
+        start_index_map=(0,),
+        operand_batching_dims=(),
+        start_indices_batching_dims=(),
+    )
+    res_g = lax.gather(operand, indices, dimension_numbers=g_dnums, slice_sizes=(1, 3))
+    assert isinstance(res_g, jax.Array)
+    res_g_clip = lax.gather(
+        operand,
+        indices,
+        dimension_numbers=g_dnums,
+        slice_sizes=(1, 3),
+        mode=lax.GatherScatterMode.CLIP,
+    )
+    assert isinstance(res_g_clip, jax.Array)
+
+    s_dnums = lax.ScatterDimensionNumbers(
+        update_window_dims=(1,),
+        inserted_window_dims=(0,),
+        scatter_dims_to_operand_dims=(0,),
+        operand_batching_dims=(),
+        scatter_indices_batching_dims=(),
+    )
+    updates = jnp.ones((2, 3))
+    assert_shape(lax.scatter(operand, indices, updates, s_dnums).shape, (5, 3))
+    assert_shape(
+        lax.scatter(
+            operand, indices, updates, s_dnums, mode=lax.GatherScatterMode.FILL_OR_DROP
+        ).shape,
+        (5, 3),
+    )
+    assert_shape(lax.scatter_add(operand, indices, updates, s_dnums).shape, (5, 3))
+    assert_shape(
+        lax.scatter_apply(
+            operand, indices, lambda u: u * 2, s_dnums, update_shape=(2, 3)
+        ).shape,
+        (5, 3),
+    )
+    assert_shape(lax.scatter_max(operand, indices, updates, s_dnums).shape, (5, 3))
+    assert_shape(lax.scatter_min(operand, indices, updates, s_dnums).shape, (5, 3))
+    assert_shape(lax.scatter_mul(operand, indices, updates, s_dnums).shape, (5, 3))
+    assert_shape(lax.scatter_sub(operand, indices, updates, s_dnums).shape, (5, 3))
+
+
+def test_lax_linear_algebra_contractions() -> None:
+    # batch_matmul
+    a = jnp.ones((2, 3, 4))
+    b = jnp.ones((2, 4, 5))
+    assert_shape(lax.batch_matmul(a, b).shape, (2, 3, 5))
+    assert_shape(
+        lax.batch_matmul(a, b, precision=lax.Precision.HIGHEST).shape, (2, 3, 5)
+    )
+    a4 = jnp.ones((7, 2, 3, 4))
+    b4 = jnp.ones((7, 2, 4, 5))
+    assert_shape(lax.batch_matmul(a4, b4).shape, (7, 2, 3, 5))
+
+    # dot
+    v1 = jnp.ones(3)
+    v2 = jnp.ones(3)
+    mat23 = jnp.ones((2, 3))
+    mat34 = jnp.ones((3, 4))
+    assert_shape(lax.dot(v1, v2).shape, ())
+    assert_shape(lax.dot(mat23, v1).shape, (2,))
+    assert_shape(lax.dot(v1, mat34).shape, (4,))
+    assert_shape(lax.dot(mat23, mat34).shape, (2, 4))
+    assert_shape(lax.dot(mat23, mat34, precision=lax.Precision.DEFAULT).shape, (2, 4))
+
+    # dot_general
+    dg_res = lax.dot_general(mat23, mat34, (((1,), (0,)), ((), ())))
+    assert_shape(dg_res.shape, (2, 4))
+
+    # conv & friends
+    lhs = jnp.ones((1, 1, 8, 8))
+    rhs = jnp.ones((1, 1, 3, 3))
+    conv_res = lax.conv(lhs, rhs, (1, 1), "SAME")
+    assert isinstance(conv_res, jax.Array)
+
+    cdnums = lax.conv_dimension_numbers(
+        (1, 1, 8, 8), (1, 1, 3, 3), ("NCHW", "OIHW", "NCHW")
+    )
+    assert cdnums is not None
+
+    cgd_res = lax.conv_general_dilated(lhs, rhs, (1, 1), "SAME")
+    assert isinstance(cgd_res, jax.Array)
+
+    cgdp_res = lax.conv_general_dilated_patches(lhs, (3, 3), (1, 1), "SAME")
+    assert isinstance(cgdp_res, jax.Array)
+
+    cgdl_lhs = jnp.ones((1, 8, 8, 1))
+    cgdl_rhs = jnp.ones((8, 8, 9, 1))
+    cgdl_res = lax.conv_general_dilated_local(
+        cgdl_lhs,
+        cgdl_rhs,
+        (1, 1),
+        "SAME",
+        (3, 3),
+        dimension_numbers=("NHWC", "HWIO", "NHWC"),
+    )
+    assert isinstance(cgdl_res, jax.Array)
+
+    perms = lax.conv_general_permutations(("NCHW", "OIHW", "NCHW"))
+    assert len(perms) == 3
+
+    st1 = lax.conv_general_shape_tuple(
+        (1, 1, 8, 8), (1, 1, 3, 3), (1, 1), "SAME", ("NCHW", "OIHW", "NCHW")
+    )
+    assert len(st1) == 4
+
+    st2 = lax.conv_shape_tuple((1, 1, 8, 8), (1, 1, 3, 3), (1, 1), [(1, 1), (1, 1)])
+    assert len(st2) == 4
+
+    ct_lhs = jnp.ones((1, 8, 8, 1))
+    ct_rhs = jnp.ones((3, 3, 1, 1))
+    ct_res = lax.conv_transpose(ct_lhs, ct_rhs, (1, 1), "SAME")
+    assert isinstance(ct_res, jax.Array)
+
+    st3 = lax.conv_transpose_shape_tuple(
+        (1, 1, 8, 8), (1, 1, 3, 3), (1, 1), "SAME", ("NCHW", "OIHW", "NCHW")
+    )
+    assert len(st3) == 4
+
+    cwgp_res = lax.conv_with_general_padding(lhs, rhs, (1, 1), "SAME", None, None)
+    assert isinstance(cwgp_res, jax.Array)
+
+    # custom_linear_solve & custom_root
+    b_vec = jnp.ones(3)
+    sol_cls = lax.custom_linear_solve(lambda x: x, b_vec, lambda f, x: x)
+    assert sol_cls is not None
+
+    sol_cr = lax.custom_root(lambda x: x, b_vec, lambda f, x: x, lambda f, x: x)
+    assert sol_cr is not None
+
+    # ragged_dot
+    rlhs = jnp.ones((6, 4))
+    rrhs = jnp.ones((2, 4, 5))
+    group_sizes = jnp.array([3, 3])
+    rd_res = lax.ragged_dot(rlhs, rrhs, group_sizes)
+    assert_shape(rd_res.shape, (6, 5))
+
+    rddnums = lax.RaggedDotDimensionNumbers(
+        dot_dimension_numbers=(((1,), (1,)), ((), ())),
+        lhs_ragged_dimensions=(0,),
+        rhs_group_dimensions=(0,),
+    )
+    rdg_res = lax.ragged_dot_general(rlhs, rrhs, group_sizes, rddnums)
+    assert isinstance(rdg_res, jax.Array)
+
+    # scaled_dot
+    sd_res = lax.scaled_dot(mat23, mat34)
+    assert isinstance(sd_res, jax.Array)
+
+    # Section 13: Types, Enums & Dimension Descriptors
+    assert lax.AccuracyMode is not None
+    assert lax.DotAlgorithm is not None
+    assert lax.DotAlgorithmPreset is not None
+    assert lax.FftType is not None
+    assert lax.GatherDimensionNumbers is not None
+    assert lax.GatherScatterMode is not None
+    assert lax.Precision is not None
+    assert lax.RandomAlgorithm is not None
+    assert lax.RoundingMethod is not None
+    assert lax.ScatterDimensionNumbers is not None
+    assert lax.Tolerance is not None


### PR DESCRIPTION
## Summary

Add stubs for a number of additional `jax.lax` APIs related to indexing, contractions, linear algebra, etc.

In some cases here (e.g. `gather`) we punt for now and avoid trying to statically determine the output shape.

## Testing

Expanded existing unit tests; new tests pass:
```
$ uv tool run --from ruff==0.14.3 ruff format --check --config ruff.toml .
333 files already formatted
$ uv tool run --from ruff==0.14.3 ruff check --select I --config ruff.toml .
All checks passed!
$ uv run python test.py --no-test --no-conformance --no-jsonschema
Running formatting...
Finished in 2.59 seconds.
Running linting...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.77s
Finished in 1.01 seconds.
$ uv run python tensor-shapes/pyrefly-jax-stubs/run_pyrefly.py --release
+ cargo build -p pyrefly --release
    Finished `release` profile [optimized + debuginfo] target(s) in 0.59s
PASS stubs (9 files)
PASS arithmetic (1 files)
PASS contractions (1 files)
PASS creation (1 files)
PASS fft (1 files)
PASS indexing (1 files)
PASS lax (1 files)
PASS linalg (1 files)
PASS matmul (1 files)
PASS nn (1 files)
PASS reductions (1 files)
PASS reshape (1 files)
PASS searching-sorting (1 files)
PASS structural (1 files)
PASS examples (1 files)
```

## AI disclosure

This change was created with a Gemini coding agent.