### PR TITLE
[tensor-shapes] add stubs for jax.numpy constants, dtypes, etc.

### DIFF
--- a/pyrefly/lib/test/pydantic/util.rs
+++ b/pyrefly/lib/test/pydantic/util.rs
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use crate::test::util::TestEnv;
 use pyrefly_python::ignore::TypeIgnoreUnknownTagBehavior;
+
+use crate::test::util::TestEnv;
 
 pub fn pydantic_env() -> TestEnv {
     let path = std::env::var("PYDANTIC_TEST_PATH").expect("PYDANTIC_TEST_PATH must be set");

--- a/pyrefly/lib/test/suppression.rs
+++ b/pyrefly/lib/test/suppression.rs
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use pyrefly_python::ignore::TypeIgnoreUnknownTagBehavior as UnknownTagBehavior;
+
 use crate::state::require::Require;
 use crate::test::util::TestEnv;
 use crate::testcase;
-use pyrefly_python::ignore::TypeIgnoreUnknownTagBehavior as UnknownTagBehavior;
 
 testcase!(
     test_pyrefly_suppression,

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
@@ -3,7 +3,16 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Callable, Literal, NamedTuple, overload, Sequence, Unpack
+from typing import (
+    Any,
+    Callable,
+    ContextManager,
+    Literal,
+    NamedTuple,
+    overload,
+    Sequence,
+    Unpack,
+)
 
 from jax._array import Array as Array, Array as ndarray
 from jax._shapes import (
@@ -53,6 +62,31 @@ from jax._shapes import (
     vstack_shape,
 )
 from jax.typing import DTypeLike
+from numpy import (
+    array_repr as array_repr,
+    array_str as array_str,
+    character as character,
+    complexfloating as complexfloating,
+    dtype as dtype,
+    e as e,
+    euler_gamma as euler_gamma,
+    flexible as flexible,
+    floating as floating,
+    generic as generic,
+    inexact as inexact,
+    inf as inf,
+    integer as integer,
+    iterable as iterable,
+    nan as nan,
+    newaxis as newaxis,
+    number as number,
+    object_ as object_,
+    pi as pi,
+    save as save,
+    savez as savez,
+    signedinteger as signedinteger,
+    unsignedinteger as unsignedinteger,
+)
 from shape_extensions import (
     broadcast,
     Elements,
@@ -3254,10 +3288,234 @@ def ix_[Shapes: IntTuples](
 @overload
 def ix_(*args: Array[Any]) -> tuple[Array[IntTuple], ...]: ...
 
-float32: Any
-float64: Any
+class finfo:
+    bits: int
+    dtype: Any
+    eps: float
+    epsneg: float
+    iexp: int
+    machep: int
+    max: float
+    maxexp: int
+    min: float
+    minexp: int
+    negep: int
+    nexp: int
+    nmant: int
+    precision: int
+    resolution: float
+    smallest_normal: float
+    smallest_subnormal: float
+    tiny: float
+    def __init__(self, dtype: DTypeLike) -> None: ...
+
+class iinfo:
+    bits: int
+    dtype: Any
+    kind: str
+    max: int
+    min: int
+    def __init__(self, dtype: DTypeLike) -> None: ...
+
+class ufunc:
+    @property
+    def nin(self) -> int: ...
+    @property
+    def nout(self) -> int: ...
+    @property
+    def nargs(self) -> int: ...
+    @property
+    def ntypes(self) -> int: ...
+    @property
+    def types(self) -> list[str]: ...
+    @property
+    def identity(self) -> Any: ...
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+    def reduce(
+        self,
+        a: Any,
+        axis: int = 0,
+        dtype: Any = None,
+        out: Any = None,
+        keepdims: bool = False,
+    ) -> Any: ...
+    def accumulate(
+        self,
+        a: Any,
+        axis: int = 0,
+        dtype: Any = None,
+        out: Any = None,
+    ) -> Any: ...
+    def reduceat(
+        self,
+        a: Any,
+        indices: Sequence[int],
+        axis: int = 0,
+        dtype: Any = None,
+        out: Any = None,
+    ) -> Any: ...
+    def outer(self, A: Any, B: Any, /, **kwargs: Any) -> Any: ...
+
+class ComplexWarning(UserWarning): ...
+
+@overload
+def astype[Shape: _Shape](
+    x: Array[Shape],
+    dtype: DTypeLike | None,
+    /,
+    *,
+    copy: bool = False,
+    device: Any = None,
+) -> Array[Shape]: ...
+@overload
+def astype(
+    x: _Scalar,
+    dtype: DTypeLike | None,
+    /,
+    *,
+    copy: bool = False,
+    device: Any = None,
+) -> Array[()]: ...
+@overload
+def astype(
+    x: Any,
+    dtype: DTypeLike | None,
+    /,
+    *,
+    copy: bool = False,
+    device: Any = None,
+) -> Array[IntTuple]: ...
+def can_cast(from_: Any, to: DTypeLike, casting: str = "safe") -> bool: ...
+def isdtype(
+    dtype: DTypeLike, kind: str | DTypeLike | tuple[str | DTypeLike, ...]
+) -> bool: ...
+def issubdtype(arg1: DTypeLike, arg2: DTypeLike) -> bool: ...
+def promote_types(a: DTypeLike, b: DTypeLike) -> Any: ...
+def result_type(*args: Any) -> Any: ...
+
+class _Mgrid:
+    @overload
+    def __getitem__(self, key: slice) -> Array[[Any]]: ...
+    @overload
+    def __getitem__(self, key: tuple[slice, slice]) -> Array[[2, Any, Any]]: ...
+    @overload
+    def __getitem__(
+        self, key: tuple[slice, slice, slice]
+    ) -> Array[[3, Any, Any, Any]]: ...
+    @overload
+    def __getitem__(self, key: tuple[slice, ...]) -> Array[IntTuple]: ...
+    @overload
+    def __getitem__(self, key: Any) -> Array[IntTuple]: ...
+
+class _Ogrid:
+    @overload
+    def __getitem__(self, key: slice) -> Array[[Any]]: ...
+    @overload
+    def __getitem__(self, key: tuple[slice, slice]) -> list[Array[IntTuple]]: ...
+    @overload
+    def __getitem__(self, key: tuple[slice, slice, slice]) -> list[Array[IntTuple]]: ...
+    @overload
+    def __getitem__(self, key: tuple[slice, ...]) -> list[Array[IntTuple]]: ...
+    @overload
+    def __getitem__(self, key: Any) -> Array[IntTuple] | list[Array[IntTuple]]: ...
+
+mgrid: _Mgrid
+ogrid: _Ogrid
+
+class _CClass:
+    def __getitem__(self, key: Any) -> Array[IntTuple]: ...
+
+class _RClass:
+    def __getitem__(self, key: Any) -> Array[IntTuple]: ...
+
+c_: _CClass
+r_: _RClass
+
+class _IndexExpression:
+    @overload
+    def __getitem__[TupleT: tuple[Any, ...]](self, item: TupleT) -> TupleT: ...
+    @overload
+    def __getitem__[T](self, item: T) -> tuple[T]: ...
+
+class _SClass:
+    def __getitem__[T](self, item: T) -> T: ...
+
+index_exp: _IndexExpression
+s_: _SClass
+
+def ndim(a: Any) -> int: ...
+@overload
+def shape[Shape: _Shape](a: Array[Shape]) -> Shape: ...
+@overload
+def shape(a: Any) -> tuple[int, ...]: ...
+def size(a: Any, axis: int | Sequence[int] | None = None) -> int: ...
+def get_printoptions() -> dict[str, Any]: ...
+def set_printoptions(
+    precision: int | None = None,
+    threshold: int | None = None,
+    edgeitems: int | None = None,
+    linewidth: int | None = None,
+    suppress: bool | None = None,
+    nanstr: str | None = None,
+    infstr: str | None = None,
+    formatter: dict[str, Callable[..., str]] | None = None,
+    sign: str | None = None,
+    floatmode: str | None = None,
+    **kwarg: Any,
+) -> None: ...
+def printoptions(*args: Any, **kwargs: Any) -> ContextManager[dict[str, Any]]: ...
+def apply_along_axis(
+    func1d: Callable[..., Any], axis: int, arr: Any, *args: Any, **kwargs: Any
+) -> Array[IntTuple]: ...
+def apply_over_axes(
+    func: Callable[[Any, int], Any], a: Any, axes: Sequence[int]
+) -> Array[IntTuple]: ...
+def frompyfunc(
+    func: Callable[..., Any], /, nin: int, nout: int, *, identity: Any = None
+) -> ufunc: ...
+def vectorize(pyfunc: Any, *, excluded: Any = ..., signature: Any = None) -> Any: ...
+def load(file: Any, *args: Any, **kwargs: Any) -> Any: ...
+
+# Scalar constructors
+
+bool: Any
+bool_: Any
+int_: Any
+int8: Any
+int16: Any
 int32: Any
 int64: Any
+uint: Any
+uint8: Any
+uint16: Any
+uint32: Any
+uint64: Any
+int1: Any
+int2: Any
+int4: Any
+uint1: Any
+uint2: Any
+uint4: Any
+float_: Any
+float16: Any
+float32: Any
+float64: Any
+bfloat16: Any
+single: Any
+double: Any
+csingle: Any
+cdouble: Any
+complex_: Any
 complex64: Any
 complex128: Any
-bool_: Any
+float4_e2m1fn: Any
+float6_e2m3fn: Any
+float6_e3m2fn: Any
+float8_e3m4: Any
+float8_e4m3: Any
+float8_e4m3b11fnuz: Any
+float8_e4m3fn: Any
+float8_e4m3fnuz: Any
+float8_e5m2: Any
+float8_e5m2fnuz: Any
+float8_e8m0fnu: Any

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_creation.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_creation.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import math
+
 import jax.numpy as jnp
 from shape_extensions import assert_shape
 
@@ -192,3 +194,77 @@ def test_array_and_asarray() -> None:
     assert jnp.asarray([1, 2, 3]).shape == (3,)
     assert jnp.array([[1, 2], [3, 4]]).shape == (2, 2)
     assert jnp.asarray([[1, 2], [3, 4]]).shape == (2, 2)
+
+
+def test_astype() -> None:
+    x = jnp.ones((2, 3))
+    assert_shape(jnp.astype(x, jnp.int32).shape, (2, 3))
+    assert_shape(jnp.astype(x, None).shape, (2, 3))
+    assert_shape(jnp.astype(5, jnp.float32).shape, ())
+    assert_shape(jnp.astype(2.5, jnp.int32).shape, ())
+
+
+def test_shape_ndim_size() -> None:
+    x = jnp.ones((2, 3, 4))
+    assert_shape(jnp.shape(x), (2, 3, 4))
+    assert jnp.shape(x) == (2, 3, 4)
+    assert jnp.ndim(x) == 3
+    assert jnp.size(x) == 24
+    assert jnp.size(x, axis=0) == 2
+    assert jnp.size(x, axis=1) == 3
+    assert jnp.size(x, axis=2) == 4
+
+    # Scalars
+    assert jnp.shape(5) == ()
+    assert jnp.ndim(5) == 0
+    assert jnp.size(5) == 1
+
+    # Generic inputs
+    assert jnp.shape([[1, 2], [3, 4]]) == (2, 2)
+    assert jnp.ndim([[1, 2], [3, 4]]) == 2
+    assert jnp.size([[1, 2], [3, 4]]) == 4
+
+
+def test_constants() -> None:
+    assert jnp.pi > 3.14
+    assert jnp.e > 2.71
+    assert jnp.euler_gamma > 0.57
+    assert jnp.inf > 1e10
+    assert math.isnan(jnp.nan)
+    assert jnp.newaxis is None
+
+    x = jnp.array([jnp.pi, jnp.e])
+    assert_shape(x.shape, (2,))
+    assert_shape(x[:, jnp.newaxis].shape, (2, 1))
+
+
+def test_dtypes_and_type_inspection() -> None:
+    # Scalar classes and hierarchy
+    assert issubclass(jnp.floating, jnp.inexact)
+    assert issubclass(jnp.integer, jnp.number)
+    assert issubclass(jnp.number, jnp.generic)
+
+    # Dtype objects and info
+    fi = jnp.finfo(jnp.float32)
+    assert fi.bits == 32
+    assert fi.max > 1e30
+
+    ii = jnp.iinfo(jnp.int32)
+    assert ii.bits == 32
+    assert ii.max == 2147483647
+
+    # Casting & inspection
+    assert jnp.can_cast(jnp.int32, jnp.int64)
+    assert not jnp.can_cast(jnp.int64, jnp.int32)
+    assert jnp.isdtype(jnp.float32, "real floating")
+    assert jnp.isdtype(jnp.int32, "integral")
+    assert jnp.issubdtype(jnp.int32, jnp.integer)
+    assert jnp.promote_types(jnp.int32, jnp.float32) == jnp.float32
+    assert jnp.result_type(jnp.int32, jnp.float32) == jnp.float32
+
+    # Various dtype constants exist and can be used with array constructors
+    assert_shape(jnp.zeros(2, dtype=jnp.bfloat16).shape, (2,))
+    assert_shape(jnp.zeros(2, dtype=jnp.float8_e4m3fn).shape, (2,))
+    assert_shape(jnp.zeros(2, dtype=jnp.int8).shape, (2,))
+    assert_shape(jnp.zeros(2, dtype=jnp.uint32).shape, (2,))
+    assert_shape(jnp.zeros(2, dtype=jnp.complex64).shape, (2,))

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_indexing.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_indexing.py
@@ -365,3 +365,26 @@ def test_delete_and_insert() -> None:
 def test_trim_zeros() -> None:
     a = jnp.array([0, 0, 1, 2, 0])
     assert_shape(jnp.trim_zeros(a).shape, (2,))
+
+
+def test_mgrid_and_ogrid() -> None:
+    assert_shape(jnp.mgrid[0:5].shape, (5,))
+    assert_shape(jnp.mgrid[0:5, 0:3].shape, (2, 5, 3))
+    assert_shape(jnp.mgrid[0:5, 0:3, 0:2].shape, (3, 5, 3, 2))
+
+    assert_shape(jnp.ogrid[0:5].shape, (5,))
+    o1, o2 = jnp.ogrid[0:5, 0:3]
+    assert_shape(o1.shape, (5, 1))
+    assert_shape(o2.shape, (1, 3))
+
+
+def test_index_concatenation_and_slice_objects() -> None:
+    a = jnp.array([1, 2, 3])
+    b = jnp.array([4, 5, 6])
+    assert_shape(jnp.c_[a, b].shape, (3, 2))
+    assert_shape(jnp.r_[a, b].shape, (6,))
+
+    s = jnp.s_[0:5]
+    assert s == slice(0, 5, None)
+    idx = jnp.index_exp[0:5, 1]
+    assert idx == (slice(0, 5, None), 1)


### PR DESCRIPTION
## Summary

Constants, dtypes, and APIs imported directly from NumPy.