### PR TITLE
test: Add CONDA_PREFIX test

### DIFF
--- a/test/interpreter.md
+++ b/test/interpreter.md
@@ -1,5 +1,23 @@
 # Tests for interpreter selection
 
+## Active Conda environment takes priority over an ancestor venv
+
+The active environment uses the Pixi layout without a `pyvenv.cfg`. Its interpreter
+must be found through `CONDA_PREFIX`, even when it is not on `PATH`.
+
+```scrut {output_stream: stdout}
+$ mkdir -p "$TMPDIR/conda-priority/project/.pixi/envs/default/bin" "$TMPDIR/conda-priority/venv/bin" && \
+> touch "$TMPDIR/conda-priority/project/pyrefly.toml" "$TMPDIR/conda-priority/project/test.py" && \
+> touch "$TMPDIR/conda-priority/venv/pyvenv.cfg" "$TMPDIR/conda-priority/venv/bin/python" && \
+> ln -s "$(python3 -c 'import sys; print(sys.executable)')" "$TMPDIR/conda-priority/project/.pixi/envs/default/bin/python" && \
+> env -u VIRTUAL_ENV CONDA_PREFIX="$TMPDIR/conda-priority/project/.pixi/envs/default" \
+> "$PYREFLY" dump-config -c "$TMPDIR/conda-priority/project/pyrefly.toml"
+Configuration at * (glob)
+  Using interpreter: */conda-priority/project/.pixi/envs/default/bin/python (glob)
+* (glob+)
+[0]
+```
+
 ## Interpreter priority takes CLI interpreter
 
 ```scrut {output_stream: stdout}


### PR DESCRIPTION
# Summary

I noticed a bug related to how the interpreter gets resolved in conda environments in pyrefly 1.2.0.
This was already fixed in https://github.com/facebook/pyrefly/commit/ef9e9a0e6cf27d5096e56ec846ff1dc6532bb953. This PR adds a test for this to ensure it won't happen again.