### PR TITLE
Fix tensor-shapes virtualenv setup on Windows

### DIFF
--- a/tensor-shapes/bootstrap_venv.py
+++ b/tensor-shapes/bootstrap_venv.py
@@ -95,9 +95,8 @@ def main() -> int:
     # Deliberately `install` rather than `sync`: this file pins direct
     # dependencies but is not a fully resolved lock, so `sync` would treat every
     # transitive dependency as extraneous and uninstall it.
-    python = venv / ("Scripts" if os.name == "nt" else "bin") / "python"
     run(
-        [uv, "pip", "install", "--python", str(python), "-r", str(REQUIREMENTS)],
+        [uv, "pip", "install", "--python", str(venv), "-r", str(REQUIREMENTS)],
         env=env,
     )
 


### PR DESCRIPTION
## Problem

Recent PRs are [failing](https://github.com/facebook/pyrefly/actions/runs/34356006018/job/102480724689?pr=4871) Windows tests with a tensor-shapes venv setup error:

```
subprocess.CalledProcessError: 
Command '[
  'C:\\hostedtoolcache\\windows\\uv\\0.12.11\\x86_64\\uv.EXE', 
  'pip', 'install', '--python', 
  'C:\\Users\\runneradmin\\.tensor-shapes-venv\\Scripts\\python', 
  '-r', 'D:\\a\\pyrefly\\pyrefly\\tensor-shapes\\test-requirements.txt'
]'
returned non-zero exit status 2.
```

## Solution

Let `uv` resolve the interpreter from the virtualenv directory so bootstrap does not construct an executable path that's missing the Windows `.exe` suffix.
