### PR TITLE
Find SQLAlchemy Mapped model fields in parent classes

### DIFF
--- a/pyrefly/lib/alt/expr.rs
+++ b/pyrefly/lib/alt/expr.rs
@@ -1554,10 +1554,21 @@ impl<'ctx, 'answer, Ans: LookupAnswer> AnswersSolver<'ctx, 'answer, Ans> {
     }
 
     fn sqlalchemy_mapped_model_fields(&self, model: &Class) -> SmallSet<Name> {
-        self.get_class_field_map(model)
-            .into_iter()
+        let mut seen_fields = SmallSet::new();
+
+        std::iter::once(model)
+            .chain(
+                self.get_mro_for_class(model)
+                    .ancestors_no_object()
+                    .iter()
+                    .map(|ancestor| ancestor.class_object()),
+            )
+            .flat_map(|class| self.get_class_field_map(class))
             .filter_map(|(name, field)| {
-                if name.as_str().starts_with('_') || field.is_class_var() {
+                if !seen_fields.insert(name.clone())
+                    || name.as_str().starts_with('_')
+                    || field.is_class_var()
+                {
                     return None;
                 }
                 let (_, annotation, _) = field.for_variance_inference();

--- a/pyrefly/lib/test/descriptors.rs
+++ b/pyrefly/lib/test/descriptors.rs
@@ -1019,6 +1019,33 @@ update(User).values(nam="alice")
 );
 
 testcase!(
+    test_sqlalchemy_update_values_checks_inherited_mapped_fields,
+    sqlalchemy_mapped_env(),
+    r#"
+import sqlalchemy as sa
+from sqlalchemy.orm import DeclarativeBase, Mapped
+
+class Base(DeclarativeBase):
+    pass
+
+class SoftDeleteMixin:
+    deleted: Mapped[bool]
+
+class User(Base, SoftDeleteMixin):
+    id: Mapped[int]
+    name: Mapped[str]
+
+class AdminUser(User):
+    role: Mapped[str]
+    deleted: bool  # type: ignore
+
+sa.update(AdminUser).where(AdminUser.id == 1).values(name="alice")
+sa.update(User).where(User.id == 1).values(name="alice", deleted=False)
+sa.update(AdminUser).where(AdminUser.id == 1).values(deleted=False)  # E: Unexpected SQLAlchemy update field `deleted`
+    "#,
+);
+
+testcase!(
     test_stub_annotation_only_descriptor_has_descriptor_semantics,
     stub_descriptor_env(),
     r#"


### PR DESCRIPTION
# Summary

This solves #4903 by going through the method resolution order and finding all the Mapped fields on it or its parent classes, instead of just looking at the target class itself.

Fixes #4903

# Test Plan

Added tests with both a parent class that is an SQLAlchemy model and one that isn't, and thus has to use it as a Mixin to get its Mapped fields.
