### PR TITLE
[tensor-shapes] add type stubs for remaining jax.lax APIs

### DIFF
--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/lax/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/lax/__init__.pyi
@@ -3,8 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Callable, overload, Sequence
+from typing import Any, Callable, Hashable, overload, Sequence
 
+import numpy as np
 from jax._array import Array
 from jax._shapes import (
     broadcast_to_rank_shape,
@@ -379,6 +380,71 @@ def zeta[Shape: _Shape](x: _Scalar, q: Array[Shape], /) -> Array[Shape]: ...
 def zeta[Shape1: _Shape, Shape2: _Shape](
     x: Array[Shape1], q: Array[Shape2], /
 ) -> Array[lax_broadcast(Shape1, Shape2)]: ...
+@overload
+def betainc[Shape: _Shape](
+    a: Array[Shape],
+    b: Array[Shape] | _Scalar,
+    x: Array[Shape] | _Scalar,
+    /,
+) -> Array[Shape]: ...
+@overload
+def betainc[Shape: _Shape](
+    a: _Scalar,
+    b: Array[Shape],
+    x: Array[Shape] | _Scalar,
+    /,
+) -> Array[Shape]: ...
+@overload
+def betainc[Shape: _Shape](
+    a: _Scalar,
+    b: _Scalar,
+    x: Array[Shape],
+    /,
+) -> Array[Shape]: ...
+@overload
+def betainc(
+    a: _Scalar,
+    b: _Scalar,
+    x: _Scalar,
+    /,
+) -> Array[[]]: ...
+@overload
+def betainc(
+    a: Any,
+    b: Any,
+    x: Any,
+    /,
+) -> Array[IntTuple]: ...
+@overload
+def fft[Shape: _Shape](
+    x: Array[Shape],
+    fft_type: FftType | str,
+    fft_lengths: Sequence[int],
+) -> Array[IntTuple]: ...
+@overload
+def fft(
+    x: Any,
+    fft_type: FftType | str,
+    fft_lengths: Sequence[int],
+) -> Array[IntTuple]: ...
+@overload
+def random_gamma_grad[Shape: _Shape](
+    a: Array[Shape],
+    x: Array[Shape],
+    /,
+) -> Array[Shape]: ...
+@overload
+def random_gamma_grad[Shape1: _Shape, Shape2: _Shape](
+    a: Array[Shape1],
+    x: Array[Shape2],
+    /,
+) -> Array[lax_broadcast(Shape1, Shape2)]: ...
+@overload
+def random_gamma_grad(
+    a: Any,
+    x: Any,
+    /,
+) -> Array[IntTuple]: ...
 
 # -----------------------------------------------------------------------------
 # Array Creation & Constants
@@ -1629,3 +1695,394 @@ def top_k(
     axis: int = -1,
     is_stable: bool = True,
 ) -> tuple[Array[IntTuple], Array[IntTuple]]: ...
+
+# -----------------------------------------------------------------------------
+# Control Flow & Higher-Order Functions
+# -----------------------------------------------------------------------------
+
+@overload
+def cond[InVal, OutVal](
+    pred: bool | Array[[]],
+    true_fun: Callable[[InVal], OutVal],
+    false_fun: Callable[[InVal], OutVal],
+    *,
+    operand: InVal,
+) -> OutVal: ...
+@overload
+def cond[*InVals, OutVal](
+    pred: bool | Array[[]],
+    true_fun: Callable[[*InVals], OutVal],
+    false_fun: Callable[[*InVals], OutVal],
+    *operands: *InVals,
+) -> OutVal: ...
+def fori_loop[T](
+    lower: int | Array[[]],
+    upper: int | Array[[]],
+    body_fun: Callable[[int | Array[[]], T], T],
+    init_val: T,
+    *,
+    unroll: int | bool | None = None,
+) -> T: ...
+@overload
+def map[N: IntVar, InShape: _Shape, OutShape: _Shape](
+    f: Callable[[Array[InShape]], Array[OutShape]],
+    xs: Array[[N, *Elements[InShape]]],
+    *,
+    batch_size: int | None = None,
+) -> Array[[N, *Elements[OutShape]]]: ...
+@overload
+def map(
+    f: Callable[..., Any],
+    xs: Any,
+    *,
+    batch_size: int | None = None,
+) -> Any: ...
+@overload
+def scan[Carry, N: IntVar, InShape: _Shape, OutShape: _Shape](
+    f: Callable[[Carry, Array[InShape]], tuple[Carry, Array[OutShape]]],
+    init: Carry,
+    xs: Array[[N, *Elements[InShape]]],
+    length: int | None = None,
+    reverse: bool = False,
+    unroll: int | bool = 1,
+    _split_transpose: bool = False,
+) -> tuple[Carry, Array[[N, *Elements[OutShape]]]]: ...
+@overload
+def scan[Carry, X, Y](
+    f: Callable[[Carry, X], tuple[Carry, Y]],
+    init: Carry,
+    xs: X,
+    length: int | None = None,
+    reverse: bool = False,
+    unroll: int | bool = 1,
+    _split_transpose: bool = False,
+) -> tuple[Carry, Y]: ...
+@overload
+def scan[Carry, Y](
+    f: Callable[[Carry, Any], tuple[Carry, Y]],
+    init: Carry,
+    xs: None = None,
+    *,
+    length: int,
+    reverse: bool = False,
+    unroll: int | bool = 1,
+    _split_transpose: bool = False,
+) -> tuple[Carry, Y]: ...
+@overload
+def scan(
+    f: Callable[..., Any],
+    init: Any,
+    xs: Any = None,
+    length: int | None = None,
+    reverse: bool = False,
+    unroll: int | bool = 1,
+    _split_transpose: bool = False,
+) -> tuple[Any, Any]: ...
+@overload
+def switch[InVal, OutVal](
+    index: int | Array[[]],
+    branches: Sequence[Callable[[InVal], OutVal]],
+    *,
+    operand: InVal,
+) -> OutVal: ...
+@overload
+def switch[*InVals, OutVal](
+    index: int | Array[[]],
+    branches: Sequence[Callable[[*InVals], OutVal]],
+    *operands: *InVals,
+) -> OutVal: ...
+def while_loop[T](
+    cond_fun: Callable[[T], bool | Array[[]]],
+    body_fun: Callable[[T], T],
+    init_val: T,
+) -> T: ...
+
+# -----------------------------------------------------------------------------
+# Parallel & Collective Operations
+# -----------------------------------------------------------------------------
+
+@overload
+def all_gather[Shape: _Shape](
+    x: Array[Shape],
+    axis_name: Hashable,
+    *,
+    axis_index_groups: Any = None,
+    axis: int = 0,
+    tiled: bool = False,
+    to: str = "varying",
+) -> Array[IntTuple]: ...
+@overload
+def all_gather[T](
+    x: T,
+    axis_name: Hashable,
+    *,
+    axis_index_groups: Any = None,
+    axis: int = 0,
+    tiled: bool = False,
+    to: str = "varying",
+) -> T: ...
+@overload
+def all_to_all[Shape: _Shape](
+    x: Array[Shape],
+    axis_name: Hashable,
+    split_axis: int,
+    concat_axis: int,
+    *,
+    axis_index_groups: Any = None,
+    tiled: bool = False,
+) -> Array[IntTuple]: ...
+@overload
+def all_to_all[T](
+    x: T,
+    axis_name: Hashable,
+    split_axis: int,
+    concat_axis: int,
+    *,
+    axis_index_groups: Any = None,
+    tiled: bool = False,
+) -> T: ...
+def axis_index(axis_name: Hashable) -> Array[[]]: ...
+def axis_size(axis_name: Hashable) -> int: ...
+@overload
+def pbroadcast[Shape: _Shape](
+    x: Array[Shape],
+    axis_name: Hashable,
+    source: int,
+) -> Array[Shape]: ...
+@overload
+def pbroadcast[T](
+    x: T,
+    axis_name: Hashable,
+    source: int,
+) -> T: ...
+@overload
+def pcast[Shape: _Shape](
+    x: Array[Shape],
+    axis_name: Hashable,
+    *,
+    to: str,
+) -> Array[Shape]: ...
+@overload
+def pcast[T](
+    x: T,
+    axis_name: Hashable,
+    *,
+    to: str,
+) -> T: ...
+@overload
+def pmax[Shape: _Shape](
+    x: Array[Shape],
+    axis_name: Hashable,
+    *,
+    axis_index_groups: Any = None,
+) -> Array[Shape]: ...
+@overload
+def pmax[T](
+    x: T,
+    axis_name: Hashable,
+    *,
+    axis_index_groups: Any = None,
+) -> T: ...
+@overload
+def pmean[Shape: _Shape](
+    x: Array[Shape],
+    axis_name: Hashable,
+    *,
+    axis_index_groups: Any = None,
+) -> Array[Shape]: ...
+@overload
+def pmean[T](
+    x: T,
+    axis_name: Hashable,
+    *,
+    axis_index_groups: Any = None,
+) -> T: ...
+@overload
+def pmin[Shape: _Shape](
+    x: Array[Shape],
+    axis_name: Hashable,
+    *,
+    axis_index_groups: Any = None,
+) -> Array[Shape]: ...
+@overload
+def pmin[T](
+    x: T,
+    axis_name: Hashable,
+    *,
+    axis_index_groups: Any = None,
+) -> T: ...
+@overload
+def ppermute[Shape: _Shape](
+    x: Array[Shape],
+    axis_name: Hashable,
+    perm: Sequence[tuple[int, int]],
+) -> Array[Shape]: ...
+@overload
+def ppermute[T](
+    x: T,
+    axis_name: Hashable,
+    perm: Sequence[tuple[int, int]],
+) -> T: ...
+def precv(
+    token: Any,
+    out_shape: Any,
+    axis_name: Hashable,
+    perm: Sequence[tuple[int, int]],
+) -> Any: ...
+def psend(
+    x: Any,
+    axis_name: Hashable,
+    perm: Sequence[tuple[int, int]],
+) -> Any: ...
+@overload
+def pshuffle[Shape: _Shape](
+    x: Array[Shape],
+    axis_name: Hashable,
+    perm: Sequence[int],
+) -> Array[Shape]: ...
+@overload
+def pshuffle[T](
+    x: T,
+    axis_name: Hashable,
+    perm: Sequence[int],
+) -> T: ...
+@overload
+def psum[Shape: _Shape](
+    x: Array[Shape],
+    axis_name: Hashable,
+    *,
+    axis_index_groups: Any = None,
+) -> Array[Shape]: ...
+@overload
+def psum[T](
+    x: T,
+    axis_name: Hashable,
+    *,
+    axis_index_groups: Any = None,
+) -> T: ...
+@overload
+def psum_scatter[Shape: _Shape](
+    x: Array[Shape],
+    axis_name: Hashable,
+    *,
+    scatter_dimension: int = 0,
+    axis_index_groups: Any = None,
+    tiled: bool = False,
+) -> Array[IntTuple]: ...
+@overload
+def psum_scatter[T](
+    x: T,
+    axis_name: Hashable,
+    *,
+    scatter_dimension: int = 0,
+    axis_index_groups: Any = None,
+    tiled: bool = False,
+) -> T: ...
+@overload
+def pswapaxes[Shape: _Shape](
+    x: Array[Shape],
+    axis_name: Hashable,
+    axis: int,
+    *,
+    axis_index_groups: Any = None,
+) -> Array[Shape]: ...
+@overload
+def pswapaxes[T](
+    x: T,
+    axis_name: Hashable,
+    axis: int,
+    *,
+    axis_index_groups: Any = None,
+) -> T: ...
+@overload
+def ragged_all_to_all[OutputShape: _Shape](
+    operand: Any,
+    output: Array[OutputShape],
+    input_offsets: Any,
+    send_sizes: Any,
+    output_offsets: Any,
+    recv_sizes: Any,
+    *,
+    axis_name: Hashable,
+    axis_index_groups: Any = None,
+) -> Array[OutputShape]: ...
+@overload
+def ragged_all_to_all(
+    operand: Any,
+    output: Any,
+    input_offsets: Any,
+    send_sizes: Any,
+    output_offsets: Any,
+    recv_sizes: Any,
+    *,
+    axis_name: Hashable,
+    axis_index_groups: Any = None,
+) -> Array[IntTuple]: ...
+
+# -----------------------------------------------------------------------------
+# Data Types, Bitcasting & RNG
+# -----------------------------------------------------------------------------
+
+def dtype(x: Any) -> np.dtype: ...
+@overload
+def rng_bit_generator[KeyShape: _Shape, Shape: _Shape](
+    key: Array[KeyShape],
+    shape: Shape,
+    dtype: DTypeLike = ...,
+    algorithm: RandomAlgorithm = ...,
+    *,
+    out_sharding: Any = None,
+) -> tuple[Array[KeyShape], Array[Shape]]: ...
+@overload
+def rng_bit_generator[KeyShape: _Shape](
+    key: Array[KeyShape],
+    shape: Sequence[int] | int,
+    dtype: DTypeLike = ...,
+    algorithm: RandomAlgorithm = ...,
+    *,
+    out_sharding: Any = None,
+) -> tuple[Array[KeyShape], Array[IntTuple]]: ...
+@overload
+def rng_bit_generator(
+    key: Any,
+    shape: Any,
+    dtype: DTypeLike = ...,
+    algorithm: RandomAlgorithm = ...,
+    *,
+    out_sharding: Any = None,
+) -> tuple[Array[IntTuple], Array[IntTuple]]: ...
+@overload
+def rng_uniform[Shape: _Shape](
+    a: float | Array[[]],
+    b: float | Array[[]],
+    shape: Shape,
+) -> Array[Shape]: ...
+@overload
+def rng_uniform(
+    a: float | Array[[]],
+    b: float | Array[[]],
+    shape: Sequence[int] | int,
+) -> Array[IntTuple]: ...
+
+# -----------------------------------------------------------------------------
+# Compiler, Token & Miscellaneous
+# -----------------------------------------------------------------------------
+
+def after_all(*operands: Any) -> Any: ...
+def composite[F: Callable[..., Any]](
+    decomposition: F,
+    name: str,
+    version: int = 0,
+) -> F: ...
+def create_token(_: Any = None) -> Any: ...
+def dce_sink(val: Any, *, prevent_mlir_dce: bool = False) -> None: ...
+def optimization_barrier[T](operand: T, /) -> T: ...
+def platform_dependent[*Args, T](
+    *args: *Args,
+    default: Callable[[*Args], T] | None = None,
+    **per_platform: Callable[[*Args], T],
+) -> T: ...
+def shape_as_value(shape: Any) -> Array[IntTuple]: ...
+def stage[Shape: _Shape](x: Array[Shape], /) -> Array[Shape]: ...
+def stop_gradient[T](x: T) -> T: ...
+def with_sharding_constraint[T](x: T, shardings: Any) -> T: ...

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_lax.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_lax.py
@@ -5,9 +5,12 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import jax
 import jax.lax as lax
 import jax.numpy as jnp
+import numpy as np
 from shape_extensions import assert_shape, IntTuple
 
 
@@ -907,3 +910,295 @@ def test_lax_linear_algebra_contractions() -> None:
     assert lax.RoundingMethod is not None
     assert lax.ScatterDimensionNumbers is not None
     assert lax.Tolerance is not None
+
+
+def generic_control_flow[Shape: IntTuple](
+    x: jax.Array[Shape],
+    pred_scalar: jax.Array[[]],
+) -> tuple[
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+]:
+    c = lax.cond(True, lambda v: v, lambda v: v, x)
+    c2 = lax.cond(pred_scalar, lambda v: v, lambda v: v, x)
+    fl = lax.fori_loop(0, 10, lambda i, v: v, x)
+    sw = lax.switch(0, [lambda v: v], x)
+    sw2 = lax.switch(0, [lambda v: v], operand=x)
+    sw3 = lax.switch(pred_scalar, [lambda v: v], x)
+    wl = lax.while_loop(lambda v: True, lambda v: v, x)
+    return c, c2, fl, sw, sw2, sw3, wl
+
+
+def test_control_flow_and_higher_order() -> None:
+    # cond with bool scalar, 0-D array, and keyword operand
+    c1 = lax.cond(True, lambda x: x + 1, lambda x: x - 1, jnp.ones((2, 3)))
+    assert_shape(c1.shape, (2, 3))
+
+    c2 = lax.cond(jnp.array(True), lambda x: x + 1, lambda x: x - 1, jnp.ones((2, 3)))
+    assert_shape(c2.shape, (2, 3))
+
+    c3 = lax.cond(False, lambda x: x, lambda x: x, operand=jnp.ones((2, 3)))
+    assert_shape(c3.shape, (2, 3))
+
+    c4 = lax.cond(True, lambda: jnp.ones(4), lambda: jnp.zeros(4))
+    assert_shape(c4.shape, (4,))
+
+    c5 = lax.cond(
+        True,
+        lambda a, b: a + b,
+        lambda a, b: a - b,
+        jnp.ones((2, 3)),
+        jnp.ones((2, 3)),
+    )
+    assert_shape(c5.shape, (2, 3))
+
+    # fori_loop
+    fl = lax.fori_loop(0, 5, lambda i, x: x + 1, jnp.zeros((2, 3)))
+    assert_shape(fl.shape, (2, 3))
+
+    fl2 = lax.fori_loop(
+        jnp.array(0), jnp.array(5), lambda i, x: x + 1, jnp.zeros((2, 3))
+    )
+    assert_shape(fl2.shape, (2, 3))
+
+    # map
+    m = lax.map(lambda x: x * 2, jnp.ones((4, 3)))
+    assert_shape(m.shape, (4, 3))
+
+    # scan
+    carry, ys = lax.scan(lambda c, x: (c + x, c * x), jnp.zeros(3), jnp.ones((5, 3)))
+    assert_shape(carry.shape, (3,))
+    assert_shape(ys.shape, (5, 3))
+
+    # switch
+    sw1 = lax.switch(1, [lambda x: x, lambda x: x * 2], jnp.ones((2, 3)))
+    assert_shape(sw1.shape, (2, 3))
+
+    sw2 = lax.switch(1, [lambda x: x, lambda x: x * 2], operand=jnp.ones((2, 3)))
+    assert_shape(sw2.shape, (2, 3))
+
+    sw3 = lax.switch(jnp.array(0), [lambda x: x, lambda x: x * 2], jnp.ones((2, 3)))
+    assert_shape(sw3.shape, (2, 3))
+
+    sw4 = lax.switch(0, [lambda: jnp.ones((2, 3)), lambda: jnp.zeros((2, 3))])
+    assert_shape(sw4.shape, (2, 3))
+
+    sw5 = lax.switch(
+        0,
+        [lambda a, b: a + b, lambda a, b: a - b],
+        jnp.ones((2, 3)),
+        jnp.ones((2, 3)),
+    )
+    assert_shape(sw5.shape, (2, 3))
+
+    # while_loop
+    wl = lax.while_loop(lambda x: x[0, 0] < 5, lambda x: x + 1, jnp.zeros((2, 3)))
+    assert_shape(wl.shape, (2, 3))
+
+
+def generic_parallel_ops[Shape: IntTuple](
+    x: jax.Array[Shape],
+) -> tuple[
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[IntTuple],
+    jax.Array[IntTuple],
+    jax.Array[IntTuple],
+    jax.Array[Shape],
+    jax.Array[[]],
+    int,
+]:
+    p1 = lax.pbroadcast(x, "i", 0)
+    p2 = lax.pcast(x, "i", to="varying")
+    p3 = lax.pmax(x, "i")
+    p4 = lax.pmean(x, "i")
+    p5 = lax.pmin(x, "i")
+    p6 = lax.ppermute(x, "i", [(0, 0)])
+    p7 = lax.pshuffle(x, "i", [0])
+    p8 = lax.psum(x, "i")
+    p9 = lax.pswapaxes(x, "i", 0)
+    p10 = lax.all_gather(x, "i")
+    p11 = lax.all_to_all(x, "i", 0, 0)
+    p12 = lax.psum_scatter(x, "i")
+    p13 = lax.ragged_all_to_all(
+        x,
+        x,
+        jnp.array([0]),
+        jnp.array([1]),
+        jnp.array([0]),
+        jnp.array([1]),
+        axis_name="i",
+    )
+    p14 = lax.axis_index("i")
+    p15 = lax.axis_size("i")
+    tok = lax.psend(x, "i", [(0, 0)])
+    _ = lax.precv(tok, x, "i", [(0, 0)])
+    return (
+        p1,
+        p2,
+        p3,
+        p4,
+        p5,
+        p6,
+        p7,
+        p8,
+        p9,
+        p10,
+        p11,
+        p12,
+        p13,
+        p14,
+        p15,
+    )
+
+
+def test_parallel_operations() -> None:
+    # Section 10 APIs: callable / existence
+    assert callable(lax.all_gather)
+    assert callable(lax.all_to_all)
+    assert callable(lax.axis_index)
+    assert callable(lax.axis_size)
+    assert callable(lax.pbroadcast)
+    assert callable(lax.pcast)
+    assert callable(lax.pmax)
+    assert callable(lax.pmean)
+    assert callable(lax.pmin)
+    assert callable(lax.ppermute)
+    assert callable(lax.precv)
+    assert callable(lax.psend)
+    assert callable(lax.pshuffle)
+    assert callable(lax.psum)
+    assert callable(lax.psum_scatter)
+    assert callable(lax.pswapaxes)
+    assert callable(lax.ragged_all_to_all)
+
+    # Static helper verification
+    x = jnp.ones((2, 3))
+    assert_shape(x.shape, (2, 3))
+
+
+def generic_special_math[Shape: IntTuple](
+    a: jax.Array[Shape],
+    b: jax.Array[Shape],
+    x: jax.Array[Shape],
+) -> tuple[
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[[]],
+    jax.Array[Shape],
+    jax.Array[IntTuple],
+]:
+    b1 = lax.betainc(a, b, x)
+    b2 = lax.betainc(1.0, 2.0, x)
+    b3 = lax.betainc(1.0, 2.0, 0.5)
+    r1 = lax.random_gamma_grad(a, x)
+    f1 = lax.fft(a, lax.FftType.FFT, (3,))
+    return b1, b2, b3, r1, f1
+
+
+def test_special_math() -> None:
+    a = jnp.ones((2, 3))
+    x = jnp.ones((2, 3)) * 0.5
+    assert_shape(lax.betainc(a, a, x).shape, (2, 3))
+    assert_shape(lax.betainc(1.0, 2.0, x).shape, (2, 3))
+    assert_shape(lax.betainc(1.0, 2.0, 0.5).shape, ())
+    assert_shape(lax.random_gamma_grad(a, x).shape, (2, 3))
+    assert_shape(lax.fft(lax.complex(a, a), lax.FftType.FFT, (3,)).shape, (2, 3))
+
+
+def generic_rng_and_data_types[KeyShape: IntTuple, Shape: IntTuple](
+    key: jax.Array[KeyShape],
+    shape: Shape,
+    zero_dim: jax.Array[[]],
+) -> tuple[
+    np.dtype,
+    jax.Array[KeyShape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+]:
+    dt = lax.dtype(key)
+    k_out, bits = lax.rng_bit_generator(key, shape)
+    u1 = lax.rng_uniform(0.0, 1.0, shape)
+    u2 = lax.rng_uniform(zero_dim, zero_dim, shape)
+    return dt, k_out, bits, u1, u2
+
+
+def test_rng_and_data_types() -> None:
+    k = jnp.zeros((4,), dtype="uint32")
+    k_out, bits = lax.rng_bit_generator(
+        k, (2, 3), algorithm=lax.RandomAlgorithm.RNG_THREE_FRY
+    )
+    assert_shape(k_out.shape, (4,))
+    assert_shape(bits.shape, (2, 3))
+    u1 = lax.rng_uniform(0.0, 1.0, (2, 3))
+    assert_shape(u1.shape, (2, 3))
+    u2 = lax.rng_uniform(jnp.array(0.0), jnp.array(1.0), (2, 3))
+    assert_shape(u2.shape, (2, 3))
+    assert lax.dtype(jnp.ones(3)) == jnp.float32
+
+
+def generic_compiler_and_misc[Shape: IntTuple](
+    x: jax.Array[Shape],
+    sharding: Any,
+) -> tuple[
+    Any,
+    Any,
+    jax.Array[Shape],
+    jax.Array[IntTuple],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+    jax.Array[Shape],
+]:
+    tok = lax.create_token()
+    tok2 = lax.after_all(tok)
+    lax.dce_sink(x)
+    ob = lax.optimization_barrier(x)
+    sav = lax.shape_as_value((2, 3))
+    st = lax.stage(x)
+    sg = lax.stop_gradient(x)
+    wsc = lax.with_sharding_constraint(x, sharding)
+    comp = lax.composite(lambda v: v, "comp")(x)
+    pd = lax.platform_dependent(x, default=lambda v: v)
+    return tok, tok2, ob, sav, st, sg, wsc, comp, pd
+
+
+def test_compiler_and_misc() -> None:
+    x = jnp.ones((2, 3))
+    tok = lax.create_token()
+    tok2 = lax.after_all(tok)
+    assert tok is not None and tok2 is not None
+    lax.dce_sink(x)
+    ob = lax.optimization_barrier(x)
+    assert_shape(ob.shape, (2, 3))
+    sav = lax.shape_as_value((2, 3))
+    assert_shape(sav.shape, (2,))
+    st = lax.stage(x)
+    assert_shape(st.shape, (2, 3))
+    sg = lax.stop_gradient(x)
+    assert_shape(sg.shape, (2, 3))
+    shd = getattr(jax, "sharding").SingleDeviceSharding(getattr(jax, "devices")()[0])
+    wsc = lax.with_sharding_constraint(x, shd)
+    assert_shape(wsc.shape, (2, 3))
+    comp_fn = lax.composite(lambda v: v * 2, "double")
+    assert_shape(comp_fn(x).shape, (2, 3))
+    pd1 = lax.platform_dependent(x, default=lambda v: v + 1, cpu=lambda v: v * 2)
+    assert_shape(pd1.shape, (2, 3))
+    pd2 = lax.platform_dependent(
+        x, x, default=lambda a, b: a + b, cpu=lambda a, b: a - b
+    )
+    assert_shape(pd2.shape, (2, 3))


### PR DESCRIPTION
## Summary

Rounds out the type stubs for `jax.lax`!

## Test plan

Updated existing unit tests; all pass locally:
```
$ uv tool run --from ruff==0.14.3 ruff format --check --config ruff.toml .
343 files already formatted
$ uv tool run --from ruff==0.14.3 ruff check --select I --config ruff.toml .
All checks passed!
$ uv run python test.py --no-test --no-conformance --no-jsonschema
Running formatting...
Finished in 2.71 seconds.
Running linting...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.92s
Finished in 1.16 seconds.
$ TENSOR_SHAPES_VENV=.venv uv run python tensor-shapes/pyrefly-jax-stubs/run_pyrefly.py --release
+ cargo build -p pyrefly --release
    Finished `release` profile [optimized + debuginfo] target(s) in 0.58s
PASS stubs (9 files)
PASS arithmetic (1 files)
PASS contractions (1 files)
PASS creation (1 files)
PASS fft (1 files)
PASS indexing (1 files)
PASS lax (1 files)
PASS linalg (1 files)
PASS matmul (1 files)
PASS nn (1 files)
PASS reductions (1 files)
PASS reshape (1 files)
PASS searching-sorting (1 files)
PASS structural (1 files)
PASS examples (1 files)
```

## AI disclosure

Changes generated with the assistance of a Gemini coding agent.