### PR TITLE
Track literal shapes in array constructors (#4874)

### DIFF
--- a/crates/pyrefly_util/src/gas.rs
+++ b/crates/pyrefly_util/src/gas.rs
@@ -7,6 +7,7 @@
 
 //! Used to guard computation that could potentially loop forever.
 
+#[derive(Clone)]
 pub struct Gas(isize);
 
 impl Gas {

--- a/pyrefly/lib/alt.rs
+++ b/pyrefly/lib/alt.rs
@@ -23,6 +23,7 @@ pub mod operators;
 pub mod overload;
 pub mod polars_specials;
 pub mod regex;
+pub mod scalar;
 pub mod shape_extension;
 pub mod shape_flag;
 pub mod shape_index;

--- a/pyrefly/lib/alt.rs
+++ b/pyrefly/lib/alt.rs
@@ -7,6 +7,7 @@
 
 pub mod answers;
 pub mod answers_solver;
+pub mod array_coercible;
 pub mod attr;
 pub mod call;
 pub mod callable;

--- a/pyrefly/lib/alt/array_coercible.rs
+++ b/pyrefly/lib/alt/array_coercible.rs
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! List-literal inference for `shape_extensions.ArrayCoercible`.
+//!
+//! The marker representation and subset logic live in `crate::solver::shape_markers`; this module
+//! keeps only the `AnswersSolver` work of projecting list literals against a domain.
+
+use pyrefly_types::dimension::Int;
+use pyrefly_types::shaped_array::IntTuple;
+use pyrefly_types::shaped_array::IntTupleView;
+use pyrefly_types::types::Type;
+use ruff_python_ast::Expr;
+use ruff_python_ast::ExprList;
+use ruff_text_size::Ranged;
+use ruff_text_size::TextRange;
+
+use crate::alt::answers::LookupAnswer;
+use crate::alt::answers_solver::AnswersSolver;
+use crate::alt::unwrap::HintRef;
+use crate::alt::unwrap::MAX_HINT_WIDTH;
+use crate::error::collector::ErrorCollector;
+use crate::solver::shape_markers::array_coercible;
+use crate::solver::solver::VarSnapshot;
+
+impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
+    /// Project a rectangular, unstarred list literal against one scalar-leaf domain.
+    fn project_array_coercible_list(
+        &self,
+        list: &ExprList,
+        domain: &Type,
+        errors: &ErrorCollector,
+        inference_snapshots: &mut Vec<VarSnapshot>,
+        projected_lists: &mut Vec<(TextRange, IntTuple)>,
+    ) -> Option<IntTuple> {
+        if list
+            .elts
+            .iter()
+            .any(|element| matches!(element, Expr::Starred(_)))
+        {
+            return None;
+        }
+        let mut child_shape: Option<IntTuple> = None;
+        let concrete_matches_unpacked = |concrete: &[Int], prefix: &[Int], suffix: &[Int]| {
+            concrete.len() >= prefix.len() + suffix.len()
+                && concrete.starts_with(prefix)
+                && concrete.ends_with(suffix)
+        };
+        for element in &list.elts {
+            let shape = match element {
+                Expr::List(child) => Some(self.project_array_coercible_list(
+                    child,
+                    domain,
+                    errors,
+                    inference_snapshots,
+                    projected_lists,
+                )?),
+                _ => {
+                    let ty =
+                        self.expr_infer_with_hint(element, Some(HintRef::soft(domain)), errors);
+                    if self.type_order().is_deferred_array_coercible_container(&ty) {
+                        return None;
+                    }
+                    if ty.is_any() {
+                        None
+                    } else {
+                        let snapshot = self
+                            .solver()
+                            .snapshot_for_speculative_inference(&[&ty, domain]);
+                        if !self.is_subset_eq(&ty, domain) {
+                            self.solver().restore_vars(snapshot);
+                            return None;
+                        }
+                        // Each AnswersSolver subset check owns a transient subset, so retain only
+                        // the solver-variable snapshot needed for outer rollback.
+                        inference_snapshots.push(snapshot);
+                        Some(IntTuple::new(Vec::new()))
+                    }
+                }
+            };
+            if let Some(shape) = shape {
+                match child_shape.as_ref() {
+                    Some(expected) if expected == &shape => {}
+                    Some(expected) => match (expected.view(), shape.view()) {
+                        (IntTupleView::Gradual, _) => {}
+                        (_, IntTupleView::Gradual) => child_shape = Some(shape),
+                        (
+                            IntTupleView::Concrete(concrete),
+                            IntTupleView::Unpacked { prefix, suffix, .. },
+                        ) if concrete_matches_unpacked(concrete, prefix, suffix) => {}
+                        (
+                            IntTupleView::Unpacked { prefix, suffix, .. },
+                            IntTupleView::Concrete(concrete),
+                        ) if concrete_matches_unpacked(concrete, prefix, suffix) => {
+                            child_shape = Some(shape)
+                        }
+                        _ => return None,
+                    },
+                    None => child_shape = Some(shape),
+                }
+            }
+        }
+        let outer = Int::Literal(list.elts.len() as i64);
+        let shape = match child_shape {
+            Some(child_shape) => match child_shape.view() {
+                IntTupleView::Concrete(child) => {
+                    let mut dims = Vec::with_capacity(child.len() + 1);
+                    dims.push(outer);
+                    dims.extend(child.iter().cloned());
+                    IntTuple::new(dims)
+                }
+                IntTupleView::Gradual => IntTuple::unpacked(
+                    vec![outer],
+                    IntTuple::shapeless().to_shape_arg_type(),
+                    Vec::new(),
+                ),
+                IntTupleView::Unpacked {
+                    prefix,
+                    middle,
+                    suffix,
+                } => {
+                    let mut outer_prefix = Vec::with_capacity(prefix.len() + 1);
+                    outer_prefix.push(outer);
+                    outer_prefix.extend(prefix.iter().cloned());
+                    IntTuple::unpacked(outer_prefix, middle.clone(), suffix.to_vec())
+                }
+            },
+            None if list.is_empty() => IntTuple::new(vec![outer]),
+            None => IntTuple::unpacked(
+                vec![outer],
+                IntTuple::shapeless().to_shape_arg_type(),
+                Vec::new(),
+            ),
+        };
+        projected_lists.push((list.range(), shape.clone()));
+        Some(shape)
+    }
+
+    /// Infer a list literal from an `ArrayCoercible` hint, returning `None` to use ordinary list
+    /// inference when the literal cannot be projected safely.
+    pub(crate) fn infer_array_coercible_list(
+        &self,
+        list: &ExprList,
+        hint: HintRef,
+        errors: &ErrorCollector,
+    ) -> Option<Type> {
+        if !self.solver().tensor_shapes {
+            return None;
+        }
+        if hint.types().len() > MAX_HINT_WIDTH {
+            return None;
+        }
+        // Each marker domain is a distinct soft hint and can change leaf inference, so projection
+        // results cannot be shared across alternatives. The hint-width limit bounds this work.
+        for hint_ty in hint.types() {
+            let Some(marker) = array_coercible(hint_ty) else {
+                continue;
+            };
+            let branch_errors = self.error_collector();
+            let mut inference_snapshots = Vec::new();
+            let mut projected_lists = Vec::new();
+            let snapshot = self
+                .solver()
+                .snapshot_for_speculative_inference(&[&marker.shape, &marker.domain]);
+            let rollback = |inference_snapshots: Vec<VarSnapshot>| {
+                for inference_snapshot in inference_snapshots.into_iter().rev() {
+                    self.solver().restore_vars(inference_snapshot);
+                }
+                self.solver().restore_vars(snapshot);
+            };
+            match self.project_array_coercible_list(
+                list,
+                &marker.domain,
+                &branch_errors,
+                &mut inference_snapshots,
+                &mut projected_lists,
+            ) {
+                Some(shape) if !branch_errors.has_hard() => {
+                    let projected = marker.with_shape(shape);
+                    if !self.is_subset_eq(&projected, hint_ty) {
+                        rollback(inference_snapshots);
+                        continue;
+                    }
+                    for (range, shape) in projected_lists {
+                        self.record_type_trace(range, &marker.with_shape(shape));
+                    }
+                    errors.extend(branch_errors);
+                    return Some(projected);
+                }
+                Some(_) | None => {
+                    // Projection failures are alternative-specific, and an ordinary union
+                    // alternative may still accept the literal.
+                    rollback(inference_snapshots);
+                }
+            }
+        }
+        None
+    }
+}

--- a/pyrefly/lib/alt/attr.rs
+++ b/pyrefly/lib/alt/attr.rs
@@ -35,6 +35,7 @@ use crate::alt::call::CallTargetLookup;
 use crate::alt::callable::CallArg;
 use crate::alt::class::class_field::ClassAttribute;
 use crate::alt::expr::TypeOrExpr;
+use crate::alt::scalar::scalar_upper_bound;
 use crate::binding::binding::ExprOrBinding;
 use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
@@ -2468,6 +2469,17 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     }
 
     fn as_attribute_base1(&self, ty: Type, acc: &mut Vec<AttributeBase1>) {
+        let ty = self.normalize_scalar_type(ty);
+        self.as_attribute_base1_normalized(ty, acc);
+    }
+
+    fn as_attribute_base1_normalized(&self, ty: Type, acc: &mut Vec<AttributeBase1>) {
+        if self.solver().tensor_shapes
+            && let Some(upper_bound) = scalar_upper_bound(self.solver(), &ty)
+        {
+            self.as_attribute_base1_normalized(upper_bound, acc);
+            return;
+        }
         match ty {
             Type::ClassType(class_type) => {
                 if let Some(shaped_array) =
@@ -2503,8 +2515,12 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 // NNModule delegates attribute access to its underlying class
                 acc.push(AttributeBase1::ClassInstance(module.class.clone()))
             }
-            Type::DataFrame(schema) => self.as_attribute_base1(schema.underlying_type(), acc),
-            Type::Series(schema) => self.as_attribute_base1(schema.underlying_type(), acc),
+            Type::DataFrame(schema) => {
+                self.as_attribute_base1_normalized(schema.underlying_type(), acc)
+            }
+            Type::Series(schema) => {
+                self.as_attribute_base1_normalized(schema.underlying_type(), acc)
+            }
             Type::Int(_) => {
                 // Dimension values behave like int for attribute access
                 acc.push(AttributeBase1::ClassInstance(self.stdlib.int().clone()))
@@ -2594,7 +2610,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             Type::Callable(_) | Type::CallableResidual(_) => acc.push(
                 AttributeBase1::ClassInstance(self.stdlib.function_type().clone()),
             ),
-            Type::KwCall(call) => self.as_attribute_base1(call.return_ty, acc),
+            Type::KwCall(call) => self.as_attribute_base1_normalized(call.return_ty, acc),
             Type::Function(f) => acc.push(AttributeBase1::ClassInstance(
                 if let FunctionKind::CallbackProtocol(cls) = f.metadata.kind {
                     *cls
@@ -2615,7 +2631,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             Type::BoundMethod(bound_method) => {
                 acc.push(AttributeBase1::BoundMethod(bound_method.func.clone()));
             }
-            Type::Forall(forall) => self.as_attribute_base1(forall.body.as_type(), acc),
+            Type::Forall(forall) => self.as_attribute_base1_normalized(forall.body.as_type(), acc),
             Type::Var(v) => {
                 self.force_var_for_attribute_base(v, |ty| self.as_attribute_base1(ty, acc))
             }
@@ -2625,7 +2641,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             }
             Type::Union(f) => {
                 for ty in f.members {
-                    self.as_attribute_base1(ty, acc)
+                    self.as_attribute_base1_normalized(ty, acc)
                 }
             }
             Type::Quantified(quantified) => match quantified.restriction() {
@@ -2707,10 +2723,10 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             Type::Intersect(x) => {
                 let mut acc_intersect = Vec::new();
                 for t in x.0 {
-                    self.as_attribute_base1(t, &mut acc_intersect);
+                    self.as_attribute_base1_normalized(t, &mut acc_intersect);
                 }
                 let mut acc_fallback = Vec::new();
-                self.as_attribute_base1(x.1, &mut acc_fallback);
+                self.as_attribute_base1_normalized(x.1, &mut acc_fallback);
                 acc.push(AttributeBase1::Intersect(acc_intersect, acc_fallback));
             }
             Type::ElementOfTypeVarTuple(_) => {

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -55,6 +55,7 @@ use crate::error::context::ErrorContext;
 use crate::error::context::TypeCheckContext;
 use crate::error::context::TypeCheckKind;
 use crate::error::display::function_suffix;
+use crate::solver::shape::union_shape_widening_vars;
 use crate::solver::solver::ArgumentKey;
 use crate::solver::solver::ArgumentSide;
 use crate::solver::solver::CallBoundary;
@@ -2210,7 +2211,14 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             }
             call_boundary.defer_quantified(qs);
         }
-        let call_context = call_context.with_shape_extension_vars(shape_extension_vars);
+        let widening_vars = self
+            .solver()
+            .tensor_shapes
+            .then(|| union_shape_widening_vars(&callable.params, &callable.ret))
+            .flatten();
+        let call_context = call_context
+            .with_shape_extension_vars(shape_extension_vars)
+            .with_union_shape_widening_vars(widening_vars);
         self.constrain_forwarded_overload_return(ForwardedOverloadCall {
             params: &callable.params,
             has_self: self_obj.is_some(),

--- a/pyrefly/lib/alt/callable.rs
+++ b/pyrefly/lib/alt/callable.rs
@@ -2391,7 +2391,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             .collect();
 
         (
-            self.reproject_tuple_carrier_shape(ret),
+            self.normalize_scalar_type(self.reproject_tuple_carrier_shape(ret)),
             errors,
             return_type_errors,
             argmap,

--- a/pyrefly/lib/alt/class/class_field.rs
+++ b/pyrefly/lib/alt/class/class_field.rs
@@ -3335,7 +3335,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
 
     fn normalize_attr_ty(&self, mut ty: Type) -> Type {
         self.expand_mut(&mut ty);
-        ty.finalize_callable_residuals_at_boundary(self.heap, false)
+        self.normalize_scalar_type(ty.finalize_callable_residuals_at_boundary(self.heap, false))
     }
 
     /// Filter out overload signatures whose explicit `self:` annotation is not

--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -784,40 +784,44 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 )
             }
             Expr::Tuple(x) => self.tuple_infer(x, hint, errors),
-            Expr::List(x) => self.infer_with_decomposed_hint(
-                hint,
-                |hint| self.decompose_list(hint),
-                |elt_hint, hint| {
-                    if x.is_empty() {
-                        let elem_ty = match elt_hint {
-                            Some(ListElementHint::Hint(elem_hint)) => elem_hint,
-                            Some(ListElementHint::UninformativeAny(_)) | None => self
-                                .solver()
-                                .fresh_partial_contained(self.uniques, x.range)
-                                .to_type(self.heap),
-                        };
-                        self.heap.mk_class_type(self.stdlib.list(elem_ty))
-                    } else {
-                        let (elt_hint, partial_fallback) = elt_hint
-                            .map(ListElementHint::into_parts)
-                            .unwrap_or_default();
-                        let elem_tys = self.elts_infer(
-                            &x.elts,
-                            HintRef::with_ty_opt(hint, elt_hint.as_ref()),
-                            errors,
-                        );
-                        let ty = self
-                            .heap
-                            .mk_class_type(self.stdlib.list(self.unions(elem_tys)));
-                        if let Some(partial_fallback) = partial_fallback {
-                            self.solver()
-                                .replace_unresolved_partials(ty, &partial_fallback)
-                        } else {
-                            ty
-                        }
-                    }
-                },
-            ),
+            Expr::List(x) => hint
+                .and_then(|hint| self.infer_array_coercible_list(x, hint, errors))
+                .unwrap_or_else(|| {
+                    self.infer_with_decomposed_hint(
+                        hint,
+                        |hint| self.decompose_list(hint),
+                        |elt_hint, hint| {
+                            if x.is_empty() {
+                                let elem_ty = match elt_hint {
+                                    Some(ListElementHint::Hint(elem_hint)) => elem_hint,
+                                    Some(ListElementHint::UninformativeAny(_)) | None => self
+                                        .solver()
+                                        .fresh_partial_contained(self.uniques, x.range)
+                                        .to_type(self.heap),
+                                };
+                                self.heap.mk_class_type(self.stdlib.list(elem_ty))
+                            } else {
+                                let (elt_hint, partial_fallback) = elt_hint
+                                    .map(ListElementHint::into_parts)
+                                    .unwrap_or_default();
+                                let elem_tys = self.elts_infer(
+                                    &x.elts,
+                                    HintRef::with_ty_opt(hint, elt_hint.as_ref()),
+                                    errors,
+                                );
+                                let ty = self
+                                    .heap
+                                    .mk_class_type(self.stdlib.list(self.unions(elem_tys)));
+                                if let Some(partial_fallback) = partial_fallback {
+                                    self.solver()
+                                        .replace_unresolved_partials(ty, &partial_fallback)
+                                } else {
+                                    ty
+                                }
+                            }
+                        },
+                    )
+                }),
             Expr::Dict(x) => self.dict_infer(&x.items, hint, x.range, errors),
             Expr::Set(x) => self.infer_with_decomposed_hint(
                 hint,
@@ -4529,7 +4533,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                     expr.range(),
                     ErrorKind::InvalidAnnotation,
                     format!(
-                        "Tensor shape dimensions must be positive integer literals, string literals, type variables, or expressions, got `{}`",
+                        "Tensor shape dimensions must be integer literals, string literals, type variables, or expressions, got `{}`",
                         self.for_display(expr_type)
                     ),
                 );
@@ -4539,7 +4543,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     }
 
     /// Parse a list of dimension expressions, simplifying and validating each one.
-    /// Returns None if any dimension fails to parse or is non-positive.
+    /// Returns None if any dimension fails to parse or is negative.
     pub(super) fn parse_dimension_list(
         &self,
         args: &[Expr],
@@ -4612,15 +4616,15 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             };
             let simplified = canonicalize(dim);
 
-            // Validate that literal dimensions are positive
+            // Array extents may be zero, but negative extents are invalid.
             if let Type::Int(Int::Literal(value)) = &simplified
-                && value <= &0
+                && value < &0
             {
                 self.error(
                     errors,
                     arg.range(),
                     ErrorKind::InvalidAnnotation,
-                    format!("Tensor shape dimension must be positive, got {}", value),
+                    format!("Tensor shape dimension must be non-negative, got {}", value),
                 );
                 return Err(DimensionExprError::Invalid);
             }

--- a/pyrefly/lib/alt/function.rs
+++ b/pyrefly/lib/alt/function.rs
@@ -855,7 +855,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             }
         }
 
-        let callable = if let Some(q) = &def.paramspec {
+        let mut callable = if let Some(q) = &def.paramspec {
             Callable::concatenate(
                 def.params
                     .iter()
@@ -905,6 +905,25 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         // in the signature, and detect mixing of native and jaxtyping syntax.
         let tparams =
             self.collect_jaxtyping_tparams(&callable, &def.tparams, stmt.name.range, errors);
+
+        if self.solver().tensor_shapes {
+            let parameter_ranges = stmt
+                .parameters
+                .iter()
+                .map(|parameter| {
+                    parameter
+                        .annotation()
+                        .map_or_else(|| parameter.name().range(), Ranged::range)
+                })
+                .collect::<Vec<_>>();
+            self.simplify_redundant_scalar_unions(
+                &mut callable,
+                &tparams,
+                &parameter_ranges,
+                stmt.name.range,
+                errors,
+            );
+        }
 
         self.validate_shape_extension_function_parameters(stmt, &def.params, &tparams, errors);
 

--- a/pyrefly/lib/alt/scalar.rs
+++ b/pyrefly/lib/alt/scalar.rs
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Solver integration for `shape_extensions.Scalar`.
+
+use pyrefly_types::heap::TypeHeap;
+use pyrefly_types::shaped_array::IntTuple;
+use pyrefly_types::shaped_array::IntTupleView;
+use pyrefly_types::shaped_array::tuple_carrier_to_shape;
+use pyrefly_types::types::Type;
+use pyrefly_util::visit::VisitMut;
+
+use crate::alt::answers::LookupAnswer;
+use crate::alt::answers_solver::AnswersSolver;
+use crate::solver::solver::Solver;
+use crate::solver::solver::Subset;
+use crate::solver::solver::SubsetError;
+
+/// The shape witness and scalar domain extracted from `Scalar[Shape, Domain]`.
+struct ScalarFamily {
+    shape: Type,
+    domain: Type,
+}
+
+/// The semantic form of a `Scalar` after its shape has been normalized.
+enum ScalarNormalForm {
+    /// A rank-zero or gradual shape exposes the scalar domain.
+    Domain(Type),
+    /// The shape is not yet known, so its relationship with the domain must be preserved.
+    Suspended(ScalarFamily),
+}
+
+fn scalar(ty: &Type) -> Option<ScalarFamily> {
+    let Type::ClassType(cls) = ty else {
+        return None;
+    };
+    if cls.has_qname("shape_extensions", "Scalar") {
+        let [shape, domain] = cls.targs().as_slice() else {
+            return None;
+        };
+        Some(ScalarFamily {
+            shape: shape.clone(),
+            domain: domain.clone(),
+        })
+    } else {
+        None
+    }
+}
+
+fn scalar_normal_form(heap: &TypeHeap, marker: ScalarFamily) -> ScalarNormalForm {
+    let shape = match &marker.shape {
+        Type::Any(_) => return ScalarNormalForm::Domain(marker.domain),
+        Type::IntTuple(shape) => shape.normalize(),
+        shape => match tuple_carrier_to_shape(shape) {
+            Some(shape) => shape.normalize(),
+            // Unresolved or invalid shapes retain the marker. Validation reports malformed
+            // specializations, while inference may later solve suspended variables.
+            None => return ScalarNormalForm::Suspended(marker),
+        },
+    };
+    match shape.view() {
+        IntTupleView::Concrete([]) => ScalarNormalForm::Domain(marker.domain),
+        IntTupleView::Concrete(_) => ScalarNormalForm::Domain(heap.mk_never()),
+        IntTupleView::Gradual => ScalarNormalForm::Domain(marker.domain),
+        IntTupleView::Unpacked { prefix, suffix, .. }
+            if !prefix.is_empty() || !suffix.is_empty() =>
+        {
+            ScalarNormalForm::Domain(heap.mk_never())
+        }
+        IntTupleView::Unpacked { .. } => ScalarNormalForm::Suspended(marker),
+    }
+}
+
+/// Whether `ty` contains a `Scalar` marker that normalization may replace.
+fn contains_scalar(ty: &Type) -> bool {
+    ty.any(|candidate| scalar(candidate).is_some())
+}
+
+fn contains_var(ty: &Type) -> bool {
+    ty.any(|candidate| matches!(candidate, Type::Var(_)))
+}
+
+fn expanded_scalar_normal_form(solver: &Solver, ty: &Type) -> Option<ScalarNormalForm> {
+    let mut marker = scalar(ty)?;
+    if contains_var(&marker.shape) {
+        solver.expand_with_bounds(&mut marker.shape);
+    }
+    Some(scalar_normal_form(&solver.heap, marker))
+}
+
+/// Return the ordinary domain represented by a viable `Scalar` specialization.
+///
+/// `None` means that `ty` is not a `Scalar`.
+pub(crate) fn scalar_upper_bound(solver: &Solver, ty: &Type) -> Option<Type> {
+    match expanded_scalar_normal_form(solver, ty) {
+        Some(
+            ScalarNormalForm::Domain(domain)
+            | ScalarNormalForm::Suspended(ScalarFamily { domain, .. }),
+        ) => Some(domain),
+        None => None,
+    }
+}
+
+impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
+    fn is_subset_domain_to_suspended(
+        &mut self,
+        got: &Type,
+        want: &ScalarFamily,
+    ) -> Result<(), SubsetError> {
+        self.with_speculative_subset_branch_result(&[got, &want.domain, &want.shape], |me| {
+            me.is_subset_eq(got, &want.domain)?;
+            me.is_subset_eq(&IntTuple::new(Vec::new()).to_shape_arg_type(), &want.shape)
+        })
+    }
+
+    /// Handle a subset relation involving `Scalar`, or delegate by returning `None`.
+    ///
+    /// Successful speculative branches retain inferred variable constraints. Failed branches and
+    /// probes restore all subset state captured by the transaction helper.
+    pub(crate) fn is_subset_scalar(
+        &mut self,
+        got: &Type,
+        want: &Type,
+    ) -> Option<Result<(), SubsetError>> {
+        if !self.solver.tensor_shapes {
+            return None;
+        }
+        if got.is_any() || want.is_any() {
+            return None;
+        }
+        let got_scalar = expanded_scalar_normal_form(self.solver, got);
+        let want_scalar = expanded_scalar_normal_form(self.solver, want);
+        if got.is_never() && want_scalar.is_some() {
+            return Some(Ok(()));
+        }
+        match (got_scalar, want_scalar) {
+            (None, None) => None,
+            (Some(ScalarNormalForm::Domain(domain)), None) => {
+                Some(self.is_subset_eq(&domain, want))
+            }
+            (Some(ScalarNormalForm::Suspended(got_marker)), None) => {
+                if let Type::Union(union) = want {
+                    for member in union
+                        .members
+                        .iter()
+                        .filter(|member| scalar(member).is_some())
+                    {
+                        if self
+                            .with_speculative_subset_branch_result(
+                                &[got, &got_marker.shape, &got_marker.domain, member],
+                                |me| me.is_subset_eq(got, member),
+                            )
+                            .is_ok()
+                        {
+                            return Some(Ok(()));
+                        }
+                    }
+                }
+                Some(self.is_subset_eq(&got_marker.domain, want))
+            }
+            (None, Some(ScalarNormalForm::Domain(domain))) => Some(self.is_subset_eq(got, &domain)),
+            (None, Some(ScalarNormalForm::Suspended(want))) => {
+                Some(self.is_subset_domain_to_suspended(got, &want))
+            }
+            (
+                Some(ScalarNormalForm::Domain(got_domain)),
+                Some(ScalarNormalForm::Domain(want_domain)),
+            ) => Some(self.is_subset_eq(&got_domain, &want_domain)),
+            (
+                Some(ScalarNormalForm::Domain(got_domain)),
+                Some(ScalarNormalForm::Suspended(want_marker)),
+            ) => Some(self.is_subset_domain_to_suspended(&got_domain, &want_marker)),
+            (
+                Some(ScalarNormalForm::Suspended(got_marker)),
+                Some(ScalarNormalForm::Domain(want_domain)),
+            ) => Some(self.is_subset_eq(&got_marker.domain, &want_domain)),
+            (
+                Some(ScalarNormalForm::Suspended(got_marker)),
+                Some(ScalarNormalForm::Suspended(want_marker)),
+            ) => {
+                if contains_var(&got_marker.shape) || contains_var(&want_marker.shape) {
+                    return Some(self.with_speculative_subset_branch_result(
+                        &[
+                            &got_marker.domain,
+                            &got_marker.shape,
+                            &want_marker.domain,
+                            &want_marker.shape,
+                        ],
+                        |me| {
+                            me.is_subset_eq(&got_marker.domain, &want_marker.domain)?;
+                            me.is_subset_eq(&got_marker.shape, &want_marker.shape)?;
+                            me.is_subset_eq(&want_marker.shape, &got_marker.shape)
+                        },
+                    ));
+                }
+                Some(
+                    self.probe_speculative_subset_branch_result(
+                        &[&got_marker.shape, &want_marker.shape],
+                        |me| {
+                            me.is_subset_eq(&got_marker.shape, &want_marker.shape)?;
+                            me.is_subset_eq(&want_marker.shape, &got_marker.shape)
+                        },
+                    )
+                    .and_then(|()| self.is_subset_eq(&got_marker.domain, &want_marker.domain)),
+                )
+            }
+        }
+    }
+}
+
+impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
+    fn normalize_scalar_type_inner(&self, ty: &mut Type) -> bool {
+        let mut changed = false;
+        ty.recurse_mut(&mut |child| changed |= self.normalize_scalar_type_inner(child));
+
+        if let Some(ScalarNormalForm::Domain(domain)) =
+            expanded_scalar_normal_form(self.solver(), ty)
+            && *ty != domain
+        {
+            *ty = domain;
+            changed = true;
+        }
+        if changed && let Type::Union(union) = ty {
+            let simplified = self.unions(union.members.clone());
+            if simplified != *ty {
+                *ty = simplified;
+            }
+        }
+        changed
+    }
+
+    /// Replace resolved `Scalar` occurrences with their domain or `Never` normal form.
+    ///
+    /// Union members are normalized before their containing union so redundant members can be
+    /// simplified together.
+    pub(crate) fn normalize_scalar_type(&self, ty: Type) -> Type {
+        if !self.solver().tensor_shapes || !contains_scalar(&ty) {
+            return ty;
+        }
+        let mut ty = ty;
+        self.normalize_scalar_type_inner(&mut ty);
+        ty
+    }
+}

--- a/pyrefly/lib/alt/scalar.rs
+++ b/pyrefly/lib/alt/scalar.rs
@@ -7,15 +7,23 @@
 
 //! Solver integration for `shape_extensions.Scalar`.
 
+use pyrefly_types::callable::Callable;
+use pyrefly_types::callable::Params;
 use pyrefly_types::heap::TypeHeap;
+use pyrefly_types::quantified::Quantified;
 use pyrefly_types::shaped_array::IntTuple;
 use pyrefly_types::shaped_array::IntTupleView;
 use pyrefly_types::shaped_array::tuple_carrier_to_shape;
+use pyrefly_types::type_var::Restriction;
+use pyrefly_types::types::TParams;
 use pyrefly_types::types::Type;
 use pyrefly_util::visit::VisitMut;
+use ruff_text_size::TextRange;
 
 use crate::alt::answers::LookupAnswer;
 use crate::alt::answers_solver::AnswersSolver;
+use crate::config::error_kind::ErrorKind;
+use crate::error::collector::ErrorCollector;
 use crate::solver::solver::Solver;
 use crate::solver::solver::Subset;
 use crate::solver::solver::SubsetError;
@@ -231,6 +239,143 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             }
         }
         changed
+    }
+
+    /// Remove redundant `Scalar` union arms and reject annotations that would strand an observable
+    /// shape variable by doing so.
+    pub(crate) fn simplify_redundant_scalar_unions(
+        &self,
+        callable: &mut Callable,
+        tparams: &TParams,
+        parameter_ranges: &[TextRange],
+        fallback_range: TextRange,
+        errors: &ErrorCollector,
+    ) {
+        let ret = &callable.ret;
+        let Params::List(params) = &mut callable.params else {
+            return;
+        };
+        if !params
+            .items()
+            .iter()
+            .any(|param| contains_scalar(param.as_type()))
+        {
+            return;
+        }
+        let original_parameter_types = params
+            .items()
+            .iter()
+            .map(|param| param.as_type().clone())
+            .collect::<Vec<_>>();
+        let mut simplified_parameter_types = original_parameter_types
+            .iter()
+            .map(|parameter_type| {
+                let Type::Union(union) = parameter_type else {
+                    return parameter_type.clone();
+                };
+                let ordinary = union
+                    .members
+                    .iter()
+                    .filter(|member| scalar(member).is_none())
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if ordinary.is_empty() {
+                    return parameter_type.clone();
+                }
+                let ordinary = self.unions(ordinary);
+                let members = union
+                    .members
+                    .iter()
+                    .filter(|member| {
+                        let Some(marker) = scalar(member) else {
+                            return true;
+                        };
+                        let snapshot = self
+                            .solver()
+                            .snapshot_for_speculative_inference(&[&marker.domain, &ordinary]);
+                        let redundant = self.is_subset_eq(&marker.domain, &ordinary);
+                        self.solver().restore_vars(snapshot);
+                        !redundant
+                    })
+                    .cloned()
+                    .collect();
+                self.unions(members)
+            })
+            .collect::<Vec<_>>();
+
+        let contains_tparam = |ty: &Type, tparam: &Quantified| {
+            ty.any(|ty| matches!(ty, Type::Quantified(other) if other.as_ref() == tparam))
+        };
+        let mut observable_tparams = tparams
+            .iter()
+            .filter(|tparam| contains_tparam(ret, tparam))
+            .collect::<Vec<_>>();
+        loop {
+            let mut changed = false;
+            for dependency in tparams.iter() {
+                if observable_tparams.contains(&dependency) {
+                    continue;
+                }
+                let referenced_by_observable = observable_tparams.iter().any(|observable| {
+                    observable
+                        .default()
+                        .is_some_and(|default| contains_tparam(default, dependency))
+                        || match observable.restriction() {
+                            Restriction::Bound(bound) => contains_tparam(bound, dependency),
+                            Restriction::Constraints(constraints) => constraints
+                                .iter()
+                                .any(|constraint| contains_tparam(constraint, dependency)),
+                            Restriction::ShapeExtension(_) | Restriction::Unrestricted => false,
+                        }
+                });
+                if referenced_by_observable {
+                    observable_tparams.push(dependency);
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+
+        for tparam in observable_tparams {
+            let mentions_tparam = |ty: &Type| contains_tparam(ty, tparam);
+            if simplified_parameter_types.iter().any(&mentions_tparam) {
+                continue;
+            }
+            let lost_indices = original_parameter_types
+                .iter()
+                .zip(&simplified_parameter_types)
+                .enumerate()
+                .filter_map(|(index, (original, simplified))| {
+                    (mentions_tparam(original) && !mentions_tparam(simplified)).then_some(index)
+                })
+                .collect::<Vec<_>>();
+            if let Some(&first_index) = lost_indices.first() {
+                self.error(
+                    errors,
+                    parameter_ranges
+                        .get(first_index)
+                        .copied()
+                        .unwrap_or(fallback_range),
+                    ErrorKind::InvalidAnnotation,
+                    format!(
+                        "Redundant `Scalar` union arm cannot bind observable type parameter `{}`",
+                        tparam.name()
+                    ),
+                );
+                for index in lost_indices {
+                    simplified_parameter_types[index] = original_parameter_types[index].clone();
+                }
+            }
+        }
+        for (param, parameter_type) in params
+            .items_mut()
+            .iter_mut()
+            .zip(simplified_parameter_types)
+        {
+            *param.as_type_mut() = parameter_type;
+        }
     }
 
     /// Replace resolved `Scalar` occurrences with their domain or `Never` normal form.

--- a/pyrefly/lib/alt/scalar.rs
+++ b/pyrefly/lib/alt/scalar.rs
@@ -5,15 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Solver integration for `shape_extensions.Scalar`.
+//! Normalization and redundant-union simplification for `shape_extensions.Scalar`.
+//!
+//! The marker representation and subset logic live in `crate::solver::shape_markers`; this module
+//! keeps only the `AnswersSolver` work of normalizing markers and simplifying signatures.
 
 use pyrefly_types::callable::Callable;
 use pyrefly_types::callable::Params;
-use pyrefly_types::heap::TypeHeap;
+use pyrefly_types::callable::PrefixParam;
+use pyrefly_types::callable::Required;
 use pyrefly_types::quantified::Quantified;
-use pyrefly_types::shaped_array::IntTuple;
-use pyrefly_types::shaped_array::IntTupleView;
-use pyrefly_types::shaped_array::tuple_carrier_to_shape;
 use pyrefly_types::type_var::Restriction;
 use pyrefly_types::types::TParams;
 use pyrefly_types::types::Type;
@@ -24,80 +25,15 @@ use crate::alt::answers::LookupAnswer;
 use crate::alt::answers_solver::AnswersSolver;
 use crate::config::error_kind::ErrorKind;
 use crate::error::collector::ErrorCollector;
+use crate::solver::shape_markers::ScalarFamily;
+use crate::solver::shape_markers::ScalarNormalForm;
+use crate::solver::shape_markers::expanded_scalar_normal_form;
+use crate::solver::shape_markers::scalar;
 use crate::solver::solver::Solver;
-use crate::solver::solver::Subset;
-use crate::solver::solver::SubsetError;
-
-/// The shape witness and scalar domain extracted from `Scalar[Shape, Domain]`.
-struct ScalarFamily {
-    shape: Type,
-    domain: Type,
-}
-
-/// The semantic form of a `Scalar` after its shape has been normalized.
-enum ScalarNormalForm {
-    /// A rank-zero or gradual shape exposes the scalar domain.
-    Domain(Type),
-    /// The shape is not yet known, so its relationship with the domain must be preserved.
-    Suspended(ScalarFamily),
-}
-
-fn scalar(ty: &Type) -> Option<ScalarFamily> {
-    let Type::ClassType(cls) = ty else {
-        return None;
-    };
-    if cls.has_qname("shape_extensions", "Scalar") {
-        let [shape, domain] = cls.targs().as_slice() else {
-            return None;
-        };
-        Some(ScalarFamily {
-            shape: shape.clone(),
-            domain: domain.clone(),
-        })
-    } else {
-        None
-    }
-}
-
-fn scalar_normal_form(heap: &TypeHeap, marker: ScalarFamily) -> ScalarNormalForm {
-    let shape = match &marker.shape {
-        Type::Any(_) => return ScalarNormalForm::Domain(marker.domain),
-        Type::IntTuple(shape) => shape.normalize(),
-        shape => match tuple_carrier_to_shape(shape) {
-            Some(shape) => shape.normalize(),
-            // Unresolved or invalid shapes retain the marker. Validation reports malformed
-            // specializations, while inference may later solve suspended variables.
-            None => return ScalarNormalForm::Suspended(marker),
-        },
-    };
-    match shape.view() {
-        IntTupleView::Concrete([]) => ScalarNormalForm::Domain(marker.domain),
-        IntTupleView::Concrete(_) => ScalarNormalForm::Domain(heap.mk_never()),
-        IntTupleView::Gradual => ScalarNormalForm::Domain(marker.domain),
-        IntTupleView::Unpacked { prefix, suffix, .. }
-            if !prefix.is_empty() || !suffix.is_empty() =>
-        {
-            ScalarNormalForm::Domain(heap.mk_never())
-        }
-        IntTupleView::Unpacked { .. } => ScalarNormalForm::Suspended(marker),
-    }
-}
 
 /// Whether `ty` contains a `Scalar` marker that normalization may replace.
 fn contains_scalar(ty: &Type) -> bool {
     ty.any(|candidate| scalar(candidate).is_some())
-}
-
-fn contains_var(ty: &Type) -> bool {
-    ty.any(|candidate| matches!(candidate, Type::Var(_)))
-}
-
-fn expanded_scalar_normal_form(solver: &Solver, ty: &Type) -> Option<ScalarNormalForm> {
-    let mut marker = scalar(ty)?;
-    if contains_var(&marker.shape) {
-        solver.expand_with_bounds(&mut marker.shape);
-    }
-    Some(scalar_normal_form(&solver.heap, marker))
 }
 
 /// Return the ordinary domain represented by a viable `Scalar` specialization.
@@ -110,113 +46,6 @@ pub(crate) fn scalar_upper_bound(solver: &Solver, ty: &Type) -> Option<Type> {
             | ScalarNormalForm::Suspended(ScalarFamily { domain, .. }),
         ) => Some(domain),
         None => None,
-    }
-}
-
-impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
-    fn is_subset_domain_to_suspended(
-        &mut self,
-        got: &Type,
-        want: &ScalarFamily,
-    ) -> Result<(), SubsetError> {
-        self.with_speculative_subset_branch_result(&[got, &want.domain, &want.shape], |me| {
-            me.is_subset_eq(got, &want.domain)?;
-            me.is_subset_eq(&IntTuple::new(Vec::new()).to_shape_arg_type(), &want.shape)
-        })
-    }
-
-    /// Handle a subset relation involving `Scalar`, or delegate by returning `None`.
-    ///
-    /// Successful speculative branches retain inferred variable constraints. Failed branches and
-    /// probes restore all subset state captured by the transaction helper.
-    pub(crate) fn is_subset_scalar(
-        &mut self,
-        got: &Type,
-        want: &Type,
-    ) -> Option<Result<(), SubsetError>> {
-        if !self.solver.tensor_shapes {
-            return None;
-        }
-        if got.is_any() || want.is_any() {
-            return None;
-        }
-        let got_scalar = expanded_scalar_normal_form(self.solver, got);
-        let want_scalar = expanded_scalar_normal_form(self.solver, want);
-        if got.is_never() && want_scalar.is_some() {
-            return Some(Ok(()));
-        }
-        match (got_scalar, want_scalar) {
-            (None, None) => None,
-            (Some(ScalarNormalForm::Domain(domain)), None) => {
-                Some(self.is_subset_eq(&domain, want))
-            }
-            (Some(ScalarNormalForm::Suspended(got_marker)), None) => {
-                if let Type::Union(union) = want {
-                    for member in union
-                        .members
-                        .iter()
-                        .filter(|member| scalar(member).is_some())
-                    {
-                        if self
-                            .with_speculative_subset_branch_result(
-                                &[got, &got_marker.shape, &got_marker.domain, member],
-                                |me| me.is_subset_eq(got, member),
-                            )
-                            .is_ok()
-                        {
-                            return Some(Ok(()));
-                        }
-                    }
-                }
-                Some(self.is_subset_eq(&got_marker.domain, want))
-            }
-            (None, Some(ScalarNormalForm::Domain(domain))) => Some(self.is_subset_eq(got, &domain)),
-            (None, Some(ScalarNormalForm::Suspended(want))) => {
-                Some(self.is_subset_domain_to_suspended(got, &want))
-            }
-            (
-                Some(ScalarNormalForm::Domain(got_domain)),
-                Some(ScalarNormalForm::Domain(want_domain)),
-            ) => Some(self.is_subset_eq(&got_domain, &want_domain)),
-            (
-                Some(ScalarNormalForm::Domain(got_domain)),
-                Some(ScalarNormalForm::Suspended(want_marker)),
-            ) => Some(self.is_subset_domain_to_suspended(&got_domain, &want_marker)),
-            (
-                Some(ScalarNormalForm::Suspended(got_marker)),
-                Some(ScalarNormalForm::Domain(want_domain)),
-            ) => Some(self.is_subset_eq(&got_marker.domain, &want_domain)),
-            (
-                Some(ScalarNormalForm::Suspended(got_marker)),
-                Some(ScalarNormalForm::Suspended(want_marker)),
-            ) => {
-                if contains_var(&got_marker.shape) || contains_var(&want_marker.shape) {
-                    return Some(self.with_speculative_subset_branch_result(
-                        &[
-                            &got_marker.domain,
-                            &got_marker.shape,
-                            &want_marker.domain,
-                            &want_marker.shape,
-                        ],
-                        |me| {
-                            me.is_subset_eq(&got_marker.domain, &want_marker.domain)?;
-                            me.is_subset_eq(&got_marker.shape, &want_marker.shape)?;
-                            me.is_subset_eq(&want_marker.shape, &got_marker.shape)
-                        },
-                    ));
-                }
-                Some(
-                    self.probe_speculative_subset_branch_result(
-                        &[&got_marker.shape, &want_marker.shape],
-                        |me| {
-                            me.is_subset_eq(&got_marker.shape, &want_marker.shape)?;
-                            me.is_subset_eq(&want_marker.shape, &got_marker.shape)
-                        },
-                    )
-                    .and_then(|()| self.is_subset_eq(&got_marker.domain, &want_marker.domain)),
-                )
-            }
-        }
     }
 }
 
@@ -241,8 +70,48 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         changed
     }
 
-    /// Remove redundant `Scalar` union arms and reject annotations that would strand an observable
-    /// shape variable by doing so.
+    /// Remove `Scalar` members already covered by ordinary members of the same union.
+    fn simplify_redundant_scalar_unions_in_type(&self, ty: Type) -> Type {
+        ty.transform(&mut |candidate| {
+            let Type::Union(union) = candidate else {
+                return;
+            };
+            let ordinary_members = union
+                .members
+                .iter()
+                .filter(|member| scalar(member).is_none())
+                .cloned()
+                .collect::<Vec<_>>();
+            if ordinary_members.is_empty() {
+                return;
+            }
+            let ordinary = self.unions(ordinary_members);
+            let members = union
+                .members
+                .iter()
+                .filter(|member| {
+                    let Some(marker) = scalar(member) else {
+                        return true;
+                    };
+                    let snapshot = self
+                        .solver()
+                        .snapshot_for_speculative_inference(&[&marker.domain, &ordinary]);
+                    // `AnswersSolver::is_subset_eq` owns a transient `Subset`, so only solver
+                    // variables need to be restored after this probe.
+                    let redundant = self.is_subset_eq(&marker.domain, &ordinary);
+                    self.solver().restore_vars(snapshot);
+                    !redundant
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if members.len() != union.members.len() {
+                *candidate = self.unions(members);
+            }
+        })
+    }
+
+    /// Remove redundant `Scalar` union arms recursively and reject annotations that would strand
+    /// an observable shape variable by doing so.
     pub(crate) fn simplify_redundant_scalar_unions(
         &self,
         callable: &mut Callable,
@@ -252,54 +121,44 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
         errors: &ErrorCollector,
     ) {
         let ret = &callable.ret;
-        let Params::List(params) = &mut callable.params else {
-            return;
+        let (original_parameter_types, required_parameters) = match &callable.params {
+            Params::List(params) => (
+                params
+                    .items()
+                    .iter()
+                    .map(|param| param.as_type().clone())
+                    .collect::<Vec<_>>(),
+                params
+                    .items()
+                    .iter()
+                    .map(|param| param.is_required())
+                    .collect::<Vec<_>>(),
+            ),
+            Params::ParamSpec(prefix, _) => (
+                prefix
+                    .iter()
+                    .map(|param| param.ty().clone())
+                    .collect::<Vec<_>>(),
+                prefix
+                    .iter()
+                    .map(|param| {
+                        matches!(
+                            param,
+                            PrefixParam::PosOnly(_, _, Required::Required)
+                                | PrefixParam::Pos(_, _, Required::Required)
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+            ),
+            Params::Partial(_) | Params::Ellipsis | Params::Materialization => return,
         };
-        if !params
-            .items()
-            .iter()
-            .any(|param| contains_scalar(param.as_type()))
-        {
+        if !original_parameter_types.iter().any(contains_scalar) {
             return;
         }
-        let original_parameter_types = params
-            .items()
-            .iter()
-            .map(|param| param.as_type().clone())
-            .collect::<Vec<_>>();
         let mut simplified_parameter_types = original_parameter_types
             .iter()
             .map(|parameter_type| {
-                let Type::Union(union) = parameter_type else {
-                    return parameter_type.clone();
-                };
-                let ordinary = union
-                    .members
-                    .iter()
-                    .filter(|member| scalar(member).is_none())
-                    .cloned()
-                    .collect::<Vec<_>>();
-                if ordinary.is_empty() {
-                    return parameter_type.clone();
-                }
-                let ordinary = self.unions(ordinary);
-                let members = union
-                    .members
-                    .iter()
-                    .filter(|member| {
-                        let Some(marker) = scalar(member) else {
-                            return true;
-                        };
-                        let snapshot = self
-                            .solver()
-                            .snapshot_for_speculative_inference(&[&marker.domain, &ordinary]);
-                        let redundant = self.is_subset_eq(&marker.domain, &ordinary);
-                        self.solver().restore_vars(snapshot);
-                        !redundant
-                    })
-                    .cloned()
-                    .collect();
-                self.unions(members)
+                self.simplify_redundant_scalar_unions_in_type(parameter_type.clone())
             })
             .collect::<Vec<_>>();
 
@@ -340,7 +199,11 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
 
         for tparam in observable_tparams {
             let mentions_tparam = |ty: &Type| contains_tparam(ty, tparam);
-            if simplified_parameter_types.iter().any(&mentions_tparam) {
+            if simplified_parameter_types
+                .iter()
+                .zip(&required_parameters)
+                .any(|(parameter_type, required)| *required && mentions_tparam(parameter_type))
+            {
                 continue;
             }
             let lost_indices = original_parameter_types
@@ -369,19 +232,35 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
                 }
             }
         }
-        for (param, parameter_type) in params
-            .items_mut()
-            .iter_mut()
-            .zip(simplified_parameter_types)
-        {
-            *param.as_type_mut() = parameter_type;
+        match &mut callable.params {
+            Params::List(params) => {
+                for (param, parameter_type) in params
+                    .items_mut()
+                    .iter_mut()
+                    .zip(simplified_parameter_types)
+                {
+                    *param.as_type_mut() = parameter_type;
+                }
+            }
+            Params::ParamSpec(prefix, _) => {
+                for (param, parameter_type) in prefix.iter_mut().zip(simplified_parameter_types) {
+                    match param {
+                        PrefixParam::PosOnly(_, ty, _) | PrefixParam::Pos(_, ty, _) => {
+                            *ty = parameter_type
+                        }
+                    }
+                }
+            }
+            Params::Partial(_) | Params::Ellipsis | Params::Materialization => {
+                unreachable!("only callable parameters collected above are rewritten")
+            }
         }
     }
 
     /// Replace resolved `Scalar` occurrences with their domain or `Never` normal form.
     ///
-    /// Union members are normalized before their containing union so redundant members can be
-    /// simplified together.
+    /// Union members are normalized first so their containing union can simplify redundant
+    /// members. Unchanged unions are left intact to preserve alias display names.
     pub(crate) fn normalize_scalar_type(&self, ty: Type) -> Type {
         if !self.solver().tensor_shapes || !contains_scalar(&ty) {
             return ty;

--- a/pyrefly/lib/alt/solve.rs
+++ b/pyrefly/lib/alt/solve.rs
@@ -7082,6 +7082,7 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
             }
         };
         let result = self.validate_type_form(result, x.range(), type_form_context, errors);
+        let result = self.normalize_scalar_type(result);
 
         self.interpret_map_int_tuples_at_annotation_root(result, type_form_context)
     }

--- a/pyrefly/lib/solver.rs
+++ b/pyrefly/lib/solver.rs
@@ -6,6 +6,7 @@
  */
 
 pub(crate) mod shape;
+pub(crate) mod shape_markers;
 pub mod solver;
 pub mod subset;
 pub mod type_order;

--- a/pyrefly/lib/solver/shape.rs
+++ b/pyrefly/lib/solver/shape.rs
@@ -10,6 +10,10 @@
 //! The generic solver remains responsible for variable state and subset traversal. This module
 //! isolates the shape-specific decisions it needs when admitting or simplifying solver values.
 
+use std::sync::Arc;
+
+use pyrefly_types::callable::Param;
+use pyrefly_types::callable::Params;
 use pyrefly_types::dimension::Int;
 use pyrefly_types::dimension::canonicalize;
 use pyrefly_types::dimension::gradual_size;
@@ -19,13 +23,169 @@ use pyrefly_types::heap::TypeHeap;
 use pyrefly_types::quantified::Quantified;
 use pyrefly_types::quantified::QuantifiedKind;
 use pyrefly_types::shaped_array::IntTuple;
+use pyrefly_types::shaped_array::IntTupleView;
 use pyrefly_types::shaped_array::is_int_tuples_type;
 use pyrefly_types::shaped_array::tuple_carrier_to_shape;
 use pyrefly_types::simplify::unions;
 use pyrefly_types::stdlib::Stdlib;
 use pyrefly_types::tuple::Tuple;
 use pyrefly_types::type_var::Restriction;
+use pyrefly_types::types::TParams;
 use pyrefly_types::types::Type;
+use pyrefly_types::types::Var;
+
+/// Join concrete equal-rank shapes dimension-wise; other differing shapes become gradual.
+pub(crate) fn join_int_tuples(left: &IntTuple, right: &IntTuple) -> IntTuple {
+    if left == right {
+        return left.clone();
+    }
+    match (left.view(), right.view()) {
+        (IntTupleView::Concrete(left), IntTupleView::Concrete(right))
+            if left.len() == right.len() =>
+        {
+            IntTuple::new(
+                left.iter()
+                    .zip(right)
+                    .map(|(left, right)| {
+                        if left == right {
+                            left.clone()
+                        } else {
+                            Int::Int
+                        }
+                    })
+                    .collect(),
+            )
+        }
+        _ => IntTuple::shapeless(),
+    }
+}
+
+fn contains_parameter(ty: &Type, parameter: Var) -> bool {
+    ty.any(|ty| matches!(ty, Type::Var(candidate) if *candidate == parameter))
+}
+
+/// Index of the unique `IntTuple`-bounded type parameter, if there is exactly one.
+fn unique_int_tuple_bound_index(tparams: &TParams) -> Option<usize> {
+    let mut indices = tparams
+        .iter()
+        .enumerate()
+        .filter_map(|(index, parameter)| has_int_tuple_bound(parameter).then_some(index));
+    let shape_index = indices.next()?;
+    indices.next().is_none().then_some(shape_index)
+}
+
+/// Extract the sole `IntTuple`-bounded argument when it is a solver variable used by no other
+/// argument of the same class.
+fn shape_parameter(ty: &Type) -> Option<Var> {
+    let (targs, shape_index) = match ty {
+        Type::ShapedArray(array) => (
+            array.base_class.targs().as_slice(),
+            array.tuple_carrier_shape_arg_index()?,
+        ),
+        Type::ClassType(cls) => (
+            cls.targs().as_slice(),
+            unique_int_tuple_bound_index(cls.tparams())?,
+        ),
+        _ => return None,
+    };
+    let Type::Var(parameter) = targs.get(shape_index)? else {
+        return None;
+    };
+    has_only_shape_argument_occurrences(targs, Some(shape_index), *parameter).then_some(*parameter)
+}
+
+/// Extract the sole eligible shape variable from a union or a single-spelled parameter.
+///
+/// Union arms that do not mention the variable are allowed so ordinary alternatives such as
+/// `None` do not disable shape joining. Any arm that mentions the variable must use it solely as
+/// its shape argument.
+fn union_shape_parameter(ty: &Type) -> Option<Var> {
+    match ty {
+        Type::Union(union) => {
+            let mut parameters = union.members.iter().filter_map(shape_parameter);
+            let parameter = parameters.next()?;
+            if parameters.any(|candidate| candidate != parameter) {
+                return None;
+            }
+            union
+                .members
+                .iter()
+                .all(|member| {
+                    shape_parameter(member) == Some(parameter)
+                        || !contains_parameter(member, parameter)
+                })
+                .then_some(parameter)
+        }
+        _ => shape_parameter(ty),
+    }
+}
+
+/// Check that every occurrence of a variable is an array-like shape argument in the return type.
+fn has_only_return_shape_occurrences(ty: &Type, parameter: Var) -> bool {
+    match ty {
+        Type::Union(union) => union.members.iter().all(|member| {
+            !contains_parameter(member, parameter)
+                || has_only_return_shape_occurrences(member, parameter)
+        }),
+        Type::ShapedArray(array) => has_only_shape_argument_occurrences(
+            array.base_class.targs().as_slice(),
+            array.tuple_carrier_shape_arg_index(),
+            parameter,
+        ),
+        Type::ClassType(cls) => has_only_shape_argument_occurrences(
+            cls.targs().as_slice(),
+            unique_int_tuple_bound_index(cls.tparams()),
+            parameter,
+        ),
+        _ => !contains_parameter(ty, parameter),
+    }
+}
+
+/// Check that a variable occurs in the unique shape argument and nowhere else in the arguments.
+fn has_only_shape_argument_occurrences(
+    targs: &[Type],
+    shape_index: Option<usize>,
+    parameter: Var,
+) -> bool {
+    let Some(shape_index) = shape_index else {
+        return false;
+    };
+    targs
+        .get(shape_index)
+        .is_some_and(|shape| contains_parameter(shape, parameter))
+        && !targs
+            .iter()
+            .enumerate()
+            .any(|(index, ty)| index != shape_index && contains_parameter(ty, parameter))
+}
+
+/// Return shape variables whose union-derived gradual solution cannot weaken another parameter or
+/// a non-shape return occurrence.
+pub(crate) fn union_shape_widening_vars(params: &Params, ret: &Type) -> Option<Arc<Vec<Var>>> {
+    // A partial signature omits already-bound parameters, so it cannot prove that the shape
+    // variable is owned solely by one remaining parameter.
+    let Params::List(params) = params else {
+        return None;
+    };
+    let vars = params
+        .items()
+        .iter()
+        .enumerate()
+        .filter(|(_, param)| !matches!(param, Param::Varargs(..) | Param::Kwargs(..)))
+        .filter_map(|(index, param)| {
+            union_shape_parameter(param.as_type()).map(|parameter| (index, parameter))
+        })
+        .filter_map(|(owner_index, parameter)| {
+            let solely_owned = !params.items().iter().enumerate().any(|(index, param)| {
+                index != owner_index && contains_parameter(param.as_type(), parameter)
+            });
+            let return_shaped_only = contains_parameter(ret, parameter)
+                && has_only_return_shape_occurrences(ret, parameter);
+            (solely_owned && return_shaped_only).then_some(parameter)
+        })
+        .collect::<Vec<_>>();
+    (!vars.is_empty()).then(|| Arc::new(vars))
+}
 
 /// Normalize a candidate answer for an `IntVar`.
 ///

--- a/pyrefly/lib/solver/shape_markers.rs
+++ b/pyrefly/lib/solver/shape_markers.rs
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Subset logic for the `shape_extensions` markers `Scalar` and `ArrayCoercible`.
+//!
+//! The generic solver remains responsible for variable state and subset traversal. This module
+//! isolates the shape-specific subset decisions it needs, keeping them out of `alt/`, which
+//! retains only the `AnswersSolver` work: literal projection, scalar normalization, and
+//! redundant-union simplification.
+
+use pyrefly_types::class::ClassType;
+use pyrefly_types::heap::TypeHeap;
+use pyrefly_types::shaped_array::IntTuple;
+use pyrefly_types::shaped_array::IntTupleView;
+use pyrefly_types::shaped_array::tuple_carrier_to_shape;
+use pyrefly_types::type_var::Restriction;
+use pyrefly_types::types::Type;
+
+use crate::alt::answers::LookupAnswer;
+use crate::solver::shape::has_int_tuple_bound;
+use crate::solver::solver::Solver;
+use crate::solver::solver::Subset;
+use crate::solver::solver::SubsetError;
+use crate::solver::type_order::TypeOrder;
+
+/// The shape and element domain extracted from `ArrayCoercible[Shape, Domain]`.
+///
+/// The original two-argument class type is retained so literal projection can replace only its
+/// shape argument without reconstructing the marker.
+pub(crate) struct ArrayCoercible {
+    /// The shape accepted or inferred for the value.
+    pub(crate) shape: Type,
+    /// The type accepted for every scalar leaf.
+    pub(crate) domain: Type,
+    class_type: ClassType,
+}
+
+/// Extract an `ArrayCoercible` marker from its class-type representation.
+pub(crate) fn array_coercible(ty: &Type) -> Option<ArrayCoercible> {
+    let Type::ClassType(cls) = ty else {
+        return None;
+    };
+    if !cls.has_qname("shape_extensions", "ArrayCoercible") {
+        return None;
+    }
+    let [shape, domain] = cls.targs().as_slice() else {
+        return None;
+    };
+    Some(ArrayCoercible {
+        shape: shape.clone(),
+        domain: domain.clone(),
+        class_type: cls.clone(),
+    })
+}
+
+impl<Ans: LookupAnswer> TypeOrder<'_, Ans> {
+    /// Whether a value may contain array structure that cannot be projected from its expression.
+    ///
+    /// False positives deliberately fall back to ordinary typing rather than treating an existing
+    /// container as one scalar leaf. Strings and bytes are leaves despite being sequences.
+    pub(crate) fn is_deferred_array_coercible_container(self, ty: &Type) -> bool {
+        match ty {
+            Type::Var(_) => {
+                let mut expanded = ty.clone();
+                self.expand_with_bounds(&mut expanded);
+                // An unresolved variable may still solve to a container, so treat it as
+                // deferred rather than pinning a scalar shape for it.
+                matches!(expanded, Type::Var(_))
+                    || self.is_deferred_array_coercible_container(&expanded)
+            }
+            Type::Tuple(_) | Type::ShapedArray(_) => true,
+            Type::Union(union) => union
+                .members
+                .iter()
+                .any(|member| self.is_deferred_array_coercible_container(member)),
+            Type::Intersect(intersect) => {
+                intersect
+                    .0
+                    .iter()
+                    .any(|member| self.is_deferred_array_coercible_container(member))
+                    || self.is_deferred_array_coercible_container(&intersect.1)
+            }
+            Type::Quantified(quantified) => {
+                self.is_deferred_array_coercible_restriction(quantified.restriction())
+            }
+            Type::TypeVar(type_var) => {
+                self.is_deferred_array_coercible_restriction(type_var.restriction())
+            }
+            _ if array_coercible(ty).is_some() => true,
+            _ if scalar(ty).is_some() => false,
+            Type::ClassType(cls) | Type::SelfType(cls) => {
+                // `has_superclass` includes identity, so subclasses of leaves and
+                // sequences are covered without separate equality checks.
+                if self.has_superclass(cls.class_object(), self.stdlib().str().class_object())
+                    || self.has_superclass(cls.class_object(), self.stdlib().bytes().class_object())
+                {
+                    return false;
+                }
+                self.shaped_array_shape_for_class_type(cls).is_some()
+                    || cls.tparams().iter().any(has_int_tuple_bound)
+                    || self.has_superclass(cls.class_object(), self.stdlib().list_object())
+                    || self.has_superclass(cls.class_object(), self.stdlib().tuple_object())
+                    || self.has_superclass(
+                        cls.class_object(),
+                        self.stdlib().sequence(Type::any_implicit()).class_object(),
+                    )
+            }
+            _ => false,
+        }
+    }
+
+    /// Whether a type-variable restriction permits array structure.
+    fn is_deferred_array_coercible_restriction(self, restriction: &Restriction) -> bool {
+        match restriction {
+            Restriction::Bound(bound) => self.is_deferred_array_coercible_container(bound),
+            Restriction::Constraints(constraints) => constraints
+                .iter()
+                .any(|constraint| self.is_deferred_array_coercible_container(constraint)),
+            Restriction::Unrestricted => true,
+            Restriction::ShapeExtension(_) => false,
+        }
+    }
+}
+
+impl ArrayCoercible {
+    /// Replace the marker's shape argument while preserving its domain and class metadata.
+    pub(crate) fn with_shape(&self, shape: IntTuple) -> Type {
+        let mut class_type = self.class_type.clone();
+        class_type.targs_mut().as_mut()[0] = shape.to_shape_arg_type();
+        class_type.to_type()
+    }
+}
+
+impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
+    /// Handle a subset relation involving `ArrayCoercible`, or delegate by returning `None`.
+    ///
+    /// Left-hand unions are delegated so generic union distribution can check each member.
+    pub(crate) fn is_subset_array_coercible(
+        &mut self,
+        got: &Type,
+        want: &Type,
+    ) -> Option<Result<(), SubsetError>> {
+        if !self.solver.tensor_shapes {
+            return None;
+        }
+        let got_marker = array_coercible(got);
+        let want_marker = array_coercible(want);
+        if got.is_never() && want_marker.is_some() {
+            return Some(Ok(()));
+        }
+        if got.is_any() || want.is_any() || matches!(got, Type::Union(_)) {
+            return None;
+        }
+        match (got_marker, want_marker) {
+            (None, None) => None,
+            (Some(_), None) => None,
+            (Some(got), Some(want)) => Some(self.with_speculative_subset_branch_result(
+                &[&got.domain, &got.shape, &want.domain, &want.shape],
+                |me| {
+                    me.is_subset_eq(&got.domain, &want.domain)?;
+                    me.is_subset_eq(&got.shape, &want.shape)
+                },
+            )),
+            (None, Some(_)) if self.type_order.is_deferred_array_coercible_container(got) => None,
+            (None, Some(want)) => Some(self.with_speculative_subset_branch_result(
+                &[got, &want.domain, &want.shape],
+                |me| {
+                    me.is_subset_eq(got, &want.domain)?;
+                    me.is_subset_eq(&IntTuple::new(Vec::new()).to_shape_arg_type(), &want.shape)
+                },
+            )),
+        }
+    }
+}
+
+/// The shape witness and scalar domain extracted from `Scalar[Shape, Domain]`.
+pub(crate) struct ScalarFamily {
+    /// The shape accepted for the scalar value.
+    pub(crate) shape: Type,
+    /// The type accepted for the scalar value.
+    pub(crate) domain: Type,
+}
+
+/// The semantic form of a `Scalar` after its shape has been normalized.
+pub(crate) enum ScalarNormalForm {
+    /// A rank-zero or gradual shape exposes the scalar domain.
+    Domain(Type),
+    /// The shape is not yet known, so its relationship with the domain must be preserved.
+    Suspended(ScalarFamily),
+}
+
+/// Extract a `Scalar` marker from its class-type representation.
+pub(crate) fn scalar(ty: &Type) -> Option<ScalarFamily> {
+    let Type::ClassType(cls) = ty else {
+        return None;
+    };
+    if cls.has_qname("shape_extensions", "Scalar") {
+        // Qualified names are user input: a user module can shadow `Scalar` with a different
+        // arity, and malformed specializations are reachable during error recovery, so a
+        // length mismatch degrades to "not a Scalar" instead of panicking.
+        let [shape, domain] = cls.targs().as_slice() else {
+            return None;
+        };
+        Some(ScalarFamily {
+            shape: shape.clone(),
+            domain: domain.clone(),
+        })
+    } else {
+        None
+    }
+}
+
+fn scalar_normal_form(heap: &TypeHeap, marker: ScalarFamily) -> ScalarNormalForm {
+    let shape = match &marker.shape {
+        Type::Any(_) => return ScalarNormalForm::Domain(marker.domain),
+        Type::IntTuple(shape) => shape.normalize(),
+        shape => match tuple_carrier_to_shape(shape) {
+            Some(shape) => shape.normalize(),
+            // Unresolved or invalid shapes retain the marker. Validation reports malformed
+            // specializations, while inference may later solve suspended variables.
+            None => return ScalarNormalForm::Suspended(marker),
+        },
+    };
+    match shape.view() {
+        IntTupleView::Concrete([]) => ScalarNormalForm::Domain(marker.domain),
+        IntTupleView::Concrete(_) => ScalarNormalForm::Domain(heap.mk_never()),
+        IntTupleView::Gradual => ScalarNormalForm::Domain(marker.domain),
+        IntTupleView::Unpacked { prefix, suffix, .. }
+            if !prefix.is_empty() || !suffix.is_empty() =>
+        {
+            ScalarNormalForm::Domain(heap.mk_never())
+        }
+        IntTupleView::Unpacked { .. } => ScalarNormalForm::Suspended(marker),
+    }
+}
+
+fn contains_var(ty: &Type) -> bool {
+    ty.any(|candidate| matches!(candidate, Type::Var(_)))
+}
+
+/// Expand inference variables in a `Scalar` shape before normalizing it.
+pub(crate) fn expanded_scalar_normal_form(solver: &Solver, ty: &Type) -> Option<ScalarNormalForm> {
+    let mut marker = scalar(ty)?;
+    if contains_var(&marker.shape) {
+        solver.expand_with_bounds(&mut marker.shape);
+    }
+    Some(scalar_normal_form(&solver.heap, marker))
+}
+
+impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
+    fn is_subset_domain_to_suspended(
+        &mut self,
+        got: &Type,
+        want: &ScalarFamily,
+    ) -> Result<(), SubsetError> {
+        self.with_speculative_subset_branch_result(&[got, &want.domain, &want.shape], |me| {
+            me.is_subset_eq(got, &want.domain)?;
+            me.is_subset_eq(&IntTuple::new(Vec::new()).to_shape_arg_type(), &want.shape)
+        })
+    }
+
+    /// Handle a subset relation involving `Scalar`, or delegate by returning `None`.
+    ///
+    /// Successful speculative branches retain inferred variable constraints. Failed branches and
+    /// probes restore all subset state captured by the transaction helper.
+    pub(crate) fn is_subset_scalar(
+        &mut self,
+        got: &Type,
+        want: &Type,
+    ) -> Option<Result<(), SubsetError>> {
+        if !self.solver.tensor_shapes {
+            return None;
+        }
+        if got.is_any() || want.is_any() {
+            return None;
+        }
+        let got_scalar = expanded_scalar_normal_form(self.solver, got);
+        let want_scalar = expanded_scalar_normal_form(self.solver, want);
+        if got.is_never() && want_scalar.is_some() {
+            return Some(Ok(()));
+        }
+        match (got_scalar, want_scalar) {
+            (None, None) => None,
+            (Some(ScalarNormalForm::Domain(domain)), None) => {
+                Some(self.is_subset_eq(&domain, want))
+            }
+            (Some(ScalarNormalForm::Suspended(got_marker)), None) => {
+                if let Type::Union(union) = want {
+                    for member in union
+                        .members
+                        .iter()
+                        .filter(|member| scalar(member).is_some())
+                    {
+                        if self
+                            .with_speculative_subset_branch_result(
+                                &[got, &got_marker.shape, &got_marker.domain, member],
+                                |me| me.is_subset_eq(got, member),
+                            )
+                            .is_ok()
+                        {
+                            return Some(Ok(()));
+                        }
+                    }
+                }
+                Some(self.is_subset_eq(&got_marker.domain, want))
+            }
+            (None, Some(ScalarNormalForm::Domain(domain))) => Some(self.is_subset_eq(got, &domain)),
+            (None, Some(ScalarNormalForm::Suspended(want))) => {
+                Some(self.is_subset_domain_to_suspended(got, &want))
+            }
+            (
+                Some(ScalarNormalForm::Domain(got_domain)),
+                Some(ScalarNormalForm::Domain(want_domain)),
+            ) => Some(self.is_subset_eq(&got_domain, &want_domain)),
+            (
+                Some(ScalarNormalForm::Domain(got_domain)),
+                Some(ScalarNormalForm::Suspended(want_marker)),
+            ) => Some(self.is_subset_domain_to_suspended(&got_domain, &want_marker)),
+            (
+                Some(ScalarNormalForm::Suspended(got_marker)),
+                Some(ScalarNormalForm::Domain(want_domain)),
+            ) => Some(self.is_subset_eq(&got_marker.domain, &want_domain)),
+            (
+                Some(ScalarNormalForm::Suspended(got_marker)),
+                Some(ScalarNormalForm::Suspended(want_marker)),
+            ) => {
+                if contains_var(&got_marker.shape) || contains_var(&want_marker.shape) {
+                    return Some(self.with_speculative_subset_branch_result(
+                        &[
+                            &got_marker.domain,
+                            &got_marker.shape,
+                            &want_marker.domain,
+                            &want_marker.shape,
+                        ],
+                        |me| {
+                            me.is_subset_eq(&got_marker.domain, &want_marker.domain)?;
+                            me.is_subset_eq(&got_marker.shape, &want_marker.shape)?;
+                            me.is_subset_eq(&want_marker.shape, &got_marker.shape)
+                        },
+                    ));
+                }
+                Some(
+                    self.probe_speculative_subset_branch_result(
+                        &[&got_marker.shape, &want_marker.shape],
+                        |me| {
+                            me.is_subset_eq(&got_marker.shape, &want_marker.shape)?;
+                            me.is_subset_eq(&want_marker.shape, &got_marker.shape)
+                        },
+                    )
+                    .and_then(|()| self.is_subset_eq(&got_marker.domain, &want_marker.domain)),
+                )
+            }
+        }
+    }
+}

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -555,11 +555,11 @@ enum NewBound {
     AddBound(Type),
 }
 
-/// Result of `with_snapshot`, which performs an `is_subset_eq` call with var snapshotting.
+/// Outcome of a speculative subset transaction.
 pub enum SubsetWithSnapshotResult {
-    /// `is_subset_eq` call was successful.
+    /// The subset check succeeded without introducing inconsistent variable solutions.
     Ok,
-    /// `is_subset_eq` call failed.
+    /// The subset check failed or introduced an inconsistent variable solution.
     Err(SubsetError),
 }
 

--- a/pyrefly/lib/solver/solver.rs
+++ b/pyrefly/lib/solver/solver.rs
@@ -170,7 +170,7 @@ pub struct OverloadBranchCapture {
 type OverloadWitnessCapturesByArgument = SmallMap<ArgumentKey, Vec<OverloadBranchCapture>>;
 
 /// Witness captures collected during subset checking and consumed at solve boundaries.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 struct WitnessCaptures {
     overload: OverloadWitnessCapturesByArgument,
     generic: Vec<GenericWitnessCapture>,
@@ -938,6 +938,16 @@ impl Solver {
                 }
             }
         }
+    }
+
+    /// Whether `var` is an unsolved type variable bounded by `IntTuple`.
+    pub(crate) fn has_int_tuple_bound_var(&self, var: Var) -> bool {
+        let variables = self.variables.lock();
+        matches!(
+            &*variables.get(var),
+            Variable::Quantified { quantified, .. } | Variable::PartialQuantified(quantified)
+                if has_int_tuple_bound(quantified)
+        )
     }
 
     /// Snapshots the given vars, calls `f`, and rolls back the vars if the call fails.
@@ -3022,14 +3032,11 @@ impl ArgumentSide {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
-pub(crate) enum SubsetCacheContext {
-    #[default]
-    Default,
-    Witness {
-        argument: ArgumentKey,
-        argument_side: ArgumentSide,
-    },
+/// Context that can change either subset results or the side effects required on success.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub(crate) struct SubsetCacheContext {
+    witness: Option<(ArgumentKey, ArgumentSide)>,
+    union_shape_widening_vars: Option<Arc<Vec<Var>>>,
 }
 
 // The context in which we are collecting residuals.
@@ -3113,6 +3120,11 @@ struct CallBoundaryState {
     witness_captures: WitnessCaptures,
 }
 
+struct CallBoundarySnapshot {
+    quantified_handle_count: usize,
+    witness_captures: WitnessCaptures,
+}
+
 /// The unique owner of quantified vars and residual captures deferred to a call boundary.
 #[derive(Debug)]
 #[must_use = "Call boundaries must be passed to finish_call_boundary."]
@@ -3135,6 +3147,7 @@ impl CallBoundary {
             boundary: Some(self),
             shape_extension_vars: None,
             shape_extension_binding_source: None,
+            union_shape_widening_vars: None,
         }
     }
 
@@ -3148,6 +3161,29 @@ impl CallBoundary {
         if !handle.0.is_empty() {
             self.state().lock().quantified_handles.push(handle);
         }
+    }
+
+    fn snapshot_for_speculative_subset(&self) -> CallBoundarySnapshot {
+        let state = self.state().lock();
+        CallBoundarySnapshot {
+            quantified_handle_count: state.quantified_handles.len(),
+            witness_captures: state.witness_captures.clone(),
+        }
+    }
+
+    /// Restore captures and detach handles created after the snapshot.
+    ///
+    /// Callers must finish the returned handles before restoring solver variables they may own.
+    fn restore_after_speculative_subset(
+        &self,
+        snapshot: CallBoundarySnapshot,
+    ) -> Vec<QuantifiedHandle> {
+        let mut state = self.state().lock();
+        let handles = state
+            .quantified_handles
+            .split_off(snapshot.quantified_handle_count);
+        state.witness_captures = snapshot.witness_captures;
+        handles
     }
 
     fn persist_overload_witness_captures(
@@ -3224,6 +3260,7 @@ pub struct CallContext<'subset> {
     boundary: Option<&'subset CallBoundary>,
     shape_extension_vars: Option<Arc<SmallSet<Var>>>,
     shape_extension_binding_source: Option<Var>,
+    union_shape_widening_vars: Option<Arc<Vec<Var>>>,
 }
 
 impl<'subset> CallContext<'subset> {
@@ -3275,6 +3312,24 @@ impl<'subset> CallContext<'subset> {
         )
     }
 
+    /// Authorize call-local union joining for shape-only variables from this signature.
+    pub(crate) fn with_union_shape_widening_vars(mut self, vars: Option<Arc<Vec<Var>>>) -> Self {
+        self.union_shape_widening_vars = vars;
+        self
+    }
+
+    /// Whether this call authorizes union joining for any shape-only variable.
+    pub(crate) fn has_union_shape_widening_vars(&self) -> bool {
+        self.union_shape_widening_vars.is_some()
+    }
+
+    /// Whether this call permits gradual union joining for `var`.
+    pub(crate) fn allows_union_shape_widening(&self, var: Var) -> bool {
+        self.union_shape_widening_vars
+            .as_ref()
+            .is_some_and(|vars| vars.contains(&var))
+    }
+
     pub(crate) fn for_shape_extension_binding_source(&self, ty: &Type) -> Option<Self> {
         let Type::Var(var) = ty else {
             return None;
@@ -3300,6 +3355,7 @@ impl<'subset> CallContext<'subset> {
         self.argument_side = Default::default();
         self.shape_extension_vars = Default::default();
         self.shape_extension_binding_source = None;
+        self.union_shape_widening_vars = None;
         self
     }
 
@@ -3335,16 +3391,12 @@ impl<'subset> CallContext<'subset> {
     }
 
     pub(crate) fn subset_cache_context(&self) -> SubsetCacheContext {
-        if let Some(witness) = &self.witness {
-            // Context-scoped cache keying preserves memoization while keeping
-            // witness/polarity-sensitive side effects isolated. Most checks run
-            // under Default context and keep prior cache behavior.
-            SubsetCacheContext::Witness {
-                argument: witness.argument,
-                argument_side: self.argument_side,
-            }
-        } else {
-            SubsetCacheContext::Default
+        SubsetCacheContext {
+            witness: self
+                .witness
+                .as_ref()
+                .map(|witness| (witness.argument, self.argument_side)),
+            union_shape_widening_vars: self.union_shape_widening_vars.clone(),
         }
     }
 
@@ -3442,6 +3494,102 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
         deferred_vars: SmallMap<ArgumentKey, SmallSet<Var>>,
     ) {
         self.witness_deferred_vars = deferred_vars;
+    }
+
+    /// Run a speculative subset branch and retain its value and state only on consistent success.
+    ///
+    /// `types` identifies the variables whose solutions are snapshotted. Rollback also restores
+    /// subset caches, protocol assumptions, deferred witnesses, call-boundary captures,
+    /// recursion gas, and coinductive-use flags.
+    pub(crate) fn with_speculative_subset_branch_result<T>(
+        &mut self,
+        types: &[&Type],
+        check: impl FnOnce(&mut Self) -> Result<T, SubsetError>,
+    ) -> Result<T, SubsetError> {
+        self.speculative_subset_branch(types, check, OverloadPruningSubsetMode::Commit)
+    }
+
+    /// Run a speculative subset branch, return its value, and discard its inference side effects.
+    ///
+    /// `types` identifies the variables whose solutions are snapshotted. The probe also restores
+    /// subset caches, protocol assumptions, deferred witnesses, call-boundary captures,
+    /// recursion gas, and coinductive-use flags.
+    pub(crate) fn probe_speculative_subset_branch_result<T>(
+        &mut self,
+        types: &[&Type],
+        check: impl FnOnce(&mut Self) -> Result<T, SubsetError>,
+    ) -> Result<T, SubsetError> {
+        self.speculative_subset_branch(types, check, OverloadPruningSubsetMode::Probe)
+    }
+
+    fn speculative_subset_branch<T>(
+        &mut self,
+        types: &[&Type],
+        check: impl FnOnce(&mut Self) -> Result<T, SubsetError>,
+        mode: OverloadPruningSubsetMode,
+    ) -> Result<T, SubsetError> {
+        let vars = self.solver.snapshot_for_speculative_inference(types);
+        let gas = self.gas.clone();
+        let subset_cache = self.subset_cache.clone();
+        // Isolate the branch from pre-existing cache entries: a stale `Ok` (in particular one
+        // recorded under a coinductive assumption) must not rescue a check the branch
+        // re-derives, and branch entries must not survive a rollback. This mirrors
+        // `check_subset_constraints_for_pruning`.
+        self.subset_cache.clear();
+        let class_protocol_assumptions = self.class_protocol_assumptions.clone();
+        let witness_deferred_vars = self.snapshot_witness_deferred_vars();
+        let coinductive_assumptions_used = self.coinductive_assumptions_used;
+        let type_order_coinductive = self.type_order.coinductive_assumptions_used();
+        let call_boundary = self.active_call_context.boundary;
+        let call_boundary_snapshot =
+            call_boundary.map(CallBoundary::snapshot_for_speculative_subset);
+        let result = check(self).and_then(|value| {
+            if self.solver.has_new_instantiation_errors(&vars) {
+                Err(SubsetError::Other)
+            } else {
+                Ok(value)
+            }
+        });
+        if mode == OverloadPruningSubsetMode::Probe || result.is_err() {
+            let abandoned_handles = call_boundary
+                .zip(call_boundary_snapshot)
+                .map_or_else(Vec::new, |(boundary, snapshot)| {
+                    boundary.restore_after_speculative_subset(snapshot)
+                });
+            // Finish abandoned handles before restoring variables. Handles deferred during the
+            // branch own either snapshot-covered variables (pre-existing variables reachable
+            // from the branch inputs, such as a call's shape variable solved and deferred by
+            // the branch) or branch-created variables the snapshot predates. Restoring after
+            // finishing resets the covered variables to pre-branch state exactly, erasing
+            // whatever finishing did, while branch-created variables are unreachable once the
+            // boundary, captures, and caches are restored. Finishing after the restore would
+            // instead solve the restored-but-unsolved covered variables and persist solutions
+            // the rollback was supposed to erase, so this order is load-bearing.
+            for handle in abandoned_handles {
+                let _ = self.solver.finish_quantified(
+                    handle,
+                    self.solver.infer_with_first_use,
+                    self.type_order,
+                );
+            }
+            self.solver.restore_vars(vars);
+            self.gas = gas;
+            self.subset_cache = subset_cache;
+            self.class_protocol_assumptions = class_protocol_assumptions;
+            self.restore_witness_deferred_vars(witness_deferred_vars);
+            self.coinductive_assumptions_used = coinductive_assumptions_used;
+            self.type_order
+                .set_coinductive_assumptions_used(type_order_coinductive);
+        } else {
+            // Restore the pre-branch insertion order before overlaying newly derived entries.
+            // Outer recursive checks roll back by truncating this map, so moving an older entry
+            // behind branch entries would make a later rollback remove the wrong keys.
+            let branch_cache = mem::replace(&mut self.subset_cache, subset_cache);
+            for (key, entry) in branch_cache {
+                self.subset_cache.insert(key, entry);
+            }
+        }
+        result
     }
 
     /// Check one overload branch's constraints as a transaction during quantified finishing.

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -1808,6 +1808,11 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
         got: &Type,
         want: &Type,
     ) -> Result<(), SubsetError> {
+        // The shape-marker hooks below self-guard on `tensor_shapes`; keep the check in
+        // that one layer rather than duplicating it here.
+        if let Some(result) = self.is_subset_array_coercible(got, want) {
+            return result;
+        }
         if let Some(result) = self.is_subset_scalar(got, want) {
             return result;
         }
@@ -3407,9 +3412,9 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
     /// Infer `IntTuple` parameters shared by several right-hand union arms from all left-hand
     /// alternatives before committing any one arm's solution.
     ///
-    /// Shapes have an intentional gradual join that preserves common rank and dimensions. This
-    /// makes a single useful shape available to later shape operations without defining analogous
-    /// union inference for unrestricted type variables.
+    /// Shapes have an intentional gradual join that preserves common rank and dimensions while
+    /// the candidate search is bounded. Wider products use a fully gradual shape and validate the
+    /// complete union, avoiding both quadratic probing and width-dependent rejection.
     fn try_join_union_shape_parameters(
         &mut self,
         members: &[Type],
@@ -3436,8 +3441,8 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
             .collect::<Vec<_>>();
         if vars.is_empty()
             || vars.iter().any(|var| {
-                !self.solver.has_int_tuple_bound_var(*var)
-                    || !self.active_call_context.allows_union_shape_widening(*var)
+                !self.active_call_context.allows_union_shape_widening(*var)
+                    || !self.solver.has_int_tuple_bound_var(*var)
             })
         {
             return None;

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -9,6 +9,7 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::iter;
+use std::slice;
 use std::sync::Arc;
 
 use itertools::EitherOrBoth;
@@ -51,6 +52,7 @@ use crate::alt::answers::LookupAnswer;
 use crate::alt::callable::CallArg;
 use crate::alt::expr::TypeOrExpr;
 use crate::solver::shape::has_int_tuple_bound;
+use crate::solver::shape::join_int_tuples;
 use crate::solver::shape::type_as_intvar_solution;
 use crate::solver::solver::ArgumentSide;
 use crate::solver::solver::OpenTypedDictSubsetError;
@@ -1937,7 +1939,13 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
                 )
             }
             (Type::Intersect(l), u) => any(l.0.iter(), |l| self.is_subset_eq(l, u)),
-            (Type::Union(l_union), u) => all(l_union.members.iter(), |l| self.is_subset_eq(l, u)),
+            (Type::Union(l_union), u) => {
+                if let Some(result) = self.try_join_union_shape_parameters(&l_union.members, u) {
+                    result
+                } else {
+                    all(l_union.members.iter(), |l| self.is_subset_eq(l, u))
+                }
+            }
             // Int <: Int - expand bound Vars, canonicalize, and compare for structural equality
             (Type::Int(s1), Type::Int(s2)) => {
                 // Expand any bound Vars in both expressions
@@ -3391,5 +3399,126 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
         }
 
         Ok(())
+    }
+
+    /// Infer `IntTuple` parameters shared by several right-hand union arms from all left-hand
+    /// alternatives before committing any one arm's solution.
+    ///
+    /// Shapes have an intentional gradual join that preserves common rank and dimensions. This
+    /// makes a single useful shape available to later shape operations without defining analogous
+    /// union inference for unrestricted type variables.
+    fn try_join_union_shape_parameters(
+        &mut self,
+        members: &[Type],
+        want: &Type,
+    ) -> Option<Result<(), SubsetError>> {
+        const MAX_UNION_SHAPE_PROBES: usize = 32;
+
+        if !self.solver.tensor_shapes
+            || members.is_empty()
+            || !self.active_call_context.has_union_shape_widening_vars()
+        {
+            return None;
+        }
+        // A single-spelled shape-generic parameter widens the same way as a union of them:
+        // each got member is probed against it directly.
+        let want_members: &[Type] = match want {
+            Type::Union(want_union) => &want_union.members,
+            _ => slice::from_ref(want),
+        };
+        let vars = want
+            .collect_maybe_placeholder_vars()
+            .into_iter()
+            .unique()
+            .collect::<Vec<_>>();
+        if vars.is_empty()
+            || vars.iter().any(|var| {
+                !self.solver.has_int_tuple_bound_var(*var)
+                    || !self.active_call_context.allows_union_shape_widening(*var)
+            })
+        {
+            return None;
+        }
+        let mut candidates = vars
+            .iter()
+            .map(|var| (*var, Vec::new()))
+            .collect::<SmallMap<Var, Vec<IntTuple>>>();
+        // Each candidate requires a full speculative subset transaction. Above the cost cap,
+        // deliberately drop shape precision and validate once instead of probing quadratically.
+        if members.len().saturating_mul(want_members.len()) > MAX_UNION_SHAPE_PROBES {
+            for shapes in candidates.values_mut() {
+                shapes.push(IntTuple::shapeless());
+            }
+        } else {
+            for member in members {
+                let mut matched = false;
+                for want_member in want_members {
+                    let Ok(answers) = self.probe_speculative_subset_branch_result(
+                        &[member, want_member],
+                        |probe| {
+                            probe.is_subset_eq(member, want_member)?;
+                            Ok(vars
+                                .iter()
+                                .filter_map(|var| {
+                                    let mut answer = Type::Var(*var);
+                                    probe.solver.expand_with_bounds(&mut answer);
+                                    match answer {
+                                        Type::IntTuple(shape) => Some((*var, *shape)),
+                                        _ => None,
+                                    }
+                                })
+                                .collect::<Vec<_>>())
+                        },
+                    ) else {
+                        continue;
+                    };
+                    matched = true;
+                    if answers.len() != vars.len() {
+                        // This arm accepts the member without binding every candidate shape
+                        // variable. It contributes no shape, but later arms still may.
+                        continue;
+                    }
+                    for (var, shape) in answers {
+                        candidates
+                            .get_mut(&var)
+                            .expect("answers use a candidate shape variable")
+                            .push(shape);
+                    }
+                }
+                if !matched {
+                    return None;
+                }
+            }
+        }
+
+        if candidates.values().any(Vec::is_empty) {
+            return None;
+        }
+
+        let mut transaction_types = members.iter().collect::<Vec<_>>();
+        transaction_types.push(want);
+        match self.with_speculative_subset_branch_result(&transaction_types, |me| {
+            for (var, shapes) in candidates {
+                // The guard above proves that each candidate has at least one contributing arm.
+                let joined = shapes
+                    .into_iter()
+                    .reduce(|left, right| join_int_tuples(&left, &right))
+                    .expect("each candidate shape variable has a probed shape");
+                let joined = joined.to_shape_arg_type();
+                me.is_subset_eq(&joined, &Type::Var(var))?;
+                // Pin the join before rechecking members so the first member cannot replace the
+                // shared solution with its narrower candidate.
+                me.solver.force_var(var);
+            }
+            for member in members {
+                me.is_subset_eq(member, want)?;
+            }
+            Ok(())
+        }) {
+            Ok(()) => Some(Ok(())),
+            // The joined solution was not valid for the complete union. The transaction has
+            // rolled back, so let ordinary subset checking produce the final result.
+            Err(_) => None,
+        }
     }
 }

--- a/pyrefly/lib/solver/subset.rs
+++ b/pyrefly/lib/solver/subset.rs
@@ -1808,6 +1808,9 @@ impl<'solver, 'subset, Ans: LookupAnswer> Subset<'solver, 'subset, Ans> {
         got: &Type,
         want: &Type,
     ) -> Result<(), SubsetError> {
+        if let Some(result) = self.is_subset_scalar(got, want) {
+            return result;
+        }
         match (got, want) {
             (Type::Any(_), _) => {
                 all(want.collect_maybe_placeholder_vars().iter(), |var| {

--- a/pyrefly/lib/solver/type_order.rs
+++ b/pyrefly/lib/solver/type_order.rs
@@ -66,6 +66,11 @@ impl<'solver, Ans: LookupAnswer> TypeOrder<'solver, Ans> {
         self.0.stdlib
     }
 
+    /// Expand inference variables without exposing the solver through the type-order API.
+    pub(crate) fn expand_with_bounds(self, ty: &mut Type) {
+        self.0.solver().expand_with_bounds(ty);
+    }
+
     pub fn has_superclass(self, got: &Class, want: &Class) -> bool {
         self.0.has_superclass(got, want)
     }

--- a/pyrefly/lib/test/array_coercible.rs
+++ b/pyrefly/lib/test/array_coercible.rs
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::test::util::shape_extensions_env;
+use crate::testcase;
+
+testcase!(
+    array_coercible_literals,
+    shape_extensions_env(),
+    r#"
+from collections.abc import Sequence
+from typing import Any, Callable, assert_type
+from shape_extensions import ArrayCoercible, Elements, IntTuple, Scalar
+
+class Array[Shape: IntTuple]: ...
+
+class IntList(list[int]): ...
+class IntTupleSubclass(tuple[int, ...]): ...
+class TextSubclass(str): ...
+class BytesSubclass(bytes): ...
+
+def consume[Shape: IntTuple](x: ArrayCoercible[Shape, int]) -> Array[Shape]: ...
+def consume_objects[Shape: IntTuple](
+    x: ArrayCoercible[Shape, object],
+) -> Array[Shape]: ...
+def consume_any[Shape: IntTuple](
+    x: ArrayCoercible[Shape, Any],
+) -> Array[Shape]: ...
+def factory[Shape: IntTuple](
+    x: ArrayCoercible[Shape, int] | list[object],
+) -> Array[Shape]: ...
+def precise_only[Shape: IntTuple](
+    x: ArrayCoercible[Shape, int] | ArrayCoercible[Shape, str],
+) -> Array[Shape]: ...
+def array_or_data[Shape: IntTuple](
+    x: Array[Shape] | ArrayCoercible[Shape, int],
+) -> Array[Shape]: ...
+def array_scalar_or_data[Shape: IntTuple](
+    x: Array[Shape] | Scalar[Shape, int] | ArrayCoercible[Shape, int],
+) -> Array[Shape]: ...
+type Data[Shape: IntTuple] = ArrayCoercible[Shape, int]
+type DataOrObjects[Shape: IntTuple] = ArrayCoercible[Shape, int] | list[object]
+def aliased[Shape: IntTuple](x: Data[Shape]) -> Array[Shape]: ...
+def aliased_factory[Shape: IntTuple](x: DataOrObjects[Shape]) -> Array[Shape]: ...
+def require_one(x: ArrayCoercible[[1], int]) -> Array[[1]]: ...
+def consume_callbacks[Shape: IntTuple](
+    x: ArrayCoercible[Shape, Callable[[int], int]],
+) -> Array[Shape]: ...
+def consume_str_callbacks[Shape: IntTuple](
+    x: ArrayCoercible[Shape, Callable[[str], str]],
+) -> Array[Shape]: ...
+def pick_int_or_str[Shape: IntTuple](
+    x: ArrayCoercible[Shape, int] | ArrayCoercible[Shape, str],
+) -> Array[Shape]: ...
+def pick_int_or_str_callback[Shape: IntTuple](
+    x: ArrayCoercible[Shape, Callable[[int], int]]
+    | ArrayCoercible[Shape, Callable[[str], str]],
+) -> Array[Shape]: ...
+def pick_str_or_int_callback[Shape: IntTuple](
+    x: ArrayCoercible[Shape, Callable[[str], str]]
+    | ArrayCoercible[Shape, Callable[[int], int]],
+) -> Array[Shape]: ...
+def pick_callback_or_str[Shape: IntTuple](
+    x: ArrayCoercible[Shape, Callable[[int], int]] | ArrayCoercible[Shape, str],
+) -> Array[Shape]: ...
+def marker_or_ordinary_callbacks[Shape: IntTuple](
+    x: ArrayCoercible[Shape, Callable[[int], int]]
+    | list[Callable[[str], str]],
+) -> None: ...
+def concrete_marker_or_list(x: ArrayCoercible[[3], int] | list[int]) -> None: ...
+def ident[T](x: T) -> T: ...
+def generic_domain[Shape: IntTuple, T](
+    x: ArrayCoercible[Shape, T],
+) -> tuple[Array[Shape], T]: ...
+
+def scalar_family_is_a_leaf[Phantom: IntTuple](x: Scalar[Phantom, int]) -> None:
+    assert_type(consume(x), Array[[]])
+    assert_type(consume([x]), Array[[1]])
+    require_one(x)  # E: is not assignable
+    assert_type(require_one([x]), Array[[1]])
+
+def concrete_scalar_family_is_a_leaf(x: Scalar[[], int]) -> None:
+    assert_type(consume(x), Array[[]])
+    assert_type(consume([x]), Array[[1]])
+
+assert_type(consume(1), Array[[]])
+assert_type(consume([]), Array[[0]])
+assert_type(consume([1, 2, 3]), Array[[3]])
+assert_type(consume([[1, 2], [3, 4]]), Array[[2, 2]])
+assert_type(consume([[]]), Array[[1, 0]])
+assert_type(aliased([[1], [2]]), Array[[2, 1]])
+assert_type(aliased_factory([1, 2]), Array[[2]])
+assert_type(array_scalar_or_data([1, 2]), Array[[2]])
+assert_type(consume_callbacks([lambda value: value + 1]), Array[[1]])
+consume_callbacks([lambda value: value + "bad"])  # E: is not assignable
+assert_type(pick_int_or_str(["a", "b"]), Array[[2]])
+assert_type(pick_int_or_str([1, 2]), Array[[2]])
+assert_type(
+    pick_int_or_str_callback([lambda value: value + "bad"]), Array[[1]]
+)
+assert_type(
+    pick_str_or_int_callback([lambda value: value + "bad"]), Array[[1]]
+)
+assert_type(
+    # No clean alternative exists, so ordinary list inference rejects the argument.
+    pick_callback_or_str([lambda value: value + "bad"]),  # E: is not assignable
+    Array[IntTuple],
+)
+# An errorful marker projection must not hide a valid ordinary union alternative.
+marker_or_ordinary_callbacks([lambda value: value + "good"])
+# A concrete marker with the wrong shape does not hide a compatible ordinary arm.
+concrete_marker_or_list([1, 2])
+# Lambda parameters follow the domain hint: the same body that errors under
+# `Callable[[int], int]` above is clean under `Callable[[str], str]`.
+assert_type(consume_str_callbacks([lambda value: value + "good"]), Array[[1]])
+assert_type(consume_str_callbacks([lambda value: value + "bad"]), Array[[1]])
+generic_result = generic_domain([1, missing_generic])  # E: Could not find name `missing_generic`
+assert_type(generic_result, tuple[Array[[2]], int])
+
+defaulted: ArrayCoercible = 1
+assert_type(defaulted, ArrayCoercible[[], bool | int | float | complex])
+typed_scalar: int = 1
+typed_scalar_view: ArrayCoercible[[], int] = typed_scalar
+
+one: ArrayCoercible[[2], int] = [1, 2]
+empty: ArrayCoercible[[0], int] = []
+nested: list[ArrayCoercible[[2], int]] = [[1, 2], [3, 4]]
+strings: ArrayCoercible[[2], str] = ["a", "b"]
+wide: ArrayCoercible[IntTuple, object] = one
+
+def accepts_exact_strings(text: str, blob: bytes) -> None:
+    text_scalar: ArrayCoercible[[], str] = text
+    bytes_scalar: ArrayCoercible[[], bytes] = blob
+    text_list: ArrayCoercible[[2], str] = [text, text]
+    bytes_list: ArrayCoercible[[2], bytes] = [blob, blob]
+
+def pair() -> ArrayCoercible[[2], int]:
+    return [1, 2]
+
+def preserve[Shape: IntTuple](
+    x: ArrayCoercible[Shape, int],
+) -> ArrayCoercible[Shape, object]:
+    return x
+
+raw = [1, 2]
+raw_tuple = (1, 2)
+bad_raw: ArrayCoercible[[2], int] = raw  # E: is not assignable
+bad_tuple: ArrayCoercible[[2], int] = (1, 2)  # E: is not assignable
+bad_star: ArrayCoercible[[2], int] = [*raw]  # E: is not assignable
+bad_leaf: ArrayCoercible[[1], int] = ["x"]  # E: is not assignable
+bad_shape: ArrayCoercible[[3], int] = [1, 2]  # E: is not assignable
+bad_scalar_shape: ArrayCoercible[[1], int] = 1  # E: is not assignable
+one.append(3)  # E: Object of class `ArrayCoercible` has no attribute `append`
+
+consume([[1], [2, 3]])  # E: is not assignable to parameter `x`
+consume([1, [2]])  # E: is not assignable to parameter `x`
+assert_type(factory([["x"], ["y", "z"]]), Array[IntTuple])
+precise_only([["x"], ["y", "z"]])  # E: is not assignable to parameter `x`
+consume([[missing], [2, 3]])  # E: Could not find name `missing` # E: is not assignable to parameter `x`
+
+assert_type(factory([1, 2]), Array[[2]])
+assert_type(factory(["x"]), Array[IntTuple])
+
+def use_array(x: Array[[2]]) -> None:
+    assert_type(array_or_data(x), Array[[2]])
+
+def rejects_array_leaf(x: Array[[2]]) -> None:
+    consume([x])  # E: is not assignable
+    consume_objects([x])  # E: is not assignable
+    consume_objects(x)  # E: is not assignable
+
+def rejects_deferred_containers(
+    xs: IntList,
+    ts: IntTupleSubclass,
+    maybe_xs: int | list[int],
+    coercible: ArrayCoercible[[2], int],
+    sequence: Sequence[int],
+) -> None:
+    consume_objects(xs)  # E: is not assignable
+    consume_objects([xs])  # E: is not assignable
+    consume_objects(ts)  # E: is not assignable
+    consume_objects([ts])  # E: is not assignable
+    consume_objects([raw])  # E: is not assignable
+    consume_objects([raw_tuple])  # E: is not assignable
+    consume_objects([maybe_xs])  # E: is not assignable
+    consume_any(xs)  # E: is not assignable
+    consume_any([xs])  # E: is not assignable
+    consume_any(ts)  # E: is not assignable
+    consume_any([ts])  # E: is not assignable
+    consume_objects([coercible])  # E: is not assignable
+    consume_objects(sequence)  # E: is not assignable
+    consume_objects([sequence])  # E: is not assignable
+
+def rejects_bounded_container[T: list[int]](value: T) -> None:
+    consume_objects(value)  # E: is not assignable
+    consume_objects([value])  # E: is not assignable
+
+def string_subclasses_are_leaves(text: TextSubclass, blob: BytesSubclass) -> None:
+    assert_type(consume_objects(text), Array[[]])
+    assert_type(consume_objects([text]), Array[[1]])
+    assert_type(consume_objects(blob), Array[[]])
+    assert_type(consume_objects([blob]), Array[[1]])
+
+def rejects_unrestricted_type_var[T](value: T) -> None:
+    consume_objects(value)
+    consume_objects([value])  # E: is not assignable
+
+def unresolved_generic_is_not_a_scalar_leaf[T](value: T) -> None:
+    # A generic return value delegates to ordinary typing instead of pinning a
+    # scalar shape, so a literal containing one is rejected exactly like the
+    # unrestricted type variable above. Solved variables expand first and
+    # unresolved solver variables take the same deferred path.
+    consume_objects([ident(value)])  # E: is not assignable
+
+def any_leaf(x: Any, y: Any) -> None:
+    assert_type(consume([1, x]), Array[[2]])
+    assert_type(consume([[], x]), Array[[2, 0]])
+    assert_type(consume([x]), Array[[1, *Elements[IntTuple]]])
+    assert_type(consume([x, y]), Array[[2, *Elements[IntTuple]]])
+    assert_type(consume([[x]]), Array[[1, 1, *Elements[IntTuple]]])
+    assert_type(consume([[x], [y]]), Array[[2, 1, *Elements[IntTuple]]])
+    assert_type(consume([[x], [1]]), Array[[2, 1]])
+    consume([[x], [[y]]])  # E: is not assignable
+    consume([[x], [[y]], [1]])  # E: is not assignable
+    consume([[1], [x], [[y]]])  # E: is not assignable
+
+def any_argument(x: Any) -> None:
+    assert_type(consume(x), Array[Any])
+
+def soft_hint(x: ArrayCoercible[[1], int]) -> None:
+    x or [[1], [2, 3]]
+"#,
+);

--- a/pyrefly/lib/test/mod.rs
+++ b/pyrefly/lib/test/mod.rs
@@ -9,6 +9,7 @@
 
 mod abstract_methods;
 mod annotation;
+mod array_coercible;
 mod assign;
 mod attribute_narrow;
 mod attributes;

--- a/pyrefly/lib/test/mod.rs
+++ b/pyrefly/lib/test/mod.rs
@@ -72,6 +72,7 @@ mod query;
 mod recursive_alias;
 mod redundant_cast;
 mod returns;
+mod scalar;
 mod scope;
 mod self_cls_default;
 mod semantic_syntax_errors;

--- a/pyrefly/lib/test/scalar.rs
+++ b/pyrefly/lib/test/scalar.rs
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::test::util::shape_extensions_env;
+use crate::testcase;
+
+testcase!(
+    scalar_normalization_and_inference,
+    shape_extensions_env(),
+    r#"
+from typing import Any, Never, assert_type
+from shape_extensions import Elements, IntTuple, Scalar
+
+class Array[Shape: IntTuple]: ...
+
+type ArrayLike[Shape: IntTuple] = Array[Shape] | Scalar[Shape]
+
+def array_like[Shape: IntTuple](x: ArrayLike[Shape]) -> Array[Shape]: ...
+def suspended[Shape: IntTuple](x: Scalar[Shape, int]) -> Scalar[Shape, int]:
+    y: int = x
+    # Reading the scalar through its upper bound does not constrain Shape.
+    assert_type(x, Scalar[Shape, int])
+    assert_type(x.bit_length(), int)
+    return x
+
+def preserve_family_in_union[Shape: IntTuple](
+    x: Scalar[Shape, int],
+) -> Array[Shape] | Scalar[Shape, int]:
+    return x
+
+def cannot_manufacture[Shape: IntTuple](x: int) -> Scalar[Shape, int]:
+    return x  # E: is not assignable to declared return type
+
+def consume[Shape: IntTuple](x: Scalar[Shape, int]) -> Array[Shape]: ...
+def consume_unpacked[Shape: IntTuple](
+    x: Scalar[IntTuple[*Elements[Shape]], int],
+) -> Array[Shape]: ...
+def scalar_identity[Shape: IntTuple](x: Scalar[Shape, int]) -> Scalar[Shape, int]: ...
+def identity_helper[T](x: T) -> T: ...
+
+def normalize_through_solver_var(x: Scalar[[2], int]) -> None:
+    assert_type(identity_helper(x), Never)
+
+def any_through_solver_var(x: Any) -> None:
+    consume_never(identity_helper(x))
+
+def propagate[Actual: IntTuple](x: Scalar[Actual, int]) -> Array[Actual]:
+    return consume(x)
+
+def relay[Actual: IntTuple](x: Scalar[Actual, int]) -> Scalar[Actual, int]:
+    return scalar_identity(x)
+
+def relay_through_inference[Actual: IntTuple](
+    x: Scalar[Actual, int],
+) -> Scalar[Actual, int]:
+    return scalar_identity(identity_helper(x))
+
+assert_type(array_like(1), Array[[]])
+assert_type(consume_unpacked(1), Array[[]])
+
+def use_array(array: Array[[2, 3]]) -> None:
+    assert_type(array_like(array), Array[[2, 3]])
+
+def use_scalar_union(value: int | float) -> None:
+    assert_type(array_like(value), Array[[]])
+
+def use_mixed_union(value: int | Array[[2, 3]]) -> None:
+    assert_type(array_like(value), Array[IntTuple])
+
+def same_shape[Shape: IntTuple](
+    left: ArrayLike[Shape], right: ArrayLike[Shape]
+) -> Array[Shape]: ...
+
+assert_type(same_shape(1, 2), Array[[]])
+
+def shared_shape_rejects_widening(
+    value: int | Array[[2]], array: Array[[2]]
+) -> None:
+    same_shape(
+        value,  # E: is not assignable to parameter `left`
+        array,
+    )
+
+default_scalar: Scalar = 1
+empty_scalar: Scalar[[], int] = 1
+gradual_scalar: Scalar[IntTuple, int] = 1
+any_shape_scalar: Scalar[Any, int] = 1
+positive_scalar: Scalar[[2], int] = 1  # E: is not assignable to `Never`
+positive_gradual_scalar: Scalar[[Any], int] = 1  # E: is not assignable to `Never`
+bad_shape: Scalar[int, int]  # E: is not assignable to upper bound `IntTuple`
+too_many: Scalar[[], int, str]  # E: Expected 2 type arguments for `Scalar`, got 3
+
+assert_type(default_scalar, bool | int | float | complex)
+assert_type(empty_scalar, int)
+assert_type(gradual_scalar, int)
+assert_type(any_shape_scalar, int)
+assert_type(consume(empty_scalar), Array[[]])
+
+def consume_never(x: Scalar[[2], int]) -> Never:
+    return x
+
+def consume_tuple_empty(x: Scalar[tuple[()], int]) -> int:
+    return x
+
+def consume_tuple_never(x: Scalar[tuple[int], int]) -> Never:
+    return x
+"#,
+);
+
+testcase!(
+    scalar_is_first_class,
+    shape_extensions_env(),
+    r#"
+from typing import Callable, Literal, Never, assert_type, overload
+from shape_extensions import Elements, IntTuple, Scalar
+
+def identity[Shape: IntTuple](x: Scalar[Shape, int]) -> Scalar[Shape, int]:
+    return x
+
+def tuple_identity[Shape: IntTuple](
+    x: Scalar[IntTuple[*Elements[Shape]], int],
+) -> Scalar[IntTuple[*Elements[Shape]], int]: ...
+
+def relay_tuple[Actual: IntTuple](
+    x: Scalar[IntTuple[*Elements[Actual]], int],
+) -> Scalar[IntTuple[*Elements[Actual]], int]:
+    return tuple_identity(x)
+
+@overload
+def prefer_exact(x: int) -> Literal["exact"]: ...
+@overload
+def prefer_exact[Shape: IntTuple](x: Scalar[Shape, int]) -> Literal["scalar"]: ...
+def prefer_exact(x: object) -> str: ...
+
+@overload
+def prefer_exact_reversed[Shape: IntTuple](x: Scalar[Shape, int]) -> Literal["scalar"]: ...
+@overload
+def prefer_exact_reversed(x: int) -> Literal["exact"]: ...
+def prefer_exact_reversed(x: object) -> str: ...
+
+def operators[Shape: IntTuple](x: Scalar[Shape, int]) -> int:
+    assert_type(x + 1, int)
+    assert_type(1 + x, int)
+    assert_type(-x, int)
+    return x.bit_length()
+
+def scalar_result[Shape: IntTuple](x: Scalar[Shape, int]) -> Scalar[Shape, int]: ...
+
+class Box[Shape: IntTuple]:
+    value: Scalar[Shape, int]
+
+def use_boxes(empty: Box[[]], positive: Box[[2]]) -> None:
+    assert_type(empty.value, int)
+    assert_type(empty.value.bit_length(), int)
+    assert_type(positive.value, Never)
+
+def return_scalar() -> Scalar[[], int]:
+    return 1
+
+values: list[Scalar[[], int]] = [1, 2]
+type ScalarAlias[Shape: IntTuple] = Scalar[Shape, int]
+type ScalarOrStr[Shape: IntTuple] = ScalarAlias[Shape] | str
+type ImpossibleScalar = ScalarAlias[[1]]
+type OrdinaryUnion = int | str
+aliased: ScalarAlias[[]] = 1
+impossible_alias: ScalarAlias[[1]] = 1  # E: is not assignable to `Never`
+possible_union: ScalarOrStr[[1]] = "ok"
+impossible_union: ScalarOrStr[[1]] = 1  # E: is not assignable to `str`
+callback: Callable[[int], int] = identity
+
+def ordinary_result[T](x: T) -> OrdinaryUnion: ...
+
+def impossible_alias_is_never(x: ImpossibleScalar) -> Scalar[[2], int]:
+    return x
+
+def impossible_union_is_never(
+    x: Scalar[[1], int] | Scalar[[2], int],
+) -> Scalar[[3], int]:
+    return x
+
+def bottom_domain_is_never(x: Scalar[[], Never]) -> Scalar[[1], int]:
+    return x
+
+def suspended_bottom_domain_is_never[Shape: IntTuple](
+    x: Scalar[Shape, Never],
+) -> Scalar[[1], int]:
+    return x
+
+assert_type(return_scalar(), int)
+assert_type(prefer_exact(1), Literal["exact"])
+assert_type(prefer_exact_reversed(1), Literal["scalar"])
+assert_type(scalar_result(1), int)
+assert_type(scalar_result(1).bit_length(), int)
+assert_type(values, list[int])
+assert_type(aliased, int)
+assert_type(possible_union, str)
+assert_type(ordinary_result(1), OrdinaryUnion)
+"#,
+);

--- a/pyrefly/lib/test/scalar.rs
+++ b/pyrefly/lib/test/scalar.rs
@@ -12,14 +12,18 @@ testcase!(
     scalar_normalization_and_inference,
     shape_extensions_env(),
     r#"
-from typing import Any, Never, assert_type
-from shape_extensions import Elements, IntTuple, Scalar
+from typing import Any, Callable, Never, assert_type
+from shape_extensions import Elements, IntTuple, Scalar, broadcast
 
 class Array[Shape: IntTuple]: ...
+class TypedArray[Shape: IntTuple, T]: ...
 
 type ArrayLike[Shape: IntTuple] = Array[Shape] | Scalar[Shape]
 
 def array_like[Shape: IntTuple](x: ArrayLike[Shape]) -> Array[Shape]: ...
+def add[Left: IntTuple, Right: IntTuple](
+    left: ArrayLike[Left], right: ArrayLike[Right]
+) -> Array[broadcast(Left, Right)]: ...
 def suspended[Shape: IntTuple](x: Scalar[Shape, int]) -> Scalar[Shape, int]:
     y: int = x
     # Reading the scalar through its upper bound does not constrain Shape.
@@ -71,9 +75,42 @@ def use_scalar_union(value: int | float) -> None:
 def use_mixed_union(value: int | Array[[2, 3]]) -> None:
     assert_type(array_like(value), Array[IntTuple])
 
+def use_same_rank_union(value: Array[[2, 3]] | Array[[4, 3]]) -> None:
+    assert_type(array_like(value), Array[[Any, 3]])
+
+def use_scalar_and_rank_zero(value: int | Array[[]]) -> None:
+    assert_type(array_like(value), Array[[]])
+
+def use_bounded_union[T: int | Array[[2, 3]]](value: T) -> None:
+    assert_type(array_like(value), Array[IntTuple])
+
+def callback_or_scalar[Shape: IntTuple](
+    value: Callable[[int], int] | Scalar[Shape, int],
+) -> Array[Shape]: ...
+
+callback_or_scalar(lambda value: value + "bad")  # E: `+` is not supported
+
+def use_independent_widening(
+    left: Array[[2, 3]] | Array[[4, 3]], right: int | Array[[]]
+) -> None:
+    assert_type(add(left, right), Array[[Any, 3]])
+
 def same_shape[Shape: IntTuple](
     left: ArrayLike[Shape], right: ArrayLike[Shape]
 ) -> Array[Shape]: ...
+def variadic_shape[Shape: IntTuple](*values: ArrayLike[Shape]) -> Array[Shape]: ...
+def keyword_variadic_shape[Shape: IntTuple](
+    **values: ArrayLike[Shape],
+) -> Array[Shape]: ...
+def generic_project[Shape: IntTuple, T](
+    x: TypedArray[Shape, T] | Scalar[Shape, int],
+) -> Array[Shape]: ...
+def nested_return_project[Shape: IntTuple](
+    x: ArrayLike[Shape],
+) -> list[Array[Shape]]: ...
+def non_shape_dsl_return[Shape: IntTuple](
+    x: ArrayLike[Shape],
+) -> TypedArray[[], broadcast(Shape, IntTuple[()])]: ...
 
 assert_type(same_shape(1, 2), Array[[]])
 
@@ -84,6 +121,21 @@ def shared_shape_rejects_widening(
         value,  # E: is not assignable to parameter `left`
         array,
     )
+    variadic_shape(
+        value,  # E: is not assignable to parameter `*values`
+        array,
+    )
+    keyword_variadic_shape(
+        value=value,  # E: is not assignable to parameter `**values`
+        array=array,
+    )
+
+def generic_projection(value: int | TypedArray[[2], int]) -> None:
+    generic_project(value)  # E: is not assignable to parameter `x`
+
+def nested_return_rejects_widening(value: int | Array[[2]]) -> None:
+    nested_return_project(value)  # E: is not assignable to parameter `x`
+    non_shape_dsl_return(value)  # E: is not assignable to parameter `x`
 
 default_scalar: Scalar = 1
 empty_scalar: Scalar[[], int] = 1
@@ -199,5 +251,56 @@ assert_type(values, list[int])
 assert_type(aliased, int)
 assert_type(possible_union, str)
 assert_type(ordinary_result(1), OrdinaryUnion)
+"#,
+);
+
+testcase!(
+    scalar_redundant_union_binder,
+    shape_extensions_env(),
+    r#"
+from shape_extensions import Elements, IntTuple, Scalar
+
+class Array[Shape: IntTuple]: ...
+
+def redundant_int[Shape: IntTuple](
+    x: int | Scalar[Shape, int],  # E: Redundant `Scalar` union arm cannot bind observable type parameter `Shape`
+) -> Array[Shape]: ...
+
+def redundant_numeric[Shape: IntTuple](
+    x: float | Scalar[Shape, int],  # E: Redundant `Scalar` union arm cannot bind observable type parameter `Shape`
+) -> Array[Shape]: ...
+
+def unobservable[Shape: IntTuple](x: int | Scalar[Shape, int]) -> None: ...
+
+def bound_elsewhere[Shape: IntTuple](
+    x: int | Scalar[Shape, int], array: Array[Shape]
+) -> Array[Shape]: ...
+
+def redundant_twice[Shape: IntTuple](
+    x: int | Scalar[Shape, int],  # E: Redundant `Scalar` union arm cannot bind observable type parameter `Shape`
+    y: int | Scalar[Shape, int],
+) -> Array[Shape]: ...
+
+def wrapped_shape[Shape: IntTuple](
+    x: int | Scalar[IntTuple[*Elements[Shape]], int],  # E: Redundant `Scalar` union arm cannot bind observable type parameter `Shape`
+) -> Array[Shape]: ...
+
+def defaulted[Shape: IntTuple = IntTuple[()]](
+    x: int | Scalar[Shape, int],  # E: Redundant `Scalar` union arm cannot bind observable type parameter `Shape`
+) -> Array[Shape]: ...
+
+def nonempty_default[Shape: IntTuple = IntTuple[1]](
+    x: int | Scalar[Shape, int],  # E: Redundant `Scalar` union arm cannot bind observable type parameter `Shape`
+) -> Array[Shape]: ...
+
+def dependent_default[
+    Shape: IntTuple = IntTuple[1], Result = Array[Shape]
+](
+    x: int | Scalar[Shape, int],  # E: Redundant `Scalar` union arm cannot bind observable type parameter `Shape`
+) -> Result: ...
+
+def not_redundant[Shape: IntTuple](
+    x: str | Scalar[Shape, int],
+) -> Array[Shape]: ...
 "#,
 );

--- a/pyrefly/lib/test/scalar.rs
+++ b/pyrefly/lib/test/scalar.rs
@@ -43,6 +43,14 @@ def consume[Shape: IntTuple](x: Scalar[Shape, int]) -> Array[Shape]: ...
 def consume_unpacked[Shape: IntTuple](
     x: Scalar[IntTuple[*Elements[Shape]], int],
 ) -> Array[Shape]: ...
+def unpacked_prefix_is_never[Shape: IntTuple](
+    x: Scalar[IntTuple[2, *Elements[Shape]], int],
+) -> Never:
+    return x
+def unpacked_suffix_is_never[Shape: IntTuple](
+    x: Scalar[IntTuple[*Elements[Shape], 2], int],
+) -> Never:
+    return x
 def scalar_identity[Shape: IntTuple](x: Scalar[Shape, int]) -> Scalar[Shape, int]: ...
 def identity_helper[T](x: T) -> T: ...
 
@@ -298,6 +306,26 @@ def dependent_default[
 ](
     x: int | Scalar[Shape, int],  # E: Redundant `Scalar` union arm cannot bind observable type parameter `Shape`
 ) -> Result: ...
+
+def nested[Shape: IntTuple](
+    x: list[int | Scalar[Shape, int]],  # E: Redundant `Scalar` union arm cannot bind observable type parameter `Shape`
+) -> Array[Shape]: ...
+
+def paramspec[Shape: IntTuple, **P](
+    x: int | Scalar[Shape, int],  # E: Redundant `Scalar` union arm cannot bind observable type parameter `Shape`
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> Array[Shape]: ...
+
+def optional_binder[Shape: IntTuple](
+    x: int | Scalar[Shape, int],  # E: Redundant `Scalar` union arm cannot bind observable type parameter `Shape`
+    array: Array[Shape] | None = None,
+) -> Array[Shape]: ...
+
+def variadic_binder[Shape: IntTuple](
+    x: int | Scalar[Shape, int],  # E: Redundant `Scalar` union arm cannot bind observable type parameter `Shape`
+    *arrays: Array[Shape],
+) -> Array[Shape]: ...
 
 def not_redundant[Shape: IntTuple](
     x: str | Scalar[Shape, int],

--- a/pyrefly/lib/test/shape_dsl.rs
+++ b/pyrefly/lib/test/shape_dsl.rs
@@ -14345,31 +14345,50 @@ def check(
 "#,
 );
 
-// Current inference pins the first compatible target arm and rejects later source arms; union
-// normalization means reversing the source spelling need not change that choice. The desired
-// behavior joins every compatible arm, widening differing ranks to gradual `IntTuple`.
+// Compatible arms contribute shape candidates to one gradual join. Equal dimensions remain
+// precise, differing dimensions widen to `Any`, and differing ranks widen to gradual `IntTuple`.
 testcase!(
-    bug = "union arms should share shape information",
     test_shape_parameter_shared_across_union_arms,
     shape_extensions_env(),
     r#"
-from typing import assert_type
+from typing import Any, assert_type
 from shape_extensions import IntTuple
 
 class Array[Shape: IntTuple]: ...
 class NdArray[Shape: IntTuple]: ...
+class BothA(Array[[2, 3]], NdArray[[2, 4]]): ...
+class BothB(Array[[2, 5]], NdArray[[2, 4]]): ...
 
 type ArrayLike[Shape: IntTuple] = Array[Shape] | NdArray[Shape]
+type ReversedArrayLike[Shape: IntTuple] = NdArray[Shape] | Array[Shape]
+type OptionalArrayLike[Shape: IntTuple] = Array[Shape] | NdArray[Shape] | None
+type TaggedArrayLike[Shape: IntTuple] = Array[Shape] | NdArray[Shape] | str
 
 def as_array[Shape: IntTuple](value: ArrayLike[Shape]) -> Array[Shape]: ...
+def as_reversed_array[Shape: IntTuple](
+    value: ReversedArrayLike[Shape],
+) -> Array[Shape]: ...
+def as_optional_array[Shape: IntTuple](
+    value: OptionalArrayLike[Shape],
+) -> Array[Shape]: ...
+def as_tagged_array[Shape: IntTuple](value: TaggedArrayLike[Shape]) -> Array[Shape]: ...
 
 def check(
     value: Array[[2, 3]] | NdArray[[4, 3]],
     reversed_value: NdArray[[4, 3]] | Array[[2, 3]],
     different_ranks: Array[[2]] | NdArray[[3, 4]],
+    ambiguous: BothA | BothB,
+    optional: Array[[2, 3]] | NdArray[[4, 3]] | None,
+    tagged: Array[[2, 3]] | NdArray[[4, 3]] | str,
 ) -> None:
-    assert_type(as_array(value), Array[[2, 3]])  # E: is not assignable to parameter `value`
-    assert_type(as_array(reversed_value), Array[[2, 3]])  # E: is not assignable to parameter `value`
-    assert_type(as_array(different_ranks), Array[[2]])  # E: is not assignable to parameter `value`
+    assert_type(as_array(value), Array[[Any, 3]])
+    assert_type(as_array(reversed_value), Array[[Any, 3]])
+    assert_type(as_array(different_ranks), Array[IntTuple])
+    # Multiple inheritance lets each source arm match both target arms, so inference falls back
+    # to the fully gradual shape rather than selecting a dimension-wise join.
+    assert_type(as_array(ambiguous), Array[IntTuple])
+    assert_type(as_reversed_array(ambiguous), Array[IntTuple])
+    assert_type(as_optional_array(optional), Array[[Any, 3]])
+    assert_type(as_tagged_array(tagged), Array[[Any, 3]])
 "#,
 );

--- a/pyrefly/lib/test/shape_dsl.rs
+++ b/pyrefly/lib/test/shape_dsl.rs
@@ -1263,7 +1263,7 @@ def direct_int_tuple_form[N: Int, M: IntVar](
     direct_literal: Array[IntTuple[5], int],
     direct_int_var: Array[IntTuple[M], int],
     direct_arithmetic: Array[IntTuple[M + 1], int],
-    direct_explicit_int: Array[IntTuple[Int[5]], int],  # E: Tensor shape dimensions must be positive integer literals, string literals, type variables, or expressions, got `type[Int[5]]`
+    direct_explicit_int: Array[IntTuple[Int[5]], int],  # E: Tensor shape dimensions must be integer literals, string literals, type variables, or expressions, got `type[Int[5]]`
     direct_ordinary: Array[IntTuple[N], int],  # E: `N` must be an `IntVar` to be used as a shape dimension
 ) -> None:
     assert_type(direct_literal, Array[[5], int])
@@ -1277,7 +1277,7 @@ def direct_int_tuple_form[N: Int, M: IntVar](
 def bare_list_form[N: Int, M: IntVar](
     raw: Array[[5, M], int],
     arithmetic: Array[[M + 1], int],
-    bare_explicit_int: Array[[Int[5]], int],  # E: Tensor shape dimensions must be positive integer literals, string literals, type variables, or expressions, got `type[Int[5]]`
+    bare_explicit_int: Array[[Int[5]], int],  # E: Tensor shape dimensions must be integer literals, string literals, type variables, or expressions, got `type[Int[5]]`
     bare_ordinary: Array[[N], int],  # E: `N` must be an `IntVar` to be used as a shape dimension
 ) -> None:
     assert_type(raw, Array[[5, M], int])
@@ -1313,7 +1313,7 @@ type Dim[N: IntVar] = Int[N]
 def explicit_class(bad: Box[str]) -> None:  # E: Tensor shape dimensions must be integer literals or type variables
     reveal_type(bad.dim)  # E: revealed type: Int[int]
 
-def explicit_class_non_shape_arg(bad: Box[list[int]]) -> None:  # E: Tensor shape dimensions must be positive integer literals, string literals, type variables, or expressions
+def explicit_class_non_shape_arg(bad: Box[list[int]]) -> None:  # E: Tensor shape dimensions must be integer literals, string literals, type variables, or expressions
     reveal_type(bad.dim)  # E: revealed type: Int[int]
 
 def explicit_alias(x: Dim[str]) -> None:  # E: Tensor shape dimensions must be integer literals or type variables
@@ -1951,9 +1951,9 @@ def check(two: Tensor[[2]], three: Tensor[[3]], gradual: Tensor[[int]], matrix: 
     assert_type(wrapped_two_symbols(two, three), Tensor[[5]])
     assert_type(svd_min(matrix), Tensor[[2]])
 
-def ordinary_shape[N: IntVar](x: Tensor[[Int[N] + 1]]) -> None: ...  # E: Tensor shape dimensions must be positive integer literals, string literals, type variables, or expressions, got `type[Int[N]]`
+def ordinary_shape[N: IntVar](x: Tensor[[Int[N] + 1]]) -> None: ...  # E: Tensor shape dimensions must be integer literals, string literals, type variables, or expressions, got `type[Int[N]]`
 def invalid_wrapper() -> Tensor[[identity(Int[str])]]: ...  # E: Tensor shape dimensions must be integer literals or type variables, got `type[str]`
-def invalid_nested_wrapper[N: IntVar]() -> Tensor[[identity(Int[Int[N]])]]: ...  # E: Tensor shape dimensions must be positive integer literals, string literals, type variables, or expressions, got `type[Int[N]]`
+def invalid_nested_wrapper[N: IntVar]() -> Tensor[[identity(Int[Int[N]])]]: ...  # E: Tensor shape dimensions must be integer literals, string literals, type variables, or expressions, got `type[Int[N]]`
 def invalid_bare_typevar[T]() -> Tensor[[identity(D[T])]]: ...  # E: `T` must be an `IntVar` to be used as a shape dimension
 "#,
 );
@@ -4521,6 +4521,8 @@ def int_identity(x: Int) -> Int:
 def shape_identity(x: IntTuple) -> IntTuple:
     return x
 
+zero_extent: Tensor[[0]]
+
 def missing[S: IntTuple](x: Tensor[S]) -> Tensor[shape_identity()]: ...  # E: Expected 1 argument for `shape_identity`, got 0
 def extra[S: IntTuple](x: Tensor[S]) -> Tensor[shape_identity(S, S)]: ...  # E: Expected 1 argument for `shape_identity`, got 2
 def keyword[S: IntTuple](x: Tensor[S]) -> Tensor[shape_identity(x=S)]: ...  # E: `shape_identity` does not accept keyword arguments
@@ -4531,7 +4533,7 @@ def nested_wrong_domain(x: Tensor[[2]]) -> Tensor[shape_identity(int_identity(In
 def malformed_int(x: Tensor[[2]]) -> Tensor[[int_identity("x")]]: ...  # E: String literals are not valid tensor dimensions
 def recovered_dimension[N: IntVar]() -> Tensor[[int_identity(Int[N + MissingDim])]]: ...  # E: Could not find name `MissingDim`
 def recovered_ordinary() -> Tensor[[int_identity(list[MissingType])]]: ...  # E: Could not find name `MissingType`  # E: Expected an `Int` argument for parameter `x` (position 1) of `int_identity`, got `list[Unknown]`
-def nonpositive_int(x: Tensor[[2]]) -> Tensor[[int_identity(-1)]]: ...  # E: Tensor shape dimension must be positive, got -1
+def negative_int(x: Tensor[[2]]) -> Tensor[[int_identity(-1)]]: ...  # E: Tensor shape dimension must be non-negative, got -1
 def malformed_shape(x: Tensor[[2]]) -> Tensor[shape_identity(IntTuple["x"])]: ...  # E: String literals are not valid tensor dimensions
 def unbound_shape(x: Tensor[[2]]) -> Tensor[shape_identity(MissingShape)]: ...  # E: Could not find name `MissingShape`
 
@@ -7215,8 +7217,8 @@ def f[N, M](
     no_arg: Tensor[[D()]],  # E: Expected 1 positional argument for `D`, got 0
     too_many: Tensor[[D(N, M)]],  # E: Expected 1 positional argument for `D`, got 2
     keyword: Tensor[[D(N, dim=M)]],  # E: `D` accepts exactly 1 positional argument and no keyword arguments, got 1 positional and 1 keyword
-    non_d_subscript: Tensor[[Box[N]]],  # E: Tensor shape dimensions must be positive integer literals, string literals, type variables, or expressions, got `type[Box[N]]`
-    non_d_call: Tensor[[Factory(N)]],  # E: Tensor shape dimensions must be positive integer literals, string literals, type variables, or expressions, got `Factory`
+    non_d_subscript: Tensor[[Box[N]]],  # E: Tensor shape dimensions must be integer literals, string literals, type variables, or expressions, got `type[Box[N]]`
+    non_d_call: Tensor[[Factory(N)]],  # E: Tensor shape dimensions must be integer literals, string literals, type variables, or expressions, got `Factory`
 ) -> None:
     pass
 "#,
@@ -14390,5 +14392,84 @@ def check(
     assert_type(as_reversed_array(ambiguous), Array[IntTuple])
     assert_type(as_optional_array(optional), Array[[Any, 3]])
     assert_type(as_tagged_array(tagged), Array[[Any, 3]])
+"#,
+);
+
+// A single-spelled shape-generic parameter widens the same way as a union-spelled one: a
+// same-base union argument joins across arms instead of pinning the first arm's shape.
+testcase!(
+    test_shape_parameter_shared_across_single_spelled_param,
+    shape_extensions_env(),
+    r#"
+from typing import Any, assert_type
+from shape_extensions import IntTuple
+
+class Array[Shape: IntTuple]: ...
+class NdArray[Shape: IntTuple]: ...
+
+type ArrayLike[Shape: IntTuple] = Array[Shape] | NdArray[Shape]
+
+def as_array[Shape: IntTuple](value: ArrayLike[Shape]) -> Array[Shape]: ...
+def as_plain[Shape: IntTuple](value: Array[Shape]) -> Array[Shape]: ...
+
+def check(same_base: Array[[2, 3]] | Array[[4, 3]]) -> None:
+    assert_type(as_array(same_base), Array[[Any, 3]])
+    assert_type(as_plain(same_base), Array[[Any, 3]])
+
+def check_cross_base(cross_base: Array[[2, 3]] | NdArray[[4, 3]]) -> None:
+    as_plain(cross_base)  # E: is not assignable to parameter `value`
+"#,
+);
+
+// Probing stays bounded: 32 pairs (16 got arms times 2 want arms) retain their common
+// dimension, while a wider product uses a gradual shape and remains assignable.
+testcase!(
+    test_union_shape_join_probe_cap,
+    shape_extensions_env(),
+    r#"
+from typing import Any, assert_type
+from shape_extensions import IntTuple
+
+class Array[Shape: IntTuple]: ...
+class NdArray[Shape: IntTuple]: ...
+class Other[Shape: IntTuple]: ...
+
+type ArrayLike[Shape: IntTuple] = Array[Shape] | NdArray[Shape]
+type Triple[Shape: IntTuple] = Array[Shape] | NdArray[Shape] | Other[Shape]
+
+def as_array[Shape: IntTuple](value: ArrayLike[Shape]) -> Array[Shape]: ...
+def as_triple[Shape: IntTuple](value: Triple[Shape]) -> Array[Shape]: ...
+
+def check_capped(
+    wide: Array[[0, 3]] | Array[[1, 3]] | Array[[2, 3]] | Array[[3, 3]] | Array[[4, 3]] | Array[[5, 3]] | Array[[6, 3]] | Array[[7, 3]] | Array[[8, 3]] | Array[[9, 3]] | Array[[10, 3]] | Array[[11, 3]] | Array[[12, 3]] | Array[[13, 3]] | Array[[14, 3]] | Array[[15, 3]],
+) -> None:
+    assert_type(as_array(wide), Array[[Any, 3]])
+
+def check_over_cap(
+    too_wide: Array[[0, 7]] | Array[[1, 7]] | Array[[2, 7]] | Array[[3, 7]] | Array[[4, 7]] | Array[[5, 7]] | Array[[6, 7]] | Array[[7, 7]] | Array[[8, 7]] | Array[[9, 7]] | Array[[10, 7]],
+) -> None:
+    assert_type(as_triple(too_wide), Array[IntTuple])
+"#,
+);
+
+// Aborting the join commits nothing: a member matching no arm falls back to the ordinary
+// union check, which reports the mismatch instead of a partial join.
+testcase!(
+    test_union_shape_join_abort_falls_back,
+    shape_extensions_env(),
+    r#"
+from typing import Any, assert_type
+from shape_extensions import IntTuple
+
+class Array[Shape: IntTuple]: ...
+class NdArray[Shape: IntTuple]: ...
+
+type ArrayLike[Shape: IntTuple] = Array[Shape] | NdArray[Shape]
+
+def as_array[Shape: IntTuple](value: ArrayLike[Shape]) -> Array[Shape]: ...
+
+def check(value: Array[[2, 3]] | NdArray[[4, 3]], bad: Array[[2, 3]] | int) -> None:
+    assert_type(as_array(value), Array[[Any, 3]])
+    as_array(bad)  # E: is not assignable to parameter `value`
 "#,
 );

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
@@ -47,6 +47,7 @@ from jax._shapes import (
 )
 from jax.typing import DTypeLike
 from shape_extensions import (
+    ArrayCoercible,
     broadcast,
     Elements,
     Flag,
@@ -68,8 +69,8 @@ type _NewShape = int | tuple[int, ...] | None
 type _Scalar = bool | int | float | complex
 
 @overload
-def array(
-    object: _Scalar,
+def array[Shape: _Shape](
+    object: Array[Shape],
     dtype: DTypeLike | None = ...,
     copy: bool | None = ...,
     order: str | None = ...,
@@ -77,10 +78,10 @@ def array(
     *,
     device: Any = ...,
     out_sharding: Any = ...,
-) -> Array[[]]: ...
+) -> Array[Shape]: ...
 @overload
 def array[Shape: _Shape](
-    object: Array[Shape],
+    object: ArrayCoercible[Shape, _Scalar],
     dtype: DTypeLike | None = ...,
     copy: bool | None = ...,
     order: str | None = ...,
@@ -101,18 +102,18 @@ def array(
     out_sharding: Any = ...,
 ) -> Array[IntTuple]: ...
 @overload
-def asarray(
-    a: _Scalar,
+def asarray[Shape: _Shape](
+    a: Array[Shape],
     dtype: DTypeLike | None = ...,
     order: str | None = ...,
     *,
     copy: bool | None = ...,
     device: Any = ...,
     out_sharding: Any = ...,
-) -> Array[[]]: ...
+) -> Array[Shape]: ...
 @overload
 def asarray[Shape: _Shape](
-    a: Array[Shape],
+    a: ArrayCoercible[Shape, _Scalar],
     dtype: DTypeLike | None = ...,
     order: str | None = ...,
     *,

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_creation.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_creation.py
@@ -5,8 +5,10 @@
 
 from __future__ import annotations
 
+from typing import assert_type, TYPE_CHECKING
+
 import jax.numpy as jnp
-from shape_extensions import assert_shape
+from shape_extensions import assert_shape, IntTuple
 
 # A multi-argument `arange` has a length the DSL cannot compute, and a shape
 # outside the exact ranks is gradual, so `assert_shape` cannot be used for
@@ -15,6 +17,34 @@ GRADUAL_SHAPE_RUNTIME_TESTS = {
     "test_multi_argument_arange_length_is_gradual",
     "test_shapes_outside_the_exact_ranks_are_gradual",
 }
+
+
+def check_array_and_asarray_list_literal_types() -> None:
+    assert_type(jnp.array(1), jnp.Array[[]])
+    assert_type(jnp.array([1, 2, 3]), jnp.Array[[3]])
+    assert_type(jnp.asarray([[1, 2], [3, 4]]), jnp.Array[[2, 2]])
+    assert_type(jnp.asarray([[], []]), jnp.Array[[2, 0]])
+    assert_type(jnp.array([1, 2], dtype=jnp.float32), jnp.Array[[2]])
+
+
+def test_array_and_asarray_list_literals() -> None:
+    assert_shape(jnp.array([1, 2, 3]).shape, (3,))
+    assert_shape(jnp.array([[1, 2], [3, 4]]).shape, (2, 2))
+    assert_shape(jnp.array([[], []]).shape, (2, 0))
+    assert_shape(jnp.asarray([1, 2, 3]).shape, (3,))
+    assert_shape(jnp.asarray([[1, 2], [3, 4]]).shape, (2, 2))
+    assert_shape(jnp.asarray([[], []]).shape, (2, 0))
+
+
+def check_array_compatibility(array: jnp.Array[[2, 3]], raw: list[int]) -> None:
+    assert_type(jnp.array(array), jnp.Array[[2, 3]])
+    assert_type(jnp.array(raw), jnp.Array[IntTuple])
+    assert_type(jnp.array([1, 2], ndmin=2), jnp.Array[IntTuple])
+
+
+if TYPE_CHECKING:
+    assert_type(jnp.array([[1], [2, 3]]), jnp.Array[IntTuple])
+    assert_type(jnp.asarray(["not", "numeric"]), jnp.Array[IntTuple])
 
 
 def test_zeros_ones_and_empty() -> None:

--- a/tensor-shapes/pyrefly-numpy-stubs/numpy-stubs/__init__.pyi
+++ b/tensor-shapes/pyrefly-numpy-stubs/numpy-stubs/__init__.pyi
@@ -375,6 +375,7 @@ from numpy.matrixlib import (
     matrix as matrix,
 )
 from shape_extensions import (
+    ArrayCoercible,
     broadcast as _broadcast_shape,
     Flag,
     Index,
@@ -420,6 +421,7 @@ class intp(generic): ...
 
 type _IndexScalar = int | bool_ | int32 | int64 | intp
 type _IndexSequence = Sequence[_IndexScalar] | Sequence[Sequence[_IndexScalar]]
+type _ArrayScalar = None | bool | int | float | complex | str | bytes | generic
 
 __version__: Final[str]
 e: Final[float]
@@ -1141,6 +1143,113 @@ matvec: _MatvecUFunc
 vecdot: _VecdotUFunc
 vecmat: _VecmatUFunc
 
+# Constructor overloads preserve dtype only when it is omitted, preserve shape only for
+# `ndmin=0`, and delegate non-None `like` dispatch with an `Any` result.
+@overload
+def array[Shape: _Shape, DType](
+    object: ndarray[Shape, DType],
+    dtype: None = None,
+    *,
+    copy: bool | None = ...,
+    order: str = ...,
+    subok: bool = ...,
+    ndmin: Literal[0] = 0,
+    like: None = None,
+) -> ndarray[Shape, DType]: ...
+@overload
+def array[Shape: _Shape](
+    object: ndarray[Shape, Any],
+    dtype: Any,
+    *,
+    copy: bool | None = ...,
+    order: str = ...,
+    subok: bool = ...,
+    ndmin: Literal[0] = 0,
+    like: None = None,
+) -> ndarray[Shape]: ...
+@overload
+def array[Shape: _Shape](
+    object: ArrayCoercible[Shape, _ArrayScalar],
+    dtype: Any = ...,
+    *,
+    copy: bool | None = ...,
+    order: str = ...,
+    subok: bool = ...,
+    ndmin: Literal[0] = 0,
+    like: None = None,
+) -> ndarray[Shape]: ...
+@overload
+def array(
+    object: Any,
+    dtype: Any = ...,
+    *,
+    copy: bool | None = ...,
+    order: str = ...,
+    subok: bool = ...,
+    ndmin: int = ...,
+    like: None = None,
+) -> ndarray[IntTuple]: ...
+@overload
+def array(
+    object: Any,
+    dtype: Any = ...,
+    *,
+    copy: bool | None = ...,
+    order: str = ...,
+    subok: bool = ...,
+    ndmin: int = ...,
+    like: Any,
+) -> Any: ...
+@overload
+def asarray[Shape: _Shape, DType](
+    a: ndarray[Shape, DType],
+    dtype: None = None,
+    order: str | None = None,
+    *,
+    device: Any = ...,
+    copy: bool | None = ...,
+    like: None = None,
+) -> ndarray[Shape, DType]: ...
+@overload
+def asarray[Shape: _Shape](
+    a: ndarray[Shape, Any],
+    dtype: Any,
+    order: str | None = None,
+    *,
+    device: Any = ...,
+    copy: bool | None = ...,
+    like: None = None,
+) -> ndarray[Shape]: ...
+@overload
+def asarray[Shape: _Shape](
+    a: ArrayCoercible[Shape, _ArrayScalar],
+    dtype: Any = ...,
+    order: str | None = None,
+    *,
+    device: Any = ...,
+    copy: bool | None = ...,
+    like: None = None,
+) -> ndarray[Shape]: ...
+@overload
+def asarray(
+    a: Any,
+    dtype: Any = ...,
+    order: str | None = None,
+    *,
+    device: Any = ...,
+    copy: bool | None = ...,
+    like: None = None,
+) -> ndarray[IntTuple]: ...
+@overload
+def asarray(
+    a: Any,
+    dtype: Any = ...,
+    order: str | None = None,
+    *,
+    device: Any = ...,
+    copy: bool | None = ...,
+    like: Any,
+) -> Any: ...
 def round[Shape: _Shape](x: ndarray[Shape]) -> ndarray[Shape]: ...
 def clip[Shape: _Shape](
     a: ndarray[Shape], a_min: int | float, a_max: int | float

--- a/tensor-shapes/pyrefly-numpy-stubs/test/test_creation_basics.py
+++ b/tensor-shapes/pyrefly-numpy-stubs/test/test_creation_basics.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, assert_type
+from typing import Any, assert_type, TYPE_CHECKING
 
 import numpy as np
 from shape_extensions import assert_shape, IntTuple, IntVar
@@ -14,6 +14,50 @@ GRADUAL_SHAPE_RUNTIME_TESTS = {
     "test_diag_dtype_and_broad_offset",
     "test_diag_matrix_runtime_shape",
 }
+
+
+def check_array_and_asarray_list_literal_types() -> None:
+    assert_type(np.array(1), np.ndarray[[], Any])
+    assert_type(np.array(None), np.ndarray[[], Any])
+    assert_type(np.array([1, 2, 3]), np.ndarray[[3], Any])
+    assert_type(np.array([[None], [None]]), np.ndarray[[2, 1], Any])
+    assert_type(np.array([[1, 2], [3, 4]]), np.ndarray[[2, 2], Any])
+    assert_type(np.asarray([[], []]), np.ndarray[[2, 0], Any])
+    assert_type(np.asarray(["a", "b"]), np.ndarray[[2], Any])
+    assert_type(np.array([1, 2], dtype=np.float32), np.ndarray[[2], Any])
+
+
+def test_array_and_asarray_list_literals() -> None:
+    assert_shape(np.array([1, 2, 3]).shape, (3,))
+    assert_shape(np.array([[1, 2], [3, 4]]).shape, (2, 2))
+    assert_shape(np.array([[], []]).shape, (2, 0))
+    assert_shape(np.asarray([1, 2, 3]).shape, (3,))
+    assert_shape(np.asarray([[1, 2], [3, 4]]).shape, (2, 2))
+    assert_shape(np.asarray([[], []]).shape, (2, 0))
+
+
+def check_array_compatibility[DType](
+    array: np.ndarray[[2, 3], DType], raw: list[int], dynamic: Any
+) -> None:
+    assert_type(np.array(array), np.ndarray[[2, 3], DType])
+    assert_type(np.asarray(array), np.ndarray[[2, 3], DType])
+    assert_type(np.array(array, dtype=np.float32), np.ndarray[[2, 3], Any])
+    assert_type(np.asarray(array, dtype=np.float32), np.ndarray[[2, 3], Any])
+    assert_type(np.array(raw), np.ndarray[IntTuple, Any])
+    assert_type(np.asarray(dynamic), np.ndarray[Any, Any])
+    assert_type(np.array([1, 2], like=dynamic), Any)
+    assert_type(np.asarray([1, 2], like=dynamic), Any)
+    assert_type(np.array([1, 2], like=object()), Any)
+    assert_type(np.asarray([1, 2], like=object()), Any)
+    assert_type(np.array([1, 2], like=None), np.ndarray[[2], Any])
+    assert_type(np.asarray([1, 2], like=None), np.ndarray[[2], Any])
+    assert_type(np.array([1, 2], ndmin=0), np.ndarray[[2], Any])
+    assert_type(np.array([1, 2], ndmin=2), np.ndarray[IntTuple, Any])
+
+
+if TYPE_CHECKING:
+    assert_type(np.array([[1], [2, 3]]), np.ndarray[IntTuple, Any])
+    assert_type(np.asarray([1, [2]]), np.ndarray[IntTuple, Any])
 
 
 def test_zeros_1d_int_shape() -> None:

--- a/tensor-shapes/pyrefly-shape-extensions/README.md
+++ b/tensor-shapes/pyrefly-shape-extensions/README.md
@@ -8,4 +8,11 @@ typing primitives so annotations such as `Tensor[B, T]`, `IntVar("B")`, and
 `assert_shape(x.shape, (2, 3))` can be evaluated by Python while Pyrefly uses the
 corresponding stubs for static shape checking.
 
+`Scalar[Shape, Domain]` represents a scalar from `Domain` when `Shape` is empty;
+for example, `Scalar[[], int]` behaves as `int`, while `Scalar[[2], int]` is
+uninhabited. `ArrayCoercible[Shape, Domain]` projects rectangular list literals;
+for example, `[[1, 2], [3, 4]]` binds `Shape` to `[2, 2]`. Unsupported containers
+and ragged literals use ordinary typing and any fallback overload supplied by the
+consumer.
+
 The package is versioned in lockstep with Pyrefly.

--- a/tensor-shapes/pyrefly-shape-extensions/pyproject.toml
+++ b/tensor-shapes/pyrefly-shape-extensions/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
 ]
+dependencies = ["typing-extensions>=4.12"]
 
 [project.urls]
 homepage = "https://pyrefly.org"

--- a/tensor-shapes/pyrefly-shape-extensions/shape_extensions/__init__.py
+++ b/tensor-shapes/pyrefly-shape-extensions/shape_extensions/__init__.py
@@ -15,6 +15,8 @@ don't crash when evaluated by Python.
 import typing
 from dataclasses import dataclass
 
+from typing_extensions import TypeVar
+
 __all__ = [
     "D",
     "Elements",
@@ -25,6 +27,7 @@ __all__ = [
     "Index",
     "MapIntTuples",
     "ProxyMethod",
+    "Scalar",
     "SymbolicArithExpr",
     "TypeVarTuple",
     "assert_shape",
@@ -176,6 +179,23 @@ class ProxyMethod[T]:
     """Type-checker marker for method forwarding annotations."""
 
     pass
+
+
+_Shape = TypeVar("_Shape", bound=IntTuple, default=IntTuple[()], covariant=True)
+_Domain = TypeVar("_Domain", default=bool | int | float | complex, covariant=True)
+
+
+class Scalar(typing.Generic[_Shape, _Domain]):
+    """A value from ``Domain`` indexed by a potential array ``Shape``.
+
+    Rank-zero and gradual shapes expose ``Domain`` and its attributes. A
+    statically non-empty specialization normalizes to ``Never``. An unresolved
+    symbolic shape remains linked to the scalar until inference determines
+    whether it is empty.
+    """
+
+    def __class_getitem__(cls, params):
+        return cls
 
 
 @dataclass(frozen=True)

--- a/tensor-shapes/pyrefly-shape-extensions/shape_extensions/__init__.py
+++ b/tensor-shapes/pyrefly-shape-extensions/shape_extensions/__init__.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing_extensions import TypeVar
 
 __all__ = [
+    "ArrayCoercible",
     "D",
     "Elements",
     "Int",
@@ -189,9 +190,22 @@ class Scalar(typing.Generic[_Shape, _Domain]):
     """A value from ``Domain`` indexed by a potential array ``Shape``.
 
     Rank-zero and gradual shapes expose ``Domain`` and its attributes. A
-    statically non-empty specialization normalizes to ``Never``. An unresolved
-    symbolic shape remains linked to the scalar until inference determines
-    whether it is empty.
+    shape with a known dimension normalizes to ``Never``. An unresolved symbolic
+    shape remains linked to the scalar until inference determines whether it is
+    empty.
+    """
+
+    def __class_getitem__(cls, params):
+        return cls
+
+
+class ArrayCoercible(typing.Generic[_Shape, _Domain]):
+    """Python data structurally convertible to an array of ``Domain`` leaves.
+
+    Scalars bind ``Shape`` to ``IntTuple[()]``. Rectangular list literals bind an
+    exact shape, such as ``[[1, 2], [3, 4]]`` binding ``IntTuple[2, 2]``.
+    Existing containers, starred literals, and statically ragged literals are
+    not projected; callers may provide an ordinary gradual fallback overload.
     """
 
     def __class_getitem__(cls, params):

--- a/tensor-shapes/pyrefly-torch-stubs/test/runtime_tests/test_annotation_runtime.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/runtime_tests/test_annotation_runtime.py
@@ -26,6 +26,7 @@ from typing import Any, Generic, Never, TypedDict
 
 import torch
 from shape_extensions import (
+    ArrayCoercible,
     assert_shape,
     D,
     defines_assert_shape,
@@ -68,6 +69,9 @@ class TestSubscriptRuntime(unittest.TestCase):
 
     def test_scalar_shape_subscript_erases_to_scalar(self):
         self.assertIs(Scalar[[], int], Scalar)
+
+    def test_array_coercible_shape_subscript_erases_to_marker(self):
+        self.assertIs(ArrayCoercible[[2], int], ArrayCoercible)
 
 
 class TestTorchScriptRuntimeCompat(unittest.TestCase):

--- a/tensor-shapes/pyrefly-torch-stubs/test/runtime_tests/test_annotation_runtime.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/runtime_tests/test_annotation_runtime.py
@@ -34,6 +34,7 @@ from shape_extensions import (
     IntTuple,
     IntVar,
     MapIntTuples,
+    Scalar,
     TypeVarTuple,
 )
 
@@ -64,6 +65,9 @@ class TestSubscriptRuntime(unittest.TestCase):
             return x
 
         self.assertTrue(callable(f))
+
+    def test_scalar_shape_subscript_erases_to_scalar(self):
+        self.assertIs(Scalar[[], int], Scalar)
 
 
 class TestTorchScriptRuntimeCompat(unittest.TestCase):

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_phase1_creation.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_phase1_creation.py
@@ -4,11 +4,56 @@
 # LICENSE file in the root directory of this source tree.
 
 # Phase 1.3: Tensor creation operations tests
-from typing import assert_type
+from typing import Any, assert_type, TYPE_CHECKING
 
 import torch
 from shape_extensions import IntTuple
 from torch import Tensor
+
+
+def test_tensor_data_constructors() -> None:
+    assert_type(torch.tensor(1), Tensor[[]])
+    assert_type(torch.tensor([1, 2, 3]), Tensor[[3]])
+    assert_type(torch.tensor([[1, 2], [3, 4]]), Tensor[[2, 2]])
+    assert_type(torch.tensor([[], []]), Tensor[[2, 0]])
+    assert_type(torch.tensor([1, 2], dtype=torch.float32), Tensor[[2]])
+    assert_type(
+        torch.tensor([1, 2], device="cpu", requires_grad=False, pin_memory=False),
+        Tensor[[2]],
+    )
+    assert_type(torch.Tensor([1, 2, 3]), Tensor[[3]])
+    assert_type(torch.Tensor([[1, 2], [3, 4]]), Tensor[[2, 2]])
+
+
+def test_tensor_size_constructor() -> None:
+    assert_type(torch.Tensor(), Tensor[[0]])
+    assert_type(torch.Tensor(device="cpu"), Tensor[[0]])
+    assert_type(torch.Tensor(2), Tensor[[2]])
+    assert_type(torch.Tensor(2, device="cpu"), Tensor[[2]])
+    assert_type(torch.Tensor(2, 3), Tensor[[2, 3]])
+    assert_type(torch.Tensor([1, 2], device="cpu"), Tensor[[2]])
+
+
+def check_tensor_constructor_compatibility(
+    tensor: Tensor[[2, 3]], raw: list[int], dynamic: Any, size: int
+) -> None:
+    assert_type(torch.tensor(tensor), Tensor[[2, 3]])
+    assert_type(torch.tensor(tensor, pin_memory=False), Tensor[[2, 3]])
+    assert_type(torch.Tensor(tensor), Tensor[[2, 3]])
+    assert_type(torch.Tensor(size), Tensor[IntTuple[int]])
+    assert_type(torch.Tensor(size, size), Tensor[IntTuple[int, int]])
+    assert_type(torch.tensor(raw), Tensor[IntTuple])
+    assert_type(torch.tensor(dynamic), Tensor[Any])
+
+
+if TYPE_CHECKING:
+    assert_type(torch.tensor([[1], [2, 3]]), Tensor[IntTuple])
+    assert_type(torch.Tensor([[1], [2, 3]]), Tensor[IntTuple])
+    assert_type(torch.Tensor(True), Tensor[IntTuple])
+    assert_type(torch.Tensor(data=True), Tensor[IntTuple])
+    assert_type(torch.Tensor(1.0), Tensor[IntTuple])
+    assert_type(torch.Tensor(data=2), Tensor[IntTuple])
+    assert_type(torch.Tensor([1 + 2j]), Tensor[IntTuple])
 
 # ==== *_like Operations (preserve shape) ====
 

--- a/tensor-shapes/pyrefly-torch-stubs/torch-stubs/__init__.pyi
+++ b/tensor-shapes/pyrefly-torch-stubs/torch-stubs/__init__.pyi
@@ -16,6 +16,7 @@ from types import EllipsisType
 from typing import Any, Callable, overload, Self, TYPE_CHECKING, Unpack
 
 from shape_extensions import (
+    ArrayCoercible,
     broadcast,
     Elements,
     Flag,
@@ -87,6 +88,8 @@ __all__ = ["Tensor"]
 
 type _Shape = IntTuple
 type _BasicIndex = builtins.int | slice | list[builtins.int] | None | EllipsisType
+type _TensorScalar = builtins.bool | builtins.int | builtins.float | builtins.complex
+type _LegacyTensorScalar = builtins.bool | builtins.int | builtins.float
 
 # ============================================================================
 # Device Type
@@ -127,6 +130,41 @@ class Tensor[Shape: _Shape = _Shape]:
     Most shape transformations are handled by meta-shape functions registered
     in the type checker, not by explicit type signatures here.
     """
+
+    @overload
+    def __new__(cls, *, device: Any = None) -> Tensor[[0]]: ...
+    # Unsupported scalar forms stay gradual; `Never` would incorrectly make the caller's
+    # remaining control flow unreachable.
+    @overload
+    def __new__(
+        cls, data: builtins.bool, *, device: Any = None
+    ) -> Tensor[IntTuple]: ...
+    @overload
+    def __new__[Size: IntTuple](
+        cls, *size: *Size, device: Any = None
+    ) -> Tensor[Size]: ...
+    @overload
+    def __new__(cls, *, data: builtins.int, device: Any = None) -> Tensor[IntTuple]: ...
+    @overload
+    def __new__(
+        cls,
+        data: builtins.float | builtins.complex,
+        *,
+        device: Any = None,
+    ) -> Tensor[IntTuple]: ...
+    @overload
+    def __new__[DataShape: IntTuple](
+        cls, data: Tensor[DataShape], *, device: Any = None
+    ) -> Tensor[DataShape]: ...
+    @overload
+    def __new__[DataShape: IntTuple](
+        cls,
+        data: ArrayCoercible[DataShape, _LegacyTensorScalar],
+        *,
+        device: Any = None,
+    ) -> Tensor[DataShape]: ...
+    @overload
+    def __new__(cls, data: Any, *, device: Any = None) -> Tensor[IntTuple]: ...
 
     # ==== Tensor Properties ====
     shape: Shape  # Tensor shape as a tuple
@@ -3206,13 +3244,34 @@ class dtype:
 # Tensor Creation with dtype support
 # ==============================================================================
 
-def tensor(
-    data: Any,
+@overload
+def tensor[Shape: IntTuple](
+    data: Tensor[Shape],
+    *,
     dtype: Any = None,
     device: Any = None,
-    requires_grad: bool = False,
-) -> Tensor:
-    """Create tensor from data. Returns shapeless tensor (shape depends on input data)."""
+    requires_grad: builtins.bool = False,
+    pin_memory: builtins.bool = False,
+) -> Tensor[Shape]: ...
+@overload
+def tensor[Shape: IntTuple](
+    data: ArrayCoercible[Shape, _TensorScalar],
+    *,
+    dtype: Any = None,
+    device: Any = None,
+    requires_grad: builtins.bool = False,
+    pin_memory: builtins.bool = False,
+) -> Tensor[Shape]: ...
+@overload
+def tensor(
+    data: Any,
+    *,
+    dtype: Any = None,
+    device: Any = None,
+    requires_grad: builtins.bool = False,
+    pin_memory: builtins.bool = False,
+) -> Tensor[IntTuple]:
+    """Create a tensor from data, preserving or inferring its shape when possible."""
     ...
 
 def as_tensor(


### PR DESCRIPTION
Summary:

Adopt `ArrayCoercible` in the NumPy, JAX, and PyTorch array constructors so ordinary nested scalar literals infer precise shapes. Preserve existing shaped inputs, integer-size `torch.Tensor` construction, and broad gradual fallbacks for unsupported or dynamic inputs.

For example:

```python
assert_type(np.array([[1, 2], [3, 4]]), np.ndarray[[2, 2], Any])
assert_type(jnp.asarray([[], []]), jnp.Array[[2, 0]])
assert_type(torch.tensor([1, 2, 3]), Tensor[[3]])
assert_type(torch.Tensor(2, 3), Tensor[[2, 3]])  # existing size constructor
```

Differential Revision: D119041654
