### PR TITLE
fix(torch-stubs): return torch.return_types named tuples

### DIFF
--- a/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_return_types_errors.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/negative_tests/test_return_types_errors.py
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Test that `torch.return_types` tuples expose only their documented fields."""
+
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from torch import Tensor
+
+
+def test_wrong_field_names(x: Tensor[[4, 3]]) -> None:
+    x.sort(dim=0).value  # E: no attribute `value`
+    x.aminmax().values  # E: no attribute `values`
+    x.slogdet().indices  # E: no attribute `indices`

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_meta_shape_basic.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_meta_shape_basic.py
@@ -222,7 +222,7 @@ def test_shape_ops_negative_axes_and_scalar_squeeze():
     assert_type(scalar.squeeze(-1), Tensor[[]])
     assert_type(torch.transpose(scalar, 0, -1), Tensor[[]])
     assert_type(scalar.transpose(-1, 0), Tensor[[]])
-    assert_type(scalar.topk(1), tuple[Tensor[[]], Tensor[[]]])
+    assert_type(scalar.topk(1), torch.return_types.topk[[]])
 
 
 def check_shape_ops_gradual_and_bare_fallback(
@@ -288,13 +288,8 @@ def check_axis_extent_ops_symbolic_suffix[Ts: IntTuple, K: IntVar](
 
     assert_type(x.narrow(-1, 0, extent), Tensor[[*Elements[Ts], K]])
     assert_type(torch.narrow(x, -1, 0, extent), Tensor[[*Elements[Ts], K]])
-    assert_type(
-        x.topk(extent), tuple[Tensor[[*Elements[Ts], K]], Tensor[[*Elements[Ts], K]]]
-    )
-    assert_type(
-        torch.topk(x, extent),
-        tuple[Tensor[[*Elements[Ts], K]], Tensor[[*Elements[Ts], K]]],
-    )
+    assert_type(x.topk(extent), torch.return_types.topk[[*Elements[Ts], K]])
+    assert_type(torch.topk(x, extent), torch.return_types.topk[[*Elements[Ts], K]])
     assert_type(x.multinomial(extent), Tensor[IntTuple])
     assert_type(torch.multinomial(x, extent), Tensor[IntTuple])
 
@@ -304,10 +299,10 @@ def check_axis_extent_ops_gradual(
 ) -> None:
     assert_type(x.narrow(1, 0, extent), Tensor[[2, int, 4]])
     assert_type(torch.narrow(x, dim, 0, 2), Tensor[IntTuple])
-    assert_type(x.topk(extent, dim=1), tuple[Tensor[[2, int, 4]], Tensor[[2, int, 4]]])
-    assert_type(torch.topk(x, 2, dim=dim), tuple[Tensor[IntTuple], Tensor[IntTuple]])
+    assert_type(x.topk(extent, dim=1), torch.return_types.topk[[2, int, 4]])
+    assert_type(torch.topk(x, 2, dim=dim), torch.return_types.topk[IntTuple])
     assert_type(torch.narrow(bare, 0, 0, 2), Tensor[IntTuple])
-    assert_type(bare.topk(2), tuple[Tensor[IntTuple], Tensor[IntTuple]])
+    assert_type(bare.topk(2), torch.return_types.topk[IntTuple])
     assert_type(torch.multinomial(bare, 2), Tensor[IntTuple])
 
 
@@ -316,9 +311,9 @@ def test_axis_extent_ops_literals() -> None:
     vector: Tensor[[3]] = torch.randn(3)
     matrix: Tensor[[2, 3]] = torch.randn(2, 3)
 
-    assert_type(torch.topk(x, 2, dim=1), tuple[Tensor[[2, 2, 4]], Tensor[[2, 2, 4]]])
-    assert_type(x.topk(2, dim=-2), tuple[Tensor[[2, 2, 4]], Tensor[[2, 2, 4]]])
-    assert_type(x.topk(3), tuple[Tensor[[2, 3, 3]], Tensor[[2, 3, 3]]])
+    assert_type(torch.topk(x, 2, dim=1), torch.return_types.topk[[2, 2, 4]])
+    assert_type(x.topk(2, dim=-2), torch.return_types.topk[[2, 2, 4]])
+    assert_type(x.topk(3), torch.return_types.topk[[2, 3, 3]])
     assert_type(torch.narrow(x, -2, 0, 2), Tensor[[2, 2, 4]])
     assert_type(torch.multinomial(vector, 5), Tensor[[5]])
     assert_type(matrix.multinomial(6), Tensor[[2, 6]])

--- a/tensor-shapes/pyrefly-torch-stubs/test/test_return_types.py
+++ b/tensor-shapes/pyrefly-torch-stubs/test/test_return_types.py
@@ -1,0 +1,149 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Test the named tuples in `torch.return_types` keep their shapes."""
+
+from typing import assert_type, TYPE_CHECKING
+
+import torch
+from shape_extensions import IntTuple
+
+if TYPE_CHECKING:
+    from torch import Tensor
+
+
+def test_sort() -> None:
+    x: Tensor[[4, 3]] = torch.randn(4, 3)
+    result = x.sort(dim=0)
+    assert_type(result, torch.return_types.sort[[4, 3]])
+    assert_type(result.values, Tensor[[4, 3]])
+    assert_type(result.indices, Tensor[[4, 3]])
+    assert_type(torch.sort(x, dim=0), torch.return_types.sort[[4, 3]])
+    assert_type(torch.sort(x, dim=0).values, Tensor[[4, 3]])
+    assert_type(torch.sort(x, dim=0).indices, Tensor[[4, 3]])
+
+
+def test_sort_is_a_tuple() -> None:
+    x: Tensor[[4, 3]] = torch.randn(4, 3)
+    result = x.sort(dim=0)
+    assert_type(result[0], Tensor[[4, 3]])
+    assert_type(result[1], Tensor[[4, 3]])
+    values, indices = result
+    assert_type(values, Tensor[[4, 3]])
+    assert_type(indices, Tensor[[4, 3]])
+
+
+def test_cummax() -> None:
+    x: Tensor[[4, 3]] = torch.randn(4, 3)
+    assert_type(x.cummax(0), torch.return_types.cummax[[4, 3]])
+    assert_type(x.cummax(0).values, Tensor[[4, 3]])
+    assert_type(x.cummax(0).indices, Tensor[[4, 3]])
+    assert_type(torch.cummax(x, 0), torch.return_types.cummax[[4, 3]])
+    assert_type(torch.cummax(x, 0).values, Tensor[[4, 3]])
+    assert_type(torch.cummax(x, 0).indices, Tensor[[4, 3]])
+
+
+def test_cummin() -> None:
+    x: Tensor[[4, 3]] = torch.randn(4, 3)
+    assert_type(x.cummin(1), torch.return_types.cummin[[4, 3]])
+    assert_type(x.cummin(1).values, Tensor[[4, 3]])
+    assert_type(x.cummin(1).indices, Tensor[[4, 3]])
+    assert_type(torch.cummin(x, 1), torch.return_types.cummin[[4, 3]])
+    assert_type(torch.cummin(x, 1).values, Tensor[[4, 3]])
+    assert_type(torch.cummin(x, 1).indices, Tensor[[4, 3]])
+
+
+def test_max() -> None:
+    x: Tensor[[4, 3]] = torch.randn(4, 3)
+    assert_type(x.max(dim=1), torch.return_types.max[[4]])
+    assert_type(x.max(dim=1).values, Tensor[[4]])
+    assert_type(x.max(dim=1).indices, Tensor[[4]])
+    assert_type(torch.max(x, dim=1), torch.return_types.max[[4]])
+    assert_type(torch.max(x, dim=1).values, Tensor[[4]])
+    assert_type(torch.max(x, dim=1).indices, Tensor[[4]])
+    assert_type(torch.max(x, dim=0, keepdim=True), torch.return_types.max[[1, 3]])
+
+
+def test_min() -> None:
+    x: Tensor[[4, 3]] = torch.randn(4, 3)
+    assert_type(x.min(dim=1), torch.return_types.min[[4]])
+    assert_type(x.min(dim=1).values, Tensor[[4]])
+    assert_type(x.min(dim=1).indices, Tensor[[4]])
+    assert_type(torch.min(x, dim=1), torch.return_types.min[[4]])
+    assert_type(torch.min(x, dim=1).values, Tensor[[4]])
+    assert_type(torch.min(x, dim=1).indices, Tensor[[4]])
+
+
+def test_topk() -> None:
+    x: Tensor[[4, 3]] = torch.randn(4, 3)
+    assert_type(x.topk(2, dim=0), torch.return_types.topk[[2, 3]])
+    assert_type(x.topk(2, dim=0).values, Tensor[[2, 3]])
+    assert_type(x.topk(2, dim=0).indices, Tensor[[2, 3]])
+    assert_type(torch.topk(x, 2, dim=0), torch.return_types.topk[[2, 3]])
+    assert_type(torch.topk(x, 2, dim=0).values, Tensor[[2, 3]])
+    assert_type(torch.topk(x, 2, dim=0).indices, Tensor[[2, 3]])
+
+
+def test_kthvalue() -> None:
+    x: Tensor[[4, 3]] = torch.randn(4, 3)
+    assert_type(x.kthvalue(2, dim=1), torch.return_types.kthvalue[[4]])
+    assert_type(x.kthvalue(2, dim=1).values, Tensor[[4]])
+    assert_type(x.kthvalue(2, dim=1).indices, Tensor[[4]])
+    assert_type(torch.kthvalue(x, 2, dim=1), torch.return_types.kthvalue[[4]])
+    assert_type(torch.kthvalue(x, 2, dim=1).values, Tensor[[4]])
+    assert_type(torch.kthvalue(x, 2, dim=1).indices, Tensor[[4]])
+
+
+def test_median() -> None:
+    x: Tensor[[4, 3]] = torch.randn(4, 3)
+    assert_type(x.median(dim=0), torch.return_types.median[[3]])
+    assert_type(x.median(dim=0).values, Tensor[[3]])
+    assert_type(x.median(dim=0).indices, Tensor[[3]])
+    assert_type(torch.median(x, dim=0), torch.return_types.median[[3]])
+    assert_type(torch.median(x, dim=0).values, Tensor[[3]])
+    assert_type(torch.median(x, dim=0).indices, Tensor[[3]])
+
+
+def test_mode() -> None:
+    x: Tensor[[4, 3]] = torch.randn(4, 3)
+    assert_type(x.mode(dim=0), torch.return_types.mode[[3]])
+    assert_type(x.mode(dim=0).values, Tensor[[3]])
+    assert_type(x.mode(dim=0).indices, Tensor[[3]])
+    assert_type(torch.mode(x, dim=0), torch.return_types.mode[[3]])
+    assert_type(torch.mode(x, dim=0).values, Tensor[[3]])
+    assert_type(torch.mode(x, dim=0).indices, Tensor[[3]])
+
+
+def test_aminmax() -> None:
+    x: Tensor[[4, 3]] = torch.randn(4, 3)
+    assert_type(x.aminmax(), torch.return_types.aminmax[[]])
+    assert_type(x.aminmax().min, Tensor[[]])
+    assert_type(x.aminmax().max, Tensor[[]])
+    assert_type(torch.aminmax(x, dim=0), torch.return_types.aminmax[[3]])
+    assert_type(torch.aminmax(x, dim=0).min, Tensor[[3]])
+    assert_type(torch.aminmax(x, dim=0).max, Tensor[[3]])
+
+
+def test_slogdet() -> None:
+    m: Tensor[[2, 3, 3]] = torch.randn(2, 3, 3)
+    assert_type(m.slogdet(), torch.return_types.slogdet[[2]])
+    assert_type(m.slogdet().sign, Tensor[[2]])
+    assert_type(m.slogdet().logabsdet, Tensor[[2]])
+    assert_type(torch.slogdet(m), torch.return_types.slogdet[[2]])
+    assert_type(torch.slogdet(m).sign, Tensor[[2]])
+    assert_type(torch.slogdet(m).logabsdet, Tensor[[2]])
+
+
+def test_linalg_slogdet() -> None:
+    m: Tensor[[2, 3, 3]] = torch.randn(2, 3, 3)
+    assert_type(torch.linalg.slogdet(m), torch.return_types.linalg_slogdet[[2]])
+    assert_type(torch.linalg.slogdet(m).sign, Tensor[[2]])
+    assert_type(torch.linalg.slogdet(m).logabsdet, Tensor[[2]])
+
+
+def test_slogdet_shapeless_input(m: Tensor) -> None:
+    assert_type(m.slogdet(), torch.return_types.slogdet[IntTuple])
+    assert_type(torch.slogdet(m).sign, Tensor[IntTuple])
+    assert_type(torch.linalg.slogdet(m), torch.return_types.linalg_slogdet[IntTuple])

--- a/tensor-shapes/pyrefly-torch-stubs/torch-stubs/__init__.pyi
+++ b/tensor-shapes/pyrefly-torch-stubs/torch-stubs/__init__.pyi
@@ -26,6 +26,7 @@ from shape_extensions import (
     IntVar,
     MapIntTuples,
 )
+from torch import return_types
 
 # `Generator` is not defined anywhere in this package, and resolving it relies
 # on how a partial stub package is looked up. The `py.typed` file here contains
@@ -873,10 +874,7 @@ class Tensor[Shape: _Shape = _Shape]:
     @overload
     def max[Shape: IntTuple, Dim: Flag[builtins.int], Keepdim: Flag[builtins.bool]](
         self: Tensor[Shape], dim: Dim, keepdim: Keepdim = False
-    ) -> tuple[
-        Tensor[reduce_shape(Shape, Dim, Keepdim)],
-        Tensor[reduce_shape(Shape, Dim, Keepdim)],
-    ]:
+    ) -> return_types.max[reduce_shape(Shape, Dim, Keepdim)]:
         """Max along dimension. Returns (values, indices). Shape inference via meta-shape: torch.Tensor.max"""
         ...
 
@@ -888,10 +886,7 @@ class Tensor[Shape: _Shape = _Shape]:
     @overload
     def min[Shape: IntTuple, Dim: Flag[builtins.int], Keepdim: Flag[builtins.bool]](
         self: Tensor[Shape], dim: Dim, keepdim: Keepdim = False
-    ) -> tuple[
-        Tensor[reduce_shape(Shape, Dim, Keepdim)],
-        Tensor[reduce_shape(Shape, Dim, Keepdim)],
-    ]:
+    ) -> return_types.min[reduce_shape(Shape, Dim, Keepdim)]:
         """Min along dimension. Returns (values, indices). Shape inference via meta-shape: torch.Tensor.min"""
         ...
 
@@ -955,10 +950,7 @@ class Tensor[Shape: _Shape = _Shape]:
     @overload
     def median[Shape: IntTuple, Dim: Flag[builtins.int], Keepdim: Flag[builtins.bool]](
         self: Tensor[Shape], dim: Dim, keepdim: Keepdim = False
-    ) -> tuple[
-        Tensor[reduce_shape(Shape, Dim, Keepdim)],
-        Tensor[reduce_shape(Shape, Dim, Keepdim)],
-    ]:
+    ) -> return_types.median[reduce_shape(Shape, Dim, Keepdim)]:
         """Median along dimension. Returns (values, indices). Shape inference via meta-shape: torch.Tensor.median"""
         ...
 
@@ -985,10 +977,7 @@ class Tensor[Shape: _Shape = _Shape]:
         Keepdim: Flag[builtins.bool],
     ](
         self: Tensor[Shape], *, dim: Dim = None, keepdim: Keepdim = False
-    ) -> tuple[
-        Tensor[reduce_shape(Shape, Dim, Keepdim)],
-        Tensor[reduce_shape(Shape, Dim, Keepdim)],
-    ]:
+    ) -> return_types.aminmax[reduce_shape(Shape, Dim, Keepdim)]:
         """Min and max along dimension(s). Shape inference via meta-shape: torch.Tensor.aminmax"""
         ...
 
@@ -1019,13 +1008,13 @@ class Tensor[Shape: _Shape = _Shape]:
 
     def cummax[Shape: IntTuple](
         self: Tensor[Shape], dim: int
-    ) -> tuple[Tensor[Shape], Tensor[Shape]]:
+    ) -> return_types.cummax[Shape]:
         """Cumulative maximum along dimension. Returns (values, indices). Shape-preserving operation."""
         ...
 
     def cummin[Shape: IntTuple](
         self: Tensor[Shape], dim: int
-    ) -> tuple[Tensor[Shape], Tensor[Shape]]:
+    ) -> return_types.cummin[Shape]:
         """Cumulative minimum along dimension. Returns (values, indices). Shape-preserving operation."""
         ...
 
@@ -1033,10 +1022,7 @@ class Tensor[Shape: _Shape = _Shape]:
 
     def mode[Shape: IntTuple, Dim: Flag[builtins.int], Keepdim: Flag[builtins.bool]](
         self: Tensor[Shape], dim: Dim = -1, keepdim: Keepdim = False
-    ) -> tuple[
-        Tensor[reduce_shape(Shape, Dim, Keepdim)],
-        Tensor[reduce_shape(Shape, Dim, Keepdim)],
-    ]:
+    ) -> return_types.mode[reduce_shape(Shape, Dim, Keepdim)]:
         """Mode along dimension. Returns (values, indices). Shape inference via meta-shape: torch.Tensor.mode"""
         ...
 
@@ -1046,10 +1032,7 @@ class Tensor[Shape: _Shape = _Shape]:
         dim: Dim = -1,
         largest: bool = True,
         sorted: bool = True,
-    ) -> tuple[
-        Tensor[topk_shape(Shape, Dim, K)],
-        Tensor[topk_shape(Shape, Dim, K)],
-    ]:
+    ) -> return_types.topk[topk_shape(Shape, Dim, K)]:
         """Top k elements. Returns (values, indices). Shape inference via meta-shape: torch.Tensor.topk"""
         ...
 
@@ -1058,7 +1041,7 @@ class Tensor[Shape: _Shape = _Shape]:
         dim: int = -1,
         descending: bool = False,
         stable: bool = False,
-    ) -> tuple[Tensor[Shape], Tensor[Shape]]:
+    ) -> return_types.sort[Shape]:
         """Sort tensor. Returns (values, indices). Shape-preserving operation."""
         ...
 
@@ -1068,10 +1051,7 @@ class Tensor[Shape: _Shape = _Shape]:
         Keepdim: Flag[builtins.bool],
     ](
         self: Tensor[Shape], k: int, dim: Dim = -1, keepdim: Keepdim = False
-    ) -> tuple[
-        Tensor[reduce_shape(Shape, Dim, Keepdim)],
-        Tensor[reduce_shape(Shape, Dim, Keepdim)],
-    ]:
+    ) -> return_types.kthvalue[reduce_shape(Shape, Dim, Keepdim)]:
         """Kth smallest value. Returns (values, indices). Shape inference via meta-shape: torch.Tensor.kthvalue"""
         ...
 
@@ -1510,11 +1490,11 @@ class Tensor[Shape: _Shape = _Shape]:
     @overload
     def slogdet[Batch: IntTuple, M: IntVar, N: IntVar](
         self: Tensor[[*Elements[Batch], M, N]],
-    ) -> tuple[Tensor[Batch], Tensor[Batch]]: ...
+    ) -> return_types.slogdet[Batch]: ...
     @overload
     def slogdet[Shape: IntTuple](
         self: Tensor[Shape],
-    ) -> tuple[Tensor[slogdet_shape(Shape)], Tensor[slogdet_shape(Shape)]]: ...
+    ) -> return_types.slogdet[slogdet_shape(Shape)]: ...
     def matrix_power(self, n: int) -> Self:
         """Matrix power. Shape inference via generic fixture signature."""
         ...
@@ -1838,10 +1818,7 @@ def max[Shape: IntTuple, OtherShape: IntTuple](
 @overload
 def max[Shape: IntTuple, Dim: Flag[builtins.int], Keepdim: Flag[builtins.bool]](
     input: Tensor[Shape], dim: Dim, keepdim: Keepdim = False
-) -> tuple[
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
-]:
+) -> return_types.max[reduce_shape(Shape, Dim, Keepdim)]:
     """Max along dimension. Returns (values, indices). Shape inference via meta-shape: torch.max"""
     ...
 
@@ -1860,10 +1837,7 @@ def min[Shape: IntTuple, OtherShape: IntTuple](
 @overload
 def min[Shape: IntTuple, Dim: Flag[builtins.int], Keepdim: Flag[builtins.bool]](
     input: Tensor[Shape], dim: Dim, keepdim: Keepdim = False
-) -> tuple[
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
-]:
+) -> return_types.min[reduce_shape(Shape, Dim, Keepdim)]:
     """Min along dimension. Returns (values, indices). Shape inference via meta-shape: torch.min"""
     ...
 
@@ -2323,10 +2297,7 @@ def median[Shape: IntTuple](input: Tensor[Shape]) -> Tensor[[]]:
 @overload
 def median[Shape: IntTuple, Dim: Flag[builtins.int], Keepdim: Flag[builtins.bool]](
     input: Tensor[Shape], dim: Dim, keepdim: Keepdim = False
-) -> tuple[
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
-]:
+) -> return_types.median[reduce_shape(Shape, Dim, Keepdim)]:
     """Median along dimension. Returns (values, indices). Shape inference via meta-shape: torch.median"""
     ...
 
@@ -2353,10 +2324,7 @@ def aminmax[
     Keepdim: Flag[builtins.bool],
 ](
     input: Tensor[Shape], *, dim: Dim = None, keepdim: Keepdim = False
-) -> tuple[
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
-]:
+) -> return_types.aminmax[reduce_shape(Shape, Dim, Keepdim)]:
     """Min and max along dimension(s). Shape inference via meta-shape: torch.aminmax"""
     ...
 
@@ -2387,23 +2355,20 @@ def cumprod[Shape: IntTuple](input: Tensor[Shape], dim: int) -> Tensor[Shape]:
 
 def cummax[Shape: IntTuple](
     input: Tensor[Shape], dim: int
-) -> tuple[Tensor[Shape], Tensor[Shape]]:
+) -> return_types.cummax[Shape]:
     """Cumulative maximum along dimension. Returns (values, indices). Shape-preserving operation."""
     ...
 
 def cummin[Shape: IntTuple](
     input: Tensor[Shape], dim: int
-) -> tuple[Tensor[Shape], Tensor[Shape]]:
+) -> return_types.cummin[Shape]:
     """Cumulative minimum along dimension. Returns (values, indices). Shape-preserving operation."""
     ...
 
 # Tier 2: Additional reduction operations (always return tuples)
 def mode[Shape: IntTuple, Dim: Flag[builtins.int], Keepdim: Flag[builtins.bool]](
     input: Tensor[Shape], dim: Dim = -1, keepdim: Keepdim = False
-) -> tuple[
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
-]:
+) -> return_types.mode[reduce_shape(Shape, Dim, Keepdim)]:
     """Mode along dimension. Returns (values, indices). Shape inference via meta-shape: torch.mode"""
     ...
 
@@ -2413,25 +2378,19 @@ def topk[Shape: IntTuple, K: _Int, Dim: Flag[builtins.int]](
     dim: Dim = -1,
     largest: bool = True,
     sorted: bool = True,
-) -> tuple[
-    Tensor[topk_shape(Shape, Dim, K)],
-    Tensor[topk_shape(Shape, Dim, K)],
-]:
+) -> return_types.topk[topk_shape(Shape, Dim, K)]:
     """Top k elements. Returns (values, indices). Shape inference via meta-shape: torch.topk"""
     ...
 
 def sort[Shape: IntTuple](
     input: Tensor[Shape], dim: int = -1, descending: bool = False, stable: bool = False
-) -> tuple[Tensor[Shape], Tensor[Shape]]:
+) -> return_types.sort[Shape]:
     """Sort tensor. Returns (values, indices). Shape-preserving operation."""
     ...
 
 def kthvalue[Shape: IntTuple, Dim: Flag[builtins.int], Keepdim: Flag[builtins.bool]](
     input: Tensor[Shape], k: int, dim: Dim = -1, keepdim: Keepdim = False
-) -> tuple[
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
-]:
+) -> return_types.kthvalue[reduce_shape(Shape, Dim, Keepdim)]:
     """Kth smallest value. Returns (values, indices). Shape inference via meta-shape: torch.kthvalue"""
     ...
 
@@ -2454,8 +2413,7 @@ def var_mean[
     unbiased: builtins.bool = True,
     keepdim: Keepdim = False,
 ) -> tuple[
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
+    Tensor[reduce_shape(Shape, Dim, Keepdim)], Tensor[reduce_shape(Shape, Dim, Keepdim)]
 ]:
     """Variance and mean. Returns (var, mean). Shape inference via meta-shape: torch.var_mean"""
     ...
@@ -2478,8 +2436,7 @@ def std_mean[
     unbiased: builtins.bool = True,
     keepdim: Keepdim = False,
 ) -> tuple[
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
-    Tensor[reduce_shape(Shape, Dim, Keepdim)],
+    Tensor[reduce_shape(Shape, Dim, Keepdim)], Tensor[reduce_shape(Shape, Dim, Keepdim)]
 ]:
     """Standard deviation and mean. Returns (std, mean). Shape inference via meta-shape: torch.std_mean"""
     ...
@@ -3021,11 +2978,11 @@ def logdet[Batch: IntTuple, M: IntVar, N: IntVar](
 @overload
 def slogdet[Batch: IntTuple, M: IntVar, N: IntVar](
     self: Tensor[[*Elements[Batch], M, N]],
-) -> tuple[Tensor[Batch], Tensor[Batch]]: ...
+) -> return_types.slogdet[Batch]: ...
 @overload
 def slogdet[Shape: IntTuple](
     self: Tensor[Shape],
-) -> tuple[Tensor[slogdet_shape(Shape)], Tensor[slogdet_shape(Shape)]]: ...
+) -> return_types.slogdet[slogdet_shape(Shape)]: ...
 
 # Matrix power and exponential
 def matrix_power[Shape: IntTuple](input: Tensor[Shape], n: int) -> Tensor[Shape]:

--- a/tensor-shapes/pyrefly-torch-stubs/torch-stubs/linalg.pyi
+++ b/tensor-shapes/pyrefly-torch-stubs/torch-stubs/linalg.pyi
@@ -7,7 +7,7 @@
 from typing import Any, overload
 
 from shape_extensions import Elements, IntTuple, IntVar
-from torch import Tensor
+from torch import return_types, Tensor
 from torch._shapes import eig_shape, eigvals_shape, slogdet_shape
 
 # Eigenvalue decomposition
@@ -72,11 +72,11 @@ def det[Batch: IntTuple, M: IntVar, N: IntVar](
 @overload
 def slogdet[Batch: IntTuple, M: IntVar, N: IntVar](
     self: Tensor[[*Elements[Batch], M, N]],
-) -> tuple[Tensor[Batch], Tensor[Batch]]: ...
+) -> return_types.linalg_slogdet[Batch]: ...
 @overload
 def slogdet[Shape: IntTuple](
     self: Tensor[Shape],
-) -> tuple[Tensor[slogdet_shape(Shape)], Tensor[slogdet_shape(Shape)]]: ...
+) -> return_types.linalg_slogdet[slogdet_shape(Shape)]: ...
 
 # Matrix power
 def matrix_power[Shape: IntTuple](input: Tensor[Shape], n: int) -> Tensor[Shape]: ...

--- a/tensor-shapes/pyrefly-torch-stubs/torch-stubs/return_types.pyi
+++ b/tensor-shapes/pyrefly-torch-stubs/torch-stubs/return_types.pyi
@@ -1,0 +1,84 @@
+"""Shape-generic named tuples returned by torch operations.
+
+Mirrors ``torch.return_types``, which torch generates from the output names in
+``native_functions.yaml`` as tuple subclasses with a property per field.
+"""
+
+from typing import Any
+
+from shape_extensions import IntTuple
+from torch import Tensor
+
+class aminmax[Shape: IntTuple](tuple[Tensor[Shape], Tensor[Shape]]):
+    @property
+    def min(self) -> Tensor[Shape]: ...
+    @property
+    def max(self) -> Tensor[Shape]: ...
+
+class cummax[Shape: IntTuple](tuple[Tensor[Shape], Tensor[Shape]]):
+    @property
+    def values(self) -> Tensor[Shape]: ...
+    @property
+    def indices(self) -> Tensor[Shape]: ...
+
+class cummin[Shape: IntTuple](tuple[Tensor[Shape], Tensor[Shape]]):
+    @property
+    def values(self) -> Tensor[Shape]: ...
+    @property
+    def indices(self) -> Tensor[Shape]: ...
+
+class kthvalue[Shape: IntTuple](tuple[Tensor[Shape], Tensor[Shape]]):
+    @property
+    def values(self) -> Tensor[Shape]: ...
+    @property
+    def indices(self) -> Tensor[Shape]: ...
+
+class max[Shape: IntTuple](tuple[Tensor[Shape], Tensor[Shape]]):
+    @property
+    def values(self) -> Tensor[Shape]: ...
+    @property
+    def indices(self) -> Tensor[Shape]: ...
+
+class median[Shape: IntTuple](tuple[Tensor[Shape], Tensor[Shape]]):
+    @property
+    def values(self) -> Tensor[Shape]: ...
+    @property
+    def indices(self) -> Tensor[Shape]: ...
+
+class min[Shape: IntTuple](tuple[Tensor[Shape], Tensor[Shape]]):
+    @property
+    def values(self) -> Tensor[Shape]: ...
+    @property
+    def indices(self) -> Tensor[Shape]: ...
+
+class mode[Shape: IntTuple](tuple[Tensor[Shape], Tensor[Shape]]):
+    @property
+    def values(self) -> Tensor[Shape]: ...
+    @property
+    def indices(self) -> Tensor[Shape]: ...
+
+class sort[Shape: IntTuple](tuple[Tensor[Shape], Tensor[Shape]]):
+    @property
+    def values(self) -> Tensor[Shape]: ...
+    @property
+    def indices(self) -> Tensor[Shape]: ...
+
+class topk[Shape: IntTuple](tuple[Tensor[Shape], Tensor[Shape]]):
+    @property
+    def values(self) -> Tensor[Shape]: ...
+    @property
+    def indices(self) -> Tensor[Shape]: ...
+
+class linalg_slogdet[Shape: IntTuple](tuple[Tensor[Shape], Tensor[Shape]]):
+    @property
+    def sign(self) -> Tensor[Shape]: ...
+    @property
+    def logabsdet(self) -> Tensor[Shape]: ...
+
+class slogdet[Shape: IntTuple](tuple[Tensor[Shape], Tensor[Shape]]):
+    @property
+    def sign(self) -> Tensor[Shape]: ...
+    @property
+    def logabsdet(self) -> Tensor[Shape]: ...
+
+def __getattr__(name: str) -> Any: ...


### PR DESCRIPTION
# Summary

Add a stub for `torch.return_types` and use it for the operations that return named tuples. Currently `sort`, `max(dim=...)`, `topk`, `aminmax`, `slogdet`, etc. return types are annotated as plain `tuple[Tensor, Tensor]` and `.values`, `.indices`, `.sign`, and the other documented fields are reported as `missing-attribute` errors.

PyTorch adds these annotations by generating its own `return_types.pyi` from the output names in `native_functions.yaml`:

https://github.com/pytorch/pytorch/blob/d6c03540dc0f040e1d8a920d19d9333de6513545/torchgen/api/python.py#L1012-L1033

For simplicity we just write the stubs manually here instead of generating them.

Note: `linalg_slogdet` is included as well although its missing in the PyTorch generated stubs.

# Test Plan

Run `test.py`.