### PR TITLE
feat: Add `pyrefly completion` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2348,6 +2357,7 @@ dependencies = [
  "blake3",
  "capnp",
  "clap",
+ "clap_complete",
  "codspeed-criterion-compat",
  "crossbeam-channel",
  "dashmap",

--- a/pyrefly/Cargo.toml
+++ b/pyrefly/Cargo.toml
@@ -40,6 +40,7 @@ arc-swap = { version = "1.9.2", features = ["weak"] }
 blake3 = { version = "=1.8.6", features = ["mmap", "rayon", "traits-preview"] }
 capnp = "0.25.6"
 clap = { version = "4.6.2", features = ["cargo", "derive", "env", "string", "unicode", "wrap_help"] }
+clap_complete = "4.6.9"
 crossbeam-channel = "0.5.16"
 dashmap = { version = "6.2.1", features = ["rayon", "serde"] }
 dupe = "0.9.1"

--- a/pyrefly/bin/main.rs
+++ b/pyrefly/bin/main.rs
@@ -10,8 +10,7 @@ use std::process::ExitCode;
 
 use clap::Parser;
 use clap::crate_version;
-use library::Command;
-use library::util::CommonGlobalArgs;
+use library::Args;
 use pyrefly::commands::lsp::filter_unrecognized_lsp_args;
 use pyrefly::library::library::library::library;
 use pyrefly_util::args::get_args_expanded;
@@ -28,22 +27,6 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[global_allocator]
 #[cfg(target_os = "windows")]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
-/// Main CLI entrypoint for Pyrefly.
-#[deny(clippy::missing_docs_in_private_items)]
-#[derive(Debug, Parser)]
-#[command(name = "pyrefly")]
-#[command(about = "A fast Python type checker", long_about = None)]
-#[command(version)]
-struct Args {
-    /// Common global arguments shared across commands.
-    #[command(flatten)]
-    common: CommonGlobalArgs,
-
-    /// Subcommand execution args.
-    #[command(subcommand)]
-    command: Command,
-}
 
 /// Run based on the command line arguments.
 async fn run() -> anyhow::Result<ExitCode> {

--- a/pyrefly/lib/commands/all.rs
+++ b/pyrefly/lib/commands/all.rs
@@ -5,9 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::io;
+use std::io::Write;
 use std::sync::Arc;
 
+use clap::CommandFactory;
+use clap::Parser;
 use clap::Subcommand;
+use clap_complete::Shell;
+use clap_complete::generate;
 use pyrefly_util::telemetry::Telemetry;
 use pyrefly_util::thread_pool::ThreadCount;
 
@@ -27,7 +33,24 @@ use crate::commands::stubgen::StubgenArgs;
 use crate::commands::suppress::SuppressArgs;
 use crate::commands::tsp::TspArgs;
 use crate::commands::util::CommandExitStatus;
+use crate::commands::util::CommonGlobalArgs;
 use crate::lsp::non_wasm::external_provider::NoExternalProvider;
+
+/// Main CLI entrypoint for Pyrefly.
+#[deny(clippy::missing_docs_in_private_items)]
+#[derive(Debug, Parser)]
+#[command(name = "pyrefly")]
+#[command(about = "A fast Python type checker", long_about = None)]
+#[command(version)]
+pub struct Args {
+    /// Common global arguments shared across commands.
+    #[command(flatten)]
+    pub common: CommonGlobalArgs,
+
+    /// Subcommand execution args.
+    #[command(subcommand)]
+    pub command: Command,
+}
 
 /// Subcommands to run Pyrefly with.
 #[deny(clippy::missing_docs_in_private_items)]
@@ -35,6 +58,13 @@ use crate::lsp::non_wasm::external_provider::NoExternalProvider;
 pub enum Command {
     /// Full type checking on a file or a project
     Check(FullCheckArgs),
+
+    /// Generate a shell completion script on stdout.
+    Completion {
+        /// Shell to generate completions for.
+        #[arg(long, value_enum)]
+        shell: Shell,
+    },
 
     /// Check a Python code snippet
     Snippet(SnippetCheckArgs),
@@ -86,6 +116,13 @@ impl Command {
             Command::Check(args) => {
                 args.run(version, config_configurer_wrapper, thread_count)
                     .await
+            }
+            Command::Completion { shell } => {
+                // Buffer generation so stdout errors are returned instead of panicking.
+                let mut script = Vec::new();
+                generate(shell, &mut Args::command(), "pyrefly", &mut script);
+                io::stdout().lock().write_all(&script)?;
+                Ok((CommandExitStatus::Success, None))
             }
             Command::Snippet(args) => args.run(version, thread_count).await,
             Command::BuckCheck(args) => Ok((args.run(thread_count)?, None)),

--- a/pyrefly/lib/lib.rs
+++ b/pyrefly/lib/lib.rs
@@ -67,6 +67,7 @@ pub mod library {
     pub mod library {
         pub mod library {
             pub mod library {
+                pub use crate::commands::all::Args;
                 pub use crate::commands::all::Command;
                 pub use crate::commands::check::CheckArgs;
                 pub use crate::commands::check::CheckResult;

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -83,6 +83,53 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
+## Shell completion
+
+Generate a completion script with `pyrefly completion --shell <shell>`. Supported
+shells are `bash`, `zsh`, `fish`, `powershell`, and `elvish`. The script is written
+to standard output.
+
+For Bash, add this to `~/.bashrc`:
+
+```bash
+source <(pyrefly completion --shell bash)
+```
+
+For Zsh, add this to `~/.zshrc` after initializing completion with `compinit`:
+
+```zsh
+autoload -Uz compinit
+compinit
+source <(pyrefly completion --shell zsh)
+```
+
+For Fish, save the script in its completions directory:
+
+```fish
+mkdir -p ~/.config/fish/completions
+pyrefly completion --shell fish > ~/.config/fish/completions/pyrefly.fish
+```
+
+For PowerShell, add this to your profile (`$PROFILE`):
+
+```powershell
+pyrefly completion --shell powershell | Out-String | Invoke-Expression
+```
+
+For Elvish, save the script and load it from `~/.config/elvish/rc.elv`:
+
+```sh
+mkdir -p ~/.config/elvish/lib
+pyrefly completion --shell elvish > ~/.config/elvish/lib/pyrefly.elv
+```
+
+```elvish
+use pyrefly
+```
+
+Restart your shell after setup. Regenerate saved completion files after upgrading
+Pyrefly to include any new commands and options.
+
 ## Configure
 
 You can set up a basic configuration file to type-check your project. You can add configuration options to a `pyproject.toml` file or create a `pyrefly.toml` file in your project directory. All [configuration options are documented here](../configuration).


### PR DESCRIPTION
# Summary

<!-- Describe the change in this PR -->

Fixes #4882

# Test Plan

```
$ cargo run -- completion --shell fish > pyrefly.fish
$ cargo run -- completion --shell bash > pyrefly.bash
$ cargo run -- completion --shell zsh > pyrefly.zsh

# fish
$ source pyrefly.fish
$ pyrefly <TAB>
bazel-check                                                 (Entry point for Bazel integration)
buck-check                                                   (Entry point for Buck integration)
check                                               (Full type checking on a file or a project)
completion                                       (Generate a shell completion script on stdout)
coverage                                                               (Type coverage commands)
dump-config  (Dump info about pyrefly's configuration. Use by replacing `check` with `dump-co…)
help                                (Print this message or the help of the given subcommand(s))
infer                               (Automatically add type annotations to a file or directory)
init  (Initialize a new pyrefly config in the given directory, or migrate an existing mypy or…)
lsp                                                                       (Start an LSP server)
report  (Deprecated alias for `pyrefly coverage report`. Use `pyrefly coverage report` instead)
snippet                                                           (Check a Python code snippet)
stubgen                                     (Generate .pyi stub files from Python source files)
suppress             (Suppress type errors by adding ignore comments, or remove unused ignores)
tsp                                                                        (Start a TSP server)

# bash
$ source pyrefly.bash
$ pyrefly <TAB>
-j           --threads    --version    dump-config  lsp          report
-v           --color      check        buck-check   tsp          suppress
-h           --verbose    completion   bazel-check  infer        stubgen
-V           --help       snippet      init         coverage     help

# zsh
$ source pyrefly.zsh
$ pyrefly <TAB>
bazel-check  -- Entry point for Bazel integration
buck-check   -- Entry point for Buck integration
check        -- Full type checking on a file or a project
completion   -- Generate a shell completion script on stdout
coverage     -- Type coverage commands
dump-config  -- Dump info about pyrefly's configuration. Use by replacing `check` with `dum
help         -- Print this message or the help of the given subcommand(s)
infer        -- Automatically add type annotations to a file or directory
init         -- Initialize a new pyrefly config in the given directory, or migrate an exist
lsp          -- Start an LSP server
report       -- Deprecated alias for `pyrefly coverage report`. Use `pyrefly coverage repor
snippet      -- Check a Python code snippet
stubgen      -- Generate .pyi stub files from Python source files
suppress     -- Suppress type errors by adding ignore comments, or remove unused ignores
tsp          -- Start a TSP server
```

this can then get added to the homebrew formula like in https://github.com/Homebrew/homebrew-core/blob/fbd5caa399af11f0e4bb74c014204bbefc9318a6/Formula/p/pixi.rb#L45 or to the conda recipe like in https://github.com/conda-forge/ty-feedstock/blob/14216677727cdb373eb51ff871a225cec2f10cea/recipe/recipe.yaml#L51 to enable shell completions for all brew / pixi users automatically