### PR TITLE
[tensor-shapes] add stubs for remaining jax.numpy APIs

### DIFF
--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/_shapes.pyi
@@ -1357,3 +1357,211 @@ def ix_shapes(shapes: IntTuples) -> IntTuples:
             for shape, i in zip(shapes, range(len(shapes)))
         )
     )
+
+@type_shape_dsl_function
+def convolve_shape(a_shape: IntTuple, v_shape: IntTuple, mode: str) -> IntTuple:
+    if len(a_shape) != 1 or len(v_shape) != 1:
+        return dsl.Invalid("convolve and correlate only support 1-dimensional inputs")
+    n = a_shape[0]
+    m = v_shape[0]
+    zero_tuple = dsl.IntTuple((0,))
+    zero = zero_tuple[0]
+    if n == zero or m == zero:
+        return dsl.Invalid("inputs cannot be empty")
+    if mode == "full":
+        return dsl.IntTuple((n + m - 1,))
+    if mode == "same":
+        if n == m:
+            return dsl.IntTuple((n,))
+        if dsl.is_concrete_int(n) and dsl.is_concrete_int(m):
+            if n < m:
+                return dsl.IntTuple((m,))
+            return dsl.IntTuple((n,))
+        return dsl.IntTuple((dsl.Int.gradual(),))
+    if mode == "valid":
+        if n == m:
+            return dsl.IntTuple((1,))
+        if dsl.is_concrete_int(n) and dsl.is_concrete_int(m):
+            if n < m:
+                return dsl.IntTuple((m - n + 1,))
+            return dsl.IntTuple((n - m + 1,))
+        return dsl.IntTuple((dsl.Int.gradual(),))
+    return dsl.Invalid("mode must be one of ['full', 'same', 'valid']")
+
+@type_shape_dsl_function
+def append_shape(
+    arr_shape: IntTuple, values_shape: IntTuple, axis: int | None
+) -> IntTuple:
+    if axis is None:
+        return dsl.IntTuple((dsl.prod(arr_shape) + dsl.prod(values_shape),))
+    if dsl.is_int_value(axis):
+        rank = len(arr_shape)
+        if rank == 0 or len(values_shape) == 0:
+            return dsl.Invalid("zero-dimensional arrays cannot be concatenated")
+        if rank != len(values_shape):
+            return dsl.Invalid(
+                "all input arrays must have the same number of dimensions"
+            )
+        if axis < 0 - rank or axis >= rank:
+            return dsl.Invalid("axis out of bounds")
+        if axis < 0:
+            norm_axis = axis + rank
+        else:
+            norm_axis = axis + 0
+        if any(arr_shape[i] != values_shape[i] for i in range(rank) if i != norm_axis):
+            return dsl.Invalid(
+                "all input array dimensions for the concatenation axis must match exactly"
+            )
+        return dsl.IntTuple(
+            (
+                arr_shape[i] + values_shape[i] if i == norm_axis else arr_shape[i]
+                for i in range(rank)
+            )
+        )
+    return dsl.Invalid("axis must be an integer or None")
+
+@type_shape_dsl_function
+def packbits_shape(shape: IntTuple, axis: int | None) -> IntTuple:
+    if axis is None:
+        return dsl.IntTuple(((dsl.prod(shape) + 7) // 8,))
+    if dsl.is_int_value(axis):
+        rank = len(shape)
+        if rank == 0:
+            return dsl.Invalid("zero-dimensional array cannot be packed along an axis")
+        if axis < 0 - rank or axis >= rank:
+            return dsl.Invalid("axis out of bounds")
+        if axis < 0:
+            norm_axis = axis + rank
+        else:
+            norm_axis = axis + 0
+        return dsl.IntTuple(
+            ((shape[i] + 7) // 8 if i == norm_axis else shape[i] for i in range(rank))
+        )
+    return dsl.Invalid("axis must be an integer or None")
+
+@type_shape_dsl_function
+def unpackbits_shape(shape: IntTuple, axis: int | None, count: int | None) -> IntTuple:
+    if axis is None:
+        if count is not None:
+            if dsl.is_int_value(count):
+                return dsl.IntTuple((count + 0,))
+            return dsl.Invalid("count must be an integer or None")
+        return dsl.IntTuple((dsl.prod(shape) * 8,))
+    if dsl.is_int_value(axis):
+        rank = len(shape)
+        if rank == 0:
+            return dsl.Invalid(
+                "zero-dimensional array cannot be unpacked along an axis"
+            )
+        if axis < 0 - rank or axis >= rank:
+            return dsl.Invalid("axis out of bounds")
+        if axis < 0:
+            norm_axis = axis + rank
+        else:
+            norm_axis = axis + 0
+        if count is not None:
+            if dsl.is_int_value(count):
+                return dsl.IntTuple(
+                    (count + 0 if i == norm_axis else shape[i] for i in range(rank))
+                )
+            return dsl.Invalid("count must be an integer or None")
+        return dsl.IntTuple(
+            (shape[i] * 8 if i == norm_axis else shape[i] for i in range(rank))
+        )
+    return dsl.Invalid("axis must be an integer or None")
+
+@type_shape_dsl_function
+def histogram_counts_shape(bins: int) -> IntTuple:
+    if bins < 0:
+        return dsl.Invalid("bins must be non-negative")
+    return dsl.IntTuple((bins + 0,))
+
+@type_shape_dsl_function
+def histogram_edges_shape(bins: int) -> IntTuple:
+    if bins < 0:
+        return dsl.Invalid("bins must be non-negative")
+    return dsl.IntTuple((bins + 1,))
+
+@type_shape_dsl_function
+def histogram2d_counts_shape(bins: int) -> IntTuple:
+    if bins < 0:
+        return dsl.Invalid("bins must be non-negative")
+    return dsl.IntTuple((bins + 0, bins + 0))
+
+@type_shape_dsl_function
+def poly_shape(shape: IntTuple) -> IntTuple:
+    rank = len(shape)
+    if rank == 1:
+        return dsl.IntTuple((shape[0] + 1,))
+    if rank == 2:
+        if shape[0] != shape[1]:
+            return dsl.Invalid("input must be 1d or non-empty square 2d array")
+        return dsl.IntTuple((shape[0] + 1,))
+    return dsl.Invalid("input must be 1d or non-empty square 2d array")
+
+@type_shape_dsl_function
+def polyadd_shape(s1: IntTuple, s2: IntTuple) -> IntTuple:
+    if len(s1) != 1 or len(s2) != 1:
+        return dsl.Invalid("polynomial inputs must be 1-dimensional")
+    n = s1[0]
+    m = s2[0]
+    if n == m:
+        return s1
+    if dsl.is_concrete_int(n) and dsl.is_concrete_int(m):
+        if n < m:
+            return s2
+        return s1
+    return dsl.IntTuple((dsl.Int.gradual(),))
+
+@type_shape_dsl_function
+def polyder_shape(shape: IntTuple, m: int) -> IntTuple:
+    if len(shape) != 1:
+        return dsl.Invalid("input must be 1-dimensional")
+    if m < 0:
+        return dsl.Invalid("Order of derivative must be positive")
+    if m == 0:
+        return shape
+    n = shape[0]
+    m_dim_tuple = dsl.IntTuple((m + 0,))
+    m_dim = m_dim_tuple[0]
+    if n == m_dim:
+        return dsl.IntTuple((0,))
+    if dsl.is_concrete_int(n):
+        if n < m_dim:
+            return dsl.IntTuple((0,))
+        return dsl.IntTuple((n - m_dim,))
+    return dsl.IntTuple((dsl.Int.gradual(),))
+
+@type_shape_dsl_function
+def polyint_shape(shape: IntTuple, m: int) -> IntTuple:
+    if len(shape) != 1:
+        return dsl.Invalid("input must be 1-dimensional")
+    if m < 0:
+        return dsl.Invalid("Order of integral must be positive")
+    return dsl.IntTuple((shape[0] + m,))
+
+@type_shape_dsl_function
+def polydiv_quotient_shape(u_shape: IntTuple, v_shape: IntTuple) -> IntTuple:
+    if len(u_shape) != 1 or len(v_shape) != 1:
+        return dsl.Invalid("polynomial inputs must be 1-dimensional")
+    n = u_shape[0]
+    m = v_shape[0]
+    if n == m:
+        return dsl.IntTuple((1,))
+    if dsl.is_concrete_int(n) and dsl.is_concrete_int(m):
+        if n < m:
+            return dsl.IntTuple((1,))
+        return dsl.IntTuple((n - m + 1,))
+    return dsl.IntTuple((dsl.Int.gradual(),))
+
+@type_shape_dsl_function
+def polyfit_shape(deg: int) -> IntTuple:
+    if deg < 0:
+        return dsl.Invalid("deg must be non-negative")
+    return dsl.IntTuple((deg + 1,))
+
+@type_shape_dsl_function
+def polyfit_cov_shape(deg: int) -> IntTuple:
+    if deg < 0:
+        return dsl.Invalid("deg must be non-negative")
+    return dsl.IntTuple((deg + 1, deg + 1))

--- a/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
+++ b/tensor-shapes/pyrefly-jax-stubs/jax-stubs/numpy/__init__.pyi
@@ -16,6 +16,7 @@ from typing import (
 
 from jax._array import Array as Array, Array as ndarray
 from jax._shapes import (
+    append_shape,
     atleast_1d_shape,
     atleast_2d_shape,
     atleast_3d_shape,
@@ -23,6 +24,7 @@ from jax._shapes import (
     column_stack_shape,
     compress_shape,
     concatenate_shape,
+    convolve_shape,
     cross_axes_shape,
     cross_axis_shape,
     diag_indices_from_shape,
@@ -33,6 +35,9 @@ from jax._shapes import (
     expand_dims_shape,
     fill_diagonal_shape,
     flip_shape,
+    histogram2d_counts_shape,
+    histogram_counts_shape,
+    histogram_edges_shape,
     hstack_shape,
     inner_shape,
     int_min,
@@ -41,7 +46,15 @@ from jax._shapes import (
     matmul_shape,
     matvec_shape,
     moveaxis_shape,
+    packbits_shape,
     permute_shape,
+    poly_shape,
+    polyadd_shape,
+    polyder_shape,
+    polydiv_quotient_shape,
+    polyfit_cov_shape,
+    polyfit_shape,
+    polyint_shape,
     ravel_shape,
     reduce_shape,
     reshape_shape,
@@ -59,6 +72,7 @@ from jax._shapes import (
     tensordot_shape,
     top_k_shape,
     trace_shape,
+    unpackbits_shape,
     vecmat_shape,
     vstack_shape,
 )
@@ -172,6 +186,10 @@ def asarray(
     device: Any = ...,
     out_sharding: Any = ...,
 ) -> Array[IntTuple]: ...
+@overload
+def copy[Shape: _Shape](a: Array[Shape], order: str | None = None) -> Array[Shape]: ...
+@overload
+def copy(a: Any, order: str | None = None) -> Array[IntTuple]: ...
 
 # Literal tuples and values typed as `IntTuple` retain their shape. Other integer
 # sequences fall through to a gradual overload rather than being rejected.
@@ -1507,6 +1525,18 @@ def concatenate(
 
 concat = concatenate
 
+@overload
+def append[Shape1: _Shape, Shape2: _Shape, Axis: Flag[int | None] = None](
+    arr: Array[Shape1],
+    values: Array[Shape2],
+    axis: Axis = None,
+) -> Array[append_shape(Shape1, Shape2, Axis)]: ...
+@overload
+def append(
+    arr: Any,
+    values: Any,
+    axis: int | None = None,
+) -> Array[IntTuple]: ...
 @overload
 def stack[Shapes: IntTuples, Axis: Flag[int] = 0](
     arrays: MapIntTuples[lambda S: Array[S], Shapes],
@@ -3785,6 +3815,276 @@ def frompyfunc(
 ) -> ufunc: ...
 def vectorize(pyfunc: Any, *, excluded: Any = ..., signature: Any = None) -> Any: ...
 def load(file: Any, *args: Any, **kwargs: Any) -> Any: ...
+
+# Bit packing
+
+@overload
+def packbits[Shape: _Shape, Axis: Flag[int | None] = None](
+    a: Array[Shape],
+    axis: Axis = None,
+    bitorder: str = "big",
+) -> Array[packbits_shape(Shape, Axis)]: ...
+@overload
+def packbits(
+    a: Any,
+    axis: int | None = None,
+    bitorder: str = "big",
+) -> Array[IntTuple]: ...
+@overload
+def unpackbits[
+    Shape: _Shape,
+    Axis: Flag[int | None] = None,
+    Count: Flag[int | None] = None,
+](
+    a: Array[Shape],
+    axis: Axis = None,
+    count: Count = None,
+    bitorder: str = "big",
+) -> Array[unpackbits_shape(Shape, Axis, Count)]: ...
+@overload
+def unpackbits(
+    a: Any,
+    axis: int | None = None,
+    count: int | None = None,
+    bitorder: str = "big",
+) -> Array[IntTuple]: ...
+
+# Interpolation
+
+def interp[Shape: _Shape, N: IntVar](
+    x: Array[Shape],
+    xp: Array[[N]],
+    fp: Array[[N]],
+    left: Any = None,
+    right: Any = None,
+    period: Any = None,
+) -> Array[Shape]: ...
+
+# Convolutions & Signal Processing
+
+@overload
+def convolve[ShapeA: _Shape, ShapeV: _Shape, Mode: Flag[str] = "full"](
+    a: Array[ShapeA],
+    v: Array[ShapeV],
+    mode: Mode = "full",
+    *,
+    precision: Any = None,
+    preferred_element_type: DTypeLike | None = None,
+) -> Array[convolve_shape(ShapeA, ShapeV, Mode)]: ...
+@overload
+def convolve(
+    a: Any,
+    v: Any,
+    mode: str = "full",
+    *,
+    precision: Any = None,
+    preferred_element_type: DTypeLike | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def correlate[ShapeA: _Shape, ShapeV: _Shape, Mode: Flag[str] = "valid"](
+    a: Array[ShapeA],
+    v: Array[ShapeV],
+    mode: Mode = "valid",
+    *,
+    precision: Any = None,
+    preferred_element_type: DTypeLike | None = None,
+) -> Array[convolve_shape(ShapeA, ShapeV, Mode)]: ...
+@overload
+def correlate(
+    a: Any,
+    v: Any,
+    mode: str = "valid",
+    *,
+    precision: Any = None,
+    preferred_element_type: DTypeLike | None = None,
+) -> Array[IntTuple]: ...
+
+# Histograms
+
+@overload
+def histogram[Bins: Flag[int] = 10](
+    a: Array[Any],
+    bins: Bins = 10,
+    range: Sequence[Any] | None = None,
+    weights: Array[Any] | None = None,
+    density: bool | None = None,
+) -> tuple[Array[histogram_counts_shape(Bins)], Array[histogram_edges_shape(Bins)]]: ...
+@overload
+def histogram(
+    a: Any,
+    bins: Any = 10,
+    range: Sequence[Any] | None = None,
+    weights: Any = None,
+    density: bool | None = None,
+) -> tuple[Array[IntTuple], Array[IntTuple]]: ...
+@overload
+def histogram2d[Bins: Flag[int] = 10](
+    x: Array[Any],
+    y: Array[Any],
+    bins: Bins = 10,
+    range: Sequence[Any] | None = None,
+    weights: Array[Any] | None = None,
+    density: bool | None = None,
+) -> tuple[
+    Array[histogram2d_counts_shape(Bins)],
+    Array[histogram_edges_shape(Bins)],
+    Array[histogram_edges_shape(Bins)],
+]: ...
+@overload
+def histogram2d(
+    x: Any,
+    y: Any,
+    bins: Any = 10,
+    range: Sequence[Any] | None = None,
+    weights: Any = None,
+    density: bool | None = None,
+) -> tuple[Array[IntTuple], Array[IntTuple], Array[IntTuple]]: ...
+@overload
+def histogram_bin_edges[Bins: Flag[int] = 10](
+    a: Array[Any],
+    bins: Bins = 10,
+    range: Any = None,
+    weights: Array[Any] | None = None,
+) -> Array[histogram_edges_shape(Bins)]: ...
+@overload
+def histogram_bin_edges(
+    a: Any,
+    bins: Any = 10,
+    range: Any = None,
+    weights: Any = None,
+) -> Array[IntTuple]: ...
+def histogramdd(
+    sample: Array[Any],
+    bins: Any = 10,
+    range: Sequence[Any] | None = None,
+    weights: Array[Any] | None = None,
+    density: bool | None = None,
+) -> tuple[Array[IntTuple], list[Array[IntTuple]]]: ...
+
+# Polynomials
+
+@overload
+def poly[Shape: _Shape](
+    seq_of_zeros: Array[Shape],
+) -> Array[poly_shape(Shape)]: ...
+@overload
+def poly(seq_of_zeros: Any) -> Array[IntTuple]: ...
+@overload
+def polyadd[Shape1: _Shape, Shape2: _Shape](
+    a1: Array[Shape1],
+    a2: Array[Shape2],
+) -> Array[polyadd_shape(Shape1, Shape2)]: ...
+@overload
+def polyadd(a1: Any, a2: Any) -> Array[IntTuple]: ...
+@overload
+def polyder[Shape: _Shape, M: Flag[int] = 1](
+    p: Array[Shape],
+    m: M = 1,
+) -> Array[polyder_shape(Shape, M)]: ...
+@overload
+def polyder(p: Any, m: int = 1) -> Array[IntTuple]: ...
+@overload
+def polydiv[Shape1: _Shape, Shape2: _Shape](
+    u: Array[Shape1],
+    v: Array[Shape2],
+    *,
+    trim_leading_zeros: Literal[False] = False,
+) -> tuple[Array[polydiv_quotient_shape(Shape1, Shape2)], Array[Shape1]]: ...
+@overload
+def polydiv(
+    u: Any,
+    v: Any,
+    *,
+    trim_leading_zeros: bool = False,
+) -> tuple[Array[IntTuple], Array[IntTuple]]: ...
+@overload
+def polyfit[Deg: Flag[int]](
+    x: Array[Any],
+    y: Array[Any],
+    deg: Deg,
+    rcond: float | None = None,
+    full: Literal[False] = False,
+    w: Array[Any] | None = None,
+    cov: Literal[False] = False,
+) -> Array[polyfit_shape(Deg)]: ...
+@overload
+def polyfit[Deg: Flag[int]](
+    x: Array[Any],
+    y: Array[Any],
+    deg: Deg,
+    rcond: float | None = None,
+    full: Literal[False] = False,
+    w: Array[Any] | None = None,
+    cov: Literal[True, "unscaled"] = ...,
+) -> tuple[Array[polyfit_shape(Deg)], Array[polyfit_cov_shape(Deg)]]: ...
+@overload
+def polyfit(
+    x: Array[Any],
+    y: Array[Any],
+    deg: int,
+    rcond: float | None = None,
+    full: Literal[True] = ...,
+    w: Array[Any] | None = None,
+    cov: bool = False,
+) -> tuple[Array[IntTuple], ...]: ...
+@overload
+def polyfit(
+    x: Any,
+    y: Any,
+    deg: int,
+    rcond: float | None = None,
+    full: bool = False,
+    w: Any = None,
+    cov: bool | str = False,
+) -> Any: ...
+@overload
+def polyint[Shape: _Shape, M: Flag[int] = 1](
+    p: Array[Shape],
+    m: M = 1,
+    k: int | Array[Any] | None = None,
+) -> Array[polyint_shape(Shape, M)]: ...
+@overload
+def polyint(
+    p: Any,
+    m: int = 1,
+    k: int | Any | None = None,
+) -> Array[IntTuple]: ...
+@overload
+def polymul[Shape1: _Shape, Shape2: _Shape](
+    a1: Array[Shape1],
+    a2: Array[Shape2],
+    *,
+    trim_leading_zeros: Literal[False] = False,
+) -> Array[convolve_shape(Shape1, Shape2, "full")]: ...
+@overload
+def polymul(
+    a1: Any,
+    a2: Any,
+    *,
+    trim_leading_zeros: bool = False,
+) -> Array[IntTuple]: ...
+@overload
+def polysub[Shape1: _Shape, Shape2: _Shape](
+    a1: Array[Shape1],
+    a2: Array[Shape2],
+) -> Array[polyadd_shape(Shape1, Shape2)]: ...
+@overload
+def polysub(a1: Any, a2: Any) -> Array[IntTuple]: ...
+@overload
+def polyval[Shape: _Shape](
+    p: Array[Any],
+    x: Array[Shape],
+    *,
+    unroll: int = 16,
+) -> Array[Shape]: ...
+@overload
+def polyval(
+    p: Any,
+    x: Any,
+    *,
+    unroll: int = 16,
+) -> Array[IntTuple]: ...
+def roots(p: Array[Any], *, strip_zeros: bool = True) -> Array[IntTuple]: ...
 
 # Scalar constructors
 

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_polynomials.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_polynomials.py
@@ -1,0 +1,219 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from shape_extensions import assert_shape
+
+
+def test_interp() -> None:
+    x = jnp.ones((2, 3))
+    xp = jnp.array([0.0, 1.0, 2.0])
+    fp = jnp.array([0.0, 1.0, 4.0])
+    assert_shape(jnp.interp(x, xp, fp).shape, (2, 3))
+    assert_shape(jnp.interp(jnp.ones(5), xp, fp).shape, (5,))
+
+    # Rejection of mismatched xp and fp shapes
+    try:
+        # E: Argument `Array[IntTuple[4]]` is not assignable to parameter `fp` with type `Array[IntTuple[3]]`
+        jnp.interp(x, jnp.ones(3), jnp.ones(4))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject mismatched xp and fp in interp")
+
+    # Rejection of non-1D xp and fp
+    try:
+        # E: Argument `Array[IntTuple[2, 2]]` is not assignable to parameter `xp` with type `Array[IntTuple[@_]]`
+        # E: Argument `Array[IntTuple[2, 2]]` is not assignable to parameter `fp` with type `Array[IntTuple[@_]]`
+        jnp.interp(x, jnp.ones((2, 2)), jnp.ones((2, 2)))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject non-1D arrays in interp")
+
+
+def test_convolve_correlate() -> None:
+    a = jnp.ones(5)
+    v = jnp.ones(3)
+    # Default modes
+    assert_shape(jnp.convolve(a, v).shape, (7,))
+    assert_shape(jnp.correlate(a, v).shape, (3,))
+
+    # mode="full"
+    assert_shape(jnp.convolve(a, v, mode="full").shape, (7,))
+    assert_shape(jnp.convolve(v, a, mode="full").shape, (7,))
+    assert_shape(jnp.correlate(a, v, mode="full").shape, (7,))
+    assert_shape(jnp.correlate(v, a, mode="full").shape, (7,))
+
+    # mode="same"
+    assert_shape(jnp.convolve(a, v, mode="same").shape, (5,))
+    assert_shape(jnp.convolve(v, a, mode="same").shape, (5,))
+    assert_shape(jnp.correlate(a, v, mode="same").shape, (5,))
+    assert_shape(jnp.correlate(v, a, mode="same").shape, (5,))
+
+    # mode="valid"
+    assert_shape(jnp.convolve(a, v, mode="valid").shape, (3,))
+    assert_shape(jnp.convolve(v, a, mode="valid").shape, (3,))
+    assert_shape(jnp.correlate(a, v, mode="valid").shape, (3,))
+    assert_shape(jnp.correlate(v, a, mode="valid").shape, (3,))
+
+    # Equal lengths
+    eq = jnp.ones(4)
+    assert_shape(jnp.convolve(eq, eq, mode="full").shape, (7,))
+    assert_shape(jnp.convolve(eq, eq, mode="same").shape, (4,))
+    assert_shape(jnp.convolve(eq, eq, mode="valid").shape, (1,))
+    assert_shape(jnp.correlate(eq, eq, mode="valid").shape, (1,))
+
+    # Rejection of non-1-dimensional inputs
+    try:
+        # E: Cannot evaluate type-level shape DSL call: convolve and correlate only support 1-dimensional inputs
+        jnp.convolve(jnp.ones((2, 2)), jnp.ones(3))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject non-1D input to convolve")
+
+    try:
+        # E: Cannot evaluate type-level shape DSL call: convolve and correlate only support 1-dimensional inputs
+        jnp.correlate(jnp.ones(3), jnp.ones((2, 2)))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject non-1D input to correlate")
+
+    # Rejection of empty inputs
+    try:
+        # E: Cannot evaluate type-level shape DSL call: inputs cannot be empty
+        jnp.convolve(jnp.ones(0), jnp.ones(3))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject empty input to convolve")
+
+    # Rejection of invalid mode
+    try:
+        # E: Cannot evaluate type-level shape DSL call: mode must be one of ['full', 'same', 'valid']
+        jnp.convolve(jnp.ones(3), jnp.ones(3), mode="invalid")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject invalid mode to convolve")
+
+
+def test_histograms() -> None:
+    a = jnp.ones(10)
+    # Default bins=10
+    h_def, edges_def = jnp.histogram(a)
+    assert_shape(h_def.shape, (10,))
+    assert_shape(edges_def.shape, (11,))
+
+    h, edges = jnp.histogram(a, bins=5)
+    assert_shape(h.shape, (5,))
+    assert_shape(edges.shape, (6,))
+
+    # Default 2D
+    h2_def, xedges_def, yedges_def = jnp.histogram2d(a, a)
+    assert_shape(h2_def.shape, (10, 10))
+    assert_shape(xedges_def.shape, (11,))
+    assert_shape(yedges_def.shape, (11,))
+
+    h2, xedges, yedges = jnp.histogram2d(a, a, bins=4)
+    assert_shape(h2.shape, (4, 4))
+    assert_shape(xedges.shape, (5,))
+    assert_shape(yedges.shape, (5,))
+
+    assert_shape(jnp.histogram_bin_edges(a).shape, (11,))
+    assert_shape(jnp.histogram_bin_edges(a, bins=5).shape, (6,))
+
+    sample = jnp.ones((10, 2))
+    hdd, ddedges = jnp.histogramdd(sample, bins=(3, 4))
+    assert_shape(hdd.shape, (3, 4))
+    assert len(ddedges) == 2
+
+
+def test_polynomials() -> None:
+    p = jnp.array([1.0, -2.0, 1.0])
+    x = jnp.ones((2, 3))
+    assert_shape(jnp.polyval(p, x).shape, (2, 3))
+
+    r = jnp.roots(p)
+    assert_shape(r.shape, (2,))
+
+    poly_from_roots = jnp.poly(r)
+    assert_shape(poly_from_roots.shape, (3,))
+
+    # poly from 2D square matrix
+    assert_shape(jnp.poly(jnp.ones((3, 3))).shape, (4,))
+
+    p1 = jnp.array([1.0, 2.0])
+    p2 = jnp.array([3.0, 4.0, 5.0])
+    assert_shape(jnp.polyadd(p1, p2).shape, (3,))
+    assert_shape(jnp.polyadd(p2, p1).shape, (3,))
+    assert_shape(jnp.polysub(p1, p2).shape, (3,))
+    assert_shape(jnp.polymul(p1, p2).shape, (4,))
+
+    q, rem = jnp.polydiv(p, p1)
+    assert_shape(q.shape, (2,))
+    assert_shape(rem.shape, (3,))
+
+    _, rem_trimmed = jnp.polydiv(p, p1, trim_leading_zeros=True)
+    assert_shape(rem_trimmed.shape, (1,))
+
+    assert_shape(jnp.polyder(p).shape, (2,))
+    assert_shape(jnp.polyder(p, m=2).shape, (1,))
+    assert jnp.polyder(p, m=3).size == 0
+    assert_shape(jnp.polyint(p).shape, (4,))
+    assert_shape(jnp.polyint(p, m=2).shape, (5,))
+
+    x_data = jnp.array([0.0, 1.0, 2.0, 3.0])
+    y_data = jnp.array([0.0, 1.0, 4.0, 9.0])
+    c = jnp.polyfit(x_data, y_data, 2)
+    assert_shape(c.shape, (3,))
+    assert_shape(jnp.polyfit(x_data, y_data, 3).shape, (4,))
+
+    c_cov, cov = jnp.polyfit(x_data, y_data, 2, cov=True)
+    assert_shape(c_cov.shape, (3,))
+    assert_shape(cov.shape, (3, 3))
+
+    fit_full = jnp.polyfit(x_data, y_data, 2, full=True)
+    assert len(fit_full) == 5
+
+    # Rejection of non-square 2d array in poly
+    try:
+        # E: Cannot evaluate type-level shape DSL call: input must be 1d or non-empty square 2d array
+        jnp.poly(jnp.ones((2, 3)))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject non-square 2d array in poly")
+
+    # Rejection of negative derivative order in polyder
+    try:
+        # E: Cannot evaluate type-level shape DSL call: Order of derivative must be positive
+        jnp.polyder(jnp.ones(3), m=-1)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject negative order in polyder")
+
+    # Rejection of negative integral order in polyint
+    try:
+        # E: Cannot evaluate type-level shape DSL call: Order of integral must be positive
+        jnp.polyint(jnp.ones(3), m=-1)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject negative order in polyint")
+
+    # Rejection of negative degree in polyfit
+    try:
+        # E: Cannot evaluate type-level shape DSL call: deg must be non-negative
+        jnp.polyfit(x_data, y_data, -1)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject negative deg in polyfit")

--- a/tensor-shapes/pyrefly-jax-stubs/test/test_structural.py
+++ b/tensor-shapes/pyrefly-jax-stubs/test/test_structural.py
@@ -435,3 +435,55 @@ def test_broadcast_arrays_and_shapes() -> None:
     assert_shape(c1.shape, (2, 3))
 
     assert jnp.broadcast_shapes((2, 1), (1, 3)) == (2, 3)
+
+
+def test_copy() -> None:
+    x = jnp.ones((2, 3))
+    assert_shape(jnp.copy(x).shape, (2, 3))
+    assert_shape(jnp.copy(x, order="K").shape, (2, 3))
+
+
+def test_append() -> None:
+    a = jnp.ones((2, 3))
+    b = jnp.ones((1, 3))
+    c = jnp.ones((2, 4))
+    assert_shape(jnp.append(a, b, axis=0).shape, (3, 3))
+    assert_shape(jnp.append(a, c, axis=1).shape, (2, 7))
+    assert_shape(jnp.append(a, b).shape, (9,))
+    assert_shape(jnp.append(jnp.ones(2), jnp.ones(3)).shape, (5,))
+
+    # Rejection of mismatched shapes along non-concatenation axis
+    try:
+        # E: Cannot evaluate type-level shape DSL call: all input array dimensions for the concatenation axis must match exactly
+        jnp.append(a, c, axis=0)
+    except (ValueError, TypeError):
+        pass
+    else:
+        raise AssertionError("expected JAX to reject mismatched append")
+
+    # Rejection of out of bounds axis
+    try:
+        # E: Cannot evaluate type-level shape DSL call: axis out of bounds
+        jnp.append(a, b, axis=5)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected JAX to reject out of bounds axis in append")
+
+
+def test_packbits_unpackbits() -> None:
+    a = jnp.ones((2, 8), dtype=jnp.uint8)
+    packed = jnp.packbits(a, axis=-1)
+    assert_shape(packed.shape, (2, 1))
+    unpacked = jnp.unpackbits(packed, axis=-1)
+    assert_shape(unpacked.shape, (2, 8))
+
+    # Flatted pack/unpack
+    packed_flat = jnp.packbits(a)
+    assert_shape(packed_flat.shape, (2,))
+    unpacked_flat = jnp.unpackbits(packed_flat)
+    assert_shape(unpacked_flat.shape, (16,))
+
+    # Unpackbits with count
+    assert_shape(jnp.unpackbits(packed, axis=-1, count=5).shape, (2, 5))
+    assert_shape(jnp.unpackbits(packed_flat, count=10).shape, (10,))


### PR DESCRIPTION
## Summary

This completes the stubs for `jax.numpy` (short of `ArrayLike` changes which need to be done across all APIs).