### PR TITLE
fix Generics usage for a TypedDict's extra_items breaks type checking #4870

### DIFF
--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -1511,6 +1511,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         let metadata = self.get_metadata_for_class(class);
         if metadata.is_typed_dict() {
             return self.calculate_typed_dict_field(
+                class,
                 metadata,
                 name,
                 range,

--- a/pyrefly/lib/alt/class/class_metadata.rs
+++ b/pyrefly/lib/alt/class/class_metadata.rs
@@ -16,10 +16,10 @@ use pyrefly_python::module_name::ModuleName;
 use pyrefly_python::short_identifier::ShortIdentifier;
 use pyrefly_types::annotation::Annotation;
 use pyrefly_types::callable::Params;
+use pyrefly_types::class::PrecomputedTParams;
 use pyrefly_types::quantified::Quantified;
 use pyrefly_types::quantified::QuantifiedKind;
 use pyrefly_types::type_var::Restriction;
-use pyrefly_types::typed_dict::ExtraItem;
 use pyrefly_types::typed_dict::ExtraItems;
 use pyrefly_types::typed_dict::TypedDict;
 use pyrefly_types::types::Forallable;
@@ -74,6 +74,7 @@ use crate::binding::binding::Key;
 use crate::binding::binding::KeyAnnotation;
 use crate::binding::binding::KeyClassField;
 use crate::binding::binding::KeyDecorator;
+use crate::binding::binding::KeyTParams;
 use crate::binding::binding::ShapedArrayMetadata as ShapedArrayDecoratorMetadata;
 use crate::binding::django::DjangoFieldInfo;
 use crate::binding::pydantic::EXTRA;
@@ -213,6 +214,10 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             .map(|x| self.parse_base_class(x, is_new_type))
             .collect::<Vec<_>>();
         let contains_base_class_any = parsed_results.iter().any(|x| x.is_any());
+        let is_typed_dict = has_typed_dict_base_class
+            || parsed_results.iter().any(|base| {
+                matches!(base, BaseClassParseResult::Parsed(base) if base.metadata.is_typed_dict())
+            });
         let protocol_metadata = self.final_protocol_metadata(
             initial_protocol_metadata,
             &decorators,
@@ -254,7 +259,11 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 Some(name) if name.id == "metaclass" => metaclasses.push(&keyword.value),
                 Some(name) => keyword_annotations.push((
                     name.id.clone(),
-                    self.expr_class_keyword(&keyword.value, errors),
+                    if is_typed_dict && name.id == "extra_items" {
+                        self.expr_class_keyword(&keyword.value, errors)
+                    } else {
+                        Annotation::new_type(self.expr_infer(&keyword.value, errors))
+                    },
                 )),
                 None => {
                     self.extend_unpacked_class_keywords(keyword, &mut keyword_annotations, errors)
@@ -439,10 +448,6 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             cls.range(),
         );
 
-        let is_typed_dict = has_typed_dict_base_class
-            || bases_with_metadata
-                .iter()
-                .any(|(_, metadata)| metadata.is_typed_dict());
         if is_typed_dict
             && let Some(bad) = bases_with_metadata.iter().find(|x| !x.1.is_typed_dict())
         {
@@ -954,7 +959,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                         extra_items = Some(ExtraItems::Default);
                     }
                     ("extra_items", value_ty) => {
-                        let ty = self.untype_opt(value_ty.clone(), cls.range(), errors).unwrap_or_else(|| {
+                        let mut ty = self.untype_opt(value_ty.clone(), cls.range(), errors).unwrap_or_else(|| {
                             self.error(
                                 errors,
                                 cls.range(),
@@ -962,6 +967,30 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                                 format!("Expected `extra_items` to be a type form, got instance of `{}`", self.for_display(value_ty.clone())),
                             )
                         });
+                        // Class keywords are evaluated as runtime expressions. Only TypedDict
+                        // extra items reinterpret references to already-declared legacy parameters.
+                        if matches!(cls.precomputed_tparams(), PrecomputedTParams::FromBinding)
+                            && ty.any(|ty| ty.is_raw_legacy_type_variable())
+                        {
+                            let binding = self
+                                .bindings()
+                                .get(self.bindings().key_to_idx(&KeyTParams(cls.index())));
+                            let parameters: SmallMap<_, _> = binding
+                                .legacy_tparams
+                                .iter()
+                                .filter_map(|key| {
+                                    let parameter = self.get_idx(*key).parameter()?;
+                                    let value = self.legacy_tparam_value(self.bindings().get(*key));
+                                    Some((value.into_ty(), parameter.clone().to_type(self.heap)))
+                                })
+                                .collect();
+                            ty.transform_types_in_type_variable_positions(&mut |ty| {
+                                if let Some(parameter) = parameters.get(ty) {
+                                    *ty = parameter.clone();
+                                }
+                            });
+                        }
+                        self.check_legacy_typevar_scoping(&mut ty, cls.range(), errors);
                         extra_items = Some(ExtraItems::extra(ty, &value.qualifiers));
                     }
                     ("total", Type::Literal(lit)) if matches!(lit.value, Lit::Bool(_)) => {}
@@ -992,87 +1021,25 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             }
             let fields =
                 self.calculate_typed_dict_metadata_fields(cls, bases_with_metadata, is_total);
-            let extra_items = self.calculate_typed_dict_extra_items(
-                extra_items,
-                bases_with_metadata,
-                cls.range(),
-                errors,
-            );
+            let (extra_items, extra_items_from) = match extra_items {
+                Some(extra_items) => (extra_items, cls.dupe()),
+                None => bases_with_metadata
+                    .iter()
+                    .find_map(|(_, metadata)| {
+                        metadata
+                            .typed_dict_metadata()
+                            .map(|td| (td.extra_items.clone(), td.extra_items_from.dupe()))
+                    })
+                    .unwrap_or_else(|| (ExtraItems::Default, cls.dupe())),
+            };
             Some(TypedDictMetadata {
                 fields,
                 extra_items,
+                extra_items_from,
             })
         } else {
             None
         }
-    }
-
-    fn calculate_typed_dict_extra_items(
-        &self,
-        cur_extra_items: Option<ExtraItems>,
-        bases_with_metadata: &[(Class, &ClassMetadata)],
-        range: TextRange,
-        errors: &ErrorCollector,
-    ) -> ExtraItems {
-        let inherited_extra_items = bases_with_metadata.iter().find_map(|(base, metadata)| {
-            metadata
-                .typed_dict_metadata()
-                .map(|td| (base, &td.extra_items))
-        });
-        if cur_extra_items.is_none() || inherited_extra_items.is_none() {
-            return cur_extra_items.unwrap_or_else(|| {
-                inherited_extra_items.map_or(ExtraItems::Default, |(_, extra)| extra.clone())
-            });
-        }
-        let cur_extra_items = cur_extra_items.unwrap();
-        let (base_typed_dict, inherited_extra_items) = inherited_extra_items.unwrap();
-        match (&cur_extra_items, inherited_extra_items) {
-            (ExtraItems::Default, ExtraItems::Closed | ExtraItems::Extra(_)) => {
-                let base = if *inherited_extra_items == ExtraItems::Closed {
-                    format!("closed TypedDict `{}`", base_typed_dict.name())
-                } else {
-                    format!("TypedDict `{}` with extra items", base_typed_dict.name())
-                };
-                self.error(
-                    errors,
-                    range,
-                    ErrorKind::BadTypedDict,
-                    format!("Non-closed TypedDict cannot inherit from {base}"),
-                );
-            }
-            (
-                ExtraItems::Closed,
-                ExtraItems::Extra(ExtraItem {
-                    read_only: false, ..
-                }),
-            ) => {
-                self.error(
-                    errors,
-                    range,
-                    ErrorKind::BadTypedDict,
-                    format!("Closed TypedDict cannot inherit from TypedDict `{}` with non-read-only extra items", base_typed_dict.name()),
-                );
-            }
-            (
-                ExtraItems::Extra(ExtraItem { ty: cur_ty, .. }),
-                ExtraItems::Extra(ExtraItem {
-                    ty: inherited_ty,
-                    read_only: false,
-                }),
-            ) if cur_ty != inherited_ty => {
-                self.error(
-                    errors,
-                    range,
-                    ErrorKind::BadTypedDict,
-                    format!(
-                        "Cannot change the non-read-only extra items type of TypedDict `{}`",
-                        base_typed_dict.name()
-                    ),
-                );
-            }
-            _ => {}
-        }
-        cur_extra_items
     }
 
     fn enum_metadata(

--- a/pyrefly/lib/alt/class/typed_dict.rs
+++ b/pyrefly/lib/alt/class/typed_dict.rs
@@ -7,6 +7,7 @@
 
 use std::sync::Arc;
 
+use dupe::Dupe;
 use pyrefly_python::dunder;
 use pyrefly_types::simplify::unions_with_literals;
 use pyrefly_types::typed_dict::ExtraItem;
@@ -228,9 +229,105 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     }
 
     fn typed_dict_extra_items_for_cls(&self, cls: &Class) -> ExtraItems {
-        self.get_metadata_for_class(cls)
-            .typed_dict_metadata()
-            .map_or(ExtraItems::Default, |m| m.extra_items.clone())
+        let metadata = self.get_metadata_for_class(cls);
+        let Some(td) = metadata.typed_dict_metadata() else {
+            return ExtraItems::Default;
+        };
+        let mut extra_items = td.extra_items.clone();
+        if let ExtraItems::Extra(extra) = &mut extra_items
+            && td.extra_items_from != *cls
+        {
+            if let Some(ancestor) = self
+                .get_mro_for_class(cls)
+                .ancestors(self.stdlib)
+                .find(|base| *base.class_object() == td.extra_items_from)
+            {
+                ancestor.targs().substitute_into_mut(&mut extra.ty);
+            } else {
+                // Cyclic or inconsistent inheritance can omit the defining class from the MRO.
+                extra.ty = self.heap.mk_any_error();
+            }
+        }
+        extra_items
+    }
+
+    /// Return the first TypedDict base's extra items specialized for this subclass.
+    fn inherited_typed_dict_extra_items(&self, cls: &Class) -> Option<(Class, ExtraItems)> {
+        self.get_base_types_for_class(cls).iter().find_map(|base| {
+            if !self
+                .get_metadata_for_class(base.class_object())
+                .is_typed_dict()
+            {
+                return None;
+            }
+            let typed_dict = TypedDict::new(base.class_object().dupe(), base.targs().clone());
+            Some((
+                base.class_object().dupe(),
+                self.typed_dict_extra_items(&typed_dict),
+            ))
+        })
+    }
+
+    /// Check extra-item overrides after base type arguments have been resolved.
+    pub fn check_typed_dict_extra_items(&self, cls: &Class, errors: &ErrorCollector) {
+        let metadata = self.get_metadata_for_class(cls);
+        let Some(td) = metadata.typed_dict_metadata() else {
+            return;
+        };
+        if td.extra_items_from != *cls {
+            return;
+        }
+        let Some((base_typed_dict, inherited_extra_items)) =
+            self.inherited_typed_dict_extra_items(cls)
+        else {
+            return;
+        };
+        match (&td.extra_items, &inherited_extra_items) {
+            (ExtraItems::Default, ExtraItems::Closed | ExtraItems::Extra(_)) => {
+                let base = if inherited_extra_items == ExtraItems::Closed {
+                    format!("closed TypedDict `{}`", base_typed_dict.name())
+                } else {
+                    format!("TypedDict `{}` with extra items", base_typed_dict.name())
+                };
+                self.error(
+                    errors,
+                    cls.range(),
+                    ErrorKind::BadTypedDict,
+                    format!("Non-closed TypedDict cannot inherit from {base}"),
+                );
+            }
+            (
+                ExtraItems::Closed,
+                ExtraItems::Extra(ExtraItem {
+                    read_only: false, ..
+                }),
+            ) => {
+                self.error(
+                    errors,
+                    cls.range(),
+                    ErrorKind::BadTypedDict,
+                    format!("Closed TypedDict cannot inherit from TypedDict `{}` with non-read-only extra items", base_typed_dict.name()),
+                );
+            }
+            (
+                ExtraItems::Extra(ExtraItem { ty: cur_ty, .. }),
+                ExtraItems::Extra(ExtraItem {
+                    ty: inherited_ty,
+                    read_only: false,
+                }),
+            ) if cur_ty != inherited_ty => {
+                self.error(
+                    errors,
+                    cls.range(),
+                    ErrorKind::BadTypedDict,
+                    format!(
+                        "Cannot change the non-read-only extra items type of TypedDict `{}`",
+                        base_typed_dict.name()
+                    ),
+                );
+            }
+            _ => {}
+        }
     }
 
     pub fn typed_dict_extra_items(&self, typed_dict: &TypedDict) -> ExtraItems {
@@ -981,6 +1078,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
 
     pub fn calculate_typed_dict_field(
         &self,
+        cls: &Class,
         metadata: &ClassMetadata,
         name: &Name,
         range: TextRange,
@@ -1041,11 +1139,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         {
             // If this is a TypedDict field, make sure it is compatible with any inherited metadata
             // restricting extra items.
-            let inherited_extra = metadata.base_class_objects().iter().find_map(|base| {
-                self.get_metadata_for_class(base)
-                    .typed_dict_metadata()
-                    .map(|m| (base, m.extra_items.clone()))
-            });
+            let inherited_extra = self.inherited_typed_dict_extra_items(cls);
             match inherited_extra {
                 Some((base, ExtraItems::Closed)) => {
                     self.error(

--- a/pyrefly/lib/alt/class/typed_dict.rs
+++ b/pyrefly/lib/alt/class/typed_dict.rs
@@ -236,7 +236,11 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     pub fn typed_dict_extra_items(&self, typed_dict: &TypedDict) -> ExtraItems {
         match typed_dict {
             TypedDict::TypedDict(inner) => {
-                self.typed_dict_extra_items_for_cls(inner.class_object())
+                let mut extra_items = self.typed_dict_extra_items_for_cls(inner.class_object());
+                if let ExtraItems::Extra(extra) = &mut extra_items {
+                    inner.targs().substitute_into_mut(&mut extra.ty);
+                }
+                extra_items
             }
             TypedDict::Anonymous(_) => ExtraItems::Extra(ExtraItem {
                 ty: self.get_typed_dict_value_type(typed_dict),
@@ -776,7 +780,9 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             TypedDict::TypedDict(inner) => {
                 let cls = inner.class_object();
                 if let Some(metadata) = self.get_metadata_for_class(cls).typed_dict_metadata() {
-                    self.get_typed_dict_value_type_from_fields(cls, &metadata.fields)
+                    inner.targs().substitute_into(
+                        self.get_typed_dict_value_type_from_fields(cls, &metadata.fields),
+                    )
                 } else {
                     self.heap.mk_class_type(self.stdlib.object().clone())
                 }

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -374,24 +374,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         binding: &BindingLegacyTypeParam,
         scope_anchor: TextRange,
     ) -> LegacyTypeParameterLookup {
-        let maybe_parameter = match binding {
-            BindingLegacyTypeParam::ParamKeyed(k) => self.get_idx(*k).clone(),
-            BindingLegacyTypeParam::ModuleKeyed(module) => {
-                // Errors in attribute lookup are reported elsewhere.
-                module
-                    .attrs
-                    .iter()
-                    .fold(self.get_idx(module.base).clone(), |acc, attr| {
-                        self.attr_infer(
-                            &acc,
-                            attr,
-                            TextRange::default(),
-                            &self.error_swallower(),
-                            None,
-                        )
-                    })
-            }
-        };
+        let maybe_parameter = self.legacy_tparam_value(binding);
         // Use the scope_anchor (the KeyLegacyTypeParam's own range, i.e. the first occurrence
         // of this TypeVar name in the enclosing function/class/alias scope) as the identity
         // anchor. This gives each (scope, TypeVar) pair a distinct Quantified even when multiple
@@ -431,6 +414,28 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 LegacyTypeParameterLookup::Parameter(q)
             }
             ty => LegacyTypeParameterLookup::NotParameter(ty.clone()),
+        }
+    }
+
+    /// Resolve the runtime value underlying a possible legacy type parameter.
+    pub(crate) fn legacy_tparam_value(&self, binding: &BindingLegacyTypeParam) -> TypeInfo {
+        match binding {
+            BindingLegacyTypeParam::ParamKeyed(k) => self.get_idx(*k).clone(),
+            BindingLegacyTypeParam::ModuleKeyed(module) => {
+                // Errors in attribute lookup are reported elsewhere.
+                module
+                    .attrs
+                    .iter()
+                    .fold(self.get_idx(module.base).clone(), |acc, attr| {
+                        self.attr_infer(
+                            &acc,
+                            attr,
+                            TextRange::default(),
+                            &self.error_swallower(),
+                            None,
+                        )
+                    })
+            }
         }
     }
 
@@ -2965,6 +2970,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             self.check_variance_for_class(cls, class_bases, &class_field_map, errors);
             self.check_shape_flag_constructor_sources(cls, errors);
             self.check_self_in_typed_dict(cls, &class_field_map, errors);
+            self.check_typed_dict_extra_items(cls, errors);
             self.check_invalid_abstract_methods(cls, &class_field_map, errors);
         }
         EmptyAnswer

--- a/pyrefly/lib/alt/types/class_metadata.rs
+++ b/pyrefly/lib/alt/types/class_metadata.rs
@@ -647,6 +647,9 @@ pub struct TypedDictMetadata {
     /// Field name to the value of the `total` keyword in the defining class.
     pub fields: SmallMap<Name, bool>,
     pub extra_items: ExtraItems,
+    /// The class whose type parameters occur in `extra_items`. Specialization is deferred
+    /// until the MRO is available, since metadata cannot depend on base type arguments.
+    pub extra_items_from: Class,
 }
 
 #[derive(Clone, Debug, TypeEq, PartialEq, Eq)]

--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -388,7 +388,21 @@ impl<'a> BindingsBuilder<'a> {
         let mut keywords = Vec::new();
         if let Some(args) = &mut x.arguments {
             args.keywords.iter_mut().for_each(|keyword| {
-                self.ensure_expr(&mut keyword.value, class_object.usage());
+                if keyword
+                    .arg
+                    .as_ref()
+                    .is_some_and(|arg| arg.id == "extra_items")
+                {
+                    self.ensure_type_with_usage(
+                        &mut keyword.value,
+                        Some(&mut legacy),
+                        &mut Usage::StaticTypeInformation {
+                            is_annotation: false,
+                        },
+                    );
+                } else {
+                    self.ensure_expr(&mut keyword.value, class_object.usage());
+                }
                 keywords.push(keyword.clone());
             });
         }

--- a/pyrefly/lib/binding/class.rs
+++ b/pyrefly/lib/binding/class.rs
@@ -388,21 +388,7 @@ impl<'a> BindingsBuilder<'a> {
         let mut keywords = Vec::new();
         if let Some(args) = &mut x.arguments {
             args.keywords.iter_mut().for_each(|keyword| {
-                if keyword
-                    .arg
-                    .as_ref()
-                    .is_some_and(|arg| arg.id == "extra_items")
-                {
-                    self.ensure_type_with_usage(
-                        &mut keyword.value,
-                        Some(&mut legacy),
-                        &mut Usage::StaticTypeInformation {
-                            is_annotation: false,
-                        },
-                    );
-                } else {
-                    self.ensure_expr(&mut keyword.value, class_object.usage());
-                }
+                self.ensure_expr(&mut keyword.value, class_object.usage());
                 keywords.push(keyword.clone());
             });
         }

--- a/pyrefly/lib/test/typed_dict.rs
+++ b/pyrefly/lib/test/typed_dict.rs
@@ -1368,12 +1368,142 @@ d: TD[str] = {"a": 1}
 assert_type(d["b"], str)
 d2: TD[str] = {"a": 1, "b": "b"}
 assert_type(d2["b"], str)
+d2["b"] = 5  # E: `Literal[5]` is not assignable to TypedDict key `b` with type `str`
+assert_type(d2.pop("b"), int | str)
 
 class Foo[T]:
     def __init__(self, b: T):
         self.td: TD[T] = {"a": 1, "b": b}
 
 assert_type(Foo("b").td["b"], str)
+    "#,
+);
+
+testcase!(
+    test_generic_extra_items_inheritance,
+    r#"
+from typing import NotRequired, ReadOnly, TypedDict, assert_type
+
+class Parent[T](TypedDict, extra_items=T):
+    pass
+class Child(Parent[str]):
+    b: NotRequired[str]
+class BadChild(Parent[str]):
+    b: NotRequired[int]  # E: `int` is not consistent with `extra_items` type `str`
+class Same(Parent[str], extra_items=str):
+    pass
+class Changed(Parent[str], extra_items=int):  # E: Cannot change the non-read-only extra items type
+    pass
+
+child: Child = {"extra": "ok"}
+assert_type(child["extra"], str)
+assert_type(child.pop("extra"), str)
+child["extra"] = 5  # E: `Literal[5]` is not assignable to TypedDict key `extra` with type `str`
+assert_type(Child(extra="ok")["extra"], str)
+
+class Middle[U](Parent[list[U]]):
+    pass
+class Leaf(Middle[str]):
+    pass
+leaf: Leaf = {"extra": ["ok"]}
+assert_type(leaf["extra"], list[str])
+
+class Recursive(Parent["Recursive"]):
+    pass
+recursive: Recursive = {}
+assert_type(recursive["extra"], Recursive)
+
+class ReadOnlyParent[T](TypedDict, extra_items=ReadOnly[T]):
+    pass
+class ReadOnlyChild(ReadOnlyParent[str]):
+    field: str
+class BadReadOnlyChild(ReadOnlyParent[str]):
+    field: int  # E: `int` is not assignable to `extra_items` type `str`
+
+readonly: ReadOnlyParent[str] = {"extra": "ok"}
+assert_type(readonly["extra"], str)
+readonly["extra"] = "ok"  # E: Key `extra` in TypedDict `ReadOnlyParent` is read-only
+inherited_readonly: ReadOnlyChild = {"field": "ok", "extra": "ok"}
+assert_type(inherited_readonly["extra"], str)
+    "#,
+);
+
+testcase!(
+    test_generic_extra_items_legacy_scope,
+    r#"
+from typing import Any, Generic, ReadOnly, TypeVar, TypedDict, assert_type
+
+T = TypeVar("T")
+class TD(TypedDict, Generic[T], extra_items=list[T]):
+    pass
+d: TD[str] = {"extra": ["ok"]}
+assert_type(d["extra"], list[str])
+
+class ReadOnlyTD(TypedDict, Generic[T], extra_items=ReadOnly[T]):
+    pass
+readonly: ReadOnlyTD[str] = {"extra": "ok"}
+assert_type(readonly["extra"], str)
+readonly["extra"] = "ok"  # E: Key `extra` in TypedDict `ReadOnlyTD` is read-only
+
+# Class keywords do not declare legacy type parameters; Generic[T] is required.
+class Unbound(TypedDict, extra_items=T):  # E: Type variable `T` is not in scope
+    pass
+unbound: Unbound = {"extra": 1}
+assert_type(unbound["extra"], Any)
+
+# Functional TypedDict definitions cannot declare type parameters.
+Functional = TypedDict("Functional", {"a": int}, extra_items=T)  # E: Type variable `T` is not in scope
+functional: Functional = {"a": 1, "extra": "ok"}
+assert_type(functional["extra"], Any)
+    "#,
+);
+
+testcase!(
+    test_generic_extra_items_imported,
+    TestEnv::one(
+        "lib",
+        "from typing import TypeVar\nT = TypeVar('T')\nU = TypeVar('U')"
+    ),
+    r#"
+from typing import Generic, TypedDict, assert_type
+import lib
+
+class Parent(TypedDict, Generic[lib.T, lib.U], extra_items=tuple[lib.T, lib.U]):
+    pass
+class Child(Parent[str, int]):
+    pass
+child: Child = {"extra": ("ok", 1)}
+assert_type(child["extra"], tuple[str, int])
+    "#,
+);
+
+testcase!(
+    test_extra_items_ordinary_class_keyword,
+    r#"
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+class Base:
+    def __init_subclass__(cls, *, extra_items: TypeVar) -> None:
+        pass
+class C(Base, extra_items=T):
+    pass
+class G(Base, Generic[T], extra_items=T):
+    pass
+c: C[int]  # E: Expected 0 type arguments
+    "#,
+);
+
+testcase!(
+    test_extra_items_runtime_forward_reference,
+    r#"
+from __future__ import annotations
+from typing import TypedDict
+
+class TD(TypedDict, extra_items=Later):  # E: `Later` is uninitialized
+    pass
+class Later:
+    pass
     "#,
 );
 

--- a/pyrefly/lib/test/typed_dict.rs
+++ b/pyrefly/lib/test/typed_dict.rs
@@ -1357,6 +1357,27 @@ class TD(TypedDict, extra_items=ReadOnly[int]):
 );
 
 testcase!(
+    test_generic_extra_items,
+    r#"
+from typing import TypedDict, assert_type
+
+class TD[T](TypedDict, extra_items=T):
+    a: int
+
+d: TD[str] = {"a": 1}
+assert_type(d["b"], str)
+d2: TD[str] = {"a": 1, "b": "b"}
+assert_type(d2["b"], str)
+
+class Foo[T]:
+    def __init__(self, b: T):
+        self.td: TD[T] = {"a": 1, "b": b}
+
+assert_type(Foo("b").td["b"], str)
+    "#,
+);
+
+testcase!(
     test_bad_extra_items,
     r#"
 from typing import TypedDict


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4870

Generic `extra_items` now uses the supplied type arguments, including legacy `Generic[T]` syntax.

# Test Plan

<!-- Describe how you tested this PR -->

<!-- Run test.py and commit any changes to generated files -->

add test